### PR TITLE
8236484: Compile error in monocle dispman

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/monocle/dispman/DispmanScreen.c
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/dispman/DispmanScreen.c
@@ -82,6 +82,6 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_monocle_DispmanScreen_wrapNativeSym
 #ifdef USE_DISPMAN
     load_bcm_symbols();
 #else
-    return 0l;
+    return;
 #endif /* USE_DISPMAN */
 }


### PR DESCRIPTION
Trivial fix for a compiler error where a void function returns a long
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8236484](https://bugs.openjdk.java.net/browse/JDK-8236484): Compile error in monocle dispman


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)