### PR TITLE
8232824: Removing TabPane with strong referenced content causes memory leak from weak one

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -263,6 +263,7 @@ public abstract class Parent extends Node {
     private final List<Node> viewOrderChildren = new ArrayList(1);
 
     void markViewOrderChildrenDirty() {
+        viewOrderChildren.clear();
         NodeHelper.markDirty(this, DirtyBits.PARENT_CHILDREN_VIEW_ORDER);
     }
 
@@ -459,7 +460,7 @@ public abstract class Parent extends Node {
             NodeHelper.markDirty(Parent.this, DirtyBits.NODE_FORCE_SYNC);
 
             if (viewOrderChildrenDirty) {
-                NodeHelper.markDirty(Parent.this, DirtyBits.PARENT_CHILDREN_VIEW_ORDER);
+                markViewOrderChildrenDirty();
             }
         }
 

--- a/tests/system/src/test/java/test/javafx/scene/control/TabPaneHeaderLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/TabPaneHeaderLeakTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.control;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import junit.framework.Assert;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import test.util.Util;
+
+public class TabPaneHeaderLeakTest extends Application {
+
+    private static CountDownLatch startupLatch;
+    private static StackPane root;
+    private static Stage stage;
+    private static TabPane tabPane;
+    private static WeakReference<TextField> textFieldWeakRef;
+    private static WeakReference<Tab> tabWeakRef;
+
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+        stage = primaryStage;
+        TextField tf = new TextField("Weak ref TF");
+        textFieldWeakRef = new WeakReference<>(tf);
+        Tab tab = new Tab("Tab", tf);
+        tabWeakRef = new WeakReference<>(tab);
+        tabPane = new TabPane(tab, new Tab("Tab1"));
+        tab = null;
+        tf = null;
+
+        root = new StackPane(tabPane);
+        Scene scene = new Scene(root);
+        primaryStage.setScene(scene);
+        primaryStage.setOnShown(l -> {
+            startupLatch.countDown();
+        });
+        primaryStage.show();
+    }
+
+    @BeforeClass
+    public static void initFX() {
+        startupLatch = new CountDownLatch(1);
+        new Thread(() -> Application.launch(TabPaneHeaderLeakTest.class, (String[]) null)).start();
+        try {
+            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
+                Assert.fail("Timeout waiting for FX runtime to start");
+            }
+        } catch (InterruptedException ex) {
+            Assert.fail("Unexpected exception: " + ex);
+        }
+    }
+
+    @Test
+    public void testTabPaneHeaderLeak() throws Exception {
+        Util.sleep(100);
+        Util.runAndWait(() -> {
+            tabPane.getTabs().clear();
+            root.getChildren().clear();
+        });
+        for (int i = 0; i < 10; i++) {
+            System.gc();
+            System.runFinalization();
+            if (tabWeakRef.get() == null &&
+                textFieldWeakRef.get() == null) {
+                break;
+            }
+            Util.sleep(500);
+        }
+        // Ensure that Tab and TextField are GCed.
+        Assert.assertNull("Couldn't collect Tab", tabWeakRef.get());
+        Assert.assertNull("Couldn't collect TextField", textFieldWeakRef.get());
+    }
+
+    @AfterClass
+    public static void teardownOnce() {
+        Platform.runLater(() -> {
+            stage.hide();
+            Platform.exit();
+        });
+    }
+}

--- a/tests/system/src/test/java/test/javafx/scene/control/TabPaneHeaderLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/TabPaneHeaderLeakTest.java
@@ -43,8 +43,9 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import test.util.Util;
+import static org.junit.Assert.assertTrue;
 
