### PR TITLE
8235480: Regression: [RTL] Arrow keys navigation doesn't respect TableView orientation

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableViewBehaviorBase.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableViewBehaviorBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,6 +135,8 @@ public abstract class TableViewBehaviorBase<C extends Control, T, TC extends Tab
         // create a map for TableView(Base)-specific mappings
         tableViewInputMap = createInputMap();
 
+        boolean rtl = isRTL();
+
         KeyMapping enterKeyActivateMapping, escapeKeyCancelEditMapping;
         addDefaultMapping(tableViewInputMap,
                 new KeyMapping(TAB, FocusTraversalInputMap::traverseNext),
@@ -146,20 +148,21 @@ public abstract class TableViewBehaviorBase<C extends Control, T, TC extends Tab
                 new KeyMapping(PAGE_UP, e -> scrollUp()),
                 new KeyMapping(PAGE_DOWN, e -> scrollDown()),
 
-                new KeyMapping(LEFT, e -> selectLeftCell()),
-                new KeyMapping(KP_LEFT, e -> selectLeftCell()),
-                new KeyMapping(RIGHT, e -> selectRightCell()),
-                new KeyMapping(KP_RIGHT, e -> selectRightCell()),
+
+                new KeyMapping(LEFT, (rtl? e -> selectRightCell() : e -> selectLeftCell())),
+                new KeyMapping(KP_LEFT, (rtl? e -> selectRightCell() : e -> selectLeftCell())),
+                new KeyMapping(RIGHT, (rtl? e -> selectLeftCell() : e -> selectRightCell())),
+                new KeyMapping(KP_RIGHT, (rtl? e -> selectLeftCell() :e -> selectRightCell())),
 
                 new KeyMapping(UP, e -> selectPreviousRow()),
                 new KeyMapping(KP_UP, e -> selectPreviousRow()),
                 new KeyMapping(DOWN, e -> selectNextRow()),
                 new KeyMapping(KP_DOWN, e -> selectNextRow()),
 
-                new KeyMapping(LEFT, FocusTraversalInputMap::traverseLeft),
-                new KeyMapping(KP_LEFT, FocusTraversalInputMap::traverseLeft),
-                new KeyMapping(RIGHT, FocusTraversalInputMap::traverseRight),
-                new KeyMapping(KP_RIGHT, FocusTraversalInputMap::traverseRight),
+                new KeyMapping(LEFT, (rtl? FocusTraversalInputMap::traverseRight : FocusTraversalInputMap::traverseLeft)),
+                new KeyMapping(KP_LEFT, (rtl? FocusTraversalInputMap::traverseRight : FocusTraversalInputMap::traverseLeft)),
+                new KeyMapping(RIGHT, (rtl? FocusTraversalInputMap::traverseLeft : FocusTraversalInputMap::traverseRight)),
+                new KeyMapping(KP_RIGHT, (rtl? FocusTraversalInputMap::traverseLeft : FocusTraversalInputMap::traverseRight)),
                 new KeyMapping(UP, FocusTraversalInputMap::traverseUp),
                 new KeyMapping(KP_UP, FocusTraversalInputMap::traverseUp),
                 new KeyMapping(DOWN, FocusTraversalInputMap::traverseDown),
@@ -178,17 +181,17 @@ public abstract class TableViewBehaviorBase<C extends Control, T, TC extends Tab
                 new KeyMapping(new KeyBinding(SPACE).shift(), e -> selectAllToFocus(false)),
                 new KeyMapping(new KeyBinding(SPACE).shortcut().shift(), e -> selectAllToFocus(true)),
 
-                new KeyMapping(new KeyBinding(LEFT).shift(), e -> alsoSelectLeftCell()),
-                new KeyMapping(new KeyBinding(KP_LEFT).shift(), e -> alsoSelectLeftCell()),
-                new KeyMapping(new KeyBinding(RIGHT).shift(), e -> alsoSelectRightCell()),
-                new KeyMapping(new KeyBinding(KP_RIGHT).shift(), e -> alsoSelectRightCell()),
+                new KeyMapping(new KeyBinding(LEFT).shift(), (rtl? e -> alsoSelectRightCell() : e -> alsoSelectLeftCell())),
+                new KeyMapping(new KeyBinding(KP_LEFT).shift(), (rtl? e -> alsoSelectRightCell() : e -> alsoSelectLeftCell())),
+                new KeyMapping(new KeyBinding(RIGHT).shift(), (rtl? e -> alsoSelectLeftCell() : e -> alsoSelectRightCell())),
+                new KeyMapping(new KeyBinding(KP_RIGHT).shift(), (rtl? e -> alsoSelectLeftCell() : e -> alsoSelectRightCell())),
 
                 new KeyMapping(new KeyBinding(UP).shortcut(), e -> focusPreviousRow()),
                 new KeyMapping(new KeyBinding(DOWN).shortcut(), e -> focusNextRow()),
-                new KeyMapping(new KeyBinding(RIGHT).shortcut(), e -> focusRightCell()),
-                new KeyMapping(new KeyBinding(KP_RIGHT).shortcut(), e -> focusRightCell()),
-                new KeyMapping(new KeyBinding(LEFT).shortcut(), e -> focusLeftCell()),
-                new KeyMapping(new KeyBinding(KP_LEFT).shortcut(), e -> focusLeftCell()),
+                new KeyMapping(new KeyBinding(RIGHT).shortcut(), (rtl? e -> focusLeftCell() : e -> focusRightCell())),
+                new KeyMapping(new KeyBinding(KP_RIGHT).shortcut(), (rtl? e -> focusLeftCell() : e -> focusRightCell())),
+                new KeyMapping(new KeyBinding(LEFT).shortcut(), (rtl? e -> focusRightCell() : e -> focusLeftCell())),
+                new KeyMapping(new KeyBinding(KP_LEFT).shortcut(), (rtl? e -> focusRightCell() : e -> focusLeftCell())),
 
                 new KeyMapping(new KeyBinding(A).shortcut(), e -> selectAll()),
                 new KeyMapping(new KeyBinding(HOME).shortcut(), e -> focusFirstRow()),
@@ -198,8 +201,8 @@ public abstract class TableViewBehaviorBase<C extends Control, T, TC extends Tab
 
                 new KeyMapping(new KeyBinding(UP).shortcut().shift(), e -> discontinuousSelectPreviousRow()),
                 new KeyMapping(new KeyBinding(DOWN).shortcut().shift(), e -> discontinuousSelectNextRow()),
-                new KeyMapping(new KeyBinding(LEFT).shortcut().shift(), e -> discontinuousSelectPreviousColumn()),
-                new KeyMapping(new KeyBinding(RIGHT).shortcut().shift(), e -> discontinuousSelectNextColumn()),
+                new KeyMapping(new KeyBinding(LEFT).shortcut().shift(), (rtl? e -> discontinuousSelectNextColumn() : e -> discontinuousSelectPreviousColumn())),
+                new KeyMapping(new KeyBinding(RIGHT).shortcut().shift(), (rtl? e -> discontinuousSelectPreviousColumn() : e -> discontinuousSelectNextColumn())),
                 new KeyMapping(new KeyBinding(PAGE_UP).shortcut().shift(), e -> discontinuousSelectPageUp()),
                 new KeyMapping(new KeyBinding(PAGE_DOWN).shortcut().shift(), e -> discontinuousSelectPageDown()),
                 new KeyMapping(new KeyBinding(HOME).shortcut().shift(), e -> discontinuousSelectAllToFirstRow()),

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableViewBehaviorBase.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableViewBehaviorBase.java
@@ -159,7 +159,7 @@ public abstract class TableViewBehaviorBase<C extends Control, T, TC extends Tab
                 new KeyMapping(LEFT,   e -> { if(isRTL()) focusTraverseRight(); else focusTraverseLeft(); }),
                 new KeyMapping(KP_LEFT, e -> { if(isRTL()) focusTraverseRight(); else focusTraverseLeft(); }),
                 new KeyMapping(RIGHT, e -> { if(isRTL()) focusTraverseLeft(); else focusTraverseRight(); }),
-                new KeyMapping(KP_RIGHT,e -> { if(isRTL()) focusTraverseLeft(); else focusTraverseRight(); }),
+                new KeyMapping(KP_RIGHT, e -> { if(isRTL()) focusTraverseLeft(); else focusTraverseRight(); }),
                 new KeyMapping(UP, FocusTraversalInputMap::traverseUp),
                 new KeyMapping(KP_UP, FocusTraversalInputMap::traverseUp),
                 new KeyMapping(DOWN, FocusTraversalInputMap::traverseDown),

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableViewBehaviorBase.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableViewBehaviorBase.java
@@ -135,8 +135,6 @@ public abstract class TableViewBehaviorBase<C extends Control, T, TC extends Tab
         // create a map for TableView(Base)-specific mappings
         tableViewInputMap = createInputMap();
 
-        boolean rtl = isRTL();
-
         KeyMapping enterKeyActivateMapping, escapeKeyCancelEditMapping;
         addDefaultMapping(tableViewInputMap,
                 new KeyMapping(TAB, FocusTraversalInputMap::traverseNext),
@@ -148,21 +146,20 @@ public abstract class TableViewBehaviorBase<C extends Control, T, TC extends Tab
                 new KeyMapping(PAGE_UP, e -> scrollUp()),
                 new KeyMapping(PAGE_DOWN, e -> scrollDown()),
 
-
-                new KeyMapping(LEFT, (rtl? e -> selectRightCell() : e -> selectLeftCell())),
-                new KeyMapping(KP_LEFT, (rtl? e -> selectRightCell() : e -> selectLeftCell())),
-                new KeyMapping(RIGHT, (rtl? e -> selectLeftCell() : e -> selectRightCell())),
-                new KeyMapping(KP_RIGHT, (rtl? e -> selectLeftCell() :e -> selectRightCell())),
+                new KeyMapping(LEFT, e -> { if(isRTL()) selectRightCell(); else selectLeftCell(); }),
+                new KeyMapping(KP_LEFT,e -> { if(isRTL()) selectRightCell(); else selectLeftCell(); }),
+                new KeyMapping(RIGHT, e -> { if(isRTL()) selectLeftCell(); else selectRightCell(); }),
+                new KeyMapping(KP_RIGHT, e -> { if(isRTL()) selectLeftCell(); else selectRightCell(); }),
 
                 new KeyMapping(UP, e -> selectPreviousRow()),
                 new KeyMapping(KP_UP, e -> selectPreviousRow()),
                 new KeyMapping(DOWN, e -> selectNextRow()),
                 new KeyMapping(KP_DOWN, e -> selectNextRow()),
 
-                new KeyMapping(LEFT, (rtl? FocusTraversalInputMap::traverseRight : FocusTraversalInputMap::traverseLeft)),
-                new KeyMapping(KP_LEFT, (rtl? FocusTraversalInputMap::traverseRight : FocusTraversalInputMap::traverseLeft)),
-                new KeyMapping(RIGHT, (rtl? FocusTraversalInputMap::traverseLeft : FocusTraversalInputMap::traverseRight)),
-                new KeyMapping(KP_RIGHT, (rtl? FocusTraversalInputMap::traverseLeft : FocusTraversalInputMap::traverseRight)),
+                new KeyMapping(LEFT,   e -> { if(isRTL()) focusTraverseRight(); else focusTraverseLeft(); }),
+                new KeyMapping(KP_LEFT, e -> { if(isRTL()) focusTraverseRight(); else focusTraverseLeft(); }),
+                new KeyMapping(RIGHT, e -> { if(isRTL()) focusTraverseLeft(); else focusTraverseRight(); }),
+                new KeyMapping(KP_RIGHT,e -> { if(isRTL()) focusTraverseLeft(); else focusTraverseRight(); }),
                 new KeyMapping(UP, FocusTraversalInputMap::traverseUp),
                 new KeyMapping(KP_UP, FocusTraversalInputMap::traverseUp),
                 new KeyMapping(DOWN, FocusTraversalInputMap::traverseDown),
@@ -181,17 +178,17 @@ public abstract class TableViewBehaviorBase<C extends Control, T, TC extends Tab
                 new KeyMapping(new KeyBinding(SPACE).shift(), e -> selectAllToFocus(false)),
                 new KeyMapping(new KeyBinding(SPACE).shortcut().shift(), e -> selectAllToFocus(true)),
 
-                new KeyMapping(new KeyBinding(LEFT).shift(), (rtl? e -> alsoSelectRightCell() : e -> alsoSelectLeftCell())),
-                new KeyMapping(new KeyBinding(KP_LEFT).shift(), (rtl? e -> alsoSelectRightCell() : e -> alsoSelectLeftCell())),
-                new KeyMapping(new KeyBinding(RIGHT).shift(), (rtl? e -> alsoSelectLeftCell() : e -> alsoSelectRightCell())),
-                new KeyMapping(new KeyBinding(KP_RIGHT).shift(), (rtl? e -> alsoSelectLeftCell() : e -> alsoSelectRightCell())),
+                new KeyMapping(new KeyBinding(LEFT).shift(), e -> { if(isRTL()) alsoSelectRightCell(); else alsoSelectLeftCell(); }),
+                new KeyMapping(new KeyBinding(KP_LEFT).shift(),  e -> { if(isRTL()) alsoSelectRightCell(); else alsoSelectLeftCell(); }),
+                new KeyMapping(new KeyBinding(RIGHT).shift(),  e -> { if(isRTL()) alsoSelectLeftCell(); else alsoSelectRightCell(); }),
+                new KeyMapping(new KeyBinding(KP_RIGHT).shift(), e -> { if(isRTL()) alsoSelectLeftCell(); else alsoSelectRightCell(); }),
 
                 new KeyMapping(new KeyBinding(UP).shortcut(), e -> focusPreviousRow()),
                 new KeyMapping(new KeyBinding(DOWN).shortcut(), e -> focusNextRow()),
-                new KeyMapping(new KeyBinding(RIGHT).shortcut(), (rtl? e -> focusLeftCell() : e -> focusRightCell())),
-                new KeyMapping(new KeyBinding(KP_RIGHT).shortcut(), (rtl? e -> focusLeftCell() : e -> focusRightCell())),
-                new KeyMapping(new KeyBinding(LEFT).shortcut(), (rtl? e -> focusRightCell() : e -> focusLeftCell())),
-                new KeyMapping(new KeyBinding(KP_LEFT).shortcut(), (rtl? e -> focusRightCell() : e -> focusLeftCell())),
+                new KeyMapping(new KeyBinding(RIGHT).shortcut(), e -> { if(isRTL()) focusLeftCell(); else focusRightCell(); }),
+                new KeyMapping(new KeyBinding(KP_RIGHT).shortcut(), e -> { if(isRTL()) focusLeftCell(); else focusRightCell(); }),
+                new KeyMapping(new KeyBinding(LEFT).shortcut(), e -> { if(isRTL()) focusRightCell(); else focusLeftCell(); }),
+                new KeyMapping(new KeyBinding(KP_LEFT).shortcut(), e -> { if(isRTL()) focusRightCell(); else focusLeftCell(); }),
 
                 new KeyMapping(new KeyBinding(A).shortcut(), e -> selectAll()),
                 new KeyMapping(new KeyBinding(HOME).shortcut(), e -> focusFirstRow()),
@@ -201,8 +198,8 @@ public abstract class TableViewBehaviorBase<C extends Control, T, TC extends Tab
 
                 new KeyMapping(new KeyBinding(UP).shortcut().shift(), e -> discontinuousSelectPreviousRow()),
                 new KeyMapping(new KeyBinding(DOWN).shortcut().shift(), e -> discontinuousSelectNextRow()),
-                new KeyMapping(new KeyBinding(LEFT).shortcut().shift(), (rtl? e -> discontinuousSelectNextColumn() : e -> discontinuousSelectPreviousColumn())),
-                new KeyMapping(new KeyBinding(RIGHT).shortcut().shift(), (rtl? e -> discontinuousSelectPreviousColumn() : e -> discontinuousSelectNextColumn())),
+                new KeyMapping(new KeyBinding(LEFT).shortcut().shift(), e -> { if(isRTL()) discontinuousSelectNextColumn(); else discontinuousSelectPreviousColumn(); }),
+                new KeyMapping(new KeyBinding(RIGHT).shortcut().shift(), e -> { if(isRTL()) discontinuousSelectPreviousColumn(); else discontinuousSelectNextColumn(); }),
                 new KeyMapping(new KeyBinding(PAGE_UP).shortcut().shift(), e -> discontinuousSelectPageUp()),
                 new KeyMapping(new KeyBinding(PAGE_DOWN).shortcut().shift(), e -> discontinuousSelectPageDown()),
                 new KeyMapping(new KeyBinding(HOME).shortcut().shift(), e -> discontinuousSelectAllToFirstRow()),
@@ -1311,5 +1308,13 @@ public abstract class TableViewBehaviorBase<C extends Control, T, TC extends Tab
         }
 
         if (onMoveToLastCell != null) onMoveToLastCell.run();
+    }
+
+    private EventHandler<KeyEvent> focusTraverseLeft() {
+        return FocusTraversalInputMap::traverseLeft;
+    }
+
+    private EventHandler<KeyEvent> focusTraverseRight() {
+        return FocusTraversalInputMap::traverseRight;
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewHorizontalArrowsTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewHorizontalArrowsTest.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.control;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.BiConsumer;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.*;
+import static test.com.sun.javafx.scene.control.infrastructure.KeyModifier.*;
+
+import javafx.geometry.NodeOrientation;
+import javafx.scene.control.SelectionMode;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TablePosition;
+import javafx.scene.control.TableView;
+import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
+import test.com.sun.javafx.scene.control.infrastructure.KeyModifier;
+import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
+
+/**
+ * Test basic horizontal navigation mappings for TableView. It's parametrized on NodeOrientation
+ */
+@RunWith(Parameterized.class)
+public class TableViewHorizontalArrowsTest {
+    @Parameterized.Parameters
+    public static Collection<?> implementations() {
+        return Arrays.asList(new Object[][] {
+            {NodeOrientation.LEFT_TO_RIGHT},
+            {NodeOrientation.RIGHT_TO_LEFT} 
+        });
+    }
+
+    private TableView<String> tableView;
+    private TableView.TableViewSelectionModel<String> sm;
+    private TableView.TableViewFocusModel<String> fm;
+
+    private TableColumn<String, String> col0;
+    private TableColumn<String, String> col1;
+    private TableColumn<String, String> col2;
+    private TableColumn<String, String> col3;
+    private TableColumn<String, String> col4;
+
+    private KeyEventFirer keyboard;
+    private StageLoader stageLoader;
+    private NodeOrientation orientation;
+
+    public TableViewHorizontalArrowsTest(NodeOrientation val) {
+        orientation = val;
+    }
+
+    @Before
+    public void setup() {
+        tableView = new TableView<String>();
+        tableView.setNodeOrientation(orientation);
+        sm = tableView.getSelectionModel();
+        fm = tableView.getFocusModel();
+
+        sm.setSelectionMode(SelectionMode.MULTIPLE);
+        sm.setCellSelectionEnabled(false);
+
+        tableView.getItems().setAll("1", "2", "3", "4", "5", "6", "7", "8", "9",
+                                    "10", "11", "12");
+
+        col0 = new TableColumn<String, String>("col0");
+        col1 = new TableColumn<String, String>("col1");
+        col2 = new TableColumn<String, String>("col2");
+        col3 = new TableColumn<String, String>("col3");
+        col4 = new TableColumn<String, String>("col4");
+        tableView.getColumns().setAll(col0, col1, col2, col3, col4);
+
+        keyboard = new KeyEventFirer(tableView);
+
+        stageLoader = new StageLoader(tableView);
+        stageLoader.getStage().show();
+    }
+
+    @After
+    public void tearDown() {
+        tableView.getSkin().dispose();
+        stageLoader.dispose();
+    }
+
+    // ---------------- Helper methods -------------------------
+    /**
+     * Toggles the nodeOrientation of tableView.
+     */
+    private void changeNodeOrientation() {
+        orientation = (orientation == NodeOrientation.LEFT_TO_RIGHT?
+            NodeOrientation.RIGHT_TO_LEFT : NodeOrientation.LEFT_TO_RIGHT);
+        tableView.setNodeOrientation(orientation);
+    }
+
+    /**
+     * Orientation-aware forward horizontal navigation with arrow keys.
+     * @param modifiers the modifiers to use on keyboard
+     */
+    private void forward(KeyModifier... modifiers) {
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doRightArrowPress(modifiers);
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doLeftArrowPress(modifiers);
+        }
+    }
+
+    /**
+     * Orientation-aware backward horizontal navigation with arrow keys.
+     * @param modifiers the modifiers to use on keyboard
+     */
+    private void backward(KeyModifier... modifiers) {
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doLeftArrowPress(modifiers);
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doRightArrowPress(modifiers);
+        }
+    }
+
+
+    // ----------------------- Tests ----------------------------
+
+    @Test
+    public void testForwardSelect() {
+        sm.setCellSelectionEnabled(true);
+        sm.select(0, col0);
+        forward();
+        assertTrue("next cell must be selected", sm.isSelected(0, col1));
+        assertFalse("old cell not be selected", sm.isSelected(0, col0));
+    }
+
+    @Test
+    public void testBackwardSelect() {
+        sm.setCellSelectionEnabled(true);
+        sm.select(0, col4);
+        backward();
+        assertTrue("next cell must be selected", sm.isSelected(0, col3));
+        assertFalse("old cell not be selected", sm.isSelected(0, col4));
+    }
+
+    @Test
+    public void testForwardFocus() {
+        sm.setCellSelectionEnabled(true);
+        sm.select(0, col0);
+        forward(getShortcutKey());
+        assertTrue("selected cell must still be selected", sm.isSelected(0, col0));
+        assertFalse("next cell must not be selected", sm.isSelected(0, col1));
+        TablePosition<?, ?> focusedCell = fm.getFocusedCell();
+        assertEquals("focused cell must moved to next", col1, focusedCell.getTableColumn());
+    }
+
+    @Test
+    public void testBackwardFocus() {
+        sm.setCellSelectionEnabled(true);
+        sm.select(0, col4);
+        backward(getShortcutKey());
+        assertTrue("selected cell must still be selected", sm.isSelected(0, col4));
+        assertFalse("previous cell must not be selected", sm.isSelected(0, col3));
+        TablePosition<?, ?> focusedCell = fm.getFocusedCell();
+        assertEquals("focused cell must moved to prev", col3, focusedCell.getTableColumn());
+    }
+
+
+
+    @Test
+    public void testChangeOrientationSimpleForwardSelect() {
+        sm.setCellSelectionEnabled(true);
+        sm.select(0, col0);
+        forward();
+        assertTrue(sm.isSelected(0, col1));
+        assertFalse(sm.isSelected(0, col0));
+
+        changeNodeOrientation();
+
+        // Now, test that the forward select resprects change in NodeOrientation
+        forward();
+
+        assertFalse(sm.isSelected(0, col1));
+        assertTrue(sm.isSelected(0, col2));
+    }
+
+    @Test
+    public void testChangeOrientationSimpleBackwardSelect() {
+        sm.setCellSelectionEnabled(true);
+        sm.select(0, col4);
+        backward();
+        assertTrue(sm.isSelected(0, col3));
+        assertFalse(sm.isSelected(0, col4));
+
+        changeNodeOrientation();
+
+        // Now, test that the backward select resprects change in NodeOrientation
+        backward();
+        assertFalse(sm.isSelected(0, col3));
+        assertTrue(sm.isSelected(0, col2));
+    }
+
+    // TBD: add tests for all keyMappings with modifiers
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewHorizontalArrowsTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewHorizontalArrowsTest.java
@@ -115,9 +115,10 @@ public class TableViewHorizontalArrowsTest {
 
     // ---------------- Helper methods -------------------------
     /**
-     * Toggles the nodeOrientation of tableView.
+     * Toggles the parameter nodeOrientation and
+     * sets the tableView's orientation to the new toggled value
      */
-    private void changeNodeOrientation() {
+    private void toggleNodeOrientation() {
         orientation = (orientation == NodeOrientation.LEFT_TO_RIGHT?
             NodeOrientation.RIGHT_TO_LEFT : NodeOrientation.LEFT_TO_RIGHT);
         tableView.setNodeOrientation(orientation);
@@ -200,8 +201,6 @@ public class TableViewHorizontalArrowsTest {
         assertEquals("focused cell must moved to prev", col3, focusedCell.getTableColumn());
     }
 
-
-    // Note : Any test that changs NodeOrientation must restore it back at the end of it
     @Test
     public void testChangeOrientationSimpleForwardSelect() {
         sm.select(0, col0);
@@ -209,19 +208,15 @@ public class TableViewHorizontalArrowsTest {
         assertTrue(sm.isSelected(0, col1));
         assertFalse(sm.isSelected(0, col0));
 
-        changeNodeOrientation();
+        toggleNodeOrientation();
 
         // Now, test that the forward select respects change in NodeOrientation
         forward();
 
         assertFalse(sm.isSelected(0, col1));
         assertTrue(sm.isSelected(0, col2));
-
-        // Restore Node orientation
-        changeNodeOrientation();
     }
 
-    // Note : Any test that changs NodeOrientation must restore it back at the end of it
     @Test
     public void testChangeOrientationSimpleBackwardSelect() {
         sm.select(0, col4);
@@ -229,15 +224,12 @@ public class TableViewHorizontalArrowsTest {
         assertTrue(sm.isSelected(0, col3));
         assertFalse(sm.isSelected(0, col4));
 
-        changeNodeOrientation();
+        toggleNodeOrientation();
 
         // Now, test that the backward select respects change in NodeOrientation
         backward();
         assertFalse(sm.isSelected(0, col3));
         assertTrue(sm.isSelected(0, col2));
-
-        // Restore Node orientation
-        changeNodeOrientation();
     }
 
     @Test public void testShiftBackwardWhenAtFirstCol() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewHorizontalArrowsTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewHorizontalArrowsTest.java
@@ -56,7 +56,7 @@ public class TableViewHorizontalArrowsTest {
     public static Collection<?> implementations() {
         return Arrays.asList(new Object[][] {
             {NodeOrientation.LEFT_TO_RIGHT},
-            {NodeOrientation.RIGHT_TO_LEFT} 
+            {NodeOrientation.RIGHT_TO_LEFT}
         });
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewHorizontalArrowsTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewHorizontalArrowsTest.java
@@ -257,7 +257,7 @@ public class TableViewHorizontalArrowsTest {
         assertTrue("Selected cell remains selected", sm.isSelected(0, col0));
         assertTrue("forward cell must also be selected", sm.isSelected(0, col1));
     }
-    
+
     @Test public void testShiftBackwardWhenAtLastCol() {
         sm.select(0, col4);
         backward(KeyModifier.SHIFT);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewKeyInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewKeyInputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,8 +35,6 @@ import javafx.scene.control.Button;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.HBox;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 
@@ -59,31 +57,18 @@ import javafx.scene.control.TableFocusModel;
 import javafx.scene.control.TablePosition;
 import javafx.scene.control.TableSelectionModel;
 import javafx.scene.control.TableView;
-import javafx.geometry.NodeOrientation;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-
 import static org.junit.Assert.fail;
 
-@RunWith(Parameterized.class)
 public class TableViewKeyInputTest {
-    @Parameterized.Parameters public static Collection implementations() {
-        return Arrays.asList(new Object[][]{
-                {NodeOrientation.LEFT_TO_RIGHT},
-                {NodeOrientation.RIGHT_TO_LEFT}
-        });
-    }
-
     private TableView<String> tableView;
 //    private TableSelectionModel<String> sm;
     private TableView.TableViewSelectionModel<String> sm;
@@ -99,15 +84,8 @@ public class TableViewKeyInputTest {
     private TableColumn<String, String> col3;
     private TableColumn<String, String> col4;
 
-    private NodeOrientation orientation;
-
-    public TableViewKeyInputTest(NodeOrientation val) {
-        orientation = val;
-    }
-
     @Before public void setup() {
         tableView = new TableView<String>();
-        tableView.setNodeOrientation(orientation);
         sm = tableView.getSelectionModel();
         fm = tableView.getFocusModel();
 
@@ -1131,14 +1109,8 @@ public class TableViewKeyInputTest {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.setCellSelectionEnabled(true);
         sm.select(0, col0);
-
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
-            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
-            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
-        }
+        keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
+        keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
         keyboard.doKeyPress(KeyCode.SPACE,
                 KeyModifier.getShortcutKey(),
                 (Utils.isMac()  ? KeyModifier.CTRL : null));
@@ -1146,13 +1118,8 @@ public class TableViewKeyInputTest {
         assertTrue(sm.isSelected(0,col2));
         assertTrue(isAnchor(0,2));
 
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        }
+        keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
         assertTrue(sm.isSelected(0,col0));
         assertTrue(sm.isSelected(0,col2));
         assertTrue(sm.isSelected(0,col3));
@@ -1165,13 +1132,8 @@ public class TableViewKeyInputTest {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.setCellSelectionEnabled(true);
         sm.select(0, col4);
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
-            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
-            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
-        }
+        keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
+        keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
         keyboard.doKeyPress(KeyCode.SPACE,
                 KeyModifier.getShortcutKey(),
                 (Utils.isMac()  ? KeyModifier.CTRL : null));
@@ -1179,13 +1141,8 @@ public class TableViewKeyInputTest {
         assertTrue(sm.isSelected(0,col2));
         assertTrue(isAnchor(0,2));
 
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        }
+        keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
         assertTrue(sm.isSelected(0,col0));
         assertTrue(sm.isSelected(0,col1));
         assertTrue(sm.isSelected(0,col2));
@@ -1198,13 +1155,8 @@ public class TableViewKeyInputTest {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.setCellSelectionEnabled(true);
         sm.select(0, col0);
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
-            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
-            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
-        }
+        keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
+        keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
         keyboard.doKeyPress(KeyCode.SPACE,
                 KeyModifier.getShortcutKey(),
                 (Utils.isMac()  ? KeyModifier.CTRL : null));
@@ -1212,28 +1164,17 @@ public class TableViewKeyInputTest {
         assertTrue(sm.isSelected(0,col2));
         assertTrue(isAnchor(0,2));
 
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        }
+        keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
         assertTrue(sm.isSelected(0,col0));
         assertTrue(sm.isSelected(0,col2));
         assertTrue(sm.isSelected(0,col3));
         assertTrue(sm.isSelected(0,col4));
         assertTrue(isAnchor(0,2));
 
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        }
+        keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
         assertTrue(sm.isSelected(0,col0));
         assertTrue(sm.isSelected(0,col1));
         assertTrue(sm.isSelected(0,col2));
@@ -1247,14 +1188,8 @@ public class TableViewKeyInputTest {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.setCellSelectionEnabled(true);
         sm.select(0, col4);
-
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
-            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
-            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
-        }
+        keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
+        keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
         keyboard.doKeyPress(KeyCode.SPACE,
                 KeyModifier.getShortcutKey(),
                 (Utils.isMac()  ? KeyModifier.CTRL : null));
@@ -1262,28 +1197,17 @@ public class TableViewKeyInputTest {
         assertTrue(sm.isSelected(0,col2));
         assertTrue(isAnchor(0,2));
 
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        }
+        keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
         assertTrue(sm.isSelected(0,col0));
         assertTrue(sm.isSelected(0,col1));
         assertTrue(sm.isSelected(0,col2));
         assertTrue(sm.isSelected(0,col4));
         assertTrue(isAnchor(0,2));
 
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        }
+        keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
         assertTrue(sm.isSelected(0,col0));
         assertTrue(sm.isSelected(0,col1));
         assertTrue(sm.isSelected(0,col2));
@@ -1559,33 +1483,18 @@ public class TableViewKeyInputTest {
         keyboard.doLeftArrowPress(KeyModifier.SHIFT);   // select (1, col3)
         keyboard.doLeftArrowPress(KeyModifier.SHIFT);   // select (1, col2)
         keyboard.doLeftArrowPress(KeyModifier.SHIFT);   // select (1, col1)
-
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            assertTrue(sm.isSelected(1, col4));
-            assertTrue(sm.isSelected(1, col3));
-            assertTrue(sm.isSelected(1, col2));
-            assertTrue(sm.isSelected(1, col1));
-            assertTrue(sm.isSelected(1, col0));
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            assertTrue(sm.isSelected(1, col4));
-            assertFalse(sm.isSelected(1, col3));
-            assertFalse(sm.isSelected(1, col2));
-            assertFalse(sm.isSelected(1, col1));
-            assertFalse(sm.isSelected(1, col0));
-        }
+        assertTrue(sm.isSelected(1, col4));
+        assertTrue(sm.isSelected(1, col3));
+        assertTrue(sm.isSelected(1, col2));
+        assertTrue(sm.isSelected(1, col1));
+        assertTrue(sm.isSelected(1, col0));
 
         keyboard.doRightArrowPress(KeyModifier.SHIFT);   // deselect (1, col1)
-
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            assertTrue(sm.isSelected(1, col4));
-            assertTrue(sm.isSelected(1, col3));
-            assertTrue(sm.isSelected(1, col2));
-            assertTrue(debug(), sm.isSelected(1, col1));
-            assertFalse(sm.isSelected(1, col0));
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            assertTrue(sm.isSelected(1, col4));
-            assertTrue(sm.isSelected(1, col3));
-        }
+        assertTrue(sm.isSelected(1, col4));
+        assertTrue(sm.isSelected(1, col3));
+        assertTrue(sm.isSelected(1, col2));
+        assertTrue(debug(), sm.isSelected(1, col1));
+        assertFalse(sm.isSelected(1, col0));
     }
 
     @Test public void test_rt18488_selectToRight() {
@@ -1596,36 +1505,18 @@ public class TableViewKeyInputTest {
         keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (1, col3)
         keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (1, col4)
         keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (1, col5)
-
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            assertTrue(sm.isSelected(1, col4));
-            assertTrue(sm.isSelected(1, col3));
-            assertTrue(sm.isSelected(1, col2));
-            assertTrue(sm.isSelected(1, col1));
-            assertTrue(sm.isSelected(1, col0));
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            assertFalse(sm.isSelected(1, col4));
-            assertFalse(sm.isSelected(1, col3));
-            assertFalse(sm.isSelected(1, col2));
-            assertFalse(sm.isSelected(1, col1));
-            assertTrue(sm.isSelected(1, col0));
-        }
+        assertTrue(sm.isSelected(1, col4));
+        assertTrue(sm.isSelected(1, col3));
+        assertTrue(sm.isSelected(1, col2));
+        assertTrue(sm.isSelected(1, col1));
+        assertTrue(sm.isSelected(1, col0));
 
         keyboard.doLeftArrowPress(KeyModifier.SHIFT);   // deselect (1, col5)
-
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            assertFalse(sm.isSelected(1, col4));
-            assertTrue(sm.isSelected(1, col3));
-            assertTrue(sm.isSelected(1, col2));
-            assertTrue(sm.isSelected(1, col1));
-            assertTrue(sm.isSelected(1, col0));
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            assertFalse(sm.isSelected(1, col4));
-            assertFalse(sm.isSelected(1, col3));
-            assertFalse(sm.isSelected(1, col2));
-            assertTrue(sm.isSelected(1, col1));
-            assertTrue(sm.isSelected(1, col0));
-        }
+        assertFalse(sm.isSelected(1, col4));
+        assertTrue(sm.isSelected(1, col3));
+        assertTrue(sm.isSelected(1, col2));
+        assertTrue(sm.isSelected(1, col1));
+        assertTrue(sm.isSelected(1, col0));
     }
 
     @Test public void test_rt18488_comment1() {
@@ -1638,124 +1529,62 @@ public class TableViewKeyInputTest {
         keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (1, col5)
         keyboard.doDownArrowPress(KeyModifier.SHIFT);    // select (2, col5)
 
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            assertTrue(sm.isSelected(2, col4));
-            assertTrue(sm.isSelected(1, col4));
-            assertTrue(sm.isSelected(1, col3));
-            assertTrue(sm.isSelected(1, col2));
-            assertTrue(sm.isSelected(1, col1));
-            assertTrue(sm.isSelected(1, col0));
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT)  {
-            assertFalse(sm.isSelected(1, col4));
-            assertFalse(sm.isSelected(1, col3));
-            assertFalse(sm.isSelected(1, col2));
-            assertFalse(sm.isSelected(1, col1));
-            assertTrue(sm.isSelected(1, col0));
-            assertTrue(sm.isSelected(2, col0));
-        }
+        assertTrue(sm.isSelected(2, col4));
+        assertTrue(sm.isSelected(1, col4));
+        assertTrue(sm.isSelected(1, col3));
+        assertTrue(sm.isSelected(1, col2));
+        assertTrue(sm.isSelected(1, col1));
+        assertTrue(sm.isSelected(1, col0));
 
         keyboard.doUpArrowPress(KeyModifier.SHIFT);     // deselect (2, col5)
-
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            assertFalse(sm.isSelected(2, col4));
-            assertTrue(sm.isSelected(1, col4));
-            assertTrue(sm.isSelected(1, col3));
-            assertTrue(sm.isSelected(1, col2));
-            assertTrue(sm.isSelected(1, col1));
-            assertTrue(sm.isSelected(1, col0));
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT)  {
-            assertFalse(sm.isSelected(1, col4));
-            assertFalse(sm.isSelected(1, col3));
-            assertFalse(sm.isSelected(1, col2));
-            assertFalse(sm.isSelected(1, col1));
-            assertTrue(sm.isSelected(1, col0));
-            assertFalse(sm.isSelected(2, col0));
-        }
+        assertFalse(sm.isSelected(2, col4));
+        assertTrue(sm.isSelected(1, col4));
+        assertTrue(sm.isSelected(1, col3));
+        assertTrue(sm.isSelected(1, col2));
+        assertTrue(sm.isSelected(1, col1));
+        assertTrue(sm.isSelected(1, col0));
     }
 
     @Test public void test_rt18536_positive_horizontal() {
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            // Test shift selection when focus is elsewhere (so as to select a range)
-            sm.setCellSelectionEnabled(true);
-            sm.clearAndSelect(1, col0);
+        // Test shift selection when focus is elsewhere (so as to select a range)
+        sm.setCellSelectionEnabled(true);
+        sm.clearAndSelect(1, col0);
 
-            // move focus by holding down ctrl button
-            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col2)
-            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col3)
-            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col4)
-            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col5)
-            assertTrue(fm.isFocused(1, col4));
+        // move focus by holding down ctrl button
+        keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col2)
+        keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col3)
+        keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col4)
+        keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col5)
+        assertTrue(fm.isFocused(1, col4));
 
