### PR TITLE
8211308: Support HTTP/2 in WebView

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/ByteBufferPool.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/ByteBufferPool.java
@@ -112,6 +112,7 @@ final class ByteBufferPool {
          */
         @Override
         public void release(ByteBuffer byteBuffer) {
+            byteBuffer.clear();
             byteBuffers.add(byteBuffer);
             semaphore.release();
         }

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/HTTP2Loader.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/HTTP2Loader.java
@@ -1,0 +1,648 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.webkit.network;
+
+import com.sun.javafx.logging.PlatformLogger.Level;
+import com.sun.javafx.logging.PlatformLogger;
+import com.sun.javafx.tk.Toolkit;
+import com.sun.webkit.Invoker;
+import com.sun.webkit.LoadListenerClient;
+import com.sun.webkit.WebPage;
+import java.io.EOFException;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.SequenceInputStream;
+import java.io.UnsupportedEncodingException;
+import java.lang.annotation.Native;
+import java.net.ConnectException;
+import java.net.CookieHandler;
+import java.net.HttpRetryException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.NoRouteToHostException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLDecoder;
+import java.net.UnknownHostException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandler;
+import java.net.http.HttpResponse.BodySubscriber;
+import java.net.http.HttpResponse;
+import java.net.http.HttpTimeoutException;
+import java.nio.ByteBuffer;
+import java.security.AccessControlException;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Vector;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.InflaterInputStream;
+import javax.net.ssl.SSLHandshakeException;
+import static com.sun.webkit.network.URLs.newURL;
+import static java.net.http.HttpClient.Redirect;
+import static java.net.http.HttpClient.Version;
+import static java.net.http.HttpResponse.BodyHandlers;
+import static java.net.http.HttpResponse.BodySubscribers;
+
+final class HTTP2Loader extends URLLoaderBase {
+
+    private static final PlatformLogger logger =
+            PlatformLogger.getLogger(URLLoader.class.getName());
+
+    private final WebPage webPage;
+    private final boolean asynchronous;
+    private String url;
+    private String method;
+    private final String headers;
+    private FormDataElement[] formDataElements;
+    private final long data;
+    private volatile boolean canceled = false;
+
+    private final CompletableFuture<Void> response;
+    // Use singleton instance of HttpClient to get the maximum benefits
+    private final static HttpClient HTTP_CLIENT = HttpClient.newBuilder()
+                   .version(Version.HTTP_2)  // this is the default
+                   .followRedirects(Redirect.NEVER) // WebCore handles redirection
+                   .connectTimeout(Duration.ofSeconds(30)) // FIXME: Add a property to control the timeout
+                   .cookieHandler(CookieHandler.getDefault())
+                   .build();
+
+    // Singleton instance of direct ByteBuffer to transfer downloaded bytes from
+    // Java to native
+    private static final int DEFAULT_BUFSIZE = 40 * 1024;
+    private final static ByteBuffer BUFFER;
+    static {
+       int bufSize  = AccessController.doPrivileged(
+                        (PrivilegedAction<Integer>) () ->
+                            Integer.valueOf(System.getProperty("jdk.httpclient.bufsize", Integer.toString(DEFAULT_BUFSIZE))));
+       BUFFER = ByteBuffer.allocateDirect(bufSize);
+    }
+
+    /**
+     * Creates a new {@code HTTP2Loader}.
+     */
+    static HTTP2Loader create(WebPage webPage,
+              ByteBufferPool byteBufferPool,
+              boolean asynchronous,
+              String url,
+              String method,
+              String headers,
+              FormDataElement[] formDataElements,
+              long data) {
+        if (url.startsWith("http://") || url.startsWith("https://")) {
+            return new HTTP2Loader(
+                webPage,
+                byteBufferPool,
+                asynchronous,
+                url,
+                method,
+                headers,
+                formDataElements,
+                data);
+        }
+        return null;
+    }
+
+    // following 2 methods can be generalized and keep a common
+    // implementation with URLLoader.java
+    private String[] getCustomHeaders() {
+        final var loc = Locale.getDefault();
+        String lang = "";
+        if (!loc.equals(Locale.US) && !loc.equals(Locale.ENGLISH)) {
+            lang = loc.getCountry().isEmpty() ?
+                loc.getLanguage() + ",":
+                loc.getLanguage() + "-" + loc.getCountry() + ",";
+        }
+
+        return new String[] { "Accept-Language", lang.toLowerCase() + "en-us;q=0.8,en;q=0.7",
+                              "Accept-Encoding", "gzip, inflate",
+                              "Accept-Charset", "ISO-8859-1,utf-8;q=0.7,*;q=0.7",
+        };
+    }
+
+    private String[] getRequestHeaders() {
+        return Arrays.stream(headers.split("\n"))
+                     .flatMap(s -> Stream.of(s.split(":", 2))) // split from first occurance of :
+                     .toArray(String[]::new);
+    }
+
+    private URI toURI() throws MalformedURLException {
+        URI uriObj;
+        try {
+            uriObj = new URI(this.url);
+        } catch(URISyntaxException | IllegalArgumentException e) {
+            // slow path
+            try {
+                var urlObj = newURL(this.url);
+                uriObj = new URI(
+                        urlObj.getProtocol(),
+                        urlObj.getUserInfo(),
+                        urlObj.getHost(),
+                        urlObj.getPort(),
+                        urlObj.getPath(),
+                        urlObj.getQuery(),
+                        urlObj.getRef());
+            } catch(URISyntaxException | MalformedURLException | IllegalArgumentException ex) {
+                throw new MalformedURLException(this.url);
+            }
+        }
+        return uriObj;
+    }
+
+    private HttpRequest.BodyPublisher getFormDataPublisher() {
+        if (this.formDataElements == null) {
+            return HttpRequest.BodyPublishers.noBody();
+        }
+
+        final var formDataElementsStream = new Vector<InputStream>();
+        final AtomicLong length = new AtomicLong();
+        for (final var formData : formDataElements) {
+            try {
+                formData.open();
+                length.addAndGet(formData.getSize());
+                formDataElementsStream.add(formData.getInputStream());
+            } catch(IOException ex) {
+                return null;
+            }
+        }
+
+        final var stream = new SequenceInputStream(formDataElementsStream.elements());
+        final var streamBodyPublisher = HttpRequest.BodyPublishers.ofInputStream(() -> stream);
+        // Forwarding implementation to send didSendData notification
+        // to WebCore. Otherwise `formDataPublisher = streamBodyPublisher`
+        // can do the job.
+        final var formDataPublisher = new HttpRequest.BodyPublisher() {
+            @Override
+            public long contentLength() {
+                // streaming or fixed length
+                return length.longValue() <= Integer.MAX_VALUE ? length.longValue() : -1;
+            }
+
+            @Override
+            public void subscribe(Flow.Subscriber<? super ByteBuffer> subscriber) {
+                streamBodyPublisher.subscribe(new Flow.Subscriber<ByteBuffer>() {
+                    @Override
+                    public void onComplete() {
+                        subscriber.onComplete();
+                    }
+
+                    @Override
+                    public void onError(Throwable th) {
+                        subscriber.onError(th);
+                    }
+
+                    @Override
+                    public void onNext(ByteBuffer bytes) {
+                        subscriber.onNext(bytes);
+                        didSendData(bytes.limit(), length.longValue());
+                    }
+
+                    @Override
+                    public void onSubscribe(Flow.Subscription subscription) {
+                        subscriber.onSubscribe(subscription);
+                    }
+                });
+            }
+        };
+        return formDataPublisher;
+    }
+
+    // InputStream based subscriber is used to handle gzip|inflate encoded body. Since InputStream based subscriber is costly interms
+    // of memory usage and thread usage, use only when response content-encoding is set to gzip|inflate.
+    // There will be 2 threads involved while reading data from InputStream provided by BodySubscriber.
+    //      1. The main worker which downloads HTTP data and writes to stream
+    //      2. Other worker which reads data from the InputStream(getBody.thenAcceptAsync)
+    // For the better efficiency, we should consider using java.util.zip.Inflater directly
+    // to deal with gzip and inflate encoded data.
+    private InputStream createZIPStream(final String type, InputStream in) throws IOException {
+        if ("gzip".equalsIgnoreCase(type))
+            return new GZIPInputStream(in);
+        else if ("deflate".equalsIgnoreCase(type))
+            return new InflaterInputStream(in);
+        return in;
+    }
+
+    private BodySubscriber<Void> createZIPEncodedBodySubscriber(final String contentEncoding) {
+        // Discard body if content type is unknown
+        if (!("gzip".equalsIgnoreCase(contentEncoding)
+                    || "inflate".equalsIgnoreCase(contentEncoding))) {
+            logger.severe(String.format("Unknown encoding type '%s' found, discarding", contentEncoding));
+            return BodySubscribers.discarding();
+        }
+
+        final BodySubscriber<InputStream> streamSubscriber = BodySubscribers.ofInputStream();
+        final CompletionStage<Void> unzipTask = streamSubscriber.getBody().thenAcceptAsync(is -> {
+            try (
+                // To AutoClose the InputStreams
+                final InputStream stream = is;
+                final InputStream in = createZIPStream(contentEncoding, stream);
+            ) {
+                while (!canceled) {
+                    // same as URLLoader.java
+                    final byte[] buf = new byte[8 * 1024];
+                    final int read = in.read(buf);
+                    if (read < 0) {
+                        didFinishLoading();
+                        break;
+                    }
+                    didReceiveData(buf, read);
+                }
+            } catch (IOException ex) {
+                didFail(ex);
+            }
+        });
+        return new BodySubscriber<Void>() {
+                @Override
+                public void onComplete() {
+                    streamSubscriber.onComplete();
+                }
+
+                @Override
+                public void onError(Throwable th) {
+                    streamSubscriber.onError(th);
+                }
+
+                @Override
+                public void onNext(List<ByteBuffer> bytes) {
+                    streamSubscriber.onNext(bytes);
+                }
+
+                @Override
+                public void onSubscribe(Flow.Subscription subscription) {
+                    streamSubscriber.onSubscribe(subscription);
+                }
+
+                @Override
+                public CompletionStage<Void> getBody() {
+                    return streamSubscriber.getBody().thenCombine(unzipTask, (t, u) -> null);
+                }
+        };
+    }
+
+    // Normal plain body handler, simple, easy to use and pass data to downstream.
+    private BodySubscriber<Void> createNormalBodySubscriber() {
+        final BodySubscriber<Void> normalBodySubscriber = BodySubscribers.fromSubscriber(new Flow.Subscriber<List<ByteBuffer>>() {
+            private Flow.Subscription subscription;
+            private final AtomicBoolean subscribed = new AtomicBoolean();
+
+            @Override
+            public void onComplete() {
+                didFinishLoading();
+            }
+
+            @Override
+            public void onError(Throwable th) {}
+
+            @Override
+            public void onNext(final List<ByteBuffer> bytes) {
+                didReceiveData(bytes);
+                requestIfNotCancelled();
+            }
+
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                if (!subscribed.compareAndSet(false, true)) {
+                    subscription.cancel();
+                } else {
+                    this.subscription = subscription;
+                    requestIfNotCancelled();
+                }
+            }
+
+            private void requestIfNotCancelled() {
+                if (canceled) {
+                    subscription.cancel();
+                } else {
+                    subscription.request(1);
+                }
+            }
+        });
+        return normalBodySubscriber;
+    }
+
+    private BodySubscriber<Void> getBodySubscriber(final String contentEncoding) {
+        return contentEncoding.isEmpty() ?
+                  createNormalBodySubscriber() : createZIPEncodedBodySubscriber(contentEncoding);
+    }
+
+    private HTTP2Loader(WebPage webPage,
+              ByteBufferPool byteBufferPool,
+              boolean asynchronous,
+              String url,
+              String method,
+              String headers,
+              FormDataElement[] formDataElements,
+              long data)
+    {
+        this.webPage = webPage;
+        this.asynchronous = asynchronous;
+        this.url = url;
+        this.method = method;
+        this.headers = headers;
+        this.formDataElements = formDataElements;
+        this.data = data;
+
+        URI uri;
+        try {
+            uri = toURI();
+        } catch(MalformedURLException e) {
+            this.response = null;
+            didFail(e);
+            return;
+        }
+
+        final var request = HttpRequest.newBuilder()
+                               .uri(uri)
+                               .headers(getRequestHeaders()) // headers from WebCore
+                               .headers(getCustomHeaders()) // headers set by us
+                               .version(Version.HTTP_2)  // this is the default
+                               .method(method, getFormDataPublisher())
+                               .build();
+
+        final BodyHandler<Void> bodyHandler = rsp -> {
+            if(!handleRedirectionIfNeeded(rsp)) {
+                didReceiveResponse(rsp);
+            }
+            return getBodySubscriber(getContentEncoding(rsp));
+        };
+
+        // Run the HttpClient in the page's access control context
+        this.response = AccessController.doPrivileged((PrivilegedAction<CompletableFuture<Void>>) () -> {
+            return HTTP_CLIENT.sendAsync(request, bodyHandler)
+                              .thenAccept($ -> {})
+                              .exceptionally(ex -> didFail(ex.getCause()));
+        }, webPage.getAccessControlContext());
+
+        if (!asynchronous) {
+            waitForRequestToComplete();
+        }
+    }
+
+    /**
+     * Cancels this loader.
+     */
+    @Override
+    public void fwkCancel() {
+        if (logger.isLoggable(Level.FINEST)) {
+            logger.finest(String.format("data: [0x%016X]", data));
+        }
+        canceled = true;
+    }
+
+    private void callBackIfNotCanceled(final Runnable r) {
+        Invoker.getInvoker().invokeOnEventThread(() -> {
+            if (!canceled) {
+                r.run();
+            }
+        });
+    }
+
+    private void waitForRequestToComplete() {
+        // Wait for the response using nested event loop. Once the response
+        // arrives, nested event loop will be terminated.
+        final Object key = new Object();
+        this.response.handle((r, th) -> {
+            Invoker.getInvoker().invokeOnEventThread(() ->
+                Toolkit.getToolkit().exitNestedEventLoop(key, null));
+            return null;
+        });
+        Toolkit.getToolkit().enterNestedEventLoop(key);
+        // No need to join, nested event loop takes care of
+        // blocking the caller until response arrives.
+        // this.response.join();
+    }
+
+    private boolean handleRedirectionIfNeeded(final HttpResponse.ResponseInfo rsp) {
+        switch(rsp.statusCode()) {
+                case 301: // Moved Permanently
+                case 302: // Found
+                case 303: // See Other
+                case 307: // Temporary Redirect
+                    willSendRequest(rsp);
+                    return true;
+
+                case 304: // Not Modified
+                    didReceiveResponse(rsp);
+                    didFinishLoading();
+                    return true;
+        }
+        return false;
+    }
+
+    private static long getContentLength(final HttpResponse.ResponseInfo rsp) {
+        return rsp.headers().firstValueAsLong("content-length").orElse(-1);
+    }
+
+    private static String getContentType(final HttpResponse.ResponseInfo rsp) {
+        return rsp.headers().firstValue("content-type").orElse("application/octet-stream");
+    }
+
+    private static String getContentEncoding(final HttpResponse.ResponseInfo rsp) {
+        return rsp.headers().firstValue("content-encoding").orElse("");
+    }
+
+    private static String getHeadersAsString(final HttpResponse.ResponseInfo rsp) {
+        return rsp.headers()
+                  .map()
+                  .entrySet()
+                  .stream()
+                  .map(e -> String.format("%s:%s", e.getKey(), e.getValue().stream().collect(Collectors.joining(","))))
+                  .collect(Collectors.joining("\n")) + "\n";
+    }
+
+    private void willSendRequest(final HttpResponse.ResponseInfo rsp) {
+        callBackIfNotCanceled(() -> {
+            twkWillSendRequest(
+                    rsp.statusCode(),
+                    getContentType(rsp),
+                    "",
+                    getContentLength(rsp),
+                    getHeadersAsString(rsp),
+                    this.url,
+                    data);
+        });
+    }
+
+    private void didReceiveResponse(final HttpResponse.ResponseInfo rsp) {
+        callBackIfNotCanceled(() -> {
+            twkDidReceiveResponse(
+                    rsp.statusCode(),
+                    getContentType(rsp),
+                    "",
+                    getContentLength(rsp),
+                    getHeadersAsString(rsp),
+                    this.url,
+                    data);
+        });
+    }
+
+    private ByteBuffer getDirectBuffer(int size) {
+        ByteBuffer dbb = BUFFER;
+        // Though the chance of reaching here is rare, handle the
+        // case by allocating a tmp direct buffer.
+        if (size > dbb.capacity()) {
+            dbb = ByteBuffer.allocateDirect(size);
+        }
+        return dbb.clear();
+    }
+
+    private ByteBuffer copyToDirectBuffer(final ByteBuffer bb) {
+        return getDirectBuffer(bb.limit()).put(bb).flip();
+    }
+
+    // another variant to use from createZIPEncodedBodySubscriber
+    private void didReceiveData(final byte[] bytes, int size) {
+        callBackIfNotCanceled(() -> {
+            notifyDidReceiveData(getDirectBuffer(size).put(bytes, 0, size).flip());
+        });
+    }
+
+    private void didReceiveData(final List<ByteBuffer> bytes) {
+        callBackIfNotCanceled(() -> bytes.stream()
+                                          .map(this::copyToDirectBuffer)
+                                          .forEach(this::notifyDidReceiveData)
+        );
+    }
+
+    private void notifyDidReceiveData(ByteBuffer byteBuffer) {
+        Invoker.getInvoker().checkEventThread();
+        if (logger.isLoggable(Level.FINEST)) {
+            logger.finest(String.format(
+                    "byteBuffer: [%s], "
+                    + "position: [%s], "
+                    + "remaining: [%s], "
+                    + "data: [0x%016X]",
+                    byteBuffer,
+                    byteBuffer.position(),
+                    byteBuffer.remaining(),
+                    data));
+        }
+        twkDidReceiveData(byteBuffer, byteBuffer.position(), byteBuffer.remaining(), data);
+    }
+
+    private void didFinishLoading() {
+        callBackIfNotCanceled(this::notifyDidFinishLoading);
+    }
+
+    private void notifyDidFinishLoading() {
+        Invoker.getInvoker().checkEventThread();
+        if (logger.isLoggable(Level.FINEST)) {
+            logger.finest(String.format("data: [0x%016X]", data));
+        }
+        twkDidFinishLoading(data);
+    }
+
+
+    private Void didFail(final Throwable th) {
+        callBackIfNotCanceled(() ->  {
+            // FIXME: simply copied from URLLoader.java, it should be
+            // retwritten using if..else rather than throw.
+            int errorCode;
+            try {
+                throw th;
+            } catch (MalformedURLException ex) {
+                errorCode = LoadListenerClient.MALFORMED_URL;
+            } catch (AccessControlException ex) {
+                errorCode = LoadListenerClient.PERMISSION_DENIED;
+            } catch (UnknownHostException ex) {
+                errorCode = LoadListenerClient.UNKNOWN_HOST;
+            } catch (NoRouteToHostException ex) {
+                errorCode = LoadListenerClient.NO_ROUTE_TO_HOST;
+            } catch (ConnectException ex) {
+                errorCode = LoadListenerClient.CONNECTION_REFUSED;
+            } catch (SocketException ex) {
+                errorCode = LoadListenerClient.CONNECTION_RESET;
+            } catch (SSLHandshakeException ex) {
+                errorCode = LoadListenerClient.SSL_HANDSHAKE;
+            } catch (SocketTimeoutException | HttpTimeoutException ex) {
+                errorCode = LoadListenerClient.CONNECTION_TIMED_OUT;
+            } catch (FileNotFoundException ex) {
+                errorCode = LoadListenerClient.FILE_NOT_FOUND;
+            } catch (Throwable ex) {
+                errorCode = LoadListenerClient.UNKNOWN_ERROR;
+            }
+            notifyDidFail(errorCode, url, th.getMessage());
+        });
+        return null;
+    }
+
+    private void notifyDidFail(int errorCode, String url, String message) {
+        Invoker.getInvoker().checkEventThread();
+        if (logger.isLoggable(Level.FINEST)) {
+            logger.finest(String.format(
+                    "errorCode: [%d], "
+                    + "url: [%s], "
+                    + "message: [%s], "
+                    + "data: [0x%016X]",
+                    errorCode,
+                    url,
+                    message,
+                    data));
+        }
+        twkDidFail(errorCode, url, message, data);
+    }
+
+    private void didSendData(final long totalBytesSent,
+                             final long totalBytesToBeSent)
+    {
+        callBackIfNotCanceled(() -> notifyDidSendData(totalBytesSent, totalBytesToBeSent));
+    }
+
+    private void notifyDidSendData(long totalBytesSent,
+                                   long totalBytesToBeSent)
+    {
+        Invoker.getInvoker().checkEventThread();
+        if (logger.isLoggable(Level.FINEST)) {
+            logger.finest(String.format(
+                    "totalBytesSent: [%d], "
+                    + "totalBytesToBeSent: [%d], "
+                    + "data: [0x%016X]",
+                    totalBytesSent,
+                    totalBytesToBeSent,
+                    data));
+        }
+        twkDidSendData(totalBytesSent, totalBytesToBeSent, data);
+    }
+}

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/HTTP2Loader.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/HTTP2Loader.java
@@ -102,13 +102,13 @@ final class HTTP2Loader extends URLLoaderBase {
 
     private final CompletableFuture<Void> response;
     // Use singleton instance of HttpClient to get the maximum benefits
-    private final static HttpClient HTTP_CLIENT = HttpClient.newBuilder()
-                   .version(Version.HTTP_2)  // this is the default
-                   .followRedirects(Redirect.NEVER) // WebCore handles redirection
-                   .connectTimeout(Duration.ofSeconds(30)) // FIXME: Add a property to control the timeout
-                   .cookieHandler(CookieHandler.getDefault())
-                   .build();
-
+    private final static HttpClient HTTP_CLIENT =
+        AccessController.doPrivileged((PrivilegedAction<HttpClient>) () -> HttpClient.newBuilder()
+                .version(Version.HTTP_2)  // this is the default
+                .followRedirects(Redirect.NEVER) // WebCore handles redirection
+                .connectTimeout(Duration.ofSeconds(30)) // FIXME: Add a property to control the timeout
+                .cookieHandler(CookieHandler.getDefault())
+                .build());
     // Singleton instance of direct ByteBuffer to transfer downloaded bytes from
     // Java to native
     private static final int DEFAULT_BUFSIZE = 40 * 1024;

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/NetworkContext.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/NetworkContext.java
@@ -63,6 +63,12 @@ final class NetworkContext {
     private static final int DEFAULT_HTTP_MAX_CONNECTIONS = 5;
 
     /**
+     * The default value of the maximum concurrent connections for
+     * new gen HTTP2 client
+     */
+    private static final int DEFAULT_HTTP2_MAX_CONNECTIONS = 20;
+
+    /**
      * The buffer size for the shared pool of byte buffers.
      */
     private static final int BYTE_BUFFER_SIZE = 1024 * 40;
@@ -71,6 +77,11 @@ final class NetworkContext {
      * The thread pool used to execute asynchronous loaders.
      */
     private static final ThreadPoolExecutor threadPool;
+
+    /**
+     * Can use HTTP2Loader
+     */
+    private static final boolean useHTTP2Loader;
     static {
         threadPool = new ThreadPoolExecutor(
                 THREAD_POOL_SIZE,
@@ -80,6 +91,8 @@ final class NetworkContext {
                 new LinkedBlockingQueue<Runnable>(),
                 new URLLoaderThreadFactory());
         threadPool.allowCoreThreadTimeOut(true);
+
+        useHTTP2Loader = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.valueOf(System.getProperty("com.sun.webkit.useHTTP2Loader", "true")));
     }
 
     /**
@@ -117,7 +130,7 @@ final class NetworkContext {
     /**
      * Starts an asynchronous load or executes a synchronous one.
      */
-    private static URLLoader fwkLoad(WebPage webPage,
+    private static URLLoaderBase fwkLoad(WebPage webPage,
                                      boolean asynchronous,
                                      String url,
                                      String method,
@@ -143,6 +156,22 @@ final class NetworkContext {
                     data,
                     Util.formatHeaders(headers)));
         }
+
+        if (useHTTP2Loader) {
+            final URLLoaderBase loader = HTTP2Loader.create(
+                webPage,
+                byteBufferPool,
+                asynchronous,
+                url,
+                method,
+                headers,
+                formDataElements,
+                data);
+            if (loader != null) {
+                return loader;
+            }
+        }
+
         URLLoader loader = new URLLoader(
                 webPage,
                 byteBufferPool,
@@ -184,6 +213,10 @@ final class NetworkContext {
         // system property.
         int propValue = AccessController.doPrivileged(
                 (PrivilegedAction<Integer>) () -> Integer.getInteger("http.maxConnections", -1));
+
+        if (useHTTP2Loader) {
+            return propValue >= 0 ? propValue : DEFAULT_HTTP2_MAX_CONNECTIONS;
+        }
         return propValue >= 0 ? propValue : DEFAULT_HTTP_MAX_CONNECTIONS;
     }
 

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/NetworkContext.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/NetworkContext.java
@@ -92,7 +92,12 @@ final class NetworkContext {
                 new URLLoaderThreadFactory());
         threadPool.allowCoreThreadTimeOut(true);
 
-        useHTTP2Loader = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.valueOf(System.getProperty("com.sun.webkit.useHTTP2Loader", "true")));
+        useHTTP2Loader = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
+            // Use HTTP2 by default on JDK 12 or later
+            final var version = Runtime.Version.parse(System.getProperty("java.version"));
+            final String defaultUseHTTP2 = version.feature() >= 12 ? "true" : "false";
+            return Boolean.valueOf(System.getProperty("com.sun.webkit.useHTTP2Loader", defaultUseHTTP2));
+        });
     }
 
     /**

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/URLLoaderBase.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/URLLoaderBase.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.webkit.network;
+
+import java.lang.annotation.Native;
+import java.nio.ByteBuffer;
+
+abstract class URLLoaderBase {
+    @Native public static final int ALLOW_UNASSIGNED = java.net.IDN.ALLOW_UNASSIGNED;
+
+    /**
+     * Cancels the loader.
+     */
+    protected abstract void fwkCancel();
+
+    protected static native void twkDidSendData(long totalBytesSent,
+                                              long totalBytesToBeSent,
+                                              long data);
+
+    protected static native void twkWillSendRequest(int status,
+                                                     String contentType,
+                                                     String contentEncoding,
+                                                     long contentLength,
+                                                     String headers,
+                                                     String url,
+                                                     long data);
+
+    protected static native void twkDidReceiveResponse(int status,
+                                                     String contentType,
+                                                     String contentEncoding,
+                                                     long contentLength,
+                                                     String headers,
+                                                     String url,
+                                                     long data);
+
+    protected static native void twkDidReceiveData(ByteBuffer byteBuffer,
+                                                 int position,
+                                                 int remaining,
+                                                 long data);
+
+    protected static native void twkDidFinishLoading(long data);
+
+    protected static native void twkDidFail(int errorCode,
+                                          String url,
+                                          String message,
+                                          long data);
+
+}

