### PR TITLE
8236912: NullPointerException when clicking in WebView with Button 4 or Button 5

### DIFF
--- a/modules/javafx.web/src/main/java/javafx/scene/web/WebView.java
+++ b/modules/javafx.web/src/main/java/javafx/scene/web/WebView.java
@@ -994,12 +994,13 @@ final public class WebView extends Parent {
         }
 
         final Integer id = idMap.get(type);
-        if (id == null) {
+        final Integer button = idMap.get(ev.getButton());
+        if (id == null || button == null) {
             // not supported by webkit
             return;
         }
         WCMouseEvent mouseEvent =
-                new WCMouseEvent(id, idMap.get(ev.getButton()),
+                new WCMouseEvent(id, button,
                     ev.getClickCount(), (int) x, (int) y,
                     (int) screenX, (int) screenY,
                     System.currentTimeMillis(),

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/WebViewTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/WebViewTest.java
@@ -30,7 +30,9 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.util.concurrent.FutureTask;
 
-import javafx.application.Platform;
+import javafx.event.Event;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.web.WebEngineShim;
 import javafx.scene.web.WebView;
 
@@ -52,6 +54,18 @@ public class WebViewTest extends TestBase {
 
         checkFontScale(view, SCALE);
         checkZoom(view, ZOOM);
+    }
+
+    @Test public void testForwardMouseButton() {
+        WebView view = getView();
+        Event forward = new MouseEvent(MouseEvent.MOUSE_PRESSED, 0, 0, 0, 0, MouseButton.FORWARD, 1, false, false, false, false, false, false, false, false, true, true, false, true, null);
+        view.fireEvent(forward);    // must not throw NullPointerException (JDK-8236912)
+    }
+
+    @Test public void testBackMouseButton() {
+        WebView view = getView();
+        Event back = new MouseEvent(MouseEvent.MOUSE_PRESSED, 0, 0, 0, 0, MouseButton.BACK, 1, false, false, false, false, false, false, false, true, false, true, false, true, null);
+        view.fireEvent(back);    // must not throw NullPointerException (JDK-8236912)
     }
 
     void checkFontScale(WebView view, float scale) {


### PR DESCRIPTION
As documented in JDK-8236912, WebView did not check whether the idMap really contained a mapping for the given button, making it prone to errors, when things are extended (as has happened here).

The fix consists of two test cases that show the problem in unfixed WebViews and a fix which works analogously to the check whether the given event type is mapped.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8236912](https://bugs.openjdk.java.net/browse/JDK-8236912): NullPointerException when clicking in WebView with Button 4 or Button 5


## Approvers
 * Guru Hb ([ghb](@guruhb) - **Reviewer**)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)