-            // press shift + space to select all cells between (1, col1) and (1, col5)
-            keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
-            assertTrue(sm.isSelected(1, col4));
-            assertTrue(debug(), sm.isSelected(1, col3));
-            assertTrue(sm.isSelected(1, col2));
-            assertTrue(sm.isSelected(1, col1));
-            assertTrue(sm.isSelected(1, col0));
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            // Test shift selection when focus is elsewhere (so as to select a range)
-            sm.setCellSelectionEnabled(true);
-            sm.clearAndSelect(1, col4);
-
-            // move focus by holding down ctrl button
-            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col3)
-            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col2)
-            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col1)
-            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col0)
-            assertTrue(fm.isFocused(1, col0));
-
-            // press shift + space to select all cells between (1, col1) and (1, col5)
-            keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
-            assertTrue(sm.isSelected(1, col0));
-            assertTrue(debug(), sm.isSelected(1, col3));
-            assertTrue(sm.isSelected(1, col2));
-            assertTrue(sm.isSelected(1, col1));
-            assertTrue(sm.isSelected(1, col0));
-        }
+        // press shift + space to select all cells between (1, col1) and (1, col5)
+        keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
+        assertTrue(sm.isSelected(1, col4));
+        assertTrue(debug(), sm.isSelected(1, col3));
+        assertTrue(sm.isSelected(1, col2));
+        assertTrue(sm.isSelected(1, col1));
+        assertTrue(sm.isSelected(1, col0));
     }
 
     @Test public void test_rt18536_negative_horizontal() {
+        // Test shift selection when focus is elsewhere (so as to select a range)
+        sm.setCellSelectionEnabled(true);
+        sm.clearAndSelect(1, col4);
 
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            // Test shift selection when focus is elsewhere (so as to select a range)
-            sm.setCellSelectionEnabled(true);
-            sm.clearAndSelect(1, col4);
+        // move focus by holding down ctrl button
+        keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col4)
+        keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col3)
+        keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col2)
+        keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col1)
+        assertTrue(fm.isFocused(1, col0));
 
