### PR TITLE
8233338: FX javadoc headings are out of sequence

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/beans/binding/package.html
+++ b/modules/javafx.base/src/main/java/javafx/beans/binding/package.html
@@ -35,7 +35,7 @@
 <body>
     <p>Provides classes that create and operate on a {@link Binding Binding}
         that calculates a value that depends on one or more sources.</p>
-	<h1>Characteristics of Bindings</h1>
+	<h2>Characteristics of Bindings</h2>
 	<p>Bindings are assembled from one or more sources, usually called
 		their dependencies. A binding observes its dependencies for changes
 		and updates its own value according to changes in the dependencies.</p>
@@ -51,7 +51,7 @@
 		That means, if a dependency changes, the result of a binding is not
 		immediately recalculated, but it is marked as invalid. Next time the
 		value of an invalid binding is requested, it is recalculated.</p>
-	<h1>High Level API and Low Level API</h1>
+	<h2>High Level API and Low Level API</h2>
 	<p>The Binding API is roughly divided in two parts, the High Level
 		Binding API and the Low Level Binding API. The High Level Binding API
 		allows to construct simple bindings in an easy to use fashion.

--- a/modules/javafx.base/src/main/java/javafx/beans/property/package.html
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/package.html
@@ -36,7 +36,7 @@
 	<p>The package {@code javafx.beans.property} defines read-only
 		properties and writable properties, plus a number of implementations.
 	</p>
-	<h1>Read-only Properties</h1>
+	<h2>Read-only Properties</h2>
 	<p>Read-only properties have two getters, {@code get()} returns the
 		primitive value, {@code getValue()} returns the boxed value.</p>
 	<p>It is possible to observe read-only properties for changes. They
@@ -47,7 +47,7 @@
 		getBean()} and {@code getName()} are defined. They return the
 		containing bean and the name of a property.</p>
 
-	<h1>Writable Properties</h1>
+	<h2>Writable Properties</h2>
 	<p>In addition to the functionality defined for read-only
 		properties, writable properties contain the following methods.</p>
 	<p>A writable property defines two setters in addition to the

--- a/modules/javafx.base/src/main/java/javafx/beans/value/package.html
+++ b/modules/javafx.base/src/main/java/javafx/beans/value/package.html
@@ -37,7 +37,7 @@
 		fundamental interfaces {@link javafx.beans.value.ObservableValue} and {@link
 		javafx.beans.value.WritableValue} and all of its sub-interfaces.</p>
 
-	<h1>ObservableValue</h1>
+	<h2>ObservableValue</h2>
 	An ObservableValue wraps a value that can be read and observed for
 	invalidations and changes. Listeners have to implement either {@link
 	javafx.beans.InvalidationListener} or {@link javafx.beans.value.ChangeListener}. To allow
@@ -83,7 +83,7 @@
 		</tr>
 	</table>
 
-	<h1>WritableValue</h1>
+	<h2>WritableValue</h2>
 	A WritableValue wraps a value that can be read and set. As with {@code
 	ObservableValues}, a number of sub-interfaces are defined to work with
 	primitive types directly.

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ButtonBar.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ButtonBar.java
@@ -52,7 +52,7 @@ import java.util.Map;
  * annotations, as well as the overarching
  * {@link #buttonOrderProperty() button order} specified for the ButtonBar.
  *
- * <h3>Uniform button sizing</h3>
+ * <h2>Uniform button sizing</h2>
  * <p>By default all buttons are uniformly sized in a ButtonBar, meaning that all
  * buttons take the width of the widest button. It is possible to opt-out of this
  * on a per-button basis, but calling the {@link #setButtonUniformSize(Node, boolean)} method with
@@ -63,7 +63,7 @@ import java.util.Map;
  * measuring process, so its size will not influence the maximum size calculated
  * for all buttons in the ButtonBar.
  *
- * <h3>Screenshots</h3>
+ * <h2>Screenshots</h2>
  * <p>Because a ButtonBar comes with built-in support for Windows, Mac OS
  * and Linux, there are three screenshots shown below, with the same buttons
  * laid out on each of the three operating systems.
@@ -73,7 +73,7 @@ import java.util.Map;
  * <strong>Mac OS:</strong><p><img src="doc-files/buttonBar-mac.png" alt=""></p>
  * <strong>Linux:</strong><p><img src="doc-files/buttonBar-linux.png" alt=""></p>
  *
- * <h3>Code Samples</h3>
+ * <h2>Code Samples</h2>
  * <p>Instantiating and using the ButtonBar is simple, simply do the following:
  *
  * <pre>

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/Cell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/Cell.java
@@ -187,7 +187,7 @@ import javafx.css.StyleableProperty;
  * }
  * </pre>
  *
- * <h3>Key Design Goals</h3>
+ * <h2>Key Design Goals</h2>
  * <ul>
  *   <li>Both time and memory efficient for large data sets</li>
  *   <li>Easy to build and use libraries for custom cells</li>
@@ -198,7 +198,7 @@ import javafx.css.StyleableProperty;
  *   <li>Easy to animate the cell size or other properties</li>
  * </ul>
  *
- * <h3>Key Use Cases</h3>
+ * <h2>Key Use Cases</h2>
  * Following are a number of key use cases used to drive the Cell API design,
  * along with code examples showing how those use cases are satisfied by this
  * API. This is by no means to be considered the definitive list of capabilities
@@ -262,7 +262,7 @@ import javafx.css.StyleableProperty;
  *   -fx-text-fill: red;
  * }</pre>
  *
