### PR TITLE
8237078: [macOS] Media build broken on XCode 11

### DIFF
--- a/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFAudioProcessor.mm
+++ b/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFAudioProcessor.mm
@@ -108,9 +108,7 @@ static OSStatus AVFTapRenderCallback(void *inRefCon,
                 if (noErr == MTAudioProcessingTapCreate(kCFAllocatorDefault, &callbacks,
                         kMTAudioProcessingTapCreationFlag_PreEffects,
                         &audioProcessingTap)) {
-                    objc_msgSend(audioMixInputParameters,
-                            @selector(setAudioTapProcessor :),
-                            audioProcessingTap);
+                    [audioMixInputParameters setAudioTapProcessor:audioProcessingTap];
 
                     CFRelease(audioProcessingTap); // owned by the mixer now
                     mixer.inputParameters = @[audioMixInputParameters];


### PR DESCRIPTION
Fix JDK-8237078
replace the objc_msgSend call with a direct objC call.
The fix works on XCode 10.1 and XCode 11.3

Tested using
java  -Djfxmedia.platforms=OSXPlatform
with MediaPlayer playing an mp3.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8237078](https://bugs.openjdk.java.net/browse/JDK-8237078): [macOS] Media build broken on XCode 11


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Alexander Matveev ([almatvee](@sashamatveev) - **Reviewer**)