-            // move focus by holding down ctrl button
-            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col4)
-            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col3)
-            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col2)
-            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col1)
-            assertTrue(fm.isFocused(1, col0));
-
-            // press shift + space to select all cells between (1, col1) and (1, col5)
-            keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
-            assertTrue(debug(), sm.isSelected(1, col4));
-            assertTrue(sm.isSelected(1, col3));
-            assertTrue(sm.isSelected(1, col2));
-            assertTrue(sm.isSelected(1, col1));
-            assertTrue(sm.isSelected(1, col0));
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            // Test shift selection when focus is elsewhere (so as to select a range)
-            sm.setCellSelectionEnabled(true);
-            sm.clearAndSelect(1, col0);
-
-            // move focus by holding down ctrl button
-            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col1)
-            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col2)
-            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col3)
-            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col4)
-            assertTrue(fm.isFocused(1, col4));
-
-            // press shift + space to select all cells between (1, col1) and (1, col5)
-            keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
-            assertTrue(debug(), sm.isSelected(1, col0));
-            assertTrue(sm.isSelected(1, col3));
-            assertTrue(sm.isSelected(1, col2));
-            assertTrue(sm.isSelected(1, col1));
-            assertTrue(sm.isSelected(1, col0));
-        }
+        // press shift + space to select all cells between (1, col1) and (1, col5)
+        keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
+        assertTrue(debug(), sm.isSelected(1, col4));
+        assertTrue(sm.isSelected(1, col3));
+        assertTrue(sm.isSelected(1, col2));
+        assertTrue(sm.isSelected(1, col1));
+        assertTrue(sm.isSelected(1, col0));
     }
 
     //
@@ -2803,11 +2632,11 @@ public class TableViewKeyInputTest {
 
         sm.setCellSelectionEnabled(true);
 
-        sm.clearAndSelect(6, col1);
+        sm.clearAndSelect(6, col0);
         assertEquals(6, getAnchor().getRow());
-        assertEquals(1, getAnchor().getColumn());
-        assertTrue(fm.isFocused(6, col1));
-        assertTrue(sm.isSelected(6, col1));
+        assertEquals(0, getAnchor().getColumn());
+        assertTrue(fm.isFocused(6, col0));
+        assertTrue(sm.isSelected(6, col0));
 
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.getShortcutKey());
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.getShortcutKey());
@@ -2815,32 +2644,18 @@ public class TableViewKeyInputTest {
         keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.getShortcutKey());
         Toolkit.getToolkit().firePulse();
         assertEquals(6, getAnchor().getRow());
-        assertEquals(1, getAnchor().getColumn());
-
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            assertTrue(fm.isFocused(3, col2));
-            assertTrue(sm.isSelected(6, col1));
-            assertFalse(sm.isSelected(3, col2));
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            assertTrue(fm.isFocused(3, col0));
-            assertTrue(sm.isSelected(6, col1));
-            assertFalse(sm.isSelected(3, col0));
-        }
+        assertEquals(0, getAnchor().getColumn());
+        assertTrue(fm.isFocused(3, col1));
+        assertTrue(sm.isSelected(6, col0));
+        assertFalse(sm.isSelected(3, col1));
 
         keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
         Toolkit.getToolkit().firePulse();
         assertEquals(6, getAnchor().getRow());
-        assertEquals(1, getAnchor().getColumn());
-
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            assertTrue(fm.isFocused(3, col2));
-            assertTrue(sm.isSelected(3, col2));
-            assertTrue(sm.isSelected(6, col1));
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            assertTrue(fm.isFocused(3, col0));
-            assertTrue(sm.isSelected(3, col0));
-            assertTrue(sm.isSelected(6, col1));
-        }
+        assertEquals(0, getAnchor().getColumn());
+        assertTrue(fm.isFocused(3, col1));
+        assertTrue(sm.isSelected(3, col1));
+        assertTrue(sm.isSelected(6, col0));
     }
 
     @Test public void test_rt33613_up_multipleColumn_left() {
@@ -2865,31 +2680,17 @@ public class TableViewKeyInputTest {
         Toolkit.getToolkit().firePulse();
         assertEquals(6, getAnchor().getRow());
         assertEquals(1, getAnchor().getColumn());
-
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            assertTrue(fm.isFocused(3, col0));
-            assertTrue(sm.isSelected(6, col1));
-            assertFalse(sm.isSelected(3, col0));
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            assertTrue(fm.isFocused(3, col2));
-            assertTrue(sm.isSelected(6, col1));
-            assertFalse(sm.isSelected(3, col2));
-        }
+        assertTrue(fm.isFocused(3, col0));
+        assertTrue(sm.isSelected(6, col1));
+        assertFalse(sm.isSelected(3, col0));
 
         keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
         Toolkit.getToolkit().firePulse();
         assertEquals(6, getAnchor().getRow());
         assertEquals(1, getAnchor().getColumn());
-
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            assertTrue(fm.isFocused(3, col0));
-            assertTrue(sm.isSelected(3, col0));
-            assertTrue(sm.isSelected(6, col1));
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            assertTrue(fm.isFocused(3, col2));
-            assertTrue(sm.isSelected(3, col2));
-            assertTrue(sm.isSelected(6, col1));
-        }
+        assertTrue(fm.isFocused(3, col0));
+        assertTrue(sm.isSelected(3, col0));
+        assertTrue(sm.isSelected(6, col1));
     }
 
     @Test public void test_rt33613_down_oneColumn() {
@@ -2933,11 +2734,11 @@ public class TableViewKeyInputTest {
 
         sm.setCellSelectionEnabled(true);
 
-        sm.clearAndSelect(3, col1);
+        sm.clearAndSelect(3, col0);
         assertEquals(3, getAnchor().getRow());
-        assertEquals(1, getAnchor().getColumn());
-        assertTrue(fm.isFocused(3, col1));
-        assertTrue(sm.isSelected(3, col1));
+        assertEquals(0, getAnchor().getColumn());
+        assertTrue(fm.isFocused(3, col0));
+        assertTrue(sm.isSelected(3, col0));
 
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.getShortcutKey());
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.getShortcutKey());
@@ -2945,32 +2746,18 @@ public class TableViewKeyInputTest {
         keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.getShortcutKey());
         Toolkit.getToolkit().firePulse();
         assertEquals(3, getAnchor().getRow());
-        assertEquals(1, getAnchor().getColumn());
-
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            assertTrue(fm.isFocused(6, col2));
-            assertTrue(sm.isSelected(3, col1));
-            assertFalse(sm.isSelected(6, col2));
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            assertTrue(fm.isFocused(6, col0));
-            assertTrue(sm.isSelected(3, col1));
-            assertFalse(sm.isSelected(6, col0));
-        }
+        assertEquals(0, getAnchor().getColumn());
+        assertTrue(fm.isFocused(6, col1));
+        assertTrue(sm.isSelected(3, col0));
+        assertFalse(sm.isSelected(6, col1));
 
         keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
         Toolkit.getToolkit().firePulse();
         assertEquals(3, getAnchor().getRow());
-        assertEquals(1, getAnchor().getColumn());
-
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            assertTrue(fm.isFocused(6, col2));
-            assertTrue(sm.isSelected(6, col2));
-            assertTrue(sm.isSelected(3, col1));
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            assertTrue(fm.isFocused(6, col0));
-            assertTrue(sm.isSelected(6, col0));
-            assertTrue(sm.isSelected(3, col1));
-        }
+        assertEquals(0, getAnchor().getColumn());
+        assertTrue(fm.isFocused(6, col1));
+        assertTrue(sm.isSelected(6, col1));
+        assertTrue(sm.isSelected(3, col0));
     }
 
     @Test public void test_rt33613_down_multipleColumn_left() {
@@ -2994,34 +2781,19 @@ public class TableViewKeyInputTest {
         keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.getShortcutKey());
         assertEquals(3, getAnchor().getRow());
         assertEquals(1, getAnchor().getColumn());
-
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            assertTrue(fm.isFocused(6, col0));
-            assertTrue(sm.isSelected(3, col1));
-            assertFalse(sm.isSelected(6, col0));
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            assertTrue(fm.isFocused(6, col2));
-            assertTrue(sm.isSelected(3, col1));
-            assertFalse(sm.isSelected(6, col2));
-        }
+        assertTrue(fm.isFocused(6, col0));
+        assertTrue(sm.isSelected(3, col1));
+        assertFalse(sm.isSelected(6, col0));
 
         keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
         assertEquals(3, getAnchor().getRow());
         assertEquals(1, getAnchor().getColumn());
-
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            assertTrue(fm.isFocused(6, col0));
-            assertTrue(sm.isSelected(6, col0));
-            assertTrue(sm.isSelected(3, col1));
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            assertTrue(fm.isFocused(6, col2));
-            assertTrue(sm.isSelected(6, col2));
-            assertTrue(sm.isSelected(3, col1));
-        }
+        assertTrue(fm.isFocused(6, col0));
+        assertTrue(sm.isSelected(6, col0));
+        assertTrue(sm.isSelected(3, col1));
     }
 
     @Test public void test_rt18439() {
-
         final int items = 10;
         tableView.getItems().clear();
         for (int i = 0; i < items; i++) {
@@ -3031,138 +2803,70 @@ public class TableViewKeyInputTest {
         sm.setCellSelectionEnabled(true);
         sm.setSelectionMode(SelectionMode.MULTIPLE);
 
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            sm.clearAndSelect(0, col0);
+        sm.clearAndSelect(0, col0);
 
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 4
-            assertEquals(0, getAnchor().getRow());
-            assertEquals(0, getAnchor().getColumn());              // anchor does not move
-            assertTrue(fm.isFocused(0, col4));
-            assertTrue(sm.isSelected(0, col0));
-            assertTrue(sm.isSelected(0, col1));
-            assertTrue(sm.isSelected(0, col2));
-            assertTrue(sm.isSelected(0, col3));
-            assertTrue(sm.isSelected(0, col4));
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 4
+        assertEquals(0, getAnchor().getRow());
+        assertEquals(0, getAnchor().getColumn());              // anchor does not move
+        assertTrue(fm.isFocused(0, col4));
+        assertTrue(sm.isSelected(0, col0));
+        assertTrue(sm.isSelected(0, col1));
+        assertTrue(sm.isSelected(0, col2));
+        assertTrue(sm.isSelected(0, col3));
+        assertTrue(sm.isSelected(0, col4));
 
-            keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 1
-            keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 2
-            assertEquals(0, getAnchor().getRow());
-            assertEquals(0, getAnchor().getColumn());             // anchor does not move
-            assertTrue(fm.isFocused(2, col4));
-            assertTrue(sm.isSelected(0, col0));
-            assertTrue(sm.isSelected(0, col1));
-            assertTrue(sm.isSelected(0, col2));
-            assertTrue(sm.isSelected(0, col3));
-            assertTrue(sm.isSelected(0, col4));
-            assertTrue(sm.isSelected(1, col4));
-            assertTrue(sm.isSelected(2, col4));
+        keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 1
+        keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 2
+        assertEquals(0, getAnchor().getRow());
+        assertEquals(0, getAnchor().getColumn());             // anchor does not move
+        assertTrue(fm.isFocused(2, col4));
+        assertTrue(sm.isSelected(0, col0));
+        assertTrue(sm.isSelected(0, col1));
+        assertTrue(sm.isSelected(0, col2));
+        assertTrue(sm.isSelected(0, col3));
+        assertTrue(sm.isSelected(0, col4));
+        assertTrue(sm.isSelected(1, col4));
+        assertTrue(sm.isSelected(2, col4));
 
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 0
-            assertEquals(0, getAnchor().getRow());
-            assertEquals(0, getAnchor().getColumn());             // anchor does not move
-            assertTrue(fm.isFocused(2, col0));
-            assertTrue(sm.isSelected(0, col0));
-            assertTrue(sm.isSelected(0, col1));
-            assertTrue(sm.isSelected(0, col2));
-            assertTrue(sm.isSelected(0, col3));
-            assertTrue(sm.isSelected(0, col4));
-            assertTrue(sm.isSelected(1, col4));
-            assertTrue(sm.isSelected(2, col4));
-            assertTrue(sm.isSelected(2, col3));
-            assertTrue(sm.isSelected(2, col2));
-            assertTrue(sm.isSelected(2, col1));
-            assertTrue(sm.isSelected(2, col0));
+        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
+        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
+        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
+        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 0
+        assertEquals(0, getAnchor().getRow());
+        assertEquals(0, getAnchor().getColumn());             // anchor does not move
+        assertTrue(fm.isFocused(2, col0));
+        assertTrue(sm.isSelected(0, col0));
+        assertTrue(sm.isSelected(0, col1));
+        assertTrue(sm.isSelected(0, col2));
+        assertTrue(sm.isSelected(0, col3));
+        assertTrue(sm.isSelected(0, col4));
+        assertTrue(sm.isSelected(1, col4));
+        assertTrue(sm.isSelected(2, col4));
+        assertTrue(sm.isSelected(2, col3));
+        assertTrue(sm.isSelected(2, col2));
+        assertTrue(sm.isSelected(2, col1));
+        assertTrue(sm.isSelected(2, col0));
 
-            keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT); // row 1
-            keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT); // row 0
-            assertEquals(0, getAnchor().getRow());
-            assertEquals(0, getAnchor().getColumn());           // anchor does not move
-            assertTrue(fm.isFocused(0, col0));
-            assertFalse(sm.isSelected(0, col0));                // we've gone right around - this cell is now unselected
-            assertTrue(sm.isSelected(0, col1));
-            assertTrue(sm.isSelected(0, col2));
-            assertTrue(sm.isSelected(0, col3));
-            assertTrue(sm.isSelected(0, col4));
-            assertTrue(sm.isSelected(1, col4));
-            assertTrue(sm.isSelected(2, col4));
-            assertTrue(sm.isSelected(2, col3));
-            assertTrue(sm.isSelected(2, col2));
-            assertTrue(sm.isSelected(2, col1));
-            assertTrue(sm.isSelected(2, col0));
-            assertTrue(sm.isSelected(1, col0));
-        }
-        else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            sm.clearAndSelect(0, col4);
-
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 0
-            assertEquals(0, getAnchor().getRow());
-            assertEquals(4, getAnchor().getColumn());              // anchor does not move
-            assertTrue(fm.isFocused(0, col0));
-            assertTrue(sm.isSelected(0, col4));
-            assertTrue(sm.isSelected(0, col3));
-            assertTrue(sm.isSelected(0, col2));
-            assertTrue(sm.isSelected(0, col1));
-            assertTrue(sm.isSelected(0, col0));
-
-            keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 1
-            keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 2
-            assertEquals(0, getAnchor().getRow());
-            assertEquals(4, getAnchor().getColumn());             // anchor does not move
-            assertTrue(fm.isFocused(2, col0));
-            assertTrue(sm.isSelected(0, col4));
-            assertTrue(sm.isSelected(0, col3));
-            assertTrue(sm.isSelected(0, col2));
-            assertTrue(sm.isSelected(0, col1));
-            assertTrue(sm.isSelected(0, col0));
-            assertTrue(sm.isSelected(1, col0));
-            assertTrue(sm.isSelected(2, col0));
-
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 0
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
-            assertEquals(0, getAnchor().getRow());
-            assertEquals(4, getAnchor().getColumn());             // anchor does not move
-            assertTrue(fm.isFocused(2, col4));
-            assertTrue(sm.isSelected(0, col0));
-            assertTrue(sm.isSelected(0, col1));
-            assertTrue(sm.isSelected(0, col2));
-            assertTrue(sm.isSelected(0, col3));
-            assertTrue(sm.isSelected(0, col4));
-            assertTrue(sm.isSelected(1, col0));
-            assertTrue(sm.isSelected(2, col4));
-            assertTrue(sm.isSelected(2, col3));
-            assertTrue(sm.isSelected(2, col2));
-            assertTrue(sm.isSelected(2, col1));
-            assertTrue(sm.isSelected(2, col0));
-
-            keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT); // row 0
-            keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT); // row 1
-            assertEquals(0, getAnchor().getRow());
-            assertEquals(4, getAnchor().getColumn());           // anchor does not move
-            assertTrue(fm.isFocused(0, col4));
-            assertFalse(sm.isSelected(0, col4));                // we've gone right around - this cell is now unselected
-            assertTrue(sm.isSelected(0, col1));
-            assertTrue(sm.isSelected(0, col2));
-            assertTrue(sm.isSelected(0, col3));
-            assertTrue(sm.isSelected(0, col0));
-            assertTrue(sm.isSelected(1, col4));
-            assertTrue(sm.isSelected(2, col4));
-            assertTrue(sm.isSelected(2, col3));
-            assertTrue(sm.isSelected(2, col2));
-            assertTrue(sm.isSelected(2, col1));
-            assertTrue(sm.isSelected(2, col0));
-            assertTrue(sm.isSelected(1, col0));
-        }
+        keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT); // row 1
+        keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT); // row 0
+        assertEquals(0, getAnchor().getRow());
+        assertEquals(0, getAnchor().getColumn());           // anchor does not move
+        assertTrue(fm.isFocused(0, col0));
+        assertFalse(sm.isSelected(0, col0));                // we've gone right around - this cell is now unselected
+        assertTrue(sm.isSelected(0, col1));
+        assertTrue(sm.isSelected(0, col2));
+        assertTrue(sm.isSelected(0, col3));
+        assertTrue(sm.isSelected(0, col4));
+        assertTrue(sm.isSelected(1, col4));
+        assertTrue(sm.isSelected(2, col4));
+        assertTrue(sm.isSelected(2, col3));
+        assertTrue(sm.isSelected(2, col2));
+        assertTrue(sm.isSelected(2, col1));
+        assertTrue(sm.isSelected(2, col0));
+        assertTrue(sm.isSelected(1, col0));
     }
 
     // this is an extension of the previous test, where we had a bug where going up resulted in all cells between the
