### PR TITLE
8223296: NullPointerException in GlassScene.java at line 325

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassScene.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassScene.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,6 +86,7 @@ abstract class GlassScene implements TKScene {
     @Override
     public void dispose() {
         assert stage == null; // dispose() is called after setStage(null)
+        setTKScenePaintListener(null);
         root = null;
         camera = null;
         fillPaint = null;
@@ -94,7 +95,6 @@ abstract class GlassScene implements TKScene {
         dragSourceListener = null;
         dropTargetListener = null;
         inputMethodRequests = null;
-        scenePaintListener = null;
         sceneState = null;
     }
 


### PR DESCRIPTION
Issue: NPE in GlassScene.frameRendered().

Cause: scenePaintListener is set in setTKScenePaintListener(), used in frameRendered() and 
set to null in dispose().
setTKScenePaintListener() and dispose() are called on JavaFX Application Thread and 
frameRendered() is called by QuantumRenderer thread.
setTKScenePaintListener() and frameRendered() are synchronized but dispose() is not.

Fix:
dispose() should use the synchronized setTKScenePaintListener() to set scenePaintListener to null.

Verification:
This is a very rare issue and cannot be reliably reproduced with a test case.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8223296](https://bugs.openjdk.java.net/browse/JDK-8223296): NullPointerException in GlassScene.java at line 325


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)