### PR TITLE
8228867: Fix mistakes in FX API docs

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/collections/FXCollections.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/FXCollections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.base/src/main/java/javafx/collections/FXCollections.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/FXCollections.java
@@ -576,7 +576,7 @@ public class FXCollections {
     }
 
     /**
-     * Reverse the order in the list
+     * Reverses the order in the list.
      * Fires only <b>one</b> change notification on the list.
      * @param list the list to be reversed
      * @see Collections#reverse(java.util.List)

--- a/modules/javafx.base/src/main/java/javafx/collections/ListChangeListener.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/ListChangeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.base/src/main/java/javafx/collections/ListChangeListener.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/ListChangeListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -231,11 +231,9 @@ public interface ListChangeListener<E> {
          * Returns a subList view of the list that contains only the elements added. This is actually a shortcut to
          * <code>c.getList().subList(c.getFrom(), c.getTo());</code>
          *
-         * <pre>{@code
-         * for (Node n : change.getAddedSubList()) {
+         * <pre><code> for (Node n : change.getAddedSubList()) {
          *       // do something
-         * }
-         * }</pre>
+         * }</code></pre>
          * @return the newly created sublist view that contains all the added elements.
          * @throws IllegalStateException if this Change instance is in initial state
          */

--- a/modules/javafx.base/src/main/java/javafx/collections/ListChangeListener.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/ListChangeListener.java
@@ -231,9 +231,11 @@ public interface ListChangeListener<E> {
          * Returns a subList view of the list that contains only the elements added. This is actually a shortcut to
          * <code>c.getList().subList(c.getFrom(), c.getTo());</code>
          *
-         * <pre><code> for (Node n : change.getAddedSubList()) {
+         * <pre>{@code
+         * for (Node n : change.getAddedSubList()) {
          *       // do something
-         * }</code></pre>
+         * }
+         * }</pre>
          * @return the newly created sublist view that contains all the added elements.
          * @throws IllegalStateException if this Change instance is in initial state
          */

--- a/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
@@ -417,7 +417,7 @@ public abstract class Animation {
 
     /**
      * Read-only variable to indicate the total duration of this
-     * {@code Animation}, including repeats. A {@code Animation} with a {@code cycleCount}
+     * {@code Animation}, including repeats. An {@code Animation} with a {@code cycleCount}
      * of {@code Animation.INDEFINITE} will have a {@code totalDuration} of
      * {@code Duration.INDEFINITE}.
      *
@@ -961,7 +961,7 @@ public abstract class Animation {
 
     /**
      * Stops the animation and resets the play head to its initial position. If
-     * the animation is not currently running, this method has no effect.
+     * the animation is already stopped, this method has no effect.
      * <p>
      * Note: <ul>
      * <li>{@code stop()} is an asynchronous call, the {@code Animation} may not stop

--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -175,7 +175,7 @@ public final class Platform {
 
     /**
      * Returns true if the calling thread is the JavaFX Application Thread.
-     * Use this call the ensure that a given task is being executed
+     * Use this call to ensure that a given task is being executed
      * (or not being executed) on the JavaFX Application Thread.
      *
      * @return true if running on the JavaFX Application Thread

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -1566,7 +1566,7 @@ public abstract class Node implements EventTarget, Styleable {
     }
 
     /**
-     * Specifies a {@code Node} to use to define the the clipping shape for this
+     * Specifies a {@code Node} to use to define the clipping shape for this
      * Node. This clipping Node is not a child of this {@code Node} in the scene
      * graph sense. Rather, it is used to define the clip for this {@code Node}.
      * <p>

--- a/modules/javafx.graphics/src/main/native-glass/win/OleUtils.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/OleUtils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-glass/win/OleUtils.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/OleUtils.h
@@ -227,7 +227,7 @@ inline HRESULT checkJavaException(JNIEnv *env)
                 s_jcidThrowable_getMessage
             ));
             if(jsMessage){
-                STRACE1(_T("Java Messsge:%s"), (LPCWSTR)JString(env, jsMessage) );
+                STRACE1(_T("Java Message:%s"), (LPCWSTR)JString(env, jsMessage) );
             }
             env->ExceptionDescribe();
         }


### PR DESCRIPTION
Docs fixes for OpenJFX 14. We can wait with integrating this in case there are last minute fixes, but reviews can start.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8228867](https://bugs.openjdk.java.net/browse/JDK-8228867): Fix mistakes in FX API docs


### Reviewers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/110/head:pull/110`
`$ git checkout pull/110`
