### PR TITLE
8234712: Add pivot properties for scale and rotation in Node, ScaleTransition and RotateTransition

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/NodeHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/NodeHelper.java
@@ -236,16 +236,16 @@ public abstract class NodeHelper {
         return nodeAccessor.traverse(node, direction);
     }
 
-    public static double getPivotX(Node node) {
-        return nodeAccessor.getPivotX(node);
+    public static double getCenterPivotX(Node node) {
+        return nodeAccessor.getCenterPivotX(node);
     }
 
-    public static double getPivotY(Node node) {
-        return nodeAccessor.getPivotY(node);
+    public static double getCenterPivotY(Node node) {
+        return nodeAccessor.getCenterPivotY(node);
     }
 
-    public static double getPivotZ(Node node) {
-        return nodeAccessor.getPivotZ(node);
+    public static double getCenterPivotZ(Node node) {
+        return nodeAccessor.getCenterPivotZ(node);
     }
 
     public static void pickNode(Node node, PickRay pickRay,
@@ -346,9 +346,9 @@ public abstract class NodeHelper {
         boolean isShowMnemonics(Node node);
         BooleanProperty showMnemonicsProperty(Node node);
         boolean traverse(Node node, Direction direction);
-        double getPivotX(Node node);
-        double getPivotY(Node node);
-        double getPivotZ(Node node);
+        double getCenterPivotX(Node node);
+        double getCenterPivotY(Node node);
+        double getCenterPivotZ(Node node);
         void pickNode(Node node, PickRay pickRay, PickResultChooser result);
         boolean intersects(Node node, PickRay pickRay, PickResultChooser pickResult);
         double intersectsBounds(Node node, PickRay pickRay);

--- a/modules/javafx.graphics/src/main/java/javafx/animation/PathTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/PathTransition.java
@@ -342,8 +342,8 @@ public final class PathTransition extends Transition {
                 }
             }
         }
-        cachedNode.setTranslateX(x - NodeHelper.getPivotX(cachedNode));
-        cachedNode.setTranslateY(y - NodeHelper.getPivotY(cachedNode));
+        cachedNode.setTranslateX(x - NodeHelper.getCenterPivotX(cachedNode));
+        cachedNode.setTranslateY(y - NodeHelper.getCenterPivotY(cachedNode));
         // Need to handle orientation if it is requested
         if (cachedIsNormalRequired) {
             cachedNode.setRotate(rotateAngle);

--- a/modules/javafx.graphics/src/main/java/javafx/animation/RotateTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/RotateTransition.java
@@ -212,24 +212,64 @@ public final class RotateTransition extends Transition {
         return axis;
     }
 
-    private ObjectProperty<Point3D> pivot;
-    private static final Point3D DEFAULT_PIVOT = null;
+    private DoubleProperty pivotX;
+    private static final double DEFAULT_PIVOT_X = 0.5;
 
-    public final void setPivot(Point3D value) {
-        if ((pivot != null) || (value != DEFAULT_PIVOT)) {
-            pivotProperty().set(value);
+    public final void setPivotX(double value) {
+        if ((pivotX != null) || (value != DEFAULT_PIVOT_X)) {
+            pivotXProperty().set(value);
         }
     }
 
-    public final Point3D getPivot() {
-        return (pivot == null) ? DEFAULT_PIVOT : pivot.get();
+    public final double getPivotX() {
+        return (pivotX == null) ? DEFAULT_PIVOT_X : pivotX.get();
     }
 
-    public final ObjectProperty<Point3D> pivotProperty() {
-        if (pivot == null) {
-            pivot = new SimpleObjectProperty<>(this, "pivot", DEFAULT_PIVOT);
+    public final DoubleProperty pivotXProperty() {
+        if (pivotX == null) {
+            pivotX = new SimpleDoubleProperty(this, "pivotX", DEFAULT_PIVOT_X);
         }
-        return pivot;
+        return pivotX;
+    }
+
+    private DoubleProperty pivotY;
+    private static final double DEFAULT_PIVOT_Y = 0.5;
+
+    public final void setPivotY(double value) {
+        if ((pivotY != null) || (value != DEFAULT_PIVOT_Y)) {
+            pivotYProperty().set(value);
+        }
+    }
+
+    public final double getPivotY() {
+        return (pivotY == null) ? DEFAULT_PIVOT_Y : pivotY.get();
+    }
+
+    public final DoubleProperty pivotYProperty() {
+        if (pivotY == null) {
+            pivotY = new SimpleDoubleProperty(this, "pivotY", DEFAULT_PIVOT_Y);
+        }
+        return pivotY;
+    }
+
+    private DoubleProperty pivotZ;
+    private static final double DEFAULT_PIVOT_Z = 0.5;
+
+    public final void setPivotZ(double value) {
+        if ((pivotZ != null) || (value != DEFAULT_PIVOT_Z)) {
+            pivotZProperty().set(value);
+        }
+    }
+
+    public final double getPivotZ() {
+        return (pivotZ == null) ? DEFAULT_PIVOT_Z : pivotZ.get();
+    }
+
+    public final DoubleProperty pivotZProperty() {
+        if (pivotZ == null) {
+            pivotZ = new SimpleDoubleProperty(this, "pivotZ", DEFAULT_PIVOT_Z);
+        }
+        return pivotZ;
     }
 
     /**
@@ -385,10 +425,13 @@ public final class RotateTransition extends Transition {
             if (_axis != null) {
                 node.get().setRotationAxis(_axis);
             }
-            Point3D pivot = getPivot();
-            if (pivot != null) {
-                node.get().setRotationPivot(pivot);
-            }
+
+            double pivotX = getPivotX();
+            node.get().setRotationPivotX(pivotX);
+            double pivotY = getPivotY();
+            node.get().setRotationPivotY(pivotY);
+            double pivotZ = getPivotZ();
+            node.get().setRotationPivotZ(pivotZ);
         }
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/animation/RotateTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/RotateTransition.java
@@ -202,14 +202,34 @@ public final class RotateTransition extends Transition {
     }
 
     public final Point3D getAxis() {
-        return (axis == null)? DEFAULT_AXIS : axis.get();
+        return (axis == null) ? DEFAULT_AXIS : axis.get();
     }
 
     public final ObjectProperty<Point3D> axisProperty() {
         if (axis == null) {
-            axis = new SimpleObjectProperty<Point3D>(this, "axis", DEFAULT_AXIS);
+            axis = new SimpleObjectProperty<>(this, "axis", DEFAULT_AXIS);
         }
         return axis;
+    }
+
+    private ObjectProperty<Point3D> pivot;
+    private static final Point3D DEFAULT_PIVOT = null;
+
+    public final void setPivot(Point3D value) {
+        if ((pivot != null) || (value != DEFAULT_PIVOT)) {
+            pivotProperty().set(value);
+        }
+    }
+
+    public final Point3D getPivot() {
+        return (pivot == null) ? DEFAULT_PIVOT : pivot.get();
+    }
+
+    public final ObjectProperty<Point3D> pivotProperty() {
+        if (pivot == null) {
+            pivot = new SimpleObjectProperty<>(this, "pivot", DEFAULT_PIVOT);
+        }
+        return pivot;
     }
 
     /**
@@ -359,12 +379,15 @@ public final class RotateTransition extends Transition {
             cachedNode = getTargetNode();
             final double _fromAngle = getFromAngle();
             final double _toAngle = getToAngle();
-            start = (!Double.isNaN(_fromAngle)) ? _fromAngle : cachedNode
-                    .getRotate();
+            start = (!Double.isNaN(_fromAngle)) ? _fromAngle : cachedNode.getRotate();
             delta = (!Double.isNaN(_toAngle)) ? _toAngle - start : getByAngle();
             final Point3D _axis = getAxis();
             if (_axis != null) {
                 node.get().setRotationAxis(_axis);
+            }
+            Point3D pivot = getPivot();
+            if (pivot != null) {
+                node.get().setRotationPivot(pivot);
             }
         }
     }

--- a/modules/javafx.graphics/src/main/java/javafx/animation/ScaleTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/ScaleTransition.java
@@ -30,6 +30,7 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ObjectPropertyBase;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.geometry.Point3D;
 import javafx.scene.Node;
 import javafx.util.Duration;
 
@@ -185,6 +186,26 @@ public final class ScaleTransition extends Transition {
             };
         }
         return duration;
+    }
+
+    private ObjectProperty<Point3D> pivot;
+    private static final Point3D DEFAULT_PIVOT = null;
+
+    public final void setPivot(Point3D value) {
+        if ((pivot != null) || (value != null /* DEFAULT_PIVOT */)) {
+            pivotProperty().set(value);
+        }
+    }
+
+    public final Point3D getPivot() {
+        return (pivot == null) ? DEFAULT_PIVOT : pivot.get();
+    }
+
+    public final ObjectProperty<Point3D> pivotProperty() {
+        if (pivot == null) {
+            pivot = new SimpleObjectProperty<>(this, "pivot", DEFAULT_PIVOT);
+        }
+        return pivot;
     }
 
     /**
@@ -549,6 +570,10 @@ public final class ScaleTransition extends Transition {
             } else {
                 startZ = (!Double.isNaN(_fromZ)) ? _fromZ : cachedNode.getScaleZ();
                 deltaZ = (!Double.isNaN(_toZ)) ? _toZ - startZ : getByZ();
+            }
+            Point3D pivot = getPivot();
+            if (pivot != null) {
+                node.get().setScalePivot(pivot);
             }
         }
     }

--- a/modules/javafx.graphics/src/main/java/javafx/animation/ScaleTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/ScaleTransition.java
@@ -30,7 +30,6 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ObjectPropertyBase;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
-import javafx.geometry.Point3D;
 import javafx.scene.Node;
 import javafx.util.Duration;
 
@@ -188,24 +187,64 @@ public final class ScaleTransition extends Transition {
         return duration;
     }
 
-    private ObjectProperty<Point3D> pivot;
-    private static final Point3D DEFAULT_PIVOT = null;
+    private DoubleProperty pivotX;
+    private static final double DEFAULT_PIVOT_X = 0.5;
 
-    public final void setPivot(Point3D value) {
-        if ((pivot != null) || (value != null /* DEFAULT_PIVOT */)) {
-            pivotProperty().set(value);
+    public final void setPivotX(double value) {
+        if ((pivotX != null) || (value != DEFAULT_PIVOT_X)) {
+            pivotXProperty().set(value);
         }
     }
 
-    public final Point3D getPivot() {
-        return (pivot == null) ? DEFAULT_PIVOT : pivot.get();
+    public final double getPivotX() {
+        return (pivotX == null) ? DEFAULT_PIVOT_X : pivotX.get();
     }
 
-    public final ObjectProperty<Point3D> pivotProperty() {
-        if (pivot == null) {
-            pivot = new SimpleObjectProperty<>(this, "pivot", DEFAULT_PIVOT);
+    public final DoubleProperty pivotXProperty() {
+        if (pivotX == null) {
+            pivotX = new SimpleDoubleProperty(this, "pivotX", DEFAULT_PIVOT_X);
         }
-        return pivot;
+        return pivotX;
+    }
+
+    private DoubleProperty pivotY;
+    private static final double DEFAULT_PIVOT_Y = 0.5;
+
+    public final void setPivotY(double value) {
+        if ((pivotY != null) || (value != DEFAULT_PIVOT_Y)) {
+            pivotYProperty().set(value);
+        }
+    }
+
+    public final double getPivotY() {
+        return (pivotY == null) ? DEFAULT_PIVOT_Y : pivotY.get();
+    }
+
+    public final DoubleProperty pivotYProperty() {
+        if (pivotY == null) {
+            pivotY = new SimpleDoubleProperty(this, "pivotY", DEFAULT_PIVOT_Y);
+        }
+        return pivotY;
+    }
+
+    private DoubleProperty pivotZ;
+    private static final double DEFAULT_PIVOT_Z = 0.5;
+
+    public final void setPivotZ(double value) {
+        if ((pivotZ != null) || (value != DEFAULT_PIVOT_Z)) {
+            pivotZProperty().set(value);
+        }
+    }
+
+    public final double getPivotZ() {
+        return (pivotZ == null) ? DEFAULT_PIVOT_Z : pivotZ.get();
+    }
+
+    public final DoubleProperty pivotZProperty() {
+        if (pivotZ == null) {
+            pivotZ = new SimpleDoubleProperty(this, "pivotZ", DEFAULT_PIVOT_Z);
+        }
+        return pivotZ;
     }
 
     /**
@@ -571,10 +610,13 @@ public final class ScaleTransition extends Transition {
                 startZ = (!Double.isNaN(_fromZ)) ? _fromZ : cachedNode.getScaleZ();
                 deltaZ = (!Double.isNaN(_toZ)) ? _toZ - startZ : getByZ();
             }
-            Point3D pivot = getPivot();
-            if (pivot != null) {
-                node.get().setScalePivot(pivot);
-            }
+
+            double pivotX = getPivotX();
+            node.get().setScalePivotX(pivotX);
+            double pivotY = getPivotY();
+            node.get().setScalePivotY(pivotY);
+            double pivotZ = getPivotZ();
+            node.get().setScalePivotZ(pivotZ);
         }
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -5619,8 +5619,7 @@ public abstract class Node implements EventTarget, Styleable {
     }
 
     public final double getScaleX() {
-        return (nodeTransformation == null) ? DEFAULT_SCALE_X
-                                            : nodeTransformation.getScaleX();
+        return (nodeTransformation == null) ? DEFAULT_SCALE_X : nodeTransformation.getScaleX();
     }
 
     /**
@@ -5632,8 +5631,8 @@ public abstract class Node implements EventTarget, Styleable {
      * default, which makes it ideal for scaling the entire node after
      * all effects and transforms have been taken into account.
      * <p>
-     * The pivot point about which the scale occurs is the center of the
-     * untransformed {@link #layoutBoundsProperty layoutBounds}.
+     * The pivot point about which the scale occurs is defined by the {@link #scalePivotProperty() scale pivot},
+     * which by default is the center of the untransformed {@link #layoutBoundsProperty layoutBounds}.
      *
      * @return the scaleX for this {@code Node}
      * @defaultValue 1.0
@@ -5647,8 +5646,7 @@ public abstract class Node implements EventTarget, Styleable {
     }
 
     public final double getScaleY() {
-        return (nodeTransformation == null) ? DEFAULT_SCALE_Y
-                                            : nodeTransformation.getScaleY();
+        return (nodeTransformation == null) ? DEFAULT_SCALE_Y : nodeTransformation.getScaleY();
     }
 
     /**
@@ -5660,8 +5658,8 @@ public abstract class Node implements EventTarget, Styleable {
      * default, which makes it ideal for scaling the entire node after
      * all effects and transforms have been taken into account.
      * <p>
-     * The pivot point about which the scale occurs is the center of the
-     * untransformed {@link #layoutBoundsProperty layoutBounds}.
+     * The pivot point about which the scale occurs is defined by the {@link #scalePivotProperty() scale pivot},
+     * which by default is the center of the untransformed {@link #layoutBoundsProperty layoutBounds}.
      *
      * @return the scaleY for this {@code Node}
      * @defaultValue 1.0
@@ -5675,8 +5673,7 @@ public abstract class Node implements EventTarget, Styleable {
     }
 
     public final double getScaleZ() {
-        return (nodeTransformation == null) ? DEFAULT_SCALE_Z
-                                            : nodeTransformation.getScaleZ();
+        return (nodeTransformation == null) ? DEFAULT_SCALE_Z : nodeTransformation.getScaleZ();
     }
 
     /**
@@ -5688,9 +5685,10 @@ public abstract class Node implements EventTarget, Styleable {
      * default, which makes it ideal for scaling the entire node after
      * all effects and transforms have been taken into account.
      * <p>
-     * The pivot point about which the scale occurs is the center of the
-     * rectangular bounds formed by taking {@link #boundsInLocalProperty boundsInLocal} and applying
-     * all the transforms in the {@link #getTransforms transforms} ObservableList.
+     * The pivot point about which the scale occurs is defined by the {@link #scalePivotProperty() scale pivot},
+     * which by default is the center of the rectangular bounds formed by taking
+     * {@link #boundsInLocalProperty boundsInLocal} and applying all the transforms in the
+     * {@link #getTransforms transforms} {@code ObservableList}.
      * <p>
      * Note that this is a conditional feature. See
      * {@link javafx.application.ConditionalFeature#SCENE3D ConditionalFeature.SCENE3D}
@@ -5742,20 +5740,21 @@ public abstract class Node implements EventTarget, Styleable {
      * default, which makes it ideal for rotating the entire node after
      * all effects and transforms have been taken into account.
      * <p>
-     * The pivot point about which the rotation occurs is the center of the
+     * The rotation axis is defined by the {@link #rotationAxisProperty() rotation axis}.
+     * The pivot point about which the rotation occurs is defined by the
+     * {@link #rotationPivotProperty() rotation pivot}, which by default is the center of the
      * untransformed {@link #layoutBoundsProperty layoutBounds}.
      * <p>
-     * Note that because the pivot point is computed as the center of this
+     * Note that in the default case where the pivot point is computed as the center of this
      * {@code Node}'s layout bounds, any change to the layout bounds will cause
      * the pivot point to change, which can move the object. For a leaf node,
      * any change to the geometry will cause the layout bounds to change.
      * For a group node, any change to any of its children, including a
      * change in a child's geometry, clip, effect, position, orientation, or
      * scale, will cause the group's layout bounds to change. If this movement
-     * of the pivot point is not
-     * desired, applications should instead use the Node's {@link #getTransforms transforms}
-     * ObservableList, and add a {@link javafx.scene.transform.Rotate} transform,
-     * which has a user-specifiable pivot point.
+     * of the pivot point is not desired, applications should instead set their own pivot or
+     * use the Node's {@link #getTransforms transforms} {@code ObservableList}, and add a
+     * {@link javafx.scene.transform.Rotate} transform, which also has a user-specifiable pivot point.
      *
      * @return the rotate for this {@code Node}
      * @defaultValue 0.0
@@ -5782,7 +5781,7 @@ public abstract class Node implements EventTarget, Styleable {
      * for more information.
      *
      * @return the rotationAxis for this {@code Node}
-     * @defaultValue Rotate.Z_AXIS
+     * @defaultValue {@code Rotate.Z_AXIS}
      */
     public final ObjectProperty<Point3D> rotationAxisProperty() {
         return getNodeTransformation().rotationAxisProperty();

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -5037,7 +5037,6 @@ public abstract class Node implements EventTarget, Styleable {
                 if (mirroringCenter == 0.0) {
                     mirroringCenter = getCenterPivotX();
                 }
-
                 localToParentTx = localToParentTx.deriveWithTranslation(mirroringCenter, 0.0);
                 localToParentTx = localToParentTx.deriveWithScale(-1.0, 1.0, 1.0);
                 localToParentTx = localToParentTx.deriveWithTranslation(-mirroringCenter, 0.0);
@@ -5054,10 +5053,13 @@ public abstract class Node implements EventTarget, Styleable {
             double rotPivotX = getRotationPivot().getX();
             double rotPivotY = getRotationPivot().getY();
             double rotPivotZ = getRotationPivot().getZ();
+            double rotAxisX = getRotationAxis().getX();
+            double rotAxisY = getRotationAxis().getY();
+            double rotAxisZ = getRotationAxis().getZ();
+            double rotAngle = Math.toRadians(getRotate());
 
             localToParentTx = localToParentTx.deriveWithTranslation(rotPivotX, rotPivotY, rotPivotZ)
-                                             .deriveWithRotation(Math.toRadians(getRotate()),
-                            getRotationAxis().getX(), getRotationAxis().getY(), getRotationAxis().getZ())
+                                             .deriveWithRotation(rotAngle, rotAxisX, rotAxisY, rotAxisZ)
                                              .deriveWithTranslation(-rotPivotX, -rotPivotY, -rotPivotZ);
         }
 
@@ -5710,14 +5712,14 @@ public abstract class Node implements EventTarget, Styleable {
     }
 
     /**
-     * Defines the axis of rotation of this {@code Node}.
+     * The point of origin for the scaling of this {@code Node}. If this value is not defined, the center
+     * of the node is used. Setting to null will cause an NPE.
      * <p>
      * Note that this is a conditional feature. See
      * {@link javafx.application.ConditionalFeature#SCENE3D ConditionalFeature.SCENE3D}
      * for more information.
      *
-     * @return the rotationAxis for this {@code Node}
-     * @defaultValue Rotate.Z_AXIS
+     * @return the scale pivot for this {@code Node}
      */
     public final ObjectProperty<Point3D> scalePivotProperty() {
         return getNodeTransformation().scalePivotProperty();
@@ -5795,14 +5797,14 @@ public abstract class Node implements EventTarget, Styleable {
     }
 
     /**
-     * Defines the axis of rotation of this {@code Node}.
+     * The rotation pivot of this {@code Node}. If this value is not defined, the center
+     * of the node is used. Setting to null will cause an NPE.
      * <p>
      * Note that this is a conditional feature. See
      * {@link javafx.application.ConditionalFeature#SCENE3D ConditionalFeature.SCENE3D}
      * for more information.
      *
-     * @return the rotationAxis for this {@code Node}
-     * @defaultValue Rotate.Z_AXIS
+     * @return the rotation pivot for this {@code Node}
      */
     public final ObjectProperty<Point3D> rotationPivotProperty() {
         return getNodeTransformation().rotationPivotProperty();

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -5724,7 +5724,7 @@ public abstract class Node implements EventTarget, Styleable {
     public final ObjectProperty<Point3D> scalePivotProperty() {
         return getNodeTransformation().scalePivotProperty();
     }
-    
+
     public final void setRotate(double value) {
         rotateProperty().set(value);
     }
@@ -5808,8 +5808,8 @@ public abstract class Node implements EventTarget, Styleable {
      */
     public final ObjectProperty<Point3D> rotationPivotProperty() {
         return getNodeTransformation().rotationPivotProperty();
-    }    
-    
+    }
+
     /**
      * An affine transform that holds the computed local-to-parent transform.
      * This is the concatenation of all transforms in this node, including all

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1566,7 +1566,7 @@ public abstract class Node implements EventTarget, Styleable {
     }
 
     /**
-     * Specifies a {@code Node} to use to define the the clipping shape for this
+     * Specifies a {@code Node} to use to define the clipping shape for this
      * Node. This clipping Node is not a child of this {@code Node} in the scene
      * graph sense. Rather, it is used to define the clip for this {@code Node}.
      * <p>
@@ -5728,8 +5728,7 @@ public abstract class Node implements EventTarget, Styleable {
     }
 
     public final double getRotate() {
-        return (nodeTransformation == null) ? DEFAULT_ROTATE
-                                            : nodeTransformation.getRotate();
+        return (nodeTransformation == null) ? DEFAULT_ROTATE : nodeTransformation.getRotate();
     }
 
     /**

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/bounds/GroupBoundsTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/bounds/GroupBoundsTest.java
@@ -473,11 +473,11 @@ public class GroupBoundsTest {
     @Test
     public void testPivotXAndPivotY() {
         Rectangle rect = new Rectangle(100, 100);
-        assertEquals(50.0f, (float) NodeHelper.getPivotX(rect));
-        assertEquals(50.0f, (float) NodeHelper.getPivotY(rect));
+        assertEquals(50.0f, (float) NodeHelper.getCenterPivotX(rect));
+        assertEquals(50.0f, (float) NodeHelper.getCenterPivotY(rect));
         rect.setWidth(70.0f);
-        assertEquals(35.0f, (float) NodeHelper.getPivotX(rect));
-        assertEquals(50.0f, (float) NodeHelper.getPivotY(rect));
+        assertEquals(35.0f, (float) NodeHelper.getCenterPivotX(rect));
+        assertEquals(50.0f, (float) NodeHelper.getCenterPivotY(rect));
     }
 
     /***************************************************************************


### PR DESCRIPTION
CSR will be submitted at a later phase.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Whitespace errors (failed with the updated jcheck configuration)

### Issue
 * [JDK-8234712](https://bugs.openjdk.org/browse/JDK-8234712): Add pivot properties for scale and rotation in Node, ScaleTransition and RotateTransition (**Enhancement** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/53/head:pull/53` \
`$ git checkout pull/53`

Update a local copy of the PR: \
`$ git checkout pull/53` \
`$ git pull https://git.openjdk.org/jfx.git pull/53/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 53`

View PR using the GUI difftool: \
`$ git pr show -t 53`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/53.diff">https://git.openjdk.org/jfx/pull/53.diff</a>

</details>
