### PR TITLE
8234916: [macos 10.15] Garbled text running with native-image

### DIFF
--- a/modules/javafx.graphics/src/main/native-font/coretext.c
+++ b/modules/javafx.graphics/src/main/native-font/coretext.c
@@ -388,7 +388,15 @@ JNIEXPORT jlong JNICALL OS_NATIVE(CTFontCreateWithName)
     CGAffineTransform _arg2, *lparg2=NULL;
     jlong rc = 0;
     if (arg2) if ((lparg2 = getCGAffineTransformFields(env, arg2, &_arg2)) == NULL) goto fail;
-    rc = (jlong)CTFontCreateWithName((CFStringRef)arg0, (CGFloat)arg1, (CGAffineTransform*)lparg2);
+    CFStringRef fontName = (CFStringRef)arg0;
+    if (CFStringGetCharacterAtIndex(fontName, 0) == '.') {
+        bool bold = CFStringFind(fontName, CFSTR("bold"), kCFCompareCaseInsensitive).location != kCFNotFound;
+        CTFontRef font = CTFontCreateUIFontForLanguage(bold ? kCTFontUIFontEmphasizedSystem : kCTFontUIFontSystem, 0.0, NULL);
+        rc = (jlong) CTFontCreateCopyWithAttributes(font, (CGFloat)arg1, (CGAffineTransform*)lparg2, NULL);
+        CFRelease(font);
+    } else {
+        rc = (jlong) CTFontCreateWithName(fontName, (CGFloat)arg1, (CGAffineTransform*)lparg2);
+    }
 fail:
     /* In only */
 //    if (arg2 && lparg2) setCGAffineTransformFields(env, arg2, lparg2);


### PR DESCRIPTION
Running on MacOS Catalina, when doing static builds of `libjavafx_font.a` and linking against this in a JavaFX app compiled with GraalVM native-image, if default fonts are used, the rendered text is garbled, and a warning message is printed: 

```
CoreText note: Client requested name ".SFUI-Regular", it will get TimesNewRomanPSMT rather than the intended font. All system UI font access should be through proper APIs such as CTFontCreateUIFontForLanguage() or +[UIFont systemFontOfSize:]. 
CoreText note: Set a breakpoint on CTFontLogSystemFontNameRequest to debug. 
```

On Mac OS, when a map with all the regular fonts is created, we also add two system fonts: [System regular](https://github.com/openjdk/jfx/blob/master/modules/javafx.graphics/src/main/native-font/MacFontFinder.c#L178), and [System bold](https://github.com/openjdk/jfx/blob/master/modules/javafx.graphics/src/main/native-font/MacFontFinder.c#L187). These will be the default fonts to be used if the project doesn't specify a font.

On runtime, when a font is [created](https://github.com/openjdk/jfx/blob/master/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontStrike.java#L90), `CTFontCreateWithName` is [used](https://github.com/openjdk/jfx/blob/master/modules/javafx.graphics/src/main/native-font/coretext.c#L391), which according to Apple guidelines should be used only for the regular fonts (those that are not system fonts). In fact the above warning doesn't happen when creating any of those fonts.

Following the warning message, one of the options to create system fonts is to use `CTFontCreateUIFontForLanguage`, which according to the documentation in `CTFont.h`: 
> Returns the special UI font for the given language and UI type.

and matches what we already do in `MacFontFinder` to create such fonts. (The other option will require the use of UIKit.)


This PR modifies `CTFontCreateWithName` in `coretext.c` to detect if the font is a system font in the first place, else use the same existing mechanism.

As an aside, the constants `kCTFontSystemFontType` and `kCTFontEmphasizedSystemFontType` are deprecated, and this PR uses now the new ones, but in both cases their int value is the same (2 and 3, in that order). As a follow-up PR, we could replace these deprecated constants.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8234916](https://bugs.openjdk.java.net/browse/JDK-8234916): [macos 10.15] Garbled text running with native-image


## Approvers
 * Phil Race ([prr](@prrace) - **Reviewer**)