### PR TITLE
8231735: gradle checkrepo is obsolete and doesn't work with git

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5170,32 +5170,6 @@ compileTargets { t ->
     }
 }
 
-task checkrepo() {
-    doLast {
-        logger.info("checking for whitespace (open)");
-        exec {
-            if (IS_WINDOWS) {
-                commandLine  'bash', 'tools/scripts/checkWhiteSpace'
-            } else {
-                commandLine  'bash', 'tools/scripts/checkWhiteSpace', '-x'
-            }
-        }
-    }
-}
-
-task checkrepoall() {
-    doLast {
-        logger.info("checking for all whitespace (open)");
-        exec {
-            if (IS_WINDOWS) {
-                commandLine  'bash', 'tools/scripts/checkWhiteSpace', '-a'
-            } else {
-                commandLine  'bash', 'tools/scripts/checkWhiteSpace', '-x', '-a'
-            }
-        }
-    }
-}
-
 /******************************************************************************
  *                                                                            *
  *                              BUILD_CLOSED                                  *


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8231735

This removes the obsolete `checkrepo` and `checkrepoall` gradle tasks. They use a script which assumes Mercurial support, and so no longer run. Also, with `git jcheck` support now available, these tasks are no longer needed.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Approvers
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)