### PR TITLE
8232929: Duplicate symbols when building static libraries

### DIFF
--- a/modules/javafx.graphics/src/main/native-prism-sw/JNIUtil.c
+++ b/modules/javafx.graphics/src/main/native-prism-sw/JNIUtil.c
@@ -49,7 +49,7 @@ initializeFieldIds(jfieldID* dest, JNIEnv* env, jclass classHandle,
     while (fields->name != NULL) {
         *dest = (*env)->GetFieldID(env, classHandle, fields->name,
                                    fields->signature);
-        checkAndClearException(env);
+        prismsw_checkAndClearException(env);
         if (*dest == NULL) {
             retVal = JNI_FALSE;
             break;
@@ -69,7 +69,7 @@ initializeStaticFieldIds(jfieldID* dest, JNIEnv* env, jclass classHandle,
     while (fields->name != NULL) {
         *dest = (*env)->GetStaticFieldID(env, classHandle, fields->name,
                                          fields->signature);
-        checkAndClearException(env);
+        prismsw_checkAndClearException(env);
         if (*dest == NULL) {
             retVal = JNI_FALSE;
             break;
@@ -99,7 +99,7 @@ JNI_ThrowNew(JNIEnv* env, const char* throwable, const char* message) {
 }
 
 jboolean
-checkAndClearException(JNIEnv *env) {
+prismsw_checkAndClearException(JNIEnv *env) {
     if (!(*env)->ExceptionCheck(env)) {
         return JNI_FALSE;
     }

--- a/modules/javafx.graphics/src/main/native-prism-sw/JNIUtil.h
+++ b/modules/javafx.graphics/src/main/native-prism-sw/JNIUtil.h
@@ -43,6 +43,6 @@ jboolean initializeStaticFieldIds(jfieldID* dest, JNIEnv* env,
 
 void JNI_ThrowNew(JNIEnv* env, const char* throwable, const char* message);
 
-jboolean checkAndClearException(JNIEnv *env);
+jboolean prismsw_checkAndClearException(JNIEnv *env);
 
 #endif

--- a/modules/javafx.graphics/src/main/native-prism-sw/JPiscesRenderer.c
+++ b/modules/javafx.graphics/src/main/native-prism-sw/JPiscesRenderer.c
@@ -332,7 +332,7 @@ initializeObjectFieldIds(JNIEnv *env,
         classHandle = (*env)->GetObjectClass(env, objectHandle);
     } else if (className != 0) {
         classHandle = (*env)->FindClass(env, className);
-        if (checkAndClearException(env)) return JNI_FALSE;
+        if (prismsw_checkAndClearException(env)) return JNI_FALSE;
     } else {
         return JNI_FALSE;
     }


### PR DESCRIPTION
This PR only affects native code in the prism-sw pipeline.

JBS issue: https://bugs.openjdk.java.net/browse/JDK-8232929
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8232929](https://bugs.openjdk.java.net/browse/JDK-8232929): Duplicate symbols when building static libraries


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)