--- a/modules/javafx.web/src/main/java/module-info.java
+++ b/modules/javafx.web/src/main/java/module-info.java
@@ -32,9 +32,10 @@
  */
 module javafx.web {
     requires java.desktop;
+    requires java.net.http;
     requires javafx.media;
-    requires jdk.xml.dom;
     requires jdk.jsobject;
+    requires jdk.xml.dom;
 
     requires transitive java.xml;
     requires transitive javafx.base;

--- a/modules/javafx.web/src/main/native/Source/WebCore/mapfile-macosx
+++ b/modules/javafx.web/src/main/native/Source/WebCore/mapfile-macosx
@@ -1786,9 +1786,9 @@
                _Java_com_sun_webkit_network_SocketStreamHandle_twkDidFail
                _Java_com_sun_webkit_network_SocketStreamHandle_twkDidOpen
                _Java_com_sun_webkit_network_SocketStreamHandle_twkDidReceiveData
-               _Java_com_sun_webkit_network_URLLoader_twkDidFail
-               _Java_com_sun_webkit_network_URLLoader_twkDidFinishLoading
-               _Java_com_sun_webkit_network_URLLoader_twkDidReceiveData
-               _Java_com_sun_webkit_network_URLLoader_twkDidReceiveResponse
-               _Java_com_sun_webkit_network_URLLoader_twkDidSendData
-               _Java_com_sun_webkit_network_URLLoader_twkWillSendRequest
+               _Java_com_sun_webkit_network_URLLoaderBase_twkDidFail
+               _Java_com_sun_webkit_network_URLLoaderBase_twkDidFinishLoading
+               _Java_com_sun_webkit_network_URLLoaderBase_twkDidReceiveData
+               _Java_com_sun_webkit_network_URLLoaderBase_twkDidReceiveResponse
+               _Java_com_sun_webkit_network_URLLoaderBase_twkDidSendData
+               _Java_com_sun_webkit_network_URLLoaderBase_twkWillSendRequest

--- a/modules/javafx.web/src/main/native/Source/WebCore/mapfile-vers
+++ b/modules/javafx.web/src/main/native/Source/WebCore/mapfile-vers
@@ -1981,12 +1981,12 @@ SUNWprivate_1.0 {
                Java_com_sun_webkit_network_SocketStreamHandle_twkDidFail;
                Java_com_sun_webkit_network_SocketStreamHandle_twkDidOpen;
                Java_com_sun_webkit_network_SocketStreamHandle_twkDidReceiveData;
-               Java_com_sun_webkit_network_URLLoader_twkDidFail;
-               Java_com_sun_webkit_network_URLLoader_twkDidFinishLoading;
-               Java_com_sun_webkit_network_URLLoader_twkDidReceiveData;
-               Java_com_sun_webkit_network_URLLoader_twkDidReceiveResponse;
-               Java_com_sun_webkit_network_URLLoader_twkDidSendData;
-               Java_com_sun_webkit_network_URLLoader_twkWillSendRequest;
+               Java_com_sun_webkit_network_URLLoaderBase_twkDidFail;
+               Java_com_sun_webkit_network_URLLoaderBase_twkDidFinishLoading;
+               Java_com_sun_webkit_network_URLLoaderBase_twkDidReceiveData;
+               Java_com_sun_webkit_network_URLLoaderBase_twkDidReceiveResponse;
+               Java_com_sun_webkit_network_URLLoaderBase_twkDidSendData;
+               Java_com_sun_webkit_network_URLLoaderBase_twkWillSendRequest;
                kJSClassDefinitionEmpty;
         local:
                 *;

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/java/IDNJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/java/IDNJava.cpp
@@ -25,8 +25,8 @@
 
 #include "config.h"
 #include "IDNJava.h"
-#include "PlatformJavaClasses.h"
-#include "com_sun_webkit_network_URLLoader.h"
+#include <wtf/java/JavaEnv.h>
+#include "com_sun_webkit_network_URLLoaderBase.h"
 
 namespace IDNJavaInternal {
 
@@ -62,9 +62,8 @@ String toASCII(const String& hostname)
             idnClass,
             toASCIIMID,
             (jstring)hostname.toJavaString(env),
-            com_sun_webkit_network_URLLoader_ALLOW_UNASSIGNED));
+            com_sun_webkit_network_URLLoaderBase_ALLOW_UNASSIGNED));
     WTF::CheckAndClearException(env);
