### PR TITLE
8157224: isNPOTSupported check is too strict

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Pipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Pipeline.java
@@ -43,6 +43,7 @@ public class ES2Pipeline extends GraphicsPipeline {
             pixelFormatAttributes = new GLPixelFormat.Attributes();
     static final boolean msaa;
     static final boolean npotSupported;
+    private static final boolean supports3D;
     private static boolean es2Enabled;
     private static boolean isEglfb = false;
 
@@ -89,10 +90,14 @@ public class ES2Pipeline extends GraphicsPipeline {
             factories = new ES2ResourceFactory[glFactory.getAdapterCount()];
             msaa = glFactory.isGLExtensionSupported("GL_ARB_multisample");
             npotSupported = glFactory.isNPOTSupported();
+            // 3D requires platform that has non-power of two (NPOT) support, but
+            // also works on iOS with OpenGL ES 2.0 or greater
+            supports3D = npotSupported || PlatformUtil.isIOS();
         } else {
             theInstance = null;
             msaa = false;
             npotSupported = false;
+            supports3D = false;
         }
 
     }
@@ -201,8 +206,7 @@ public class ES2Pipeline extends GraphicsPipeline {
 
     @Override
     public boolean is3DSupported() {
-        // 3D requires platform that has non-power of two (NPOT) support.
-        return npotSupported;
+        return supports3D;
     }
 
     @Override


### PR DESCRIPTION
This PR enables support for 3D on iOS devices, as they use OpenGL ES 2.0, which has (limited) support for npot support.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8157224](https://bugs.openjdk.java.net/browse/JDK-8157224): isNPOTSupported check is too strict


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)