### PR TITLE
8232687: No static JNI loader for libprism-sw

### DIFF
--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -169,7 +169,7 @@ MAC.prism = [:]
 MAC.prism.javahInclude = ["com/sun/prism/impl/**/*", "com/sun/prism/PresentableState*"]
 MAC.prism.nativeSource = file("${project("graphics").projectDir}/src/main/native-prism")
 MAC.prism.compiler = compiler
-MAC.prism.ccFlags = ["-O3", "-DINLINE=inline", "-c", ccBaseFlags].flatten()
+MAC.prism.ccFlags = ["-O3", "-DINLINE=inline", "-c", IS_STATIC_BUILD? "-DSTATIC_BUILD" : "", ccBaseFlags].flatten()
 MAC.prism.linker = linker
 MAC.prism.linkFlags = linkFlagsAlt
 MAC.prism.lib = "prism_common"

--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -169,7 +169,7 @@ MAC.prism = [:]
 MAC.prism.javahInclude = ["com/sun/prism/impl/**/*", "com/sun/prism/PresentableState*"]
 MAC.prism.nativeSource = file("${project("graphics").projectDir}/src/main/native-prism")
 MAC.prism.compiler = compiler
-MAC.prism.ccFlags = ["-O3", "-DINLINE=inline", "-c", IS_STATIC_BUILD? "-DSTATIC_BUILD" : "", ccBaseFlags].flatten()
+MAC.prism.ccFlags = ["-O3", "-DINLINE=inline", "-c", IS_STATIC_BUILD ? "-DSTATIC_BUILD" : "", ccBaseFlags].flatten()
 MAC.prism.linker = linker
 MAC.prism.linkFlags = linkFlagsAlt
 MAC.prism.lib = "prism_common"

--- a/modules/javafx.graphics/src/main/native-prism-sw/JNIUtil.c
+++ b/modules/javafx.graphics/src/main/native-prism-sw/JNIUtil.c
@@ -24,6 +24,22 @@
  */
 
 #include <JNIUtil.h>
+#ifdef STATIC_BUILD
+JNIEXPORT jint JNICALL
+JNI_OnLoad_prism_sw(JavaVM *vm, void * reserved) {
+#ifdef JNI_VERSION_1_8
+    //min. returned JNI_VERSION required by JDK8 for builtin libraries
+    JNIEnv *env;
+    if ((*vm)->GetEnv(vm, (void **)&env, JNI_VERSION_1_8) != JNI_OK) {
+        return JNI_VERSION_1_4;
+    }
+    return JNI_VERSION_1_8;
+#else
+    return JNI_VERSION_1_4;
+#endif
+}
+#endif // STATIC_BUILD
+
 
 jboolean
 initializeFieldIds(jfieldID* dest, JNIEnv* env, jclass classHandle,


### PR DESCRIPTION
This PR adds a JNI_OnLoad_prism_sw call to the static lib libprism_sw.a.
This approach is similar to the addition of e.g. JNI_OnLoad_prism_es2 that has been done as part of https://bugs.openjdk.java.net/browse/JDK-8223760 

Unless -PSTATIC_BUILD is provided when building, this patch has no impact.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8232687](https://bugs.openjdk.java.net/browse/JDK-8232687): No static JNI loader for libprism-sw


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**) **Note!** Review applies to f34a99a394bc3c9fe3b2b11c7fc984b70188c5b4