- * <h3>Editing</h3>
+ * <h2>Editing</h2>
  * <p>Most virtualized controls that use the Cell architecture (e.g. {@link ListView},
  * {@link TreeView}, {@link TableView} and {@link TreeTableView}) all support
  * the notion of editing values directly via the cell. You can learn more about

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBox.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBox.java
@@ -123,7 +123,7 @@ import java.lang.ref.WeakReference;
  * a different type is specified and the ComboBox is to be editable, it is
  * necessary to specify a custom {@link StringConverter}.
  *
- * <h3>A warning about inserting Nodes into the ComboBox items list</h3>
+ * <h2>A warning about inserting Nodes into the ComboBox items list</h2>
  * ComboBox allows for the items list to contain elements of any type, including
  * {@link Node} instances. Putting nodes into
  * the items list is <strong>strongly not recommended</strong>. This is because

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/Dialog.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/Dialog.java
@@ -152,7 +152,7 @@ import com.sun.javafx.tk.Toolkit;
  * the above is to help introduce developers to the {@link Optional} API, which
  * is new in Java 8 and may be foreign to many developers.
  *
- * <h3>Dialog Validation / Intercepting Button Actions</h3>
+ * <h2>Dialog Validation / Intercepting Button Actions</h2>
  *
  * <p>In some circumstances it is desirable to prevent a dialog from closing
  * until some aspect of the dialog becomes internally consistent (e.g. a form
@@ -175,7 +175,7 @@ import com.sun.javafx.tk.Toolkit;
  *     }
  * });}</pre>
  *
- * <h3>Dialog Closing Rules</h3>
+ * <h2>Dialog Closing Rules</h2>
  *
  * <p>It is important to understand what happens when a Dialog is closed, and
  * also how a Dialog can be closed, especially in abnormal closing situations

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListView.java
@@ -88,7 +88,7 @@ import javafx.util.Pair;
  * making use of ListView, as all modern IDEs are able to auto-complete far
  * more successfully with the additional type information.
  *
- * <h3>Populating a ListView</h3>
+ * <h2>Populating a ListView</h2>
  * <p>A simple example of how to create and populate a ListView of names (Strings)
  * is shown here:
  *
@@ -122,7 +122,7 @@ import javafx.util.Pair;
  * copied into the items list - meaning that subsequent changes to the content
  * list are not observed, and will not be reflected visually within the ListView.
  *
- * <h3>ListView Selection / Focus APIs</h3>
+ * <h2>ListView Selection / Focus APIs</h2>
  * <p>To track selection and focus, it is necessary to become familiar with the
  * {@link SelectionModel} and {@link FocusModel} classes. A ListView has at most
  * one instance of each of these classes, available from
@@ -142,14 +142,14 @@ import javafx.util.Pair;
  *
  * <pre> {@code listView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);}</pre>
  *
- * <h3>Customizing ListView Visuals</h3>
+ * <h2>Customizing ListView Visuals</h2>
  * <p>The visuals of the ListView can be entirely customized by replacing the
  * default {@link #cellFactoryProperty() cell factory}. A cell factory is used to
  * generate {@link ListCell} instances, which are used to represent an item in the
  * ListView. See the {@link Cell} class documentation for a more complete
  * description of how to write custom Cells.
  *
- * <h3>Editing</h3>
+ * <h2>Editing</h2>
  * <p>This control supports inline editing of values, and this section attempts to
  * give an overview of the available APIs and how you should use them.</p>
  *

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/Pagination.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/Pagination.java
@@ -51,7 +51,7 @@ import javafx.scene.control.skin.PaginationSkin;
  * which has been divided into smaller parts.
  * </p>
  *
- * <h3>Styling the page indicators</h3>
+ * <h2>Styling the page indicators</h2>
  * <p>
  * The control can be customized to display numeric page indicators or bullet style indicators by
  * setting the style class {@link #STYLE_CLASS_BULLET}.  The
@@ -60,14 +60,14 @@ import javafx.scene.control.skin.PaginationSkin;
  * via CSS using -fx-max-page-indicator-count.
  *</p>
  *
- * <h3>Page count</h3>
+ * <h2>Page count</h2>
  * <p>
  * The {@link #pageCountProperty() pageCountProperty} controls the number of
  * pages this pagination control has.  If the page count is
  * not known {@link #INDETERMINATE} should be used as the page count.
  * </p>
  *
- * <h3>Page factory</h3>
+ * <h2>Page factory</h2>
  * <p>
  * The {@link #pageFactoryProperty() pageFactoryProperty} is a callback function
  * that is called when a page has been selected by the application or
@@ -76,7 +76,7 @@ import javafx.scene.control.skin.PaginationSkin;
  * Null should be returned if the selected page index does not exist.
  * </p>
  *
- * <h3>Creating a Pagination control:</h3>
+ * <h2>Creating a Pagination control:</h2>
  * <p>
  * A simple example of how to create a pagination control with ten pages and
  * each page containing text.

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeView.java
@@ -99,7 +99,7 @@ import java.util.Map;
  * nodes of the root node are shown. By default, the root node is shown in the
  * TreeView.
  *
- * <h3>TreeView Selection / Focus APIs</h3>
+ * <h2>TreeView Selection / Focus APIs</h2>
  * <p>To track selection and focus, it is necessary to become familiar with the
  * {@link SelectionModel} and {@link FocusModel} classes. A TreeView has at most
  * one instance of each of these classes, available from
@@ -119,14 +119,14 @@ import java.util.Map;
  *
  * <pre> {@code treeView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);}</pre>
  *
- * <h3>Customizing TreeView Visuals</h3>
+ * <h2>Customizing TreeView Visuals</h2>
  * <p>The visuals of the TreeView can be entirely customized by replacing the
  * default {@link #cellFactoryProperty() cell factory}. A cell factory is used to
  * generate {@link TreeCell} instances, which are used to represent an item in the
  * TreeView. See the {@link Cell} class documentation for a more complete
  * description of how to write custom Cells.
  *
- * <h3>Editing</h3>
+ * <h2>Editing</h2>
  * <p>This control supports inline editing of values, and this section attempts to
  * give an overview of the available APIs and how you should use them.</p>
  *

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -225,7 +225,7 @@ import com.sun.javafx.logging.PlatformLogger.Level;
  * an UnsupportedOperationException being thrown.
  * </p>
  *
- * <h3>String ID</h3>
+ * <h2>String ID</h2>
  * <p>
  * Each node in the scene graph can be given a unique {@link #idProperty id}. This id is
  * much like the "id" attribute of an HTML tag in that it is up to the designer
@@ -235,7 +235,7 @@ import com.sun.javafx.logging.PlatformLogger.Level;
  * scene graph. The id can also be used identify nodes for applying styles; see
  * the CSS section below.
  *
- * <h3>Coordinate System</h3>
+ * <h2>Coordinate System</h2>
  * <p>
  * The {@code Node} class defines a traditional computer graphics "local"
  * coordinate system in which the {@code x} axis increases to the right and the
@@ -268,7 +268,7 @@ import com.sun.javafx.logging.PlatformLogger.Level;
  * important context-specific information about coordinate mapping and how
  * it can affect rendering.
  *
- * <h3>Transformations</h3>
+ * <h2>Transformations</h2>
  * <p>
  * Any {@code Node} can have transformations applied to it. These include
  * translation, rotation, scaling, or shearing.
@@ -325,7 +325,7 @@ import com.sun.javafx.logging.PlatformLogger.Level;
  * chain of transforms.  The order in which the transforms are applied is
  * defined by the ObservableList specified in the {@link #getTransforms transforms} variable.
  *
- * <h3>Bounding Rectangles</h3>
+ * <h2>Bounding Rectangles</h2>
  * <p>
  * Since every {@code Node} has transformations, every Node's geometric
  * bounding rectangle can be described differently depending on whether
@@ -381,7 +381,7 @@ import com.sun.javafx.logging.PlatformLogger.Level;
  * respective bounds"> </p>
  *
  *
- * <h3>CSS</h3>
+ * <h2>CSS</h2>
  * <p>
  * The {@code Node} class contains {@code id}, {@code styleClass}, and
  * {@code style} variables that are used in styling this node from

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/DragEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/DragEvent.java
@@ -51,7 +51,7 @@ import java.io.IOException;
  * Drag entered/exited events behave similarly to mouse entered/exited
  * events, please see {@code MouseEvent} overview.
  *
- * <h3>Drag sources: initiating a drag and drop gesture</h3>
+ * <h2>Drag sources: initiating a drag and drop gesture</h2>
  *
  * When a drag gesture is detected, an application can decide whether to
  * start a drag and drop gesture or continue with a press-drag-release gesture.
@@ -95,7 +95,7 @@ rect.setOnDragDetected(new EventHandler&lt;MouseEvent&gt;() {
 });
  * </pre>
  *
- * <br><h3>Potential drop targets</h3>
+ * <br><h2>Potential drop targets</h2>
  *
  * <p>
  * After the drag and drop gesture has been started, any object
@@ -183,7 +183,7 @@ rect.setOnDragDropped(new EventHandler&lt;DragEvent&gt;() {
 });
  * </pre>
  *
- * <h3>Drag sources: finalizing drag and drop gesture</h3>
+ * <h2>Drag sources: finalizing drag and drop gesture</h2>
  *
  * <p>
  * After the gesture has been finished, whether by successful or unsuccessful

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/MouseEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/MouseEvent.java
@@ -49,7 +49,7 @@ import java.io.IOException;
  * screenX,screenY - relative to origin of the screen that
  * contains the mouse pointer.
  *
- * <h3>Dragging gestures</h3>
+ * <h2>Dragging gestures</h2>
  * <p>
  * There are three types of dragging gestures. They are all initiated by
  * a mouse press event and terminated as a result of a mouse released
@@ -94,7 +94,7 @@ import java.io.IOException;
  * {@code isSynthesized()} method may be used to detect the problem and make the
  * dragging handlers behave accordingly.
  *
- * <h3>Mouse enter/exit handling</h3>
+ * <h2>Mouse enter/exit handling</h2>
  * <p>
  * When mouse enters a node, the node gets {@code MOUSE_ENTERED} event, when
  * it leaves, it gets {@code MOUSE_EXITED} event. These events are delivered
@@ -122,7 +122,7 @@ import java.io.IOException;
  * {@code MOUSE_ENTERED_TARGET} event handler will receive the
  * {@code MOUSE_ENTERED} event on target.
  *
- * <h3>Notes</h3>
+ * <h2>Notes</h2>
  * <ul>
  *   <li>For triggering context menus see the {@link ContextMenuEvent}.</li>
  * </ul>

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/AnchorPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/AnchorPane.java
@@ -42,7 +42,7 @@ import javafx.scene.Node;
  * AnchorPanes may be styled with backgrounds and borders using CSS.  See
  * {@link javafx.scene.layout.Region Region} superclass for details.</p>
  *
- * <h3>Anchor Constraints</h3>
+ * <h2>Anchor Constraints</h2>
  * <p>
  * The application sets anchor constraints on each child to configure the anchors
  * on one or more sides.  If a child is anchored on opposite sides (and is resizable), the
@@ -75,7 +75,7 @@ import javafx.scene.Node;
  *     anchorPane.getChildren().addAll(list, button);
  * </code></pre>
  *
- * <h3>Resizable Range</h3>
+ * <h2>Resizable Range</h2>
  * <p>
  * An anchor pane's parent will resize the anchor pane within the anchor pane's resizable range
  * during layout.   By default the anchor pane computes this range based on its content

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/BorderPane.java
@@ -82,7 +82,7 @@ import static javafx.scene.layout.Region.positionInArea;
  * BorderPane lays out each child set in the five positions regardless of the child's
  * visible property value; unmanaged children are ignored.</p>
  *
- * <h3>Resizable Range</h3>
+ * <h2>Resizable Range</h2>
  * <p>
  * BorderPane is commonly used as the root of a {@link javafx.scene.Scene Scene},
  * in which case its size will track the size of the scene.  If the scene or stage
@@ -122,7 +122,7 @@ import static javafx.scene.layout.Region.positionInArea;
  * bounds may extend outside its own bounds if a child's min size prevents it from
  * being fit within it space.</p>
  *
- * <h4>Optional Layout Constraints</h4>
+ * <h2>Optional Layout Constraints</h2>
  *
  * <p>
  * An application may set constraints on individual children to customize BorderPane's layout.

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/FlowPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/FlowPane.java
@@ -98,7 +98,7 @@ import javafx.util.Callback;
  * FlowPane may be styled with backgrounds and borders using CSS.  See
  * {@link javafx.scene.layout.Region Region} superclass for details.</p>
  *
- * <h3>Resizable Range</h3>
+ * <h2>Resizable Range</h2>
  *
  * <p>
  * A flowpane's parent will resize the flowpane within the flowpane's resizable range

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/GridPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/GridPane.java
@@ -81,7 +81,7 @@ import javafx.util.Callback;
  * GridPane may be styled with backgrounds and borders using CSS.  See
  * {@link javafx.scene.layout.Region Region} superclass for details.</p>
  *
- * <h3>Grid Constraints</h3>
+ * <h2>Grid Constraints</h2>
  * <p>
  * A child's placement within the grid is defined by it's layout constraints:
  * </p>
@@ -132,7 +132,7 @@ import javafx.util.Callback;
  * </code></pre>
  *
  *
- * <h3>Row/Column Sizing</h3>
+ * <h2>Row/Column Sizing</h2>
  *
  * By default, rows and columns will be sized to fit their content;
  * a column will be wide enough to accommodate the widest child, a
@@ -162,7 +162,7 @@ import javafx.util.Callback;
  * The affected rows/columns are resized by the following priority: grow priorities, last row.
  * This is with respect to row/column constraints.
  *
- * <h3>Percentage Sizing</h3>
+ * <h2>Percentage Sizing</h2>
  *
  * Alternatively, RowConstraints and ColumnConstraints allow the size to be specified
  * as a percentage of gridpane's available space:
@@ -181,7 +181,7 @@ import javafx.util.Callback;
  * be treated as weights.  e.g.  if 3 columns are each given a widthPercent of 50,
  * then each will be allocated 1/3 of the gridpane's available width (50/(50+50+50)).
  *
- * <h3>Mixing Size Types</h3>
+ * <h2>Mixing Size Types</h2>
  *
  * An application may freely mix the size-types of rows/columns (computed from content, fixed,
  * or percentage).  The percentage rows/columns will always be allocated space first
@@ -189,7 +189,7 @@ import javafx.util.Callback;
  * The remaining space will be allocated to rows/columns given their minimum, preferred,
  * and maximum sizes and grow priorities.
  *
- * <h3>Resizable Range</h3>
+ * <h2>Resizable Range</h2>
  * <p>
  * A gridpane's parent will resize the gridpane within the gridpane's resizable range
  * during layout.   By default the gridpane computes this range based on its content
@@ -227,7 +227,7 @@ import javafx.util.Callback;
  * bounds may extend outside its own bounds if a child's min size prevents it from
  * being fit within it space.</p>
  *
- * <h3>Optional Layout Constraints</h3>
+ * <h2>Optional Layout Constraints</h2>
  *
  * <p>
  * An application may set additional constraints on children to customize how the

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/HBox.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/HBox.java
@@ -76,7 +76,7 @@ import javafx.util.Callback;
  * HBox lays out each managed child regardless of the child's
  * visible property value; unmanaged children are ignored.</p>
  *
- * <h3>Resizable Range</h3>
+ * <h2>Resizable Range</h2>
  *
  * <p>
  * An hbox's parent will resize the hbox within the hbox's resizable range
@@ -113,7 +113,7 @@ import javafx.util.Callback;
  * bounds may extend outside its own bounds if a child's min size prevents it from
  * being fit within the hbox.</p>
  *
- * <h3>Optional Layout Constraints</h3>
+ * <h2>Optional Layout Constraints</h2>
  *
  * <p>
  * An application may set constraints on individual children to customize HBox's layout.

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Pane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Pane.java
@@ -58,7 +58,7 @@ import javafx.scene.Node;
  * Pane resizes each managed child regardless of the child's visible property value;
  * unmanaged children are ignored for all layout calculations.</p>
  *
- * <h3>Resizable Range</h3>
+ * <h2>Resizable Range</h2>
  *
  * <p>
  * A pane's parent will resize the pane within the pane's resizable range

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/StackPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/StackPane.java
@@ -67,7 +67,7 @@ import javafx.util.Callback;
  * StackPane may be styled with backgrounds and borders using CSS.  See
  * {@link javafx.scene.layout.Region Region} for details.</p>
  *
- * <h3>Resizable Range</h3>
+ * <h2>Resizable Range</h2>
  *
  * <p>
  * A stackpane's parent will resize the stackpane within the stackpane's resizable range
@@ -106,7 +106,7 @@ import javafx.util.Callback;
  * bounds may extend outside its own bounds if a child's min size prevents it from
  * being fit within the stackpane.</p>
  *
- * <h3>Optional Layout Constraints</h3>
+ * <h2>Optional Layout Constraints</h2>
  *
  * <p>
  * An application may set constraints on individual children to customize StackPane's layout.

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/TilePane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/TilePane.java
@@ -105,7 +105,7 @@ import javafx.util.Callback;
  * resizable or its size limits prevented it) then it will be aligned within the
  * tile using tileAlignment.
  *
- * <h3>Resizable Range</h3>
+ * <h2>Resizable Range</h2>
  *
  * <p>
  * A tilepane's parent will resize the tilepane within the tilepane's resizable range
@@ -156,7 +156,7 @@ import javafx.util.Callback;
  * is resized smaller than its preferred size, it may not be able to fit all the
  * tiles within its bounds and the content will extend outside.
  *
- * <h3>Optional Layout Constraints</h3>
+ * <h2>Optional Layout Constraints</h2>
  *
  * <p>
  * An application may set constraints on individual children to customize TilePane's layout.

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/VBox.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/VBox.java
@@ -74,7 +74,7 @@ import javafx.util.Callback;
  * VBox lays out each managed child regardless of the child's
  * visible property value; unmanaged children are ignored.</p>
  *
- * <h3>Resizable Range</h3>
+ * <h2>Resizable Range</h2>
  *
  * <p>
  * A vbox's parent will resize the vbox within the vbox's resizable range
@@ -113,7 +113,7 @@ import javafx.util.Callback;
  * bounds may extend outside its own bounds if a child's min size prevents it from
  * being fit within the vbox.</p>
  *
- * <h3>Optional Layout Constraints</h3>
+ * <h2>Optional Layout Constraints</h2>
  *
  * <p>
  * An application may set constraints on individual children to customize VBox's layout.

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/package.html
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/package.html
@@ -43,7 +43,7 @@ should not position or resize the node directly; see &quot;Node Resizability&quo
 for more details.
 </p>
 
-<h3>Scene Graph Layout Mechanism</h3>
+<h2>Scene Graph Layout Mechanism</h2>
 <p>
 The scene graph layout mechanism is driven automatically by the system once
 the application creates and displays a {@link javafx.scene.Scene Scene}.
@@ -59,7 +59,7 @@ change. Therefore, applications should not invoke layout directly on nodes.
 </p>
 
 
-<h3>Node Resizability</h3>
+<h2>Node Resizability</h2>
 <p>
 The scene graph supports both resizable and non-resizable node classes.  The
 {@code isResizable()} method on {@link javafx.scene.Node Node} returns whether a
@@ -101,7 +101,7 @@ needs to set appropriate geometric properties which determine its size:
     circle.setRadius(50);
 </code></pre>
 
-<h3>Resizable Range</h3>
+<h2>Resizable Range</h2>
 
 Each resizable node class computes an appropriate min, pref, and max size based
 on its own content and property settings (it's 'intrinsic' size range).
@@ -126,7 +126,7 @@ And finally, if the application needs to restore the intrinsically computed valu
 <pre><code>    listview.setPrefSize(Region.USE_COMPUTED_SIZE, Region.USE_COMPUTED_SIZE);
 </code></pre>
 
-<h3>CSS Styling and Node Sizing</h3>
+<h2>CSS Styling and Node Sizing</h2>
 
 Applications cannot reliably query the bounds of a resizable node until it has been
 added to a scene because the size of that node may be dependent on CSS.  This is
@@ -142,7 +142,7 @@ the layout pass.
 
 
 
-<h3>Visual Bounds vs. Layout Bounds</h3>
+<h2>Visual Bounds vs. Layout Bounds</h2>
 
 A graphically rich user interface often has the need to make a distinction between
 a node's visual bounds and the bounds used for layout.  For example, the tight visual

--- a/modules/javafx.graphics/src/main/java/javafx/scene/package.html
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/package.html
@@ -79,7 +79,7 @@ list of a {@link javafx.scene.Parent Parent} or as the clip of a
 {@link javafx.scene.Node Node}.
 See the {@link javafx.scene.Node Node} class for more details on these restrictions.</p>
 
-<h3>Example</h3>
+<h2>Example</h2>
 
 <p>An example JavaFX scene graph is as follows:</p>
 
@@ -127,7 +127,7 @@ public class Example extends Application {
 
 <p><img src="doc-files/Scene1.png" alt="A visual rendering of the JavaFX Scene example"></p>
 
-<h3>Coordinate System and Transformations</h3>
+<h2>Coordinate System and Transformations</h2>
 
 <p>The {@code Node} class defines a traditional computer graphics "local"
 coordinate system in which the {@code x} axis increases to the right and the
@@ -146,7 +146,7 @@ viewed from the parent of the node that has been transformed.</p>
 
 <p>See the {@link javafx.scene.Node Node} class for more information on transformations.</p>
 
-<h3>Bounding Rectangle</h3>
+<h2>Bounding Rectangle</h2>
 
 <p>Since every {@code Node} has transformations, every Node's geometric
 bounding rectangle can be described differently depending on whether
@@ -175,7 +175,7 @@ only the shape geometry.</li>
 
 <p>See the {@link javafx.scene.Node Node} class for more information on bounding rectangles.</p>
 
-<h3>CSS</h3>
+<h2>CSS</h2>
 <p>
 The JavaFX Scene Graph provides the facility to style nodes using
 CSS (Cascading Style Sheets).

--- a/modules/javafx.graphics/src/main/java/javafx/scene/shape/Shape.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/shape/Shape.java
@@ -92,7 +92,7 @@ import java.lang.ref.WeakReference;
  * an UnsupportedOperationException being thrown.
  * </p>
  *
- * <h3>Interaction with coordinate systems</h3>
+ * <h2>Interaction with coordinate systems</h2>
  * Most nodes tend to have only integer translations applied to them and
  * quite often they are defined using integer coordinates as well.  For
  * this common case, fills of shapes with straight line edges tend to be

--- a/modules/javafx.graphics/src/main/java/javafx/scene/text/TextFlow.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/text/TextFlow.java
@@ -110,7 +110,7 @@ import javafx.css.StyleableProperty;
  * TextFlow may be styled with backgrounds and borders using CSS.  See
  * {@link javafx.scene.layout.Region Region} superclass for details.</p>
  *
- * <h3>Resizable Range</h3>
+ * <h2>Resizable Range</h2>
  *
  * <p>
  * A textflow's parent will resize the textflow within the textflow's range


### PR DESCRIPTION
As indicated in [JDK-8233338](https://bugs.openjdk.java.net/browse/JDK-8233338), this fixes all of our javadoc HTML headings to conform with the rule that all HTML heading tags in class documents must start with `<h2>` and be nested correctly (i.e., no skipping levels). See [JDK-8219801](https://bugs.openjdk.java.net/browse/JDK-8219801) and [JDK-8220379](https://bugs.openjdk.java.net/browse/JDK-8220379).

We have a few places where we are using `<h1>` tags and several more where we are using `<h3>`. As a result, the build of FX docs via `gradle javadoc` fails with JDK 13. We had one `<h4>` heading that wasn't supposed to be nested with the previous `<h3>` heading, so I made both of the `<h2>` to reflect this.

This fix can go in at any time, but must be done before we can switch the boot JDK to 13 in [JDK-8232064](https://bugs.openjdk.java.net/browse/JDK-8232064), else the build will fail.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8233338](https://bugs.openjdk.java.net/browse/JDK-8233338): FX javadoc headings are out of sequence


## Approvers
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)