### PR TITLE
8232063: Upgrade gradle to version 6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1833,7 +1833,10 @@ allprojects {
         repositories {
             ivy {
                 url JFX_DEPS_URL
-                layout "pattern", {
+                metadataSources {
+                    artifact()
+                }
+                patternLayout {
                     artifact "[artifact]-[revision](-[classifier]).[ext]"
                     artifact "[artifact].[ext]"
                 }
@@ -1846,7 +1849,10 @@ allprojects {
             mavenCentral()
             ivy {
                 url "https://download.eclipse.org/eclipse/updates/4.6/R-4.6.3-201703010400/plugins/"
-                layout "pattern", {
+                metadataSources {
+                    artifact()
+                }
+                patternLayout {
                     artifact "[artifact].[ext]"
                 }
             }
@@ -1857,13 +1863,19 @@ allprojects {
         repositories {
             ivy {
                 url libAVRepositoryURL
-                layout "pattern", {
+                metadataSources {
+                    artifact()
+                }
+                patternLayout {
                     artifact "[artifact].[ext]"
                 }
             }
             ivy {
                 url FFmpegRepositoryURL
-                layout "pattern", {
+                metadataSources {
+                    artifact()
+                }
+                patternLayout {
                     artifact "[artifact].[ext]"
                 }
             }

--- a/build.properties
+++ b/build.properties
@@ -84,7 +84,7 @@ jfx.build.jdk.buildnum.min=28
 # gradle/legal/gradle.md.
 # The jfx.gradle.version.min property defines the minimum version of gradle
 # that is supported. It must be <= jfx.gradle.version.
-jfx.gradle.version=5.3
+jfx.gradle.version=6.0
 jfx.gradle.version.min=5.3
 
 # Toolchains

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,10 @@ repositories {
     if (buildClosed) {
         ivy {
             url jfxRepositoryURL
-            layout "pattern", {
+            metadataSources {
+                artifact()
+            }
+            patternLayout {
                 artifact "[artifact]-[revision].[ext]"
                 artifact "[artifact].[ext]"
             }

--- a/gradle/legal/gradle.md
+++ b/gradle/legal/gradle.md
@@ -1,4 +1,4 @@
-## Gradle v5.3
+## Gradle v6.0
 
 ### Apache 2.0 License
 ```

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR upgrades the version of gradle used to build JavaFX to 6.0. In addition to keeping up to date, this will allow us to subsequently upgrade the boot JDK to JDK 13.

This change does the following:

1. Use ivy `patternLayout ...` instead of `layout "pattern" ...` and specify no metadata for ivy repositories. This was split out of [JDK-8226754](https://bugs.openjdk.java.net/browse/JDK-8226754), PR #9, because the replacement API is documented as unstable in gradle 5.x (although it works fine) and isn't needed until we actually upgrade to 6.0.

2. Bump the gradle version used by the build from 5.3 to 6.0.

Note that this does not change the minimum required version of gradle, which remains at 5.3.

I have compared the artifacts produced before and after this change and there are no differences.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8232063](https://bugs.openjdk.java.net/browse/JDK-8232063): Upgrade gradle to version 6.0


## Approvers
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)