### PR TITLE
8231692: Test Infrastructure: enhance KeyEventFirer to inject keyEvents into scene

### DIFF
--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyEventFirer.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyEventFirer.java
@@ -78,8 +78,9 @@ public class KeyEventFirer {
     public KeyEventFirer(EventTarget target, Scene scene) {
         this.target = target;
         this.scene = scene;
-        if (target == null && scene == null)
+        if (target == null && scene == null) {
             throw new NullPointerException("both target and scene are null");
+        }
     }
 
     public void doUpArrowPress(KeyModifier... modifiers) {

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyEventFirer.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyEventFirer.java
@@ -27,19 +27,59 @@ package test.com.sun.javafx.scene.control.infrastructure;
 
 import java.util.Arrays;
 import java.util.List;
-import javafx.event.EventType;
-import javafx.scene.input.KeyCode;
-import javafx.scene.input.KeyEvent;
+import java.util.Objects;
+
 import javafx.event.Event;
 import javafx.event.EventTarget;
+import javafx.event.EventType;
+import javafx.scene.Scene;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 
 
 public class KeyEventFirer {
 
     private final EventTarget target;
+    private final Scene scene;
 
+    /**
+     * Instantiates a KeyEventFirer on the given event target. KeyEvents are
+     * fired directly onto the target.
+     *
+     * <p>
+     * Beware: using this constructor on an <code>EventTarget</code> of type <code>Node</code>
+     * which is not focusOwner may lead
+     * to false greens (see https://bugs.openjdk.java.net/browse/JDK-8231692).
+     *
+     * @param target the target to fire keyEvents onto, must not be null.
+     * @throws NullPointerException if target is null.
+     */
     public KeyEventFirer(EventTarget target) {
+        this(Objects.requireNonNull(target), null);
+    }
+
+    /**
+     * Instantiates a KeyEventFirer for the given target and scene.
+     * Any one of those can be null, but not both. A null/not null scene decides
+     * about the delivering path of events. If null, events are delivered
+     * via <code>EventUtils.fire(target, keyEvent)</code>, otherwise via
+     * <code>scene.processKeyEvent(keyEvent)</code>.
+     * <p>
+     * Note that in the latter case, the target doesn't matter - the scene
+     * delivers keyEvents to its focusOwner. Calling code is responsible to
+     * setup focus state as required.
+     *
+     * @param target eventTarget used to create the event for and fire events onto
+     *    if there's no scene
+     * @param scene to use for delivering events to its focusOwner if not null
+     *
+     * @throws NullPointerException if both target and scene are null
+     */
+    public KeyEventFirer(EventTarget target, Scene scene) {
         this.target = target;
+        this.scene = scene;
+        if (target == null && scene == null)
+            throw new NullPointerException("both target and scene are null");
     }
 
     public void doUpArrowPress(KeyModifier... modifiers) {
@@ -66,9 +106,21 @@ public class KeyEventFirer {
         fireEvents(createEvent(keyCode, KeyEvent.KEY_TYPED, modifiers));
     }
 
+    /**
+     * Dispatches the given events. The process depends on the state of
+     * this firer. If the scene is null, the events are delivered via
+     * Event.fireEvent(target,..), otherwise they are delivered via
+     * scene.processKeyEvent.
+     *
+     * @param events the events to dispatch.
+     */
     private void fireEvents(KeyEvent... events) {
         for (KeyEvent evt : events) {
-            Event.fireEvent(target, evt);
+            if (scene != null) {
+                scene.processKeyEvent(evt);
+            } else {
+                Event.fireEvent(target, evt);
+            }
         }
     }
 

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyEventFirerTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyEventFirerTest.java
@@ -1,0 +1,206 @@
+/*
+ * Created on 22.10.2019
+ *
+ */
+package test.com.sun.javafx.scene.control.infrastructure;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.Ignore;
+
+import static javafx.scene.input.KeyCode.*;
+import static javafx.scene.input.KeyEvent.*;
+import static org.junit.Assert.*;
+
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.TextField;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+/**
+ * Test of enhanced KeyEventFirer.
+ * <p>
+ *
+ * Most of these tests are meant to document how to use the KeyEventFirer and what
+ * happens if used incorrectly. The latter are ignored, because the build should pass.
+ *
+ */
+public class KeyEventFirerTest {
+
+    private TextField textField;
+    private Button button;
+    private Pane root;
+    private Stage stage;
+    private Scene scene;
+    private ComboBox<String> comboBox;
+
+    /**
+     * Verify failing test from bug report example.
+     */
+    @Ignore
+    @Test
+    public void testFireComboEditorFailing() {
+        showAndFocus(comboBox);
+        List<KeyEvent> keys = new ArrayList<>();
+        comboBox.getEditor().addEventFilter(KEY_PRESSED, keys::add);
+        KeyEventFirer keyboard = new KeyEventFirer(comboBox.getEditor(), scene);
+        keyboard.doKeyPress(ENTER);
+        assertEquals("pressed ENTER filter on editor", 1, keys.size());
+    }
+
+    /**
+     * False-green from bug report example.
+     */
+    @Ignore
+    @Test
+    public void testFireComboEditorFalseGreen() {
+        showAndFocus(comboBox);
+        List<KeyEvent> keys = new ArrayList<>();
+        comboBox.getEditor().addEventFilter(KEY_PRESSED, keys::add);
+        KeyEventFirer keyboard = new KeyEventFirer(comboBox.getEditor());
+        keyboard.doKeyPress(ENTER);
+        assertEquals("pressed ENTER filter on editor", 1, keys.size());
+        fail("false green by firing directly on target which is not focusOwner");
+    }
+
+    /**
+     * Test that keyEvent is delivered to focused control and nowhere else.
+     * Here we fire directly onto the scene - and see a different outcome from
+     * using scene.process: the events are delivered to the scene only, not
+     * the focused node.
+     */
+    @Ignore
+    @Test
+    public void testFireSceneAsTarget() {
+        showAndFocus(button);
+        List<KeyEvent> buttonEvents = new ArrayList<>();
+        button.addEventHandler(KEY_PRESSED, buttonEvents::add);
+        List<KeyEvent> textFieldEvents = new ArrayList<>();
+        textField.addEventHandler(KEY_PRESSED, textFieldEvents::add);
+        KeyEventFirer firer = new KeyEventFirer(scene);
+        firer.doKeyPress(A);
+        assertEquals("button must have received the key", 1, buttonEvents.size());
+        assertEquals("textField must not have received the key", 0, textFieldEvents.size());
+    }
+
+    /**
+     * Test that keyEvent is delivered to focused control and nowhere else.
+     */
+    @Test
+    public void testFireViaScene() {
+        showAndFocus(button);
+        List<KeyEvent> buttonEvents = new ArrayList<>();
+        button.addEventHandler(KEY_PRESSED, buttonEvents::add);
+        List<KeyEvent> textFieldEvents = new ArrayList<>();
+        textField.addEventHandler(KEY_PRESSED, textFieldEvents::add);
+        KeyEventFirer firer = new KeyEventFirer(textField, scene);
+        firer.doKeyPress(A);
+        assertEquals("button must have received the key", 1, buttonEvents.size());
+        assertEquals("textField must not have received the key", 0, textFieldEvents.size());
+    }
+
+    /**
+     * Test that keyEvent is delivered to focused control and nowhere else.
+     * Here we test that the target is not required.
+     */
+    @Test
+    public void testFireViaSceneNullTarget() {
+        showAndFocus(button);
+        List<KeyEvent> buttonEvents = new ArrayList<>();
+        button.addEventHandler(KEY_PRESSED, buttonEvents::add);
+        List<KeyEvent> textFieldEvents = new ArrayList<>();
+        textField.addEventHandler(KEY_PRESSED, textFieldEvents::add);
+        KeyEventFirer firer = new KeyEventFirer(null, scene);
+        firer.doKeyPress(A);
+        assertEquals("button must have received the key", 1, buttonEvents.size());
+        assertEquals("textField must not have received the key", 0, textFieldEvents.size());
+    }
+
+    /**
+     * This simulates a false positive: even though not focused, the textField handlers
+     * are notified when firing directly. That's possible, but typically not what we want to test!
+     */
+    @Ignore
+    @Test
+    public void testFireTargetFalseGreen() {
+        showAndFocus(button);
+        List<KeyEvent> buttonEvents = new ArrayList<>();
+        button.addEventHandler(KEY_PRESSED, buttonEvents::add);
+        List<KeyEvent> textFieldEvents = new ArrayList<>();
+        textField.addEventHandler(KEY_PRESSED, textFieldEvents::add);
+        KeyEventFirer firer = new KeyEventFirer(textField);
+        firer.doKeyPress(A);
+        assertEquals("textField must have received the key", 1, textFieldEvents.size());
+        assertEquals("button must have received the key", 0, buttonEvents.size());
+        fail("false green by firing directly on target which is not focusOwner");
+    }
+
+    @Test (expected= NullPointerException.class)
+    public void testTwoParamConstructorNPE() {
+        new KeyEventFirer(null, null);
+    }
+
+    @Test (expected= NullPointerException.class)
+    public void testSingleParamConstructorNPE() {
+        new KeyEventFirer(null);
+    }
+
+    /**
+     * Need all: stage.show, stage.requestFocus and control.requestFocus to
+     * have consistent focused state on control (that is focusOwner and isFocused)
+     */
+    @Test
+    public void testUIState() {
+        assertEquals(List.of(button, textField, comboBox), root.getChildren());
+        stage.show();
+        stage.requestFocus();
+        button.requestFocus();
+        assertEquals(button, scene.getFocusOwner());
+        assertTrue(button.isFocused());
+    }
+
+    private void showAndFocus(Node focused) {
+        stage.show();
+        stage.requestFocus();
+        if (focused != null) {
+            focused.requestFocus();
+            assertTrue(focused.isFocused());
+            assertSame(focused, scene.getFocusOwner());
+        }
+    }
+
+    @Before
+    public void setup() {
+        // This step is not needed (Just to make sure StubToolkit is loaded into VM)
+        // @SuppressWarnings("unused")
+        // Toolkit tk = (StubToolkit)Toolkit.getToolkit();
+        root = new VBox();
+        scene = new Scene(root);
+        stage = new Stage();
+        stage.setScene(scene);
+        button = new Button("I'm a button");
+        textField = new TextField("some text");
+        // to test the false-green example in the bug report
+        comboBox = new ComboBox<>();
+        comboBox.getItems().addAll("Test", "hello", "world");
+        comboBox.setEditable(true);
+        root.getChildren().addAll(button, textField, comboBox);
+    }
+
+    @After
+    public void cleanup() {
+        if (stage != null) {
+            stage.hide();
+        }
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyEventFirerTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyEventFirerTest.java
@@ -1,7 +1,28 @@
 /*
- * Created on 22.10.2019
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
+
 package test.com.sun.javafx.scene.control.infrastructure;
 
 import java.util.ArrayList;

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyEventFirerTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyEventFirerTest.java
@@ -112,8 +112,8 @@ public class KeyEventFirerTest {
         // firing on the scene makes a difference
         KeyEventFirer correctFirer = new KeyEventFirer(null, scene);
         correctFirer.doKeyPress(A);
-        assertNotEquals(falseTextFieldNotification, textFieldEvents.size());
-        assertNotEquals(falseButtonNotification, buttonEvents.size());
+        assertEquals(falseTextFieldNotification - 1, textFieldEvents.size());
+        assertEquals(falseButtonNotification + 1, buttonEvents.size());
     }
 
     @Test (expected= NullPointerException.class)

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyEventFirerTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyEventFirerTest.java
@@ -31,7 +31,6 @@ import java.util.List;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
 
 import static javafx.scene.input.KeyCode.*;
 import static javafx.scene.input.KeyEvent.*;
@@ -40,7 +39,6 @@ import static org.junit.Assert.*;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
-import javafx.scene.control.ComboBox;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Pane;
@@ -49,11 +47,6 @@ import javafx.stage.Stage;
 
 /**
  * Test of enhanced KeyEventFirer.
- * <p>
- *
- * Most of these tests are meant to document how to use the KeyEventFirer and what
- * happens if used incorrectly. The latter are ignored, because the build should pass.
- *
  */
 public class KeyEventFirerTest {
 
@@ -62,56 +55,6 @@ public class KeyEventFirerTest {
     private Pane root;
     private Stage stage;
     private Scene scene;
-    private ComboBox<String> comboBox;
-
-    /**
-     * Verify failing test from bug report example.
-     */
-    @Ignore
-    @Test
-    public void testFireComboEditorFailing() {
-        showAndFocus(comboBox);
-        List<KeyEvent> keys = new ArrayList<>();
-        comboBox.getEditor().addEventFilter(KEY_PRESSED, keys::add);
-        KeyEventFirer keyboard = new KeyEventFirer(comboBox.getEditor(), scene);
-        keyboard.doKeyPress(ENTER);
-        assertEquals("pressed ENTER filter on editor", 1, keys.size());
-    }
-
-    /**
-     * False-green from bug report example.
-     */
-    @Ignore
-    @Test
-    public void testFireComboEditorFalseGreen() {
-        showAndFocus(comboBox);
-        List<KeyEvent> keys = new ArrayList<>();
-        comboBox.getEditor().addEventFilter(KEY_PRESSED, keys::add);
-        KeyEventFirer keyboard = new KeyEventFirer(comboBox.getEditor());
-        keyboard.doKeyPress(ENTER);
-        assertEquals("pressed ENTER filter on editor", 1, keys.size());
-        fail("false green by firing directly on target which is not focusOwner");
-    }
-
-    /**
-     * Test that keyEvent is delivered to focused control and nowhere else.
-     * Here we fire directly onto the scene - and see a different outcome from
-     * using scene.process: the events are delivered to the scene only, not
-     * the focused node.
-     */
-    @Ignore
-    @Test
-    public void testFireSceneAsTarget() {
-        showAndFocus(button);
-        List<KeyEvent> buttonEvents = new ArrayList<>();
-        button.addEventHandler(KEY_PRESSED, buttonEvents::add);
-        List<KeyEvent> textFieldEvents = new ArrayList<>();
-        textField.addEventHandler(KEY_PRESSED, textFieldEvents::add);
-        KeyEventFirer firer = new KeyEventFirer(scene);
-        firer.doKeyPress(A);
-        assertEquals("button must have received the key", 1, buttonEvents.size());
-        assertEquals("textField must not have received the key", 0, textFieldEvents.size());
-    }
 
     /**
      * Test that keyEvent is delivered to focused control and nowhere else.
@@ -150,7 +93,6 @@ public class KeyEventFirerTest {
      * This simulates a false positive: even though not focused, the textField handlers
      * are notified when firing directly. That's possible, but typically not what we want to test!
      */
-    @Ignore
     @Test
     public void testFireTargetFalseGreen() {
         showAndFocus(button);
@@ -158,11 +100,20 @@ public class KeyEventFirerTest {
         button.addEventHandler(KEY_PRESSED, buttonEvents::add);
         List<KeyEvent> textFieldEvents = new ArrayList<>();
         textField.addEventHandler(KEY_PRESSED, textFieldEvents::add);
-        KeyEventFirer firer = new KeyEventFirer(textField);
-        firer.doKeyPress(A);
-        assertEquals("textField must have received the key", 1, textFieldEvents.size());
-        assertEquals("button must have received the key", 0, buttonEvents.size());
-        fail("false green by firing directly on target which is not focusOwner");
+        // firing on a node that is not focusOwner
+        KeyEventFirer incorrectFirer = new KeyEventFirer(textField);
+        incorrectFirer.doKeyPress(A);
+        int falseTextFieldNotification = textFieldEvents.size();
+        int falseButtonNotification = buttonEvents.size();
+        assertEquals("false green - textField must have received the key", 1, textFieldEvents.size());
+        assertEquals("false green - button must not have received the key", 0, buttonEvents.size());
+        textFieldEvents.clear();
+        buttonEvents.clear();
+        // firing on the scene makes a difference
+        KeyEventFirer correctFirer = new KeyEventFirer(null, scene);
+        correctFirer.doKeyPress(A);
+        assertNotEquals(falseTextFieldNotification, textFieldEvents.size());
+        assertNotEquals(falseButtonNotification, buttonEvents.size());
     }
 
     @Test (expected= NullPointerException.class)
@@ -181,7 +132,7 @@ public class KeyEventFirerTest {
      */
     @Test
     public void testUIState() {
-        assertEquals(List.of(button, textField, comboBox), root.getChildren());
+        assertEquals(List.of(button, textField), root.getChildren());
         stage.show();
         stage.requestFocus();
         button.requestFocus();
@@ -201,20 +152,13 @@ public class KeyEventFirerTest {
 
     @Before
     public void setup() {
-        // This step is not needed (Just to make sure StubToolkit is loaded into VM)
-        // @SuppressWarnings("unused")
-        // Toolkit tk = (StubToolkit)Toolkit.getToolkit();
         root = new VBox();
         scene = new Scene(root);
         stage = new Stage();
         stage.setScene(scene);
         button = new Button("I'm a button");
         textField = new TextField("some text");
-        // to test the false-green example in the bug report
-        comboBox = new ComboBox<>();
-        comboBox.getItems().addAll("Test", "hello", "world");
-        comboBox.setEditable(true);
-        root.getChildren().addAll(button, textField, comboBox);
+        root.getChildren().addAll(button, textField);
     }
 
     @After


### PR DESCRIPTION
The issue is that firing keyEvents on a node that is not focusOwner might produce false green tests, please see the issue for details.

fix for https://bugs.openjdk.java.net/browse/JDK-8231692
- added contructor taking the scene
- changed event firing to use either the target directly or inject into
scene
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8231692](https://bugs.openjdk.java.net/browse/JDK-8231692): Test Infrastructure: enhance KeyEventFirer to inject keyEvents into scene


## Approvers
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)