### PR TITLE
Added isActive getter to AnimationTimer

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/animation/AnimationTimer.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/AnimationTimer.java
@@ -116,4 +116,12 @@ public abstract class AnimationTimer {
             active = false;
         }
     }
+    
+    /**
+    * Return the state of the {@code AnimationTimers}. 
+    * @return 
+    */
+    public boolean isActive() {
+        return active;
+    }
 }


### PR DESCRIPTION
Added isActive getter, to return the state of the AnimationTimer, so, you can check if it's active or not.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed