### PR TITLE
8238755: allow to create static lib for javafx.media on linux

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/PlatformUtil.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/PlatformUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,6 +71,7 @@ public class PlatformUtil {
     private static final boolean LINUX = os.startsWith("Linux") && !ANDROID;
     private static final boolean SOLARIS = os.startsWith("SunOS");
     private static final boolean IOS = os.startsWith("iOS");
+    private static final boolean STATIC_BUILD = "Substrate VM".equals(System.getProperty("java.vm.name"));
 
     /**
      * Utility method used to determine whether the version number as
@@ -175,6 +176,13 @@ public class PlatformUtil {
      */
     public static boolean isIOS(){
         return IOS;
+    }
+
+    /**
+     * Returns true if the current runtime is a statically linked image
+     */
+    public static boolean isStaticBuild(){
+        return STATIC_BUILD;
     }
 
     private static void loadPropertiesFromFile(final File file) {

--- a/modules/javafx.base/src/main/java/module-info.java
+++ b/modules/javafx.base/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,7 @@ module javafx.base {
         javafx.controls,
         javafx.graphics,
         javafx.fxml,
+        javafx.media,
         javafx.swing;
     exports com.sun.javafx.beans to
         javafx.controls,

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/locator/ConnectionHolder.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/locator/ConnectionHolder.java
@@ -258,7 +258,7 @@ public abstract class ConnectionHolder {
         boolean isSeekable() {
             return (urlConnection instanceof HttpURLConnection) ||
                    (urlConnection instanceof JarURLConnection) ||
-                   isJRT();
+                   isJRT() || isResource();
         }
 
         boolean isRandomAccess() {
@@ -299,7 +299,7 @@ public abstract class ConnectionHolder {
                         Locator.closeConnection(tmpURLConnection);
                     }
                 }
-            } else if ((urlConnection instanceof JarURLConnection) || isJRT()) {
+            } else if ((urlConnection instanceof JarURLConnection) || isJRT() || isResource()) {
                 try {
                     closeConnection();
 
@@ -342,6 +342,12 @@ public abstract class ConnectionHolder {
             String scheme = uri.getScheme().toLowerCase();
             return "jrt".equals(scheme);
         }
+
+        private boolean isResource() {
+            String scheme = uri.getScheme().toLowerCase();
+            return "resource".equals(scheme);
+        }
+
     }
 
     // A "ConnectionHolder" that "reads" from a ByteBuffer, generally loaded from

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/locator/Locator.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/locator/Locator.java
@@ -417,7 +417,7 @@ public class Locator {
                             }
 
                             // FIXME: get cache settings from server, honor them
-                        } else if (scheme.equals("file") || scheme.equals("jar") || scheme.equals("jrt")) {
+                        } else if (scheme.equals("file") || scheme.equals("jar") || scheme.equals("jrt") || (scheme.equals("resource")) ) {
                             InputStream stream = getInputStream(uri);
                             stream.close();
                             isConnected = true;

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/platform/PlatformManager.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/platform/PlatformManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package com.sun.media.jfxmediaimpl.platform;
 
+import com.sun.javafx.PlatformUtil;
 import com.sun.media.jfxmedia.Media;
 import com.sun.media.jfxmedia.MediaPlayer;
 import com.sun.media.jfxmedia.MetadataParser;
@@ -198,6 +199,9 @@ public final class PlatformManager {
                     }
                 }
             }
+        }
+        if (PlatformUtil.isStaticBuild()) {
+            outProtocols.add("resource");
         }
 
         return outProtocols;

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/platform/gstreamer/GSTPlatform.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/platform/gstreamer/GSTPlatform.java
@@ -62,7 +62,8 @@ public final class GSTPlatform extends Platform {
         "file",
         "http",
         "https",
-        "jrt"
+        "jrt",
+        "resource"
     };
 
     private static GSTPlatform globalInstance = null;

--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gstreamer/gst/gst.c
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gstreamer/gst/gst.c
@@ -122,6 +122,11 @@
 
 #include "gst.h"
 
+#ifdef STATIC_BUILD
+gboolean fxplugins_init (GstPlugin * plugin);
+gboolean fxavplugins_init (GstPlugin * plugin);
+#endif
+
 #define GST_CAT_DEFAULT GST_CAT_GST_INIT
 
 #define MAX_PATH_SPLIT  16
@@ -818,6 +823,16 @@ init_post (GOptionContext * context, GOptionGroup * group, gpointer data,
       "gstplugins-lite", "gstplugins-lite",
       lite_plugins_init, VERSION, GST_LICENSE, PACKAGE,
       GST_PACKAGE_NAME, GST_PACKAGE_ORIGIN);
+#ifdef STATIC_BUILD
+  gst_plugin_register_static (GST_VERSION_MAJOR, GST_VERSION_MINOR,
+      "fxplugins", "fxplugin",
+      fxplugins_init, VERSION, GST_LICENSE, PACKAGE,
+      GST_PACKAGE_NAME, GST_PACKAGE_ORIGIN);
+  gst_plugin_register_static (GST_VERSION_MAJOR, GST_VERSION_MINOR,
+     "fxavplugins", "fxavplugin",
+      fxavplugins_init, VERSION, GST_LICENSE, PACKAGE,
+      GST_PACKAGE_NAME, GST_PACKAGE_ORIGIN);
+#endif // STATIC_BUILD
 #endif // GSTREAMER_LITE
 
   /*

--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gstreamer/gst/gst.c
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gstreamer/gst/gst.c
@@ -122,10 +122,12 @@
 
 #include "gst.h"
 
+#ifdef GSTREAMER_LITE
 #ifdef STATIC_BUILD
 gboolean fxplugins_init (GstPlugin * plugin);
 gboolean fxavplugins_init (GstPlugin * plugin);
-#endif
+#endif // STATIC_BUILD
+#endif // GSTREAMER_LITE
 
 #define GST_CAT_DEFAULT GST_CAT_GST_INIT
 

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/av/fxavcodecplugin.c
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/av/fxavcodecplugin.c
@@ -30,13 +30,18 @@
 #include <videodecoder.h>
 #include <mpegtsdemuxer.h>
 
+#ifdef STATIC_BUILD
+gboolean fxavplugins_init (GstPlugin * plugin)
+#else
 static gboolean fxplugins_init (GstPlugin * plugin)
+#endif
 {
     return audiodecoder_plugin_init(plugin) &&
            videodecoder_plugin_init(plugin) &&
            mpegts_demuxer_plugin_init(plugin);
 }
 
+#ifndef STATIC_BUILD
 GstPluginDesc gst_plugin_desc =
 {
     GST_VERSION_MAJOR,
@@ -51,3 +56,4 @@ GstPluginDesc gst_plugin_desc =
     "http://javafx.com/",
     NULL
 };
+#endif

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/fxplugins.c
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/fxplugins.c
@@ -39,7 +39,11 @@
 gboolean dshowwrapper_init(GstPlugin* aacdecoder);
 #endif
 
+#ifdef STATIC_BUILD
+gboolean fxplugins_init (GstPlugin * plugin)
+#else
 static gboolean fxplugins_init (GstPlugin * plugin)
+#endif
 {
     return java_source_plugin_init(plugin) &&
            hls_progress_buffer_plugin_init(plugin) &&

--- a/modules/javafx.media/src/main/native/jfxmedia/platform/gstreamer/GstPlatform.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/platform/gstreamer/GstPlatform.cpp
@@ -53,7 +53,11 @@ extern "C" {
     /*
      * Specify the require JNI version.
      */
+#ifdef STATIC_BUILD
+    JNIEXPORT jint JNICALL JNI_OnLoad_jfxmedia(JavaVM *vm, void *reserved)
+#else
     JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
+#endif
     {
         g_pJVM = vm;
         return JNI_VERSION_1_2;


### PR DESCRIPTION
* add support for the "resource" protocol (which is used in the GraalVM URLs pointing to statically bundled resources)
* avoid duplicate symbols with different gst plugins
* statically register gst plugins
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8238755](https://bugs.openjdk.java.net/browse/JDK-8238755): allow to create static lib for javafx.media on linux


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Alexander Matveev ([almatvee](@sashamatveev) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/109/head:pull/109`
`$ git checkout pull/109`
