### PR TITLE
8233747: JVM crash in com.sun.webkit.dom.DocumentImpl.createAttribute

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/DOM/JavaDocument.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/DOM/JavaDocument.cpp
@@ -1254,13 +1254,7 @@ JNIEXPORT jlong JNICALL Java_com_sun_webkit_dom_DocumentImpl_createAttributeImpl
     , jstring name)
 {
     WebCore::JSMainThreadNullState state;
-
-    auto result = IMPL->createAttribute(String(env, name));
-    if (result.hasException()) {
-        raiseDOMErrorException(env, result.releaseException());
-        return {};
-    }
-    return JavaReturn<Attr>(env, WTF::getPtr(result.releaseReturnValue()));
+    return JavaReturn<Attr>(env, WTF::getPtr(raiseOnDOMError(env, IMPL->createAttribute(String(env, name)))));
 }
 
 

--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/DOM/JavaDocument.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/DOM/JavaDocument.cpp
@@ -1254,7 +1254,13 @@ JNIEXPORT jlong JNICALL Java_com_sun_webkit_dom_DocumentImpl_createAttributeImpl
     , jstring name)
 {
     WebCore::JSMainThreadNullState state;
-    return JavaReturn<Attr>(env, WTF::getPtr(raiseOnDOMError(env, IMPL->createAttribute(String(env, name)))));
+
+    auto result = IMPL->createAttribute(String(env, name));
+    if (result.hasException()) {
+        raiseDOMErrorException(env, result.releaseException());
+        return {};
+    }
+    return JavaReturn<Attr>(env, WTF::getPtr(result.releaseReturnValue()));
 }
 
 

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/DOMTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/DOMTest.java
@@ -417,6 +417,26 @@ public class DOMTest extends TestBase {
         });
     }
 
+    // JDK-8233747
+    @Test public void testCreateAttribute() {
+        final Document doc = getDocumentFor("src/test/resources/test/html/dom.html");
+        submit(() -> {
+            try {
+                //invalid attribute
+                Attr attr = doc.createAttribute(":/test");
+                fail("DOMException expected but not thrown");
+            } catch (DOMException ex) {
+                // Expected.
+            } catch (Throwable ex) {
+                fail("DOMException expected but instead threw "+ex.getClass().getName());
+            }
+
+            String attributeName = "test";
+            Attr attr = doc.createAttribute(attributeName);
+            assertEquals("Created attribute", attributeName, attr.getName());
+        });
+    }
+
     // helper methods
 
     private void verifyChildRemoved(Node parent,

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/DOMTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/DOMTest.java
@@ -428,7 +428,7 @@ public class DOMTest extends TestBase {
             } catch (DOMException ex) {
                 // Expected.
             } catch (Throwable ex) {
-                fail("DOMException expected but instead threw "+ex.getClass().getName());
+                fail("DOMException expected but instead threw " + ex.getClass().getName());
             }
 
             String attributeName = "test";


### PR DESCRIPTION
Issue: Native part of WebView throws a DOMException and then, continues executing the rest of the function assuming that value is present. This causes the JVM to crash when retrieving the value.

Fix: Return from the function if exception was raised (code is similar to exception handling in [WebKitLegacy/java/DOM/JavaTreeWalker.cpp](https://github.com/openjdk/jfx/blob/master/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/DOM/JavaTreeWalker.cpp))

This fix also needs to be applied to all function calls in [WebKitLegacy/java/DOM](https://github.com/openjdk/jfx/tree/master/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/DOM) functions which raises DOMError similar to createAttributeImpl().
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8233747](https://bugs.openjdk.java.net/browse/JDK-8233747): JVM crash in com.sun.webkit.dom.DocumentImpl.createAttribute


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**) **Note!** Review applies to 7f6ed5bf7d81f4fc554a2eaa35264f52c2883024
 * Guru Hb ([ghb](@guruhb) - **Reviewer**)