@@ -3180,34 +2884,21 @@ public class TableViewKeyInputTest {
 
         sm.clearAndSelect(0, col0);
 
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 4
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 4
-        }
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 4
 
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 1
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 2
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 3
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 4
 
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 0
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 4
-        }
+        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
+        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
+        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
+        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 0
+
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT); // row 3
         assertEquals(0, getAnchor().getRow());
         assertEquals(0, getAnchor().getColumn());           // anchor does not move
@@ -3249,28 +2940,17 @@ public class TableViewKeyInputTest {
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 3
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 4
 
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 0
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 0
-        }
+        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
+        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
+        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
+        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 0
 
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT);   // row 3
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT);   // row 2
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT);   // row 1
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT);   // row 0
 
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
-        }
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
         assertEquals(0, getAnchor().getRow());
         assertEquals(4, getAnchor().getColumn());           // anchor does not move
         assertTrue(fm.isFocused(0, col1));
@@ -3306,34 +2986,20 @@ public class TableViewKeyInputTest {
 
         sm.clearAndSelect(4, col4);
 
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 0
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 0
-        }
+        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
+        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
+        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
+        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 0
 
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT);   // row 3
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT);   // row 2
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT);   // row 1
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT);   // row 0
 
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 4
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 4
-        }
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 4
 
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 1
         assertEquals(4, getAnchor().getRow());
@@ -3376,28 +3042,17 @@ public class TableViewKeyInputTest {
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT); // row 1
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT); // row 0
 
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT);   // col 1
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT);   // col 2
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT);   // col 3
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT);   // col 4
-        } if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT);   // col 1
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT);   // col 2
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT);   // col 3
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT);   // col 4
-        }
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT);   // col 1
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT);   // col 2
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT);   // col 3
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT);   // col 4
 
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 1
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 2
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 3
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 4
 
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
-        } if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
-        }
+        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
         assertEquals(4, getAnchor().getRow());
         assertEquals(0, getAnchor().getColumn());           // anchor does not move
         assertTrue(fm.isFocused(4, col3));
@@ -4363,59 +4018,31 @@ public class TableViewKeyInputTest {
     }
 
     @Test public void test_rt_18440_goLeft() {
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            test_rt_18440(KeyCode.LEFT, 3, false, colIndex -> {
-                keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
-                return colIndex - 1;
-            });
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            test_rt_18440(KeyCode.LEFT, 0, false, colIndex -> {
-                keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
-                return colIndex + 1;
-            });
-        }
+        test_rt_18440(KeyCode.LEFT, 3, false, colIndex -> {
+            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
+            return colIndex - 1;
+        });
     }
 
     @Test public void test_rt_18440_goLeft_toEnd() {
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            test_rt_18440(KeyCode.LEFT, 3, true, colIndex -> {
-                keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
-                return colIndex - 1;
-            });
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            test_rt_18440(KeyCode.LEFT, 0, true, colIndex -> {
-                keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
-                return colIndex + 1;
-            });
-        }
+        test_rt_18440(KeyCode.LEFT, 3, true, colIndex -> {
+            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
+            return colIndex - 1;
+        });
     }
 
     @Test public void test_rt_18440_goRight() {
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            test_rt_18440(KeyCode.RIGHT, 0, false, colIndex -> {
-                keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
-                return colIndex + 1;
-            });
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            test_rt_18440(KeyCode.RIGHT, 3, false, colIndex -> {
-                keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
-                return colIndex - 1;
-            });
-        }
+        test_rt_18440(KeyCode.RIGHT, 0, false, colIndex -> {
+            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
+            return colIndex + 1;
+        });
     }
 
     @Test public void test_rt_18440_goRight_toEnd() {
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            test_rt_18440(KeyCode.RIGHT, 0, true, colIndex -> {
-                keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
-                return colIndex + 1;
-            });
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            test_rt_18440(KeyCode.RIGHT, 3, true, colIndex -> {
-                keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
-                return colIndex - 1;
-            });
-        }
+        test_rt_18440(KeyCode.RIGHT, 0, true, colIndex -> {
+            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
+            return colIndex + 1;
+        });
     }
 
     private void test_rt_18440(KeyCode direction, int startColumn, boolean goToEnd, Function<Integer, Integer> r) {
@@ -4472,21 +4099,13 @@ public class TableViewKeyInputTest {
             assertEquals(tableView.getColumns().get(expectedColumn), fm.getFocusedCell().getTableColumn());
         }
 
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            expectedColumn = direction == KeyCode.RIGHT ? 3 : 0;
-            keyboard.doKeyPress(direction, KeyModifier.SHIFT);
-            assertEquals(0, sm.getSelectedIndex());
-            assertEquals(debug(), 4, sm.getSelectedCells().size());
-            assertEquals(0, fm.getFocusedIndex());
-            assertEquals(tableView.getColumns().get(expectedColumn), fm.getFocusedCell().getTableColumn());
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            expectedColumn = direction == KeyCode.LEFT ? 3 : 0;
-            keyboard.doKeyPress(direction, KeyModifier.SHIFT);
-            assertEquals(0, sm.getSelectedIndex());
-            assertEquals(debug(), 4, sm.getSelectedCells().size());
-            assertEquals(0, fm.getFocusedIndex());
-            assertEquals(tableView.getColumns().get(expectedColumn), fm.getFocusedCell().getTableColumn());
-        }
+        expectedColumn = direction == KeyCode.RIGHT ? 3 : 0;
+        keyboard.doKeyPress(direction, KeyModifier.SHIFT);
+        assertEquals(0, sm.getSelectedIndex());
+        assertEquals(debug(), 4, sm.getSelectedCells().size());
+        assertEquals(0, fm.getFocusedIndex());
+        assertEquals(tableView.getColumns().get(expectedColumn), fm.getFocusedCell().getTableColumn());
+
         sl.dispose();
     }
 
@@ -4599,33 +4218,17 @@ public class TableViewKeyInputTest {
     }
 
     @Test public void test_rt_39792_goLeft_goPastEnd() {
-
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            test_rt_39792(3, colIndex -> {
-                keyboard.doLeftArrowPress(KeyModifier.SHIFT);
-                return colIndex - 1;
-            });
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            test_rt_39792(0, colIndex -> {
-                keyboard.doLeftArrowPress(KeyModifier.SHIFT);
-                return colIndex + 1;
-            });
-        }
+        test_rt_39792(3, colIndex -> {
+            keyboard.doLeftArrowPress(KeyModifier.SHIFT);
+            return colIndex - 1;
+        });
     }
 
     @Test public void test_rt_39792_goRight_goPastEnd() {
-
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            test_rt_39792(0, colIndex -> {
-                keyboard.doRightArrowPress(KeyModifier.SHIFT);
-                return colIndex + 1;
-            });
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            test_rt_39792(3, colIndex -> {
-                keyboard.doRightArrowPress(KeyModifier.SHIFT);
-                return colIndex - 1;
-            });
-        }
+        test_rt_39792(0, colIndex -> {
+            keyboard.doRightArrowPress(KeyModifier.SHIFT);
+            return colIndex + 1;
+        });
     }
 
     private void test_rt_39792(int startColumn, Function<Integer, Integer> r) {
@@ -4710,67 +4313,5 @@ public class TableViewKeyInputTest {
         keyboard.doUpArrowPress();
 
         assertEquals(0, tableView.getSelectionModel().getSelectedIndex());
-    }
-
-    @Test public void test_dynamic_NodeOrientation_change() {
-
-        sm.setCellSelectionEnabled(true);
-        sm.clearAndSelect(1, col2);
-
-        keyboard.doLeftArrowPress();
-
-        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
-            assertFalse(sm.isSelected(1, col0));
-            assertTrue(sm.isSelected(1, col1));
-            assertFalse(sm.isSelected(1, col2));
-            assertFalse(sm.isSelected(1, col3));
-            assertFalse(sm.isSelected(1, col4));
-
-            tableView.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
-            orientation = NodeOrientation.RIGHT_TO_LEFT;
-
-        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
-            assertFalse(sm.isSelected(1, col0));
-            assertFalse(sm.isSelected(1, col1));
-            assertFalse(sm.isSelected(1, col2));
-            assertTrue(sm.isSelected(1, col3));
-            assertFalse(sm.isSelected(1, col4));
-
-            tableView.setNodeOrientation(NodeOrientation.LEFT_TO_RIGHT);
-            orientation = NodeOrientation.LEFT_TO_RIGHT;
-         }
-
-        keyboard.doRightArrowPress();
-
-        if (tableView.getNodeOrientation() == NodeOrientation.LEFT_TO_RIGHT) {
-            assertFalse(sm.isSelected(1, col0));
-            assertFalse(sm.isSelected(1, col1));
-            assertFalse(sm.isSelected(1, col2));
-            assertFalse(sm.isSelected(1, col3));
-            assertTrue(sm.isSelected(1, col4));
-
-            keyboard.doLeftArrowPress(KeyModifier.SHIFT);
-
-            assertFalse(sm.isSelected(1, col0));
-            assertFalse(sm.isSelected(1, col1));
-            assertFalse(sm.isSelected(1, col2));
-            assertTrue(sm.isSelected(1, col3));
-            assertTrue(sm.isSelected(1, col4));
-
-        } else if (tableView.getNodeOrientation() == NodeOrientation.RIGHT_TO_LEFT) {
-            assertTrue(sm.isSelected(1, col0));
-            assertFalse(sm.isSelected(1, col1));
-            assertFalse(sm.isSelected(1, col2));
-            assertFalse(sm.isSelected(1, col3));
-            assertFalse(sm.isSelected(1, col4));
-
-            keyboard.doLeftArrowPress(KeyModifier.SHIFT);
-
-            assertTrue(sm.isSelected(1, col0));
-            assertTrue(sm.isSelected(1, col1));
-            assertFalse(sm.isSelected(1, col2));
-            assertFalse(sm.isSelected(1, col3));
-            assertFalse(sm.isSelected(1, col4));
-        }
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewKeyInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewKeyInputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,8 @@ import javafx.scene.control.Button;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.HBox;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
 
@@ -57,18 +59,31 @@ import javafx.scene.control.TableFocusModel;
 import javafx.scene.control.TablePosition;
 import javafx.scene.control.TableSelectionModel;
 import javafx.scene.control.TableView;
+import javafx.geometry.NodeOrientation;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
 import static org.junit.Assert.fail;
 
+@RunWith(Parameterized.class)
 public class TableViewKeyInputTest {
+    @Parameterized.Parameters public static Collection implementations() {
+        return Arrays.asList(new Object[][]{
+                {NodeOrientation.LEFT_TO_RIGHT},
+                {NodeOrientation.RIGHT_TO_LEFT}
+        });
+    }
+
     private TableView<String> tableView;
 //    private TableSelectionModel<String> sm;
     private TableView.TableViewSelectionModel<String> sm;
@@ -84,8 +99,15 @@ public class TableViewKeyInputTest {
     private TableColumn<String, String> col3;
     private TableColumn<String, String> col4;
 
+    private NodeOrientation orientation;
+
+    public TableViewKeyInputTest(NodeOrientation val) {
+        orientation = val;
+    }
+
     @Before public void setup() {
         tableView = new TableView<String>();
+        tableView.setNodeOrientation(orientation);
         sm = tableView.getSelectionModel();
         fm = tableView.getFocusModel();
 
@@ -1109,8 +1131,14 @@ public class TableViewKeyInputTest {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.setCellSelectionEnabled(true);
         sm.select(0, col0);
-        keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
-        keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
+
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
+            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
+            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
+        }
         keyboard.doKeyPress(KeyCode.SPACE,
                 KeyModifier.getShortcutKey(),
                 (Utils.isMac()  ? KeyModifier.CTRL : null));
@@ -1118,8 +1146,13 @@ public class TableViewKeyInputTest {
         assertTrue(sm.isSelected(0,col2));
         assertTrue(isAnchor(0,2));
 
-        keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        }
         assertTrue(sm.isSelected(0,col0));
         assertTrue(sm.isSelected(0,col2));
         assertTrue(sm.isSelected(0,col3));
@@ -1132,8 +1165,13 @@ public class TableViewKeyInputTest {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.setCellSelectionEnabled(true);
         sm.select(0, col4);
-        keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
-        keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
+            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
+            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
+        }
         keyboard.doKeyPress(KeyCode.SPACE,
                 KeyModifier.getShortcutKey(),
                 (Utils.isMac()  ? KeyModifier.CTRL : null));
@@ -1141,8 +1179,13 @@ public class TableViewKeyInputTest {
         assertTrue(sm.isSelected(0,col2));
         assertTrue(isAnchor(0,2));
 
-        keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        }
         assertTrue(sm.isSelected(0,col0));
         assertTrue(sm.isSelected(0,col1));
         assertTrue(sm.isSelected(0,col2));
@@ -1155,8 +1198,13 @@ public class TableViewKeyInputTest {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.setCellSelectionEnabled(true);
         sm.select(0, col0);
-        keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
-        keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
+            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
+            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
+        }
         keyboard.doKeyPress(KeyCode.SPACE,
                 KeyModifier.getShortcutKey(),
                 (Utils.isMac()  ? KeyModifier.CTRL : null));
@@ -1164,17 +1212,28 @@ public class TableViewKeyInputTest {
         assertTrue(sm.isSelected(0,col2));
         assertTrue(isAnchor(0,2));
 
-        keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        }
         assertTrue(sm.isSelected(0,col0));
         assertTrue(sm.isSelected(0,col2));
         assertTrue(sm.isSelected(0,col3));
         assertTrue(sm.isSelected(0,col4));
         assertTrue(isAnchor(0,2));
 
-        keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        }
         assertTrue(sm.isSelected(0,col0));
         assertTrue(sm.isSelected(0,col1));
         assertTrue(sm.isSelected(0,col2));
@@ -1188,8 +1247,14 @@ public class TableViewKeyInputTest {
         sm.setSelectionMode(SelectionMode.MULTIPLE);
         sm.setCellSelectionEnabled(true);
         sm.select(0, col4);
-        keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
-        keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
+
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
+            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
+            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
+        }
         keyboard.doKeyPress(KeyCode.SPACE,
                 KeyModifier.getShortcutKey(),
                 (Utils.isMac()  ? KeyModifier.CTRL : null));
@@ -1197,17 +1262,28 @@ public class TableViewKeyInputTest {
         assertTrue(sm.isSelected(0,col2));
         assertTrue(isAnchor(0,2));
 
-        keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        }
         assertTrue(sm.isSelected(0,col0));
         assertTrue(sm.isSelected(0,col1));
         assertTrue(sm.isSelected(0,col2));
         assertTrue(sm.isSelected(0,col4));
         assertTrue(isAnchor(0,2));
 
-        keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
-        keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+            keyboard.doRightArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+            keyboard.doLeftArrowPress(KeyModifier.SHIFT, KeyModifier.getShortcutKey());
+        }
         assertTrue(sm.isSelected(0,col0));
         assertTrue(sm.isSelected(0,col1));
         assertTrue(sm.isSelected(0,col2));
@@ -1483,18 +1559,33 @@ public class TableViewKeyInputTest {
         keyboard.doLeftArrowPress(KeyModifier.SHIFT);   // select (1, col3)
         keyboard.doLeftArrowPress(KeyModifier.SHIFT);   // select (1, col2)
         keyboard.doLeftArrowPress(KeyModifier.SHIFT);   // select (1, col1)
-        assertTrue(sm.isSelected(1, col4));
-        assertTrue(sm.isSelected(1, col3));
-        assertTrue(sm.isSelected(1, col2));
-        assertTrue(sm.isSelected(1, col1));
-        assertTrue(sm.isSelected(1, col0));
+
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            assertTrue(sm.isSelected(1, col4));
+            assertTrue(sm.isSelected(1, col3));
+            assertTrue(sm.isSelected(1, col2));
+            assertTrue(sm.isSelected(1, col1));
+            assertTrue(sm.isSelected(1, col0));
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            assertTrue(sm.isSelected(1, col4));
+            assertFalse(sm.isSelected(1, col3));
+            assertFalse(sm.isSelected(1, col2));
+            assertFalse(sm.isSelected(1, col1));
+            assertFalse(sm.isSelected(1, col0));
+        }
 
         keyboard.doRightArrowPress(KeyModifier.SHIFT);   // deselect (1, col1)
-        assertTrue(sm.isSelected(1, col4));
-        assertTrue(sm.isSelected(1, col3));
-        assertTrue(sm.isSelected(1, col2));
-        assertTrue(debug(), sm.isSelected(1, col1));
-        assertFalse(sm.isSelected(1, col0));
+
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            assertTrue(sm.isSelected(1, col4));
+            assertTrue(sm.isSelected(1, col3));
+            assertTrue(sm.isSelected(1, col2));
+            assertTrue(debug(), sm.isSelected(1, col1));
+            assertFalse(sm.isSelected(1, col0));
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            assertTrue(sm.isSelected(1, col4));
+            assertTrue(sm.isSelected(1, col3));
+        }
     }
 
     @Test public void test_rt18488_selectToRight() {
@@ -1505,18 +1596,36 @@ public class TableViewKeyInputTest {
         keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (1, col3)
         keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (1, col4)
         keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (1, col5)
-        assertTrue(sm.isSelected(1, col4));
-        assertTrue(sm.isSelected(1, col3));
-        assertTrue(sm.isSelected(1, col2));
-        assertTrue(sm.isSelected(1, col1));
-        assertTrue(sm.isSelected(1, col0));
+
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            assertTrue(sm.isSelected(1, col4));
+            assertTrue(sm.isSelected(1, col3));
+            assertTrue(sm.isSelected(1, col2));
+            assertTrue(sm.isSelected(1, col1));
+            assertTrue(sm.isSelected(1, col0));
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            assertFalse(sm.isSelected(1, col4));
+            assertFalse(sm.isSelected(1, col3));
+            assertFalse(sm.isSelected(1, col2));
+            assertFalse(sm.isSelected(1, col1));
+            assertTrue(sm.isSelected(1, col0));
+        }
 
         keyboard.doLeftArrowPress(KeyModifier.SHIFT);   // deselect (1, col5)
-        assertFalse(sm.isSelected(1, col4));
-        assertTrue(sm.isSelected(1, col3));
-        assertTrue(sm.isSelected(1, col2));
-        assertTrue(sm.isSelected(1, col1));
-        assertTrue(sm.isSelected(1, col0));
+
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            assertFalse(sm.isSelected(1, col4));
+            assertTrue(sm.isSelected(1, col3));
+            assertTrue(sm.isSelected(1, col2));
+            assertTrue(sm.isSelected(1, col1));
+            assertTrue(sm.isSelected(1, col0));
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            assertFalse(sm.isSelected(1, col4));
+            assertFalse(sm.isSelected(1, col3));
+            assertFalse(sm.isSelected(1, col2));
+            assertTrue(sm.isSelected(1, col1));
+            assertTrue(sm.isSelected(1, col0));
+        }
     }
 
     @Test public void test_rt18488_comment1() {
@@ -1529,62 +1638,124 @@ public class TableViewKeyInputTest {
         keyboard.doRightArrowPress(KeyModifier.SHIFT);   // select (1, col5)
         keyboard.doDownArrowPress(KeyModifier.SHIFT);    // select (2, col5)
 
-        assertTrue(sm.isSelected(2, col4));
-        assertTrue(sm.isSelected(1, col4));
-        assertTrue(sm.isSelected(1, col3));
-        assertTrue(sm.isSelected(1, col2));
-        assertTrue(sm.isSelected(1, col1));
-        assertTrue(sm.isSelected(1, col0));
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            assertTrue(sm.isSelected(2, col4));
+            assertTrue(sm.isSelected(1, col4));
+            assertTrue(sm.isSelected(1, col3));
+            assertTrue(sm.isSelected(1, col2));
+            assertTrue(sm.isSelected(1, col1));
+            assertTrue(sm.isSelected(1, col0));
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT)  {
+            assertFalse(sm.isSelected(1, col4));
+            assertFalse(sm.isSelected(1, col3));
+            assertFalse(sm.isSelected(1, col2));
+            assertFalse(sm.isSelected(1, col1));
+            assertTrue(sm.isSelected(1, col0));
+            assertTrue(sm.isSelected(2, col0));
+        }
 
         keyboard.doUpArrowPress(KeyModifier.SHIFT);     // deselect (2, col5)
-        assertFalse(sm.isSelected(2, col4));
-        assertTrue(sm.isSelected(1, col4));
-        assertTrue(sm.isSelected(1, col3));
-        assertTrue(sm.isSelected(1, col2));
-        assertTrue(sm.isSelected(1, col1));
-        assertTrue(sm.isSelected(1, col0));
+
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            assertFalse(sm.isSelected(2, col4));
+            assertTrue(sm.isSelected(1, col4));
+            assertTrue(sm.isSelected(1, col3));
+            assertTrue(sm.isSelected(1, col2));
+            assertTrue(sm.isSelected(1, col1));
+            assertTrue(sm.isSelected(1, col0));
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT)  {
+            assertFalse(sm.isSelected(1, col4));
+            assertFalse(sm.isSelected(1, col3));
+            assertFalse(sm.isSelected(1, col2));
+            assertFalse(sm.isSelected(1, col1));
+            assertTrue(sm.isSelected(1, col0));
+            assertFalse(sm.isSelected(2, col0));
+        }
     }
 
     @Test public void test_rt18536_positive_horizontal() {
-        // Test shift selection when focus is elsewhere (so as to select a range)
-        sm.setCellSelectionEnabled(true);
-        sm.clearAndSelect(1, col0);
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            // Test shift selection when focus is elsewhere (so as to select a range)
+            sm.setCellSelectionEnabled(true);
+            sm.clearAndSelect(1, col0);
 
-        // move focus by holding down ctrl button
-        keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col2)
-        keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col3)
-        keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col4)
-        keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col5)
-        assertTrue(fm.isFocused(1, col4));
+            // move focus by holding down ctrl button
+            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col2)
+            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col3)
+            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col4)
+            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col5)
+            assertTrue(fm.isFocused(1, col4));
 
-        // press shift + space to select all cells between (1, col1) and (1, col5)
-        keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
-        assertTrue(sm.isSelected(1, col4));
-        assertTrue(debug(), sm.isSelected(1, col3));
-        assertTrue(sm.isSelected(1, col2));
-        assertTrue(sm.isSelected(1, col1));
-        assertTrue(sm.isSelected(1, col0));
+            // press shift + space to select all cells between (1, col1) and (1, col5)
+            keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
+            assertTrue(sm.isSelected(1, col4));
+            assertTrue(debug(), sm.isSelected(1, col3));
+            assertTrue(sm.isSelected(1, col2));
+            assertTrue(sm.isSelected(1, col1));
+            assertTrue(sm.isSelected(1, col0));
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            // Test shift selection when focus is elsewhere (so as to select a range)
+            sm.setCellSelectionEnabled(true);
+            sm.clearAndSelect(1, col4);
+
+            // move focus by holding down ctrl button
+            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col3)
+            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col2)
+            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col1)
+            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col0)
+            assertTrue(fm.isFocused(1, col0));
+
+            // press shift + space to select all cells between (1, col1) and (1, col5)
+            keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
+            assertTrue(sm.isSelected(1, col0));
+            assertTrue(debug(), sm.isSelected(1, col3));
+            assertTrue(sm.isSelected(1, col2));
+            assertTrue(sm.isSelected(1, col1));
+            assertTrue(sm.isSelected(1, col0));
+        }
     }
 
     @Test public void test_rt18536_negative_horizontal() {
-        // Test shift selection when focus is elsewhere (so as to select a range)
-        sm.setCellSelectionEnabled(true);
-        sm.clearAndSelect(1, col4);
 
-        // move focus by holding down ctrl button
-        keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col4)
-        keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col3)
-        keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col2)
-        keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col1)
-        assertTrue(fm.isFocused(1, col0));
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            // Test shift selection when focus is elsewhere (so as to select a range)
+            sm.setCellSelectionEnabled(true);
+            sm.clearAndSelect(1, col4);
 
-        // press shift + space to select all cells between (1, col1) and (1, col5)
-        keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
-        assertTrue(debug(), sm.isSelected(1, col4));
-        assertTrue(sm.isSelected(1, col3));
-        assertTrue(sm.isSelected(1, col2));
-        assertTrue(sm.isSelected(1, col1));
-        assertTrue(sm.isSelected(1, col0));
+            // move focus by holding down ctrl button
+            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col4)
+            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col3)
+            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col2)
+            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col1)
+            assertTrue(fm.isFocused(1, col0));
+
+            // press shift + space to select all cells between (1, col1) and (1, col5)
+            keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
+            assertTrue(debug(), sm.isSelected(1, col4));
+            assertTrue(sm.isSelected(1, col3));
+            assertTrue(sm.isSelected(1, col2));
+            assertTrue(sm.isSelected(1, col1));
+            assertTrue(sm.isSelected(1, col0));
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            // Test shift selection when focus is elsewhere (so as to select a range)
+            sm.setCellSelectionEnabled(true);
+            sm.clearAndSelect(1, col0);
+
+            // move focus by holding down ctrl button
+            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col1)
+            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col2)
+            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col3)
+            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());   // move focus to (1, col4)
+            assertTrue(fm.isFocused(1, col4));
+
+            // press shift + space to select all cells between (1, col1) and (1, col5)
+            keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
+            assertTrue(debug(), sm.isSelected(1, col0));
+            assertTrue(sm.isSelected(1, col3));
+            assertTrue(sm.isSelected(1, col2));
+            assertTrue(sm.isSelected(1, col1));
+            assertTrue(sm.isSelected(1, col0));
+        }
     }
 
     //
@@ -2632,11 +2803,11 @@ public class TableViewKeyInputTest {
 
         sm.setCellSelectionEnabled(true);
 
-        sm.clearAndSelect(6, col0);
+        sm.clearAndSelect(6, col1);
         assertEquals(6, getAnchor().getRow());
-        assertEquals(0, getAnchor().getColumn());
-        assertTrue(fm.isFocused(6, col0));
-        assertTrue(sm.isSelected(6, col0));
+        assertEquals(1, getAnchor().getColumn());
+        assertTrue(fm.isFocused(6, col1));
+        assertTrue(sm.isSelected(6, col1));
 
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.getShortcutKey());
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.getShortcutKey());
@@ -2644,18 +2815,32 @@ public class TableViewKeyInputTest {
         keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.getShortcutKey());
         Toolkit.getToolkit().firePulse();
         assertEquals(6, getAnchor().getRow());
