### PR TITLE
8227425: Add support for e-paper displays on i.MX6 devices

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDFrameBuffer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDFrameBuffer.java
@@ -69,6 +69,11 @@ class EPDFrameBuffer {
      */
     private static final int POWERDOWN_DELAY = 1_000;
 
+    /**
+     * Linux system error: ENOTTY 25 Inappropriate ioctl for device.
+     */
+    private static final int ENOTTY = 25;
+
     private final PlatformLogger logger = Logging.getJavaFXLogger();
     private final EPDSettings settings;
     private final LinuxSystem system;
@@ -296,6 +301,16 @@ class EPDFrameBuffer {
      * <li>{@link EPDSystem#WAVEFORM_MODE_A2}</li>
      * </ul>
      *
+     * @implNote This method fails on the Kobo Glo HD Model N437 with the error
+     * ENOTTY (25), "Inappropriate ioctl for device." The driver on that device
+     * uses an extended structure with four additional integers, changing its
+     * size and its corresponding request code. This method could use the
+     * extended structure, but the driver on the Kobo Glo HD ignores it and
+     * returns immediately, anyway. Furthermore, newer devices support both the
+     * current structure and the extended one, but define the extra fields in a
+     * different order. Therefore, simply use the current structure and ignore
+     * an error of ENOTTY, picking up the default values for any extra fields.
+     *
      * @param init the initialization mode for clearing the screen to all white
      * @param du the direct update mode for changing any gray values to either
      * all black or all white
@@ -308,7 +323,7 @@ class EPDFrameBuffer {
         var modes = new MxcfbWaveformModes();
         modes.setModes(modes.p, init, du, gc4, gc8, gc16, gc32);
         int rc = system.ioctl(fd, driver.MXCFB_SET_WAVEFORM_MODES, modes.p);
-        if (rc != 0) {
+        if (rc != 0 && system.errno() != ENOTTY) {
             logger.severe("Failed setting waveform modes: {0} ({1})",
                     system.getErrorMessage(), system.errno());
         }
@@ -325,7 +340,7 @@ class EPDFrameBuffer {
     private void setTemperature(int temp) {
         int rc = driver.ioctl(fd, driver.MXCFB_SET_TEMPERATURE, temp);
         if (rc != 0) {
-            logger.severe("Failed setting temperature to {2} °C: {0} ({1})",
+            logger.severe("Failed setting temperature to {2} degrees Celsius: {0} ({1})",
                     system.getErrorMessage(), system.errno(), temp);
         }
     }
@@ -421,7 +436,7 @@ class EPDFrameBuffer {
             logger.severe("Failed sending update {2}: {0} ({1})",
                     system.getErrorMessage(), system.errno(), Integer.toUnsignedLong(updateMarker));
         } else if (logger.isLoggable(Level.FINER)) {
-            logger.finer("Sent update: {0} × {1}, waveform {2}, selected {3}, flags 0x{4}, marker {5}",
+            logger.finer("Sent update: {0} x {1}, waveform {2}, selected {3}, flags 0x{4}, marker {5}",
                     update.getUpdateRegionWidth(update.p), update.getUpdateRegionHeight(update.p),
                     waveformMode, update.getWaveformMode(update.p),
                     Integer.toHexString(update.getFlags(update.p)).toUpperCase(),
@@ -482,7 +497,7 @@ class EPDFrameBuffer {
             logger.severe("Failed getting power-down delay: {0} ({1})",
                     system.getErrorMessage(), system.errno());
         }
-        return integer.getInteger(integer.p);
+        return integer.get(integer.p);
     }
 
     /**
@@ -571,20 +586,57 @@ class EPDFrameBuffer {
          * "QuantumRenderer modifies buffer in use by JavaFX Application Thread"
          * <https://bugs.openjdk.java.net/browse/JDK-8201567>.
          */
-        int size = xresVirtual * yresVirtual * Integer.SIZE;
+        int size = xresVirtual * yres * Integer.BYTES;
         return ByteBuffer.allocateDirect(size);
     }
 
     /**
      * Creates a new mapping of the Linux frame buffer device into memory.
      *
+     * @implNote The virtual y-resolution reported by the device driver can be
+     * wrong, as shown by the following example on the Kobo Glo HD Model N437
+     * which reports 2,304 pixels when the correct value is 1,152 pixels
+     * (6,782,976 / 5,888). Therefore, this method cannot use the frame buffer
+     * virtual resolution to calculate its size.
+     *
+     * <pre>{@code
+     * $ sudo fbset -i
+     *
+     * mode "1448x1072-46"
+     * # D: 80.000 MHz, H: 50.188 kHz, V: 46.385 Hz
+     * geometry 1448 1072 1472 2304 32
+     * timings 12500 16 102 4 4 28 2
+     * rgba 8/16,8/8,8/0,8/24
+     * endmode
+     *
+     * Frame buffer device information:
+     * Name        : mxc_epdc_fb
+     * Address     : 0x88000000
+     * Size        : 6782976
+     * Type        : PACKED PIXELS
+     * Visual      : TRUECOLOR
+     * XPanStep    : 1
+     * YPanStep    : 1
+     * YWrapStep   : 0
+     * LineLength  : 5888
+     * Accelerator : No
+     * }</pre>
+     *
      * @return a byte buffer containing the mapping of the Linux frame buffer
-     * device
+     * device if successful; otherwise {@code null}
      */
     ByteBuffer getMappedBuffer() {
-        int size = xresVirtual * yresVirtual * bytesPerPixel;
+        ByteBuffer buffer = null;
+        int size = xresVirtual * yres * bytesPerPixel;
+        logger.fine("Mapping frame buffer: {0} bytes", size);
         long addr = system.mmap(0l, size, LinuxSystem.PROT_WRITE, LinuxSystem.MAP_SHARED, fd, 0);
-        return addr == LinuxSystem.MAP_FAILED ? null : C.getC().NewDirectByteBuffer(addr, size);
+        if (addr == LinuxSystem.MAP_FAILED) {
+            logger.severe("Failed mapping {2} bytes of frame buffer: {0} ({1})",
+                    system.getErrorMessage(), system.errno(), size);
+        } else {
+            buffer = C.getC().NewDirectByteBuffer(addr, size);
+        }
+        return buffer;
     }
 
     /**
@@ -594,7 +646,13 @@ class EPDFrameBuffer {
      * buffer device
      */
     void releaseMappedBuffer(ByteBuffer buffer) {
-        system.munmap(C.getC().GetDirectBufferAddress(buffer), buffer.capacity());
+        int size = buffer.capacity();
+        logger.fine("Unmapping frame buffer: {0} bytes", size);
+        int rc = system.munmap(C.getC().GetDirectBufferAddress(buffer), size);
+        if (rc != 0) {
+            logger.severe("Failed unmapping {2} bytes of frame buffer: {0} ({1})",
+                    system.getErrorMessage(), system.errno(), size);
+        }
     }
 
     /**
@@ -614,26 +672,31 @@ class EPDFrameBuffer {
     }
 
     /**
-     * Gets the virtual horizontal resolution of the frame buffer. See the notes
-     * for the {@linkplain EPDFrameBuffer#EPDFrameBuffer constructor} above.
+     * Gets the frame buffer width in pixels. See the notes for the
+     * {@linkplain EPDFrameBuffer#EPDFrameBuffer constructor} above.
      *
-     * @return the virtual width in pixels
+     * @implNote When using an 8-bit, unrotated, and uninverted frame buffer in
+     * the Y8 pixel format, the Kobo Clara HD Model N249 works only when this
+     * method returns the visible x-resolution ({@code xres}) instead of the
+     * normal virtual x-resolution ({@code xresVirtual}).
+     *
+     * @return the width in pixels
      */
     int getWidth() {
-        return xresVirtual;
+        return settings.getWidthVisible ? xres : xresVirtual;
     }
 
     /**
-     * Gets the visible vertical resolution of the frame buffer.
+     * Gets the frame buffer height in pixels.
      *
-     * @return the visible height in pixels
+     * @return the height in pixels
      */
     int getHeight() {
         return yres;
     }
 
     /**
-     * Gets the color depth of the frame buffer.
+     * Gets the frame buffer color depth in bits per pixel.
      *
      * @return the color depth in bits per pixel
      */

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDScreen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDScreen.java
@@ -60,7 +60,7 @@ class EPDScreen implements NativeScreen {
 
     /**
      * The density of this screen in pixels per inch. For now, the value is
-     * hard-coded to the density of a 6-inch display panel with 800 × 600 px at
+     * hard-coded to the density of a 6-inch display panel with 800 x 600 px at
      * 167 ppi.
      */
     private static final int DPI = 167;
@@ -99,6 +99,8 @@ class EPDScreen implements NativeScreen {
             width = fbDevice.getWidth();
             height = fbDevice.getHeight();
             bitDepth = fbDevice.getBitDepth();
+            logger.fine("Native screen geometry: {0} px x {1} px x {2} bpp",
+                    width, height, bitDepth);
 
             /*
              * If the Linux frame buffer is configured for 32-bit color, compose
@@ -112,8 +114,12 @@ class EPDScreen implements NativeScreen {
              * display, though, allows us to reuse the same frame buffer region
              * immediately after sending an update.
              */
+            ByteBuffer mapping = null;
             if (bitDepth == Integer.SIZE) {
-                fbMapping = fbDevice.getMappedBuffer();
+                mapping = fbDevice.getMappedBuffer();
+            }
+            if (mapping != null) {
+                fbMapping = mapping;
                 fbChannel = null;
             } else {
                 Path path = FileSystems.getDefault().getPath(fbPath);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDSettings.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDSettings.java
@@ -38,15 +38,127 @@ import java.util.HashMap;
  */
 class EPDSettings {
 
+    /**
+     * Sets the frame buffer color depth and pixel format: 8 for 8-bit grayscale
+     * in the Y8 pixel format, 16 for 16-bit color in the RGB565 pixel format,
+     * or 32 for 32-bit color in the ARGB32 pixel format. The default is 32.
+     * <p>
+     * Using the 32-bit format allows JavaFX to render directly into the Linux
+     * frame buffer and avoid the step of copying and converting each pixel from
+     * an off-screen composition buffer.</p>
+     *
+     * @implNote Corresponds to the {@code bits_per_pixel} field of
+     * {@code fb_var_screeninfo} in <i>linux/fb.h</i>.
+     */
     private static final String BITS_PER_PIXEL = "monocle.epd.bitsPerPixel";
+
+    /**
+     * Sets the frame buffer rotation: 0 for unrotated (UR), 1 for 90 degrees
+     * clockwise (CW), 2 for 180 degrees upside-down (UD), and 3 for 90 degrees
+     * counter-clockwise (CCW). The default is 0.
+     * <p>
+     * The unrotated and upside-down settings are in landscape mode, while the
+     * clockwise and counter-clockwise settings are in portrait.</p>
+     *
+     * @implNote Corresponds to the {@code rotate} field of
+     * {@code fb_var_screeninfo} in <i>linux/fb.h</i>.
+     */
     private static final String ROTATE = "monocle.epd.rotate";
-    private static final String Y8_INVERTED = "monocle.epd.y8inverted";
+
+    /**
+     * Sets an indicator for the frame buffer grayscale value: {@code true} to
+     * invert the pixels of all updates when using 8-bit grayscale in the Y8
+     * pixel format; otherwise {@code false}. The default is {@code false}.
+     * <p>
+     * The value is ignored when the frame buffer is not set to 8-bit grayscale
+     * in the Y8 pixel format.</p>
+     *
+     * @implNote Corresponds to the {@code GRAYSCALE_8BIT_INVERTED} constant in
+     * <i>linux/mxcfb.h</i>.
+     */
+    private static final String Y8_INVERTED = "monocle.epd.Y8Inverted";
+
+    /**
+     * Indicates whether to wait for the previous update to complete before
+     * sending the next update: {@code true} to avoid waiting and send updates
+     * as quickly as possible; otherwise {@code false}. The default is
+     * {@code false}.
+     * <p>
+     * The number of outstanding updates is limited by the device controller to
+     * either 16 or 64 concurrent non-colliding updates, depending on the model.
+     * A value of {@code true} may result in errors if the maximum number of
+     * concurrent non-colliding updates is exceeded.</p>
+     *
+     * @implNote Corresponds to the IOCTL call constant
+     * {@code MXCFB_WAIT_FOR_UPDATE_COMPLETE} in <i>linux/mxcfb.h</i>.
+     */
     private static final String NO_WAIT = "monocle.epd.noWait";
+
+    /**
+     * Sets the waveform mode used for updates: 1 for black-and-white direct
+     * update (DU), 2 for 16 levels of gray (GC16), 3 for 4 levels of gray
+     * (GC4), 4 for pure black-and-white animation (A2), and 257 for the
+     * automatic selection of waveform mode based on the number of gray levels
+     * in the update (AUTO). The default is 257.
+     * <p>
+     * Automatic selection chooses one of 1 (DU), 2 (GC16), or 3 (GC4). If the
+     * waveform mode is set to 2 (GC16), it may be upgraded to a compatible but
+     * optimized mode internal to the driver, if available.</p>
+     *
+     * @implNote Corresponds to the {@code waveform_mode} field of
+     * {@code mxcfb_update_data} in <i>linux/mxcfb.h</i>.
+     */
     private static final String WAVEFORM_MODE = "monocle.epd.waveformMode";
+
+    /**
+     * Sets the update flag for pixel inversion: {@code true} to invert the
+     * pixels of each update; otherwise {@code false}. The default is
+     * {@code false}.
+     *
+     * @implNote Corresponds to the {@code EPDC_FLAG_ENABLE_INVERSION} constant
+     * in <i>linux/mxcfb.h</i>.
+     */
     private static final String FLAG_ENABLE_INVERSION = "monocle.epd.enableInversion";
+
+    /**
+     * Sets the update flag for monochrome conversion: {@code true} to convert
+     * the pixels of each update to pure black and white using a 50-percent
+     * threshold; otherwise {@code false}. The default is {@code false}.
+     *
+     * @implNote Corresponds to the {@code EPDC_FLAG_FORCE_MONOCHROME} constant
+     * in <i>linux/mxcfb.h</i>.
+     */
     private static final String FLAG_FORCE_MONOCHROME = "monocle.epd.forceMonochrome";
+
+    /**
+     * Sets the update flag for 1-bit dithering: {@code true} to dither each
+     * update in an 8-bit Y8 frame buffer to 1-bit black and white, if
+     * available; otherwise {@code false}. The default is {@code false}.
+     *
+     * @implNote Corresponds to the {@code EPDC_FLAG_USE_DITHERING_Y1} constant
+     * in <i>linux/mxcfb.h</i>.
+     */
     private static final String FLAG_USE_DITHERING_Y1 = "monocle.epd.useDitheringY1";
+
+    /**
+     * Sets the update flag for 4-bit dithering: {@code true} to dither each
+     * update in an 8-bit Y8 frame buffer to 4-bit grayscale, if available;
+     * otherwise {@code false}. The default is {@code false}.
+     *
+     * @implNote Corresponds to the {@code EPDC_FLAG_USE_DITHERING_Y4} constant
+     * in <i>linux/mxcfb.h</i>.
+     */
     private static final String FLAG_USE_DITHERING_Y4 = "monocle.epd.useDitheringY4";
+
+    /**
+     * Indicates whether to work around the bug found on devices, such as the
+     * Kobo Clara HD Model N249, which require a screen width equal to the
+     * visible x-resolution, instead of the normal virtual x-resolution, when
+     * using an 8-bit, unrotated, and uninverted frame buffer in the Y8 pixel
+     * format: {@code true} to work around the bug; otherwise {@code false}. The
+     * default is {@code false}.
+     */
+    private static final String FIX_WIDTH_Y8UR = "monocle.epd.fixWidthY8UR";
 
     private static final String[] EPD_PROPERTIES = {
         BITS_PER_PIXEL,
@@ -57,7 +169,8 @@ class EPDSettings {
         FLAG_ENABLE_INVERSION,
         FLAG_FORCE_MONOCHROME,
         FLAG_USE_DITHERING_Y1,
-        FLAG_USE_DITHERING_Y4
+        FLAG_USE_DITHERING_Y4,
+        FIX_WIDTH_Y8UR
     };
 
     private static final int BITS_PER_PIXEL_DEFAULT = Integer.SIZE;
@@ -103,6 +216,7 @@ class EPDSettings {
     private final boolean flagForceMonochrome;
     private final boolean flagUseDitheringY1;
     private final boolean flagUseDitheringY4;
+    private final boolean fixWidthY8UR;
 
     final int bitsPerPixel;
     final int rotate;
@@ -110,6 +224,7 @@ class EPDSettings {
     final int waveformMode;
     final int grayscale;
     final int flags;
+    final boolean getWidthVisible;
 
     /**
      * Creates a new EPDSettings, capturing the current values of the EPD system
@@ -117,7 +232,7 @@ class EPDSettings {
      */
     private EPDSettings() {
         if (logger.isLoggable(Level.FINE)) {
-            var map = new HashMap();
+            HashMap<String, String> map = new HashMap<>();
             for (String key : EPD_PROPERTIES) {
                 String value = System.getProperty(key);
                 if (value != null) {
@@ -151,6 +266,10 @@ class EPDSettings {
                 | (flagForceMonochrome ? EPDSystem.EPDC_FLAG_FORCE_MONOCHROME : 0)
                 | (flagUseDitheringY1 ? EPDSystem.EPDC_FLAG_USE_DITHERING_Y1 : 0)
                 | (flagUseDitheringY4 ? EPDSystem.EPDC_FLAG_USE_DITHERING_Y4 : 0);
+
+        fixWidthY8UR = Boolean.getBoolean(FIX_WIDTH_Y8UR);
+        getWidthVisible = fixWidthY8UR && grayscale == EPDSystem.GRAYSCALE_8BIT
+                && rotate == EPDSystem.FB_ROTATE_UR;
     }
 
     /**
@@ -179,8 +298,10 @@ class EPDSettings {
     @Override
     public String toString() {
         return MessageFormat.format("{0}[bitsPerPixel={1} rotate={2} "
-                + "noWait={3} waveformMode={4} grayscale={5} flags=0x{6}]",
+                + "noWait={3} waveformMode={4} grayscale={5} flags=0x{6} "
+                + "getWidthVisible={7}]",
                 getClass().getName(), bitsPerPixel, rotate,
-                noWait, waveformMode, grayscale, Integer.toHexString(flags));
+                noWait, waveformMode, grayscale, Integer.toHexString(flags),
+                getWidthVisible);
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDSystem.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDSystem.java
@@ -177,7 +177,7 @@ class EPDSystem {
     static final int FB_POWERDOWN_DISABLE = -1;
 
     /**
-     * Initialization waveform (0x0...0xF → 0xF in ~4000 ms). Clears the screen
+     * Initialization waveform (0x0...0xF to 0xF in ~4000 ms). Clears the screen
      * to all white.
      * <p>
      * "A first exemplary drive scheme provides waveforms that may be used to
@@ -189,7 +189,7 @@ class EPDSystem {
     static final int WAVEFORM_MODE_INIT = 0;
 
     /**
-     * Direct update waveform (0x0...0xF → 0x0 or 0xF in ~260 ms). Changes gray
+     * Direct update waveform (0x0...0xF to 0x0 or 0xF in ~260 ms). Changes gray
      * pixels to black or white.
      * <p>
      * "A second exemplary drive scheme provides waveforms that may be used to
@@ -201,7 +201,7 @@ class EPDSystem {
     static final int WAVEFORM_MODE_DU = 1;
 
     /**
-     * Gray 4-level waveform (0x0...0xF → 0x0, 0x5, 0xA, or 0xF in ~500 ms).
+     * Gray 4-level waveform (0x0...0xF to 0x0, 0x5, 0xA, or 0xF in ~500 ms).
      * Supports 2-bit grayscale images and text with lower quality.
      * <p>
      * "A third exemplary drive scheme provides waveforms that may be used to
@@ -214,8 +214,8 @@ class EPDSystem {
     static final int WAVEFORM_MODE_GC4 = 3;
 
     /**
-     * Gray 16-level waveform (0x0...0xF → 0x0...0xF in ~760 ms). Supports 4-bit
-     * grayscale images and text with high quality.
+     * Gray 16-level waveform (0x0...0xF to 0x0...0xF in ~760 ms). Supports
+     * 4-bit grayscale images and text with high quality.
      * <p>
      * "A fourth exemplary drive scheme provides waveforms that may be used to
      * change the display state of a pixel from any initial display state to a
@@ -227,7 +227,7 @@ class EPDSystem {
     static final int WAVEFORM_MODE_GC16 = 2;
 
     /**
-     * Animation waveform (0x0 or 0xF → 0x0 or 0xF in ~120 ms). Provides a fast
+     * Animation waveform (0x0 or 0xF to 0x0 or 0xF in ~120 ms). Provides a fast
      * 1-bit black-and-white animation mode of up to eight frames per second.
      * <p>
      * "A fifth exemplary drive scheme provides waveforms that may be used to
@@ -345,9 +345,11 @@ class EPDSystem {
     }
 
     /**
-     * Passes an integer parameter by value to the device driver through the
-     * IOCTL interface. ({@link LinuxSystem#ioctl}, instead, takes a pointer as
-     * its third parameter, passing its data by reference.)
+     * Calls the {@code ioctl} system function, passing a <i>write</i> integer
+     * parameter. This method is more convenient than passing the pointer to an
+     * {@code IntStructure} with {@link LinuxSystem#ioctl} and can be used when
+     * the request code is created by {@link LinuxSystem#IOW} for setting an
+     * integer value.
      *
      * @param fd an open file descriptor
      * @param request a device-dependent request code
@@ -358,7 +360,7 @@ class EPDSystem {
     native int ioctl(long fd, int request, int value);
 
     /**
-     * A structure for passing an integer by value in an IOCTL call.
+     * A structure for passing the pointer to an integer in an IOCTL call.
      */
     static class IntStructure extends C.Structure {
 
@@ -379,11 +381,11 @@ class EPDSystem {
             return BYTES;
         }
 
-        int getInteger(long p) {
+        int get(long p) {
             return data.get(VALUE);
         }
 
-        void setInteger(long p, int value) {
+        void set(long p, int value) {
             data.put(VALUE, value);
         }
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/FramebufferY8.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/FramebufferY8.java
@@ -93,14 +93,15 @@ class FramebufferY8 extends Framebuffer {
      * which defines the same primaries and white point as the sRGB color space.
      * <pre>{@code
      * Simple average:  Y' = (R' + G' + B') / 3
-     * Rec. 601 (SDTV): Y' = 0.299  × R' + 0.587  × G' + 0.114  × B'
-     * Rec. 709 (HDTV): Y' = 0.2126 × R' + 0.7152 × G' + 0.0722 × B'
-     * Rec. 2100 (HDR): Y' = 0.2627 × R' + 0.6780 × G' + 0.0593 × B'
+     * Rec. 601 (SDTV): Y' = 0.299  * R' + 0.587  * G' + 0.114  * B'
+     * Rec. 709 (HDTV): Y' = 0.2126 * R' + 0.7152 * G' + 0.0722 * B'
+     * Rec. 2100 (HDR): Y' = 0.2627 * R' + 0.6780 * G' + 0.0593 * B'
      * }</pre>
      *
      * @implNote Java rounds toward zero when converting a {@code float} to an
-     * {@code int}, so this method adds 0.5 before the type conversion to round
-     * to the nearest integer.
+     * {@code int}. The calculation of luma could be rounded to the nearest
+     * integer by adding 0.5 before the type conversion, but the extra operation
+     * seems unnecessary for a display with only 16 levels of gray.
      *
      * @param source the source integer buffer in ARGB32 format
      * @param target the target byte buffer in Y8 format
@@ -110,7 +111,7 @@ class FramebufferY8 extends Framebuffer {
         int r = (pixel32 >> 16) & 0xFF;
         int g = (pixel32 >> 8) & 0xFF;
         int b = pixel32 & 0xFF;
-        int y = (int) (0.2126f * r + 0.7152f * g + 0.0722f * b + 0.5f);
+        int y = (int) (0.2126f * r + 0.7152f * g + 0.0722f * b);
         target.put((byte) y);
     }
 
@@ -187,7 +188,6 @@ class FramebufferY8 extends Framebuffer {
                 String msg = MessageFormat.format("byteDepth={0}", byteDepth);
                 logger.severe(msg);
                 throw new IllegalStateException(msg);
-
         }
     }
 
@@ -247,7 +247,6 @@ class FramebufferY8 extends Framebuffer {
                 String msg = MessageFormat.format("byteDepth={0}", byteDepth);
                 logger.severe(msg);
                 throw new IllegalStateException(msg);
-
         }
     }
 

--- a/tests/system/src/test/java/test/com/sun/glass/ui/monocle/EPDSettingsTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/monocle/EPDSettingsTest.java
@@ -36,7 +36,7 @@ public class EPDSettingsTest {
 
     private static final String BITS_PER_PIXEL = "monocle.epd.bitsPerPixel";
     private static final String ROTATE = "monocle.epd.rotate";
-    private static final String Y8_INVERTED = "monocle.epd.y8inverted";
+    private static final String Y8_INVERTED = "monocle.epd.Y8Inverted";
     private static final String NO_WAIT = "monocle.epd.noWait";
     private static final String WAVEFORM_MODE = "monocle.epd.waveformMode";
     private static final String FLAG_ENABLE_INVERSION = "monocle.epd.enableInversion";

--- a/tests/system/src/test/java/test/com/sun/glass/ui/monocle/FramebufferY8Test.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/monocle/FramebufferY8Test.java
@@ -190,7 +190,7 @@ public class FramebufferY8Test {
     private void printTime(Object source, String method, long duration) {
         float msPerFrame = (float) duration / ITERATIONS;
         System.out.println(String.format(
-                "Converted %,d frames of %,d × %,d px to RGB565 in %,d ms (%,.0f ms/frame): %s.%s",
+                "Converted %,d frames of %,d x %,d px to RGB565 in %,d ms (%,.0f ms/frame): %s.%s",
                 ITERATIONS, WIDTH, HEIGHT, duration, msPerFrame,
                 source.getClass().getSuperclass().getSimpleName(), method));
     }


### PR DESCRIPTION
This pull request adds support for e-paper displays with the i.MX 6 Series of Applications Processors and implements [Issue #521](https://github.com/javafxports/openjdk-jfx/issues/521) in the obsolete *javafxports/openjdk-jfx* repository. Some of the changes were made to support the new device models, while others are minor changes to the existing support in JavaFX 13.

The following changes were made to support the new device models.

* Work around problems on the Kobo Glo HD Model N437.

    Ignore the error ENOTTY (25), "Inappropriate ioctl for device," when setting the waveform modes. The IOCTL call is ignored by the driver on the Kobo Glo HD where the error occurs, anyway.

    Use the visible y-resolution (`yres`), not the virtual y-resolution (`yres_virtual`), when calculating the capacity of the off-screen byte buffer and the length of the frame buffer mapping. The virtual y-resolution reported by the frame buffer device driver can be an incorrect value.

* Work around problems on the Kobo Clara HD Model N249.

    The Kobo Clara HD requires the native screen width to be set to the visible x-resolution (`xres`), instead than the normal virtual x-resolution (`xres_virtual`), when using an unrotated and uninverted 8-bit grayscale frame buffer. The work-around is provided through a new Boolean system property called *monocle.epd.fixWidthY8UR*.

The following changes were made to the existing code that supports e-paper displays in JavaFX 13.

* Use the correct constant for the number of bytes per pixel.

    Use the number of bytes per pixel (`Integer.BYTES`), not the number of bits per pixel (`Integer.SIZE`), when calculating the capacity of the 32-bit off-screen byte buffer.

* Do not round the luma value to the nearest integer.

    Use the value of luma rounded toward zero automatically by Java when converting a `float` to an `int` instead of rounding to the nearest integer. The additional rounding operation can decrease performance anywhere from zero to 10 percent and doesn't seem worth it for a display with just 16 levels of gray.

* Change camel case of system property *y8inverted*.

    Change the camel case of the system property *monocle.epd.y8inverted* to the form *monocle.epd.Y8Inverted* so that it is consistent with the other system properties containing Y1, Y4, and Y8 in their names.

* Improve error handling when mapping the frame buffer.

    Log the mapping and unmapping of the frame buffer. Log any errors that occur on either of the system calls. Handle a `null` return value from `EPDFrameBuffer.getMappedBuffer`.

* Replace non-ASCII characters with their ASCII equivalent.

    Replace non-ASCII characters in comments and log messages as follows:

    * "×" with "x" for display resolution and color depth,
    * "×" with "*" for multiplication,
    * "→" with "to" for transition, and
    * "°C" with "degrees Celsius" for temperature.

* Add descriptions to Monocle EPD system properties.

    Add Javadoc comments to each constant that defines a Monocle EPD system property.

* Rename `IntStructure.getInteger` to `IntStructure.get`.

    Rename the methods `getInteger` and `setInteger` in `IntStructure` to avoid confusion with the Java method `Integer.getInteger`, which gets the integer value of a system property.

Below are some of the more interesting test results.

* The Kobo Glo HD and Kobo Clara HD implement a true GC4 waveform mode that displays only pixels with the four gray values `0x00`, `0x55`, `0xAA`, and `0xFF`. On the older Kobo Touch models, the GC4 waveform mode is the same as GC16.

* When the *forceMonochrome* update flag is enabled, the Kobo Clara HD uses a zero-percent threshold that displays black for pixels with the value `0x00` and white for all other values. The other models use a 50-percent threshold that displays black for values `0x7F` or less and white for values `0x80` or greater.

* The OpenJDK 11 package in Ubuntu 18.04 LTS runs twice as fast as the AdoptOpenJDK build of OpenJDK 13 for some of the tests. The speed difference is greatest for the tests that require pixel conversion into an 8-bit or 16-bit frame buffer. I plan to investigate the cause of the performance difference.

* In general, the faster processor and memory bus of the newer models does not fully compensate for the threefold increase in the number of pixels in their displays. The table below shows the animation speed of each model in milliseconds per frame and frames per second.

    | Product Name  | Speed (ms) | Rate (fps) |
    | ------------- |:----------:|:----------:|
    | Kobo Touch B  | 125        | 8.0        |
    | Kobo Touch C  | 130        | 7.7        |
    | Kobo Glo HD   | 140        | 7.1        |
    | Kobo Clara HD | 145        | 6.9        |
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8227425](https://bugs.openjdk.java.net/browse/JDK-8227425): Add support for e-paper displays on i.MX6 devices


### Reviewers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/60/head:pull/60`
`$ git checkout pull/60`
