### PR TITLE
8189092: ArrayIndexOutOfBoundsException on Linux in getCachedGlyph

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/CompositeGlyphMapper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/CompositeGlyphMapper.java
@@ -92,6 +92,9 @@ public class CompositeGlyphMapper extends CharToGlyphMapper {
 
     private final int convertToGlyph(int unicode) {
         for (int slot = 0; slot < font.getNumSlots(); slot++) {
+            if (slot >= 255) { // not supposed to happen.
+                return missingGlyph;
+            }
             CharToGlyphMapper mapper = getSlotMapper(slot);
             int glyphCode = mapper.charToGlyph(unicode);
             if (glyphCode != mapper.getMissingGlyphCode()) {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/GlyphCache.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/GlyphCache.java
@@ -69,6 +69,7 @@ public class GlyphCache {
     // segmented arrays are in blocks of 32 glyphs.
     private static final int SEGSHIFT = 5;
     private static final int SEGSIZE  = 1 << SEGSHIFT;
+    private static final int SEGMASK  = SEGSIZE - 1;
     HashMap<Integer, GlyphData[]>
         glyphDataMap = new HashMap<Integer, GlyphData[]>();
 
@@ -238,8 +239,8 @@ public class GlyphCache {
     }
 
     private GlyphData getCachedGlyph(int glyphCode, int subPixel) {
-        int segIndex = glyphCode >> SEGSHIFT;
-        int subIndex = glyphCode % SEGSIZE;
+        int segIndex = glyphCode >>> SEGSHIFT;
+        int subIndex = glyphCode & SEGMASK;
         segIndex |= (subPixel << SUBPIXEL_SHIFT);
         GlyphData[] segment = glyphDataMap.get(segIndex);
         if (segment != null) {

--- a/modules/javafx.graphics/src/main/native-font/fontpath_linux.c
+++ b/modules/javafx.graphics/src/main/native-font/fontpath_linux.c
@@ -461,7 +461,7 @@ Java_com_sun_javafx_font_FontConfigManager_getFontConfig
                 /* Upstream Java code currently stores this in a byte;
                  * And we need one slot free for when this sequence is
                  * used as a fallback sequeunce.
-                 */ 
+                 */
                 break;
             }
         }

--- a/modules/javafx.graphics/src/main/native-font/fontpath_linux.c
+++ b/modules/javafx.graphics/src/main/native-font/fontpath_linux.c
@@ -402,10 +402,11 @@ Java_com_sun_javafx_font_FontConfigManager_getFontConfig
         }
         fontCount = 0;
         minGlyphs = 20;
+        FcCharSet *unionCharset = NULL;
         for (j=0; j<nfonts; j++) {
             FcPattern *fontPattern = fontset->fonts[j];
             FcChar8 *fontformat;
-            FcCharSet *unionCharset = NULL, *charset;
+            FcCharSet *charset;
 
             fontformat = NULL;
             (*FcPatternGetString)(fontPattern, FC_FONTFORMAT, 0, &fontformat);
@@ -454,6 +455,13 @@ Java_com_sun_javafx_font_FontConfigManager_getFontConfig
             (*FcPatternGetString)(fontPattern, FC_STYLE, 0, &styleStr[j]);
             (*FcPatternGetString)(fontPattern, FC_FULLNAME, 0, &fullname[j]);
             if (!includeFallbacks) {
+                break;
+            }
+            if (fontCount == 254) {
+                /* Upstream Java code currently stores this in a byte;
+                 * And we need one slot free for when this sequence is
+                 * used as a fallback sequeunce.
+                 */ 
                 break;
             }
         }


### PR DESCRIPTION
I have added an evaluation in https://bugs.openjdk.java.net/browse/JDK-8207839
Please read that for more detail, but basically we are not properly preventing or
handling cases where fontconfig causes us to overflow the byte storage used
for a font "slot".
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8189092](https://bugs.openjdk.java.net/browse/JDK-8189092): ArrayIndexOutOfBoundsException on Linux in getCachedGlyph


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)