-        assertEquals(0, getAnchor().getColumn());
-        assertTrue(fm.isFocused(3, col1));
-        assertTrue(sm.isSelected(6, col0));
-        assertFalse(sm.isSelected(3, col1));
+        assertEquals(1, getAnchor().getColumn());
+
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            assertTrue(fm.isFocused(3, col2));
+            assertTrue(sm.isSelected(6, col1));
+            assertFalse(sm.isSelected(3, col2));
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            assertTrue(fm.isFocused(3, col0));
+            assertTrue(sm.isSelected(6, col1));
+            assertFalse(sm.isSelected(3, col0));
+        }
 
         keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
         Toolkit.getToolkit().firePulse();
         assertEquals(6, getAnchor().getRow());
-        assertEquals(0, getAnchor().getColumn());
-        assertTrue(fm.isFocused(3, col1));
-        assertTrue(sm.isSelected(3, col1));
-        assertTrue(sm.isSelected(6, col0));
+        assertEquals(1, getAnchor().getColumn());
+
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            assertTrue(fm.isFocused(3, col2));
+            assertTrue(sm.isSelected(3, col2));
+            assertTrue(sm.isSelected(6, col1));
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            assertTrue(fm.isFocused(3, col0));
+            assertTrue(sm.isSelected(3, col0));
+            assertTrue(sm.isSelected(6, col1));
+        }
     }
 
     @Test public void test_rt33613_up_multipleColumn_left() {
@@ -2680,17 +2865,31 @@ public class TableViewKeyInputTest {
         Toolkit.getToolkit().firePulse();
         assertEquals(6, getAnchor().getRow());
         assertEquals(1, getAnchor().getColumn());
-        assertTrue(fm.isFocused(3, col0));
-        assertTrue(sm.isSelected(6, col1));
-        assertFalse(sm.isSelected(3, col0));
+
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            assertTrue(fm.isFocused(3, col0));
+            assertTrue(sm.isSelected(6, col1));
+            assertFalse(sm.isSelected(3, col0));
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            assertTrue(fm.isFocused(3, col2));
+            assertTrue(sm.isSelected(6, col1));
+            assertFalse(sm.isSelected(3, col2));
+        }
 
         keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
         Toolkit.getToolkit().firePulse();
         assertEquals(6, getAnchor().getRow());
         assertEquals(1, getAnchor().getColumn());
-        assertTrue(fm.isFocused(3, col0));
-        assertTrue(sm.isSelected(3, col0));
-        assertTrue(sm.isSelected(6, col1));
+
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            assertTrue(fm.isFocused(3, col0));
+            assertTrue(sm.isSelected(3, col0));
+            assertTrue(sm.isSelected(6, col1));
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            assertTrue(fm.isFocused(3, col2));
+            assertTrue(sm.isSelected(3, col2));
+            assertTrue(sm.isSelected(6, col1));
+        }
     }
 
     @Test public void test_rt33613_down_oneColumn() {
@@ -2734,11 +2933,11 @@ public class TableViewKeyInputTest {
 
         sm.setCellSelectionEnabled(true);
 
-        sm.clearAndSelect(3, col0);
+        sm.clearAndSelect(3, col1);
         assertEquals(3, getAnchor().getRow());
-        assertEquals(0, getAnchor().getColumn());
-        assertTrue(fm.isFocused(3, col0));
-        assertTrue(sm.isSelected(3, col0));
+        assertEquals(1, getAnchor().getColumn());
+        assertTrue(fm.isFocused(3, col1));
+        assertTrue(sm.isSelected(3, col1));
 
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.getShortcutKey());
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.getShortcutKey());
@@ -2746,18 +2945,32 @@ public class TableViewKeyInputTest {
         keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.getShortcutKey());
         Toolkit.getToolkit().firePulse();
         assertEquals(3, getAnchor().getRow());
-        assertEquals(0, getAnchor().getColumn());
-        assertTrue(fm.isFocused(6, col1));
-        assertTrue(sm.isSelected(3, col0));
-        assertFalse(sm.isSelected(6, col1));
+        assertEquals(1, getAnchor().getColumn());
+
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            assertTrue(fm.isFocused(6, col2));
+            assertTrue(sm.isSelected(3, col1));
+            assertFalse(sm.isSelected(6, col2));
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            assertTrue(fm.isFocused(6, col0));
+            assertTrue(sm.isSelected(3, col1));
+            assertFalse(sm.isSelected(6, col0));
+        }
 
         keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
         Toolkit.getToolkit().firePulse();
         assertEquals(3, getAnchor().getRow());
-        assertEquals(0, getAnchor().getColumn());
-        assertTrue(fm.isFocused(6, col1));
-        assertTrue(sm.isSelected(6, col1));
-        assertTrue(sm.isSelected(3, col0));
+        assertEquals(1, getAnchor().getColumn());
+
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            assertTrue(fm.isFocused(6, col2));
+            assertTrue(sm.isSelected(6, col2));
+            assertTrue(sm.isSelected(3, col1));
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            assertTrue(fm.isFocused(6, col0));
+            assertTrue(sm.isSelected(6, col0));
+            assertTrue(sm.isSelected(3, col1));
+        }
     }
 
     @Test public void test_rt33613_down_multipleColumn_left() {
@@ -2781,19 +2994,34 @@ public class TableViewKeyInputTest {
         keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.getShortcutKey());
         assertEquals(3, getAnchor().getRow());
         assertEquals(1, getAnchor().getColumn());
-        assertTrue(fm.isFocused(6, col0));
-        assertTrue(sm.isSelected(3, col1));
-        assertFalse(sm.isSelected(6, col0));
+
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            assertTrue(fm.isFocused(6, col0));
+            assertTrue(sm.isSelected(3, col1));
+            assertFalse(sm.isSelected(6, col0));
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            assertTrue(fm.isFocused(6, col2));
+            assertTrue(sm.isSelected(3, col1));
+            assertFalse(sm.isSelected(6, col2));
+        }
 
         keyboard.doKeyPress(KeyCode.SPACE, KeyModifier.SHIFT);
         assertEquals(3, getAnchor().getRow());
         assertEquals(1, getAnchor().getColumn());
-        assertTrue(fm.isFocused(6, col0));
-        assertTrue(sm.isSelected(6, col0));
-        assertTrue(sm.isSelected(3, col1));
+
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            assertTrue(fm.isFocused(6, col0));
+            assertTrue(sm.isSelected(6, col0));
+            assertTrue(sm.isSelected(3, col1));
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            assertTrue(fm.isFocused(6, col2));
+            assertTrue(sm.isSelected(6, col2));
+            assertTrue(sm.isSelected(3, col1));
+        }
     }
 
     @Test public void test_rt18439() {
+
         final int items = 10;
         tableView.getItems().clear();
         for (int i = 0; i < items; i++) {
@@ -2803,70 +3031,138 @@ public class TableViewKeyInputTest {
         sm.setCellSelectionEnabled(true);
         sm.setSelectionMode(SelectionMode.MULTIPLE);
 
-        sm.clearAndSelect(0, col0);
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            sm.clearAndSelect(0, col0);
 
-        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
-        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
-        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
-        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 4
-        assertEquals(0, getAnchor().getRow());
-        assertEquals(0, getAnchor().getColumn());              // anchor does not move
-        assertTrue(fm.isFocused(0, col4));
-        assertTrue(sm.isSelected(0, col0));
-        assertTrue(sm.isSelected(0, col1));
-        assertTrue(sm.isSelected(0, col2));
-        assertTrue(sm.isSelected(0, col3));
-        assertTrue(sm.isSelected(0, col4));
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 4
+            assertEquals(0, getAnchor().getRow());
+            assertEquals(0, getAnchor().getColumn());              // anchor does not move
+            assertTrue(fm.isFocused(0, col4));
+            assertTrue(sm.isSelected(0, col0));
+            assertTrue(sm.isSelected(0, col1));
+            assertTrue(sm.isSelected(0, col2));
+            assertTrue(sm.isSelected(0, col3));
+            assertTrue(sm.isSelected(0, col4));
 
-        keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 1
-        keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 2
-        assertEquals(0, getAnchor().getRow());
-        assertEquals(0, getAnchor().getColumn());             // anchor does not move
-        assertTrue(fm.isFocused(2, col4));
-        assertTrue(sm.isSelected(0, col0));
-        assertTrue(sm.isSelected(0, col1));
-        assertTrue(sm.isSelected(0, col2));
-        assertTrue(sm.isSelected(0, col3));
-        assertTrue(sm.isSelected(0, col4));
-        assertTrue(sm.isSelected(1, col4));
-        assertTrue(sm.isSelected(2, col4));
+            keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 1
+            keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 2
+            assertEquals(0, getAnchor().getRow());
+            assertEquals(0, getAnchor().getColumn());             // anchor does not move
+            assertTrue(fm.isFocused(2, col4));
+            assertTrue(sm.isSelected(0, col0));
+            assertTrue(sm.isSelected(0, col1));
+            assertTrue(sm.isSelected(0, col2));
+            assertTrue(sm.isSelected(0, col3));
+            assertTrue(sm.isSelected(0, col4));
+            assertTrue(sm.isSelected(1, col4));
+            assertTrue(sm.isSelected(2, col4));
 
-        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
-        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
-        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
-        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 0
-        assertEquals(0, getAnchor().getRow());
-        assertEquals(0, getAnchor().getColumn());             // anchor does not move
-        assertTrue(fm.isFocused(2, col0));
-        assertTrue(sm.isSelected(0, col0));
-        assertTrue(sm.isSelected(0, col1));
-        assertTrue(sm.isSelected(0, col2));
-        assertTrue(sm.isSelected(0, col3));
-        assertTrue(sm.isSelected(0, col4));
-        assertTrue(sm.isSelected(1, col4));
-        assertTrue(sm.isSelected(2, col4));
-        assertTrue(sm.isSelected(2, col3));
-        assertTrue(sm.isSelected(2, col2));
-        assertTrue(sm.isSelected(2, col1));
-        assertTrue(sm.isSelected(2, col0));
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 0
+            assertEquals(0, getAnchor().getRow());
+            assertEquals(0, getAnchor().getColumn());             // anchor does not move
+            assertTrue(fm.isFocused(2, col0));
+            assertTrue(sm.isSelected(0, col0));
+            assertTrue(sm.isSelected(0, col1));
+            assertTrue(sm.isSelected(0, col2));
+            assertTrue(sm.isSelected(0, col3));
+            assertTrue(sm.isSelected(0, col4));
+            assertTrue(sm.isSelected(1, col4));
+            assertTrue(sm.isSelected(2, col4));
+            assertTrue(sm.isSelected(2, col3));
+            assertTrue(sm.isSelected(2, col2));
+            assertTrue(sm.isSelected(2, col1));
+            assertTrue(sm.isSelected(2, col0));
 
-        keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT); // row 1
-        keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT); // row 0
-        assertEquals(0, getAnchor().getRow());
-        assertEquals(0, getAnchor().getColumn());           // anchor does not move
-        assertTrue(fm.isFocused(0, col0));
-        assertFalse(sm.isSelected(0, col0));                // we've gone right around - this cell is now unselected
-        assertTrue(sm.isSelected(0, col1));
-        assertTrue(sm.isSelected(0, col2));
-        assertTrue(sm.isSelected(0, col3));
-        assertTrue(sm.isSelected(0, col4));
-        assertTrue(sm.isSelected(1, col4));
-        assertTrue(sm.isSelected(2, col4));
-        assertTrue(sm.isSelected(2, col3));
-        assertTrue(sm.isSelected(2, col2));
-        assertTrue(sm.isSelected(2, col1));
-        assertTrue(sm.isSelected(2, col0));
-        assertTrue(sm.isSelected(1, col0));
+            keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT); // row 1
+            keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT); // row 0
+            assertEquals(0, getAnchor().getRow());
+            assertEquals(0, getAnchor().getColumn());           // anchor does not move
+            assertTrue(fm.isFocused(0, col0));
+            assertFalse(sm.isSelected(0, col0));                // we've gone right around - this cell is now unselected
+            assertTrue(sm.isSelected(0, col1));
+            assertTrue(sm.isSelected(0, col2));
+            assertTrue(sm.isSelected(0, col3));
+            assertTrue(sm.isSelected(0, col4));
+            assertTrue(sm.isSelected(1, col4));
+            assertTrue(sm.isSelected(2, col4));
+            assertTrue(sm.isSelected(2, col3));
+            assertTrue(sm.isSelected(2, col2));
+            assertTrue(sm.isSelected(2, col1));
+            assertTrue(sm.isSelected(2, col0));
+            assertTrue(sm.isSelected(1, col0));
+        }
+        else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            sm.clearAndSelect(0, col4);
+
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 0
+            assertEquals(0, getAnchor().getRow());
+            assertEquals(4, getAnchor().getColumn());              // anchor does not move
+            assertTrue(fm.isFocused(0, col0));
+            assertTrue(sm.isSelected(0, col4));
+            assertTrue(sm.isSelected(0, col3));
+            assertTrue(sm.isSelected(0, col2));
+            assertTrue(sm.isSelected(0, col1));
+            assertTrue(sm.isSelected(0, col0));
+
+            keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 1
+            keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 2
+            assertEquals(0, getAnchor().getRow());
+            assertEquals(4, getAnchor().getColumn());             // anchor does not move
+            assertTrue(fm.isFocused(2, col0));
+            assertTrue(sm.isSelected(0, col4));
+            assertTrue(sm.isSelected(0, col3));
+            assertTrue(sm.isSelected(0, col2));
+            assertTrue(sm.isSelected(0, col1));
+            assertTrue(sm.isSelected(0, col0));
+            assertTrue(sm.isSelected(1, col0));
+            assertTrue(sm.isSelected(2, col0));
+
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 0
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
+            assertEquals(0, getAnchor().getRow());
+            assertEquals(4, getAnchor().getColumn());             // anchor does not move
+            assertTrue(fm.isFocused(2, col4));
+            assertTrue(sm.isSelected(0, col0));
+            assertTrue(sm.isSelected(0, col1));
+            assertTrue(sm.isSelected(0, col2));
+            assertTrue(sm.isSelected(0, col3));
+            assertTrue(sm.isSelected(0, col4));
+            assertTrue(sm.isSelected(1, col0));
+            assertTrue(sm.isSelected(2, col4));
+            assertTrue(sm.isSelected(2, col3));
+            assertTrue(sm.isSelected(2, col2));
+            assertTrue(sm.isSelected(2, col1));
+            assertTrue(sm.isSelected(2, col0));
+
+            keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT); // row 0
+            keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT); // row 1
+            assertEquals(0, getAnchor().getRow());
+            assertEquals(4, getAnchor().getColumn());           // anchor does not move
+            assertTrue(fm.isFocused(0, col4));
+            assertFalse(sm.isSelected(0, col4));                // we've gone right around - this cell is now unselected
+            assertTrue(sm.isSelected(0, col1));
+            assertTrue(sm.isSelected(0, col2));
+            assertTrue(sm.isSelected(0, col3));
+            assertTrue(sm.isSelected(0, col0));
+            assertTrue(sm.isSelected(1, col4));
+            assertTrue(sm.isSelected(2, col4));
+            assertTrue(sm.isSelected(2, col3));
+            assertTrue(sm.isSelected(2, col2));
+            assertTrue(sm.isSelected(2, col1));
+            assertTrue(sm.isSelected(2, col0));
+            assertTrue(sm.isSelected(1, col0));
+        }
     }
 
     // this is an extension of the previous test, where we had a bug where going up resulted in all cells between the
