### PR TITLE
[WIP] 8228363: Fix shifts for ContextMenu shown on TOP/LEFT side

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ContextMenuHelper.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ContextMenuHelper.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.scene.control;
+
+import com.sun.javafx.stage.PopupWindowHelper;
+import com.sun.javafx.stage.WindowHelper;
+import com.sun.javafx.util.Utils;
+import javafx.geometry.Side;
+import javafx.scene.control.ContextMenu;
+import javafx.stage.PopupWindow;
+
+/*
+ * Used to access internal methods of ContextMenu.
+ */
+public class ContextMenuHelper extends PopupWindowHelper {
+
+    private static final ContextMenuHelper theInstance;
+    private static ContextMenuAccessor contextMenuAccessor;
+
+    static {
+        theInstance = new ContextMenuHelper();
+        Utils.forceInit(ContextMenu.class);
+    }
+
+    private static ContextMenuHelper getInstance() {
+        return theInstance;
+    }
+
+    public static void initHelper(ContextMenu contextMenu) {
+        setHelper(contextMenu, getInstance());
+    }
+
+    public static Side getSide(ContextMenu contextMenu) {
+        return contextMenuAccessor.getSide(contextMenu);
+    }
+
+    public static double getDeltaX(ContextMenu contextMenu) {
+        return contextMenuAccessor.getDeltaX(contextMenu);
+    }
+
+    public static double getDeltaY(ContextMenu contextMenu) {
+        return contextMenuAccessor.getDeltaX(contextMenu);
+    }
+
+    public static void setContextMenuAccessor(final ContextMenuAccessor newAccessor) {
+        if (contextMenuAccessor != null) {
+            throw new IllegalStateException();
+        }
+        contextMenuAccessor = newAccessor;
+    }
+
+    public interface ContextMenuAccessor {
+       Side getSide(ContextMenu contextMenu);
+       double getDeltaX(ContextMenu contextMenu);
+       double getDeltaY(ContextMenu contextMenu);
+    }
+
+}

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ContextMenu.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ContextMenu.java
@@ -44,8 +44,6 @@ import javafx.stage.Window;
 import com.sun.javafx.util.Utils;
 import com.sun.javafx.collections.TrackableObservableList;
 import javafx.scene.control.skin.ContextMenuSkin;
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.SimpleBooleanProperty;
 
 /**
  * <p>
@@ -250,7 +248,9 @@ public class ContextMenu extends PopupControl {
      public void show(Node anchor, Side side, double dx, double dy) {
         if (anchor == null) return;
         if (getItems().size() == 0) return;
-
+        getProperties().put("dx", dx);
+        getProperties().put("dy", dy);
+        getProperties().put("SIDE", side);
         getScene().setNodeOrientation(anchor.getEffectiveNodeOrientation());
         // FIXME because Side is not yet in javafx.geometry, we have to convert
         // to the old HPos/VPos API here, as Utils can not refer to Side in the

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ContextMenu.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ContextMenu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package javafx.scene.control;
 
 import com.sun.javafx.beans.IDProperty;
+import com.sun.javafx.scene.control.ContextMenuHelper;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ObjectPropertyBase;
 import javafx.collections.ListChangeListener.Change;
@@ -120,6 +121,26 @@ root.getChildren().add(textField);
 @IDProperty("id")
 public class ContextMenu extends PopupControl {
 
+    static {
+        ContextMenuHelper.setContextMenuAccessor(new ContextMenuHelper.ContextMenuAccessor() {
+
+            @Override
+            public Side getSide(ContextMenu contextMenu) {
+                return contextMenu.side;
+            }
+
+            @Override
+            public double getDeltaX(ContextMenu contextMenu) {
+                return contextMenu.deltaX;
+            }
+
+            @Override
+            public double getDeltaY(ContextMenu contextMenu) {
+                return contextMenu.deltaY;
+            }
+        });
+    }
+
     /***************************************************************************
      *                                                                         *
      * Fields                                                                  *
@@ -127,7 +148,9 @@ public class ContextMenu extends PopupControl {
      **************************************************************************/
 
     private boolean showRelativeToWindow = false;