-
     return String(env, result);
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/ResourceHandle.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/ResourceHandle.h
@@ -103,6 +103,11 @@ public:
     void willSendRequest(ResourceRequest&&, ResourceResponse&&, CompletionHandler<void(ResourceRequest&&)>&&);
 #endif
 
+#if PLATFORM(JAVA)
+    void continueAfterWillSendRequest(ResourceRequest&& request);
+    void willSendRequest(const ResourceResponse& response);
+#endif
+
     void didReceiveResponse(ResourceResponse&&, CompletionHandler<void()>&&);
 
     bool shouldUseCredentialStorage();

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/ResourceHandleInternal.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/ResourceHandleInternal.h
@@ -135,6 +135,7 @@ public:
 
 #if PLATFORM(JAVA)
     std::unique_ptr<URLLoader> m_loader;
+    int m_redirectCount { 0 };
 #endif
 
 #if PLATFORM(COCOA)

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/URLLoader.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/network/java/URLLoader.h
@@ -41,7 +41,8 @@ class ResourceResponse;
 class URLLoader {
 public:
     static std::unique_ptr<URLLoader> loadAsynchronously(NetworkingContext* context,
-                                                    ResourceHandle* handle);
+                                                    ResourceHandle* handle,
+                                                    const ResourceRequest& request);
     void cancel();
     static void loadSynchronously(NetworkingContext* context,
                                   const ResourceRequest& request,
@@ -54,9 +55,7 @@ public:
     public:
         virtual void didSendData(long totalBytesSent,
                                  long totalBytesToBeSent) = 0;
-        virtual bool willSendRequest(const String& newUrl,
-                                     const String& newMethod,
-                                     const ResourceResponse& response) = 0;
+        virtual bool willSendRequest(const ResourceResponse& response) = 0;
         virtual void didReceiveResponse(const ResourceResponse& response) = 0;
         virtual void didReceiveData(const char* data, int length) = 0;
         virtual void didFinishLoading() = 0;
@@ -78,9 +77,7 @@ private:
         AsynchronousTarget(ResourceHandle* handle);
 
         void didSendData(long totalBytesSent, long totalBytesToBeSent) final;
-        bool willSendRequest(const String& newUrl,
-                             const String& newMethod,
-                             const ResourceResponse& response) final;
+        bool willSendRequest(const ResourceResponse& response) final;
         void didReceiveResponse(const ResourceResponse& response) final;
         void didReceiveData(const char* data, int length) final;
         void didFinishLoading() final;
@@ -97,9 +94,7 @@ private:
                           Vector<char>& data);
 
         void didSendData(long totalBytesSent, long totalBytesToBeSent) final;
