### PR TITLE
8238249: GetPrimitiveArrayCritical passed with hardcoded FALSE value

### DIFF
--- a/modules/javafx.graphics/src/main/native-iio/jpegloader.c
+++ b/modules/javafx.graphics/src/main/native-iio/jpegloader.c
@@ -1664,8 +1664,7 @@ JNIEXPORT jboolean JNICALL Java_com_sun_javafx_iio_jpeg_JPEGImageLoader_decompre
 
         num_scanlines = jpeg_read_scanlines(cinfo, &scanline_ptr, 1);
         if (num_scanlines == 1) {
-            jboolean iscopy = FALSE;
-            jbyte *body = (*env)->GetPrimitiveArrayCritical(env, barray, &iscopy);
+            jbyte *body = (*env)->GetPrimitiveArrayCritical(env, barray, NULL);
             if (body == NULL) {
                 fprintf(stderr, "decompressIndirect: GetPrimitiveArrayCritical returns NULL: out of memory\n");
                 return JNI_FALSE;


### PR DESCRIPTION
Fix for JDK-8238249
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8238249](https://bugs.openjdk.java.net/browse/JDK-8238249): GetPrimitiveArrayCritical passed with hardcoded FALSE value


## Approvers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)