### PR TITLE
8237944: webview native cl "-m32" unknown option for windows 32-bit build

### DIFF
--- a/modules/javafx.web/src/main/native/Tools/Scripts/webkitdirs.pm
+++ b/modules/javafx.web/src/main/native/Tools/Scripts/webkitdirs.pm
@@ -2297,7 +2297,7 @@ sub generateBuildSystemFromCMakeProject
     # Some ports have production mode, but build-webkit should always use developer mode.
     push @args, "-DDEVELOPER_MODE=ON" if isGtk() || isJSCOnly() || isWPE() || isWinCairo();
 
-    if (architecture() eq "x86_64" && shouldBuild32Bit()) {
+    if (architecture() eq "x86_64" && shouldBuild32Bit() && (isJava() && !isCygwin())) {
         # CMAKE_LIBRARY_ARCHITECTURE is needed to get the right .pc
         # files in Debian-based systems, for the others
         # CMAKE_PREFIX_PATH will get us /usr/lib, which should be the

--- a/modules/javafx.web/src/main/native/Tools/Scripts/webkitdirs.pm
+++ b/modules/javafx.web/src/main/native/Tools/Scripts/webkitdirs.pm
@@ -2297,7 +2297,7 @@ sub generateBuildSystemFromCMakeProject
     # Some ports have production mode, but build-webkit should always use developer mode.
     push @args, "-DDEVELOPER_MODE=ON" if isGtk() || isJSCOnly() || isWPE() || isWinCairo();
 
-    if (architecture() eq "x86_64" && shouldBuild32Bit() && (isJava() && !isCygwin())) {
+    if (architecture() eq "x86_64" && shouldBuild32Bit() && !(isJava() && isCygwin())) {
         # CMAKE_LIBRARY_ARCHITECTURE is needed to get the right .pc
         # files in Debian-based systems, for the others
         # CMAKE_PREFIX_PATH will get us /usr/lib, which should be the


### PR DESCRIPTION
cl : Command line warning D9002 : ignoring unknown option '-m32'

post fix for "https://trac.webkit.org/changeset/242724/webkit" makes use of cross compiling 32 bit JSC in a 64 bit and its holds good only for Linux. 
'-m32' flag is gcc specifc and on windows cl.exe (visual studio) doesn't recognize this flag.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8237944](https://bugs.openjdk.java.net/browse/JDK-8237944): webview native cl "-m32" unknown option for windows 32-bit build 


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)