### PR TITLE
8236839: System menubar removed when other menubars are created or modified

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
@@ -866,7 +866,8 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
                                         setSystemMenu(stage);
                                     }
                                 } else {
-                                    if (curMBSkin != null && curMBSkin.getSkinnable() != null &&
+                                    if (getSkinnable().isUseSystemMenuBar() &&
+                                            curMBSkin != null && curMBSkin.getSkinnable() != null &&
                                             curMBSkin.getSkinnable().isUseSystemMenuBar()) {
                                         curMBSkin.getSkinnable().setUseSystemMenuBar(false);
                                     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/MenuBarSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/MenuBarSkinTest.java
@@ -26,9 +26,11 @@
 package test.javafx.scene.control.skin;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.sun.javafx.menu.MenuBase;
 import com.sun.javafx.stage.WindowHelper;
+import javafx.scene.control.MenuItem;
 import test.com.sun.javafx.pgstub.StubToolkit;
 import com.sun.javafx.tk.Toolkit;
 import javafx.beans.value.ObservableValue;
@@ -160,6 +162,35 @@ public class MenuBarSkinTest {
             // setting useSystemMenuBar to true again, should add back the system menus.
             menubar.setUseSystemMenuBar(true);
             assertEquals(menubar.getMenus().size(), getSystemMenus().size());
+        }
+    }
+
+    @Test public void testModifyingNonSystemMenuBar() {
+        if (tk.getSystemMenu().isSupported()) {
+            // Set system menubar to true
+            menubar.setUseSystemMenuBar(true);
+
+            // Create a secondary menubar that is not
+            // a system menubar
+            MenuBar secondaryMenuBar = new MenuBar(
+                    new Menu("Menu 1", null, new MenuItem("Item 1")),
+                    new Menu("Menu 2", null, new MenuItem("Item 2")));
+            secondaryMenuBar.setSkin(new MenuBarSkin(secondaryMenuBar));
+
+            // Add the secondary menubar to the scene
+            ((Group)scene.getRoot()).getChildren().add(secondaryMenuBar);
+
+            // Verify that the menubar is the system menubar
+            assertTrue(menubar.isUseSystemMenuBar());
+
+            // Remove a menu from the secondary menubar
+            // to trigger a rebuild of its UI and a call
+            // to the sceneProperty listener
+            secondaryMenuBar.getMenus().remove(1);
+
+            // Verify that this has not affected whether the
+            // original menubar is the system menubar
+            assertTrue(menubar.isUseSystemMenuBar());
         }
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/MenuBarSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/MenuBarSkinTest.java
@@ -30,7 +30,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.sun.javafx.menu.MenuBase;
 import com.sun.javafx.stage.WindowHelper;
-import javafx.scene.control.MenuItem;
 import test.com.sun.javafx.pgstub.StubToolkit;
 import com.sun.javafx.tk.Toolkit;
 import javafx.beans.value.ObservableValue;
@@ -39,6 +38,7 @@ import javafx.scene.Group;
 import javafx.scene.Scene;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuBar;
+import javafx.scene.control.MenuItem;
 import javafx.stage.Stage;
 
 import java.util.List;


### PR DESCRIPTION
This pull request fixes the sceneProperty listener in `MenuBarSkin` so that we leave the
current system menubar alone when other menubars are changed.

It also adds a test case that reproduces the problem before the fix.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8236839](https://bugs.openjdk.java.net/browse/JDK-8236839): System menubar removed when other menubars are created or modified


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)