### PR TITLE
8237770: Error creating fragment phong shader on iOS

### DIFF
--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/diffuse_color.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/diffuse_color.frag
@@ -27,7 +27,10 @@
 
 #ifdef GL_ES
 
+#ifndef EXTENSION_APPLIED
 #extension GL_OES_standard_derivatives : enable
+#define EXTENSION_APPLIED
+#endif
 
 // Define default float precision for fragment shaders
 #ifdef GL_FRAGMENT_PRECISION_HIGH

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/diffuse_color.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/diffuse_color.frag
@@ -28,8 +28,8 @@
 #ifdef GL_ES
 
 #ifndef EXTENSION_APPLIED
-#extension GL_OES_standard_derivatives : enable
 #define EXTENSION_APPLIED
+#extension GL_OES_standard_derivatives : enable
 #endif
 
 // Define default float precision for fragment shaders

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/diffuse_none.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/diffuse_none.frag
@@ -27,7 +27,10 @@
 
 #ifdef GL_ES
 
+#ifndef EXTENSION_APPLIED
 #extension GL_OES_standard_derivatives : enable
+#define EXTENSION_APPLIED
+#endif
 
 // Define default float precision for fragment shaders
 #ifdef GL_FRAGMENT_PRECISION_HIGH

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/diffuse_none.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/diffuse_none.frag
@@ -28,8 +28,8 @@
 #ifdef GL_ES
 
 #ifndef EXTENSION_APPLIED
-#extension GL_OES_standard_derivatives : enable
 #define EXTENSION_APPLIED
+#extension GL_OES_standard_derivatives : enable
 #endif
 
 // Define default float precision for fragment shaders

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/diffuse_texture.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/diffuse_texture.frag
@@ -27,7 +27,10 @@
 
 #ifdef GL_ES
 
+#ifndef EXTENSION_APPLIED
 #extension GL_OES_standard_derivatives : enable
+#define EXTENSION_APPLIED
+#endif
 
 // Define default float precision for fragment shaders
 #ifdef GL_FRAGMENT_PRECISION_HIGH

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/diffuse_texture.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/diffuse_texture.frag
@@ -28,8 +28,8 @@
 #ifdef GL_ES
 
 #ifndef EXTENSION_APPLIED
-#extension GL_OES_standard_derivatives : enable
 #define EXTENSION_APPLIED
+#extension GL_OES_standard_derivatives : enable
 #endif
 
 // Define default float precision for fragment shaders

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main0Lights.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main0Lights.frag
@@ -27,7 +27,10 @@
 
 #ifdef GL_ES
 
+#ifndef EXTENSION_APPLIED
 #extension GL_OES_standard_derivatives : enable
+#define EXTENSION_APPLIED
+#endif
 
 // Define default float precision for fragment shaders
 #ifdef GL_FRAGMENT_PRECISION_HIGH

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main0Lights.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main0Lights.frag
@@ -28,8 +28,8 @@
 #ifdef GL_ES
 
 #ifndef EXTENSION_APPLIED
-#extension GL_OES_standard_derivatives : enable
 #define EXTENSION_APPLIED
+#extension GL_OES_standard_derivatives : enable
 #endif
 
 // Define default float precision for fragment shaders

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main1Light.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main1Light.frag
@@ -27,7 +27,10 @@
 
 #ifdef GL_ES
 
+#ifndef EXTENSION_APPLIED
 #extension GL_OES_standard_derivatives : enable
+#define EXTENSION_APPLIED
+#endif
 
 // Define default float precision for fragment shaders
 #ifdef GL_FRAGMENT_PRECISION_HIGH

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main1Light.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main1Light.frag
@@ -28,8 +28,8 @@
 #ifdef GL_ES
 
 #ifndef EXTENSION_APPLIED
-#extension GL_OES_standard_derivatives : enable
 #define EXTENSION_APPLIED
+#extension GL_OES_standard_derivatives : enable
 #endif
 
 // Define default float precision for fragment shaders

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main2Lights.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main2Lights.frag
@@ -27,7 +27,10 @@
 
 #ifdef GL_ES
 
