### PR TITLE
8231513: JavaFX cause Keystroke Receiving prompt on MacOS 10.15 (Catalina)

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassTouches.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassTouches.m
@@ -42,6 +42,7 @@
 
 
 static GlassTouches* glassTouches = nil;
+static BOOL useEventTap = NO;
 
 
 @interface GlassTouches (hidden)
@@ -176,7 +177,7 @@ static CGEventRef listenTouchEvents(CGEventTapProxy proxy, CGEventType type,
 
 - (id)init
 {
-    BOOL useEventTap = YES;
+    useEventTap = YES;
     if (@available(macOS 10.15, *)) {
         useEventTap = NO;
     }
@@ -232,11 +233,6 @@ static CGEventRef listenTouchEvents(CGEventTapProxy proxy, CGEventType type,
 @implementation GlassTouches (hidden)
 - (void)terminateImpl
 {
-    BOOL useEventTap = YES;
-    if (@available(macOS 10.15, *)) {
-        useEventTap = NO;
-    }
-
     if (useEventTap) {
         LOG("TOUCHES: terminateImpl eventTap=%p runLoopSource=%p\n", self->eventTap,
             self->runLoopSource);
@@ -260,11 +256,6 @@ static CGEventRef listenTouchEvents(CGEventTapProxy proxy, CGEventType type,
 
 - (void)enableTouchInputEventTap
 {
-    BOOL useEventTap = YES;
-    if (@available(macOS 10.15, *)) {
-        useEventTap = NO;
-    }
-
     if (useEventTap) {
         CGEventTapEnable(self->eventTap, true);
     }

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassTouches.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassTouches.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -176,6 +176,11 @@ static CGEventRef listenTouchEvents(CGEventTapProxy proxy, CGEventType type,
 
 - (id)init
 {
+    BOOL useEventTap = YES;
+    if (@available(macOS 10.15, *)) {
+        useEventTap = NO;
+    }
+
     self = [super init];
     if (self != nil)
     {
@@ -185,35 +190,37 @@ static CGEventRef listenTouchEvents(CGEventTapProxy proxy, CGEventType type,
         self->touches       = nil;
         self->lastTouchId   = 0;
 
-        //
-        // Notes after fixing RT-23199:
-        //
-        //  Don't use NSMachPort and NSRunLoop to integrate CFMachPortRef
-        //  instance into run loop.
-        //
-        // Ignoring the above "don't"s results into performance degradation
-        // referenced in the bug.
-        //
+        if (useEventTap) {
+            //
+            // Notes after fixing RT-23199:
+            //
+            //  Don't use NSMachPort and NSRunLoop to integrate CFMachPortRef
+            //  instance into run loop.
+            //
+            // Ignoring the above "don't"s results into performance degradation
+            // referenced in the bug.
+            //
 
-        self->eventTap = CGEventTapCreate(kCGHIDEventTap,
-                                          kCGHeadInsertEventTap,
-                                          kCGEventTapOptionListenOnly,
-                                          CGEventMaskBit(NSEventTypeGesture),
-                                          listenTouchEvents, nil);
+            self->eventTap = CGEventTapCreate(kCGHIDEventTap,
+                                              kCGHeadInsertEventTap,
+                                              kCGEventTapOptionListenOnly,
+                                              CGEventMaskBit(NSEventTypeGesture),
+                                              listenTouchEvents, nil);
 
-        LOG("TOUCHES: eventTap=%p\n", self->eventTap);
+            LOG("TOUCHES: eventTap=%p\n", self->eventTap);
 
-        if (self->eventTap)
-        {   // Create a run loop source.
-            self->runLoopSource = CFMachPortCreateRunLoopSource(
-                                                        kCFAllocatorDefault,
-                                                        self->eventTap, 0);
+            if (self->eventTap)
+            {   // Create a run loop source.
+                self->runLoopSource = CFMachPortCreateRunLoopSource(
+                                                            kCFAllocatorDefault,
+                                                            self->eventTap, 0);
 
-            LOG("TOUCHES: runLoopSource=%p\n", self->runLoopSource);
+                LOG("TOUCHES: runLoopSource=%p\n", self->runLoopSource);
 
-            // Add to the current run loop.
-            CFRunLoopAddSource(CFRunLoopGetCurrent(), self->runLoopSource,
-                               kCFRunLoopCommonModes);
+                // Add to the current run loop.
+                CFRunLoopAddSource(CFRunLoopGetCurrent(), self->runLoopSource,
+                                   kCFRunLoopCommonModes);
+            }
         }
     }
     return self;
@@ -225,29 +232,42 @@ static CGEventRef listenTouchEvents(CGEventTapProxy proxy, CGEventType type,
 @implementation GlassTouches (hidden)
 - (void)terminateImpl
 {
-    LOG("TOUCHES: terminateImpl eventTap=%p runLoopSource=%p\n", self->eventTap,
-        self->runLoopSource);
-
-    if (self->runLoopSource)
-    {
-        CFRunLoopRemoveSource(CFRunLoopGetCurrent(), self->runLoopSource,
-                              kCFRunLoopCommonModes);
-        CFRelease(self->runLoopSource);
-        self->runLoopSource = nil;
+    BOOL useEventTap = YES;
+    if (@available(macOS 10.15, *)) {
+        useEventTap = NO;
     }
 
-    if (self->eventTap)
-    {
-        CFRelease(self->eventTap);
-        self->eventTap = nil;
-    }
+    if (useEventTap) {
+        LOG("TOUCHES: terminateImpl eventTap=%p runLoopSource=%p\n", self->eventTap,
+            self->runLoopSource);
 
+        if (self->runLoopSource)
+        {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), self->runLoopSource,
+                                  kCFRunLoopCommonModes);
+            CFRelease(self->runLoopSource);
+            self->runLoopSource = nil;
+        }
+
+        if (self->eventTap)
+        {
+            CFRelease(self->eventTap);
+            self->eventTap = nil;
+        }
+    }
     [self releaseTouches];
 }
 
 - (void)enableTouchInputEventTap
 {
-    CGEventTapEnable(self->eventTap, true);
+    BOOL useEventTap = YES;
+    if (@available(macOS 10.15, *)) {
+        useEventTap = NO;
+    }
+
+    if (useEventTap) {
+        CGEventTapEnable(self->eventTap, true);
+    }
 }
 
 - (void)sendJavaTouchEvent:(NSEvent *)theEvent


### PR DESCRIPTION
This is a fix for [JDK-8231513](https://bugs.openjdk.java.net/browse/JDK-8231513) to disable the use of `CGEventTap` when running on macOS 10.15 or later.

The effect of this bug is that a scary dialog is shown for all users the first time they run a JavaFX application and move the mouse is moved into the JavaFX window. It also is reported to block apps from being accepted in the Apple store.

This bug is caused by a change in macOS 10.15 to require additional permissions for using CGEventTap, which JavaFX uses to track touch events.

The suggested replacement API, `NSEvent::addLocalMonitorForEventsMatchingMask`, works just differently enough (it tracks events delivered to a specific view, whereas the current code is implemented using a global monitor and a global set of touch points), that it would be too risky to change it this late in the release.

For openjfx14, I am proposing to disable touch events completely if running on macOS 10.15 (or later). This will disable the tracking of native touch events, but those events are not used by default on macOS anyway. For Mac systems with a trackpad we instead rely on macOS to do the gesture recognition by default, and this fix does not intefere with that functionality.

I have verified that this avoids the dialog on macOS 10.15 and that the HelloGestures program still runs correctly and still recognizes trackpad gestures such as zoom and rotate. I also verified that the changes don't affect macOS 10.14 or earlier (the Event Tap code is still enabled on those older OS versions).

See [this thread](https://mail.openjdk.java.net/pipermail/openjfx-dev/2020-January/024876.html) on openjfx-dev for more discussion.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
## Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

## Issue
[JDK-8231513](https://bugs.openjdk.java.net/browse/JDK-8231513): JavaFX cause Keystroke Receiving prompt on MacOS 10.15 (Catalina)


## Approvers
 * Phil Race ([prr](@prrace) - **Reviewer**) **Note!** Review applies to d6109fb1167ada6eadd4319f9cda11f37787fd5a
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)