@@ -2884,21 +3180,34 @@ public class TableViewKeyInputTest {
 
         sm.clearAndSelect(0, col0);
 
-        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
-        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
-        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
-        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 4
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 4
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 4
+        }
 
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 1
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 2
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 3
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 4
 
-        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
-        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
-        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
-        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 0
-
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 0
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 4
+        }
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT); // row 3
         assertEquals(0, getAnchor().getRow());
         assertEquals(0, getAnchor().getColumn());           // anchor does not move
@@ -2940,17 +3249,28 @@ public class TableViewKeyInputTest {
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 3
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 4
 
-        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
-        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
-        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
-        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 0
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 0
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 0
+        }
 
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT);   // row 3
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT);   // row 2
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT);   // row 1
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT);   // row 0
 
-        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
+        }
         assertEquals(0, getAnchor().getRow());
         assertEquals(4, getAnchor().getColumn());           // anchor does not move
         assertTrue(fm.isFocused(0, col1));
@@ -2986,20 +3306,34 @@ public class TableViewKeyInputTest {
 
         sm.clearAndSelect(4, col4);
 
-        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
-        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
-        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
-        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 0
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 0
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 0
+        }
 
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT);   // row 3
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT);   // row 2
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT);   // row 1
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT);   // row 0
 
-        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
-        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
-        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
-        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 4
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 1
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 2
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 4
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 1
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 2
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 4
+        }
 
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 1
         assertEquals(4, getAnchor().getRow());
@@ -3042,17 +3376,28 @@ public class TableViewKeyInputTest {
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT); // row 1
         keyboard.doKeyPress(KeyCode.UP, KeyModifier.SHIFT); // row 0
 
-        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT);   // col 1
-        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT);   // col 2
-        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT);   // col 3
-        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT);   // col 4
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT);   // col 1
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT);   // col 2
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT);   // col 3
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT);   // col 4
+        } if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT);   // col 1
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT);   // col 2
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT);   // col 3
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT);   // col 4
+        }
 
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 1
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 2
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 3
         keyboard.doKeyPress(KeyCode.DOWN, KeyModifier.SHIFT); // row 4
 
-        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.SHIFT); // col 3
+        } if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT); // col 3
+        }
         assertEquals(4, getAnchor().getRow());
         assertEquals(0, getAnchor().getColumn());           // anchor does not move
         assertTrue(fm.isFocused(4, col3));
@@ -4018,31 +4363,59 @@ public class TableViewKeyInputTest {
     }
 
     @Test public void test_rt_18440_goLeft() {
-        test_rt_18440(KeyCode.LEFT, 3, false, colIndex -> {
-            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
-            return colIndex - 1;
-        });
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            test_rt_18440(KeyCode.LEFT, 3, false, colIndex -> {
+                keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
+                return colIndex - 1;
+            });
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            test_rt_18440(KeyCode.LEFT, 0, false, colIndex -> {
+                keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
+                return colIndex + 1;
+            });
+        }
     }
 
     @Test public void test_rt_18440_goLeft_toEnd() {
-        test_rt_18440(KeyCode.LEFT, 3, true, colIndex -> {
-            keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
-            return colIndex - 1;
-        });
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            test_rt_18440(KeyCode.LEFT, 3, true, colIndex -> {
+                keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
+                return colIndex - 1;
+            });
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            test_rt_18440(KeyCode.LEFT, 0, true, colIndex -> {
+                keyboard.doLeftArrowPress(KeyModifier.getShortcutKey());
+                return colIndex + 1;
+            });
+        }
     }
 
     @Test public void test_rt_18440_goRight() {
-        test_rt_18440(KeyCode.RIGHT, 0, false, colIndex -> {
-            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
-            return colIndex + 1;
-        });
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            test_rt_18440(KeyCode.RIGHT, 0, false, colIndex -> {
+                keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
+                return colIndex + 1;
+            });
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            test_rt_18440(KeyCode.RIGHT, 3, false, colIndex -> {
+                keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
+                return colIndex - 1;
+            });
+        }
     }
 
     @Test public void test_rt_18440_goRight_toEnd() {
-        test_rt_18440(KeyCode.RIGHT, 0, true, colIndex -> {
-            keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
-            return colIndex + 1;
-        });
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            test_rt_18440(KeyCode.RIGHT, 0, true, colIndex -> {
+                keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
+                return colIndex + 1;
+            });
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            test_rt_18440(KeyCode.RIGHT, 3, true, colIndex -> {
+                keyboard.doRightArrowPress(KeyModifier.getShortcutKey());
+                return colIndex - 1;
+            });
+        }
     }
 
     private void test_rt_18440(KeyCode direction, int startColumn, boolean goToEnd, Function<Integer, Integer> r) {
@@ -4099,13 +4472,21 @@ public class TableViewKeyInputTest {
             assertEquals(tableView.getColumns().get(expectedColumn), fm.getFocusedCell().getTableColumn());
         }
 
-        expectedColumn = direction == KeyCode.RIGHT ? 3 : 0;
-        keyboard.doKeyPress(direction, KeyModifier.SHIFT);
-        assertEquals(0, sm.getSelectedIndex());
-        assertEquals(debug(), 4, sm.getSelectedCells().size());
-        assertEquals(0, fm.getFocusedIndex());
-        assertEquals(tableView.getColumns().get(expectedColumn), fm.getFocusedCell().getTableColumn());
-
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            expectedColumn = direction == KeyCode.RIGHT ? 3 : 0;
+            keyboard.doKeyPress(direction, KeyModifier.SHIFT);
+            assertEquals(0, sm.getSelectedIndex());
+            assertEquals(debug(), 4, sm.getSelectedCells().size());
+            assertEquals(0, fm.getFocusedIndex());
+            assertEquals(tableView.getColumns().get(expectedColumn), fm.getFocusedCell().getTableColumn());
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            expectedColumn = direction == KeyCode.LEFT ? 3 : 0;
+            keyboard.doKeyPress(direction, KeyModifier.SHIFT);
+            assertEquals(0, sm.getSelectedIndex());
+            assertEquals(debug(), 4, sm.getSelectedCells().size());
+            assertEquals(0, fm.getFocusedIndex());
+            assertEquals(tableView.getColumns().get(expectedColumn), fm.getFocusedCell().getTableColumn());
+        }
         sl.dispose();
     }
 
@@ -4218,17 +4599,33 @@ public class TableViewKeyInputTest {
     }
 
     @Test public void test_rt_39792_goLeft_goPastEnd() {
-        test_rt_39792(3, colIndex -> {
-            keyboard.doLeftArrowPress(KeyModifier.SHIFT);
-            return colIndex - 1;
-        });
+
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            test_rt_39792(3, colIndex -> {
+                keyboard.doLeftArrowPress(KeyModifier.SHIFT);
+                return colIndex - 1;
+            });
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            test_rt_39792(0, colIndex -> {
+                keyboard.doLeftArrowPress(KeyModifier.SHIFT);
+                return colIndex + 1;
+            });
+        }
     }
 
     @Test public void test_rt_39792_goRight_goPastEnd() {
-        test_rt_39792(0, colIndex -> {
-            keyboard.doRightArrowPress(KeyModifier.SHIFT);
-            return colIndex + 1;
-        });
+
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            test_rt_39792(0, colIndex -> {
+                keyboard.doRightArrowPress(KeyModifier.SHIFT);
+                return colIndex + 1;
+            });
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            test_rt_39792(3, colIndex -> {
+                keyboard.doRightArrowPress(KeyModifier.SHIFT);
+                return colIndex - 1;
+            });
+        }
     }
 
     private void test_rt_39792(int startColumn, Function<Integer, Integer> r) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewKeyInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewKeyInputTest.java
@@ -4711,4 +4711,66 @@ public class TableViewKeyInputTest {
 
         assertEquals(0, tableView.getSelectionModel().getSelectedIndex());
     }
+
+    @Test public void test_dynamic_NodeOrientation_change() {
+
+        sm.setCellSelectionEnabled(true);
+        sm.clearAndSelect(1, col2);
+
+        keyboard.doLeftArrowPress();
+
+        if (orientation == NodeOrientation.LEFT_TO_RIGHT) {
+            assertFalse(sm.isSelected(1, col0));
+            assertTrue(sm.isSelected(1, col1));
+            assertFalse(sm.isSelected(1, col2));
+            assertFalse(sm.isSelected(1, col3));
+            assertFalse(sm.isSelected(1, col4));
+
+            tableView.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
+            orientation = NodeOrientation.RIGHT_TO_LEFT;
+
+        } else if (orientation == NodeOrientation.RIGHT_TO_LEFT) {
+            assertFalse(sm.isSelected(1, col0));
+            assertFalse(sm.isSelected(1, col1));
+            assertFalse(sm.isSelected(1, col2));
+            assertTrue(sm.isSelected(1, col3));
+            assertFalse(sm.isSelected(1, col4));
+
+            tableView.setNodeOrientation(NodeOrientation.LEFT_TO_RIGHT);
+            orientation = NodeOrientation.LEFT_TO_RIGHT;
+         }
+
+        keyboard.doRightArrowPress();
+
+        if (tableView.getNodeOrientation() == NodeOrientation.LEFT_TO_RIGHT) {
+            assertFalse(sm.isSelected(1, col0));
+            assertFalse(sm.isSelected(1, col1));
+            assertFalse(sm.isSelected(1, col2));
+            assertFalse(sm.isSelected(1, col3));
+            assertTrue(sm.isSelected(1, col4));
+
+            keyboard.doLeftArrowPress(KeyModifier.SHIFT);
+
+            assertFalse(sm.isSelected(1, col0));
+            assertFalse(sm.isSelected(1, col1));
+            assertFalse(sm.isSelected(1, col2));
+            assertTrue(sm.isSelected(1, col3));
+            assertTrue(sm.isSelected(1, col4));
+
+        } else if (tableView.getNodeOrientation() == NodeOrientation.RIGHT_TO_LEFT) {
+            assertTrue(debug(), sm.isSelected(1, col0));
+            assertFalse(debug(), sm.isSelected(1, col1));
+            assertFalse(debug(), sm.isSelected(1, col2));
+            assertFalse(debug(), sm.isSelected(1, col3));
+            assertFalse(debug(), sm.isSelected(1, col4));
+
+            keyboard.doLeftArrowPress(KeyModifier.SHIFT);
+
+            assertTrue(debug(), sm.isSelected(1, col0));
+            assertTrue(debug(), sm.isSelected(1, col1));
+            assertFalse(debug(), sm.isSelected(1, col2));
+            assertFalse(debug(), sm.isSelected(1, col3));
+            assertFalse(debug(), sm.isSelected(1, col4));
+        }
+    }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewKeyInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewKeyInputTest.java
@@ -4758,19 +4758,19 @@ public class TableViewKeyInputTest {
             assertTrue(sm.isSelected(1, col4));
 
         } else if (tableView.getNodeOrientation() == NodeOrientation.RIGHT_TO_LEFT) {
-            assertTrue(debug(), sm.isSelected(1, col0));
-            assertFalse(debug(), sm.isSelected(1, col1));
-            assertFalse(debug(), sm.isSelected(1, col2));
-            assertFalse(debug(), sm.isSelected(1, col3));
-            assertFalse(debug(), sm.isSelected(1, col4));
+            assertTrue(sm.isSelected(1, col0));
+            assertFalse(sm.isSelected(1, col1));
+            assertFalse(sm.isSelected(1, col2));
+            assertFalse(sm.isSelected(1, col3));
+            assertFalse(sm.isSelected(1, col4));
 
             keyboard.doLeftArrowPress(KeyModifier.SHIFT);
 
-            assertTrue(debug(), sm.isSelected(1, col0));
-            assertTrue(debug(), sm.isSelected(1, col1));
-            assertFalse(debug(), sm.isSelected(1, col2));
-            assertFalse(debug(), sm.isSelected(1, col3));
-            assertFalse(debug(), sm.isSelected(1, col4));
+            assertTrue(sm.isSelected(1, col0));
+            assertTrue(sm.isSelected(1, col1));
+            assertFalse(sm.isSelected(1, col2));
+            assertFalse(sm.isSelected(1, col3));
+            assertFalse(sm.isSelected(1, col4));
         }
     }
 }


### PR DESCRIPTION
Bug : https://bugs.openjdk.java.net/browse/JDK-8235480

Fix : Added the missed out RTL checks to the key mappings in TableViewBehaviorBase class.

Testing : Added a test to take NodeOrientation as a parameter and test horizontal key navigation for the TableView.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8235480](https://bugs.openjdk.java.net/browse/JDK-8235480): Regression: [RTL] Arrow keys navigation doesn't respect TableView orientation


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Jeanette Winzenburg ([fastegal](@kleopatra) - Author)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/114/head:pull/114`
`$ git checkout pull/114`
