### PR TITLE
8252936: Optimize removal of listeners from ExpressionHelper.Generic

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/ExpressionHelper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/ExpressionHelper.java
@@ -25,11 +25,13 @@
 
 package com.sun.javafx.binding;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
 import javafx.beans.InvalidationListener;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
-
-import java.util.Arrays;
 
 /**
  * A convenience class for creating implementations of {@link javafx.beans.value.ObservableValue}.
@@ -188,86 +190,55 @@ public abstract class ExpressionHelper<T> extends ExpressionHelperBase {
 
     private static class Generic<T> extends ExpressionHelper<T> {
 
-        private InvalidationListener[] invalidationListeners;
-        private ChangeListener<? super T>[] changeListeners;
-        private int invalidationSize;
-        private int changeSize;
-        private boolean locked;
+        private Map<InvalidationListener, Integer> invalidationListeners = new LinkedHashMap<>();
+        private Map<ChangeListener<? super T>, Integer> changeListeners = new LinkedHashMap<>();
         private T currentValue;
+        private int weakChangeListenerGcCount = 2;
+        private int weakInvalidationListenerGcCount = 2;
 
         private Generic(ObservableValue<T> observable, InvalidationListener listener0, InvalidationListener listener1) {
             super(observable);
-            this.invalidationListeners = new InvalidationListener[] {listener0, listener1};
-            this.invalidationSize = 2;
+            this.invalidationListeners.put(listener0, 1);
+            // use merge here in case listener1 == listener0
+            this.invalidationListeners.merge(listener1, 1, Integer::sum);
         }
 
         private Generic(ObservableValue<T> observable, ChangeListener<? super T> listener0, ChangeListener<? super T> listener1) {
             super(observable);
-            this.changeListeners = new ChangeListener[] {listener0, listener1};
-            this.changeSize = 2;
+            this.changeListeners.put(listener0, 1);
+            // use merge here in case listener1 == listener0
+            this.changeListeners.merge(listener1, 1, Integer::sum);
             this.currentValue = observable.getValue();
         }
 
         private Generic(ObservableValue<T> observable, InvalidationListener invalidationListener, ChangeListener<? super T> changeListener) {
             super(observable);
-            this.invalidationListeners = new InvalidationListener[] {invalidationListener};
-            this.invalidationSize = 1;
-            this.changeListeners = new ChangeListener[] {changeListener};
-            this.changeSize = 1;
+            this.invalidationListeners.put(invalidationListener, 1);
+            this.changeListeners.put(changeListener, 1);
             this.currentValue = observable.getValue();
         }
 
         @Override
         protected Generic<T> addListener(InvalidationListener listener) {
-            if (invalidationListeners == null) {
-                invalidationListeners = new InvalidationListener[] {listener};
-                invalidationSize = 1;
-            } else {
-                final int oldCapacity = invalidationListeners.length;
-                if (locked) {
-                    final int newCapacity = (invalidationSize < oldCapacity)? oldCapacity : (oldCapacity * 3)/2 + 1;
-                    invalidationListeners = Arrays.copyOf(invalidationListeners, newCapacity);
-                } else if (invalidationSize == oldCapacity) {
-                    invalidationSize = trim(invalidationSize, invalidationListeners);
-                    if (invalidationSize == oldCapacity) {
-                        final int newCapacity = (oldCapacity * 3)/2 + 1;
-                        invalidationListeners = Arrays.copyOf(invalidationListeners, newCapacity);
-                    }
+            if (invalidationListeners.size() == weakInvalidationListenerGcCount) {
+                removeWeakListeners(invalidationListeners);
+                if (invalidationListeners.size() == weakInvalidationListenerGcCount) {
+                    weakInvalidationListenerGcCount = (weakInvalidationListenerGcCount * 3)/2 + 1;
                 }
-                invalidationListeners[invalidationSize++] = listener;
             }
+            invalidationListeners.merge(listener, 1, Integer::sum);
             return this;
         }
 
         @Override
         protected ExpressionHelper<T> removeListener(InvalidationListener listener) {
-            if (invalidationListeners != null) {
-                for (int index = 0; index < invalidationSize; index++) {
-                    if (listener.equals(invalidationListeners[index])) {
-                        if (invalidationSize == 1) {
-                            if (changeSize == 1) {
-                                return new SingleChange<T>(observable, changeListeners[0]);
-                            }
-                            invalidationListeners = null;
-                            invalidationSize = 0;
-                        } else if ((invalidationSize == 2) && (changeSize == 0)) {
-                            return new SingleInvalidation<T>(observable, invalidationListeners[1-index]);
-                        } else {
-                            final int numMoved = invalidationSize - index - 1;
-                            final InvalidationListener[] oldListeners = invalidationListeners;
-                            if (locked) {
-                                invalidationListeners = new InvalidationListener[invalidationListeners.length];
-                                System.arraycopy(oldListeners, 0, invalidationListeners, 0, index);
-                            }
-                            if (numMoved > 0) {
-                                System.arraycopy(oldListeners, index+1, invalidationListeners, index, numMoved);
-                            }
-                            invalidationSize--;
-                            if (!locked) {
-                                invalidationListeners[invalidationSize] = null; // Let gc do its work
-                            }
-                        }
-                        break;
+            if (invalidationListeners.containsKey(listener)) {
+                if (invalidationListeners.merge(listener, -1, Integer::sum) == 0) {
+                    invalidationListeners.remove(listener);
+                    if (invalidationListeners.isEmpty() && changeListeners.size() == 1) {
+                        return new SingleChange<T>(observable, changeListeners.keySet().iterator().next());
+                    } else if ((invalidationListeners.size() == 1) && changeListeners.isEmpty()) {
+                        return new SingleInvalidation<T>(observable, invalidationListeners.keySet().iterator().next());
                     }
                 }
             }
@@ -276,24 +247,14 @@ public abstract class ExpressionHelper<T> extends ExpressionHelperBase {
 
         @Override
         protected ExpressionHelper<T> addListener(ChangeListener<? super T> listener) {
-            if (changeListeners == null) {
-                changeListeners = new ChangeListener[] {listener};
-                changeSize = 1;
-            } else {
-                final int oldCapacity = changeListeners.length;
-                if (locked) {
-                    final int newCapacity = (changeSize < oldCapacity)? oldCapacity : (oldCapacity * 3)/2 + 1;
-                    changeListeners = Arrays.copyOf(changeListeners, newCapacity);
-                } else if (changeSize == oldCapacity) {
-                    changeSize = trim(changeSize, changeListeners);
-                    if (changeSize == oldCapacity) {
-                        final int newCapacity = (oldCapacity * 3)/2 + 1;
-                        changeListeners = Arrays.copyOf(changeListeners, newCapacity);
-                    }
+            if (changeListeners.size() == weakChangeListenerGcCount) {
+                removeWeakListeners(changeListeners);
+                if (changeListeners.size() == weakChangeListenerGcCount) {
+                    weakChangeListenerGcCount = (weakChangeListenerGcCount * 3)/2 + 1;
                 }
-                changeListeners[changeSize++] = listener;
             }
-            if (changeSize == 1) {
+            changeListeners.merge(listener, 1, Integer::sum);
+            if (changeListeners.size() == 1) {
                 currentValue = observable.getValue();
             }
             return this;
@@ -301,33 +262,13 @@ public abstract class ExpressionHelper<T> extends ExpressionHelperBase {
 
         @Override
         protected ExpressionHelper<T> removeListener(ChangeListener<? super T> listener) {
-            if (changeListeners != null) {
-                for (int index = 0; index < changeSize; index++) {
-                    if (listener.equals(changeListeners[index])) {
-                        if (changeSize == 1) {
-                            if (invalidationSize == 1) {
-                                return new SingleInvalidation<T>(observable, invalidationListeners[0]);
-                            }
-                            changeListeners = null;
-                            changeSize = 0;
-                        } else if ((changeSize == 2) && (invalidationSize == 0)) {
-                            return new SingleChange<T>(observable, changeListeners[1-index]);
-                        } else {
-                            final int numMoved = changeSize - index - 1;
-                            final ChangeListener<? super T>[] oldListeners = changeListeners;
-                            if (locked) {
-                                changeListeners = new ChangeListener[changeListeners.length];
-                                System.arraycopy(oldListeners, 0, changeListeners, 0, index);
-                            }
-                            if (numMoved > 0) {
-                                System.arraycopy(oldListeners, index+1, changeListeners, index, numMoved);
-                            }
-                            changeSize--;
-                            if (!locked) {
-                                changeListeners[changeSize] = null; // Let gc do its work
-                            }
-                        }
-                        break;
+            if (changeListeners.containsKey(listener)) {
+                if (changeListeners.merge(listener, -1, Integer::sum) == 0) {
+                    changeListeners.remove(listener);
+                    if (changeListeners.isEmpty() && invalidationListeners.size() == 1) {
+                        return new SingleInvalidation<T>(observable, invalidationListeners.keySet().iterator().next());
+                    } else if ((changeListeners.size() == 1) && invalidationListeners.isEmpty()) {
+                        return new SingleChange<T>(observable, changeListeners.keySet().iterator().next());
                     }
                 }
             }
@@ -336,38 +277,47 @@ public abstract class ExpressionHelper<T> extends ExpressionHelperBase {
 
         @Override
         protected void fireValueChangedEvent() {
-            final InvalidationListener[] curInvalidationList = invalidationListeners;
-            final int curInvalidationSize = invalidationSize;
-            final ChangeListener<? super T>[] curChangeList = changeListeners;
-            final int curChangeSize = changeSize;
+            // Take a copy of listeners to ensure adding and removing listeners
+            // while the observers are being notified is safe
+            final Map<InvalidationListener, Integer> curInvalidationList = new LinkedHashMap<>(invalidationListeners);
+            final Map<ChangeListener<? super T>, Integer> curChangeList = new LinkedHashMap<>(changeListeners);
 
+            curInvalidationList.entrySet().forEach(entry -> fireInvalidationListeners(entry));
+
+            if (!curChangeList.isEmpty()) {
+                final T oldValue = currentValue;
+                currentValue = observable.getValue();
+                final boolean changed = (currentValue == null)? (oldValue != null) : !currentValue.equals(oldValue);
+                if (changed) {
+                    curChangeList.entrySet().forEach(entry -> fireChangeListeners(oldValue, entry));
+                }
+            }
+        }
+
+        private void fireInvalidationListeners(Entry<InvalidationListener, Integer> entry) {
+            final InvalidationListener listener = entry.getKey();
+            final int registrationCount = entry.getValue();
             try {
-                locked = true;
-                for (int i = 0; i < curInvalidationSize; i++) {
-                    try {
-                        curInvalidationList[i].invalidated(observable);
-                    } catch (Exception e) {
-                        Thread.currentThread().getUncaughtExceptionHandler().uncaughtException(Thread.currentThread(), e);
-                    }
+                for (int i = 0; i < registrationCount; i++) {
+                    listener.invalidated(observable);
                 }
-                if (curChangeSize > 0) {
-                    final T oldValue = currentValue;
-                    currentValue = observable.getValue();
-                    final boolean changed = (currentValue == null)? (oldValue != null) : !currentValue.equals(oldValue);
-                    if (changed) {
-                        for (int i = 0; i < curChangeSize; i++) {
-                            try {
-                                curChangeList[i].changed(observable, oldValue, currentValue);
-                            } catch (Exception e) {
-                                Thread.currentThread().getUncaughtExceptionHandler().uncaughtException(Thread.currentThread(), e);
-                            }
-                        }
-                    }
+            } catch (Exception e) {
+                Thread.currentThread().getUncaughtExceptionHandler().uncaughtException(
+                    Thread.currentThread(), e);
+            }
+        }
+
+        private void fireChangeListeners(final T oldValue, Entry<ChangeListener<? super T>, Integer> entry) {
+            final ChangeListener<? super T> listener = entry.getKey();
+            final int registrationCount = entry.getValue();
+            try {
+                for (int i  = 0; i < registrationCount; i++) {
+                    listener.changed(observable, oldValue, currentValue);
                 }
-            } finally {
-                locked = false;
+            } catch (Exception e) {
+                Thread.currentThread().getUncaughtExceptionHandler().uncaughtException(
+                    Thread.currentThread(), e);
             }
         }
     }
-
 }

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/ExpressionHelperBase.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/ExpressionHelperBase.java
@@ -25,7 +25,9 @@
 
 package com.sun.javafx.binding;
 
+import java.util.Map;
 import java.util.function.Predicate;
+
 import javafx.beans.WeakListener;
 
 public class ExpressionHelperBase {
@@ -53,6 +55,13 @@ public class ExpressionHelperBase {
         }
 
         return size;
+    }
+
+    protected static void removeWeakListeners(final Map<?, Integer> listeners) {
+        Predicate<Object> p = t -> t instanceof WeakListener &&
+                ((WeakListener)t).wasGarbageCollected();
+
+        listeners.entrySet().removeIf(e -> p.test(e.getKey()));
     }
 
 }

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ExpressionHelperTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ExpressionHelperTest.java
@@ -645,4 +645,42 @@ public class ExpressionHelperTest {
         assertEquals(4, called.get());
     }
 
+    @Test
+    public void testRegisteringAndRemovingSameChangeListenerTwice() {
+        helper = ExpressionHelper.addListener(helper, observable, changeListener[0]);
+        helper = ExpressionHelper.addListener(helper, observable, changeListener[0]);
+        observable.set(DATA_2);
+        ExpressionHelper.fireValueChangedEvent(helper);
+        changeListener[0].check(observable, DATA_1, DATA_2, 2);
+
+        helper = ExpressionHelper.removeListener(helper, changeListener[0]);
+        observable.set(DATA_1);
+        ExpressionHelper.fireValueChangedEvent(helper);
+        changeListener[0].check(observable, DATA_2, DATA_1, 1);
+
+        helper = ExpressionHelper.removeListener(helper, changeListener[0]);
+        observable.set(DATA_2);
+        ExpressionHelper.fireValueChangedEvent(helper);
+        changeListener[0].check(null, UNDEFINED, UNDEFINED, 0);
+    }
+
+    @Test
+    public void testRegisteringAndRemovingSameInvalidationListenerTwice() {
+        helper = ExpressionHelper.addListener(helper, observable, invalidationListener[0]);
+        helper = ExpressionHelper.addListener(helper, observable, invalidationListener[0]);
+        observable.set(DATA_2);
+        ExpressionHelper.fireValueChangedEvent(helper);
+        invalidationListener[0].check(observable, 2);
+
+        helper = ExpressionHelper.removeListener(helper, invalidationListener[0]);
+        observable.set(DATA_1);
+        ExpressionHelper.fireValueChangedEvent(helper);
+        invalidationListener[0].check(observable, 1);
+
+        helper = ExpressionHelper.removeListener(helper, invalidationListener[0]);
+        observable.set(DATA_2);
+        ExpressionHelper.fireValueChangedEvent(helper);
+        invalidationListener[0].check(null, 0);
+    }
+
 }

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ExpressionHelperUtility.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ExpressionHelperUtility.java
@@ -26,9 +26,13 @@
 package test.com.sun.javafx.binding;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.value.ChangeListener;
@@ -109,21 +113,21 @@ public class ExpressionHelperUtility {
         try {
             final Class clazz = Class.forName(LIST_EXPRESSION_HELPER_GENERIC);
             if (clazz.isAssignableFrom(helperClass)) {
-                return getInvalidationListenerFromGenericClass(clazz, helper);
+                return getCollectionsInvalidationListenerFromGenericClass(clazz, helper);
             }
         } catch (ClassNotFoundException ex) { }
 
         try {
             final Class clazz = Class.forName(MAP_EXPRESSION_HELPER_GENERIC);
             if (clazz.isAssignableFrom(helperClass)) {
-                return getInvalidationListenerFromGenericClass(clazz, helper);
+                return getCollectionsInvalidationListenerFromGenericClass(clazz, helper);
             }
         } catch (ClassNotFoundException ex) { }
 
         try {
             final Class clazz = Class.forName(SET_EXPRESSION_HELPER_GENERIC);
             if (clazz.isAssignableFrom(helperClass)) {
-                return getInvalidationListenerFromGenericClass(clazz, helper);
+                return getCollectionsInvalidationListenerFromGenericClass(clazz, helper);
             }
         } catch (ClassNotFoundException ex) { }
 
@@ -177,21 +181,21 @@ public class ExpressionHelperUtility {
         try {
             final Class clazz = Class.forName(LIST_EXPRESSION_HELPER_GENERIC);
             if (clazz.isAssignableFrom(helperClass)) {
-                return getChangeListenerFromGenericClass(clazz, helper);
+                return getCollectionsChangeListenerFromGenericClass(clazz, helper);
             }
         } catch (ClassNotFoundException ex) { }
 
         try {
             final Class clazz = Class.forName(MAP_EXPRESSION_HELPER_GENERIC);
             if (clazz.isAssignableFrom(helperClass)) {
-                return getChangeListenerFromGenericClass(clazz, helper);
+                return getCollectionsChangeListenerFromGenericClass(clazz, helper);
             }
         } catch (ClassNotFoundException ex) { }
 
         try {
             final Class clazz = Class.forName(SET_EXPRESSION_HELPER_GENERIC);
             if (clazz.isAssignableFrom(helperClass)) {
-                return getChangeListenerFromGenericClass(clazz, helper);
+                return getCollectionsChangeListenerFromGenericClass(clazz, helper);
             }
         } catch (ClassNotFoundException ex) { }
 
@@ -338,7 +342,7 @@ public class ExpressionHelperUtility {
         return Collections.emptyList();
     }
 
-    private static List<InvalidationListener> getInvalidationListenerFromGenericClass(Class clazz, Object helper) {
+    private static List<InvalidationListener> getCollectionsInvalidationListenerFromGenericClass(Class clazz, Object helper) {
         try {
             final Field field = clazz.getDeclaredField("invalidationListeners");
             field.setAccessible(true);
@@ -363,7 +367,7 @@ public class ExpressionHelperUtility {
         return Collections.emptyList();
     }
 
-    private static <T> List<ChangeListener<? super T>> getChangeListenerFromGenericClass(Class clazz, Object helper) {
+    private static <T> List<ChangeListener<? super T>> getCollectionsChangeListenerFromGenericClass(Class clazz, Object helper) {
         try {
             final Field field = clazz.getDeclaredField("changeListeners");
             field.setAccessible(true);
@@ -373,6 +377,34 @@ public class ExpressionHelperUtility {
                 sizeField.setAccessible(true);
                 final int size = sizeField.getInt(helper);
                 return Arrays.asList(Arrays.copyOf(listeners, size));
+            }
+        } catch (Exception ex) { }
+        return Collections.emptyList();
+    }
+
+    private static <T> List<ChangeListener<? super T>> getChangeListenerFromGenericClass(Class clazz, Object helper) {
+        try {
+            final Field field = clazz.getDeclaredField("changeListeners");
+            field.setAccessible(true);
+            final Map<ChangeListener<? super T>, Integer> listeners = (Map<ChangeListener<? super T>, Integer>)field.get(helper);
+            if (listeners != null) {
+                final ArrayList<ChangeListener<? super T>> list = new ArrayList<>();
+                list.addAll(listeners.keySet());
+                return list;
+            }
+        } catch (Exception ex) { }
+        return Collections.emptyList();
+    }
+
+    private static List<InvalidationListener> getInvalidationListenerFromGenericClass(Class clazz, Object helper) {
+        try {
+            final Field field = clazz.getDeclaredField("invalidationListeners");
+            field.setAccessible(true);
+            final Map<InvalidationListener, Integer> listeners = (Map<InvalidationListener, Integer>)field.get(helper);
+            if (listeners != null) {
+                final ArrayList<InvalidationListener> list = new ArrayList<>();
+                list.addAll(listeners.keySet());
+                return list;
             }
         } catch (Exception ex) { }
         return Collections.emptyList();


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8185886

Optimisation to ExpressionHelper.Generic class to use Sets rather than Arrays to improve listener removal speed.

This was due to the removal of listeners in TableView taking up to 50% of CPU time on the JavaFX Application thread when scrolling/adding rows to TableViews.

This may alleviate some of the issues seen here:

TableView has a horrific performance with many columns #409
https://github.com/javafxports/openjdk-jfx/issues/409#event-2206515033

JDK-8088394 : Huge memory consumption in TableView with too many columns
JDK-8166956: JavaFX TreeTableView slow scroll performance
JDK-8185887: TableRowSkinBase fails to correctly virtualise cells in horizontal direction

OpenJFX mailing list thread: TableView slow vertical scrolling with 300+ columns
https://mail.openjdk.java.net/pipermail/openjfx-dev/2020-January/024780.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (3 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 2 [Authors](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8252936](https://bugs.openjdk.org/browse/JDK-8252936): Optimize removal of listeners from ExpressionHelper.Generic


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/108/head:pull/108` \
`$ git checkout pull/108`

Update a local copy of the PR: \
`$ git checkout pull/108` \
`$ git pull https://git.openjdk.org/jfx.git pull/108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 108`

View PR using the GUI difftool: \
`$ git pr show -t 108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/108.diff">https://git.openjdk.org/jfx/pull/108.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/108#issuecomment-587353200)