### PR TITLE
8237372: NullPointerException in TabPaneSkin.stopDrag

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
@@ -2213,14 +2213,16 @@ public class TabPaneSkin extends SkinBase<TabPane> {
             return;
         }
         // Animate tab header being dragged to its final position.
-        dragHeaderSourceX = dragTabHeader.getLayoutX();
-        dragHeaderTransitionX = dragHeaderDestX - dragHeaderSourceX;
-        dragHeaderAnim.playFromStart();
+        if (dragTabHeader != null) {
+            dragHeaderSourceX = dragTabHeader.getLayoutX();
+            dragHeaderTransitionX = dragHeaderDestX - dragHeaderSourceX;
+            dragHeaderAnim.playFromStart();
 
-        // Reorder the tab list.
-        if (dragHeaderStartX != dragHeaderDestX) {
-            ((TabObservableList<Tab>) getSkinnable().getTabs()).reorder(dragTabHeader.tab, swapTab);
-            swapTab = null;
+            // Reorder the tab list.
+            if (dragHeaderStartX != dragHeaderDestX) {
+                ((TabObservableList<Tab>) getSkinnable().getTabs()).reorder(dragTabHeader.tab, swapTab);
+                swapTab = null;
+            }
         }
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
@@ -1954,6 +1954,7 @@ public class TabPaneSkin extends SkinBase<TabPane> {
                 completeHeaderReordering();
             });
         }
+        @Override
         protected void interpolate(double frac) {
             dropAnimHeader.setLayoutX(dropHeaderSourceX + dropHeaderTransitionX * frac);
         }
@@ -1970,6 +1971,7 @@ public class TabPaneSkin extends SkinBase<TabPane> {
                 resetDrag();
             });
         }
+        @Override
         protected void interpolate(double frac) {
             dragTabHeader.setLayoutX(dragHeaderSourceX + dragHeaderTransitionX * frac);
         }
@@ -1989,6 +1991,7 @@ public class TabPaneSkin extends SkinBase<TabPane> {
     }
 
     private ListChangeListener childListener = new ListChangeListener<Node>() {
+        @Override
         public void onChanged(Change<? extends Node> change) {
             while (change.next()) {
                 if (change.wasAdded()) {
@@ -2210,10 +2213,8 @@ public class TabPaneSkin extends SkinBase<TabPane> {
         if (dragState == DragState.START) {
             // No drag action was performed.
             resetDrag();
-            return;
-        }
-        // Animate tab header being dragged to its final position.
-        if (dragTabHeader != null) {
+        } else if (dragState == DragState.REORDER) {
+            // Animate tab header being dragged to its final position.
             dragHeaderSourceX = dragTabHeader.getLayoutX();
             dragHeaderTransitionX = dragHeaderDestX - dragHeaderSourceX;
             dragHeaderAnim.playFromStart();

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
@@ -1954,7 +1954,6 @@ public class TabPaneSkin extends SkinBase<TabPane> {
                 completeHeaderReordering();
             });
         }
-        @Override
         protected void interpolate(double frac) {
             dropAnimHeader.setLayoutX(dropHeaderSourceX + dropHeaderTransitionX * frac);
         }
@@ -1971,7 +1970,6 @@ public class TabPaneSkin extends SkinBase<TabPane> {
                 resetDrag();
             });
         }
-        @Override
         protected void interpolate(double frac) {
             dragTabHeader.setLayoutX(dragHeaderSourceX + dragHeaderTransitionX * frac);
         }
@@ -1991,7 +1989,6 @@ public class TabPaneSkin extends SkinBase<TabPane> {
     }
 
     private ListChangeListener childListener = new ListChangeListener<Node>() {
-        @Override
         public void onChanged(Change<? extends Node> change) {
             while (change.next()) {
                 if (change.wasAdded()) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TabPaneTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TabPaneTest.java
@@ -54,7 +54,6 @@ import javafx.geometry.Side;
 import javafx.scene.Group;
 import javafx.scene.Scene;
 import javafx.scene.input.KeyEvent;
-import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
@@ -480,7 +479,6 @@ public class TabPaneTest {
             MouseEventGenerator.generateMouseEvent(MouseEvent.MOUSE_RELEASED, xval+75, yval+20));
         tk.firePulse();
     }
-
 
     @Test public void setRotateGraphicAndSeeValueIsReflectedInModel() {
         tabPane.setRotateGraphic(true);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TabPaneTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TabPaneTest.java
@@ -54,6 +54,7 @@ import javafx.geometry.Side;
 import javafx.scene.Group;
 import javafx.scene.Scene;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
@@ -462,6 +463,24 @@ public class TabPaneTest {
         tabPane.setTabDragPolicy(TabPane.TabDragPolicy.FIXED);
         assertSame(TabPane.TabDragPolicy.FIXED, tabPane.getTabDragPolicy());
     }
+
+    @Test public void tabDragPolicyReorderAndAsymmetricMouseEvent() {
+        tabPane.setTabDragPolicy(TabPane.TabDragPolicy.REORDER);
+        tabPane.getTabs().add(tab1);
+        tabPane.getTabs().add(tab2);
+        root.getChildren().add(tabPane);
+        show();
+
+        root.layout();
+
+        double xval = (tabPane.localToScene(tabPane.getLayoutBounds())).getMinX();
+        double yval = (tabPane.localToScene(tabPane.getLayoutBounds())).getMinY();
+
+        SceneHelper.processMouseEvent(scene,
+            MouseEventGenerator.generateMouseEvent(MouseEvent.MOUSE_RELEASED, xval+75, yval+20));
+        tk.firePulse();
+    }
+
 
     @Test public void setRotateGraphicAndSeeValueIsReflectedInModel() {
         tabPane.setRotateGraphic(true);


### PR DESCRIPTION
Test simulates a single mouse-released event.
Fix simply guards against the null case.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8237372](https://bugs.openjdk.java.net/browse/JDK-8237372): NullPointerException in TabPaneSkin.stopDrag


## Approvers
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)