### PR TITLE
8237003: Remove hardcoded WebAnimationsCSSIntegrationEnabled flag in DumpRenderTree

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/drt/DumpRenderTree.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/drt/DumpRenderTree.java
@@ -196,7 +196,6 @@ public final class DumpRenderTree {
     private void resetToConsistentStateBeforeTesting(final TestOptions options) {
         // Assign default values for all supported TestOptions
         webPage.overridePreference("experimental:CSSCustomPropertiesAndValuesEnabled", "false");
-        webPage.overridePreference("experimental:WebAnimationsCSSIntegrationEnabled", "true");
         webPage.overridePreference("enableColorFilter", "false");
         webPage.overridePreference("enableIntersectionObserver", "false");
         // Enable features based on TestOption


### PR DESCRIPTION
AnimationBase and WebAnimation are two different abstract animation API provider. By default KeyFrameAnimation (which is a sub class of AnimationBase) is used for controlling and rendering the CSS animation. 
Enabling "WebAnimationsCSSIntegrationEnabled" overrides the CSSAnimationController to use WebAnimation which is not used in our port (JAVA) and we are using KeyFrameAnimation.

Test : need to run DRT test harness with this fix for "LayoutTests/animations".
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8237003](https://bugs.openjdk.java.net/browse/JDK-8237003): Remove hardcoded WebAnimationsCSSIntegrationEnabled flag in DumpRenderTree


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)