-        bool willSendRequest(const String& newUrl,
-                             const String& newMethod,
-                             const ResourceResponse& response) final;
+        bool willSendRequest(const ResourceResponse& response) final;
         void didReceiveResponse(const ResourceResponse& response) final;
         void didReceiveData(const char* data, int length) final;
         void didFinishLoading() final;


### PR DESCRIPTION
The goal of this enhancement is to use new [HttpClient APIs](https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpClient.html) available from JDK 11.

Reference:
[1] https://openjdk.java.net/groups/net/httpclient/intro.html
[2] https://docs.oracle.com/en/java/javase/11/docs/api/java.net.http/java/net/http/HttpClient.html

Though this uses JDK 11 HttpClient APIs, it needs latest JDK 12 to work correctly due to the dependency on following issues,

[JDK-8218546](https://bugs.openjdk.java.net/browse/JDK-8218546) Unable to connect to https://google.com using java.net.HttpClient
[JDK-8218662](https://bugs.openjdk.java.net/browse/JDK-8218662) Allow 204 responses with Content-Length:0
[JDK-8203850](https://bugs.openjdk.java.net/browse/JDK-8203850) java.net.http HTTP client should allow specifying Origin and Referer headers

#### Task List
- [x] simple GET requests
- [x] Runtime setting to fallback to legacy client
- [ ] Runtime settings to use *only* HTTP/1.1
- [x] sync requests
- [x] Error Handling & Propagation
- [x] POST with form data
- [x] AccessController association for HttpClient.sendAsync / send
- [x] Redirection
- [ ] Check for possibilities to write unit tests 
- [ ] Sync request handling from WebCore java platform layer
- [x] Make use of singleton instance of direct ByteBuffer instead of using allocator pool
- [x] gzip, deflate encoding support



#### HTTP/2 Test pages
- http://www.http2demo.io
- https://http2.akamai.com/demo
- https://http2.golang.org
- https://google.com

#### Redirection Test
- https://www.httpwatch.com/httpgallery/redirection/#showExample7

Here is a http2 [demo page](https://http2.akamai.com/demo) result, 

<img width="912" alt="screen shot 2018-10-11 at 12 01 12 am" src="https://user-images.githubusercontent.com/3874763/46757800-d0a8c300-cce8-11e8-8115-48f711e361c4.png">


More details are available at https://github.com/javafxports/openjdk-jfx/pull/247.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8211308](https://bugs.openjdk.java.net/browse/JDK-8211308): Support HTTP/2 in WebView


## Approvers
 * Guru Hb ([ghb](@guruhb) - **Reviewer**)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)