### PR TITLE
8196587: Remove use of deprecated finalize method from JPEGImageLoader

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ImageStorage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ImageStorage.java
@@ -272,6 +272,8 @@ public class ImageStorage {
             } else {
                 throw new ImageStorageException("No loader for image data");
             }
+        } catch (ImageStorageException ise) {
+            throw ise;
         } catch (IOException e) {
             throw new ImageStorageException(e.getMessage(), e);
         } finally {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ImageStorage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ImageStorage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -257,6 +257,8 @@ public class ImageStorage {
             double width, double height, boolean preserveAspectRatio,
             float pixelScale, boolean smooth) throws ImageStorageException {
         ImageLoader loader = null;
+        ImageFrame[] images = null;
+
         try {
             if (isIOS) {
                 // no extension/signature recognition done here,
@@ -265,17 +267,18 @@ public class ImageStorage {
             } else {
                 loader = getLoaderBySignature(input, listener);
             }
+            if (loader != null) {
+                images = loadAll(loader, width, height, preserveAspectRatio, pixelScale, smooth);
+            } else {
+                throw new ImageStorageException("No loader for image data");
+            }
         } catch (IOException e) {
             throw new ImageStorageException(e.getMessage(), e);
+        } finally {
+            if (loader != null) {
+                loader.dispose();
+            }
         }
-
-        ImageFrame[] images = null;
-        if (loader != null) {
-            images = loadAll(loader, width, height, preserveAspectRatio, pixelScale, smooth);
-        } else {
-            throw new ImageStorageException("No loader for image data");
-        }
-
         return images;
     }
 
@@ -326,6 +329,9 @@ public class ImageStorage {
                 throw new ImageStorageException("No loader for image data");
             }
         } finally {
+            if (loader != null) {
+                loader.dispose();
+            }
             try {
                 if (theStream != null) {
                     theStream.close();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ios/IosImageLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ios/IosImageLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -210,10 +210,6 @@ public class IosImageLoader extends ImageLoaderImpl {
             IosImageLoader.disposeLoader(structPointer);
             structPointer = 0L;
         }
-    }
-
-    protected void finalize() {
-        dispose();
     }
 
    /**

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/jpeg/JPEGImageLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/jpeg/JPEGImageLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -199,10 +199,6 @@ public class JPEGImageLoader extends ImageLoaderImpl {
             disposeNative(structPointer);
             structPointer = 0L;
         }
-    }
-
-    protected void finalize() {
-        dispose();
     }
 
     public ImageFrame load(int imageIndex, int width, int height, boolean preserveAspectRatio, boolean smooth) throws IOException {


### PR DESCRIPTION
The finalize() method is deprecated in JDK9. See [Java 9 deprecated features](https://www.oracle.com/technetwork/java/javase/9-deprecated-features-3745636.html).
And so the JPEGImageLoader.finalize() method should be removed.

The change is,
1. Remove finalize method from JPEGImageLoader class.

2. Instance of JPEGImageLoader is created and used in ImageStorage class. JPEGImageLoader.dispose() should be called after it's use over. This would be a common call for the other (GIF, PNG, BMP) ImageLoader classes, which have empty dispose() method.

3. JPEGImageLoader.load() method almost always calls the dispose() method after the image is loaded. In normal scenario JPEGImageLoader is disposed here. The calls to dispose() added in ImageStorage seem logically correct place to add and should be added.

Verification:
Verified :graphics:test and system tests on all three platforms.
Verified that JPEGImageLoader.dispose() is always initiated by JPEGImageLoader.load()
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8196587](https://bugs.openjdk.java.net/browse/JDK-8196587): Remove use of deprecated finalize method from JPEGImageLoader


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)