### PR TITLE
8226754: FX build fails using gradle 5.6+ or 6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1833,10 +1833,7 @@ allprojects {
         repositories {
             ivy {
                 url JFX_DEPS_URL
-                metadataSources {
-                    artifact()
-                }
-                patternLayout {
+                layout "pattern", {
                     artifact "[artifact]-[revision](-[classifier]).[ext]"
                     artifact "[artifact].[ext]"
                 }
@@ -1849,10 +1846,7 @@ allprojects {
             mavenCentral()
             ivy {
                 url "https://download.eclipse.org/eclipse/updates/4.6/R-4.6.3-201703010400/plugins/"
-                metadataSources {
-                    artifact()
-                }
-                patternLayout {
+                layout "pattern", {
                     artifact "[artifact].[ext]"
                 }
             }
@@ -1863,19 +1857,13 @@ allprojects {
         repositories {
             ivy {
                 url libAVRepositoryURL
-                metadataSources {
-                    artifact()
-                }
-                patternLayout {
+                layout "pattern", {
                     artifact "[artifact].[ext]"
                 }
             }
             ivy {
                 url FFmpegRepositoryURL
-                metadataSources {
-                    artifact()
-                }
-                patternLayout {
+                layout "pattern", {
                     artifact "[artifact].[ext]"
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -1833,7 +1833,10 @@ allprojects {
         repositories {
             ivy {
                 url JFX_DEPS_URL
-                layout "pattern", {
+                metadataSources {
+                    artifact()
+                }
+                patternLayout {
                     artifact "[artifact]-[revision](-[classifier]).[ext]"
                     artifact "[artifact].[ext]"
                 }
@@ -1846,7 +1849,10 @@ allprojects {
             mavenCentral()
             ivy {
                 url "https://download.eclipse.org/eclipse/updates/4.6/R-4.6.3-201703010400/plugins/"
-                layout "pattern", {
+                metadataSources {
+                    artifact()
+                }
+                patternLayout {
                     artifact "[artifact].[ext]"
                 }
             }
@@ -1857,13 +1863,19 @@ allprojects {
         repositories {
             ivy {
                 url libAVRepositoryURL
-                layout "pattern", {
+                metadataSources {
+                    artifact()
+                }
+                patternLayout {
                     artifact "[artifact].[ext]"
                 }
             }
             ivy {
                 url FFmpegRepositoryURL
-                layout "pattern", {
+                metadataSources {
+                    artifact()
+                }
+                patternLayout {
                     artifact "[artifact].[ext]"
                 }
             }
@@ -3810,6 +3822,7 @@ allprojects {
         project.jar.enabled = false
 
         // and redirect the resources into the module
+        project.sourceSets.main.output.resourcesDir = project.moduleDir
         project.processResources.destinationDir = project.moduleDir
     }
 
@@ -3843,6 +3856,7 @@ allprojects {
         project.sourceSets.shims.resources.srcDirs += project.sourceSets.main.resources.srcDirs
 
         // and redirect the resources into the module
+        project.sourceSets.shims.output.resourcesDir = project.moduleShimsDir
         project.processShimsResources.destinationDir = project.moduleShimsDir
 
        compileTestJava.dependsOn(copyGeneratedShimsTask)

--- a/build.properties
+++ b/build.properties
@@ -85,7 +85,7 @@ jfx.build.jdk.buildnum.min=28
 # The jfx.gradle.version.min property defines the minimum version of gradle
 # that is supported. It must be <= jfx.gradle.version.
 jfx.gradle.version=5.3
-jfx.gradle.version.min=4.8
+jfx.gradle.version.min=5.3
 
 # Toolchains
 jfx.build.linux.gcc.version=gcc8.2.0-OL6.4+1.0

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,10 @@ repositories {
     if (buildClosed) {
         ivy {
             url jfxRepositoryURL
-            layout "pattern", {
+            metadataSources {
+                artifact()
+            }
+            patternLayout {
                 artifact "[artifact]-[revision].[ext]"
                 artifact "[artifact].[ext]"
             }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,10 +60,7 @@ repositories {
     if (buildClosed) {
         ivy {
             url jfxRepositoryURL
-            metadataSources {
-                artifact()
-            }
-            patternLayout {
+            layout "pattern", {
                 artifact "[artifact]-[revision].[ext]"
                 artifact "[artifact].[ext]"
             }

--- a/settings.gradle
+++ b/settings.gradle
@@ -35,10 +35,6 @@ project(":web").projectDir = file("modules/javafx.web")
 project(":media").projectDir = file("modules/javafx.media")
 project(":systemTests").projectDir = file("tests/system")
 
-// Stable publishing behavior is the default in gradle 5.x.
-// This setting enables it in gradle 4.8 to help with the transition.
-enableFeaturePreview('STABLE_PUBLISHING')
-
 def closedDir = file("../rt-closed")
 def buildClosed = closedDir.isDirectory()
 


### PR DESCRIPTION
JBS issue: [JDK-8226754](https://bugs.openjdk.java.net/browse/JDK-8226754)

As noted in the JBS bug, the JavaFX build fails with gradle 6 (as well as not building correctly with 5.6 or later).

The existing JavaFX build uses two deprecated features that are removed in gradle 6, so the build fails when building with gradle 6. Additionally, some change that went into gradle 5.6 prevents all of our resource files (e.g., css files, images, shaders) from being included in the built artifacts, which causes JavaFX to be non-functional (our unit tests catch this failure).

The purpose of this bug fix is to allow JavaFX to build with gradle 6, which is needed to allow building with JDK 13. We will likely upgrade to gradle 6 in the near future. Additionally, this fixes the resource bug that was exposed (or introduced) in gradle 5.6 and also affects gradle 6.

NOTE: the replacement for one of the deprecated APIs, ivy `layout`, is an incubating API in gradle 5.x. Since there is no stable replacement that we can use during the transition, I will defer the change from `layout "pattern", ...` to `patternLayout ...` until the eventual update to gradle 6.

The changes are as follows:

1. Remove unneeded STABLE_PUBLISHING setting, which was transitional to allow gradle 4.x to continue working while we moved to gradle 5.x
2. ~~Use ivy `patternLayout ...` instead of `layout "pattern", ...`~~
3. ~~Specify no metadata for ivy repositories~~
4. Set output.resourcesDir of sourceSet to match processResources.destinationDir
5. Bump minimum gradle version to 5.3 (since it will no longer run with gradle 4.x after change 1)

I verified that the build artifacts produced by gradle 5.3 before and after this changes are identical (so it is behavior neutral for the supported version of gradle). After the fix, I also verified that the build artifacts produced by gradle 5.6.2 ~~and 6.0 nightly~~ match those produced by 5.3. I have tested this fully on Linux and Windows, and I will do a sanity test on Mac in parallel with the review.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8226754](https://bugs.openjdk.java.net/browse/JDK-8226754): FX build fails using gradle 5.6+ or 6


## Approvers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)