### PR TITLE
8087980: Add property to disable Monocle cursor

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/AndroidPlatform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/AndroidPlatform.java
@@ -39,7 +39,7 @@ class AndroidPlatform extends NativePlatform {
 
     @Override
     protected NativeCursor createCursor() {
-        return new NullCursor();
+        return logSelectedCursor(new NullCursor());
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/DispmanPlatform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/DispmanPlatform.java
@@ -29,7 +29,8 @@ class DispmanPlatform extends LinuxPlatform {
 
     @Override
     protected NativeCursor createCursor() {
-        return new DispmanCursor();
+        final NativeCursor c = useCursor ? new DispmanCursor() : new NullCursor();
+        return logSelectedCursor(c);
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/HeadlessPlatform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/HeadlessPlatform.java
@@ -36,7 +36,7 @@ class HeadlessPlatform extends NativePlatform {
 
     @Override
     protected NativeCursor createCursor() {
-        return new NullCursor();
+        return logSelectedCursor(new NullCursor());
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxPlatform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxPlatform.java
@@ -39,7 +39,8 @@ class LinuxPlatform extends NativePlatform {
 
     @Override
     protected NativeCursor createCursor() {
-        return new SoftwareCursor();
+        final NativeCursor c = useCursor ? new SoftwareCursor() : new NullCursor();
+        return logSelectedCursor(c);
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MX6Platform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MX6Platform.java
@@ -29,7 +29,8 @@ class MX6Platform extends LinuxPlatform {
 
     @Override
     protected NativeCursor createCursor() {
-        return new MX6Cursor();
+        final NativeCursor c = useCursor ? new MX6Cursor() : new NullCursor();
+        return logSelectedCursor(c);
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/NativePlatform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/NativePlatform.java
@@ -25,6 +25,9 @@
 
 package com.sun.glass.ui.monocle;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
 /** Abstract of a platform on which JavaFX can run. */
 public abstract class NativePlatform {
 
@@ -33,6 +36,23 @@ public abstract class NativePlatform {
     private NativeCursor cursor;
     private NativeScreen screen;
     protected AcceleratedScreen accScreen;
+
+
+    protected static final boolean useCursor =
+        AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
+            final String str =
+                System.getProperty("monocle.cursor.enabled", "true");
+            return "true".equalsIgnoreCase(str);
+        });
+
+    protected static final boolean debugCursor =
+        AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
+            final String str =
+                System.getProperty("monocle.debugcursor", "");
+            return "true".equalsIgnoreCase(str);
+        });
+
+
 
     protected NativePlatform() {
         runnableProcessor = new RunnableProcessor();
@@ -127,6 +147,21 @@ public abstract class NativePlatform {
             accScreen = new AcceleratedScreen(attributes);
         }
         return accScreen;
+    }
+
+
+    /**
+     * Log the name of the supplied native cursor class if required.
+     *
+     * @param cursor the native cursor in use, null is permitted
+     * @return the passed in cursor
+     */
+    protected NativeCursor logSelectedCursor(final NativeCursor cursor) {
+        if (debugCursor) {
+            final String name = cursor == null ? null : cursor.getClass().getSimpleName();
+            System.err.println("Using native cursor: " + name);
+        }
+        return cursor;
     }
 
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/NativePlatform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/NativePlatform.java
@@ -27,12 +27,17 @@ package com.sun.glass.ui.monocle;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import com.sun.javafx.logging.PlatformLogger;
+import com.sun.javafx.logging.PlatformLogger.Level;
+import com.sun.javafx.util.Logging;
 
 /** Abstract of a platform on which JavaFX can run. */
 public abstract class NativePlatform {
 
     private static InputDeviceRegistry inputDeviceRegistry;
     private final RunnableProcessor runnableProcessor;
+    private final PlatformLogger logger = Logging.getJavaFXLogger();
+
     private NativeCursor cursor;
     private NativeScreen screen;
     protected AcceleratedScreen accScreen;
@@ -42,13 +47,6 @@ public abstract class NativePlatform {
         AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
             final String str =
                 System.getProperty("monocle.cursor.enabled", "true");
-            return "true".equalsIgnoreCase(str);
-        });
-
-    protected static final boolean debugCursor =
-        AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
-            final String str =
-                System.getProperty("monocle.debugcursor", "");
             return "true".equalsIgnoreCase(str);
         });
 
@@ -157,9 +155,9 @@ public abstract class NativePlatform {
      * @return the passed in cursor
      */
     protected NativeCursor logSelectedCursor(final NativeCursor cursor) {
-        if (debugCursor) {
+        if (logger.isLoggable(Level.FINE)) {
             final String name = cursor == null ? null : cursor.getClass().getSimpleName();
-            System.err.println("Using native cursor: " + name);
+            logger.fine("Using native cursor: {0}", name);
         }
         return cursor;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/OMAPPlatform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/OMAPPlatform.java
@@ -29,7 +29,8 @@ class OMAPPlatform extends LinuxPlatform {
 
     @Override
     protected NativeCursor createCursor() {
-        return new OMAPCursor();
+        final NativeCursor c = useCursor ? new OMAPCursor() : new NullCursor();
+        return logSelectedCursor(c);
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/X11Platform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/X11Platform.java
@@ -61,10 +61,11 @@ class X11Platform extends NativePlatform {
      */
     @Override
     protected NativeCursor createCursor() {
-        if (x11Input) {
-            return new X11Cursor();
+        if (useCursor) {
+            final NativeCursor c = x11Input ? new X11Cursor() : new X11WarpingCursor();
+            return logSelectedCursor(c);
         } else {
-            return new X11WarpingCursor();
+            return logSelectedCursor(new NullCursor());
         }
     }
 


### PR DESCRIPTION
Often on embedded systems a cursor is not a valid input modality. On some of these systems, when the javafx toolkit initialises the native hardware cursor, it produces artefacts which can be seen on screen (in the framebuffer for example). This change adds a system property "monocle.cursor.enabled" that can disable the creation of a native cursor in each of the Monocle NativePlatform implementations in favour of a NullCursor which is a no-op implementation of the NativeCursor abstract class that all native cursors have to implement.

NullCursor class already existed and was being returned for some implementations like AndroidPlatform and HeadlessPlatform. This change builds upon that and conditionally returns NullCursor for all platforms.

A system property "monocle.debugcursor" has also been added to turn on logging of which NativeCursor has been selected when the toolkit initialises.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress


## Issue
[JDK-8087980](https://bugs.openjdk.java.net/browse/JDK-8087980): Add property to disable Monocle cursor


## Approvers
 * jgneff (no known github.com user name / role)
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)