### PR TITLE
8240969: WebView does not allow to load style sheet in modularized applications

### DIFF
--- a/modules/javafx.web/src/main/java/javafx/scene/web/WebEngine.java
+++ b/modules/javafx.web/src/main/java/javafx/scene/web/WebEngine.java
@@ -491,7 +491,7 @@ final public class WebEngine {
      * Location of the user stylesheet as a string URL.
      *
      * <p>This should be a local URL, i.e. either {@code 'data:'},
-     * {@code 'file:'}, or {@code 'jar:'}. Remote URLs are not allowed
+     * {@code 'file:'}, {@code 'jar:'}, or {@code 'jrt:'}. Remote URLs are not allowed
      * for security reasons.
      *
      * @defaultValue null
@@ -554,6 +554,7 @@ final public class WebEngine {
                         dataUrl = url;
                     } else if (url.startsWith("file:") ||
                                url.startsWith("jar:")  ||
+                               url.startsWith("jrt:")  ||
                                url.startsWith("data:"))
                     {
                         try {

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
@@ -474,7 +474,17 @@ public class MiscellaneousTest extends TestBase {
         });
     }
 
-    @Test public void loadJrtCssFileSuccessfully() {
-        getEngine().setUserStyleSheetLocation("jrt:/javafx.web/html/imported-styles.css");
+    @Test public void jrtCssFileIsNotRejected() {
+        submit(() -> {
+            try {
+                getEngine().setUserStyleSheetLocation("jrt:/javafx.web/html/imported-styles.css");
+            } catch (IllegalArgumentException e) {
+                // A jrt file is supposed to be a valid argument
+                throw new AssertionError(e);
+            } catch (RuntimeException e) {
+                // The css file cannot be loaded in the tests (since they are not modularized).
+                // We thus simply ignore this exception here
+            }
+        });
     }
 }

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
@@ -473,7 +473,7 @@ public class MiscellaneousTest extends TestBase {
             assertNull(getEngine().executeScript("window.xmlDoc.body"));
         });
     }
-    
+
     @Test public void loadJrtCssFileSuccessfully() {
         getEngine().setUserStyleSheetLocation("jrt:/javafx.web/html/imported-styles.css");
     }

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
@@ -473,4 +473,8 @@ public class MiscellaneousTest extends TestBase {
             assertNull(getEngine().executeScript("window.xmlDoc.body"));
         });
     }
+    
+    @Test public void loadJrtCssFileSuccessfully() {
+        getEngine().setUserStyleSheetLocation("jrt:/javafx.web/html/imported-styles.css");
+    }
 }


### PR DESCRIPTION
Currently, loading a style sheet file using `WebView.getEngine().setUserStyleSheetLocation(url)` fails if the url start's with `jrt`, i.e. if the file is packaged in an application image using jlink. This is fixed with this PR.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240969](https://bugs.openjdk.java.net/browse/JDK-8240969): WebView does not allow to load style sheet in modularized applications


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Arun Joseph ([ajoseph](@arun-Joseph) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/22/head:pull/22`
`$ git checkout pull/22`
