### PR TITLE
8234194: [TEST_BUG] Reenable few graphics unit tests

### DIFF
--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/scene/layout/region/BackgroundRepeatConverterTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/scene/layout/region/BackgroundRepeatConverterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package test.com.sun.javafx.scene.layout.region;
 
 import javafx.scene.layout.BackgroundRepeat;
-import org.junit.Ignore;
 import org.junit.Test;
 import javafx.css.ParsedValue;
 import com.sun.javafx.css.ParsedValueImpl;
@@ -54,8 +53,8 @@ public class BackgroundRepeatConverterTest {
     /*
         -fx-background-repeat: null
      */
-    @Ignore ("this doesn't work, but I'm not sure what would happen with a null background-repeat in reality")
-    @Test public void scenario2() {
+    @Test(expected=NullPointerException.class)
+    public void scenario2() {
         ParsedValue<String,BackgroundRepeat>[][] values = new ParsedValueImpl[][] {
                 {null}
         };
@@ -65,7 +64,6 @@ public class BackgroundRepeatConverterTest {
                         values, null
                 );
         RepeatStruct[] results = RepeatStructConverter.getInstance().convert(value, null);
-        assertEquals(0, results.length, 0);
     }
 
     /*

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/scene/layout/region/BackgroundRepeatConverterTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/scene/layout/region/BackgroundRepeatConverterTest.java
@@ -32,7 +32,7 @@ import com.sun.javafx.css.ParsedValueImpl;
 import com.sun.javafx.scene.layout.region.RepeatStruct;
 
 import static org.junit.Assert.assertEquals;
-import com.sun.javafx.scene.layout.region.RepeatStructConverter;
+import static org.junit.Assert.fail;
 import com.sun.javafx.scene.layout.region.RepeatStructConverter;
 
 /**
@@ -53,7 +53,7 @@ public class BackgroundRepeatConverterTest {
     /*
         -fx-background-repeat: null
      */
-    @Test(expected=NullPointerException.class)
+    @Test
     public void scenario2() {
         ParsedValue<String,BackgroundRepeat>[][] values = new ParsedValueImpl[][] {
                 {null}
@@ -63,7 +63,12 @@ public class BackgroundRepeatConverterTest {
                 new ParsedValueImpl<ParsedValue<String,BackgroundRepeat>[][], RepeatStruct[]>(
                         values, null
                 );
-        RepeatStruct[] results = RepeatStructConverter.getInstance().convert(value, null);
+        try {
+            RepeatStruct[] results = RepeatStructConverter.getInstance().convert(value, null);
+            fail("Expected NullPointerException");
+        } catch (NullPointerException expected) {
+            // Test Pass, NPE is expected
+        }
     }
 
     /*

--- a/modules/javafx.graphics/src/test/java/test/com/sun/scenario/animation/shared/TimelineClipCoreTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/scenario/animation/shared/TimelineClipCoreTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,6 @@ import javafx.event.EventHandler;
 import javafx.util.Duration;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -181,7 +180,6 @@ public class TimelineClipCoreTest {
         assertEquals(3, eventHandler.callCount);
     }
 
-    @Ignore
     @Test
     public void testJumpTo() {
         // jumpTo on stopped timeline

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/Node_cssStyleMap_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/Node_cssStyleMap_Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,6 @@ import static org.junit.Assert.*;
 import org.junit.Ignore;
 import org.junit.Test;
 
-@Ignore
 public class Node_cssStyleMap_Test {
 
     public Node_cssStyleMap_Test() {
@@ -101,6 +100,7 @@ public class Node_cssStyleMap_Test {
 
     }
 
+    @Ignore("JDK-8234241")
     @Test
     public void testStyleMap() {
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_cssMethods_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_cssMethods_Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@ import javafx.scene.image.Image;
 import javafx.scene.shape.Rectangle;
 
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -49,7 +48,6 @@ import javafx.scene.Cursor;
 import javafx.scene.ImageCursor;
 import javafx.scene.Node;
 
-@Ignore ("pending RT-35594")
 @RunWith(Parameterized.class)
 public final class Node_cssMethods_Test extends CssMethodsTestBase {
     private static final Node TEST_NODE = new Rectangle();

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionCSSTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionCSSTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3375,7 +3375,6 @@ public class RegionCSSTest {
         assertEquals(expected, image);
     }
 
-    @Ignore("I am not certain that supporting auto makes sense for us, and if it does, is it anything other than 1?")
     @Test public void borderImageWidth_auto() {
         region.setStyle(
                 "-fx-border-image-source: url('test/javafx/scene/layout/center-btn.png');" +
@@ -3397,7 +3396,6 @@ public class RegionCSSTest {
         assertEquals(expected, image);
     }
 
-    @Ignore("I am not certain that supporting auto makes sense for us, and if it does, is it anything other than 1?")
     @Test public void borderImageWidth_1_auto() {
         region.setStyle(
                 "-fx-border-image-source: url('test/javafx/scene/layout/center-btn.png');" +
@@ -3418,7 +3416,6 @@ public class RegionCSSTest {
         assertEquals(expected, image);
     }
 
-    @Ignore("I am not certain that supporting auto makes sense for us, and if it does, is it anything other than 1?")
     @Test public void borderImageWidth_1_2Percent_auto() {
         region.setStyle(
                 "-fx-border-image-source: url('test/javafx/scene/layout/center-btn.png');" +


### PR DESCRIPTION
Following graphics unit tests can be re-enabled.

 1. test.com.sun.javafx.scene.layout.region.BackgroundRepeatConverterTest.scenario2
RepeatStructConverter.convert() is an internal method and does not verify the parameters. Passing null value to this method results in NPE.

2. test.javafx.scene.layout.RegionCSSTest.borderImageWidth_auto
test.javafx.scene.layout.RegionCSSTest.borderImageWidth_1_auto
test.javafx.scene.layout.RegionCSSTest.borderImageWidth_1_2Percent_auto
It is not certain if the value of auto for -fx-border-image-width is 1 or 2 by defaut. But the tests seem correct and they pass.

3. test.javafx.scene.Node_cssMethods_Test
[JDK-8094155](https://bugs.openjdk.java.net/browse/JDK-8094155) is fixed and the tests can be re-enabled.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8234194](https://bugs.openjdk.java.net/browse/JDK-8234194): [TEST_BUG] Reenable few graphics unit tests


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)