### PR TITLE
8237833: Check glyph size before adding to glyph texture cache

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/GlyphCache.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/GlyphCache.java
@@ -291,7 +291,12 @@ public class GlyphCache {
                     }
                     // If add fails,clear up the cache. Try add again.
                     clearAll();
-                    packer.add(rect);
+                    if (!packer.add(rect)) {
+                        if (PrismSettings.verbose) {
+                            System.out.println(rect + " won't fit in GlyphCache");
+                        }
+                        return null;
+                    }
                 }
 
                 // We always pass skipFlush=true to backingStore.update()
@@ -320,7 +325,9 @@ public class GlyphCache {
                                         0, 0, emw, emh, stride,
                                         skipFlush);
                 } catch (Exception e) {
-                    e.printStackTrace();
+                    if (PrismSettings.verbose) {
+                        e.printStackTrace();
+                    }
                     return null;
                 }
                 // Upload the glyph


### PR DESCRIPTION
Check if the glyph will fit before trying to cache it.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8237833](https://bugs.openjdk.java.net/browse/JDK-8237833): Check glyph size before adding to glyph texture cache.


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)