+#ifndef EXTENSION_APPLIED
 #extension GL_OES_standard_derivatives : enable
+#define EXTENSION_APPLIED
+#endif
 
 // Define default float precision for fragment shaders
 #ifdef GL_FRAGMENT_PRECISION_HIGH

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main2Lights.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main2Lights.frag
@@ -28,8 +28,8 @@
 #ifdef GL_ES
 
 #ifndef EXTENSION_APPLIED
-#extension GL_OES_standard_derivatives : enable
 #define EXTENSION_APPLIED
+#extension GL_OES_standard_derivatives : enable
 #endif
 
 // Define default float precision for fragment shaders

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main3Lights.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main3Lights.frag
@@ -27,7 +27,10 @@
 
 #ifdef GL_ES
 
+#ifndef EXTENSION_APPLIED
 #extension GL_OES_standard_derivatives : enable
+#define EXTENSION_APPLIED
+#endif
 
 // Define default float precision for fragment shaders
 #ifdef GL_FRAGMENT_PRECISION_HIGH

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main3Lights.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main3Lights.frag
@@ -28,8 +28,8 @@
 #ifdef GL_ES
 
 #ifndef EXTENSION_APPLIED
-#extension GL_OES_standard_derivatives : enable
 #define EXTENSION_APPLIED
+#extension GL_OES_standard_derivatives : enable
 #endif
 
 // Define default float precision for fragment shaders

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/normalMap_none.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/normalMap_none.frag
@@ -27,7 +27,10 @@
 
 #ifdef GL_ES
 
+#ifndef EXTENSION_APPLIED
 #extension GL_OES_standard_derivatives : enable
+#define EXTENSION_APPLIED
+#endif
 
 // Define default float precision for fragment shaders
 #ifdef GL_FRAGMENT_PRECISION_HIGH

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/normalMap_none.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/normalMap_none.frag
@@ -28,8 +28,8 @@
 #ifdef GL_ES
 
 #ifndef EXTENSION_APPLIED
-#extension GL_OES_standard_derivatives : enable
 #define EXTENSION_APPLIED
+#extension GL_OES_standard_derivatives : enable
 #endif
 
 // Define default float precision for fragment shaders

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/normalMap_texture.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/normalMap_texture.frag
@@ -27,7 +27,10 @@
 
 #ifdef GL_ES
 
+#ifndef EXTENSION_APPLIED
 #extension GL_OES_standard_derivatives : enable
+#define EXTENSION_APPLIED
+#endif
 
 // Define default float precision for fragment shaders
 #ifdef GL_FRAGMENT_PRECISION_HIGH

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/normalMap_texture.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/normalMap_texture.frag
@@ -28,8 +28,8 @@
 #ifdef GL_ES
 
 #ifndef EXTENSION_APPLIED
-#extension GL_OES_standard_derivatives : enable
 #define EXTENSION_APPLIED
+#extension GL_OES_standard_derivatives : enable
 #endif
 
 // Define default float precision for fragment shaders

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/selfIllum_none.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/selfIllum_none.frag
@@ -27,7 +27,10 @@
 
 #ifdef GL_ES
 
+#ifndef EXTENSION_APPLIED
 #extension GL_OES_standard_derivatives : enable
+#define EXTENSION_APPLIED
+#endif
 
 // Define default float precision for fragment shaders
 #ifdef GL_FRAGMENT_PRECISION_HIGH

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/selfIllum_none.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/selfIllum_none.frag
@@ -28,8 +28,8 @@
 #ifdef GL_ES
 
 #ifndef EXTENSION_APPLIED
-#extension GL_OES_standard_derivatives : enable
 #define EXTENSION_APPLIED
+#extension GL_OES_standard_derivatives : enable
 #endif
 
 // Define default float precision for fragment shaders

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/selfIllum_texture.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/selfIllum_texture.frag
@@ -27,7 +27,10 @@
 
 #ifdef GL_ES
 
