### PR TITLE
8234303: [TEST_BUG] Correct ignore tag in graphics unit tests

### DIFF
--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/sg/prism/RenderRootTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/sg/prism/RenderRootTest.java
@@ -325,14 +325,16 @@ public class RenderRootTest extends NGTestBase {
         assertRenderRoot(root, rootPath);
     }
 
-    @Ignore("What is the right thing here? It seems that an empty dirty region should result in no rendering?")
+    // What is the right thing here? It seems that an empty dirty region should result in no rendering?
+    @Ignore("JDK-8234077")
     @Test
     public void emptyDirtyRegion() {
         NodePath rootPath = getRenderRoot(root, 0, 0, -1, -1);
         assertRenderRoot(root, rootPath);
     }
 
-    @Ignore("Currently fails because isEmpty doesn't take into account width == 0, height == 0")
+    // Currently fails because isEmpty doesn't take into account width == 0, height == 0")
+    @Ignore("JDK-8234077")
     @Test
     public void zeroSizeDirtyRegionWithinOpaqueRegion() {
         NodePath rootPath = getRenderRoot(root, 20, 20, 0, 0);

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/text/TextLayoutTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/text/TextLayoutTest.java
@@ -96,7 +96,7 @@ public class TextLayoutTest {
     }
 
     @SuppressWarnings("deprecation")
-    @Ignore("RT-31357")
+    @Ignore("JDK-8087615")
     @Test public void buildRuns() {
 
         PrismTextLayout layout = new PrismTextLayout();

--- a/modules/javafx.graphics/src/test/java/test/javafx/concurrent/ServiceWithSecurityManagerTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/concurrent/ServiceWithSecurityManagerTest.java
@@ -43,7 +43,7 @@ import org.junit.runners.model.Statement;
  * related tests on lots of different unit tests.
  */
 @RunWith(ServiceWithSecurityManagerTest.ServiceTestRunner.class)
-@Ignore("This class doesn't appear to run correctly, often s.evaluate isn't called. Likely bogus test at present.")
+@Ignore("JDK-8234175") // This class doesn't appear to run correctly, often s.evaluate isn't called. Likely bogus test at present.
 public class ServiceWithSecurityManagerTest extends ServiceLifecycleTest {
 
     public static final class ServiceTestRunner extends BlockJUnit4ClassRunner {

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/CssMetaDataTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/CssMetaDataTest.java
@@ -80,6 +80,7 @@ import javafx.css.StyleableProperty;
 import javafx.css.Stylesheet;
 import javafx.css.StylesheetShim;
 import org.junit.Test;
+import org.junit.Ignore;
 
 import static org.junit.Assert.*;
 
@@ -260,7 +261,8 @@ public class CssMetaDataTest {
         );
     }
 
-    @Test @org.junit.Ignore
+    @Ignore("JDK-8234142")
+    @Test
     public void testGetMatchingStyles() {
 
 
@@ -365,7 +367,8 @@ public class CssMetaDataTest {
         assertTrue(actuals.isEmpty());
     }
 
-    @Test @org.junit.Ignore
+    @Ignore("JDK-8234142")
+    @Test
     public void testGetMatchingStylesWithInlineStyleOnParent() {
 
 
@@ -488,7 +491,8 @@ public class CssMetaDataTest {
         assertTrue(actuals.isEmpty());
     }
 
-    @Test @org.junit.Ignore
+    @Ignore("JDK-8234142")
+    @Test
     public void testGetMatchingStylesWithInlineStyleOnLeaf() {
 
 
@@ -611,7 +615,8 @@ public class CssMetaDataTest {
         assertTrue(actuals.isEmpty());
     }
 
-    @Test @org.junit.Ignore
+    @Ignore("JDK-8234142")
+    @Test
     public void testGetMatchingStylesWithInlineStyleOnRootAndLeaf() {
 
 
@@ -738,7 +743,8 @@ public class CssMetaDataTest {
         assertTrue(actuals.isEmpty());
     }
 
-    @Test @org.junit.Ignore
+    @Ignore("JDK-8234142")
+    @Test
     public void testGetMatchingStylesShouldNotReturnAncestorPropertyIfNotInherited() {
 
 
@@ -846,8 +852,8 @@ public class CssMetaDataTest {
         assertTrue(actuals.isEmpty());
     }
 
-
-    @Test @org.junit.Ignore
+    @Ignore("JDK-8234142")
+    @Test
     public void testGetMatchingStylesShouldNotReturnInlineAncestorPropertyIfNotInherited() {
 
         final Stylesheet stylesheet = StylesheetShim.getStylesheet();
@@ -952,7 +958,8 @@ public class CssMetaDataTest {
         assertTrue(actuals.toString(), actuals.isEmpty());
     }
 
-    @Test @org.junit.Ignore
+    @Ignore("JDK-8234142")
+    @Test
     public void testGetMatchingStylesReturnsInheritedProperty() {
 
 
@@ -1033,7 +1040,8 @@ public class CssMetaDataTest {
         assertTrue(actuals.isEmpty());
     }
 
-    @Test @org.junit.Ignore
+    @Ignore("JDK-8234142")
+    @Test
     public void testGetMatchingStylesReturnsSubProperty() {
 
         final Stylesheet stylesheet = StylesheetShim.getStylesheet();
@@ -1221,7 +1229,8 @@ public class CssMetaDataTest {
         }
     }
 
-    @Test @org.junit.Ignore("tested CssMetaData#set method, which is deprecated")
+    @Ignore("JDK-8234143") // Tested CssMetaData#set method, which is deprecated.
+    @Test
     public void testRT_21185() {
 
         Color c1 = new Color(.1,.2,.3,1.0);
@@ -1260,8 +1269,8 @@ public class CssMetaDataTest {
 
     }
 
-
-    @Test  @org.junit.Ignore
+    @Ignore("JDK-8234142")
+    @Test
     public void testRT_24606() {
 
         final Stylesheet stylesheet = new CssParser().parse(

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/Node_cssStateTransition_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/Node_cssStateTransition_Test.java
@@ -42,7 +42,6 @@ import javafx.scene.shape.Rectangle;
 import static org.junit.Assert.*;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class Node_cssStateTransition_Test {

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/RuleTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/RuleTest.java
@@ -154,7 +154,8 @@ public class RuleTest {
         assertNull(result);
     }
 
-    @Ignore @Test
+    @Ignore("JDK-8234154")
+    @Test
     public void testApplies() {
         System.out.println("applies");
         Node node = null;
@@ -165,7 +166,8 @@ public class RuleTest {
         fail("The test case is a prototype.");
     }
 
-    @Ignore @Test
+    @Ignore("JDK-8234154")
+    @Test
     public void testToString() {
         System.out.println("toString");
         Rule instance = null;
@@ -175,7 +177,8 @@ public class RuleTest {
         fail("The test case is a prototype.");
     }
 
-    @Ignore @Test
+    @Ignore("JDK-8234154")
+    @Test
     public void testWriteBinary() throws Exception {
         System.out.println("writeBinary");
         DataOutputStream os = null;
@@ -185,7 +188,8 @@ public class RuleTest {
         fail("The test case is a prototype.");
     }
 
-    @Ignore @Test
+    @Ignore("JDK-8234154")
+    @Test
     public void testReadBinary() throws Exception {
         System.out.println("readBinary");
         DataInputStream is = null;

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_effectiveOrientation_Css_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_effectiveOrientation_Css_Test.java
@@ -44,7 +44,7 @@ import org.junit.Before;
 /**
  * Test :dir functional pseudo-class
  */
-@Ignore
+@Ignore("JDK-8234152")
 public class Node_effectiveOrientation_Css_Test {
 
     private Group root;

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/input/TouchEventTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/input/TouchEventTest.java
@@ -1550,7 +1550,7 @@ public class TouchEventTest {
     }
 
     @Test
-    @Ignore("This is a benchmark, not any functional test. Run it individually if you wish.")
+    @Ignore("JDK-8234084") // This is a benchmark, not any functional test.
     public void saneOrderingBenchmark() {
         long[] ids = new long[] { 2, 3, 4, 5, 6 };
         boolean[] active = new boolean[] { false, false, false, false, false };
@@ -1638,7 +1638,7 @@ public class TouchEventTest {
     }
 
     @Test
-    @Ignore("This is a benchmark, not any functional test. Run it individually if you wish.")
+    @Ignore("JDK-8234084") // This is a benchmark, not any functional test.
     public void crazyOrderingBenchmark() {
         long[] ids = new long[] { 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000 };
         boolean[] active = new boolean[] { false, false, false, false, false,

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/BackgroundSizeTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/BackgroundSizeTest.java
@@ -74,19 +74,19 @@ public class BackgroundSizeTest {
         new BackgroundSize(-2, 1, true, true, false, false);
     }
 
-    @Ignore("Not handling positive infinity")
+    @Ignore("JDK-8234090")
     @Test(expected = IllegalArgumentException.class)
     public void positiveInfinityWidthThrowsException() {
         new BackgroundSize(Double.POSITIVE_INFINITY, 1, true, true, false, false);
     }
 
-    @Ignore("Not handling negative infinity")
+    @Ignore("JDK-8234090")
     @Test(expected = IllegalArgumentException.class)
     public void negativeInfinityWidthThrowsException() {
         new BackgroundSize(Double.NEGATIVE_INFINITY, 1, true, true, false, false);
     }
 
-    @Ignore("Not handling NaN")
+    @Ignore("JDK-8234090")
     @Test(expected = IllegalArgumentException.class)
     public void nanWidthThrowsException() {
         new BackgroundSize(Double.NaN, 1, true, true, false, false);
@@ -112,19 +112,19 @@ public class BackgroundSizeTest {
         new BackgroundSize(1, -2, true, true, false, false);
     }
 
-    @Ignore("Not handling positive infinity")
+    @Ignore("JDK-8234090")
     @Test(expected = IllegalArgumentException.class)
     public void positiveInfinityHeightThrowsException() {
         new BackgroundSize(1, Double.POSITIVE_INFINITY, true, true, false, false);
     }
 
-    @Ignore("Not handling negative infinity")
+    @Ignore("JDK-8234090")
     @Test(expected = IllegalArgumentException.class)
     public void negativeInfinityHeightThrowsException() {
         new BackgroundSize(1, Double.NEGATIVE_INFINITY, true, true, false, false);
     }
 
-    @Ignore("Not handling NaN")
+    @Ignore("JDK-8234090")
     @Test(expected = IllegalArgumentException.class)
     public void nanHeightThrowsException() {
         new BackgroundSize(1, Double.NaN, true, true, false, false);

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/BorderPaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/BorderPaneTest.java
@@ -32,7 +32,6 @@ import javafx.geometry.Orientation;
 import javafx.scene.ParentShim;
 import javafx.scene.layout.BorderPane;
 import org.junit.Before;
-import org.junit.Ignore;
 
 import org.junit.Test;
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionCSSTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionCSSTest.java
@@ -960,7 +960,7 @@ public class RegionCSSTest {
         assertEquals(expected, image);
     }
 
-    @Ignore("We do not presently implement -fx-background-clip")
+    @Ignore("JDK-8091576") // -fx-background-clip is not implemented.
     @Test public void backgroundClip_defaultValue() {
         region.setStyle(
                 "-fx-background-image: url('test/javafx/scene/layout/red.png');");
@@ -981,7 +981,7 @@ public class RegionCSSTest {
 //        assertEquals(expected, image);
     }
 
-    @Ignore("We do not presently implement -fx-background-clip")
+    @Ignore("JDK-8091576") // -fx-background-clip is not implemented.
     @Test public void backgroundClip_BorderBox() {
         region.setStyle(
                 "-fx-background-image: url('test/javafx/scene/layout/red.png');" +
@@ -1002,7 +1002,7 @@ public class RegionCSSTest {
 //        assertEquals(expected, image);
     }
 
-    @Ignore("We do not presently implement -fx-background-clip")
+    @Ignore("JDK-8091576") // -fx-background-clip is not implemented.
     @Test public void backgroundClip_PaddingBox() {
         region.setStyle(
                 "-fx-background-image: url('test/javafx/scene/layout/red.png');" +
@@ -1023,7 +1023,7 @@ public class RegionCSSTest {
 //        assertEquals(expected, image);
     }
 
-    @Ignore("We do not presently implement -fx-background-clip")
+    @Ignore("JDK-8091576") // -fx-background-clip is not implemented.
     @Test public void backgroundClip_ContentBox() {
         region.setStyle(
                 "-fx-background-image: url('test/javafx/scene/layout/red.png');" +
@@ -1044,7 +1044,7 @@ public class RegionCSSTest {
 //        assertEquals(expected, image);
     }
 
-    @Ignore("We do not presently implement -fx-background-origin")
+    @Ignore("JDK-8091576") // -fx-background-origin is not implemented.
     @Test public void backgroundOrigin_defaultValue() {
         region.setStyle(
                 "-fx-background-image: url('test/javafx/scene/layout/red.png');");
@@ -1065,7 +1065,7 @@ public class RegionCSSTest {
 //        assertEquals(expected, image);
     }
 
-    @Ignore("We do not presently implement -fx-background-origin")
+    @Ignore("JDK-8091576") // -fx-background-origin is not implemented.
     @Test public void backgroundOrigin_BorderBox() {
         region.setStyle(
                 "-fx-background-image: url('test/javafx/scene/layout/red.png');" +
@@ -1087,7 +1087,7 @@ public class RegionCSSTest {
 //        assertEquals(expected, image);
     }
 
-    @Ignore("We do not presently implement -fx-background-origin")
+    @Ignore("JDK-8091576") // -fx-background-origin is not implemented.
     @Test public void backgroundOrigin_PaddingBox() {
         region.setStyle(
                 "-fx-background-image: url('test/javafx/scene/layout/red.png');" +
@@ -1108,7 +1108,7 @@ public class RegionCSSTest {
 //        assertEquals(expected, image);
     }
 
-    @Ignore("We do not presently implement -fx-background-origin")
+    @Ignore("JDK-8091576") // -fx-background-origin is not implemented.
     @Test public void backgroundOrigin_ContentBox() {
         region.setStyle(
                 "-fx-background-image: url('test/javafx/scene/layout/red.png');" +
@@ -1416,7 +1416,7 @@ public class RegionCSSTest {
         assertNull(region.getBorder());
     }
 
-    @Ignore("-fx-border-style-top is not supported")
+    @Ignore("JDK-8091576") // -fx-border-style-top is not implemented.
     @Test public void borderStyle_top() {
         region.setStyle("-fx-border-style-top: solid;");
         processCSS();
@@ -1434,7 +1434,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-style-right is not supported")
+    @Ignore("JDK-8091576") // -fx-border-style-right is not implemented.
     @Test public void borderStyle_right() {
         region.setStyle("-fx-border-style-right: solid;");
         processCSS();
@@ -1452,7 +1452,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-style-bottom is not supported")
+    @Ignore("JDK-8091576") // -fx-border-style-bottom is not implemented.
     @Test public void borderStyle_bottom() {
         region.setStyle("-fx-border-style-bottom: solid;");
         processCSS();
@@ -1470,7 +1470,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-style-left is not supported")
+    @Ignore("JDK-8091576") // -fx-border-style-left is not implemented.
     @Test public void borderStyle_left() {
         region.setStyle("-fx-border-style-left: solid;");
         processCSS();
@@ -1488,7 +1488,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-style-top and -fx-border-style-right are not supported")
+    @Ignore("JDK-8091576")
     @Test public void borderStyle_top_right() {
         region.setStyle(
                 "-fx-border-style-top: solid;" +
@@ -1508,7 +1508,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-style-top and -fx-border-style-bottom are not supported")
+    @Ignore("JDK-8091576")
     @Test public void borderStyle_bottom_top() {
         region.setStyle(
                 "-fx-border-style-top: solid;" +
@@ -1528,7 +1528,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-style-bottom and -fx-border-style-left are not supported")
+    @Ignore("JDK-8091576")
     @Test public void borderStyle_left_bottom() {
         region.setStyle(
                 "-fx-border-style-bottom: solid;" +
@@ -1612,7 +1612,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore ("double not supported yet")
+    @Ignore("JDK-8091576") // double value not implemented.
     @Test public void borderStyle_double() {
         region.setStyle("-fx-border-color: black; -fx-border-style: double;");
         processCSS();
@@ -1629,7 +1629,7 @@ public class RegionCSSTest {
 //        assertEquals(expected, stroke);
     }
 
-    @Ignore ("groove not supported yet")
+    @Ignore("JDK-8091576") // groove value not implemented.
     @Test public void borderStyle_groove() {
         region.setStyle("-fx-border-color: black; -fx-border-style: groove;");
         processCSS();
@@ -1646,7 +1646,7 @@ public class RegionCSSTest {
 //        assertEquals(expected, stroke);
     }
 
-    @Ignore ("ridge not supported yet")
+    @Ignore("JDK-8091576") // ridge value not implemented.
     @Test public void borderStyle_ridge() {
         region.setStyle("-fx-border-color: black; -fx-border-style: ridge;");
         processCSS();
@@ -1663,7 +1663,7 @@ public class RegionCSSTest {
 //        assertEquals(expected, stroke);
     }
 
-    @Ignore ("inset not supported yet")
+    @Ignore("JDK-8091576") // inset value not implemented.
     @Test public void borderStyle_inset() {
         region.setStyle("-fx-border-color: black; -fx-border-style: inset;");
         processCSS();
@@ -1680,7 +1680,7 @@ public class RegionCSSTest {
 //        assertEquals(expected, stroke);
     }
 
-    @Ignore ("outset not supported yet")
+    @Ignore("JDK-8091576") // outset value not implemented.
     @Test public void borderStyle_outset() {
         region.setStyle("-fx-border-color: black; -fx-border-style: outset;");
         processCSS();
@@ -1729,7 +1729,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore ("ridge not supported yet")
+    @Ignore("JDK-8091576") // ridge value not implemented.
     @Test public void borderStyle_solid_dotted_dashed_ridge() {
         region.setStyle("-fx-border-color: black; -fx-border-style: solid dotted dashed ridge;");
         processCSS();
@@ -1747,7 +1747,7 @@ public class RegionCSSTest {
 //        assertEquals(expected, stroke);
     }
 
-    @Ignore ("-fx-border-width-top is not supported")
+    @Ignore("JDK-8091576") // -fx-border-width-top is not implemented.
     @Test public void borderStrokeWidth_top() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -1764,7 +1764,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore ("-fx-border-width-right is not supported")
+    @Ignore("JDK-8091576") // -fx-border-width-right is not implemented.
     @Test public void borderStrokeWidth_right() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -1781,7 +1781,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore ("-fx-border-width-bottom is not supported")
+    @Ignore("JDK-8091576") // -fx-border-width-bottom is not implemented.
     @Test public void borderStrokeWidth_bottom() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -1798,7 +1798,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore ("-fx-border-width-left is not supported")
+    @Ignore("JDK-8091576") // -fx-border-width-left is not implemented.
     @Test public void borderStrokeWidth_left() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -1815,7 +1815,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore ("-fx-border-width-top and -fx-border-width-right are not supported")
+    @Ignore("JDK-8091576")
     @Test public void borderStrokeWidth_top_right() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -1833,7 +1833,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore ("-fx-border-width-top and -fx-border-width-bottom are not supported")
+    @Ignore("JDK-8091576")
     @Test public void borderStrokeWidth_top_bottom() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -1851,7 +1851,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore ("-fx-border-width-left and -fx-border-width-bottom are not supported")
+    @Ignore("JDK-8091576")
     @Test public void borderStrokeWidth_left_bottom() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -1914,7 +1914,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("thin keyword is not supported")
+    @Ignore("JDK-8091576") // thin value is not implemented.
     @Test public void borderStrokeWidth_thin() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -1931,7 +1931,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("thick keyword is not supported")
+    @Ignore("JDK-8091576") // thick value is not implemented.
     @Test public void borderStrokeWidth_thick() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -1948,7 +1948,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("medium keyword is not supported")
+    @Ignore("JDK-8091576") // medium value is not implemented.
     @Test public void borderStrokeWidth_medium() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -1965,7 +1965,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("thin, medium, and thick keywords are not supported")
+    @Ignore("JDK-8091576")
     @Test public void borderStrokeWidth_thin_medium_thick() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -1987,7 +1987,7 @@ public class RegionCSSTest {
 
     // TODO!! The initial width of a border is MEDIUM, NOT 0!
 
-    @Ignore("-fx-border-top-left-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-top-left-radius not implemented.
     @Test public void borderStrokeRadius_topLeft1() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2005,7 +2005,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-top-left-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-top-left-radius not implemented.
     @Test public void borderStrokeRadius_topLeft2() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2032,7 +2032,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-top-left-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-top-left-radius not implemented.
     @Test public void borderStrokeRadius_topLeft3() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2059,7 +2059,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-top-left-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-top-left-radius not implemented.
     @Test public void borderStrokeRadius_topLeft4() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2086,7 +2086,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-top-left-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-top-left-radius not implemented.
     @Test public void borderStrokeRadius_topLeft5() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2113,7 +2113,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-top-left-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-top-left-radius not implemented.
     @Test public void borderStrokeRadius_topLeft6() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2140,7 +2140,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-top-right-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-top-right-radius not implemented.
     @Test public void borderStrokeRadius_topRight1() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2158,7 +2158,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-top-right-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-top-right-radius not implemented.
     @Test public void borderStrokeRadius_topRight2() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2185,7 +2185,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-top-right-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-top-right-radius not implemented.
     @Test public void borderStrokeRadius_topRight3() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2212,7 +2212,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-top-right-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-top-right-radius not implemented.
     @Test public void borderStrokeRadius_topRight4() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2239,7 +2239,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-top-right-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-top-right-radius not implemented.
     @Test public void borderStrokeRadius_topRight5() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2266,7 +2266,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-top-right-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-top-right-radius not implemented.
     @Test public void borderStrokeRadius_topRight6() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2293,7 +2293,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-bottom-right-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-bottom-right-radius not implemented.
     @Test public void borderStrokeRadius_bottomRight1() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2311,7 +2311,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-bottom-right-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-bottom-right-radius not implemented.
     @Test public void borderStrokeRadius_bottomRight2() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2338,7 +2338,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-bottom-right-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-bottom-right-radius not implemented.
     @Test public void borderStrokeRadius_bottomRight3() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2365,7 +2365,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-bottom-right-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-bottom-right-radius not implemented.
     @Test public void borderStrokeRadius_bottomRight4() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2392,7 +2392,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-bottom-right-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-bottom-right-radius not implemented.
     @Test public void borderStrokeRadius_bottomRight5() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2419,7 +2419,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-bottom-right-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-bottom-right-radius not implemented.
     @Test public void borderStrokeRadius_bottomRight6() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2446,7 +2446,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-bottom-left-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-bottom-left-radius not implemented.
     @Test public void borderStrokeRadius_bottomLeft1() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2464,7 +2464,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-bottom-left-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-bottom-left-radius not implemented.
     @Test public void borderStrokeRadius_bottomLeft2() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2491,7 +2491,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-bottom-left-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-bottom-left-radius not implemented.
     @Test public void borderStrokeRadius_bottomLeft3() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2518,7 +2518,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-bottom-left-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-bottom-left-radius not implemented.
     @Test public void borderStrokeRadius_bottomLeft4() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2545,7 +2545,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-bottom-left-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-bottom-left-radius not implemented.
     @Test public void borderStrokeRadius_bottomLeft5() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2572,7 +2572,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-bottom-left-radius not supported")
+    @Ignore("JDK-8091576") // -fx-border-bottom-left-radius not implemented.
     @Test public void borderStrokeRadius_bottomLeft6() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2599,7 +2599,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore("-fx-border-top-left-radius and -fx-border-top-right-radius are not supported")
+    @Ignore("JDK-8091576")
     @Test public void borderStrokeRadius_topLeft_topRight() {
         region.setStyle(
                 "-fx-border-color: black;" +
@@ -2871,7 +2871,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore ("-fx-border-top-color is not supported by the CSS parser")
+    @Ignore("JDK-8091576")
     @Test public void borderStroke_top_IsSpecifiedOnly() {
         region.setStyle(
                 "-fx-border-style: solid;" +
@@ -2891,7 +2891,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore ("-fx-border-right-color is not supported by the CSS parser")
+    @Ignore("JDK-8091576")
     @Test public void borderStroke_right_IsSpecifiedOnly() {
         region.setStyle(
                 "-fx-border-style: solid;" +
@@ -2911,7 +2911,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore ("-fx-border-bottom-color is not supported by the CSS parser")
+    @Ignore("JDK-8091576") // -fx-border-bottom-color is not implemented.
     @Test public void borderStroke_bottom_IsSpecifiedOnly() {
         region.setStyle(
                 "-fx-border-style: solid;" +
@@ -2931,7 +2931,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore ("-fx-border-left-color is not supported by the CSS parser")
+    @Ignore("JDK-8091576") // -fx-border-left-color is not implemented.
     @Test public void borderStroke_left_IsSpecifiedOnly() {
         region.setStyle(
                 "-fx-border-style: solid;" +
@@ -2951,7 +2951,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore ("-fx-border-top-color and -fx-border-right-color is not supported by the CSS parser")
+    @Ignore("JDK-8091576")
     @Test public void borderStroke_top_right_IsSpecifiedOnly() {
         region.setStyle(
                 "-fx-border-style: solid;" +
@@ -2972,7 +2972,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore ("-fx-border-left-color and -fx-border-right-color is not supported by the CSS parser")
+    @Ignore("JDK-8091576")
     @Test public void borderStroke_right_left_IsSpecifiedOnly() {
         region.setStyle(
                 "-fx-border-style: solid;" +
@@ -2993,7 +2993,7 @@ public class RegionCSSTest {
         assertEquals(expected, stroke);
     }
 
-    @Ignore ("-fx-border-top-color and -fx-border-bottom-color is not supported by the CSS parser")
+    @Ignore("JDK-8091576")
     @Test public void borderStroke_bottom_top_IsSpecifiedOnly() {
         region.setStyle(
                 "-fx-border-style: solid;" +

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/ResizabilityTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/ResizabilityTest.java
@@ -40,7 +40,6 @@ import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Text;
 
 import org.junit.Test;
-import org.junit.Ignore;
 /**
  * Tests resizability apis of Node and key subclasses.
  *

--- a/modules/javafx.graphics/src/test/java/test/javafx/stage/PopupTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/stage/PopupTest.java
@@ -451,8 +451,7 @@ public class PopupTest {
         assertTrue(done);
     }
 
-
-    @Ignore ("Not sure how this ever worked, or what the point is")
+    @Ignore("JDK-8234161")
     @Test
     public void testPeerListener() {
         Popup p = new Popup();

--- a/modules/javafx.graphics/src/test/java/test/javafx/stage/Popup_parentWindow_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/stage/Popup_parentWindow_Test.java
@@ -41,7 +41,7 @@ import test.com.sun.javafx.test.objects.TestNode;
 import test.com.sun.javafx.test.objects.TestScene;
 import test.com.sun.javafx.test.objects.TestStage;
 
-@Ignore ("This test is basically invalidated with the new design and needs to be rewritten")
+@Ignore("JDK-8234153") // test needs to be rewritten.
 @RunWith(Parameterized.class)
 public final class Popup_parentWindow_Test extends PropertiesTestBase {
 


### PR DESCRIPTION
This is a simple fix to correct all the ignored tag in graphics unit tests.

Corrections are:
1. Each ignored test must be associated with a bug. There are new bugs reported for all the tests which are missing a bug.
2. Replace @org.junit.Ignore with @Ignore.
3. Remove unused import statement. 

Test count is same before and after this change on all three platforms.
tests: 22982,  failures: 0,  ignored: 273
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8234303](https://bugs.openjdk.java.net/browse/JDK-8234303): [TEST_BUG] Correct ignored tag in graphics unit tests


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)