### PR TITLE
8221334: TableViewSkin: must initialize flow's cellCount in constructor

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkin.java
@@ -133,6 +133,7 @@ public class TableViewSkin<T> extends TableViewSkinBase<T, T, TableView<T>, Tabl
 
         registerChangeListener(control.fixedCellSizeProperty(), e -> flow.setFixedCellSize(getSkinnable().getFixedCellSize()));
 
+        updateItemCount();
     }
 
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/ConcreteVirtualContainerTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/ConcreteVirtualContainerTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.control.skin;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+import javafx.collections.FXCollections;
+import javafx.scene.control.ListView;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeTableView;
+import javafx.scene.control.TreeView;
+import javafx.scene.control.skin.ListViewSkin;
+import javafx.scene.control.skin.TableViewSkin;
+import javafx.scene.control.skin.TreeTableViewSkin;
+import javafx.scene.control.skin.TreeViewSkin;
+
+/**
+ * Contains tests that should pass for all concrete implementations
+ * of VirtualContainerBase.
+ */
+public class ConcreteVirtualContainerTest {
+
+    /**
+     * Test for JDK-8221334: flow's cellCount must be initialized.
+     */
+    @Test
+    public void testTableSkinCellCountInitial() {
+        TableView<Locale> control = new TableView<>(FXCollections.observableArrayList(Locale.getAvailableLocales()));
+        control.setSkin(new TableViewSkin<>(control) {
+            {
+                assertEquals("flow's cellCount must be initialized", control.getItems().size(),
+                        getVirtualFlow().getCellCount());
+            }
+        });
+    }
+
+    @Test
+    public void testTreeTableSkinCellCountInitial() {
+        List<TreeItem<Locale>> treeItems = Arrays.stream(Locale.getAvailableLocales())
+                .map(TreeItem::new)
+                .collect(Collectors.toList());
+        TreeItem<Locale> root = new TreeItem<>(new Locale("dummy"));
+        root.setExpanded(true);
+        root.getChildren().addAll(treeItems);
+        TreeTableView<Locale> control = new TreeTableView<>(root);
+        control.setSkin(new TreeTableViewSkin<>(control) {
+            {
+                assertEquals("flow's cellCount must be initialized", treeItems.size() + 1,
+                        getVirtualFlow().getCellCount());
+            }
+        });
+    }
+
+    @Test
+    public void testTreeSkinCellCountInitial() {
+        List<TreeItem<Locale>> treeItems = Arrays.stream(Locale.getAvailableLocales())
+                .map(TreeItem::new)
+                .collect(Collectors.toList());
+        TreeItem<Locale> root = new TreeItem<>(new Locale("dummy"));
+        root.setExpanded(true);
+        root.getChildren().addAll(treeItems);
+        TreeView<Locale> control = new TreeView<>(root);
+        control.setSkin(new TreeViewSkin<>(control) {
+            {
+                assertEquals("flow's cellCount must be initialized", treeItems.size() +1,
+                        getVirtualFlow().getCellCount());
+            }
+        });
+    }
+
+    @Test
+    public void testListSkinCellCountInitial() {
+        ListView<Locale> control = new ListView<>(FXCollections.observableArrayList(Locale.getAvailableLocales()));
+        control.setSkin(new ListViewSkin<>(control) {
+            {
+                assertEquals("flow's cellCount must be initialized", control.getItems().size(),
+                        getVirtualFlow().getCellCount());
+            }
+        });
+    }
+}


### PR DESCRIPTION
This is a fix for https://bugs.openjdk.java.net/browse/JDK-8221334

- fixed as outlined in the bug report: added updateItemCount() in skin constructor (that's what all sibling skins are doing)
- added test which fails for TableViewSkin before, passes after the fix
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8221334](https://bugs.openjdk.java.net/browse/JDK-8221334): TableViewSkin: must initialize flow's cellCount in constructor


## Approvers
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)