### PR TITLE
8231870: CrossLibs script for armv6hf toolchain download fails

### DIFF
--- a/buildSrc/crosslibs/crosslibs-armv6hf.sh
+++ b/buildSrc/crosslibs/crosslibs-armv6hf.sh
@@ -228,7 +228,7 @@ installLibs() {
 
     getPackages  \
         $DESTINATION \
-        http://ftp.us.debian.org/debian/ wheezy main armhf \
+        http://archive.debian.org/debian/ wheezy main armhf \
             libatk1.0-dev \
             libatk1.0-0 \
             libc6 \
@@ -389,7 +389,7 @@ installLibs() {
     # get some rapberry Pi specials
     getPackages  \
         $DESTINATION \
-        http://archive.raspbian.org/raspbian wheezy firmware armhf \
+        http://legacy.raspbian.org/raspbian wheezy firmware armhf \
         libraspberrypi-dev
 }
 


### PR DESCRIPTION
buildSrc/crosslibs-armv6hf.sh pulls down debian and raspbian packages to be able to cross compile javafx for arm hard float. Up to now the upstream distribution versions have been debian and raspbian wheezy, but these are now end of life and have been archived to servers that have different domain names.

Tried to change to use jessie but this generates a whole load of  __THROWNL errors, so for now have updated the domain names to point to new servers so that wheezy packages can still be retrieved and cross compilation succeeds.

https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8231870
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8231870](https://bugs.openjdk.java.net/browse/JDK-8231870): CrossLibs script for armv6hf toolchain download fails 


## Approvers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)