### PR TITLE
8236733: Change JavaFX release version to 15

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -39,7 +39,7 @@
 jfx.release.suffix=-ea
 
 # UPDATE THE FOLLOWING VALUES FOR A NEW RELEASE
-jfx.release.major.version=14
+jfx.release.major.version=15
 jfx.release.minor.version=0
 jfx.release.security.version=0
 jfx.release.patch.version=0
@@ -56,8 +56,8 @@ jfx.release.patch.version=0
 
 javadoc.bottom=<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2020, Oracle and/or its affiliates. All rights reserved.</small>
 
-javadoc.title=JavaFX 14
-javadoc.header=JavaFX&nbsp;14
+javadoc.title=JavaFX 15
+javadoc.header=JavaFX&nbsp;15
 
 ##############################################################################
 #

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
@@ -89,7 +89,7 @@ public class VersionInfoTest {
         String version = VersionInfo.getVersion();
         // Need to update major version number when we develop the next
         // major release.
-        assertTrue(version.startsWith("14"));
+        assertTrue(version.startsWith("15"));
         String runtimeVersion = VersionInfo.getRuntimeVersion();
         assertTrue(runtimeVersion.startsWith(version));
     }


### PR DESCRIPTION
JDK-8236733](https://bugs.openjdk.java.net/browse/JDK-8236733).

Bump the release version to 15. As noted in the JBS issue, I will wait until right after the `jfx14` fork to integrate this.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8236733](https://bugs.openjdk.java.net/browse/JDK-8236733): Change JavaFX release version to 15


## Approvers
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)