### PR TITLE
8233040: ComboBoxPopupControl: remove eventFilter for F4

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxPopupControl.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxPopupControl.java
@@ -562,12 +562,6 @@ public abstract class ComboBoxPopupControl<T> extends ComboBoxBaseSkin<T> {
             } else if (textField != null) {
                 textField.fireEvent(ke);
             }
-        } else if (ke.getCode() == KeyCode.F4) {
-            if (ke.getEventType() == KeyEvent.KEY_RELEASED) {
-                if (comboBoxBase.isShowing()) comboBoxBase.hide();
-                else comboBoxBase.show();
-            }
-            ke.consume(); // we always do a consume here (otherwise unit tests fail)
         } else if (ke.getCode() == KeyCode.F10 || ke.getCode() == KeyCode.ESCAPE) {
             // RT-23275: The TextField fires F10 and ESCAPE key events
             // up to the parent, which are then fired back at the

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxPopupControl.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxPopupControl.java
@@ -549,7 +549,7 @@ public abstract class ComboBoxPopupControl<T> extends ComboBoxBaseSkin<T> {
     }
 
     private void handleKeyEvent(KeyEvent ke, boolean doConsume) {
-        // When the user hits the enter or F4 keys, we respond before
+        // When the user hits the enter key, we respond before
         // ever giving the event to the TextField.
         if (ke.getCode() == KeyCode.ENTER) {
             if (ke.isConsumed() || ke.getEventType() != KeyEvent.KEY_RELEASED) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboSpecialKeyTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboSpecialKeyTest.java
@@ -1,0 +1,153 @@
+/*
+ * Created on 30.10.2019
+ *
+ */
+package test.javafx.scene.control;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import com.sun.javafx.tk.Toolkit;
+
+import static javafx.scene.input.KeyCode.*;
+import static javafx.scene.input.KeyEvent.*;
+import static org.junit.Assert.*;
+
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.ColorPicker;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.ComboBoxBase;
+import javafx.scene.control.DatePicker;
+import javafx.scene.control.skin.ComboBoxPopupControl;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import test.com.sun.javafx.pgstub.StubToolkit;
+import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
+
+/**
+ * Test for https://bugs.openjdk.java.net/browse/JDK-8233040 - F4
+ * must not be consumed by EventFilter in ComboBoxPopupControl.
+ * <p>
+ * Parameterized in concrete sub of ComboBoxBase and editable.
+ */
+@RunWith(Parameterized.class)
+public class ComboSpecialKeyTest {
+
+    private Toolkit tk;
+    private Scene scene;
+    private Stage stage;
+    private Pane root;
+
+    private ComboBoxBase comboBox;
+    private Supplier<ComboBoxBase> comboFactory;
+    private boolean editable;
+
+    @Test
+    public void testF4TogglePopup() {
+        showAndFocus();
+        comboBox.setEditable(editable);
+        assertFalse(comboBox.isShowing());
+        KeyEventFirer firer = new KeyEventFirer(comboBox);
+        firer.doKeyPress(F4);
+        assertTrue(failPrefix(), comboBox.isShowing());
+        firer.doKeyPress(F4);
+        assertFalse(failPrefix(), comboBox.isShowing());
+    }
+
+    @Test
+    public void testF4ConsumeFilterNotTogglePopup() {
+        showAndFocus();
+        comboBox.setEditable(editable);
+        List<KeyEvent> events = new ArrayList<>();
+        comboBox.addEventFilter(KEY_RELEASED, e -> {
+            if (e.getCode() == F4) {
+                events.add(e);
+                e.consume();
+            }
+        });
+        KeyEventFirer firer = new KeyEventFirer(comboBox);
+        firer.doKeyPress(F4);
+        assertFalse(failPrefix() + ": popup must not be showing", comboBox.isShowing());
+    }
+
+    protected String failPrefix() {
+        String failPrefix = comboBox.getClass().getSimpleName() + " editable " + editable;
+        return failPrefix;
+    }
+
+//---------------- parameterized
+
+    // Note: name property not supported before junit 4.11
+    @Parameterized.Parameters//(name = "{index}: editable {1} ")
+    public static Collection<Object[]> data() {
+        // Supplier for type of ComboBoxBase to test, editable
+        Object[][] data = new Object[][] {
+            {(Supplier)ComboBox::new, false},
+            {(Supplier)ComboBox::new, true },
+            {(Supplier)DatePicker::new, false },
+            {(Supplier)DatePicker::new, true},
+            {(Supplier)ColorPicker::new, false },
+        };
+        return Arrays.asList(data);
+    }
+
+    public ComboSpecialKeyTest(Supplier<ComboBoxBase> factory, boolean editable) {
+        this.comboFactory = factory;
+        this.editable = editable;
+    }
+
+// --- initial and setup
+
+    @Test
+    public void testInitialState() {
+        assertNotNull(comboBox);
+        showAndFocus();
+        List<Node> expected = List.of(comboBox);
+        assertEquals(expected, root.getChildren());
+    }
+
+     protected void showAndFocus() {
+        showAndFocus(comboBox);
+    }
+
+    protected void showAndFocus(Node control) {
+        stage.show();
+        stage.requestFocus();
+        control.requestFocus();
+        assertTrue(control.isFocused());
+        assertSame(control, scene.getFocusOwner());
+    }
+
+    @After
+    public void cleanup() {
+        stage.hide();
+    }
+
+    @Before
+    public void setup() {
+        ComboBoxPopupControl c;
+        // This step is not needed (Just to make sure StubToolkit is
+        // loaded into VM)
+        tk = (StubToolkit) Toolkit.getToolkit();
+        root = new VBox();
+        scene = new Scene(root);
+        stage = new Stage();
+        stage.setScene(scene);
+        comboBox = comboFactory.get();
+        root.getChildren().addAll(comboBox);
+    }
+
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboSpecialKeyTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboSpecialKeyTest.java
@@ -1,7 +1,28 @@
 /*
- * Created on 30.10.2019
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
  */
+
 package test.javafx.scene.control;
 
 import java.util.ArrayList;


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8233040

The issue is that the eventFilter in CBPC uses F4 for toggling the popup _and_ consumes it. This prevents client code to register there own filter. 

The fix was to remove the block entirely - F4 is already handled by a keyMapping in ComboBoxBehaviorBase. Added test that fails before the change and passes after, old tests are all passing.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8233040](https://bugs.openjdk.java.net/browse/JDK-8233040): ComboBoxPopupControl: remove eventFilter for F4


## Approvers
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)