### PR TITLE
8235151: Nonexistent notifyQuit method referred from iOS GlassHelper.m

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassApplication.m
@@ -381,7 +381,7 @@ jclass classForName(JNIEnv *env, char *className)
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     {
-        (*env)->CallVoidMethod(env, self.jApplication, [GlassHelper ApplicationNotifyQuitMethod]);
+        (*env)->CallVoidMethod(env, self.jApplication, [GlassHelper ApplicationNotifyWillQuitMethod]);
     }
     [pool drain];
     GLASS_CHECK_EXCEPTION(env);

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassHelper.h
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassHelper.h
@@ -46,7 +46,7 @@
 + (jmethodID)ApplicationNotifyDidBecomeActiveMethod;
 + (jmethodID)ApplicationNotifyWillResignActiveMethod;
 + (jmethodID)ApplicationNotifyDidResignActiveMethod;
-+ (jmethodID)ApplicationNotifyQuitMethod;
++ (jmethodID)ApplicationNotifyWillQuitMethod;
 + (jmethodID)ApplicationNotifyDidReceiveMemoryWarningMethod;
 
 @end

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassHelper.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassHelper.m
@@ -223,20 +223,20 @@
 }
 
 
-+ (jmethodID)ApplicationNotifyQuitMethod
++ (jmethodID)ApplicationNotifyWillQuitMethod
 {
-    static jmethodID _ApplicationNotifyQuitMethod = NULL;
-    if (_ApplicationNotifyQuitMethod == NULL)
+    static jmethodID _ApplicationNotifyWillQuitMethod = NULL;
+    if (_ApplicationNotifyWillQuitMethod == NULL)
     {
         GET_MAIN_JENV;
-        _ApplicationNotifyQuitMethod = (*env)->GetMethodID(env, [GlassHelper ApplicationClass], "notifyQuit", "()V");
+        _ApplicationNotifyWillQuitMethod = (*env)->GetMethodID(env, [GlassHelper ApplicationClass], "notifyWillQuit", "()V");
         GLASS_CHECK_EXCEPTION(env);
     }
-    if (_ApplicationNotifyQuitMethod == NULL)
+    if (_ApplicationNotifyWillQuitMethod == NULL)
     {
-        NSLog(@"GlassHelper error: _ApplicationNotifyQuitMethod == NULL");
+        NSLog(@"GlassHelper error: _ApplicationNotifyWillQuitMethod == NULL");
     }
-    return _ApplicationNotifyQuitMethod;
+    return _ApplicationNotifyWillQuitMethod;
 }
 
 


### PR DESCRIPTION
`GlassHelper.m` for iOS contains the public method `ApplicationNotifyQuitMethod()`, that tries to find via reflection the `notifyQuit()` method in the `com.sun.glass.ui.Application` class. 

But the method `notifyQuit` doesn't exist in that class. However `notifyWillQuit` exists, and it is used in the Mac platform, for instance, when `ApplicationNotifyWillQuitMethod()` is called.

This PR renames `notifyQuit` to `notifyWillQuit`, and therefore `ApplicationNotifyQuitMethod` is also renamed to `ApplicationNotifyWillQuitMethod`.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8235151](https://bugs.openjdk.java.net/browse/JDK-8235151): Nonexistent notifyQuit method referred from iOS GlassHelper.m


## Approvers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)