### PR TITLE
8236753: Animations do not play backwards after being stopped

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
@@ -256,7 +256,7 @@ public abstract class Animation {
     /* Package-private for testing purposes */
     ClipEnvelope clipEnvelope;
 
-    private boolean lastPlayedFinished = false;
+    private boolean lastPlayedFinished = true;
 
     private boolean lastPlayedForward = true;
     /**
@@ -978,6 +978,7 @@ public abstract class Animation {
             clipEnvelope.abortCurrentPulse();
             doStop();
             jumpTo(Duration.ZERO);
+            lastPlayedFinished = true;
         }
     }
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/animation/AnimationTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/animation/AnimationTest.java
@@ -322,10 +322,19 @@ public class AnimationTest {
         assertFalse(listener.wasCalled);
         assertFalse(timer.containsPulseReceiver(animation.shim_pulseReceiver()));
         animation.stop();
-        animation.setRate(1.0);
+
+        // stopped timeline, rate = -1
+        listener.wasCalled = false;
+        animation.setRate(-1.0);
+        animation.play();
+        assertEquals(ONE_SEC.toMillis(), animation.getCurrentTime().toMillis(), EPSILON);
+        assertFalse(listener.wasCalled);
+        assertTrue(timer.containsPulseReceiver(animation.shim_pulseReceiver()));
+        animation.stop();
 
         // stopped timeline, cycleDuration = 0
         listener.wasCalled = false;
+        animation.setRate(1.0);
         animation.shim_setCycleDuration(Duration.ZERO);
         animation.play();
         assertEquals(Status.STOPPED, animation.getStatus());

--- a/modules/javafx.graphics/src/test/java/test/javafx/animation/SequentialTransitionPlayTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/animation/SequentialTransitionPlayTest.java
@@ -637,10 +637,10 @@ public class SequentialTransitionPlayTest {
         st.play();
 
         assertEquals(Status.RUNNING, st.getStatus());
-        assertEquals(Status.RUNNING, child1X.getStatus());
-        assertEquals(Status.STOPPED, child1Y.getStatus());
-        assertEquals(0, xProperty.get());
-        assertEquals(0, yProperty.get());
+        assertEquals(Status.STOPPED, child1X.getStatus());
+        assertEquals(Status.RUNNING, child1Y.getStatus());
+        assertEquals(60000, xProperty.get());
+        assertTrue(0 < yProperty.get() && yProperty.get() < 10000);
 
         st.jumpTo(TickCalculation.toDuration(100));
 


### PR DESCRIPTION
The private field `lastPlayFinished` is responsible for 2 cases where an animation in `STOPPED` status does not play after `play()` is called if the rate is negative:

1. When the animation is created, it is `STOPPED` and `lastPlayFinished` is `false`. Setting a negative rate and calling `play()` will not jump to the end of the animation (in order to play it backwards) because the `if (lastPlayedFinished)` check is `false`. Creating the animation with `lastPlayFinished = true` fixes this. However, `SequentialTransitionPlayTest#testCycleReverse`'s initial state test implies that the original behavior is correct. *That test currently fails with this change.* Either the fix is reverted or the test is corrected.
2. When the animation is stopped (if it was not `STOPPED` already), `jumpTo(Duration.ZERO)` sets `lastPlayFinished` to `false`, which causes the same issue above with `play()`. Setting `lastPlayFinished = true` at the end `stop()` fixes this issue.

A test was added for case 2 to check that the playing head indeed jumps to the end of the animation. Without this fix, it stays at the start.

I'm still somewhat confused as to what constitutes a "last play finished". Any `jumpTo` resets `lastPlayFinished` to `false`, even if the jump is to the start/end of the animation. In this case, stopping an animation, jumping to its start/end, setting the rate to negative/positive, and playing, will do nothing as the end condition is reached immediately. This is what the behavior that was fixed for cases 1 and 2, but maybe this is also incorrect behavior for jumping to start/end.

A test app is included in the "parent" [bug](https://bugs.openjdk.java.net/browse/JDK-8210238), which also mentions a bug relating to **pausing** and playing backwards, so be mindful of it when testing.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8236753](https://bugs.openjdk.java.net/browse/JDK-8236753): Animations do not play backwards after being stopped


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)