### PR TITLE
8207759: VK_ENTER not consumed by TextField when default Button exists

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextFieldBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextFieldBehavior.java
@@ -25,7 +25,16 @@
 
 package com.sun.javafx.scene.control.behavior;
 
+
+import com.sun.javafx.PlatformUtil;
+import com.sun.javafx.geom.transform.Affine3D;
+import com.sun.javafx.scene.NodeHelper;
 import com.sun.javafx.scene.control.Properties;
+import com.sun.javafx.scene.control.skin.Utils;
+import com.sun.javafx.stage.WindowHelper;
+
+import static com.sun.javafx.PlatformUtil.*;
+
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.WeakChangeListener;
 import javafx.event.ActionEvent;
@@ -35,23 +44,14 @@ import javafx.geometry.Point2D;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Node;
 import javafx.scene.Scene;
-import javafx.scene.control.ContextMenu;
 import javafx.scene.control.TextField;
 import javafx.scene.control.skin.TextFieldSkin;
-import com.sun.javafx.scene.control.skin.Utils;
 import javafx.scene.input.ContextMenuEvent;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.text.HitInfo;
 import javafx.stage.Screen;
 import javafx.stage.Window;
-import com.sun.javafx.PlatformUtil;
-import com.sun.javafx.geom.transform.Affine3D;
-
-import static com.sun.javafx.PlatformUtil.isMac;
-import static com.sun.javafx.PlatformUtil.isWindows;
-import com.sun.javafx.scene.NodeHelper;
-import com.sun.javafx.stage.WindowHelper;
 
 /**
  * Text field behavior.
@@ -183,9 +183,10 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
 
         textField.commitValue();
         textField.fireEvent(actionEvent);
-
-        if (onAction == null && !actionEvent.isConsumed()) {
-            forwardToParent(event);
+        // fix of JDK-8207759: reverted logic
+        // mapping not auto-consume and consume if handled by action
+        if (onAction != null || actionEvent.isConsumed()) {
+            event.consume();
         }
     }
 

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextInputControlBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextInputControlBehavior.java
@@ -124,6 +124,7 @@ public abstract class TextInputControlBehavior<T extends TextInputControl> exten
         final Predicate<KeyEvent> validOnLinux = e -> !PlatformUtil.isLinux();
 
         KeyMapping cancelEditMapping;
+        KeyMapping fireMapping;
         KeyMapping consumeMostPressedEventsMapping;
 
         // create a child input map for mappings which are applicable on all
@@ -136,7 +137,7 @@ public abstract class TextInputControlBehavior<T extends TextInputControl> exten
                 keyMapping(HOME, e -> c.home()),
                 keyMapping(DOWN, e -> c.end()),
                 keyMapping(END, e -> c.end()),
-                keyMapping(ENTER, this::fire),
+                fireMapping = keyMapping(ENTER, this::fire),
 
                 keyMapping(new KeyBinding(HOME).shortcut(), e -> c.home()),
                 keyMapping(new KeyBinding(END).shortcut(), e -> c.end()),
@@ -213,6 +214,8 @@ public abstract class TextInputControlBehavior<T extends TextInputControl> exten
         );
 
         cancelEditMapping.setAutoConsume(false);
+        // fix of JDK-8207759: don't auto-consume
+        fireMapping.setAutoConsume(false);
         consumeMostPressedEventsMapping.setAutoConsume(false);
 
         // mac os specific mappings
@@ -620,18 +623,7 @@ public abstract class TextInputControlBehavior<T extends TextInputControl> exten
     }
 
     protected void fire(KeyEvent event) { } // TODO move to TextFieldBehavior
-    protected void cancelEdit(KeyEvent event) { forwardToParent(event);} // not autoconsumed
-
-    protected void forwardToParent(KeyEvent event) {
-        // fix for JDK-8145515
-        if (getNode().getProperties().containsKey(DISABLE_FORWARD_TO_PARENT)) {
-            return;
-        }
-
-        if (getNode().getParent() != null) {
-            getNode().getParent().fireEvent(event);
-        }
-    }
+    protected void cancelEdit(KeyEvent event) { };
 
     protected void selectHome() {
         getNode().selectHome();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/DefaultCancelButtonTestBase.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/DefaultCancelButtonTestBase.java
@@ -1,0 +1,316 @@
+package test.javafx.scene.control;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import com.sun.javafx.tk.Toolkit;
+
+import static javafx.scene.input.KeyCode.*;
+import static javafx.scene.input.KeyEvent.*;
+import static org.junit.Assert.*;
+
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Control;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import test.com.sun.javafx.pgstub.StubToolkit;
+import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
+
+/**
+ * Abstract base test for interplay of ENTER/ESCAPE handlers on Controls with
+ * default/cancel button actions.
+ * <p>
+ * Need to test all combinations of
+ * <ul>
+ * <li> default/cancel button
+ * <li> not/consuming external handler
+ * <li> handler registration before/after showing the stage: this is due to
+ *   https://bugs.openjdk.java.net/browse/JDK-8231245 (Controls' behavior
+ *   depends on sequence of handler registration). The errors mostly show up
+ *   when the handlers are registered after the stage is shown.
+ * <li> added filter/handler/singleton handler and no handler at all
+ * </ul>
+ *
+ * The test parameterized on all combination of the first 3 bullets, handling
+ * the last by 4 test methods.
+ */
+@RunWith(Parameterized.class)
+public abstract class DefaultCancelButtonTestBase<C extends Control> {
+    /**
+     * State of default/cancel button.
+     */
+    public static enum ButtonState {
+
+        DEFAULT(ENTER),
+        CANCEL(ESCAPE);
+
+        KeyCode key;
+
+        ButtonState(KeyCode key) {
+            this.key = key;
+        }
+
+        /**
+         * KeyCode that external handlers/button type is interested in.
+         * @return
+         */
+        public KeyCode getCode() {
+            return key;
+        }
+
+        /**
+         * Creates and returns a handler that consumes the event for
+         * keyCode.
+         *
+         * @return handler that consumes if the keyCode of the
+         * event is the same as this type's keyCode.
+         */
+        public EventHandler<KeyEvent> getConsumingHandler() {
+            return e -> {
+                if (getCode() == e.getCode()) e.consume();
+            };
+        }
+
+        /**
+         * Configures the given button as either default or
+         * cancel, based on keyCode.
+         *
+         * @param button to configure.
+         */
+        public void configureButton(Button button) {
+            if (getCode() == ENTER) {
+                button.setDefaultButton(true);
+            } else if (getCode() == ESCAPE) {
+                button.setCancelButton(true);
+            }
+
+        }
+    }
+
+    public static class ButtonType {
+        Button button;
+        ButtonState type;
+
+        public ButtonType(ButtonState type) {
+            this.type = type;
+            button = new Button();
+            type.configureButton(button);
+        }
+
+        public Button getButton() {
+            return button;
+        }
+
+        public KeyCode getCode() {
+            return type.getCode();
+        }
+
+        /**
+         * Returns a competing handler (for our keyCode) that not/consumes
+         * a received keyEvent depending on the given consuming flag. The
+         * handler can be registered on another control in the same scene.
+         *
+         * @param consuming
+         * @return
+         */
+        public EventHandler<KeyEvent> getKeyHandler(boolean consuming) {
+            return consuming ? type.getConsumingHandler() : e -> {};
+        }
+
+        @Override
+        public String toString() {
+            return "" + type;
+        }
+
+
+    }
+
+    private Stage stage;
+    private VBox root;
+    private C control;
+    private Button fallback;
+    private Scene scene;
+
+    private ButtonType buttonType;
+    private boolean consume;
+    private boolean registerAfterShowing;
+
+    // TODO name doesn't compile with gradle :controls:test
+    // because the junit version is 4.8.2 - name was introduced in 4.11
+    // commenting for now until upgrade to newer junit
+    @Parameterized.Parameters //( name = "{index}: Button {0}, consuming {1}, registerAfterShowing {2} " )
+    public static Collection<Object[]> data() {
+        Object[][] data = new Object[][] {
+            // buttonType, consuming, registerAfterShowing
+            {new ButtonType(ButtonState.DEFAULT), true, true},
+            {new ButtonType(ButtonState.DEFAULT), true, false},
+            {new ButtonType(ButtonState.DEFAULT), false, true},
+            {new ButtonType(ButtonState.DEFAULT), false, false},
+            {new ButtonType(ButtonState.CANCEL), true, true},
+            {new ButtonType(ButtonState.CANCEL), true, false},
+            {new ButtonType(ButtonState.CANCEL), false, true},
+            {new ButtonType(ButtonState.CANCEL), false, false},
+        };
+        return Arrays.asList(data);
+    }
+
+    public DefaultCancelButtonTestBase(ButtonType buttonType, boolean consume,
+            boolean registerAfterShowing) {
+        this.buttonType = buttonType;
+        this.consume = consume;
+        this.registerAfterShowing = registerAfterShowing;
+    }
+
+
+    @Test
+    public void testFallbackFilter() {
+        registerHandlerAndAssertFallbackNotification(this::addEventFilter);
+    }
+
+    @Test
+    public void testFallbackHandler() {
+        registerHandlerAndAssertFallbackNotification(this::addEventHandler);
+
+    }
+
+    @Test
+    public void testFallbackSingletonHandler() {
+        registerHandlerAndAssertFallbackNotification(this::setOnKeyPressed);
+
+    }
+
+    @Test
+    public void testFallbackNoHandler() {
+        if (consume) return;
+        show();
+        assertTargetNotification(buttonType.getCode(), buttonType.getButton(), 1);
+    }
+
+    protected void registerHandlerAndAssertFallbackNotification(Consumer<EventHandler<KeyEvent>> consumer) {
+        if (registerAfterShowing) {
+            show();
+        }
+        consumer.accept(buttonType.getKeyHandler(consume));
+        if (!registerAfterShowing) {
+            show();
+        }
+
+        int expected = consume ? 0 : 1;
+        assertTargetNotification(buttonType.getCode(), buttonType.getButton(), expected);
+
+    }
+    /**
+     * Registers the given handler on the textfield by adding as handler for keyPressed.
+     * @param handler the handler to register
+     */
+    protected void addEventHandler(EventHandler<KeyEvent> handler) {
+        control.addEventHandler(KEY_PRESSED, handler);
+    }
+
+    /**
+     * Registers the given handler on the textfield by setting as singleton
+     * keyPressed handler.
+     * @param handler the handler to register
+     */
+    protected void setOnKeyPressed(EventHandler<KeyEvent> handler) {
+        control.setOnKeyPressed(handler);
+    }
+
+    /**
+     * Registers the given handler on the textfield by adding as filter for keyPressed.
+     * @param handler the handler to register
+     */
+    protected void addEventFilter(EventHandler<KeyEvent> filter) {
+        control.addEventFilter(KEY_PRESSED, filter);
+    }
+
+// ------------ assert helpers
+    /**
+     * Fires the key onto the control and asserts that
+     * the target button receives the expected number of notifications in
+     * its action handler.
+     *
+     * @param key the key to fire on the control
+     * @param target the target button to test for nori
+     * @param expected number of notifications in target button's action handler
+     */
+    protected void assertTargetNotification(KeyCode key, Button target, int expected) {
+        List<ActionEvent> actions = new ArrayList<>();
+        target.setOnAction(actions::add);
+        KeyEventFirer keyFirer = new KeyEventFirer(control);
+        keyFirer.doKeyPress(key);
+        String exp = expected > 0 ? " must " : " must not ";
+        assertEquals(key + exp + " trigger ", expected, actions.size());
+    }
+
+
+    /**
+     * sanity test of initial state and test assumptions
+     */
+    @Test
+    public void testInitial() {
+        show();
+        assertTrue(control.isFocused());
+        assertSame(root, control.getParent());
+        assertSame(root, fallback.getParent());
+    }
+
+
+    protected boolean isEnter() {
+        return buttonType.getCode() == ENTER;
+    }
+
+    protected abstract C createControl();
+    protected C getControl() {
+        return control;
+    };
+
+    protected void show() {
+        stage.show();
+        // PENDING JW: a bit weird - sometimes need to focus the stage before
+        // the node, sometimes not
+        stage.requestFocus();
+        control.requestFocus();
+    }
+
+    private void initStage() {
+        //This step is not needed (Just to make sure StubToolkit is loaded into VM)
+        @SuppressWarnings("unused")
+        Toolkit tk = (StubToolkit)Toolkit.getToolkit();
+        root = new VBox();
+        scene = new Scene(root);
+        stage = new Stage();
+        stage.setScene(scene);
+    }
+
+    @Before
+    public void setup() {
+        initStage();
+        control = createControl();
+
+        fallback = buttonType.getButton();
+        root.getChildren().addAll(control, fallback);
+
+    }
+
+    @After
+    public void cleanup() {
+        if (stage != null) {
+            stage.hide();
+        }
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/DefaultCancelButtonTestBase.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/DefaultCancelButtonTestBase.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package test.javafx.scene.control;
 
 import java.util.ArrayList;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/PasswordFieldDefaultCancelButtonTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/PasswordFieldDefaultCancelButtonTest.java
@@ -1,0 +1,25 @@
+/*
+ * Created on 16.09.2019
+ *
+ */
+package test.javafx.scene.control;
+
+import javafx.scene.control.PasswordField;
+
+/**
+ * Test for interplay of ENTER/ESCAPE handlers on PasswordField with
+ * default/cancel button actions.
+ */
+public class PasswordFieldDefaultCancelButtonTest extends DefaultCancelButtonTestBase<PasswordField> {
+
+     public PasswordFieldDefaultCancelButtonTest(ButtonType buttonType,
+            boolean consume, boolean registerAfterShowing) {
+        super(buttonType, consume, registerAfterShowing);
+    }
+
+    @Override
+    protected PasswordField createControl() {
+        return new PasswordField();
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/PasswordFieldDefaultCancelButtonTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/PasswordFieldDefaultCancelButtonTest.java
@@ -1,7 +1,28 @@
 /*
- * Created on 16.09.2019
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
+
 package test.javafx.scene.control;
 
 import javafx.scene.control.PasswordField;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextAreaDefaultCancelButtonTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextAreaDefaultCancelButtonTest.java
@@ -1,0 +1,61 @@
+/*
+ * Created on 16.09.2019
+ *
+ */
+package test.javafx.scene.control;
+
+import javafx.scene.control.TextArea;
+
+/**
+ * Test for interplay of ENTER/ESCAPE handlers on TextArea with
+ * default/cancel button actions.
+ */
+public class TextAreaDefaultCancelButtonTest extends DefaultCancelButtonTestBase<TextArea> {
+
+    public TextAreaDefaultCancelButtonTest(ButtonType buttonType,
+            boolean consume, boolean registerAfterShowing) {
+        super(buttonType, consume, registerAfterShowing);
+    }
+
+    /**
+     * Overridden to back out for ENTER (which is handled internally always)
+     */
+    @Override
+    public void testFallbackFilter() {
+        if (isEnter()) return;
+        super.testFallbackFilter();
+    }
+
+    /**
+     * Overridden to back out for ENTER (which is handled internally always)
+     */
+    @Override
+    public void testFallbackHandler() {
+        if (isEnter()) return;
+        super.testFallbackHandler();
+    }
+
+    /**
+     * Overridden to back out for ENTER (which is handled internally always)
+     */
+    @Override
+    public void testFallbackSingletonHandler() {
+        if (isEnter()) return;
+        super.testFallbackSingletonHandler();
+    }
+
+    /**
+     * Overridden to back out for ENTER (which is handled internally always)
+     */
+    @Override
+    public void testFallbackNoHandler() {
+        if (isEnter()) return;
+        super.testFallbackNoHandler();
+    }
+
+    @Override
+    protected TextArea createControl() {
+        return new TextArea();
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextAreaDefaultCancelButtonTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextAreaDefaultCancelButtonTest.java
@@ -1,7 +1,28 @@
 /*
- * Created on 16.09.2019
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
+
 package test.javafx.scene.control;
 
 import javafx.scene.control.TextArea;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldDefaultCancelButtonTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldDefaultCancelButtonTest.java
@@ -1,0 +1,25 @@
+/*
+ * Created on 11.10.2019
+ *
+ */
+package test.javafx.scene.control;
+
+import javafx.scene.control.TextField;
+
+/**
+ * Test for interplay of ENTER/ESCAPE handlers on TextField with
+ * default/cancel button actions.
+ */
+public class TextFieldDefaultCancelButtonTest extends DefaultCancelButtonTestBase<TextField> {
+
+    public TextFieldDefaultCancelButtonTest(ButtonType buttonType, boolean consume,
+            boolean registerAfterShowing) {
+        super(buttonType, consume, registerAfterShowing);
+    }
+
+    @Override
+    protected TextField createControl() {
+        return new TextField();
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldDefaultCancelButtonTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldDefaultCancelButtonTest.java
@@ -1,7 +1,28 @@
 /*
- * Created on 11.10.2019
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
+
 package test.javafx.scene.control;
 
 import javafx.scene.control.TextField;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
@@ -51,6 +51,7 @@ import javafx.event.ActionEvent;
 import javafx.event.Event;
 import javafx.event.EventHandler;
 import javafx.scene.Scene;
+import javafx.scene.control.ComboBox;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextInputControlShim;
 import javafx.scene.input.KeyCode;
@@ -305,6 +306,45 @@ public class TextFieldTest {
     private Scene scene;
     private Stage stage;
     private StackPane root;
+
+    /**
+     * Guard against potential regression of JDK-8145515: eventFilter
+     * on editor not notified for ENTER released.
+     */
+    @Test
+    public void testEditorInComboBoxEnterReleasedFilter() {
+        initStage();
+        ComboBox<String> combo = new ComboBox<>();
+        combo.setEditable(true);
+        root.getChildren().add(combo);
+        stage.show();
+        List<Event> events = new ArrayList<>();
+        combo.getEditor().addEventFilter(KEY_RELEASED, events::add);
+        KeyCode key = ENTER;
+        KeyEventFirer keyFirer = new KeyEventFirer(combo);
+        keyFirer.doKeyPress(key);
+        assertEquals(1, events.size());
+    }
+
+    /**
+     * Unfixed part of JDK-8145515, reported as regression JDK-8229914: eventFilter
+     * on editor not notified for ENTER pressed.
+     */
+    @Ignore("JDK-8229914")
+    @Test
+    public void testEditorInComboBoxEnterPressedFilter() {
+        initStage();
+        ComboBox<String> combo = new ComboBox<>();
+        combo.setEditable(true);
+        root.getChildren().add(combo);
+        stage.show();
+        List<Event> events = new ArrayList<>();
+        combo.getEditor().addEventFilter(KEY_PRESSED, events::add);
+        KeyCode key = ENTER;
+        KeyEventFirer keyFirer = new KeyEventFirer(combo);
+        keyFirer.doKeyPress(key);
+        assertEquals(1, events.size());
+    }
 
     /**
      * Test related to https://bugs.openjdk.java.net/browse/JDK-8207759

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
@@ -36,6 +36,8 @@ import org.junit.Test;
 import com.sun.javafx.tk.Toolkit;
 
 import static javafx.scene.input.KeyCode.*;
+import static javafx.scene.input.KeyEvent.*;
+import static java.util.stream.Collectors.*;
 import static org.junit.Assert.*;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.*;
 
@@ -46,10 +48,12 @@ import javafx.beans.property.StringProperty;
 import javafx.collections.ObservableSet;
 import javafx.css.PseudoClass;
 import javafx.event.ActionEvent;
+import javafx.event.Event;
 import javafx.event.EventHandler;
 import javafx.scene.Scene;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextInputControlShim;
+import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;
@@ -301,6 +305,53 @@ public class TextFieldTest {
     private Scene scene;
     private Stage stage;
     private StackPane root;
+
+    /**
+     * Test related to https://bugs.openjdk.java.net/browse/JDK-8207759
+     * broken event dispatch sequence by forwardToParent.
+     */
+    @Test
+    public void testEventSequenceEnterHandler() {
+        initStage();
+        root.getChildren().add(txtField);
+        stage.show();
+        List<Event> events = new ArrayList<>();
+        EventHandler<KeyEvent> adder = events::add;
+        scene.addEventHandler(KEY_PRESSED, adder);
+        root.addEventHandler(KEY_PRESSED, adder);
+        txtField.addEventHandler(KEY_PRESSED, adder);
+        KeyCode key = ENTER;
+        KeyEventFirer keyFirer = new KeyEventFirer(txtField);
+        keyFirer.doKeyPress(key);
+        assertEquals("event count", 3, events.size());
+        List<Object> sources = events.stream()
+                .map(e -> e.getSource())
+                .collect(toList());
+        List<Object> expected = List.of(txtField, root, scene);
+        assertEquals(expected, sources);
+    }
+
+    @Test
+    public void testEventSequenceEscapeHandler() {
+        initStage();
+        root.getChildren().add(txtField);
+        stage.show();
+        List<Event> events = new ArrayList<>();
+        EventHandler<KeyEvent> adder = events::add;
+        scene.addEventHandler(KEY_PRESSED, adder);
+        root.addEventHandler(KEY_PRESSED, adder);
+        txtField.addEventHandler(KEY_PRESSED, adder);
+        KeyCode key = ESCAPE;
+        KeyEventFirer keyFirer = new KeyEventFirer(txtField);
+        keyFirer.doKeyPress(key);
+        assertEquals("event count", 3, events.size());
+        List<Object> sources = events.stream()
+                .map(e -> e.getSource())
+                .collect(toList());
+        List<Object> expected = List.of(txtField, root, scene);
+        assertEquals(expected, sources);
+    }
+
 
     /**
      * test for JDK-8207774: ENTER must not be forwared if actionHandler

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldWithFormatterDefaultCancelButtonTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldWithFormatterDefaultCancelButtonTest.java
@@ -1,0 +1,37 @@
+/*
+ * Created on 11.10.2019
+ *
+ */
+package test.javafx.scene.control;
+
+import org.junit.Ignore;
+
+import javafx.scene.control.TextField;
+import javafx.scene.control.TextFormatter;
+
+/**
+/**
+ * Test interaction of TextField with formatter with default/cancel button
+ *
+ * Fails for cancel/not consuming - behavior.cancel
+ * consumes always with formatter. Should it?
+ *
+ * Ignoring for now
+ */
+@Ignore
+public class TextFieldWithFormatterDefaultCancelButtonTest
+        extends TextFieldDefaultCancelButtonTest {
+
+    public TextFieldWithFormatterDefaultCancelButtonTest(ButtonType buttonType,
+            boolean consume, boolean registerAfterShowing) {
+        super(buttonType, consume, registerAfterShowing);
+    }
+
+    @Override
+    protected TextField createControl() {
+        TextField input = super.createControl();
+        input.setTextFormatter(new TextFormatter<>(TextFormatter.IDENTITY_STRING_CONVERTER));
+        return input;
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldWithFormatterDefaultCancelButtonTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldWithFormatterDefaultCancelButtonTest.java
@@ -1,7 +1,28 @@
 /*
- * Created on 11.10.2019
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
+
 package test.javafx.scene.control;
 
 import org.junit.Ignore;
@@ -9,7 +30,6 @@ import org.junit.Ignore;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextFormatter;
 
-/**
 /**
  * Test interaction of TextField with formatter with default/cancel button
  *


### PR DESCRIPTION
This is a fix for https://bugs.openjdk.java.net/browse/JDK-8207759

The issue is that default/cancel button on a scene are triggered even though a onKeyPressed handler for ENTER/CANCEL consumes the keyEvent. See the bug for details on both cause and fix.

There are additional/changed tests to verify the fix. All old tests are passing.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8207759](https://bugs.openjdk.java.net/browse/JDK-8207759): VK_ENTER not consumed by TextField when default Button exists


## Approvers
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)