### PR TITLE
8232943: Gesture support is not initialized on iOS

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassViewDelegate.m
@@ -31,6 +31,7 @@
 #import "com_sun_glass_events_TouchEvent.h"
 
 #import "GlassStatics.h"
+#import "GlassHelper.h"
 #import "GlassMacros.h"
 #import "GlassWindow.h"
 
@@ -382,7 +383,7 @@ static jint getTouchStateFromPhase(int phase)
 
         // Ensure JNI stuff related to gesture processing is ready
         if (NULL == jGestureSupportClass) {
-            (*env)->FindClass(env, "com/sun/glass/ui/ios/IosGestureSupport");
+            [GlassHelper ClassForName:"com.sun.glass.ui.ios.IosGestureSupport" withEnv:env];
         }
         self.touches = NULL;
         self.lastTouchId = 0;


### PR DESCRIPTION
This PR only affects iOS native code.

JBS issue: https://bugs.openjdk.java.net/browse/JDK-8232943

Since the `IosGestureSupport` class is only instantiated from the native side, the proposal is to change in `ios/GlassViewDelegate.m` the use of `FindClass` in favor of `[GlassHelper ClassForName]`, in the same way as it is done in [`mac/GlassViewDelegate.m`](https://github.com/openjdk/jfx/blob/master/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m#L614) to instantiate `MacGestureSupport`.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8232943](https://bugs.openjdk.java.net/browse/JDK-8232943): Gesture support is not initialized on iOS


## Approvers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)