+#ifndef EXTENSION_APPLIED
 #extension GL_OES_standard_derivatives : enable
+#define EXTENSION_APPLIED
+#endif
 
 // Define default float precision for fragment shaders
 #ifdef GL_FRAGMENT_PRECISION_HIGH

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/selfIllum_texture.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/selfIllum_texture.frag
@@ -28,8 +28,8 @@
 #ifdef GL_ES
 
 #ifndef EXTENSION_APPLIED
-#extension GL_OES_standard_derivatives : enable
 #define EXTENSION_APPLIED
+#extension GL_OES_standard_derivatives : enable
 #endif
 
 // Define default float precision for fragment shaders

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/specular_color.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/specular_color.frag
@@ -27,7 +27,10 @@
 
 #ifdef GL_ES
 
+#ifndef EXTENSION_APPLIED
 #extension GL_OES_standard_derivatives : enable
+#define EXTENSION_APPLIED
+#endif
 
 // Define default float precision for fragment shaders
 #ifdef GL_FRAGMENT_PRECISION_HIGH

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/specular_color.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/specular_color.frag
@@ -28,8 +28,8 @@
 #ifdef GL_ES
 
 #ifndef EXTENSION_APPLIED
-#extension GL_OES_standard_derivatives : enable
 #define EXTENSION_APPLIED
+#extension GL_OES_standard_derivatives : enable
 #endif
 
 // Define default float precision for fragment shaders

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/specular_mix.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/specular_mix.frag
@@ -27,7 +27,10 @@
 
 #ifdef GL_ES
 
+#ifndef EXTENSION_APPLIED
 #extension GL_OES_standard_derivatives : enable
+#define EXTENSION_APPLIED
+#endif
 
 // Define default float precision for fragment shaders
 #ifdef GL_FRAGMENT_PRECISION_HIGH

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/specular_mix.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/specular_mix.frag
@@ -28,8 +28,8 @@
 #ifdef GL_ES
 
 #ifndef EXTENSION_APPLIED
-#extension GL_OES_standard_derivatives : enable
 #define EXTENSION_APPLIED
+#extension GL_OES_standard_derivatives : enable
 #endif
 
 // Define default float precision for fragment shaders

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/specular_none.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/specular_none.frag
@@ -27,7 +27,10 @@
 
 #ifdef GL_ES
 
+#ifndef EXTENSION_APPLIED
 #extension GL_OES_standard_derivatives : enable
+#define EXTENSION_APPLIED
+#endif
 
 // Define default float precision for fragment shaders
 #ifdef GL_FRAGMENT_PRECISION_HIGH

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/specular_none.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/specular_none.frag
@@ -28,8 +28,8 @@
 #ifdef GL_ES
 
 #ifndef EXTENSION_APPLIED
-#extension GL_OES_standard_derivatives : enable
 #define EXTENSION_APPLIED
+#extension GL_OES_standard_derivatives : enable
 #endif
 
 // Define default float precision for fragment shaders

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/specular_texture.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/specular_texture.frag
@@ -27,7 +27,10 @@
 
 #ifdef GL_ES
 
+#ifndef EXTENSION_APPLIED
 #extension GL_OES_standard_derivatives : enable
+#define EXTENSION_APPLIED
+#endif
 
 // Define default float precision for fragment shaders
 #ifdef GL_FRAGMENT_PRECISION_HIGH

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/specular_texture.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/specular_texture.frag
@@ -28,8 +28,8 @@
 #ifdef GL_ES
 
 #ifndef EXTENSION_APPLIED
-#extension GL_OES_standard_derivatives : enable
 #define EXTENSION_APPLIED
+#extension GL_OES_standard_derivatives : enable
 #endif
 
 // Define default float precision for fragment shaders


### PR DESCRIPTION
This PR defines a pre-processor in the phong frag files to avoid inline declaration of #extension when several frags are combined that leads to the error:

```
syntax error: #extension must always be before any non-preprocessor tokens 
```
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8237770](https://bugs.openjdk.java.net/browse/JDK-8237770): Error creating fragment phong shader on iOS


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)