### PR TITLE
8238968: Inconsisent formatting of Rectangle2D toString method

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/geometry/Rectangle2D.java
+++ b/modules/javafx.graphics/src/main/java/javafx/geometry/Rectangle2D.java
@@ -243,7 +243,7 @@ public class Rectangle2D {
      * The returned string might be empty but cannot be {@code null}.
      */
     @Override public String toString() {
-        return "Rectangle2D [minX = " + minX
+        return "Rectangle2D [minX=" + minX
                 + ", minY=" + minY
                 + ", maxX=" + maxX
                 + ", maxY=" + maxY


### PR DESCRIPTION
The output is now formatted properly. Before it had a space before and after 'minX=' , now it doesn't.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8238968](https://bugs.openjdk.java.net/browse/JDK-8238968): Inconsisent formatting of Rectangle2D toString method


### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/88/head:pull/88`
`$ git checkout pull/88`
