### PR TITLE
8238650: Allow to override buildDate with SOURCE_DATE_EPOCH

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -539,7 +539,7 @@ if (jfxReleasePatchVersion == "0") {
 defineProperty("RELEASE_VERSION", relVer)
 defineProperty("RELEASE_VERSION_PADDED", "${jfxReleaseMajorVersion}.${jfxReleaseMinorVersion}.${jfxReleaseSecurityVersion}.${jfxReleasePatchVersion}")
 
-def buildDate = new java.util.Date()
+def buildDate = System.getenv("SOURCE_DATE_EPOCH") == null ? new java.util.Date() : new java.util.Date(1000 * Long.parseLong(System.getenv("SOURCE_DATE_EPOCH")))
 def buildTimestamp = new java.text.SimpleDateFormat("yyyy-MM-dd-HHmmss").format(buildDate)
 defineProperty("BUILD_TIMESTAMP", buildTimestamp)
 def relSuffix = ""


### PR DESCRIPTION
Allow to override buildDate with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This PR was done while working on reproducible builds for openSUSE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8238650](https://bugs.openjdk.java.net/browse/JDK-8238650): Allow to override buildDate with SOURCE_DATE_EPOCH


### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/99/head:pull/99`
`$ git checkout pull/99`
