### PR TITLE
 8088198: Exception thrown from snapshot if dimensions are larger than max texture size

### DIFF
--- a/tests/system/src/test/java/test/javafx/scene/Snapshot3Test.java
+++ b/tests/system/src/test/java/test/javafx/scene/Snapshot3Test.java
@@ -1,0 +1,65 @@
+package test.javafx.scene;
+
+
+import javafx.scene.SnapshotParameters;
+import javafx.scene.image.Image;
+import javafx.scene.shape.Rectangle;
+import javafx.scene.transform.Scale;
+import org.junit.*;
+import test.util.Util;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for tiled snapshots (i.e. capturing snapshots larger than maxTextureSize. See JDK-8088198)
+ */
+public class Snapshot3Test extends SnapshotCommon {
+
+    public static int VALUE_LARGER_THAN_TEXTURE_SIZE = 40000;
+
+    @BeforeClass
+    public static void setupOnce() {
+        doSetupOnce();
+    }
+
+    @AfterClass
+    public static void teardownOnce() {
+        doTeardownOnce();
+    }
+
+    @Before
+    public void setupEach() {
+        assertNotNull(myApp);
+        assertNotNull(myApp.primaryStage);
+        assertTrue(myApp.primaryStage.isShowing());
+    }
+
+    @After
+    public void teardownEach() {
+    }
+
+    Rectangle rect = new Rectangle(1, 1);
+
+    @Test
+    public void testTiledWidthSnapshot() {
+        Util.runAndWait(() -> {
+            SnapshotParameters params = new SnapshotParameters();
+            params.setTransform(new Scale(VALUE_LARGER_THAN_TEXTURE_SIZE, 1));
+            Image image = rect.snapshot(params, null);
+            assertEquals(VALUE_LARGER_THAN_TEXTURE_SIZE, (int) image.getWidth());
+        });
+    }
+
+    @Test
+    public void testTiledHeightSnapshot() {
+        Util.runAndWait(() -> {
+            SnapshotParameters params = new SnapshotParameters();
+            params.setTransform(new Scale(1, VALUE_LARGER_THAN_TEXTURE_SIZE));
+            Image image = rect.snapshot(params, null);
+            assertEquals(VALUE_LARGER_THAN_TEXTURE_SIZE, (int) image.getHeight());
+        });
+    }
+
+}
+
+


### PR DESCRIPTION
This PR aims to address the following issue: [JDK-8088198 Exception thrown from snapshot if dimensions are larger than max texture size](https://bugs.openjdk.java.net/browse/JDK-8088198)

In order to do that, it simply captures snapshots in multiple tiles of maxTextureSize^2 dimensions (or less, as needed), and then recomposes all the tiles into a a single image.
Other than that, the logic used to do the actual snapshot is unchanged.

Tests using the existing SnapshotCommon class have been added in a new file named Snapshot3Test under SystemTest/test/javafx/scene.
These tests pass with the proposed fix, and fail without, throwing " java.lang.IllegalArgumentException: Unrecognized image loader: null"
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed