### PR TITLE
8232064: Switch FX build to use JDK 13.0.1 as boot JDK

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -73,8 +73,8 @@ javadoc.header=JavaFX&nbsp;14
 ##############################################################################
 
 # JDK
-jfx.build.jdk.version=12
-jfx.build.jdk.buildnum=33
+jfx.build.jdk.version=13.0.1
+jfx.build.jdk.buildnum=9
 jfx.build.jdk.version.min=11
 jfx.build.jdk.buildnum.min=28
 


### PR DESCRIPTION
Now that we have switched to using gradle 6 we can switch to using JDK 13 as the boot JDK for JavaFX 14 builds. The latest JDK 13 update release is JDK 13.0.1.

This will not change the minimum JDK version needed to build or run JavaFX, which remains at 11. We will continue to generate class files using `-source 11 -target 11`.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8232064](https://bugs.openjdk.java.net/browse/JDK-8232064): Switch FX build to use JDK 13.0.1 as boot JDK


## Approvers
 * Phil Race ([prr](@prrace) - **Reviewer**)
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)