### PR TITLE
8233421: Upgrade to Visual Studio 2017 version 15.9.16

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -89,7 +89,7 @@ jfx.gradle.version.min=5.3
 
 # Toolchains
 jfx.build.linux.gcc.version=gcc8.2.0-OL6.4+1.0
-jfx.build.windows.msvc.version=VS2017-15.9.6+1.0
+jfx.build.windows.msvc.version=VS2017-15.9.16+1.0
 jfx.build.macosx.xcode.version=Xcode10.1-MacOSX10.14+1.0
 
 # Build tools


### PR DESCRIPTION
[JDK-8233421](https://bugs.openjdk.java.net/browse/JDK-8233421)

This bumps the windows compiler version to VS2017 version 15.9.16 to match JDK 14. I have run a full build and test, including WebKit and media.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8233421](https://bugs.openjdk.java.net/browse/JDK-8233421): Upgrade to Visual Studio 2017 version 15.9.16


## Approvers
 * Phil Race ([prr](@prrace) - **Reviewer**)
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)