### PR TITLE
8234474: [macos 10.15] Crash in file dialog in sandbox mode

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassDialogs.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassDialogs.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassDialogs.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassDialogs.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,6 +67,24 @@ static BOOL doPerformKeyEquivalent(NSEvent* theEvent, NSWindow* panel)
         }
     }
     return false;
+}
+
+/*
+ * Function to determine whether or not to use raw NSPanel classes
+ * (either NSSavePanel or NSOpenPanel).
+ *
+ * Return: YES if we need to use the raw NSPanel classes; NO if we
+ * can use the Glass subclasses
+ */
+static BOOL useNSPanel()
+{
+    // As of macOS 10.15 all file dialogs are out of process, so we
+    // effectively can't subclass them.
+    if (@available(macOS 10.15, *)) {
+        return YES;
+    } else {
+        return [GlassApplication isSandboxed];
+    }
 }
 
 @interface GlassSavePanel : NSSavePanel
@@ -485,7 +503,7 @@ JNIEXPORT jobject JNICALL Java_com_sun_glass_ui_mac_MacCommonDialogs__1showFileO
     GLASS_ASSERT_MAIN_JAVA_THREAD(env);
     GLASS_POOL_ENTER;
     {
-        NSOpenPanel *panel = [GlassApplication isSandboxed] ? [NSOpenPanel openPanel] : [GlassOpenPanel openPanel];
+        NSOpenPanel *panel = useNSPanel() ? [NSOpenPanel openPanel] : [GlassOpenPanel openPanel];
         [panel setAllowsMultipleSelection:(jMultipleMode==JNI_TRUE)];
         [panel setTitle:[GlassHelper nsStringWithJavaString:jTitle withEnv:env]];
         NSString *folder = [GlassHelper nsStringWithJavaString:jFolder withEnv:env];
@@ -561,7 +579,7 @@ JNIEXPORT jobject JNICALL Java_com_sun_glass_ui_mac_MacCommonDialogs__1showFileS
     GLASS_ASSERT_MAIN_JAVA_THREAD(env);
     GLASS_POOL_ENTER;
     {
-        NSSavePanel *panel = [GlassApplication isSandboxed] ? [NSSavePanel savePanel] : [GlassSavePanel savePanel];
+        NSSavePanel *panel = useNSPanel() ? [NSSavePanel savePanel] : [GlassSavePanel savePanel];
         [panel setTitle:[GlassHelper nsStringWithJavaString:jTitle withEnv:env]];
         NSString *folder = [GlassHelper nsStringWithJavaString:jFolder withEnv:env];
         if ([folder length] > 0)
@@ -633,7 +651,7 @@ JNIEXPORT jobject JNICALL Java_com_sun_glass_ui_mac_MacCommonDialogs__1showFolde
     GLASS_ASSERT_MAIN_JAVA_THREAD(env);
     GLASS_POOL_ENTER;
     {
-        NSOpenPanel *panel = [GlassApplication isSandboxed] ? [NSOpenPanel openPanel] : [GlassOpenPanel openPanel];
+        NSOpenPanel *panel = useNSPanel() ? [NSOpenPanel openPanel] : [GlassOpenPanel openPanel];
         [panel setTitle:[GlassHelper nsStringWithJavaString:jTitle withEnv:env]];
         NSString *folder = [GlassHelper nsStringWithJavaString:jFolder withEnv:env];
         if ([folder length] > 0)


### PR DESCRIPTION
This PR is a fix for [JDK-8234474](https://bugs.openjdk.java.net/browse/JDK-8234474), a crash in the code that shows a file open or save dialog.

In order to provide additional support for Copy (CMD-C), Cut (CMD-X), and Paste (CMD-V), the Glass implementation for displaying a file open or save dialog subclasses NSSavePanel or NSOpenPanel to add this support. When the application is running in sandboxed mode, the dialogs are shown out-of-process by the "powerbox". In this mode, attempting to use our subclass results in a security exception. Previously, we added code to detect whether we were running in a sandbox as a fix for [JDK-8092977](https://bugs.openjdk.java.net/browse/JDK-8092977); we now use NSSavePanel or NSOpenPanel directly when in sandboxed mode.

Starting with macOS 10.15 (Catalina) Apple always displays file dialogs out-of-process via powerbox, so our use of a subclass is ineffective. Further, we have reports of some cases where we crash even though our sandbox detection code doesn't indicate that we are running in a sandbox.

Since there is no point in trying to use our subclasses on macOS 10.15 or later, I propose to fix this bug by changing the logic so that we use NSSavePanel or NSOpenPanel directly in either of the following conditions:

1) the app is running in sandbox mode
OR
2) The platform is macOS 10.15 or later
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8234474](https://bugs.openjdk.java.net/browse/JDK-8234474): [macos 10.15] Crash in file dialog in sandbox mode


## Approvers
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)
 * Phil Race ([prr](@prrace) - **Reviewer**)