### PR TITLE
8235772: Remove use of deprecated finalize method from PiscesRenderer and AbstractSurface

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/pisces/AbstractSurface.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/pisces/AbstractSurface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/pisces/AbstractSurface.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/pisces/AbstractSurface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package com.sun.pisces;
 
+import com.sun.prism.impl.Disposer;
+
 public abstract class AbstractSurface implements Surface {
 
     private long nativePtr = 0L;
@@ -44,6 +46,10 @@ public abstract class AbstractSurface implements Surface {
         }
         this.width = width;
         this.height = height;
+    }
+
+    protected void addDisposerRecord() {
+        Disposer.addRecord(this, new AbstractSurfaceDisposerRecord(nativePtr));
     }
 
     public final void getRGB(int[] argb, int offset, int scanLength, int x, int y, int width, int height) {
@@ -97,8 +103,22 @@ public abstract class AbstractSurface implements Surface {
         }
     }
 
-    protected void finalize() {
-        this.nativeFinalize();
+    private static native void disposeNative(long nativeHandle);
+
+    private static class AbstractSurfaceDisposerRecord implements Disposer.Record {
+        private long nativeHandle;
+
+        AbstractSurfaceDisposerRecord(long nh) {
+            nativeHandle = nh;
+        }
+
+        @Override
+        public void dispose() {
+            if (nativeHandle != 0L) {
+                disposeNative(nativeHandle);
+                nativeHandle = 0L;
+            }
+        }
     }
 
     public final int getWidth() {
@@ -108,6 +128,4 @@ public abstract class AbstractSurface implements Surface {
     public final int getHeight() {
         return height;
     }
-
-    private native void nativeFinalize();
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/pisces/JavaSurface.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/pisces/JavaSurface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,7 @@ public final class JavaSurface extends AbstractSurface {
         this.dataBuffer = IntBuffer.wrap(this.dataInt);
 
         initialize(dataType, width, height);
+        addDisposerRecord();
     }
 
     public IntBuffer getDataIntBuffer() {

--- a/modules/javafx.graphics/src/main/java/com/sun/pisces/JavaSurface.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/pisces/JavaSurface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,11 @@ public final class JavaSurface extends AbstractSurface {
         this.dataBuffer = IntBuffer.wrap(this.dataInt);
 
         initialize(dataType, width, height);
+        // The native method initialize() creates the native object of
+        // struct JavaSurface and saves it's reference in the super class
+        // member AbstractSurface.nativePtr. This reference is needed for
+        // creating disposer record hence the below call to addDisposerRecord()
+        // is needed here and cannot be made in super class constructor.
         addDisposerRecord();
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/pisces/PiscesRenderer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/pisces/PiscesRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/pisces/PiscesRenderer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/pisces/PiscesRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package com.sun.pisces;
+
+import com.sun.prism.impl.Disposer;
 
 /**
  * PiscesRenderer class is basic public API accessing Pisces library capabilities.
@@ -86,6 +88,7 @@ public final class PiscesRenderer {
     public PiscesRenderer(AbstractSurface surface) {
         this.surface = surface;
         initialize();
+        Disposer.addRecord(this, new PiscesRendererDisposerRecord(nativePtr));
     }
 
     private native void initialize();
@@ -436,12 +439,21 @@ public final class PiscesRenderer {
         }
     }
 
-    protected void finalize() {
-        this.nativeFinalize();
-    }
+    private static native void disposeNative(long nativeHandle);
 
-    /**
-     * Native finalizer. Releases native memory used by PiscesRenderer at lifetime.
-     */
-    private native void nativeFinalize();
+    private static class PiscesRendererDisposerRecord implements Disposer.Record {
+        private long nativeHandle;
+
+        PiscesRendererDisposerRecord(long nh) {
+            nativeHandle = nh;
+        }
+
+        @Override
+        public void dispose() {
+            if (nativeHandle != 0L) {
+                disposeNative(nativeHandle);
+                nativeHandle = 0L;
+            }
+        }
+    }
 }

--- a/modules/javafx.graphics/src/main/native-prism-sw/JAbstractSurface.c
+++ b/modules/javafx.graphics/src/main/native-prism-sw/JAbstractSurface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,6 @@ static jfieldID fieldIds[SURFACE_LAST + 1];
 static jboolean fieldIdsInitialized = JNI_FALSE;
 
 static jboolean initializeSurfaceFieldIds(JNIEnv* env, jobject objectHandle);
-static void disposeNativeImpl(JNIEnv* env, jobject objectHandle);
 
 AbstractSurface*
 surface_get(JNIEnv* env, jobject surfaceHandle) {

--- a/modules/javafx.graphics/src/main/native-prism-sw/JAbstractSurface.c
+++ b/modules/javafx.graphics/src/main/native-prism-sw/JAbstractSurface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,9 +52,14 @@ surface_initialize(JNIEnv* env, jobject surfaceHandle) {
 }
 
 JNIEXPORT void JNICALL
-Java_com_sun_pisces_AbstractSurface_nativeFinalize(JNIEnv* env,
-        jobject objectHandle) {
-    disposeNativeImpl(env, objectHandle);
+Java_com_sun_pisces_AbstractSurface_disposeNative(JNIEnv *env, jclass cls, jlong nativePtr)
+{
+    AbstractSurface* surface = (AbstractSurface*) JLongToPointer(nativePtr);
+
+    if (surface != NULL) {
+        surface->cleanup(surface);
+        surface_dispose(&surface->super);
+    }
 }
 
 JNIEXPORT void JNICALL
@@ -184,29 +189,3 @@ initializeSurfaceFieldIds(JNIEnv* env, jobject objectHandle) {
 
     return retVal;
 }
-
-static void
-disposeNativeImpl(JNIEnv* env, jobject objectHandle) {
-    AbstractSurface* surface;
-
-    if (!fieldIdsInitialized) {
-        return;
-    }
-
-    surface = (AbstractSurface*)JLongToPointer(
-                  (*env)->GetLongField(env, objectHandle,
-                                       fieldIds[SURFACE_NATIVE_PTR]));
-
-    if (surface != NULL) {
-        surface->cleanup(surface);
-        surface_dispose(&surface->super);
-        (*env)->SetLongField(env, objectHandle, fieldIds[SURFACE_NATIVE_PTR],
-                             (jlong)0);
-
-        if (JNI_TRUE == readAndClearMemErrorFlag()) {
-            JNI_ThrowNew(env, "java/lang/OutOfMemoryError",
-                         "Allocation of internal renderer buffer failed.");
-        }
-    }
-}
-

--- a/modules/javafx.graphics/src/main/native-prism-sw/JPiscesRenderer.c
+++ b/modules/javafx.graphics/src/main/native-prism-sw/JPiscesRenderer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-prism-sw/JPiscesRenderer.c
+++ b/modules/javafx.graphics/src/main/native-prism-sw/JPiscesRenderer.c
@@ -49,7 +49,6 @@ static jboolean fieldIdsInitialized = JNI_FALSE;
 static jboolean initializeRendererFieldIds(JNIEnv *env, jobject objectHandle);
 
 static int toPiscesCoords(unsigned int ff);
-static void renderer_finalize(JNIEnv *env, jobject objectHandle);
 static void fillAlphaMask(Renderer* rdr, jint minX, jint minY, jint maxX, jint maxY,
     JNIEnv *env, jobject this, jint maskType, jbyteArray jmask, jint x, jint y,
     jint maskWidth, jint maskHeight, jint offset, jint stride);
@@ -82,14 +81,11 @@ Java_com_sun_pisces_PiscesRenderer_initialize(JNIEnv* env, jobject objectHandle)
 }
 
 JNIEXPORT void JNICALL
-Java_com_sun_pisces_PiscesRenderer_nativeFinalize(JNIEnv* env,
-                                                  jobject objectHandle)
+Java_com_sun_pisces_PiscesRenderer_disposeNative(JNIEnv *env, jclass cls, jlong nativePtr)
 {
-    renderer_finalize(env, objectHandle);
-
-    if (JNI_TRUE == readAndClearMemErrorFlag()) {
-        JNI_ThrowNew(env, "java/lang/OutOfMemoryError",
-                     "Allocation of internal renderer buffer failed.");
+    Renderer* rdr = (Renderer*) JLongToPointer(nativePtr);
+    if (rdr != NULL) {
+        renderer_dispose(rdr);
     }
 }
 
@@ -291,24 +287,6 @@ renderer_get(JNIEnv* env, jobject objectHandle) {
     return (Renderer*)JLongToPointer(
                 (*env)->GetLongField(env, objectHandle,
                                      fieldIds[RENDERER_NATIVE_PTR]));
-}
-
-static void
-renderer_finalize(JNIEnv *env, jobject objectHandle) {
-    Renderer* rdr;
-
-    if (!fieldIdsInitialized) {
-        return;
-    }
-
-    rdr = (Renderer*)JLongToPointer((*env)->GetLongField(env, objectHandle,
-                                    fieldIds[RENDERER_NATIVE_PTR]));
-
-    if (rdr != (Renderer*)0) {
-        renderer_dispose(rdr);
-        (*env)->SetLongField(env, objectHandle, fieldIds[RENDERER_NATIVE_PTR],
-                         (jlong)0);
-    }
 }
 
 static jboolean


### PR DESCRIPTION
The finalize() method is deprecated in JDK9. See [Java 9 deprecated features](https://www.oracle.com/technetwork/java/javase/9-deprecated-features-3745636.html).
And so the [PiscesRenderer.finalize()](https://github.com/openjdk/jfx/blob/71ca899fbfc74d825c29b20a778d6d9eb243f90f/modules/javafx.graphics/src/main/java/com/sun/pisces/PiscesRenderer.java#L439) and [AbstractSurface.finalize()](https://github.com/openjdk/jfx/blob/71ca899fbfc74d825c29b20a778d6d9eb243f90f/modules/javafx.graphics/src/main/java/com/sun/pisces/AbstractSurface.java#L100) method should be removed.

The change is,
1. Remove finalize method from PiscesRenderer and AbstractSurface classes.
2. Use [Disposer](https://github.com/openjdk/jfx/blob/71ca899fbfc74d825c29b20a778d6d9eb243f90f/modules/javafx.graphics/src/main/java/com/sun/prism/impl/Disposer.java#L48) class for cleanup instead of finalize().  For SW pipeline the cleanup is initiated in [here](https://github.com/openjdk/jfx/blob/71ca899fbfc74d825c29b20a778d6d9eb243f90f/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/UploadingPainter.java#L195) in UploadingPainer.java.
3. Added new JNI methods to JPiscesRenderer.c and JAbstractSurface.c and removed the ones which were used previously with finalize() method.

Verification:
Verified that the newly added dispose() methods get invoked as required and no OOM occurs.
1. Create a sample program which adds and removes non 3D shapes and/or controls to stage in a loop.
2. Run the program using -Dprism.order=sw,  -Dprism.verbose=true. (optional -Xmx50m)
Expected Behavior: 
a. Maximum memory consumption after this change should reduce or remain same as that of before this change.
b. No OOM should occur with this change or without this change.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8235772](https://bugs.openjdk.java.net/browse/JDK-8235772): Remove use of deprecated finalize method from PiscesRenderer and AbstractSurface


### Reviewers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/66/head:pull/66`
`$ git checkout pull/66`
