### PR TITLE
8225571: Port DND source to use GTK instead of GDK

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkDnDClipboard.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkDnDClipboard.java
@@ -39,10 +39,7 @@ final class GtkDnDClipboard extends SystemClipboard{
         final int performedAction = pushToSystemImpl(cacheData,
                                                      supportedActions);
 
-        // drag can fail or be cancelled
-        if (performedAction != ACTION_NONE) {
-            actionPerformed(performedAction);
-        }
+        actionPerformed(performedAction);
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkDnDClipboard.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkDnDClipboard.java
@@ -38,7 +38,6 @@ final class GtkDnDClipboard extends SystemClipboard{
                                 int supportedActions) {
         final int performedAction = pushToSystemImpl(cacheData,
                                                      supportedActions);
-
         actionPerformed(performedAction);
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkDnDClipboard.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkDnDClipboard.java
@@ -38,7 +38,11 @@ final class GtkDnDClipboard extends SystemClipboard{
                                 int supportedActions) {
         final int performedAction = pushToSystemImpl(cacheData,
                                                      supportedActions);
-        actionPerformed(performedAction);
+
+        // drag can fail or be cancelled
+        if (performedAction != ACTION_NONE) {
+            actionPerformed(performedAction);
+        }
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
@@ -444,10 +444,6 @@ static void process_events(GdkEvent* event, gpointer data)
         }
     }
 
-    if (is_in_drag()) {
-        process_dnd_source(window, event);
-    }
-
     if (ctx != NULL) {
         EventsCounterHelper helper(ctx);
         try {

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_dnd.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_dnd.cpp
@@ -518,7 +518,6 @@ jobject dnd_target_get_data(JNIEnv *env, jstring mime)
 
 /************************* SOURCE *********************************************/
 
-
 static jint dnd_performed_action;
 
 const char * const SOURCE_DND_DATA = "fx-dnd-data";
@@ -740,6 +739,15 @@ static gboolean dnd_source_set_raw(GtkWidget *widget, GtkSelectionData *sel_data
     return is_data_set;
 }
 
+static gboolean dnd_destroy_drag_widget_callback(gpointer) {
+    if (drag_widget) {
+        gtk_widget_destroy(drag_widget);
+        drag_widget = NULL;
+    }
+
+    return FALSE;
+}
+
 static void dnd_end_callback(GtkWidget *widget,
                              GdkDragContext *context,
                              gpointer user_data)
@@ -747,9 +755,8 @@ static void dnd_end_callback(GtkWidget *widget,
     if (drag_widget) {
         GdkDragAction action = gdk_drag_context_get_selected_action(context);
         dnd_set_performed_action(translate_gdk_action_to_glass(action));
-        gtk_widget_destroy(drag_widget);
-        drag_widget = NULL;
     }
+    gdk_threads_add_idle((GSourceFunc) dnd_destroy_drag_widget_callback, NULL);
 }
 
 static gboolean dnd_drag_failed_callback(GtkWidget *widget,
@@ -757,9 +764,8 @@ static gboolean dnd_drag_failed_callback(GtkWidget *widget,
                                      GtkDragResult result,
                                      gpointer user_data)
 {
-    gtk_widget_destroy(drag_widget);
-    drag_widget = NULL;
     dnd_set_performed_action(com_sun_glass_ui_gtk_GtkDnDClipboard_ACTION_NONE);
+    gdk_threads_add_idle((GSourceFunc) dnd_destroy_drag_widget_callback, NULL);
 
     return FALSE;
 }
@@ -845,6 +851,7 @@ jint execute_dnd(JNIEnv *env, jobject data, jint supported)
     try {
         dnd_source_push_data(env, data, supported);
     } catch (jni_exception&) {
+        gdk_threads_add_idle((GSourceFunc) dnd_destroy_drag_widget_callback, NULL);
         return com_sun_glass_ui_gtk_GtkDnDClipboard_ACTION_NONE;
     }
 

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_dnd.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_dnd.cpp
@@ -141,6 +141,12 @@ static struct {
 
 gboolean is_dnd_owner = FALSE;
 
+GtkWidget *drag_widget = NULL;
+
+gboolean is_in_drag() {
+    return drag_widget != NULL;
+}
+
 static void reset_enter_ctx() {
     if (enter_ctx.mimes != NULL) {
         mainEnv->DeleteGlobalRef(enter_ctx.mimes);
@@ -511,122 +517,32 @@ jobject dnd_target_get_data(JNIEnv *env, jstring mime)
 }
 
 /************************* SOURCE *********************************************/
-static GdkWindow *dnd_window = NULL;
+
+
 static jint dnd_performed_action;
 
-const char * const SOURCE_DND_CONTEXT = "fx-dnd-context";
 const char * const SOURCE_DND_DATA = "fx-dnd-data";
-const char * const SOURCE_DND_ACTIONS = "fx-dnd-actions";
 
-static GdkWindow* get_dnd_window()
+static void dnd_set_performed_action(jint performed_action)
 {
-    if (dnd_window == NULL) {
-        GdkWindowAttr attr;
-        memset(&attr, 0, sizeof (GdkWindowAttr));
-        attr.override_redirect = TRUE;
-        attr.window_type = GDK_WINDOW_TEMP;
-        attr.type_hint = GDK_WINDOW_TYPE_HINT_UTILITY;
-        attr.wclass = GDK_INPUT_OUTPUT;
-        attr.event_mask = GDK_ALL_EVENTS_MASK;
-        dnd_window = gdk_window_new(NULL, &attr, GDK_WA_NOREDIR | GDK_WA_TYPE_HINT);
-
-        gdk_window_move(dnd_window, -99, -99);
-        gdk_window_resize(dnd_window, 1, 1);
-        gdk_window_show(dnd_window);
-    }
-    return dnd_window;
-}
-
-static void dnd_set_performed_action(jint performed_action) {
     dnd_performed_action = performed_action;
 }
 
-static jint dnd_get_performed_action() {
+static jint dnd_get_performed_action()
+{
     return dnd_performed_action;
 }
 
-static void dnd_pointer_grab(GdkEvent *event, GdkCursor *cursor)
+static void pixbufDestroyNotifyFunc(guchar *pixels, gpointer)
 {
-    glass_gdk_master_pointer_grab(event, dnd_window, cursor);
-}
-
-static GdkDragContext *get_drag_context() {
-    GdkDragContext *ctx;
-    ctx = (GdkDragContext*)g_object_get_data(G_OBJECT(dnd_window), SOURCE_DND_CONTEXT);
-    return ctx;
-}
-
-static gboolean dnd_finish_callback(gpointer) {
-    if (dnd_window) {
-        dnd_set_performed_action(
-                translate_gdk_action_to_glass(
-                    gdk_drag_context_get_selected_action(
-                        get_drag_context())));
-
-        gdk_window_destroy(dnd_window);
-        dnd_window = NULL;
-        DragView::reset_drag_view();
-    }
-
-    return FALSE;
-}
-
-#ifdef GLASS_GTK3
-static void dnd_finished_callback(GdkDragContext *ctx, gpointer user_data) {
-    dnd_finish_callback(user_data);
-}
-
-static gboolean dnd_update_drag_view(gpointer) {
-    gint x, y;
-
-    gdk_device_get_position(gdk_drag_context_get_device(get_drag_context()),
-                                NULL, &x, &y);
-
-
-    DragView::move(x, y);
-
-    return FALSE;
-}
-#endif
-
-gboolean is_in_drag()
-{
-    return dnd_window != NULL;
-}
-
-static void determine_actions(guint state, GdkDragAction *action, GdkDragAction *possible_actions)
-{
-    GdkDragAction suggested = static_cast<GdkDragAction>(GPOINTER_TO_INT(g_object_get_data(G_OBJECT(dnd_window), SOURCE_DND_ACTIONS)));
-
-    if (state & (GDK_SHIFT_MASK | GDK_CONTROL_MASK)) {
-        if ((state & GDK_CONTROL_MASK) && (state & GDK_SHIFT_MASK) && (suggested & GDK_ACTION_LINK)) {
-            *action = *possible_actions = GDK_ACTION_LINK;
-            return;
-        } else if ((state & GDK_SHIFT_MASK) && (suggested & GDK_ACTION_MOVE)) {
-            *action = *possible_actions = GDK_ACTION_MOVE;
-            return;
-        } else if (suggested & GDK_ACTION_COPY){
-            *action = *possible_actions = GDK_ACTION_COPY;
-            return;
-        }
-    }
-
-    *possible_actions = suggested;
-
-    if (suggested & GDK_ACTION_COPY) {
-        *action = GDK_ACTION_COPY;
-    } else if (suggested & GDK_ACTION_MOVE) {
-        *action = GDK_ACTION_MOVE;
-    } else if (suggested & GDK_ACTION_LINK) {
-        *action = GDK_ACTION_LINK;
-    } else {
-        *action = static_cast<GdkDragAction>(0);
+    if (pixels != NULL) {
+        g_free(pixels);
     }
 }
 
-static jobject dnd_source_get_data(const char *key)
+static jobject dnd_source_get_data(GtkWidget *widget, const char *key)
 {
-    jobject data = (jobject)g_object_get_data(G_OBJECT(dnd_window), SOURCE_DND_DATA);
+    jobject data = (jobject)g_object_get_data(G_OBJECT(widget), SOURCE_DND_DATA);
     jstring string = mainEnv->NewStringUTF(key);
     EXCEPTION_OCCURED(mainEnv);
     jobject result = mainEnv->CallObjectMethod(data, jMapGet, string, NULL);
@@ -634,53 +550,91 @@ static jobject dnd_source_get_data(const char *key)
     return (EXCEPTION_OCCURED(mainEnv)) ? NULL : result;
 }
 
-static gboolean dnd_source_set_utf8_string(GdkWindow *requestor, GdkAtom property)
+static void add_gtk_target_from_jstring(JNIEnv *env, GtkTargetList **list, jstring string, guint flags)
 {
-    jstring string = (jstring)dnd_source_get_data("text/plain");
-    if (!string) {
-        return FALSE;
+    const char *gstring = env->GetStringUTFChars(string, NULL);
+
+    if (g_strcmp0(gstring, "text/plain") == 0) {
+        gtk_target_list_add(*list, TARGET_UTF8_STRING_ATOM, flags, 0);
+        gtk_target_list_add(*list, TARGET_MIME_TEXT_PLAIN_ATOM, flags, 0);
+        gtk_target_list_add(*list, TARGET_STRING_ATOM, flags, 0);
+        //gtk_target_list_add(*list, TARGET_COMPOUND_TEXT_ATOM, flags, ??);
+    } else if (g_strcmp0(gstring, "application/x-java-rawimage") == 0) {
+        gtk_target_list_add(*list, TARGET_MIME_PNG_ATOM, flags, 0);
+        gtk_target_list_add(*list, TARGET_MIME_JPEG_ATOM, flags, 0);
+        gtk_target_list_add(*list, TARGET_MIME_TIFF_ATOM, flags, 0);
+        gtk_target_list_add(*list, TARGET_MIME_BMP_ATOM, flags, 0);
+    } else if (g_strcmp0(gstring, "application/x-java-file-list") == 0) {
+        gtk_target_list_add(*list, TARGET_MIME_URI_LIST_ATOM, flags, 0);
+    } else if (g_strcmp0(gstring, "application/x-java-drag-image") == 0
+        || g_strcmp0(gstring, "application/x-java-drag-image-offset") == 0) {
+        // do nothing - those are DragView information
+    } else {
+        GdkAtom atom = gdk_atom_intern(gstring, FALSE);
+        gtk_target_list_add(*list, atom, flags, 0);
     }
 
-    const char *cstring = mainEnv->GetStringUTFChars(string, NULL);
-    if (!cstring) {
-        return FALSE;
-    }
-    gint size = strlen(cstring);
-
-    gdk_property_change(requestor, property, GDK_SELECTION_TYPE_STRING,
-            8, GDK_PROP_MODE_REPLACE, (guchar *)cstring, size);
-
-    mainEnv->ReleaseStringUTFChars(string, cstring);
-    return TRUE;
+    env->ReleaseStringUTFChars(string, gstring);
 }
 
-static gboolean dnd_source_set_string(GdkWindow *requestor, GdkAtom property)
+static GtkTargetList* data_to_gtk_target_list(JNIEnv *env, jobject data)
 {
-    jstring string = (jstring)dnd_source_get_data("text/plain");
+    guint flags = GTK_TARGET_OTHER_APP | GTK_TARGET_SAME_APP;
+
+    jobject keys;
+    jobject keysIterator;
+    jstring next;
+
+    GtkTargetList *tlist = gtk_target_list_new (NULL, 0);
+
+    init_target_atoms();
+
+    gint added_count = 0;
+
+    keys = env->CallObjectMethod(data, jMapKeySet, NULL);
+    JNI_EXCEPTION_TO_CPP(env)
+    keysIterator = env->CallObjectMethod(keys, jIterableIterator, NULL);
+    JNI_EXCEPTION_TO_CPP(env)
+    while (env->CallBooleanMethod(keysIterator, jIteratorHasNext) == JNI_TRUE) {
+        next = (jstring)env->CallObjectMethod(keysIterator, jIteratorNext, NULL);
+        JNI_EXCEPTION_TO_CPP(env)
+        add_gtk_target_from_jstring(env, &tlist, next, flags);
+    }
+
+    return tlist;
+}
+
+static gboolean dnd_source_set_string(GtkWidget *widget, GtkSelectionData *data, GdkAtom atom)
+{
+    gboolean is_data_set;
+
+    jstring string = (jstring)dnd_source_get_data(widget, "text/plain");
     if (!string) {
         return FALSE;
     }
 
-    gboolean is_data_set = FALSE;
     const char *cstring = mainEnv->GetStringUTFChars(string, NULL);
     if (cstring) {
-        gchar *res_str = g_convert((gchar *)cstring, -1, "ISO-8859-1", "UTF-8", NULL, NULL, NULL);
-
-        if (res_str) {
-            gdk_property_change(requestor, property, GDK_SELECTION_TYPE_STRING,
-                    8, GDK_PROP_MODE_REPLACE, (guchar *)res_str, strlen(res_str));
-            g_free(res_str);
-            is_data_set = TRUE;
+        if (atom == TARGET_MIME_TEXT_PLAIN_ATOM) {
+            gchar *res_str = g_convert((gchar *) cstring, -1, "ISO-8859-1", "UTF-8", NULL, NULL, NULL);
+            if (res_str) {
+                is_data_set = gtk_selection_data_set_text(data, res_str, strlen(res_str));
+                g_free(res_str);
+            }
+        } else {
+            gint size = strlen(cstring);
+            is_data_set = gtk_selection_data_set_text(data, (gchar *) cstring, size);
         }
-
-        mainEnv->ReleaseStringUTFChars(string, cstring);
     }
+
+    mainEnv->ReleaseStringUTFChars(string, cstring);
+
     return is_data_set;
 }
 
-static gboolean dnd_source_set_image(GdkWindow *requestor, GdkAtom property, GdkAtom target)
+static gboolean dnd_source_set_image(GtkWidget *widget, GtkSelectionData *data, GdkAtom atom)
 {
-    jobject pixels = dnd_source_get_data("application/x-java-rawimage");
+    jobject pixels = dnd_source_get_data(widget, "application/x-java-rawimage");
     if (!pixels) {
         return FALSE;
     }
@@ -689,33 +643,20 @@ static gboolean dnd_source_set_image(GdkWindow *requestor, GdkAtom property, Gdk
     gsize size;
     const char * type;
     GdkPixbuf *pixbuf = NULL;
-    gboolean result = FALSE;
-
-    if (target == TARGET_MIME_PNG_ATOM) {
-        type = "png";
-    } else if (target == TARGET_MIME_JPEG_ATOM) {
-        type = "jpeg";
-    } else if (target == TARGET_MIME_TIFF_ATOM) {
-        type = "tiff";
-    } else if (target == TARGET_MIME_BMP_ATOM) {
-        type = "bmp";
-    } else {
-        return FALSE;
-    }
+    gboolean is_data_set;
 
     mainEnv->CallVoidMethod(pixels, jPixelsAttachData, PTR_TO_JLONG(&pixbuf));
 
-    if (!EXCEPTION_OCCURED(mainEnv)
-            && gdk_pixbuf_save_to_buffer(pixbuf, &buffer, &size, type, NULL, NULL)) {
-        gdk_property_change(requestor, property, target,
-                8, GDK_PROP_MODE_REPLACE, (guchar *)buffer, size);
-        result = TRUE;
+    if (!EXCEPTION_OCCURED(mainEnv)) {
+        is_data_set = gtk_selection_data_set_pixbuf(data, pixbuf);
     }
+
     g_object_unref(pixbuf);
-    return result;
+
+    return is_data_set;
 }
 
-static gboolean dnd_source_set_uri_list(GdkWindow *requestor, GdkAtom property)
+static gboolean dnd_source_set_uri(GtkWidget *widget, GtkSelectionData *data, GdkAtom atom)
 {
     const gchar* url = NULL;
     jstring jurl = NULL;
@@ -723,17 +664,19 @@ static gboolean dnd_source_set_uri_list(GdkWindow *requestor, GdkAtom property)
     jobjectArray files_array = NULL;
     gsize files_cnt = 0;
 
-    if (jurl = (jstring) dnd_source_get_data("text/uri-list")) {
+    if (jurl = (jstring) dnd_source_get_data(widget, "text/uri-list")) {
         url = mainEnv->GetStringUTFChars(jurl, NULL);
     }
 
-    if (files_array = (jobjectArray) dnd_source_get_data("application/x-java-file-list")) {
+    if (files_array = (jobjectArray) dnd_source_get_data(widget, "application/x-java-file-list")) {
         files_cnt = mainEnv->GetArrayLength(files_array);
     }
+
     if (!url && !files_cnt) {
         return FALSE;
     }
 
+    gboolean is_data_set;
     GString* res = g_string_new (NULL); //http://www.ietf.org/rfc/rfc2483.txt
 
     if (files_cnt > 0) {
@@ -756,27 +699,28 @@ static gboolean dnd_source_set_uri_list(GdkWindow *requestor, GdkAtom property)
         mainEnv->ReleaseStringUTFChars(jurl, url);
     }
 
-    gdk_property_change(requestor, property, GDK_SELECTION_TYPE_STRING,
-            8, GDK_PROP_MODE_REPLACE, (guchar *) res->str, res->len);
+    gchar *uri[2];
+    uri[0] = g_string_free(res, FALSE);
+    uri[1] = NULL;
 
-    g_string_free(res, TRUE);
-    return TRUE;
+    is_data_set = gtk_selection_data_set_uris(data, uri);
+
+    g_free(uri[0]);
+
+    return is_data_set;
 }
 
-static gboolean dnd_source_set_raw(GdkWindow *requestor, GdkAtom property, GdkAtom target)
+static gboolean dnd_source_set_raw(GtkWidget *widget, GtkSelectionData *sel_data, GdkAtom atom)
 {
-    gchar *target_name = gdk_atom_name(target);
-    jobject data = dnd_source_get_data(target_name);
+    gchar *target_name = gdk_atom_name(atom);
+    jobject data = dnd_source_get_data(widget, target_name);
     gboolean is_data_set = FALSE;
     if (data) {
         if (mainEnv->IsInstanceOf(data, jStringCls)) {
             const char *cstring = mainEnv->GetStringUTFChars((jstring)data, NULL);
             if (cstring) {
-                gdk_property_change(requestor, property, GDK_SELECTION_TYPE_STRING,
-                        8, GDK_PROP_MODE_REPLACE, (guchar *) cstring, strlen(cstring));
-
+                is_data_set = gtk_selection_data_set_text(sel_data, (gchar *) cstring, strlen(cstring));
                 mainEnv->ReleaseStringUTFChars((jstring)data, cstring);
-                is_data_set = TRUE;
             }
         } else if (mainEnv->IsInstanceOf(data, jByteBufferCls)) {
             jbyteArray byteArray = (jbyteArray)mainEnv->CallObjectMethod(data, jByteBufferArray);
@@ -784,10 +728,7 @@ static gboolean dnd_source_set_raw(GdkWindow *requestor, GdkAtom property, GdkAt
                 jbyte* raw = mainEnv->GetByteArrayElements(byteArray, NULL);
                 if (raw) {
                     jsize nraw = mainEnv->GetArrayLength(byteArray);
-
-                    gdk_property_change(requestor, property, target,
-                            8, GDK_PROP_MODE_REPLACE, (guchar *) raw, nraw);
-
+                    gtk_selection_data_set(sel_data, atom, 8, (guchar *) raw, nraw);
                     mainEnv->ReleaseByteArrayElements(byteArray, raw, JNI_ABORT);
                     is_data_set = TRUE;
                 }
@@ -799,323 +740,112 @@ static gboolean dnd_source_set_raw(GdkWindow *requestor, GdkAtom property, GdkAt
     return is_data_set;
 }
 
-static void process_dnd_source_selection_req(GdkWindow *window, GdkEvent *gdkEvent)
+static void dnd_end_callback(GtkWidget *widget,
+                             GdkDragContext *context,
+                             gpointer user_data)
 {
-    (void)window;
+    if (drag_widget) {
+        GdkDragAction action = gdk_drag_context_get_selected_action(context);
+        dnd_set_performed_action(translate_gdk_action_to_glass(action));
+        gtk_widget_destroy(drag_widget);
+        drag_widget = NULL;
+    }
+}
 
-    GdkEventSelection *event = &gdkEvent->selection;
+static gboolean dnd_drag_failed_callback(GtkWidget *widget,
+                                     GdkDragContext *context,
+                                     GtkDragResult result,
+                                     gpointer user_data)
+{
+    gtk_widget_destroy(drag_widget);
+    drag_widget = NULL;
+    dnd_set_performed_action(com_sun_glass_ui_gtk_GtkDnDClipboard_ACTION_NONE);
 
-#ifdef GLASS_GTK3
-    GdkWindow *requestor = (event->requestor);
-#else
-    GdkWindow *requestor =
-        gdk_x11_window_foreign_new_for_display(gdk_display_get_default(), event->requestor);
-#endif
+    return FALSE;
+}
 
-    gboolean is_data_set = FALSE;
-    if (event->target == TARGET_UTF8_STRING_ATOM
-            || event->target == TARGET_MIME_TEXT_PLAIN_ATOM) {
-        is_data_set = dnd_source_set_utf8_string(requestor, event->property);
-    } else if (event->target == TARGET_STRING_ATOM) {
-        is_data_set = dnd_source_set_string(requestor, event->property);
-//    } else if (event->target == TARGET_COMPOUND_TEXT_ATOM) { // XXX compound text
-    } else if (target_is_image(event->target)) {
-        is_data_set = dnd_source_set_image(requestor, event->property, event->target);
-    } else if (event->target == TARGET_MIME_URI_LIST_ATOM) {
-        is_data_set = dnd_source_set_uri_list(requestor, event->property);
+static void dnd_data_get_callback(GtkWidget *widget,
+                                  GdkDragContext *context,
+                                  GtkSelectionData *data,
+                                  guint info,
+                                  guint time,
+                                  gpointer user_data)
+{
+    GdkAtom atom = gtk_selection_data_get_target(data);
+
+    if (target_is_text(atom)) {
+        dnd_source_set_string(widget, data, atom);
+    } else if (target_is_image(atom)) {
+        dnd_source_set_image(widget, data, atom);
+    } else if (target_is_uri(atom)) {
+        dnd_source_set_uri(widget, data, atom);
     } else {
-        is_data_set = dnd_source_set_raw(requestor, event->property, event->target);
-    }
-
-    gdk_selection_send_notify(event->requestor, event->selection, event->target,
-                               (is_data_set) ? event->property : GDK_NONE, event->time);
-
-}
-
-static void process_dnd_source_mouse_release(GdkWindow *window, GdkEvent *event) {
-    (void)window;
-
-    glass_gdk_master_pointer_ungrab(event);
-
-    if (gdk_drag_context_get_selected_action(get_drag_context())) {
-        gdk_drag_drop(get_drag_context(), GDK_CURRENT_TIME);
-    } else {
-        gdk_drag_abort(get_drag_context(), GDK_CURRENT_TIME);
-        /* let the gdk_drag_abort messages handled before finish */
-        gdk_threads_add_idle((GSourceFunc) dnd_finish_callback, NULL);
+        dnd_source_set_raw(widget, data, atom);
     }
 }
 
-static void process_drag_motion(gint x_root, gint y_root, guint state)
+static void dnd_drag_begin_callback(GtkWidget *widget,
+                                    GdkDragContext *context,
+                                    gpointer user_data)
 {
-    GdkWindow *dest_window;
-    GdkDragProtocol prot;
-
-#ifndef GLASS_GTK3
-    // gtk3 uses a move-when-idle method
-    DragView::move(x_root, y_root);
-#endif
-
-    gdk_drag_find_window_for_screen(get_drag_context(), NULL, gdk_screen_get_default(),
-            x_root, y_root, &dest_window, &prot);
-
-    if (prot != GDK_DRAG_PROTO_NONE) {
-        GdkDragAction action, possible_actions;
-        determine_actions(state, &action, &possible_actions);
-        gdk_drag_motion(get_drag_context(), dest_window, prot, x_root, y_root,
-                action, possible_actions, GDK_CURRENT_TIME);
-    }
-}
-
-static void process_dnd_source_mouse_motion(GdkWindow *window, GdkEvent *event)
-{
-    (void)window;
-
-    GdkEventMotion *eventMotion = &event->motion;
-    process_drag_motion(eventMotion->x_root, eventMotion->y_root, eventMotion->state);
-}
-
-static void process_dnd_source_key_press_release(GdkWindow *window, GdkEvent *event)
-{
-    (void)window;
-
-    GdkEventKey *eventKey = &event->key;
-
-    if (eventKey->is_modifier) {
-        guint state = eventKey->state;
-        guint new_mod = 0;
-        gint x,y;
-        if (eventKey->keyval == GLASS_GDK_KEY_CONSTANT(Control_L) ||
-                eventKey->keyval == GLASS_GDK_KEY_CONSTANT(Control_R)) {
-            new_mod = GDK_CONTROL_MASK;
-        } else if (eventKey->keyval == GLASS_GDK_KEY_CONSTANT(Alt_L) ||
-                eventKey->keyval == GLASS_GDK_KEY_CONSTANT(Alt_R)) {
-            new_mod = GDK_MOD1_MASK;
-        } else if (eventKey->keyval == GLASS_GDK_KEY_CONSTANT(Shift_L) ||
-                eventKey->keyval == GLASS_GDK_KEY_CONSTANT(Shift_R)) {
-            new_mod = GDK_SHIFT_MASK;
-        }
-
-        if (eventKey->type == GDK_KEY_PRESS) {
-            state |= new_mod;
-        } else {
-            state ^= new_mod;
-        }
-
-#ifdef GLASS_GTK3
-        gdk_device_get_position(gdk_drag_context_get_device(get_drag_context()), NULL, &x, &y);
-#else
-        glass_gdk_master_pointer_get_position(&x, &y);
-#endif
-        process_drag_motion(x, y, state);
-    }
-}
-
-static void process_dnd_source_drag_status(GdkWindow *window, GdkEvent *event)
-{
-    (void)window;
-
-    GdkEventDND *eventDnd = &event->dnd;
-    GdkDragAction selected = gdk_drag_context_get_selected_action(eventDnd->context);
-    GdkCursor* cursor;
-
-#ifdef GLASS_GTK3
-    // dragview shows content when dragging - this updates the position
-    gdk_threads_add_idle_full (GDK_PRIORITY_REDRAW + 5, dnd_update_drag_view,
-                               NULL, NULL);
-
-#endif
-
-    if (selected & GDK_ACTION_COPY) {
-        cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "dnd-copy");
-        if (cursor == NULL) {
-            cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "copy");
-        }
-    } else if (selected & (GDK_ACTION_MOVE | GDK_ACTION_PRIVATE)) {
-        cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "dnd-move");
-        if (cursor == NULL) {
-            cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "move");
-        }
-        if (cursor == NULL) {
-            cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "closedhand");
-        }
-    } else if (selected & GDK_ACTION_LINK) {
-        cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "dnd-link");
-        if (cursor == NULL) {
-            cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "link");
-        }
-        if (cursor == NULL) {
-            cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "alias");
-        }
-    } else {
-        cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "dnd-no-drop");
-        if (cursor == NULL) {
-            cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "no-drop");
-        }
-        if (cursor == NULL) {
-            cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "not-allowed");
-        }
-        if (cursor == NULL) {
-            cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "forbidden");
-        }
-        if (cursor == NULL) {
-            cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "dnd-none");
-        }
-    }
-
-    if (cursor == NULL) {
-        cursor = gdk_cursor_new_from_name(gdk_display_get_default(), "default");
-    }
-
-    dnd_pointer_grab(event, cursor);
-}
-
-static void process_dnd_source_drop_finished(GdkWindow *window, GdkEvent *event)
-{
-    (void)window;
-    (void)event;
-
-    gdk_threads_add_idle((GSourceFunc) dnd_finish_callback, NULL);
-}
-
-void process_dnd_source(GdkWindow *window, GdkEvent *event) {
-    switch(event->type) {
-        case GDK_MOTION_NOTIFY:
-            process_dnd_source_mouse_motion(window, event);
-            break;
-        case GDK_BUTTON_RELEASE:
-            process_dnd_source_mouse_release(window, event);
-            break;
-        case GDK_DRAG_STATUS:
-            process_dnd_source_drag_status(window, event);
-            break;
-        case GDK_DROP_FINISHED:
-            process_dnd_source_drop_finished(window, event);
-            break;
-        case GDK_KEY_PRESS:
-        case GDK_KEY_RELEASE:
-            process_dnd_source_key_press_release(window, event);
-            break;
-        case GDK_DRAG_ENTER:
-            gdk_selection_owner_set(dnd_window, gdk_drag_get_selection(get_drag_context()),
-                                    GDK_CURRENT_TIME, FALSE);
-            break;
-        case GDK_SELECTION_REQUEST:
-            process_dnd_source_selection_req(window, event);
-            break;
-        default:
-            break;
-    }
-}
-
-static void add_target_from_jstring(JNIEnv *env, GList **list, jstring string)
-{
-    const char *gstring = env->GetStringUTFChars(string, NULL);
-    if (g_strcmp0(gstring, "text/plain") == 0) {
-        *list = g_list_append(*list, TARGET_UTF8_STRING_ATOM);
-        *list = g_list_append(*list, TARGET_MIME_TEXT_PLAIN_ATOM);
-        *list = g_list_append(*list, TARGET_STRING_ATOM);
-        //*list = g_list_append(list, TARGET_COMPOUND_TEXT_ATOM);
-    } else if (g_strcmp0(gstring, "application/x-java-rawimage") == 0) {
-        *list = g_list_append(*list, TARGET_MIME_PNG_ATOM);
-        *list = g_list_append(*list, TARGET_MIME_JPEG_ATOM);
-        *list = g_list_append(*list, TARGET_MIME_TIFF_ATOM);
-        *list = g_list_append(*list, TARGET_MIME_BMP_ATOM);
-    } else if (g_strcmp0(gstring, "application/x-java-file-list") == 0) {
-        *list = g_list_append(*list, TARGET_MIME_URI_LIST_ATOM);
-    } else {
-        *list = g_list_append(*list, gdk_atom_intern(gstring, FALSE));
-    }
-    env->ReleaseStringUTFChars(string, gstring);
-}
-
-static GList* data_to_targets(JNIEnv *env, jobject data)
-{
-    jobject keys;
-    jobject keysIterator;
-    jstring next;
-
-    GList *list = NULL;
-
-    init_target_atoms();
-
-    keys = env->CallObjectMethod(data, jMapKeySet, NULL);
-    JNI_EXCEPTION_TO_CPP(env)
-    keysIterator = env->CallObjectMethod(keys, jIterableIterator, NULL);
-    JNI_EXCEPTION_TO_CPP(env)
-    while (env->CallBooleanMethod(keysIterator, jIteratorHasNext) == JNI_TRUE) {
-        next = (jstring)env->CallObjectMethod(keysIterator, jIteratorNext, NULL);
-        JNI_EXCEPTION_TO_CPP(env)
-        add_target_from_jstring(env, &list, next);
-    }
-    return list;
+    DragView::set_drag_view(widget, context);
 }
 
 static void dnd_source_push_data(JNIEnv *env, jobject data, jint supported)
 {
-    GdkWindow *src_window = get_dnd_window();
-    GList *targets;
-    GdkDragContext *ctx;
-
     if (supported == 0) {
         return; // No supported actions, do nothing
     }
 
-    targets = data_to_targets(env, data);
-
     data = env->NewGlobalRef(data);
 
     GdkDragAction actions = translate_glass_action_to_gdk(supported);
-    g_object_set_data_full(G_OBJECT(src_window), SOURCE_DND_DATA, data, clear_global_ref);
-    g_object_set_data(G_OBJECT(src_window), SOURCE_DND_ACTIONS, (gpointer)actions);
 
-    DragView::set_drag_view();
+    // this widget is used only to pass events and will
+    // be destroyed on drag end
+    drag_widget = gtk_window_new(GTK_WINDOW_POPUP);
+    gtk_window_resize(GTK_WINDOW(drag_widget), 1, 1);
+    gtk_window_move(GTK_WINDOW(drag_widget), -200, -200);
+    gtk_widget_show(drag_widget);
 
-#ifdef GLASS_GTK3
-    GdkDevice *device = gdk_device_manager_get_client_pointer(
-                    gdk_display_get_device_manager(
-                        gdk_display_get_default()));
+    g_object_set_data_full(G_OBJECT(drag_widget), SOURCE_DND_DATA, data, clear_global_ref);
 
-    ctx = gdk_drag_begin_for_device(src_window, device, targets);
-#else
-    ctx = gdk_drag_begin(src_window, targets);
-#endif
+    g_signal_connect(drag_widget, "drag-begin",
+        G_CALLBACK(dnd_drag_begin_callback), NULL);
 
-    g_list_free(targets);
-    g_object_set_data(G_OBJECT(src_window), SOURCE_DND_CONTEXT, ctx);
+    g_signal_connect(drag_widget, "drag-failed",
+        G_CALLBACK(dnd_drag_failed_callback), NULL);
 
-#ifdef GLASS_GTK3
-    if (gtk_get_minor_version() >= 20) {
-        // according to GDK docs, this is only fired on managed mode, but
-        // on 3.20+ the GDK_DROP_FINISHED event stopped working and this signal
-        // works (even when not managed).
-        g_signal_connect(ctx, "dnd-finished",
-            G_CALLBACK(dnd_finished_callback), NULL);
-    }
+    g_signal_connect(drag_widget, "drag-data-get",
+        G_CALLBACK(dnd_data_get_callback), NULL);
 
-    if(gdk_device_grab(device, src_window, GDK_OWNERSHIP_NONE, FALSE,
-                    (GdkEventMask)
-                         (GDK_POINTER_MOTION_MASK
-                             | GDK_BUTTON_MOTION_MASK
-                             | GDK_BUTTON1_MOTION_MASK
-                             | GDK_BUTTON2_MOTION_MASK
-                             | GDK_BUTTON3_MOTION_MASK
-                             | GDK_BUTTON_RELEASE_MASK),
-                       NULL, GDK_CURRENT_TIME) != GDK_GRAB_SUCCESS) {
-        g_warning("Usable to grab pointer device.");
-    }
-#else
-    dnd_pointer_grab(NULL, NULL);
-#endif
+    g_signal_connect(drag_widget, "drag-end",
+        G_CALLBACK(dnd_end_callback), NULL);
+
+    GtkTargetList *tlist = data_to_gtk_target_list(env, data);
+
+    GdkDragContext *context;
+
+    gint x, y;
+    glass_gdk_master_pointer_get_position(&x, &y);
 
     is_dnd_owner = TRUE;
+
+#if GTK_CHECK_VERSION(3, 10, 0)
+    context = gtk_drag_begin_with_coordinates(drag_widget, tlist, actions, 1, NULL, x, y);
+#else
+    context = gtk_drag_begin(drag_widget, tlist, actions, 1, NULL);
+#endif
+
+    gtk_target_list_unref(tlist);
 }
 
-jint execute_dnd(JNIEnv *env, jobject data, jint supported) {
+jint execute_dnd(JNIEnv *env, jobject data, jint supported)
+{
     try {
         dnd_source_push_data(env, data, supported);
     } catch (jni_exception&) {
-        return 0;
+        return com_sun_glass_ui_gtk_GtkDnDClipboard_ACTION_NONE;
     }
 
     while (is_in_drag()) {
@@ -1126,16 +856,12 @@ jint execute_dnd(JNIEnv *env, jobject data, jint supported) {
 }
 
  /******************** DRAG VIEW ***************************/
-DragView::View* DragView::view = NULL;
+ DragView::View* DragView::view = NULL;
 
-void DragView::reset_drag_view() {
-    delete view;
-    view = NULL;
-}
-
-gboolean DragView::get_drag_image_offset(int* x, int* y) {
+ gboolean DragView::get_drag_image_offset(GtkWidget *widget, int* x, int* y)
+ {
     gboolean offset_set = FALSE;
-    jobject bb = dnd_source_get_data("application/x-java-drag-image-offset");
+    jobject bb = dnd_source_get_data(widget, "application/x-java-drag-image-offset");
     if (bb) {
         jbyteArray byteArray = (jbyteArray)mainEnv->CallObjectMethod(bb, jByteBufferArray);
         if (!EXCEPTION_OCCURED(mainEnv)) {
@@ -1155,17 +881,12 @@ gboolean DragView::get_drag_image_offset(int* x, int* y) {
     return offset_set;
 }
 
-static void pixbufDestroyNotifyFunc(guchar *pixels, gpointer) {
-    if (pixels != NULL) {
-        g_free(pixels);
-    }
-}
-
-GdkPixbuf* DragView::get_drag_image(gboolean* is_raw_image, gint* width, gint* height) {
+GdkPixbuf* DragView::get_drag_image(GtkWidget *widget, gboolean* is_raw_image, gint* width, gint* height)
+{
     GdkPixbuf *pixbuf = NULL;
     gboolean is_raw = FALSE;
 
-    jobject drag_image = dnd_source_get_data("application/x-java-drag-image");
+    jobject drag_image = dnd_source_get_data(widget, "application/x-java-drag-image");
 
     if (drag_image) {
         jbyteArray byteArray = (jbyteArray) mainEnv->CallObjectMethod(drag_image, jByteBufferArray);
@@ -1176,7 +897,7 @@ GdkPixbuf* DragView::get_drag_image(gboolean* is_raw_image, gint* width, gint* h
 
             int w = 0, h = 0;
             int whsz = sizeof(jint) * 2; // Pixels are stored right after two ints
-                                         // in this byteArray: width and height
+            // in this byteArray: width and height
             if (nraw > whsz) {
                 jint* int_raw = (jint*) raw;
                 w = BSWAP_32(int_raw[0]);
@@ -1188,7 +909,7 @@ GdkPixbuf* DragView::get_drag_image(gboolean* is_raw_image, gint* width, gint* h
                     if (data) {
                         memcpy(data, (raw + whsz), nraw - whsz);
                         pixbuf = gdk_pixbuf_new_from_data(data, GDK_COLORSPACE_RGB, TRUE, 8,
-                                w, h, w * 4, pixbufDestroyNotifyFunc, NULL);
+                                                          w, h, w * 4, pixbufDestroyNotifyFunc, NULL);
                     }
                 }
             }
@@ -1197,7 +918,7 @@ GdkPixbuf* DragView::get_drag_image(gboolean* is_raw_image, gint* width, gint* h
     }
 
     if (!GDK_IS_PIXBUF(pixbuf)) {
-        jobject pixels = dnd_source_get_data("application/x-java-rawimage");
+        jobject pixels = dnd_source_get_data(widget, "application/x-java-rawimage");
         if (pixels) {
             is_raw = TRUE;
             mainEnv->CallVoidMethod(pixels, jPixelsAttachData, PTR_TO_JLONG(&pixbuf));
@@ -1216,7 +937,6 @@ GdkPixbuf* DragView::get_drag_image(gboolean* is_raw_image, gint* width, gint* h
         double rw = DRAG_IMAGE_MAX_WIDTH / (double)w;
         double rh =  DRAG_IMAGE_MAX_HEIGH / (double)h;
         double r = MIN(rw, rh);
-
 
         int new_w = w * r;
         int new_h = h * r;
@@ -1239,61 +959,54 @@ GdkPixbuf* DragView::get_drag_image(gboolean* is_raw_image, gint* width, gint* h
     return pixbuf;
 }
 
-void DragView::set_drag_view() {
-    reset_drag_view();
-
+void DragView::set_drag_view(GtkWidget *widget, GdkDragContext *context)
+{
     gboolean is_raw_image = FALSE;
     gint w = 0, h = 0;
-    GdkPixbuf* pixbuf = get_drag_image(&is_raw_image, &w, &h);
+    GdkPixbuf* pixbuf = get_drag_image(widget, &is_raw_image, &w, &h);
 
     if (GDK_IS_PIXBUF(pixbuf)) {
         gint offset_x = w / 2;
         gint offset_y = h / 2;
 
-        gboolean is_offset_set = get_drag_image_offset(&offset_x, &offset_y);
+        gboolean is_offset_set = get_drag_image_offset(widget, &offset_x, &offset_y);
 
-        DragView::view = new DragView::View(pixbuf, is_raw_image, is_offset_set, offset_x, offset_y);
-    }
-}
-void DragView::move(gint x, gint y) {
-    if (view) {
-        view->move(x, y);
+        DragView::view = new DragView::View(context, pixbuf, w, h, is_raw_image,
+            is_offset_set, offset_x, offset_y);
     }
 }
 
-static void on_screen_changed(GtkWidget *widget, GdkScreen *previous_screen, gpointer view) {
+static void on_screen_changed(GtkWidget *widget, GdkScreen *previous_screen, gpointer view)
+{
     (void)widget;
     (void)previous_screen;
 
     ((DragView::View*) view)->screen_changed();
 }
 
-static gboolean on_draw(GtkWidget *widget, cairo_t *cr, gpointer view) {
-    (void)widget;
-
-    ((DragView::View*) view)->expose(cr);
-    return FALSE;
-}
-
-static gboolean on_expose(GtkWidget *widget, GdkEventExpose *event, gpointer view) {
+static gboolean on_expose(GtkWidget *widget, GdkEventExpose *event, gpointer view)
+{
     (void)widget;
     (void)event;
 
-    ((DragView::View*) view)->expose(NULL);
+    ((DragView::View*) view)->expose();
     return FALSE;
 }
 
-DragView::View::View(GdkPixbuf* _pixbuf, gboolean _is_raw_image,
-                                gboolean _is_offset_set, gint _offset_x, gint _offset_y) :
-        pixbuf(_pixbuf),
-        is_raw_image(_is_raw_image),
-        is_offset_set(_is_offset_set),
-        offset_x(_offset_x),
-        offset_y(_offset_y)
+DragView::View::View(GdkDragContext* _context, GdkPixbuf* _pixbuf, gint _width, gint _height,
+                     gboolean _is_raw_image, gboolean _is_offset_set, gint _offset_x, gint _offset_y) :
+    context(_context),
+    pixbuf(_pixbuf),
+    width(_width),
+    height(_height),
+    is_raw_image(_is_raw_image),
+    is_offset_set(_is_offset_set),
+    offset_x(_offset_x),
+    offset_y(_offset_y)
 {
-    width = gdk_pixbuf_get_width(pixbuf);
-    height = gdk_pixbuf_get_height(pixbuf);
-
+#ifdef GLASS_GTK3
+    gtk_drag_set_icon_pixbuf(context, pixbuf, offset_x, offset_y);
+#else
     widget = gtk_window_new(GTK_WINDOW_POPUP);
     gtk_window_set_type_hint(GTK_WINDOW(widget), GDK_WINDOW_TYPE_HINT_DND);
     gtk_widget_set_events(widget, GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK);
@@ -1303,21 +1016,18 @@ DragView::View::View(GdkPixbuf* _pixbuf, gboolean _is_raw_image,
     gtk_widget_realize(widget);
 
     gtk_widget_set_app_paintable(widget, TRUE);
-
-#ifdef GLASS_GTK3
-    g_signal_connect(G_OBJECT(widget), "draw", G_CALLBACK(on_draw), this);
-#else
     g_signal_connect(G_OBJECT(widget), "expose-event", G_CALLBACK(on_expose), this);
-#endif
     g_signal_connect(G_OBJECT(widget), "screen-changed", G_CALLBACK(on_screen_changed), this);
-
     gtk_widget_set_size_request(widget, width, height);
-
     gtk_window_set_decorated(GTK_WINDOW(widget), FALSE);
-    gtk_window_set_opacity(GTK_WINDOW(widget), .7);
+
+    gtk_widget_show_all(widget);
+    gtk_drag_set_icon_widget(context, widget, offset_x, offset_y);
+#endif
 }
 
-void DragView::View::screen_changed() {
+void DragView::View::screen_changed()
+{
     GdkScreen *screen = gtk_widget_get_screen(widget);
 
     glass_configure_window_transparency(widget, true);
@@ -1330,10 +1040,10 @@ void DragView::View::screen_changed() {
     }
 }
 
-void DragView::View::expose(cairo_t *context) {
-#ifndef GLASS_GTK3
-    context = gdk_cairo_create(gtk_widget_get_window(widget));
-#endif
+void DragView::View::expose()
+{
+    cairo_t *context = gdk_cairo_create(gtk_widget_get_window(widget));
+
     cairo_surface_t* cairo_surface;
 
     guchar* pixels = is_raw_image
@@ -1354,39 +1064,6 @@ void DragView::View::expose(cairo_t *context) {
     if (is_raw_image) {
         g_free(pixels);
     }
-
-    cairo_surface_destroy(cairo_surface);
-
-#ifndef GLASS_GTK3
     cairo_destroy(context);
-#endif
-}
-
-void DragView::View::move(gint x, gint y) {
-#ifdef GLASS_GTK3
-    // gtk3 method uses a move-when-idle method
-    gtk_window_move(GTK_WINDOW(widget), x - offset_x, y - offset_y);
-#else
-    if (!gtk_events_pending()) { // avoid sluggish window move
-        gtk_window_move(GTK_WINDOW(widget), x - offset_x, y - offset_y);
-    }
-#endif
-
-    if (gtk_widget_get_visible(widget)) {
-        gdk_window_raise(gtk_widget_get_window(widget));
-    }
-    else {
-        gtk_widget_show(widget);
-    }
-}
-
-DragView::View::~View() {
-    if (widget) {
-        gtk_widget_destroy(widget);
-        widget == NULL;
-    }
-    if (pixbuf) {
-        g_object_unref(pixbuf);
-        pixbuf == NULL;
-    }
+    cairo_surface_destroy(cairo_surface);
 }

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_dnd.h
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_dnd.h
@@ -52,6 +52,7 @@ gboolean is_in_drag();
 class DragView {
 public:
     class View {
+        GdkDragContext* context;
         GtkWidget* widget;
         GdkPixbuf* pixbuf;
         gint width, height;
@@ -59,9 +60,10 @@ public:
         gboolean is_offset_set;
         gint offset_x, offset_y;
     public:
-        View(GdkPixbuf* pixbuf, gboolean is_raw_image, gboolean is_offset_set, gint offset_x, gint offset_y);
+        View(GdkDragContext* context, GdkPixbuf* pixbuf, gint width, gint height,
+                gboolean is_raw_image, gboolean is_offset_set, gint offset_x, gint offset_y);
         void screen_changed();
-        void expose(cairo_t* context);
+        void expose();
         void move(gint x, gint y);
         ~View();
     private:
@@ -70,13 +72,13 @@ public:
     };
 
     static void reset_drag_view();
-    static void set_drag_view();
+    static void set_drag_view(GtkWidget* widget, GdkDragContext* context);
     static void move(gint x, gint y);
 
 private:
     static View* view;
-    static gboolean get_drag_image_offset(int* x, int* y);
-    static GdkPixbuf* get_drag_image(gboolean* is_raw_image, gint* width, gint* height);
+    static gboolean get_drag_image_offset(GtkWidget *widget, int* x, int* y);
+    static GdkPixbuf* get_drag_image(GtkWidget* widget, gboolean* is_raw_image, gint* width, gint* height);
 
     DragView() {}
     DragView(DragView&);
@@ -84,4 +86,3 @@ private:
 };
 
 #endif        /* GLASS_DND_H */
-

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.cpp
@@ -595,45 +595,6 @@ glass_gdk_mouse_devices_ungrab() {
 }
 
 void
-glass_gdk_master_pointer_grab(GdkEvent *event, GdkWindow *window, GdkCursor *cursor) {
-    if (disableGrab) {
-        gdk_window_set_cursor(window, cursor);
-        return;
-    }
-#ifdef GLASS_GTK3
-        GdkDevice *device = gdk_event_get_device(event);
-
-        gdk_device_grab(device, window, GDK_OWNERSHIP_NONE, FALSE,
-                        (GdkEventMask)
-                             (GDK_POINTER_MOTION_MASK
-                                 | GDK_BUTTON_MOTION_MASK
-                                 | GDK_BUTTON1_MOTION_MASK
-                                 | GDK_BUTTON2_MOTION_MASK
-                                 | GDK_BUTTON3_MOTION_MASK
-                                 | GDK_BUTTON_RELEASE_MASK),
-                           cursor, GDK_CURRENT_TIME);
-#else
-        gdk_pointer_grab(window, FALSE, (GdkEventMask)
-                         (GDK_POINTER_MOTION_MASK
-                             | GDK_BUTTON_MOTION_MASK
-                             | GDK_BUTTON1_MOTION_MASK
-                             | GDK_BUTTON2_MOTION_MASK
-                             | GDK_BUTTON3_MOTION_MASK
-                             | GDK_BUTTON_RELEASE_MASK),
-                         NULL, cursor, GDK_CURRENT_TIME);
-#endif
-}
-
-void
-glass_gdk_master_pointer_ungrab(GdkEvent *event) {
-#ifdef GLASS_GTK3
-        gdk_device_ungrab(gdk_event_get_device(event), GDK_CURRENT_TIME);
-#else
-        gdk_pointer_ungrab(GDK_CURRENT_TIME);
-#endif
-}
-
-void
 glass_gdk_master_pointer_get_position(gint *x, gint *y) {
 #ifdef GLASS_GTK3
         gdk_device_get_position(gdk_device_manager_get_client_pointer(


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8225571

To run tests (on the root of the source tree):
./gradlew apps
java @build/run.args -cp apps/toys/DragDrop/dist/DragDrop.jar dragdrop.DragDropWithControls
java @build/run.args -cp apps/toys/DragDrop/dist/DragDrop.jar dragdrop.DragDropColor

java -Djdk.gtk.version=2 @build/run.args -cp apps/toys/DragDrop/dist/DragDrop.jar dragdrop.DragDropWithControls
java -Djdk.gtk.version=2 @build/run.args -cp apps/toys/DragDrop/dist/DragDrop.jar dragdrop.DragDropColor
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8225571](https://bugs.openjdk.java.net/browse/JDK-8225571): Port Linux glass drag source (DND) to use gtk instead of gdk


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * pankaj-bansal (no known github.com user name / role)