### PR TITLE
8235627: Blank stages when running JavaFX app in a macOS virtual machine

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
@@ -93,7 +93,7 @@
         };
         GLint npix = 0;
         CGLError err = CGLChoosePixelFormat(attributes, &pix, &npix);
-        if ((err == kCGLNoError) && (npix == 0))
+        if (pix == NULL)
         {
             const CGLPixelFormatAttribute attributes2[] =
             {

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
@@ -95,6 +95,7 @@
         CGLError err = CGLChoosePixelFormat(attributes, &pix, &npix);
         if (pix == NULL)
         {
+            NSLog(@"CGLChoosePixelFormat: No matching pixel format exists for the requested attributes, trying again with limited capabilities");
             const CGLPixelFormatAttribute attributes2[] =
             {
                 kCGLPFAAllowOfflineRenderers,


### PR DESCRIPTION
This is a PR for [JDK-8235627](https://bugs.openjdk.java.net/browse/JDK-8235627).

When running a JavaFX application in macOS guest VM, the main stage is completely blank, with the following errors: CGLChoosePixelFormat error: 10002, CGLCreateContext error: 10002
This behavior was observed with a macOS 10.15 guest OS on both VMWare player and VirtualBox, on a Windows 10 host.

This is an old issue that has already been reported several times (notably as JDK-8154852) but is claimed to have been fixed by JDK-8154148.
However the fix provided by JDK-8154148 is incomplete; while it does fix a JVM crash, it doesn't prevent an incorrect pixel format to be retrieved, which is the root cause for the stage being empty.

The problematic code is located at #96 in GlassView3D.m:

095: CGLError err = CGLChoosePixelFormat(attributes, &pix, &npix);
096: if ((err == kCGLNoError) && (npix == 0))
097: {
098: const CGLPixelFormatAttribute attributes2[] =
099: {
100: kCGLPFAAllowOfflineRenderers,
101: (CGLPixelFormatAttribute)0
102: };
103: err = CGLChoosePixelFormat(attributes2, &pix, &npix);
104: }


In a comment in JDK-8154148, the following claim is made: "[...] an error happens is when something bad or invalid has occurred. An unsatisfied pixel format request is indicated by npix is 0 and pix is NULL. Hence I feel it is a cleaner and clearer logic to request a different format when npix is 0 and err is kCGLNoError." (https://bugs.openjdk.java.net/browse/JDK-8154148?focusedCommentId=13980465&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13980465)

From what I could observe, this is not necessarily true; in this case where a pixel format satisfying the initial conditions could not be found, the return code is kCGLBadPixelFormat (10002); which means we don't try to get a pixel format with less restrictive condition.
This suggests that a better condition for the second call to CGLChoosePixelFormat (line #103) should be "if (pix == NULL)" instead of "if ((err == kCGLNoError) && (npix == 0))"
This is further supported by a sample in Apple developer's documentation on how to choose a pixel format: https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/OpenGL-MacProgGuide/opengl_pixelformats/opengl_pixelformats.html
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8235627](https://bugs.openjdk.java.net/browse/JDK-8235627): Blank stages when running JavaFX app in a macOS virtual machine


## Approvers
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)