-
+    private double deltaX;
+    private double deltaY;
+    private Side side;
 
 
     /***************************************************************************
@@ -143,6 +166,7 @@ public class ContextMenu extends PopupControl {
         getStyleClass().setAll(DEFAULT_STYLE_CLASS);
         setAutoHide(true);
         setConsumeAutoHidingEvents(false);
+        ContextMenuHelper.initHelper(this);
     }
 
     /**
@@ -248,9 +272,9 @@ public class ContextMenu extends PopupControl {
      public void show(Node anchor, Side side, double dx, double dy) {
         if (anchor == null) return;
         if (getItems().size() == 0) return;
-        getProperties().put("dx", dx);
-        getProperties().put("dy", dy);
-        getProperties().put("SIDE", side);
+        deltaX = dx;
+        deltaY = dy;
+        this.side = side;
         getScene().setNodeOrientation(anchor.getEffectiveNodeOrientation());
         // FIXME because Side is not yet in javafx.geometry, we have to convert
         // to the old HPos/VPos API here, as Utils can not refer to Side in the

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ContextMenuSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ContextMenuSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package javafx.scene.control.skin;
 
 import com.sun.javafx.scene.control.ContextMenuContent;
+import com.sun.javafx.scene.control.ContextMenuHelper;
 import com.sun.javafx.scene.control.EmbeddedTextContextMenuContent;
 import com.sun.javafx.scene.control.Properties;
 import com.sun.javafx.scene.control.skin.Utils;
@@ -220,12 +221,12 @@ public class ContextMenuSkin implements Skin<ContextMenu> {
         Point2D ownerPos = getOwnerPosition();
         if (ownerPos == null) return;
 
-        final Side side = (Side) contextMenu.getProperties().get("SIDE");
+        final Side side = ContextMenuHelper.getSide(contextMenu);
         if (side == Side.TOP) {
             // shifting vertically
             final double rootPrefHeight = root.prefHeight(-1);
             shiftY = prefHeight - rootPrefHeight;
-            double dy = (double) contextMenu.getProperties().get("dy");
+            double dy = ContextMenuHelper.getDeltaY(contextMenu);
             if (shiftY != 0 && (contextMenu.getY() + rootPrefHeight + dy) != ownerPos.getY()) {
                 contextMenu.setY(contextMenu.getY() + shiftY);
             }
@@ -235,7 +236,7 @@ public class ContextMenuSkin implements Skin<ContextMenu> {
             // shifting horizontally
             final double rootPrefWidth = root.prefWidth(-1);
             shiftX = prefWidth - rootPrefWidth;
-            double dx = (double) contextMenu.getProperties().get("dx");
+            double dx = ContextMenuHelper.getDeltaX(contextMenu);
             if (shiftX != 0 && (contextMenu.getX() + rootPrefWidth + dx) != ownerPos.getX()) {
                 contextMenu.setX(contextMenu.getX() + shiftX);
             }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ContextMenuSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ContextMenuSkin.java
@@ -32,15 +32,17 @@ import com.sun.javafx.scene.control.skin.Utils;
 import javafx.event.Event;
 import javafx.event.EventHandler;
 import javafx.geometry.Bounds;
+import javafx.geometry.Point2D;
+import javafx.geometry.Side;
 import javafx.scene.AccessibleAttribute;
 import javafx.scene.Node;
 import javafx.scene.control.ContextMenu;
-import javafx.scene.control.Control;
 import javafx.scene.control.Menu;
 import javafx.scene.control.Skin;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
+import javafx.stage.Window;
 import javafx.stage.WindowEvent;
 import com.sun.javafx.scene.control.behavior.TwoLevelFocusPopupBehavior;
 
@@ -215,24 +217,41 @@ public class ContextMenuSkin implements Skin<ContextMenu> {
 
     private void performPopupShifts() {
         final ContextMenu contextMenu = getSkinnable();
-        final Node ownerNode = contextMenu.getOwnerNode();
-        if (ownerNode == null) return;
+        Point2D ownerPos = getOwnerPosition();
+        if (ownerPos == null) return;
 
-        final Bounds ownerBounds = ownerNode.localToScreen(ownerNode.getLayoutBounds());
-        if (ownerBounds == null) return;
-
-        // shifting vertically
-        final double rootPrefHeight = root.prefHeight(-1);
-        shiftY = prefHeight - rootPrefHeight;
-        if (shiftY > 0 && (contextMenu.getY() + rootPrefHeight) < ownerBounds.getMinY()) {
-            contextMenu.setY(contextMenu.getY() + shiftY);
+        final Side side = (Side) contextMenu.getProperties().get("SIDE");
+        if (side == Side.TOP) {
+            // shifting vertically
+            final double rootPrefHeight = root.prefHeight(-1);
+            shiftY = prefHeight - rootPrefHeight;
+            double dy = (double) contextMenu.getProperties().get("dy");
+            if (shiftY != 0 && (contextMenu.getY() + rootPrefHeight + dy) != ownerPos.getY()) {
+                contextMenu.setY(contextMenu.getY() + shiftY);
+            }
         }
 
-        // shifting horizontally
-        final double rootPrefWidth = root.prefWidth(-1);
-        shiftX = prefWidth - rootPrefWidth;
-        if (shiftX > 0 && (contextMenu.getX() + rootPrefWidth) < ownerBounds.getMinX()) {
-            contextMenu.setX(contextMenu.getX() + shiftX);
+        if (side == Side.LEFT) {
+            // shifting horizontally
+            final double rootPrefWidth = root.prefWidth(-1);
+            shiftX = prefWidth - rootPrefWidth;
+            double dx = (double) contextMenu.getProperties().get("dx");
+            if (shiftX != 0 && (contextMenu.getX() + rootPrefWidth + dx) != ownerPos.getX()) {
+                contextMenu.setX(contextMenu.getX() + shiftX);
+            }
         }
+    }
+
+    private Point2D getOwnerPosition() {
+        Point2D pos = null;
+        final Node ownerNode = getSkinnable().getOwnerNode();
+        final Window ownerWindow = getSkinnable().getOwnerWindow();
+        if (ownerNode != null) {
+            final Bounds ownerNodeBounds = ownerNode.localToScreen(ownerNode.getLayoutBounds());
+            pos = new Point2D(ownerNodeBounds.getMinX(), ownerNodeBounds.getMinX());
+        } else if (ownerWindow != null) {
+            pos = new Point2D(ownerWindow.getX(), ownerWindow.getY());
+        }
+        return pos;
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ContextMenuTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ContextMenuTest.java
@@ -27,6 +27,7 @@ package test.javafx.scene.control;
 
 import com.sun.javafx.scene.control.ContextMenuContent;
 import com.sun.javafx.scene.control.ContextMenuContentShim;
+import javafx.geometry.Bounds;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -619,5 +620,49 @@ public class ContextMenuTest {
         assertEquals(0, getCurrentFocusedIndex(cm));
         assertEquals("Expected " + item1.getText() + ", found " + focusedItem.getText(),
                 item1, focusedItem);
+    }
+
+    @Test public void test_position_showOnScreen() {
+        ContextMenu cm = createContextMenu(false);
+        cm.show(anchorBtn,100, 100);
+
+        assertEquals(cm.getAnchorX(), 100, 0.0);
+        assertEquals(cm.getAnchorY(), 100, 0.0);
+    }
+
+    @Test public void test_position_showOnTop() {
+        ContextMenu cm = createContextMenu(false);
+        cm.show(anchorBtn, Side.TOP, 0, 0);
+
+        final Bounds anchorBounds = anchorBtn.localToScreen(anchorBtn.getLayoutBounds());
+        assertEquals(cm.getAnchorX(), anchorBounds.getMinX(), 0.0);
+        assertEquals(cm.getAnchorY() + cm.getHeight(), anchorBounds.getMinY(), 0.0);
+    }
+
+    @Test public void test_position_showOnRight() {
+        ContextMenu cm = createContextMenu(false);
+        cm.show(anchorBtn, Side.RIGHT, 0, 0);
+
+        final Bounds anchorBounds = anchorBtn.localToScreen(anchorBtn.getLayoutBounds());
+        assertEquals(cm.getAnchorX(), anchorBounds.getMaxX(), 0.0);
+        assertEquals(cm.getAnchorY(), anchorBounds.getMinY(), 0.0);
+    }
+
+    @Test public void test_position_showOnBottom() {
+        ContextMenu cm = createContextMenu(false);
+        cm.show(anchorBtn, Side.BOTTOM, 0, 0);
+
+        final Bounds anchorBounds = anchorBtn.localToScreen(anchorBtn.getLayoutBounds());
+        assertEquals(cm.getAnchorX(), anchorBounds.getMinX(), 0.0);
+        assertEquals(cm.getAnchorY(), anchorBounds.getMaxY(), 0.0);
+    }
+
+    @Test public void test_position_showOnLeft() {
+        ContextMenu cm = createContextMenu(false);
+        cm.show(anchorBtn, Side.LEFT, 0, 0);
+
+        final Bounds anchorBounds = anchorBtn.localToScreen(anchorBtn.getLayoutBounds());
+        assertEquals(cm.getAnchorX() + cm.getWidth(), anchorBounds.getMinX(), 0.0);
+        assertEquals(cm.getAnchorY(), anchorBounds.getMinY(), 0.0);
     }
 }


### PR DESCRIPTION
Requesting for review comments.

This is an attempt to fix [JDK-8228363](https://bugs.openjdk.java.net/browse/JDK-8228363). The root cause of the issue is that `ContextMenuSkin#performPopupShifts` doesn't consider the cases where shiftX / shiftY can be negative, just as in case of the example provided by Robert in [JDK-8228363](https://bugs.openjdk.java.net/browse/JDK-8228363). Moreover, these shifts are only required for Side.TOP and Side.LEFT.

Tests fail since it ignores the css padding applied on the ContextMenu's menu/menu-item via css. I would like to ask for guidance on how to fetch "css applied" height/width of ContextMenu to make these tests pass.