### PR TITLE
8236808: javafx_iio can not be used in static environment

### DIFF
--- a/modules/javafx.graphics/src/main/native-iio/jpegloader.c
+++ b/modules/javafx.graphics/src/main/native-iio/jpegloader.c
@@ -45,10 +45,6 @@
 #define ptr_to_jlong(a) ((jlong)(int)(a))
 #endif
 
-/* On non iOS platforms we use JNI_OnLoad() shared library entrypoint. */
-#define USING_BUILTIN_LIBRARY_ENTRYPOINT 0
-
-/* On iOS we use builtin libraries, thus JNI_OnLoad_javafx_iio() is the entrypoint */
 #ifdef __APPLE__
 
 #include <TargetConditionals.h>
@@ -57,10 +53,6 @@
 #define longjmp _longjmp
 #define setjmp _setjmp
 
-#if TARGET_OS_IPHONE /* iOS */
-#undef  USING_BUILTIN_LIBRARY_ENTRYPOINT
-#define USING_BUILTIN_LIBRARY_ENTRYPOINT 1
-#endif
 #endif
 
 static jboolean checkAndClearException(JNIEnv *env) {
@@ -108,7 +100,7 @@ static jmethodID JPEGImageLoader_emitWarningID;
    first loaded */
 static JavaVM *jvm;
 
-#if USING_BUILTIN_LIBRARY_ENTRYPOINT
+#ifdef STATIC_BUILD
 
 JNIEXPORT jint JNICALL
 JNI_OnLoad_javafx_iio(JavaVM *vm, void *reserved) {
@@ -133,7 +125,7 @@ JNI_OnLoad(JavaVM *vm, void *reserved) {
     return JNI_VERSION_1_2;
 }
 
-#endif
+#endif // STATIC_BUILD
 
 
 /*


### PR DESCRIPTION
The static JNI_OnLoad naming should be used whenever we are building a static lib (not only for iOS).
We now have the STATIC_BUILD property to determine if we are making a
static build, so we no longer need to check on ios specific patterns.

Fix JDK-8236808
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8236808](https://bugs.openjdk.java.net/browse/JDK-8236808): javafx_iio can not be used in static environment


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)