### PR TITLE
8237975: Non-embedded Animations do not play backwards after being paused

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/ClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/ClipEnvelope.java
@@ -110,6 +110,10 @@ public abstract class ClipEnvelope {
 
     protected abstract double calculateCurrentRate();
 
+    protected void setInternalCurrentRate(double currentRate) {
+        this.currentRate = currentRate;
+    }
+
     protected void setCurrentRate(double currentRate) {
         this.currentRate = currentRate;
         AnimationAccessor.getDefault().setCurrentRate(animation, currentRate);

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/FiniteClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/FiniteClipEnvelope.java
@@ -82,9 +82,9 @@ public class FiniteClipEnvelope extends ClipEnvelope {
         final long newTicks = toggled? totalTicks - ticks : ticks;
         final Status status = animation.getStatus();
         if (status != Status.STOPPED) {
-            if (status == Status.RUNNING) {
-                setCurrentRate((Math.abs(currentRate - this.rate) < EPSILON) ? rate : -rate);
-            }
+//            if (status == Status.RUNNING) {
+                setInternalCurrentRate((Math.abs(currentRate - this.rate) < EPSILON) ? rate : -rate);
+//            }
             deltaTicks = newTicks - Math.round((ticks - deltaTicks) * Math.abs(rate / this.rate));
             abortCurrentPulse();
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/FiniteClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/FiniteClipEnvelope.java
@@ -82,9 +82,7 @@ public class FiniteClipEnvelope extends ClipEnvelope {
         final long newTicks = toggled? totalTicks - ticks : ticks;
         final Status status = animation.getStatus();
         if (status != Status.STOPPED) {
-//            if (status == Status.RUNNING) {
-                setInternalCurrentRate((Math.abs(currentRate - this.rate) < EPSILON) ? rate : -rate);
-//            }
+            setInternalCurrentRate((Math.abs(currentRate - this.rate) < EPSILON) ? rate : -rate);
             deltaTicks = newTicks - Math.round((ticks - deltaTicks) * Math.abs(rate / this.rate));
             abortCurrentPulse();
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/InfiniteClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/InfiniteClipEnvelope.java
@@ -70,9 +70,7 @@ public class InfiniteClipEnvelope extends ClipEnvelope {
     public void setRate(double rate) {
         final Status status = animation.getStatus();
         if (status != Status.STOPPED) {
-//            if (status == Status.RUNNING) {
-                setInternalCurrentRate((Math.abs(currentRate - this.rate) < EPSILON) ? rate : -rate);
-//            }
+            setInternalCurrentRate((Math.abs(currentRate - this.rate) < EPSILON) ? rate : -rate);
             deltaTicks = ticks - Math.round((ticks - deltaTicks) * Math.abs(rate / this.rate));
             if (rate * this.rate < 0) {
                 final long delta = 2 * cycleTicks - pos;

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/InfiniteClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/InfiniteClipEnvelope.java
@@ -70,9 +70,9 @@ public class InfiniteClipEnvelope extends ClipEnvelope {
     public void setRate(double rate) {
         final Status status = animation.getStatus();
         if (status != Status.STOPPED) {
-            if (status == Status.RUNNING) {
-                setCurrentRate((Math.abs(currentRate - this.rate) < EPSILON) ? rate : -rate);
-            }
+//            if (status == Status.RUNNING) {
+                setInternalCurrentRate((Math.abs(currentRate - this.rate) < EPSILON) ? rate : -rate);
+//            }
             deltaTicks = ticks - Math.round((ticks - deltaTicks) * Math.abs(rate / this.rate));
             if (rate * this.rate < 0) {
                 final long delta = 2 * cycleTicks - pos;

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/SingleLoopClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/SingleLoopClipEnvelope.java
@@ -37,9 +37,9 @@ public class SingleLoopClipEnvelope extends ClipEnvelope {
     public void setRate(double rate) {
         final Status status = animation.getStatus();
         if (status != Status.STOPPED) {
-            if (status == Status.RUNNING) {
-                setCurrentRate((Math.abs(currentRate - this.rate) < EPSILON) ? rate : -rate);
-            }
+//            if (status == Status.RUNNING) {
+            setInternalCurrentRate((Math.abs(currentRate - this.rate) < EPSILON) ? rate : -rate);
+//            }
             deltaTicks = ticks - Math.round((ticks - deltaTicks) * rate / this.rate);
             abortCurrentPulse();
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/SingleLoopClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/SingleLoopClipEnvelope.java
@@ -37,9 +37,7 @@ public class SingleLoopClipEnvelope extends ClipEnvelope {
     public void setRate(double rate) {
         final Status status = animation.getStatus();
         if (status != Status.STOPPED) {
-//            if (status == Status.RUNNING) {
             setInternalCurrentRate((Math.abs(currentRate - this.rate) < EPSILON) ? rate : -rate);
-//            }
             deltaTicks = ticks - Math.round((ticks - deltaTicks) * rate / this.rate);
             abortCurrentPulse();
         }

--- a/modules/javafx.graphics/src/shims/java/com/sun/scenario/animation/shared/SingleLoopClipEnvelopeShim.java
+++ b/modules/javafx.graphics/src/shims/java/com/sun/scenario/animation/shared/SingleLoopClipEnvelopeShim.java
@@ -32,4 +32,7 @@ public class SingleLoopClipEnvelopeShim extends SingleLoopClipEnvelope {
         super(animation);
     }
 
+    public long getTicks() {
+        return ticks;
+    }
 }

--- a/modules/javafx.graphics/src/shims/java/javafx/animation/AnimationShim.java
+++ b/modules/javafx.graphics/src/shims/java/javafx/animation/AnimationShim.java
@@ -48,6 +48,10 @@ public abstract class AnimationShim extends Animation {
         return clipEnvelope;
     }
 
+    public void setClipEnvelope(ClipEnvelope clipEnvelope) {
+        this.clipEnvelope= clipEnvelope;
+    }
+
     @Override
     public void doPause() {
         super.doPause();

--- a/modules/javafx.graphics/src/test/java/test/javafx/animation/AnimationSetRateTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/animation/AnimationSetRateTest.java
@@ -27,6 +27,7 @@ package test.javafx.animation;
 
 
 import javafx.animation.Animation.Status;
+import javafx.animation.TranslateTransition;
 import javafx.util.Duration;
 import test.com.sun.scenario.animation.shared.ClipEnvelopeMock;
 import org.junit.Before;
@@ -370,5 +371,18 @@ public class AnimationSetRateTest {
         assertAnimation(0.5, 0.0, Status.PAUSED, false);
         animation.play();
         assertAnimation(0.5, -0.5, Status.RUNNING, true);
+    }
+
+    @Test
+    public void testFlipRateAndPlayForPausedNonEmbeddedAnimation() {
+        animation.setRate(0.2);
+        animation.doTimePulse(100);
+        animation.pause();
+        double timeBefore = animation.getCurrentTime().toMillis();
+        animation.setRate(-0.2);
+        animation.doTimePulse(100);
+        animation.pause();
+        double timeAfter = animation.getCurrentTime().toMillis();
+        assertTrue("Playing backwards should reduce the current ticks", timeAfter < timeBefore);
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/animation/AnimationSetRateTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/animation/AnimationSetRateTest.java
@@ -27,7 +27,6 @@ package test.javafx.animation;
 
 
 import javafx.animation.Animation.Status;
-import javafx.animation.TranslateTransition;
 import javafx.util.Duration;
 import test.com.sun.scenario.animation.shared.ClipEnvelopeMock;
 import org.junit.Before;

--- a/modules/javafx.graphics/src/test/java/test/javafx/animation/AnimationSetRateTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/animation/AnimationSetRateTest.java
@@ -32,6 +32,8 @@ import test.com.sun.scenario.animation.shared.ClipEnvelopeMock;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.sun.scenario.animation.shared.SingleLoopClipEnvelopeShim;
+
 import static org.junit.Assert.*;
 
 public class AnimationSetRateTest {
@@ -374,14 +376,19 @@ public class AnimationSetRateTest {
 
     @Test
     public void testFlipRateAndPlayForPausedNonEmbeddedAnimation() {
+        var clip = new SingleLoopClipEnvelopeShim(animation);
+        animation.setClipEnvelope(clip);
         animation.setRate(0.2);
-        animation.doTimePulse(100);
+        animation.play();
+        clip.timePulse(10);
         animation.pause();
-        double timeBefore = animation.getCurrentTime().toMillis();
+        long timeBefore = clip.getTicks();
         animation.setRate(-0.2);
-        animation.doTimePulse(100);
+        animation.play();
+        clip.timePulse(5);
         animation.pause();
-        double timeAfter = animation.getCurrentTime().toMillis();
-        assertTrue("Playing backwards should reduce the current ticks", timeAfter < timeBefore);
+        long timeAfter = clip.getTicks();
+        assertEquals("A pulse to 10 at rate 0.2 with deltaTicks = 0 should reach 10 * 0.2 = 2", 2, timeBefore);
+        assertEquals("A pulse to 5 at rate -0.2 with deltaTicks = 4 should reach 4 + 5 * (-0.2) = 3", 3, timeAfter);
     }
 }


### PR DESCRIPTION
[8236858](https://bugs.openjdk.java.net/browse/JDK-8236858) (Animations do not play backwards after being paused) has been split to deal with [embedded](https://bugs.openjdk.java.net/browse/JDK-8237974) and [not embedded](https://bugs.openjdk.java.net/browse/JDK-8237975) animations. This is a fix for the latter.
The reason for the split is that embedded animations have a much more complex behavior. The current state of the relation between an animation and its clip envelope is already messy and should be corrected, even more so for embedded animations whose parent controls their behavior as well (sometimes in conflict with the child's clip envelope). This will require a redesign which can be discussed for 15. See the parent issue [8210238](https://bugs.openjdk.java.net/browse/JDK-8210238) for the list of bugs that arise from it.

This simple fix allows to change the current rate of a `ClipEnvelope` also when the animations is `PAUSED`. A possible issue with this approach is that it changes the buggy behavior of embedded animations to a different buggy behavior.

A concept test has been added, but it does not work yet since the mock clip envelope does not have sufficient behavior (`doTimePulse` does not actually do a time pulse). Open for ideas on how to make it simple, otherwise I will add a method to set a clip envelope and create a new one ad-hoc.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8237975](https://bugs.openjdk.java.net/browse/JDK-8237975): Non-embedded Animations do not play backwards after being paused


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)