### PR TITLE
8236648: javadoc warning on Text::tabSizeProperty method

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/text/Text.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/text/Text.java
@@ -1273,6 +1273,8 @@ public class Text extends Shape {
      * The size of a tab stop in spaces.
      * Values less than 1 are treated as 1.
      *
+     * @return the {@code tabSize} property
+     *
      * @defaultValue 8
      *
      * @since 14


### PR DESCRIPTION
Implemented suggested fix to address javadoc warning.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8236648](https://bugs.openjdk.java.net/browse/JDK-8236648): javadoc warning on Text::tabSizeProperty method


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)