### PR TITLE
8239454: LLIntData : invalid opcode returned for 16 and 32 bit wide instructions

### DIFF
--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/llint/LLIntData.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/llint/LLIntData.h
@@ -105,7 +105,7 @@ inline Opcode getOpcodeWide16(OpcodeID id)
 #if ENABLE(COMPUTED_GOTO_OPCODES)
     return g_opcodeMapWide16[id];
 #else
-    return static_cast<Opcode>(id - numOpcodeIDs);
+    return static_cast<Opcode>(id + numOpcodeIDs);
 #endif
 }
 
@@ -114,7 +114,7 @@ inline Opcode getOpcodeWide32(OpcodeID id)
 #if ENABLE(COMPUTED_GOTO_OPCODES)
     return g_opcodeMapWide32[id];
 #else
-    return static_cast<Opcode>(id - numOpcodeIDs);
+    return static_cast<Opcode>(id + numOpcodeIDs*2);
 #endif
 }
 


### PR DESCRIPTION
With new bytecode format introduced in Webkit 608.1, the unlinked and linked bytecodes were replaced by narrow (1-byte operand) and wide (4-byte operand) bytecodes. These were extended to narrow, wide16 and wide32 bytecodes in WebKit 609.1. In narrow instructions, each argument of the opcode has a fixed size of 1-byte. The same applies for wide 16 and wide32 with 2-byte and 4-byte, respectively.

In the Low Level Intepreter (LLInt), each opcode has a corresponding ID assigned for narrow, wide16 and wide32 implementation, and the variable `numOpcodeIDs` is used to denote the total number of opcodes. The narrow opcode IDs are mapped from 0 to (`numOpcodeIDs` - 1). The next `numOpcodeIDs` opcode IDs are mapped to wide16 opcodes, and similarly, the next `numOpcodeIDs` to wide32 opcodes. The same can be found in [LowLevelInterpreter.cpp](https://github.com/openjdk/jfx/blob/master/modules/javafx.web/src/main/native/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp#L265) and also in the autogenerated file `Bytecodes.h`. 

Bug: When `getOpcodeWide(id)` is called in `LLIntData.h`, the value (`id` - `numOpcodesIDs`) is returned.

Fix: It's modified to (`id` + `numOpcodesIDs`) in `getOpcodeWide16()` and (`id` + `numOpcodesIDs`*2) in `getOpcodeWide32()`.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8239454](https://bugs.openjdk.java.net/browse/JDK-8239454): LLIntData : invalid opcode returned for 16 and 32 bit wide instructions


### Reviewers
 * Guru Hb ([ghb](@guruhb) - **Reviewer**)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/115/head:pull/115`
`$ git checkout pull/115`