-public class TabPaneHeaderLeakTest extends Application {
+public class TabPaneHeaderLeakTest {
 
     private static CountDownLatch startupLatch;
     private static StackPane root;
@@ -53,37 +54,34 @@ public class TabPaneHeaderLeakTest extends Application {
     private static WeakReference<TextField> textFieldWeakRef;
     private static WeakReference<Tab> tabWeakRef;
 
-    @Override
-    public void start(Stage primaryStage) throws Exception {
-        stage = primaryStage;
-        TextField tf = new TextField("Weak ref TF");
-        textFieldWeakRef = new WeakReference<>(tf);
-        Tab tab = new Tab("Tab", tf);
-        tabWeakRef = new WeakReference<>(tab);
-        tabPane = new TabPane(tab, new Tab("Tab1"));
-        tab = null;
-        tf = null;
+    public static class TestApp extends Application {
+        @Override
+        public void start(Stage primaryStage) throws Exception {
+            stage = primaryStage;
+            TextField tf = new TextField("Weak ref TF");
+            textFieldWeakRef = new WeakReference<>(tf);
+            Tab tab = new Tab("Tab", tf);
+            tabWeakRef = new WeakReference<>(tab);
+            tabPane = new TabPane(tab, new Tab("Tab1"));
+            tab = null;
+            tf = null;
 
-        root = new StackPane(tabPane);
-        Scene scene = new Scene(root);
-        primaryStage.setScene(scene);
-        primaryStage.setOnShown(l -> {
-            startupLatch.countDown();
-        });
-        primaryStage.show();
+            root = new StackPane(tabPane);
+            Scene scene = new Scene(root);
+            primaryStage.setScene(scene);
+            primaryStage.setOnShown(l -> {
+                Platform.runLater(() -> startupLatch.countDown());
+            });
+            primaryStage.show();
+        }
     }
 
     @BeforeClass
-    public static void initFX() {
+    public static void initFX() throws Exception {
         startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TabPaneHeaderLeakTest.class, (String[]) null)).start();
-        try {
-            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
-                Assert.fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            Assert.fail("Unexpected exception: " + ex);
-        }
+        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
+        assertTrue("Timeout waiting for FX runtime to start",
+                   startupLatch.await(15, TimeUnit.SECONDS));
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/scene/shape/ShapeViewOrderLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/shape/ShapeViewOrderLeakTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.shape;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Group;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.scene.shape.Circle;
+import javafx.scene.shape.Rectangle;
+import javafx.scene.shape.Shape;
+import javafx.stage.Stage;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import junit.framework.Assert;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import test.util.Util;
+
+public class ShapeViewOrderLeakTest extends Application {
+
+    private static CountDownLatch startupLatch;
+    private static StackPane root;
+    private static Stage stage;
+    private static Group group;
+    private static WeakReference<Shape> shapeWeakRef;
+
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+        stage = primaryStage;
+        Shape shape1 = new Rectangle();
+        Shape shape2 = new Circle();
+        shape1.setViewOrder(1);
+        shape2.setViewOrder(0);
+        shapeWeakRef = new WeakReference<>(shape1);
+
+        group = new Group(shape1, shape2);
+        shape1 = null;
+        shape2 = null;
+
+        root = new StackPane(group);
+        Scene scene = new Scene(root);
+        primaryStage.setScene(scene);
+        primaryStage.setOnShown(l -> {
+            startupLatch.countDown();
+        });
+        primaryStage.show();
+    }
+
+    @BeforeClass
+    public static void initFX() {
+        startupLatch = new CountDownLatch(1);
+        new Thread(() -> Application.launch(ShapeViewOrderLeakTest.class, (String[]) null)).start();
+        try {
+            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
+                Assert.fail("Timeout waiting for FX runtime to start");
+            }
+        } catch (InterruptedException ex) {
+            Assert.fail("Unexpected exception: " + ex);
+        }
+    }
+
+    @Test
+    public void testShapeViewOrderLeak() throws Exception {
+        Util.sleep(100);
+        Util.runAndWait(() -> {
+            group.getChildren().clear();
+            root.getChildren().clear();
+        });
+        for (int i = 0; i < 10; i++) {
+            System.gc();
+            System.runFinalization();
+            if (shapeWeakRef.get() == null) {
+                break;
+            }
+            Util.sleep(500);
+        }
+        // Ensure that Shape is GCed.
+        Assert.assertNull("Couldn't collect Shape", shapeWeakRef.get());
+    }
+
+    @AfterClass
+    public static void teardownOnce() {
+        Platform.runLater(() -> {
+            stage.hide();
+            Platform.exit();
+        });
+    }
+}


### PR DESCRIPTION
This PR is a fix for [JDK-8232824](https://bugs.openjdk.java.net/browse/JDK-8232824)
This issue is regression of [JDK-8187074](https://bugs.openjdk.java.net/browse/JDK-8187074).

Issue.
- `Parent.viewOrderChildren` is a list of children sorted according to view order.
- `Parent.viewOrderChildren` is cleared and computed in `Parent.computeViewOrderChildren()` which is called from `Parent.doUpdatePeer()` when a `pulse `is received.

- Below is the scenario mentioned in this issue,
1. `TabPane` is created with few `tabs`.
2. For each tab,  a `TabHeaderSkin` is created with `setViewOrder(1)` and is added to `TabHeaderArea.headersRegion`
3. All these `TabHeaderSkin`s are added to `Parent.viewOrderChildren` on `pulse`.
4. When the `TabPane` is removed from scene, then on the next pulse the method `Parent.doUpdatePeer()` does not get called for `TabHeaderArea.headersRegion`, because it is not part for scenegraph anymore.
So `Parent.computeViewOrderChildren()` does not get called and the `Parent.viewOrderChildren` does not get cleared, which causes the leak.

Fix:
Clear the `Parent.viewOrderChildren` list when marking `DirtyBits.PARENT_CHILDREN_VIEW_ORDER` as dirty.
`Parent.viewOrderChildren` will be computed on next `pulse`.
This will maintain lazy computation of `Parent.viewOrderChildren`. 

Added a system test, fails without fix and passes with. No failures in existing tests.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8232824](https://bugs.openjdk.java.net/browse/JDK-8232824): Removing TabPane with strong referenced content causes memory leak from weak one


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)