### PR TITLE
8196586: Remove use of deprecated finalize methods from javafx property objects

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/BidirectionalBinding.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/BidirectionalBinding.java
@@ -163,17 +163,6 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
         return binding;
     }
 
-    public static <T extends Number> void unbindNumber(Property<T> property1, Property<Number> property2) {
-        checkParameters(property1, property2);
-        final BidirectionalBinding binding = new UntypedGenericBidirectionalBinding(property1, property2);
-        if (property1 instanceof ObservableValue) {
-            ((ObservableValue) property1).removeListener(binding);
-        }
-        if (property2 instanceof Observable) {
-            ((ObservableValue) property2).removeListener(binding);
-        }
-    }
-
     private final int cachedHashCode;
 
     private BidirectionalBinding(Object property1, Object property2) {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/BooleanProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/BooleanProperty.java
@@ -31,10 +31,6 @@ import javafx.beans.value.ObservableValue;
 import javafx.beans.value.WritableBooleanValue;
 import com.sun.javafx.binding.Logging;
 
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 /**
  * This class provides a full implementation of a {@link Property} wrapping a
  * {@code boolean} value.
@@ -141,7 +137,6 @@ public abstract class BooleanProperty extends ReadOnlyBooleanProperty implements
             throw new NullPointerException("Property cannot be null");
         }
         return property instanceof BooleanProperty ? (BooleanProperty)property : new BooleanPropertyBase() {
-            private final AccessControlContext acc = AccessController.getContext();
             {
                 BidirectionalBinding.bind(this, property);
             }
@@ -154,18 +149,6 @@ public abstract class BooleanProperty extends ReadOnlyBooleanProperty implements
             @Override
             public String getName() {
                 return property.getName();
-            }
-
-            @Override
-            protected void finalize() throws Throwable {
-                try {
-                    AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                        BidirectionalBinding.unbind(property, this);
-                        return null;
-                    }, acc);
-                } finally {
-                    super.finalize();
-                }
             }
         };
     }
@@ -182,7 +165,6 @@ public abstract class BooleanProperty extends ReadOnlyBooleanProperty implements
     @Override
     public ObjectProperty<Boolean> asObject() {
         return new ObjectPropertyBase<Boolean> () {
-            private final AccessControlContext acc = AccessController.getContext();
             {
                 BidirectionalBinding.bind(this, BooleanProperty.this);
             }
@@ -196,19 +178,6 @@ public abstract class BooleanProperty extends ReadOnlyBooleanProperty implements
             public String getName() {
                 return BooleanProperty.this.getName();
             }
-
-            @Override
-            protected void finalize() throws Throwable {
-                try {
-                    AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                        BidirectionalBinding.unbind(this, BooleanProperty.this);
-                        return null;
-                    }, acc);
-                } finally {
-                    super.finalize();
-                }
-            }
-
         };
     }
 }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/DoubleProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/DoubleProperty.java
@@ -37,10 +37,6 @@ import javafx.beans.WeakInvalidationListener;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableDoubleValue;
 
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 /**
  * This class defines a {@link Property} wrapping a {@code double} value.
  * <p>
@@ -156,7 +152,6 @@ public abstract class DoubleProperty extends ReadOnlyDoubleProperty implements
             throw new NullPointerException("Property cannot be null");
         }
         return new DoublePropertyBase() {
-            private final AccessControlContext acc = AccessController.getContext();
             {
                 BidirectionalBinding.bindNumber(this, property);
             }
@@ -169,18 +164,6 @@ public abstract class DoubleProperty extends ReadOnlyDoubleProperty implements
             @Override
             public String getName() {
                 return property.getName();
-            }
-
-            @Override
-            protected void finalize() throws Throwable {
-                try {
-                    AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                        BidirectionalBinding.unbindNumber(property, this);
-                        return null;
-                    }, acc);
-                } finally {
-                    super.finalize();
-                }
             }
         };
     }
@@ -207,7 +190,6 @@ public abstract class DoubleProperty extends ReadOnlyDoubleProperty implements
     @Override
     public ObjectProperty<Double> asObject() {
         return new ObjectPropertyBase<Double> () {
-            private final AccessControlContext acc = AccessController.getContext();
             {
                 BidirectionalBinding.bindNumber(this, DoubleProperty.this);
             }
@@ -221,19 +203,6 @@ public abstract class DoubleProperty extends ReadOnlyDoubleProperty implements
             public String getName() {
                 return DoubleProperty.this.getName();
             }
-
-            @Override
-            protected void finalize() throws Throwable {
-                try {
-                    AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                        BidirectionalBinding.unbindNumber(this, DoubleProperty.this);
-                        return null;
-                    }, acc);
-                } finally {
-                    super.finalize();
-                }
-            }
-
         };
     }
 

--- a/modules/javafx.base/src/main/java/javafx/beans/property/FloatProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/FloatProperty.java
@@ -31,10 +31,6 @@ import javafx.beans.value.ObservableValue;
 import javafx.beans.value.WritableFloatValue;
 import com.sun.javafx.binding.Logging;
 
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 /**
  * This class defines a {@link Property} wrapping a {@code float} value.
  * <p>
@@ -151,7 +147,6 @@ public abstract class FloatProperty extends ReadOnlyFloatProperty implements
             throw new NullPointerException("Property cannot be null");
         }
         return new FloatPropertyBase() {
-            private final AccessControlContext acc = AccessController.getContext();
             {
                 BidirectionalBinding.bindNumber(this, property);
             }
@@ -164,18 +159,6 @@ public abstract class FloatProperty extends ReadOnlyFloatProperty implements
             @Override
             public String getName() {
                 return property.getName();
-            }
-
-            @Override
-            protected void finalize() throws Throwable {
-                try {
-                    AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                        BidirectionalBinding.unbindNumber(property, this);
-                        return null;
-                    }, acc);
-                } finally {
-                    super.finalize();
-                }
             }
         };
     }
@@ -202,7 +185,6 @@ public abstract class FloatProperty extends ReadOnlyFloatProperty implements
     @Override
     public ObjectProperty<Float> asObject() {
         return new ObjectPropertyBase<Float> () {
-            private final AccessControlContext acc = AccessController.getContext();
             {
                 BidirectionalBinding.bindNumber(this, FloatProperty.this);
             }
@@ -216,19 +198,6 @@ public abstract class FloatProperty extends ReadOnlyFloatProperty implements
             public String getName() {
                 return FloatProperty.this.getName();
             }
-
-            @Override
-            protected void finalize() throws Throwable {
-                try {
-                    AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                        BidirectionalBinding.unbindNumber(this, FloatProperty.this);
-                        return null;
-                    }, acc);
-                } finally {
-                    super.finalize();
-                }
-            }
-
         };
     }
 

--- a/modules/javafx.base/src/main/java/javafx/beans/property/IntegerProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/IntegerProperty.java
@@ -31,10 +31,6 @@ import javafx.beans.value.ObservableValue;
 import javafx.beans.value.WritableIntegerValue;
 import com.sun.javafx.binding.Logging;
 
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 /**
  * This class defines a {@link Property} wrapping an {@code int} value.
  * <p>
@@ -151,7 +147,6 @@ public abstract class IntegerProperty extends ReadOnlyIntegerProperty implements
             throw new NullPointerException("Property cannot be null");
         }
         return new IntegerPropertyBase() {
-            private final AccessControlContext acc = AccessController.getContext();
             {
                 BidirectionalBinding.bindNumber(this, property);
             }
@@ -164,18 +159,6 @@ public abstract class IntegerProperty extends ReadOnlyIntegerProperty implements
             @Override
             public String getName() {
                 return property.getName();
-            }
-
-            @Override
-            protected void finalize() throws Throwable {
-                try {
-                    AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                        BidirectionalBinding.unbindNumber(property, this);
-                        return null;
-                    }, acc);
-                } finally {
-                    super.finalize();
-                }
             }
         };
     }
@@ -202,7 +185,6 @@ public abstract class IntegerProperty extends ReadOnlyIntegerProperty implements
     @Override
     public ObjectProperty<Integer> asObject() {
         return new ObjectPropertyBase<Integer> () {
-            private final AccessControlContext acc = AccessController.getContext();
             {
                 BidirectionalBinding.bindNumber(this, IntegerProperty.this);
             }
@@ -216,19 +198,6 @@ public abstract class IntegerProperty extends ReadOnlyIntegerProperty implements
             public String getName() {
                 return IntegerProperty.this.getName();
             }
-
-            @Override
-            protected void finalize() throws Throwable {
-                try {
-                    AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                        BidirectionalBinding.unbindNumber(this, IntegerProperty.this);
-                        return null;
-                    }, acc);
-                } finally {
-                    super.finalize();
-                }
-            }
-
         };
     }
 }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/LongProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/LongProperty.java
@@ -31,10 +31,6 @@ import javafx.beans.value.ObservableValue;
 import javafx.beans.value.WritableLongValue;
 import com.sun.javafx.binding.Logging;
 
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 /**
  * This class defines a {@link Property} wrapping a {@code long} value.
  * <p>
@@ -149,7 +145,6 @@ public abstract class LongProperty extends ReadOnlyLongProperty implements
             throw new NullPointerException("Property cannot be null");
         }
         return new LongPropertyBase() {
-            private final AccessControlContext acc = AccessController.getContext();
             {
                 BidirectionalBinding.bindNumber(this, property);
             }
@@ -162,18 +157,6 @@ public abstract class LongProperty extends ReadOnlyLongProperty implements
             @Override
             public String getName() {
                 return property.getName();
-            }
-
-            @Override
-            protected void finalize() throws Throwable {
-                try {
-                    AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                        BidirectionalBinding.unbindNumber(property, this);
-                        return null;
-                    }, acc);
-                } finally {
-                    super.finalize();
-                }
             }
         };
     }
@@ -200,7 +183,6 @@ public abstract class LongProperty extends ReadOnlyLongProperty implements
     @Override
     public ObjectProperty<Long> asObject() {
         return new ObjectPropertyBase<Long> () {
-            private final AccessControlContext acc = AccessController.getContext();
             {
                 BidirectionalBinding.bindNumber(this, LongProperty.this);
             }
@@ -214,19 +196,6 @@ public abstract class LongProperty extends ReadOnlyLongProperty implements
             public String getName() {
                 return LongProperty.this.getName();
             }
-
-            @Override
-            protected void finalize() throws Throwable {
-                try {
-                    AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                        BidirectionalBinding.unbindNumber(this, LongProperty.this);
-                        return null;
-                    }, acc);
-                } finally {
-                    super.finalize();
-                }
-            }
-
         };
     }
 }

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ObjectPropertyLeakTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ObjectPropertyLeakTest.java
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.beans.property;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.FloatProperty;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.LongProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.Property;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.beans.property.SimpleFloatProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleLongProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ObjectPropertyLeakTest {
+
+    private static final int OBJ_COUNT = 10;
+
+    private final ArrayList<Property<?>> origList = new ArrayList<>();
+    private final ArrayList<Property<?>> wrappedList = new ArrayList<>();
+
+    private final ArrayList<WeakReference<Property<?>>> origRefs = new ArrayList<>();
+    private final ArrayList<WeakReference<Property<?>>> wrappedRefs = new ArrayList<>();
+
+    private void commonLeakTest(int origExpected, int wrappedExpected)
+            throws Exception {
+
+        for (int i = 0; i < 5; i++) {
+            System.gc();
+            System.runFinalization();
+            Thread.sleep(50);
+        }
+
+        int origCount = 0;
+        for (var ref : origRefs) {
+            if (ref.get() != null) origCount++;
+        }
+        final String origMsg = origExpected > 0
+                ? "Original properties should NOT be GCed"
+                : "Original properties should be GCed";
+        assertEquals(origMsg, origExpected, origCount);
+
+        int wrappedCount = 0;
+        for (var ref : wrappedRefs) {
+            if (ref.get() != null) wrappedCount++;
+        }
+        final String wrappedMsg = wrappedExpected > 0
+                ? "Wrapped properties should NOT be GCed"
+                : "Wrapped properties should be GCed";
+        assertEquals(wrappedMsg, wrappedExpected, wrappedCount);
+    }
+
+    private void commonLeakTest() throws Exception {
+        // Verify that we hold references to both original and wrapped objects
+        commonLeakTest(OBJ_COUNT, OBJ_COUNT);
+
+        // Clear references to wrapped property objects and recheck
+        wrappedList.clear();
+        commonLeakTest(OBJ_COUNT, 0);
+
+        // Clear references to original property objects and recheck
+        origList.clear();
+        commonLeakTest(0, 0);
+    }
+
+    @Test
+    public void testBooleanPropertyAsObjectLeak() throws Exception {
+        for (int i = 0; i < OBJ_COUNT; i++) {
+            // Create original and wrapped property objects
+            final BooleanProperty origProp = new SimpleBooleanProperty(true);
+            final ObjectProperty<Boolean> wrappedProp = origProp.asObject();
+
+            // Save reference to original and wrapped objects
+            origList.add(origProp);
+            wrappedList.add(wrappedProp);
+
+            // Save weak references for GC detection
+            origRefs.add(new WeakReference<>(origProp));
+            wrappedRefs.add(new WeakReference<>(wrappedProp));
+        }
+        commonLeakTest();
+    }
+
+    @Test
+    public void testObjectToBooleanLeak() throws Exception {
+        for (int i = 0; i < OBJ_COUNT; i++) {
+            // Create original and wrapped property objects
+            final ObjectProperty<Boolean> origProp = new SimpleObjectProperty<>(true);
+            BooleanProperty wrappedProp = BooleanProperty.booleanProperty(origProp);
+
+            // Save reference to original and wrapped objects
+            origList.add(origProp);
+            wrappedList.add(wrappedProp);
+
+            // Save weak references for GC detection
+            origRefs.add(new WeakReference<>(origProp));
+            wrappedRefs.add(new WeakReference<>(wrappedProp));
+        }
+        commonLeakTest();
+    }
+
+    @Test
+    public void testDoublePropertyAsObjectLeak() throws Exception {
+        for (int i = 0; i < OBJ_COUNT; i++) {
+            // Create original and wrapped property objects
+            final DoubleProperty origProp = new SimpleDoubleProperty(1.0);
+            final ObjectProperty<Double> wrappedProp = origProp.asObject();
+
+            // Save reference to original and wrapped objects
+            origList.add(origProp);
+            wrappedList.add(wrappedProp);
+
+            // Save weak references for GC detection
+            origRefs.add(new WeakReference<>(origProp));
+            wrappedRefs.add(new WeakReference<>(wrappedProp));
+        }
+        commonLeakTest();
+    }
+
+    @Test
+    public void testObjectToDoubleLeak() throws Exception {
+        for (int i = 0; i < OBJ_COUNT; i++) {
+            // Create original and wrapped property objects
+            final ObjectProperty<Double> origProp = new SimpleObjectProperty<>(1.0);
+            DoubleProperty wrappedProp = DoubleProperty.doubleProperty(origProp);
+
+            // Save reference to original and wrapped objects
+            origList.add(origProp);
+            wrappedList.add(wrappedProp);
+
+            // Save weak references for GC detection
+            origRefs.add(new WeakReference<>(origProp));
+            wrappedRefs.add(new WeakReference<>(wrappedProp));
+        }
+        commonLeakTest();
+    }
+
+    @Test
+    public void testFloatPropertyAsObjectLeak() throws Exception {
+        for (int i = 0; i < OBJ_COUNT; i++) {
+            // Create original and wrapped property objects
+            final FloatProperty origProp = new SimpleFloatProperty(1.0f);
+            final ObjectProperty<Float> wrappedProp = origProp.asObject();
+
+            // Save reference to original and wrapped objects
+            origList.add(origProp);
+            wrappedList.add(wrappedProp);
+
+            // Save weak references for GC detection
+            origRefs.add(new WeakReference<>(origProp));
+            wrappedRefs.add(new WeakReference<>(wrappedProp));
+        }
+        commonLeakTest();
+    }
+
+    @Test
+    public void testObjectToFloatLeak() throws Exception {
+        for (int i = 0; i < OBJ_COUNT; i++) {
+            // Create original and wrapped property objects
+            final ObjectProperty<Float> origProp = new SimpleObjectProperty<>(1.0f);
+            FloatProperty wrappedProp = FloatProperty.floatProperty(origProp);
+
+            // Save reference to original and wrapped objects
+            origList.add(origProp);
+            wrappedList.add(wrappedProp);
+
+            // Save weak references for GC detection
+            origRefs.add(new WeakReference<>(origProp));
+            wrappedRefs.add(new WeakReference<>(wrappedProp));
+        }
+        commonLeakTest();
+    }
+
+    @Test
+    public void testIntegerPropertyAsObjectLeak() throws Exception {
+        for (int i = 0; i < OBJ_COUNT; i++) {
+            // Create original and wrapped property objects
+            final IntegerProperty origProp = new SimpleIntegerProperty(1);
+            final ObjectProperty<Integer> wrappedProp = origProp.asObject();
+
+            // Save reference to original and wrapped objects
+            origList.add(origProp);
+            wrappedList.add(wrappedProp);
+
+            // Save weak references for GC detection
+            origRefs.add(new WeakReference<>(origProp));
+            wrappedRefs.add(new WeakReference<>(wrappedProp));
+        }
+        commonLeakTest();
+    }
+
+    @Test
+    public void testObjectToIntegerLeak() throws Exception {
+        for (int i = 0; i < OBJ_COUNT; i++) {
+            // Create original and wrapped property objects
+            final ObjectProperty<Integer> origProp = new SimpleObjectProperty<>(1);
+            IntegerProperty wrappedProp = IntegerProperty.integerProperty(origProp);
+
+            // Save reference to original and wrapped objects
+            origList.add(origProp);
+            wrappedList.add(wrappedProp);
+
+            // Save weak references for GC detection
+            origRefs.add(new WeakReference<>(origProp));
+            wrappedRefs.add(new WeakReference<>(wrappedProp));
+        }
+        commonLeakTest();
+    }
+
+    @Test
+    public void testLongPropertyAsObjectLeak() throws Exception {
+        for (int i = 0; i < OBJ_COUNT; i++) {
+            // Create original and wrapped property objects
+            final LongProperty origProp = new SimpleLongProperty(1L);
+            final ObjectProperty<Long> wrappedProp = origProp.asObject();
+
+            // Save reference to original and wrapped objects
+            origList.add(origProp);
+            wrappedList.add(wrappedProp);
+
+            // Save weak references for GC detection
+            origRefs.add(new WeakReference<>(origProp));
+            wrappedRefs.add(new WeakReference<>(wrappedProp));
+        }
+        commonLeakTest();
+    }
+
+    @Test
+    public void testObjectToLongLeak() throws Exception {
+        for (int i = 0; i < OBJ_COUNT; i++) {
+            // Create original and wrapped property objects
+            final ObjectProperty<Long> origProp = new SimpleObjectProperty<>(1L);
+            LongProperty wrappedProp = LongProperty.longProperty(origProp);
+
+            // Save reference to original and wrapped objects
+            origList.add(origProp);
+            wrappedList.add(wrappedProp);
+
+            // Save weak references for GC detection
+            origRefs.add(new WeakReference<>(origProp));
+            wrappedRefs.add(new WeakReference<>(wrappedProp));
+        }
+        commonLeakTest();
+    }
+
+}

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ObjectPropertyLeakTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ObjectPropertyLeakTest.java
@@ -118,7 +118,7 @@ public class ObjectPropertyLeakTest {
         for (int i = 0; i < OBJ_COUNT; i++) {
             // Create original and wrapped property objects
             final ObjectProperty<Boolean> origProp = new SimpleObjectProperty<>(true);
-            BooleanProperty wrappedProp = BooleanProperty.booleanProperty(origProp);
+            final BooleanProperty wrappedProp = BooleanProperty.booleanProperty(origProp);
 
             // Save reference to original and wrapped objects
             origList.add(origProp);
@@ -154,7 +154,7 @@ public class ObjectPropertyLeakTest {
         for (int i = 0; i < OBJ_COUNT; i++) {
             // Create original and wrapped property objects
             final ObjectProperty<Double> origProp = new SimpleObjectProperty<>(1.0);
-            DoubleProperty wrappedProp = DoubleProperty.doubleProperty(origProp);
+            final DoubleProperty wrappedProp = DoubleProperty.doubleProperty(origProp);
 
             // Save reference to original and wrapped objects
             origList.add(origProp);
@@ -190,7 +190,7 @@ public class ObjectPropertyLeakTest {
         for (int i = 0; i < OBJ_COUNT; i++) {
             // Create original and wrapped property objects
             final ObjectProperty<Float> origProp = new SimpleObjectProperty<>(1.0f);
-            FloatProperty wrappedProp = FloatProperty.floatProperty(origProp);
+            final FloatProperty wrappedProp = FloatProperty.floatProperty(origProp);
 
             // Save reference to original and wrapped objects
             origList.add(origProp);
@@ -226,7 +226,7 @@ public class ObjectPropertyLeakTest {
         for (int i = 0; i < OBJ_COUNT; i++) {
             // Create original and wrapped property objects
             final ObjectProperty<Integer> origProp = new SimpleObjectProperty<>(1);
-            IntegerProperty wrappedProp = IntegerProperty.integerProperty(origProp);
+            final IntegerProperty wrappedProp = IntegerProperty.integerProperty(origProp);
 
             // Save reference to original and wrapped objects
             origList.add(origProp);
@@ -262,7 +262,7 @@ public class ObjectPropertyLeakTest {
         for (int i = 0; i < OBJ_COUNT; i++) {
             // Create original and wrapped property objects
             final ObjectProperty<Long> origProp = new SimpleObjectProperty<>(1L);
-            LongProperty wrappedProp = LongProperty.longProperty(origProp);
+            final LongProperty wrappedProp = LongProperty.longProperty(origProp);
 
             // Save reference to original and wrapped objects
             origList.add(origProp);

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ObjectPropertyLeakTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ObjectPropertyLeakTest.java
@@ -54,6 +54,18 @@ public class ObjectPropertyLeakTest {
     private final ArrayList<WeakReference<Property<?>>> origRefs = new ArrayList<>();
     private final ArrayList<WeakReference<Property<?>>> wrappedRefs = new ArrayList<>();
 
+    private void checkRefs(String name, int numExpected,
+            ArrayList<WeakReference<Property<?>>> refs) {
+
+        int count = 0;
+        for (var ref : refs) {
+            if (ref.get() != null) count++;
+        }
+        final String msg = name + " properties should "
+                + (numExpected > 0 ? "NOT be GCed" : "be GCed");
+        assertEquals(msg, numExpected, count);
+    }
+
     private void commonLeakTest(int origExpected, int wrappedExpected)
             throws Exception {
 
@@ -63,23 +75,8 @@ public class ObjectPropertyLeakTest {
             Thread.sleep(50);
         }
 
-        int origCount = 0;
-        for (var ref : origRefs) {
-            if (ref.get() != null) origCount++;
-        }
-        final String origMsg = origExpected > 0
-                ? "Original properties should NOT be GCed"
-                : "Original properties should be GCed";
-        assertEquals(origMsg, origExpected, origCount);
-
-        int wrappedCount = 0;
-        for (var ref : wrappedRefs) {
-            if (ref.get() != null) wrappedCount++;
-        }
-        final String wrappedMsg = wrappedExpected > 0
-                ? "Wrapped properties should NOT be GCed"
-                : "Wrapped properties should be GCed";
-        assertEquals(wrappedMsg, wrappedExpected, wrappedCount);
+        checkRefs("Original", origExpected, origRefs);
+        checkRefs("Wrapped", wrappedExpected, wrappedRefs);
     }
 
     private void commonLeakTest() throws Exception {
@@ -95,20 +92,23 @@ public class ObjectPropertyLeakTest {
         commonLeakTest(0, 0);
     }
 
+    private void saveRefs(Property<?> origProp, Property<?> wrappedProp) {
+        // Save reference to original and wrapped objects
+        origList.add(origProp);
+        wrappedList.add(wrappedProp);
+
+        // Save weak references for GC detection
+        origRefs.add(new WeakReference<>(origProp));
+        wrappedRefs.add(new WeakReference<>(wrappedProp));
+    }
+
     @Test
     public void testBooleanPropertyAsObjectLeak() throws Exception {
         for (int i = 0; i < OBJ_COUNT; i++) {
             // Create original and wrapped property objects
             final BooleanProperty origProp = new SimpleBooleanProperty(true);
             final ObjectProperty<Boolean> wrappedProp = origProp.asObject();
-
-            // Save reference to original and wrapped objects
-            origList.add(origProp);
-            wrappedList.add(wrappedProp);
-
-            // Save weak references for GC detection
-            origRefs.add(new WeakReference<>(origProp));
-            wrappedRefs.add(new WeakReference<>(wrappedProp));
+            saveRefs(origProp, wrappedProp);
         }
         commonLeakTest();
     }
@@ -119,14 +119,7 @@ public class ObjectPropertyLeakTest {
             // Create original and wrapped property objects
             final ObjectProperty<Boolean> origProp = new SimpleObjectProperty<>(true);
             final BooleanProperty wrappedProp = BooleanProperty.booleanProperty(origProp);
-
-            // Save reference to original and wrapped objects
-            origList.add(origProp);
-            wrappedList.add(wrappedProp);
-
-            // Save weak references for GC detection
-            origRefs.add(new WeakReference<>(origProp));
-            wrappedRefs.add(new WeakReference<>(wrappedProp));
+            saveRefs(origProp, wrappedProp);
         }
         commonLeakTest();
     }
@@ -137,14 +130,7 @@ public class ObjectPropertyLeakTest {
             // Create original and wrapped property objects
             final DoubleProperty origProp = new SimpleDoubleProperty(1.0);
             final ObjectProperty<Double> wrappedProp = origProp.asObject();
-
-            // Save reference to original and wrapped objects
-            origList.add(origProp);
-            wrappedList.add(wrappedProp);
-
-            // Save weak references for GC detection
-            origRefs.add(new WeakReference<>(origProp));
-            wrappedRefs.add(new WeakReference<>(wrappedProp));
+            saveRefs(origProp, wrappedProp);
         }
         commonLeakTest();
     }
@@ -155,14 +141,7 @@ public class ObjectPropertyLeakTest {
             // Create original and wrapped property objects
             final ObjectProperty<Double> origProp = new SimpleObjectProperty<>(1.0);
             final DoubleProperty wrappedProp = DoubleProperty.doubleProperty(origProp);
-
-            // Save reference to original and wrapped objects
-            origList.add(origProp);
-            wrappedList.add(wrappedProp);
-
-            // Save weak references for GC detection
-            origRefs.add(new WeakReference<>(origProp));
-            wrappedRefs.add(new WeakReference<>(wrappedProp));
+            saveRefs(origProp, wrappedProp);
         }
         commonLeakTest();
     }
@@ -173,14 +152,7 @@ public class ObjectPropertyLeakTest {
             // Create original and wrapped property objects
             final FloatProperty origProp = new SimpleFloatProperty(1.0f);
             final ObjectProperty<Float> wrappedProp = origProp.asObject();
-
-            // Save reference to original and wrapped objects
-            origList.add(origProp);
-            wrappedList.add(wrappedProp);
-
-            // Save weak references for GC detection
-            origRefs.add(new WeakReference<>(origProp));
-            wrappedRefs.add(new WeakReference<>(wrappedProp));
+            saveRefs(origProp, wrappedProp);
         }
         commonLeakTest();
     }
@@ -191,14 +163,7 @@ public class ObjectPropertyLeakTest {
             // Create original and wrapped property objects
             final ObjectProperty<Float> origProp = new SimpleObjectProperty<>(1.0f);
             final FloatProperty wrappedProp = FloatProperty.floatProperty(origProp);
-
-            // Save reference to original and wrapped objects
-            origList.add(origProp);
-            wrappedList.add(wrappedProp);
-
-            // Save weak references for GC detection
-            origRefs.add(new WeakReference<>(origProp));
-            wrappedRefs.add(new WeakReference<>(wrappedProp));
+            saveRefs(origProp, wrappedProp);
         }
         commonLeakTest();
     }
@@ -209,14 +174,7 @@ public class ObjectPropertyLeakTest {
             // Create original and wrapped property objects
             final IntegerProperty origProp = new SimpleIntegerProperty(1);
             final ObjectProperty<Integer> wrappedProp = origProp.asObject();
-
-            // Save reference to original and wrapped objects
-            origList.add(origProp);
-            wrappedList.add(wrappedProp);
-
-            // Save weak references for GC detection
-            origRefs.add(new WeakReference<>(origProp));
-            wrappedRefs.add(new WeakReference<>(wrappedProp));
+            saveRefs(origProp, wrappedProp);
         }
         commonLeakTest();
     }
@@ -227,14 +185,7 @@ public class ObjectPropertyLeakTest {
             // Create original and wrapped property objects
             final ObjectProperty<Integer> origProp = new SimpleObjectProperty<>(1);
             final IntegerProperty wrappedProp = IntegerProperty.integerProperty(origProp);
-
-            // Save reference to original and wrapped objects
-            origList.add(origProp);
-            wrappedList.add(wrappedProp);
-
-            // Save weak references for GC detection
-            origRefs.add(new WeakReference<>(origProp));
-            wrappedRefs.add(new WeakReference<>(wrappedProp));
+            saveRefs(origProp, wrappedProp);
         }
         commonLeakTest();
     }
@@ -245,14 +196,7 @@ public class ObjectPropertyLeakTest {
             // Create original and wrapped property objects
             final LongProperty origProp = new SimpleLongProperty(1L);
             final ObjectProperty<Long> wrappedProp = origProp.asObject();
-
-            // Save reference to original and wrapped objects
-            origList.add(origProp);
-            wrappedList.add(wrappedProp);
-
-            // Save weak references for GC detection
-            origRefs.add(new WeakReference<>(origProp));
-            wrappedRefs.add(new WeakReference<>(wrappedProp));
+            saveRefs(origProp, wrappedProp);
         }
         commonLeakTest();
     }
@@ -263,14 +207,7 @@ public class ObjectPropertyLeakTest {
             // Create original and wrapped property objects
             final ObjectProperty<Long> origProp = new SimpleObjectProperty<>(1L);
             final LongProperty wrappedProp = LongProperty.longProperty(origProp);
-
-            // Save reference to original and wrapped objects
-            origList.add(origProp);
-            wrappedList.add(wrappedProp);
-
-            // Save weak references for GC detection
-            origRefs.add(new WeakReference<>(origProp));
-            wrappedRefs.add(new WeakReference<>(wrappedProp));
+            saveRefs(origProp, wrappedProp);
         }
         commonLeakTest();
     }


### PR DESCRIPTION
This patch removes the `finalize` methods from the `Property` classes in the `javafx.base` module.

The `{Boolean,Double,Float,Int,Long}Property` classes each have a pair of methods -- `asObject` and `xxxxxProperty` -- that create a `Property<Xxxxx>` object from a primitive `XxxxxProperty` object and vice versa. Each of the methods bidirectionally binds the original property object to the created property object. All of the bidirectional bindings in question use `WeakReference`s to refer to the pair of objects being bound to each other, so that they won't cause a memory leak.

The `finalize` methods were added in an attempt to cleanup the bidirectional bindings when the created object goes away. I say attempt, because it is entirely ineffective in doing so. The logic that removes the binding creates a new one from the same pair of objects, but fails to match the original binding because the referent to the created property object has been garbage collected before the `finalize` method is called; the `WeakReference` in the binding is cleared and no longer matches. Fortunately, the only impact of this ineffective logic is that it can delay the removal of the binding (which is a small object that just contains the two weak references) from the original property object until it (the original property) is either garbage collected or modified (the binding logic already looks for a referent that has been GCed and removes the binding).

Given that the `finalize` methods don't do anything useful today, and that there is no memory leak in the first place, the proposed fix is to just remove the `finalize` methods entirely with no replacement needed. There will be no changes in behavior as a result of this.

Existing tests of the methods in question are sufficient to ensure no functional regressions, although there is no existing test for leaks, so I created new tests to verify that there is no leak. Since there is no existing leak, those tests will pass both with and without this fix.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8196586](https://bugs.openjdk.java.net/browse/JDK-8196586): Remove use of deprecated finalize methods from javafx property objects


### Reviewers
 * Nir Lisker ([nlisker](@nlisker) - Committer)
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/113/head:pull/113`
`$ git checkout pull/113`
