### PR TITLE
8234239: [TEST_BUG] Reenable few ignored web tests

### DIFF
--- a/modules/javafx.web/src/test/java/test/com/sun/webkit/network/CookieManagerTest.java
+++ b/modules/javafx.web/src/test/java/test/com/sun/webkit/network/CookieManagerTest.java
@@ -407,10 +407,7 @@ public class CookieManagerTest {
 
     /**
      * Tests if put() correctly overwrites expired cookie.
-     * This test is disabled because it takes considerable amount of time
-     * to run.
      */
-    @Ignore
     @Test
     public void testPutOverwriteExpired() {
         put("http://example.org/", "foo=bar; Max-Age=1; HttpOnly");
@@ -497,10 +494,7 @@ public class CookieManagerTest {
     /**
      * Tests if put() correctly purges individual domains
      * and takes into account cookie expiry.
-     * This test is disabled because it takes considerable amount of time
-     * to run.
      */
-    @Ignore
     @Test
     public void testPutPurgeDomainAfterExpiry() {
         for (int i = 0; i < 25; i++) {
@@ -547,10 +541,7 @@ public class CookieManagerTest {
 
     /**
      * Tests if put() correctly purges cookies globally.
-     * This test is disabled because it takes considerable amount of time
-     * to run.
      */
-    @Ignore
     @Test
     public void testPutPurgeCookiesGlobally2() {
         String urip = "http://example%d.org/";
@@ -579,10 +570,7 @@ public class CookieManagerTest {
 
     /**
      * Tests if put() correctly purges cookies globally.
-     * This test is disabled because it takes considerable amount of time
-     * to run.
      */
-    @Ignore
     @Test
     public void testPutPurgeCookiesGlobally3() {
         String urip = "http://example%d.org/";
@@ -612,10 +600,7 @@ public class CookieManagerTest {
     /**
      * Tests if put() correctly purges cookies globally and takes
      * into account cookie expiry.
-     * This test is disabled because it takes considerable amount of time
-     * to run.
      */
-    @Ignore
     @Test
     public void testPutPurgeCookiesGloballyAfterExpiry() {
         String urip = "http://example%d.org/";

--- a/modules/javafx.web/src/test/java/test/com/sun/webkit/network/CookieManagerTest.java
+++ b/modules/javafx.web/src/test/java/test/com/sun/webkit/network/CookieManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import org.junit.Ignore;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/CallbackTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/CallbackTest.java
@@ -88,7 +88,6 @@ public class CallbackTest extends TestBase {
         popupUi.clear();
     }
 
-    @Ignore("RT-34508")
     @Test public void testDefaultPopup() {
         clear();
         executeScript(JS_OPEN_DEFAULT);
@@ -106,7 +105,6 @@ public class CallbackTest extends TestBase {
         popupUi.checkCalled(VISIBILITY_CHANGED, true);
     }
 
-    @Ignore("RT-34508")
     @Test public void testCustomPopup() {
         clear();
         executeScript(JS_OPEN);

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/CallbackTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/CallbackTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,6 @@ import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebEvent;
 import javafx.util.Callback;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/LeakTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/LeakTest.java
@@ -63,7 +63,7 @@ public class LeakTest extends TestBase {
 
         Timeline time = new Timeline();
         time.setCycleCount(CYCLE_LENGTH * CYCLE_COUNT);
-        time.getKeyFrames().add(new KeyFrame(Duration.millis(1000), new EventHandler<ActionEvent>() {
+        time.getKeyFrames().add(new KeyFrame(Duration.millis(200), new EventHandler<ActionEvent>() {
             int counter = -1;
             @Override public void handle(final ActionEvent e) {
                 ++counter;

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/LeakTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/LeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,6 @@ import javafx.scene.web.WebEngineShim;
 import javafx.scene.web.WebView;
 import javafx.util.Duration;
 import netscape.javascript.JSObject;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/LeakTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/LeakTest.java
@@ -56,7 +56,6 @@ public class LeakTest extends TestBase {
 
     private static final int SLEEP_TIME = 1000;
 
-    @Ignore // RT-26710: javafx.scene.web.LeakTest hangs
     @Test public void testOleg() throws InterruptedException{
         final String URL = new File("src/test/resources/test/html/guimark2-vector.html").toURI().toASCIIString();
         final int CYCLE_COUNT = 16;
@@ -82,7 +81,6 @@ public class LeakTest extends TestBase {
         latch.await();
     }
 
-    @Ignore // RT-26710: javafx.scene.web.LeakTest hangs
     @Test public void testGarbageCollectability() throws InterruptedException {
         final BlockingQueue<WeakReference<WebPage>> webPageRefQueue =
                 new LinkedBlockingQueue<WeakReference<WebPage>>();

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/MiscellaneousTest.java
@@ -91,7 +91,6 @@ public class MiscellaneousTest extends TestBase {
         private static int dummyField;
     }
 
-    @org.junit.Ignore
     @Test public void testRT30835() throws Exception {
         class Record {
             private final Document document;


### PR DESCRIPTION
The following tests can be reenabled:

CookieManager.testPutOverwriteExpired
CookieManager.testPutPurgeDomainAfterExpiry
CookieManager.testPutPurgeCookiesGlobally2
CookieManager.testPutPurgeCookiesGlobally3
CookieManager.testPutPurgeCookiesGloballyAfterExpiry
CallbackTest.testCustomPopup
CallbackTest.testDefaultPopup
LeakTest.testGarbageCollectability
LeakTest.testOleg
MiscellaneousTest.testRT30835
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8234239](https://bugs.openjdk.java.net/browse/JDK-8234239):  [TEST_BUG] Reenable few ignored web tests


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)