### PR TITLE
8210955: DOMTest::testEventListenerCascade fails

### DIFF
--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/DOMTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/DOMTest.java
@@ -34,7 +34,6 @@ import static org.junit.Assert.fail;
 
 import javafx.scene.web.WebEngine;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.w3c.dom.*;
 import org.w3c.dom.css.*;
@@ -291,7 +290,6 @@ public class DOMTest extends TestBase {
         });
     }
 
-    @Ignore("Incorrect test, refer JDK-8210955")
     @Test public void testEventListenerCascade() {
         final Document doc = getDocumentFor("src/test/resources/test/html/dom.html");
         submit(() -> {
@@ -342,7 +340,7 @@ public class DOMTest extends TestBase {
                 EventTarget src = ((MouseEvent) evt).getTarget();
                 ((HTMLBodyElement) src).setClassName("newTestClass");
             };
-            ((EventTarget)body).addEventListener("click", listener1, true);
+            ((EventTarget)body).addEventListener("click", listener1, false);
             ((EventTarget)body).dispatchEvent(evClick);
             assertEquals("Java EventHandler does not work directly", "newTestClass", body.getClassName());
 
@@ -350,7 +348,7 @@ public class DOMTest extends TestBase {
                 //OK: stacked ScriptExecutionContext
                 listenerJS.handleEvent(evt);
             };
-            ((EventTarget)body).addEventListener("click", listener2, true);
+            ((EventTarget)body).addEventListener("click", listener2, false);
             ((EventTarget)body).dispatchEvent(evClick);
             assertEquals("JS EventHandler does not work from Java call", "testClass", body.getClassName());
         });


### PR DESCRIPTION
Modified the test to work with WebView's ordering of capturing and bubbling event listeners.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8210955](https://bugs.openjdk.java.net/browse/JDK-8210955): DOMTest::testEventListenerCascade fails


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)