### PR TITLE
8233798: Ctrl-L character mistakenly removed from gstreamer.md

### DIFF
--- a/modules/javafx.media/src/main/legal/gstreamer.md
+++ b/modules/javafx.media/src/main/legal/gstreamer.md
@@ -86,7 +86,7 @@ modified by someone else and passed on, the recipients should know
 that what they have is not the original version, so that the original
 author's reputation will not be affected by problems that might be
 introduced by others.
-
+
   Finally, software patents pose a constant threat to the existence of
 any free program.  We wish to make sure that a company cannot
 effectively restrict the users of a free program by obtaining a


### PR DESCRIPTION
Fix for [JDK-8233798](https://bugs.openjdk.java.net/browse/JDK-8233798)

Simple fix to restore a Ctrl-L character that was mistakenly deleted as part of the cleanup fix done for [JDK-8222746](https://bugs.openjdk.java.net/browse/JDK-8222746). After the missing ^L is restored the license is once again identical between `gstreamer.md` and `glib.md` (and `webkit.md`) as it should be.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8233798](https://bugs.openjdk.java.net/browse/JDK-8233798): Ctrl-L character mistakenly removed from gstreamer.md


## Approvers
 * Alexander Matveev ([almatvee](@sashamatveev) - **Reviewer**)