### PR TITLE
8234150: Address ignored tests in ComboBoxTest, LabeledTest, HyperLinkTest and TextInputControlTest

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -859,7 +859,7 @@ public class ComboBoxTest {
         assertTrue(sm.isSelected(2));
     }
 
-    @Ignore("Test not working as the heights being returned are not accurate")
+    @Ignore("JDK-8091127 Test not working as the heights being returned are not accurate")
     @Test public void test_rt20106() {
         comboBox.getItems().addAll("0","1","2","3","4","5","6","7","8","9");
 
@@ -948,7 +948,6 @@ public class ComboBoxTest {
         assertEquals("TO_STRING", cell.getText());
     }
 
-    @Ignore
     @Test public void test_rt20189() {
         comboBox.getItems().addAll("0","1","2","3","4","5","6","7","8","9");
 
@@ -957,8 +956,6 @@ public class ComboBoxTest {
         stage.setScene(scene);
         comboBox.applyCss();
         comboBox.show();
-
-        SelectionModel sm = getListView().getSelectionModel();
 
         comboBox.getSelectionModel().select(2);
         Object item = sm.getSelectedItem();
@@ -1200,7 +1197,6 @@ public class ComboBoxTest {
     }
 
     private int test_rt34603_count = 0;
-    @Ignore("Bug has not yet been resolved")
     @Test public void test_rt34603() {
         assertEquals(0, test_rt34603_count);
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/HyperlinkTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/HyperlinkTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,6 @@ import javafx.scene.control.Hyperlink;
 import javafx.scene.shape.Rectangle;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class HyperlinkTest {
@@ -174,29 +173,6 @@ public class HyperlinkTest {
         } catch (Exception e) {
             org.junit.Assert.fail(e.toString());
         }
-    }
-
-    @Ignore ("replaced by visitedPropertyIsNotStyleable")
-    @Test public void whenVisitedIsBound_impl_cssSettable_ReturnsFalse() {
-        // will return null!
-        CssMetaData styleable = ((StyleableProperty)link.visitedProperty()).getCssMetaData();
-        assertFalse(styleable.isSettable(link));
-        BooleanProperty other = new SimpleBooleanProperty(true);
-        link.visitedProperty().bind(other);
-    }
-
-    @Ignore ("replaced by visitedPropertyIsNotStyleable")
-    @Test public void whenVisitedIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsFalse() {
-        // will return null!
-        CssMetaData styleable = ((StyleableProperty)link.visitedProperty()).getCssMetaData();
-        assertFalse(styleable.isSettable(link));
-    }
-
-    @Ignore ("replaced by visitedPropertyIsNotStyleable")
-    @Test public void cannotSpecifyVisitedViaCSS() {
-        // will return null!
-        ((StyleableProperty)link.visitedProperty()).applyStyle(null, Boolean.TRUE);
-        assertFalse(link.isVisited());
     }
 
     @Test public void settingVisitedSetsPseudoClass() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/LabeledTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/LabeledTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -243,7 +243,6 @@ public class LabeledTest {
      *                                                                              *
      *******************************************************************************/
 
-    @Ignore("This is not the default whilst we await a fix for RT-12212")
     @Test public void alignmentDefaultValueIsCENTER_LEFT() {
         assertEquals(Pos.CENTER_LEFT, labeled.getAlignment());
     }
@@ -765,11 +764,10 @@ public class LabeledTest {
         assertEquals(Insets.EMPTY, labeled.labelPaddingProperty().get());
     }
 
-    @Ignore ("labelPaddingProperty returns read-only property")
     @Test public void canSpecifyLabelPaddingFromCSS() {
         Insets insets = new Insets(5, 4, 3, 2);
-//        CssMetaData styleable = ((StyleableProperty)labeled.labelPaddingProperty()).getCssMetaData();
-//        styleable.set(labeled,insets, null);
+        CssMetaData styleable = ((StyleableProperty)labeled.labelPaddingProperty()).getCssMetaData();
+        styleable.set(labeled, insets, null);
         assertEquals(insets, labeled.getLabelPadding());
         assertEquals(insets, labeled.labelPaddingProperty().get());
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextInputControlTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextInputControlTest.java
@@ -53,7 +53,6 @@ import javafx.scene.control.TextField;
 import javafx.scene.control.TextInputControl;
 import com.sun.javafx.tk.Toolkit;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -206,15 +205,6 @@ public class TextInputControlTest {
         assertEquals("Oranges", textInput.getText());
     }
 
-    @Ignore("getCssMetaData will return null for textProperty")
-    @Test public void impl_cssSettable_ReturnsFalseForTextAlways() {
-        CssMetaData styleable = ((StyleableProperty)textInput.textProperty()).getCssMetaData();
-        assertTrue(styleable.isSettable(textInput));
-        StringProperty other = new SimpleStringProperty("Apples");
-        textInput.textProperty().bind(other);
-        assertFalse(styleable.isSettable(textInput));
-    }
-
     @Test public void cannotSpecifyTextViaCSS() {
         try {
             CssMetaData styleable = ((StyleableProperty)textInput.textProperty()).getCssMetaData();
@@ -315,15 +305,6 @@ public class TextInputControlTest {
         assertFalse(textInput.isEditable());
         other.set(true);
         assertTrue(textInput.isEditable());
-    }
-
-    @Ignore("getCssMetaData will return null for editableProperty")
-    @Test public void impl_cssSettable_ReturnsFalseForEditableAlways() {
-        CssMetaData styleable = ((StyleableProperty)textInput.editableProperty()).getCssMetaData();
-        assertTrue(styleable.isSettable(textInput));
-        StringProperty other = new SimpleStringProperty("Apples");
-        textInput.textProperty().bind(other);
-        assertFalse(styleable.isSettable(textInput));
     }
 
     @Test public void cannotSpecifyEditableViaCSS() {
@@ -451,9 +432,6 @@ public class TextInputControlTest {
         assertTrue(passed[0]);
     }
 
-    @Ignore("The notification here doesn't happen because the invalid flag is set after the first set," +
-            "however setting a change listener *must* clear that, but doesn't. I copied the code for this " +
-            "straight from the beans package, so there may be a bug there.")
     @Test public void lengthChangeNotificationWhenTextIsSetToEmptyResult() {
         textInput.setText("Goodbye");
         final boolean[] passed = new boolean[] { false };
@@ -640,11 +618,6 @@ public class TextInputControlTest {
         });
         other.set("Cleared!");
         assertTrue(passed[0]);
-    }
-
-    @Ignore
-    @Test public void selectionCanBeNull() {
-
     }
 
     /******************************************************


### PR DESCRIPTION
This PR is to address ignored tests in ComboBoxTest, LabeledTest, HyperLinkTest and TextInputControlTest.

strategy is as follows -

1) Enable tests marked with @Ignore by removing that tag
2) Run the test
3) If test Passes - remove the @Ignore tag
4) If test fails - if test is invalid - remove it, else fix the test
5) In case if the failure cannot be fixed, leave the test ignored (keep @Ignore tag) 


With these corrections - here are the results:

Results BEFORE this FIX
1. ComboBoxTest -- tests:156, failures:0, ignored:4
2. LabeledTest -- tests:93, failures:0, ignored:5
3. HyperlinkTest -- tests:34, failures:0, ignored:3
4. TextInputControlTest -- tests:594, failures:0, ignored:12

Results AFTER this FIX
1. ComboBoxTest -- tests:156, failures:0, ignored:2
2. LabeledTest -- tests:93, failures:0, ignored:3
3. HyperlinkTest -- tests:31, failures:0, ignored:0
4. TextInputControlTest -- tests:585, failures:0, ignored:0
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8234150](https://bugs.openjdk.java.net/browse/JDK-8234150): Address ignored tests in ComboBoxTest, LabeledTest, HyperLinkTest and TextInputControlTest


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)