### PR TITLE
8231590: Update location of jfx repo to GitHub in third-party legal files

### DIFF
--- a/modules/javafx.media/src/main/legal/glib.md
+++ b/modules/javafx.media/src/main/legal/glib.md
@@ -17,7 +17,7 @@ this library:
 A copy of the Oracle modified GNU Glib library source code is located
 in the following OpenJDK Mercurial repository:
 
-   http://hg.openjdk.java.net/openjfx/jfx/rt
+   https://github.com/openjdk/jfx
 
 You can use Mercurial to clone the repository or you can browse the
 source using a web browser. The root directory of the GNU Glib source

--- a/modules/javafx.media/src/main/legal/gstreamer.md
+++ b/modules/javafx.media/src/main/legal/gstreamer.md
@@ -17,7 +17,7 @@ this library:
 A copy of the Oracle modified GStreamer library source code is located
 in the following OpenJDK Mercurial repository:
 
-   http://hg.openjdk.java.net/openjfx/jfx/rt
+   https://github.com/openjdk/jfx
 
 You can use Mercurial to clone the repository or you can browse the
 source using a web browser. The root directory of the GStreamer source

--- a/modules/javafx.web/src/main/legal/webkit.md
+++ b/modules/javafx.web/src/main/legal/webkit.md
@@ -17,7 +17,7 @@ this library:
 A copy of the Oracle modified WebKit library source code is located
 in the following OpenJDK Mercurial repository:
 
-   http://hg.openjdk.java.net/openjfx/jfx/rt
+   https://github.com/openjdk/jfx
 
 You can use Mercurial to clone the repository or you can browse the
 source using a web browser. The root directory of the WebKit source


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8231590

Replaces http://hg.openjdk.java.net/openjfx/jfx/rt with https://github.com/openjdk/jfx in three third-party legal files. After this change, there are no more references to `hg.openjdk.java.net` in the repo.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Approvers
 * Alexander Matveev ([almatvee](@sashamatveev) - **Reviewer**)