### PR TITLE
8231854: Change Mercurial to git in various README files

### DIFF
--- a/apps/samples/Ensemble8/UPDATING-lucene.txt
+++ b/apps/samples/Ensemble8/UPDATING-lucene.txt
@@ -22,7 +22,7 @@ $ cd apps/samples/Ensemble8
 $ rm -rf src/generated/resources/ensemble/search/index
 $ ant -Dplatforms.JDK_1.9.home=$JAVA_HOME clean ensemble-generate-search-index jar
 $ rm src/generated/resources/ensemble/search/index/write.lock
-$ hg addremove src/generated/resources/ensemble/search/index
+$ git add --all src/generated/resources/ensemble/search/index
 
 
 4. Test it by running Ensemble and entering text into the search box (upper right)

--- a/modules/javafx.media/src/main/legal/glib.md
+++ b/modules/javafx.media/src/main/legal/glib.md
@@ -15,11 +15,11 @@ this library:
    - On Windows systems: delete $(JAVA_HOME)\bin\glib-lite.dll
 
 A copy of the Oracle modified GNU Glib library source code is located
-in the following OpenJDK Mercurial repository:
+in the following OpenJDK git repository:
 
    https://github.com/openjdk/jfx
 
-You can use Mercurial to clone the repository or you can browse the
+You can use git to clone the repository or you can browse the
 source using a web browser. The root directory of the GNU Glib source
 code is here:
 

--- a/modules/javafx.media/src/main/legal/gstreamer.md
+++ b/modules/javafx.media/src/main/legal/gstreamer.md
@@ -15,11 +15,11 @@ this library:
    - On Windows systems: delete $(JAVA_HOME)\bin\gstreamer-lite.dll
 
 A copy of the Oracle modified GStreamer library source code is located
-in the following OpenJDK Mercurial repository:
+in the following OpenJDK git repository:
 
    https://github.com/openjdk/jfx
 
-You can use Mercurial to clone the repository or you can browse the
+You can use git to clone the repository or you can browse the
 source using a web browser. The root directory of the GStreamer source
 code is here:
 

--- a/modules/javafx.web/src/main/legal/webkit.md
+++ b/modules/javafx.web/src/main/legal/webkit.md
@@ -15,11 +15,11 @@ this library:
    - On Windows systems: delete $(JAVA_HOME)\bin\jfxwebkit.dll
 
 A copy of the Oracle modified WebKit library source code is located
-in the following OpenJDK Mercurial repository:
+in the following OpenJDK git repository:
 
    https://github.com/openjdk/jfx
 
-You can use Mercurial to clone the repository or you can browse the
+You can use git to clone the repository or you can browse the
 source using a web browser. The root directory of the WebKit source
 code is here:
 


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8231854

Follow-on fix to [JDK-8231590](https://bugs.openjdk.java.net/browse/JDK-8231590) -- PR #3 -- to change Mercurial or hg to git in a few README files where appropriate.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8231854](https://bugs.openjdk.java.net/browse/JDK-8231854): Change Mercurial to git in various README files


## Approvers
 * Guru Hb ([ghb](@guruhb) - **Reviewer**)