### PR TITLE
8237889: Update libxml2 to version 2.9.10

### DIFF
--- a/modules/javafx.web/src/main/legal/libxml2.md
+++ b/modules/javafx.web/src/main/legal/libxml2.md
@@ -1,4 +1,4 @@
-## xmlsoft.org: libxml2 v2.9.9
+## xmlsoft.org: libxml2 v2.9.10
 
 ### libxml2 License
 ```

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/config.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/config.h
@@ -268,7 +268,7 @@
 #define VA_LIST_IS_ARRAY 1
 
 /* Version number of package */
-#define VERSION "2.9.9"
+#define VERSION "2.9.10"
 
 /* Determine what socket length (socklen_t) data type is */
 #define XML_SOCKLEN_T socklen_t

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/include/libxml/xmlversion.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/include/libxml/xmlversion.h
@@ -29,21 +29,21 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.9.9"
+#define LIBXML_DOTTED_VERSION "2.9.10"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 20909
+#define LIBXML_VERSION 20910
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "20909"
+#define LIBXML_VERSION_STRING "20910"
 
 /**
  * LIBXML_VERSION_EXTRA:
@@ -58,7 +58,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(20909);
+#define LIBXML_TEST_VERSION xmlCheckVersion(20910);
 
 #ifndef VMS
 #if 0
@@ -91,10 +91,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * Whether the thread support is configured in
  */
 #if 1
-#if defined(_REENTRANT) || defined(__MT__) || \
-    (defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE - 0 >= 199506L))
 #define LIBXML_THREAD_ENABLED
-#endif
 #endif
 
 /**
@@ -353,6 +350,8 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * LIBXML_EXPR_ENABLED:
  *
  * Whether the formal expressions interfaces are compiled in
+ *
+ * This code is unused and disabled unconditionally for now.
  */
 #if 0
 #define LIBXML_EXPR_ENABLED

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/config.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/config.h
@@ -267,7 +267,7 @@
 #define VA_LIST_IS_ARRAY 1
 
 /* Version number of package */
-#define VERSION "2.9.9"
+#define VERSION "2.9.10"
 
 /* Determine what socket length (socklen_t) data type is */
 #define XML_SOCKLEN_T socklen_t

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/include/libxml/xmlversion.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/include/libxml/xmlversion.h
@@ -29,21 +29,21 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.9.9"
+#define LIBXML_DOTTED_VERSION "2.9.10"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 20909
+#define LIBXML_VERSION 20910
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "20909"
+#define LIBXML_VERSION_STRING "20910"
 
 /**
  * LIBXML_VERSION_EXTRA:
@@ -58,7 +58,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(20909);
+#define LIBXML_TEST_VERSION xmlCheckVersion(20910);
 
 #ifndef VMS
 #if 0
@@ -91,10 +91,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * Whether the thread support is configured in
  */
 #if 1
-#if defined(_REENTRANT) || defined(__MT__) || \
-    (defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE - 0 >= 199506L))
 #define LIBXML_THREAD_ENABLED
-#endif
 #endif
 
 /**
@@ -353,6 +350,8 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * LIBXML_EXPR_ENABLED:
  *
  * Whether the formal expressions interfaces are compiled in
+ *
+ * This code is unused and disabled unconditionally for now.
  */
 #if 0
 #define LIBXML_EXPR_ENABLED

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/ChangeLog
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/ChangeLog
@@ -463,7 +463,7 @@ Thu Jul 31 21:49:45 CEST 2008 Daniel Veillard <daniel@veillard.com>
 	  allow to make Name and NmToken validations based on the parser
 	  flags, more specifically the 5th edition of XML or not
 	* HTMLparser.c tree.c: small side effects for the previous changes
-	* parser.c SAX2.c valid.c: the bulk of teh changes are here,
+	* parser.c SAX2.c valid.c: the bulk of the changes are here,
 	  the parser and validation behaviour can be affected, parsing
 	  flags need to be copied, lot of changes. Also fixing various
 	  validation problems in the regression tests.
@@ -1328,7 +1328,7 @@ Wed Mar 21 14:23:08 HKT 2007 William Brack <wbrack@mmm.com.hk>
 Tue Mar 20 09:58:13 CET 2007  Daniel Veillard <daniel@veillard.com>
 
 	* nanoftp.c: applied patch from Björn Wiberg to try to fix again
-	  the silly __ss_familly problem on various AIXes, should fix #420184
+	  the silly __ss_family problem on various AIXes, should fix #420184
 
 Wed Mar 14 20:30:38 HKT 2007 William Brack <wbrack@mmm.com.hk>
 
@@ -1519,7 +1519,7 @@ Tue Oct 17 22:19:02 CEST 2006 Daniel Veillard <daniel@veillard.com>
 
 Tue Oct 17 22:04:31 CEST 2006 Daniel Veillard <daniel@veillard.com>
 
-	* HTMLparser.c: fixed teh 2 stupid bugs affecting htmlReadDoc() and
+	* HTMLparser.c: fixed the 2 stupid bugs affecting htmlReadDoc() and
 	  htmlReadIO() this should fix #340322
 
 Tue Oct 17 21:39:23 CEST 2006 Daniel Veillard <daniel@veillard.com>
@@ -1680,7 +1680,7 @@ Tue Oct 10 10:52:01 CEST 2006 Daniel Veillard <daniel@veillard.com>
 Tue Oct 10 10:33:43 CEST 2006 Daniel Veillard <daniel@veillard.com>
 
 	* python/libxml.py python/types.c: applied patch from Ross Reedstrom,
-	  Brian West and Stefan Anca to add XPointer suport to the Python bindings
+	  Brian West and Stefan Anca to add XPointer support to the Python bindings
 
 Fri Sep 29 11:13:59 CEST 2006 Daniel Veillard <daniel@veillard.com>
 
@@ -2022,7 +2022,7 @@ Tue May 30 11:21:34 CEST 2006 Kasimier Buchcik <libxml2-cvs@cazic.net>
 
 	* xpath.c: Enhanced xmlXPathNodeCollectAndTest() to avoid
 	  recreation (if possible) of the node-set which is used to
-	  collect the nodes in the current axis for the currect context
+	  collect the nodes in the current axis for the current context
 	  node. Especially for "//foo" this will decrease dramatically
 	  the number of created node-sets, since for each node in the
 	  result node-set of the evaluation of descendant-or-self::node()
@@ -2056,7 +2056,7 @@ Wed May 24 10:54:25 CEST 2006 Kasimier Buchcik <libxml2-cvs@cazic.net>
 	  xmlXPathNodeSetDupNs(); thus a pure memcpy is not possible.
 	  A flag on the node-set indicating if namespace nodes are in
 	  the set would help here; this is the 3rd flag which would
-	  be usefull with node-sets. The current flags I have in mind:
+	  be useful with node-sets. The current flags I have in mind:
 	  1) Is a node-set already sorted?
 	     This would allow for rebust and optimizable sorting
 	     behaviour.
@@ -2112,7 +2112,7 @@ Tue May 16 16:55:13 CEST 2006 Kasimier Buchcik <libxml2-cvs@cazic.net>
 	  compilation time (unlike normal XPath, where we can bind
 	  namespace names to prefixes at execution time).
 	* pattern.c: Enhanced to use a string dict for local-names,
-	  ns-prefixes and and namespace-names.
+	  ns-prefixes and namespace-names.
 	  Fixed xmlStreamPushInternal() not to use string-pointer
 	  comparison if a dict is available; this won't work, since
 	  one does not know it the given strings originate from the
@@ -2269,7 +2269,7 @@ Wed Mar 22 00:14:34 CET 2006 Daniel Veillard <daniel@veillard.com>
 Fri Mar 10 08:40:55 EST 2006 Daniel Veillard <daniel@veillard.com>
 
 	* c14n.c encoding.c xmlschemas.c xpath.c xpointer.c: fix a few
-	  warning raised by gcc-4.1 and latests changes
+	  warning raised by gcc-4.1 and latest changes
 
 Fri Mar 10 01:34:42 CET 2006 Daniel Veillard <daniel@veillard.com>
 
@@ -2967,12 +2967,12 @@ Mon Oct 10 15:12:43 CEST 2005 Kasimier Buchcik <libxml2-cvs@cazic.net>
 	  Fixed default/fixed values for attributes (looks like they
 	  did not work in the last  releases).
 	  Completed constraints for attribute uses.
-	  Seperated attribute derivation from attribute constraints.
+	  Separated attribute derivation from attribute constraints.
 	  Completed constraints for attribute group definitions.
 	  Disallowing <import>s of schemas in no target namespace if the
 	  importing schema is a chameleon schema. This contradicts
 	  the way Saxon, Xerces-J, XSV and IBM's SQC works, but the
-	  W3C XML Schema WG, thinks it is correct to dissalow such
+	  W3C XML Schema WG, thinks it is correct to disallow such
 	  imports.
 	  Added cos-all-limited constraints.
 	  Restructured reference resolution to model groups and element
@@ -4980,7 +4980,7 @@ Thu Jan 27 13:39:04 CET 2005 Kasimier Buchcik <libxml2-cvs@cazic.net>
 	  modules.
 	  Added machanism to store element information for the
 	  ancestor-or-self axis; this is needed for identity-constraints
-	  and should be helpfull for a future streamable validation.
+	  and should be helpful for a future streamable validation.
 	* include/libxml/xmlerror.h: Added an error code for
 	  identity-constraints.
 
@@ -5639,7 +5639,7 @@ Tue Nov  2 15:49:34 CET 2004 Daniel Veillard <daniel@veillard.com>
 	  automatic API regression test tool.
 	* SAX2.c nanoftp.c parser.c parserInternals.c tree.c xmlIO.c
 	  xmlstring.c: various API hardeing changes as a result of running
-	  teh first set of automatic API regression tests.
+	  the first set of automatic API regression tests.
 	* test/slashdot16.xml: apparently missing from CVS, commited it
 
 Mon Nov  1 15:54:18 CET 2004 Daniel Veillard <daniel@veillard.com>
@@ -5729,7 +5729,7 @@ Fri Oct 22 15:20:23 CEST 2004 Daniel Veillard <daniel@veillard.com>
 
 Fri Oct 22 21:04:20 CEST 2004 Daniel Veillard <daniel@veillard.com>
 
-	* python/libxml.c: fixed a problem occuring only in x86_64 when
+	* python/libxml.c: fixed a problem occurring only in x86_64 when
 	  very large error messages are raised to the Python handlers.
 
 Thu Oct 21 18:03:21 CEST 2004 Daniel Veillard <daniel@veillard.com>
@@ -5908,7 +5908,7 @@ Fri Sep 24 16:14:12 CEST 2004 Daniel Veillard <daniel@veillard.com>
 
 Thu Sep 23 18:23:46 CEST 2004 Daniel Veillard <daniel@veillard.com>
 
-	* xmlschemastypes.c: fixing an out of bound adressing issue
+	* xmlschemastypes.c: fixing an out of bound addressing issue
 
 Thu Sep 23 15:14:12 CEST 2004 Daniel Veillard <daniel@veillard.com>
 
@@ -6069,7 +6069,7 @@ Fri Sep  3 20:29:59 CEST 2004 Kasimier Buchcik <libxml2-cvs@cazic.net>
 	  of the wildcard.
 	  Added a check for circular attribute group references.
 	  Added a check for circular model group definition references.
-	  Fixed a dublicate xmlParserErrors enum value - see bug #151738.
+	  Fixed a duplicate xmlParserErrors enum value - see bug #151738.
 
 Fri Sep  3 10:08:13 PDT 2004 William Brack <wbrack@mmmm.com.hk>
 
@@ -6275,7 +6275,7 @@ Mon Aug 16 02:42:30 CEST 2004 Daniel Veillard <daniel@veillard.com>
 	  include/libxml/xmlerror.h: cleanup to avoid 'error' identifier 
 	  in includes #137414
 	* parser.c SAX2.c debugXML.c include/libxml/parser.h:
-	  first version of the inplementation of parsing within
+	  first version of the implementation of parsing within
 	  the context of a node in the tree #142359, new function
 	  xmlParseInNodeContext(), added support at the xmllint --shell
 	  level as the "set" function
@@ -6938,7 +6938,7 @@ Sun May  9 20:40:59 CEST 2004 Daniel Veillard <daniel@veillard.com>
 
 Sun May  9 19:46:13 CEST 2004 Daniel Veillard <daniel@veillard.com>
 
-	* xmlsave.c: apply fix for XHTML1 formating from Nick Wellnhofer
+	* xmlsave.c: apply fix for XHTML1 formatting from Nick Wellnhofer
 	  fixes bug #141266
 	* test/xhtmlcomp result//xhtmlcomp*: added the specific regression
 	  test
@@ -7753,7 +7753,7 @@ Fri Jan 23 14:03:21 CET 2004 Daniel Veillard <daniel@veillard.com>
 	  This is needed for XSLT to keep the stylesheet dictionary read-only
 	  while being able to reuse the strings for the transformation
 	  dictionary.
-	* xinclude.c: fixed a dictionary reference counting problem occuring
+	* xinclude.c: fixed a dictionary reference counting problem occurring
 	  when document parsing failed.
 	* testSAX.c: adding option --repeat for timing 100times the parsing
 	* doc/* : rebuilt all the docs
@@ -8947,7 +8947,7 @@ Sun Oct 19 00:15:38 HKT 2003 William Brack <wbrack@mmm.com.hk>
 	* include/libxml/parserInternals.h HTMLparser.c HTMLtree.c
 	  SAX2.c catalog.c debugXML.c entities.c parser.c relaxng.c
 	  testSAX.c tree.c valid.c xmlschemas.c xmlschemastypes.c
-	  xpath.c: Changed all (?) occurences where validation macros
+	  xpath.c: Changed all (?) occurrences where validation macros
 	  (IS_xxx) had single-byte arguments to use IS_xxx_CH instead
 	  (e.g. IS_BLANK changed to IS_BLANK_CH).  This gets rid of
 	  many warning messages on certain platforms, and also high-
@@ -8972,7 +8972,7 @@ Sat Oct 18 11:04:32 CEST 2003 Daniel Veillard <daniel@veillard.com>
 	  a new source, like the xmlReadxx and xmlCtxtReadxxx
 	* win32/libxml2.def.src doc/libxml2-api.xml doc/apibuild.py
 	  doc/Makefile.am: regenerated the APIs
-	* doc/xml.html: applied a patch from Stefan Kost for namesapce docs
+	* doc/xml.html: applied a patch from Stefan Kost for namespace docs
 
 Sat Oct 18 12:46:02 HKT 2003 William Brack <wbrack@mmm.com.hk>
 
@@ -9179,7 +9179,7 @@ Tue Oct  7 23:19:39 CEST 2003 Daniel Veillard <daniel@veillard.com>
 	  on Windows from Jesse Pelton
 	* parser.c: tiny safety patch for xmlStrPrintf() make sure the
 	  return is always zero terminated. Should also help detecting
-	  passing wrong buffer size easilly.
+	  passing wrong buffer size easily.
 	* result/VC/* result/valid/rss.xml.err result/valid/xlink.xml.err:
 	  updated the results to follow the errors string generated by
 	  last commit.
@@ -9192,7 +9192,7 @@ Tue Oct  7 14:16:45 CEST 2003 Daniel Veillard <daniel@veillard.com>
 Tue Oct  7 13:30:39 CEST 2003 Daniel Veillard <daniel@veillard.com>
 
 	* error.c relaxng.c include/libxml/xmlerror.h: switched Relax-NG
-	  module to teh new error reporting. Better default report, adds
+	  module to the new error reporting. Better default report, adds
 	  the element associated if found, context and node are included
 	  in the xmlError
 	* python/tests/reader2.py: the error messages changed.
@@ -10424,7 +10424,7 @@ Fri Jun 13 14:27:19 CEST 2003 Daniel Veillard <daniel@veillard.com>
 
 	* doc/Makefile.am doc/html/*: reverted back patch for #113521,
 	  due to #115104 and while fixing #115101 . HTML URLs must not
-	  be version dependant.
+	  be version dependent.
 
 Fri Jun 13 12:03:30 CEST 2003 Daniel Veillard <daniel@veillard.com>
 
@@ -10627,7 +10627,7 @@ Sat Apr 26 14:00:58 CEST 2003 Daniel Veillard <daniel@veillard.com>
 
 	* python/generator.py: fixed a problem in the generator where
 	  the way functions are remapped as methods on classes was
-	  not symetric and dependant on python internal hash order,
+	  not symmetric and dependent on python internal hash order,
 	  as reported by Stéphane Bidoul
 
 Fri Apr 25 21:52:33 MDT 2003 John Fleck <jfleck@inkstain.net>
@@ -11162,7 +11162,7 @@ Tue Mar 18 01:28:15 CET 2003 Daniel Veillard <daniel@veillard.com>
 Mon Mar 17 16:34:07 CET 2003 Daniel Veillard <daniel@veillard.com>
 
 	* relaxng.c: fixed the last core RelaxNG bug known #107083,
-	  shemas datatype ID/IDREF support still missing though.
+	  schemas datatype ID/IDREF support still missing though.
 	* xmlreader.c: fix a crashing bug with prefix raised by
 	  Merijn Broeren
 	* test/relaxng/testsuite.xml: augmented the testsuite with
@@ -11882,7 +11882,7 @@ Fri Jan 10 13:47:55 CET 2003 Daniel Veillard <daniel@veillard.com>
 
 Fri Jan 10 00:16:49 CET 2003 Daniel Veillard <daniel@veillard.com>
 
-	* parser.c: one more IsEmptyElement crazyness, that time in
+	* parser.c: one more IsEmptyElement craziness, that time in
 	  external parsed entities if substitution is asked.
 	* python/tests/reader3.py: added a specific test.
 
@@ -12145,7 +12145,7 @@ Wed Dec 25 19:22:06 MST 2002 John Fleck <jfleck@inkstain.net>
 Mon Dec 23 16:54:22 CET 2002 Daniel Veillard <daniel@veillard.com>
 
 	* xmlreader.c: Fixed the empty node detection to avoid reporting
-	  an inexistant close tag.
+	  an nonexistent close tag.
 
 Mon Dec 23 15:42:24 CET 2002 Daniel Veillard <daniel@veillard.com>
 
@@ -12482,7 +12482,7 @@ Sat Nov 16 16:30:25 CET 2002 Daniel Veillard <daniel@veillard.com>
 	* parser.c xpath.c: fixing #96925 wich was also dependent on the
 	  processing of parsed entities, and XPath computation on sustitued
 	  entities.
-	* testXPath.c: make sure entities are substitued.
+	* testXPath.c: make sure entities are substituted.
 
 Fri Nov 15 16:22:54 CET 2002 Daniel Veillard <daniel@veillard.com>
 
@@ -12673,7 +12673,7 @@ Tue Oct 22 16:23:57 CEST 2002 Daniel Veillard <daniel@veillard.com>
 Mon Oct 21 09:57:10 CEST 2002 Daniel Veillard <daniel@veillard.com>
 
 	* parser.c: tried to fix bug #91500 where doc->children may
-	  be overriden by a call to xmlParseBalancedChunkMemory()
+	  be overridden by a call to xmlParseBalancedChunkMemory()
 
 Mon Oct 21 09:04:32 CEST 2002 Daniel Veillard <daniel@veillard.com>
 
@@ -12800,7 +12800,7 @@ Thu Sep 26 19:48:06 CEST 2002 Daniel Veillard <daniel@veillard.com>
 
 	* configure.in include/libxml/xmlwin32version.h: preparing release
 	  of 2.4.25
-	* doc/*: updated and regenerated teh docs and web pages.
+	* doc/*: updated and regenerated the docs and web pages.
 
 Thu Sep 26 17:33:46 CEST 2002 Daniel Veillard <daniel@veillard.com>
 
@@ -13026,7 +13026,7 @@ Thu Sep  5 10:07:13 CEST 2002 Daniel Veillard <daniel@veillard.com>
 
 Wed Sep  4 14:13:34 CEST 2002 Daniel Veillard <daniel@veillard.com>
 
-	* libxml.spec.in: fixes libary path for x86_64 AMD
+	* libxml.spec.in: fixes library path for x86_64 AMD
 
 Tue Sep  3 21:14:19 MDT 2002 John Fleck <jfleck@inkstain.net>
 
@@ -13085,7 +13085,7 @@ Thu Aug 22 16:19:42 CEST 2002 Daniel Veillard <daniel@veillard.com>
 Thu Aug 22 11:45:50 CEST 2002 Daniel Veillard <daniel@veillard.com>
 
 	* python/Makefile.am: typo in target name resulted in libxml2.py
-	  to not be rebuilt. fixed DESTDIR similary to the libxslt one.
+	  to not be rebuilt. fixed DESTDIR similarly to the libxslt one.
 
 Thu Aug 22 09:15:00 CEST 2002 Daniel Veillard <daniel@veillard.com>
 
@@ -14044,7 +14044,7 @@ Thu Mar  7 16:11:35 CET 2002 Daniel Veillard <daniel@veillard.com>
 Thu Mar  7 12:19:36 CET 2002 Daniel Veillard <daniel@veillard.com>
 
 	* configure.in xmllint.c: trying to fix #71457 for timing
-	  precision when gettimeofday() is not availble but ftime() is
+	  precision when gettimeofday() is not available but ftime() is
 
 Thu Mar  7 11:24:02 CET 2002 Daniel Veillard <daniel@veillard.com>
 
@@ -14208,7 +14208,7 @@ Tue Feb 19 22:01:35 CET 2002 Daniel Veillard <daniel@veillard.com>
 	  when a document is standalone seems correctly handled. There
 	  is a couple of open issues left which need consideration especially
 	  PE93 on external unparsed entities and standalone status. 
-	  Ran 1819 tests: 1817 suceeded, 2 failed and 0 generated an error in 8.26 s.
+	  Ran 1819 tests: 1817 succeeded, 2 failed and 0 generated an error in 8.26 s.
 	  The 2 tests left failing are actually in error. Cleanup done.
 
 Tue Feb 19 15:17:02 CET 2002 Daniel Veillard <daniel@veillard.com>
@@ -14225,7 +14225,7 @@ Mon Feb 18 23:25:08 CET 2002 Daniel Veillard <daniel@veillard.com>
 
 	* parser.c valid.c: a couple of errors were reported but not
 	  saved back as such in the parsing context. Down to 1% failure rate
-	  Ran 1819 tests: 1801 suceeded, 18 failed and 0 generated an error
+	  Ran 1819 tests: 1801 succeeded, 18 failed and 0 generated an error
 
 Mon Feb 18 20:16:15 CET 2002 Daniel Veillard <daniel@veillard.com>
 
@@ -14266,7 +14266,7 @@ Sun Feb 17 23:45:40 CET 2002 Daniel Veillard <daniel@veillard.com>
 	* check-xml-test-suite.py: improved the behaviour a bit as
 	  well as the logs
 	* parser.c valid.c SAX.c: fixed a few more bugs 
-	  "Ran 1819 tests: 1778 suceeded, 41 failed, and 0 generated an error"
+	  "Ran 1819 tests: 1778 succeeded, 41 failed, and 0 generated an error"
 
 Sun Feb 17 20:41:37 CET 2002 Daniel Veillard <daniel@veillard.com>
 
@@ -14453,7 +14453,7 @@ Sun Feb  3 17:50:46 CET 2002 Daniel Veillard <daniel@veillard.com>
 	  context, allow to switch on and check validity
 	* python/tests/Makefile.am python/tests/error.py
 	  python/tests/invalid.xml python/tests/valid.xml
-	  python/tests/validate.py: attded more test and and added error.py
+	  python/tests/validate.py: added more test and added error.py
 	  which I forgot to commit in the last step
 
 Sun Feb  3 16:03:55 CET 2002 Daniel Veillard <daniel@veillard.com>
@@ -14576,7 +14576,7 @@ Wed Jan 23 18:53:55 CET 2002 Daniel Veillard <daniel@veillard.com>
 Wed Jan 23 15:14:22 CET 2002 Daniel Veillard <daniel@veillard.com>
 
 	* parserInternals.h: Greg Sjaardema suggested to use an
-	  eponential buffer groth policy in xmlParserAddNodeInfo()
+	  exponential buffer growth policy in xmlParserAddNodeInfo()
 
 Wed Jan 23 13:32:40 CET 2002 Daniel Veillard <daniel@veillard.com>
 
@@ -14660,7 +14660,7 @@ Sat Jan 19 16:36:21 CET 2002 Bjorn Reese <breese@users.sourceforge.net>
 
 Fri Jan 18 17:22:50 CET 2002 Daniel Veillard <daniel@veillard.com>
 
-	* globals.c xmlIO.c xmlcatalog.c: removed the last occurences
+	* globals.c xmlIO.c xmlcatalog.c: removed the last occurrences
 	  of strdup usage in the code
 
 Fri Jan 18 12:47:15 CET 2002 Daniel Veillard <daniel@veillard.com>
@@ -15488,7 +15488,7 @@ Wed Sep 12 16:58:16 CEST 2001 Daniel Veillard <daniel@veillard.com>
 Tue Sep 11 11:25:36 CEST 2001 Daniel Veillard <daniel@veillard.com>
 
 	* parser.c result/noent/wml.xml: fixed bug #59981 related
-	  to handling of '&' in attributes when entities are substitued
+	  to handling of '&' in attributes when entities are substituted
 
 Mon Sep 10 22:14:42 CEST 2001 Daniel Veillard <daniel@veillard.com>
 
@@ -16120,7 +16120,7 @@ Tue Jun 26 18:05:26 CEST 2001 Daniel Veillard <Daniel.Veillard@imag.fr>
 
 	* configure.in doc/xml.html include/libxml/xmlwin32version.h:
 	  release of 2.3.12
-	* parser.c: make an error message if unknow entities in all cases
+	* parser.c: make an error message if unknown entities in all cases
 
 Tue Jun 26 09:46:29 CEST 2001 Daniel Veillard <Daniel.Veillard@imag.fr>
 
@@ -16943,7 +16943,7 @@ Wed Apr 18 17:09:15 CEST 2001 Daniel Veillard <Daniel.Veillard@imag.fr>
 Wed Apr 18 15:06:30 CEST 2001 Daniel Veillard <Daniel.Veillard@imag.fr>
 
 	* debugXML.c hash.c tree.h valid.c : some changes related to
-	  the validation suport to improve speed with DocBook
+	  the validation support to improve speed with DocBook
 	* result/VC/OneID2 result/VC/OneID3 : this slightly changes
 	  the way validation errors get reported
 
@@ -17003,7 +17003,7 @@ Tue Apr 10 18:13:10 CEST 2001 Daniel Veillard <Daniel.Veillard@imag.fr>
 	* xpath.c: trying to get 52979 solved
 	* tree.c result/ result/noent/: trying to get 52712 solved, this
 	  also made me clean up the fact that XML output in general should
-	  not add formating blanks by default, this changed the output of
+	  not add formatting blanks by default, this changed the output of
 	  a few tests
 
 Tue Apr 10 16:30:20 CEST 2001 Daniel Veillard <Daniel.Veillard@imag.fr>
@@ -17219,7 +17219,7 @@ Wed Mar  7 20:43:47 CET 2001 Daniel Veillard <Daniel.Veillard@imag.fr>
 
 	* parser.c SAX.c: the new content parsing code raised an
 	  ugly bug in the characters() SAX callback. Found it
-	  just because of strangeness in XSLT XML Rec ouptut :-(
+	  just because of strangeness in XSLT XML Rec output :-(
 
 Wed Mar  7 16:50:22 CET 2001 Daniel Veillard <Daniel.Veillard@imag.fr>
 
@@ -17541,13 +17541,13 @@ Mon Jan 22 16:30:37 CET 2001 Daniel Veillard <Daniel.Veillard@imag.fr>
 
 Mon Jan 22 11:43:21 CET 2001 Daniel Veillard <Daniel.Veillard@imag.fr>
 
-	* xpath.c: when copying a XSLT tree object teh tree need to be copied
+	* xpath.c: when copying a XSLT tree object the tree need to be copied
 	  too, and deallocation need to occur the same way.
 
 Mon Jan 22 10:35:40 CET 2001 Daniel Veillard <Daniel.Veillard@imag.fr>
 
 	* xpathInternals.h xpath.[ch] debugXML.c: added the XPATH_XSLT_TREE
-	  type correponding to an XSLT result tree fragment. Share most
+	  type corresponding to an XSLT result tree fragment. Share most
 	  of the data format with node set, as well as operators.
 	* HTMLtree.c: added a newline at the end of the doctype output
 	  whe this one is not present initially.
@@ -17904,7 +17904,7 @@ Sun Oct 15 22:28:32 CEST 2000 Daniel Veillard <Daniel.Veillard@w3.org>
 Sun Oct 15 16:21:27 CEST 2000 Daniel Veillard <Daniel.Veillard@w3.org>
 
 	* SAX.c: HTML attributes need normalization too (Bjorn Reese)
-	* HTMLparser.[ch]: addded htmlIsScriptAttribute()
+	* HTMLparser.[ch]: added htmlIsScriptAttribute()
 
 Sun Oct 15 13:18:36 CEST 2000 Daniel Veillard <Daniel.Veillard@w3.org>
 
@@ -18010,7 +18010,7 @@ Wed Oct 11 02:53:10 CEST 2000 Daniel Veillard <Daniel.Veillard@w3.org>
 	* include/Makefile.am include/win32config.h: new directory
 	  for includes
 	* win32/Makefile.mingw win32/README.MSDev win32/libxml2/libxml2.dsp
-	  updated teh makefiles and instructions for WIN32
+	  updated the makefiles and instructions for WIN32
 	* xpath.c: small fixes
 	* test/XPath/ results/XPath: updated the testcases and results
 	* HTMLparser.c nanohttp.c testXPath.c: incorporated provided or
@@ -18255,7 +18255,7 @@ Mon Aug 28 11:58:12 CEST 2000 Daniel Veillard <Daniel.Veillard@w3.org>
 	  patches from Wayne Davison <wayned@users.sourceforge.net>,
 	  adding htmlEncodeEntities()
 	* HTMLparser.c: fixed an ignorable white space detection bug
-	  occuring when parsing with SAX only
+	  occurring when parsing with SAX only
 	* result/HTML/*.sax: updated since the output is now HTML
 	  encoded...
 
@@ -18420,7 +18420,7 @@ Fri Jul 14 16:12:20 MEST 2000 Daniel Veillard <Daniel.Veillard@w3.org>
 	  when using Sun Pro cc compiler
 	* xpath.c : cleanup memleaks
 	* nanoftp.c : added a TESTING preprocessor flag for standalong
-	  compile so that people can report bugs more easilly
+	  compile so that people can report bugs more easily
 	* nanohttp.c : ditched socklen_t which was a portability mess
 	  and replaced it with unsigned int.
 	* tree.[ch]: added xmlHasProp()
@@ -18594,7 +18594,7 @@ Mon Apr  3 21:47:10 CEST 2000 Daniel Veillard <Daniel.Veillard@w3.org>
 	  Makefile.am : added compile-time customization of libxml
 	  --with-ftp --with-http --with-html --with-xpath --with-debug
 	  --with-mem-debug
-	* *.[ch] autoconf.sh : moved to an absolute adressing of includes : 
+	* *.[ch] autoconf.sh : moved to an absolute addressing of includes :
 	  #include <libxml/xxx.h> I hope it won't break too much stuff
 	  and will be manageable in the future...
 	* xmllint.c Makefile.am libxml.spec.in : renamed tester.c to xmllint.c
@@ -18625,7 +18625,7 @@ Mon Mar 20 12:33:51 CET 2000 Daniel Veillard <Daniel.Veillard@w3.org>
 	  libxml default allocation function with another set (like gmalloc/
 	  gfree).
 	* Makefile.am, uri.c, uri.h: added a set of functions to do
-	  exact (litteraly copied from the RFC 2396 productions) parsing
+	  exact (literally copied from the RFC 2396 productions) parsing
 	  and handling of URI. Will be needed for XLink, one XML WFC, 
 	  XML Base and reused in the nano[ftp/http] modules. Still work
 	  to be done.
@@ -18688,7 +18688,7 @@ Thu Feb  3 15:59:37 CET 2000 Daniel Veillard <Daniel.Veillard@w3.org>
 
 	* nanoftp.c nanohttp.c tree.c HTMLtree.[ch] debugXML.c xpath.c: Fixed
 	  compilation warnings on various platforms.
-	* parser.c: Fixed #5281 validity error callbacks are now desactived
+	* parser.c: Fixed #5281 validity error callbacks are now deactivated
 	  by default if not validating.
 
 Thu Feb  3 13:46:14 CET 2000 Daniel Veillard <Daniel.Veillard@w3.org>
@@ -19125,7 +19125,7 @@ Wed Sep 22 11:40:31 CEST 1999 Daniel Veillard <Daniel.Veillard@w3.org>
 
 	* parser.h: modified the parser context struct to regain 1.4.0
 	            binary compatibility
-	* parser.c, xml-error.h: added errno ot teh context and defined
+	* parser.c, xml-error.h: added errno to the context and defined
 	            a set of errors values with update of errno
 	* nanohttp.[ch]: minimalist HTTP front-end for fetching remote
 	            DTDs and entities
@@ -19562,7 +19562,7 @@ Tue Oct 27 01:15:39 EST 1998 Daniel Veillard <Daniel.Veillard@w3.org>
 
 Sat Oct 24 14:23:51 EDT 1998 Daniel Veillard <Daniel.Veillard@w3.org>
 
-	* parser.c: Set up the fonctions comment block, boring but useful.
+	* parser.c: Set up the functions comment block, boring but useful.
 	* parser.h, SAX.c, parser.c: now attributes are processed through
 	  the SAX interface. The problem is that my SAX interface diverged
 	  quite a bit from the original one, well this is not an official
@@ -19571,7 +19571,7 @@ Sat Oct 24 14:23:51 EDT 1998 Daniel Veillard <Daniel.Veillard@w3.org>
 Tue Oct 20 02:11:21 EDT 1998 Daniel Veillard <Daniel.Veillard@w3.org>
 
 	* SAX.c, entities.c, tree.c, encoding.c, error.c: Set up the
-	  fonctions comment block, boring but useful.
+	  functions comment block, boring but useful.
 
 Sun Oct 18 20:40:58 EDT 1998 Daniel Veillard <Daniel.Veillard@w3.org>
 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/HTMLparser.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/HTMLparser.c
@@ -317,7 +317,7 @@ htmlNodeInfoPop(htmlParserCtxtPtr ctxt)
 
 #define SKIP_BLANKS htmlSkipBlankChars(ctxt)
 
-/* Inported from XML */
+/* Imported from XML */
 
 /* #define CUR (ctxt->token ? ctxt->token : (int) (*ctxt->input->cur)) */
 #define CUR ((int) (*ctxt->input->cur))
@@ -537,7 +537,7 @@ htmlCurrentChar(xmlParserCtxtPtr ctxt, int *len) {
 encoding_error:
     /*
      * If we detect an UTF8 error that probably mean that the
-     * input encoding didn't get properly advertized in the
+     * input encoding didn't get properly advertised in the
      * declaration header. Report the error and switch the encoding
      * to ISO-Latin-1 (if you don't like this policy, just declare the
      * encoding !)
@@ -602,8 +602,8 @@ htmlSkipBlankChars(xmlParserCtxtPtr ctxt) {
  ************************************************************************/
 
 /*
- *  Start Tag: 1 means the start tag can be ommited
- *  End Tag:   1 means the end tag can be ommited
+ *  Start Tag: 1 means the start tag can be omitted
+ *  End Tag:   1 means the end tag can be omitted
  *             2 means it's forbidden (empty elements)
  *             3 means the tag is stylistic and should be closed easily
  *  Depr:      this element is deprecated
@@ -1342,7 +1342,7 @@ htmlAutoCloseOnClose(htmlParserCtxtPtr ctxt, const xmlChar * newtag)
         if (xmlStrEqual(newtag, ctxt->nameTab[i]))
             break;
         /*
-         * A missplaced endtag can only close elements with lower
+         * A misplaced endtag can only close elements with lower
          * or equal priority, so if we find an element with higher
          * priority before we find an element with
          * matching name, we just ignore this endtag
@@ -2176,6 +2176,7 @@ htmlEncodeEntities(unsigned char* out, int *outlen,
  *                                  *
  ************************************************************************/
 
+#ifdef LIBXML_PUSH_ENABLED
 /**
  * htmlNewInputStream:
  * @ctxt:  an HTML parser context
@@ -2207,6 +2208,7 @@ htmlNewInputStream(htmlParserCtxtPtr ctxt) {
     input->length = 0;
     return(input);
 }
+#endif
 
 
 /************************************************************************
@@ -2216,9 +2218,9 @@ htmlNewInputStream(htmlParserCtxtPtr ctxt) {
  ************************************************************************/
 /*
  * all tags allowing pc data from the html 4.01 loose dtd
- * NOTE: it might be more apropriate to integrate this information
+ * NOTE: it might be more appropriate to integrate this information
  * into the html40ElementTable array but I don't want to risk any
- * binary incomptibility
+ * binary incompatibility
  */
 static const char *allowPCData[] = {
     "a", "abbr", "acronym", "address", "applet", "b", "bdo", "big",
@@ -2959,6 +2961,7 @@ htmlParseScript(htmlParserCtxtPtr ctxt) {
     }
     COPY_BUF(l,buf,nbchar,cur);
     if (nbchar >= HTML_PARSER_BIG_BUFFER_SIZE) {
+            buf[nbchar] = 0;
         if (ctxt->sax->cdataBlock!= NULL) {
         /*
          * Insert as CDATA, which is the same as HTML_PRESERVE_NODE
@@ -2983,6 +2986,7 @@ htmlParseScript(htmlParserCtxtPtr ctxt) {
     }
 
     if ((nbchar != 0) && (ctxt->sax != NULL) && (!ctxt->disableSAX)) {
+        buf[nbchar] = 0;
     if (ctxt->sax->cdataBlock!= NULL) {
         /*
          * Insert as CDATA, which is the same as HTML_PRESERVE_NODE
@@ -3028,6 +3032,8 @@ htmlParseCharDataInternal(htmlParserCtxtPtr ctxt, int readahead) {
         COPY_BUF(l,buf,nbchar,cur);
     }
     if (nbchar >= HTML_PARSER_BIG_BUFFER_SIZE) {
+            buf[nbchar] = 0;
+
         /*
          * Ok the segment is to be consumed as chars.
          */
@@ -5762,13 +5768,13 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
                 break;
         }
             case XML_PARSER_CONTENT: {
+        xmlChar chr[2] = { 0, 0 };
         long cons;
+
                 /*
          * Handle preparsed entities and charRef
          */
         if (ctxt->token != 0) {
-            xmlChar chr[2] = { 0 , 0 } ;
-
             chr[0] = (xmlChar) ctxt->token;
             htmlCheckParagraph(ctxt);
             if ((ctxt->sax != NULL) && (ctxt->sax->characters != NULL))
@@ -5780,21 +5786,22 @@ htmlParseTryOrFinish(htmlParserCtxtPtr ctxt, int terminate) {
             cur = in->cur[0];
             if ((cur != '<') && (cur != '&')) {
             if (ctxt->sax != NULL) {
+                            chr[0] = cur;
                 if (IS_BLANK_CH(cur)) {
                 if (ctxt->keepBlanks) {
                     if (ctxt->sax->characters != NULL)
                     ctxt->sax->characters(
-                        ctxt->userData, &in->cur[0], 1);
+                        ctxt->userData, chr, 1);
                 } else {
                     if (ctxt->sax->ignorableWhitespace != NULL)
                     ctxt->sax->ignorableWhitespace(
-                        ctxt->userData, &in->cur[0], 1);
+                        ctxt->userData, chr, 1);
                 }
                 } else {
                 htmlCheckParagraph(ctxt);
                 if (ctxt->sax->characters != NULL)
                     ctxt->sax->characters(
-                        ctxt->userData, &in->cur[0], 1);
+                        ctxt->userData, chr, 1);
                 }
             }
             ctxt->token = 0;

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/HTMLtree.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/HTMLtree.c
@@ -1048,7 +1048,7 @@ htmlDocContentDumpFormatOutput(xmlOutputBufferPtr buf, xmlDocPtr cur,
  * @cur:  the document
  * @encoding:  the encoding string
  *
- * Dump an HTML document. Formating return/spaces are added.
+ * Dump an HTML document. Formatting return/spaces are added.
  */
 void
 htmlDocContentDumpOutput(xmlOutputBufferPtr buf, xmlDocPtr cur,

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/Makefile.am
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/Makefile.am
@@ -126,11 +126,7 @@ testC14N_LDFLAGS =
 testC14N_DEPENDENCIES = $(DEPS)
 testC14N_LDADD= $(LDADDS)
 
-if THREADS_W32
-testThreads_SOURCES = testThreadsWin32.c
-else
 testThreads_SOURCES = testThreads.c
-endif
 testThreads_LDFLAGS = 
 testThreads_DEPENDENCIES = $(DEPS)
 testThreads_LDADD= $(BASE_THREAD_LIBS) $(LDADDS)
@@ -919,6 +915,9 @@ Regexptests: testRegexp$(EXEEXT)
 	      if [ -n "$$log" ] ; then echo $$name result ; echo "$$log" ; fi ; \
 	      rm result.$$name ; \
 	  fi ; fi ; done)
+
+# Disabled for now
+Exptests: testRegexp$(EXEEXT)
 	@echo "## Formal expresssions regression tests"
 	-@(for i in $(srcdir)/test/expr/* ; do \
 	  name=`basename $$i`; \
@@ -1235,6 +1234,7 @@ xml2Conf.sh: xml2Conf.sh.in Makefile
 	    -e 's?\@XML_INCLUDEDIR\@?$(XML_INCLUDEDIR)?g' \
 	    -e 's?\@VERSION\@?$(VERSION)?g' \
 	    -e 's?\@XML_LIBS\@?$(XML_LIBS)?g' \
+	    -e 's?\@XML_PRIVATE_LIBS\@?$(XML_PRIVATE_LIBS)?g' \
 	       < $(srcdir)/xml2Conf.sh.in > xml2Conf.tmp \
 	&& mv xml2Conf.tmp xml2Conf.sh
 
@@ -1253,7 +1253,7 @@ EXTRA_DIST = xml2-config.in xml2Conf.sh.in libxml.spec.in libxml2.spec \
 	     libxml2-config.cmake.in autogen.sh \
 	     trionan.c trionan.h triostr.c triostr.h trio.c trio.h \
 	     triop.h triodef.h libxml.h elfgcchack.h xzlib.h buf.h \
-	     enc.h save.h testThreadsWin32.c genUnicode.py TODO_SCHEMAS \
+	     enc.h save.h genUnicode.py TODO_SCHEMAS \
 	     dbgen.pl dbgenattr.pl regressions.py regressions.xml \
 	     README.tests Makefile.tests libxml2.syms timsort.h \
 	     README.zOS \

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/NEWS
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/NEWS
@@ -8,8 +8,451 @@ The change log at
 ChangeLog.html
  describes the recents commits
 to the GIT at 
-http://git.gnome.org/browse/libxml2/
+https://gitlab.gnome.org/GNOME/libxml2
  code base.Here is the list of public releases:
+v2.9.9: Jan 03 2019:
+   - Security:
+  CVE-2018-9251 CVE-2018-14567 Fix infinite loop in LZMA decompression (Nick Wellnhofer),
+  CVE-2018-14404 Fix nullptr deref with XPath logic ops (Nick Wellnhofer),
+
+   - Documentation:
+  reader: Fix documentation comment (Mohammed Sadiq)
+
+   - Portability:
+  Fix MSVC build with lzma (Nick Wellnhofer),
+  Variables need 'extern' in static lib on Cygwin (Michael Haubenwallner),
+  Really declare dllexport/dllimport for Cygwin (Michael Haubenwallner),
+  Merge branch 'patch-2' into 'master' (Nick Wellnhofer),
+  Change dir to $THEDIR after ACLOCAL_PATH check autoreconf creates aclocal.m4 in $srcdir (Vitaly Buka),
+  Improve error message if pkg.m4 couldn't be found (Nick Wellnhofer),
+  NaN and Inf fixes for pre-C99 compilers (Nick Wellnhofer)
+
+   - Bug Fixes:
+  Revert "Support xmlTextReaderNextSibling w/o preparsed doc" (Nick Wellnhofer),
+  Fix building relative URIs (Thomas Holder),
+  Problem with data in interleave in RelaxNG validation (Nikolai Weibull),
+  Fix memory leak in xmlSwitchInputEncodingInt error path (Nick Wellnhofer),
+  Set doc on element obtained from freeElems (Nick Wellnhofer),
+  Fix HTML serialization with UTF-8 encoding (Nick Wellnhofer),
+  Use actual doc in xmlTextReaderRead*Xml (Nick Wellnhofer),
+  Unlink node before freeing it in xmlSAX2StartElement (Nick Wellnhofer),
+  Check return value of nodePush in xmlSAX2StartElement (Nick Wellnhofer),
+  Free input buffer in xmlHaltParser (Nick Wellnhofer),
+  Reset HTML parser input pointers on encoding failure (Nick Wellnhofer),
+  Don't run icu_parse_test if EUC-JP is unsupported (Nick Wellnhofer),
+  Fix xmlSchemaValidCtxtPtr reuse memory leak (Greg Hildstrom),
+  Fix xmlTextReaderNext with preparsed document (Felix Bünemann),
+  Remove stray character from comment (Nick Wellnhofer),
+  Remove a misleading line from xmlCharEncOutput (Andrey Bienkowski),
+  HTML noscript should not close p (Daniel Veillard),
+  Don't change context node in xmlXPathRoot (Nick Wellnhofer),
+  Stop using XPATH_OP_RESET (Nick Wellnhofer),
+  Revert "Change calls to xmlCharEncInput to set flush false" (Nick Wellnhofer)
+
+   - Improvements:
+  Fix "Problem with data in interleave in RelaxNG validation" (Nikolai Weibull),
+  cleanup: remove some unreachable code (Thomas Holder),
+  add --relative to testURI (Thomas Holder),
+  Remove redefined starts and defines inside include elements (Nikolai Weibull),
+  Allow choice within choice in nameClass in RELAX NG (Nikolai Weibull),
+  Look inside divs for starts and defines inside include (Nikolai Weibull),
+  Add compile and libxml2-config.cmake to .gitignore (Nikolai Weibull),
+  Stop using doc->charset outside parser code (Nick Wellnhofer),
+  Add newlines to 'xmllint --xpath' output (Nick Wellnhofer),
+  Don't include SAX.h from globals.h (Nick Wellnhofer),
+  Support xmlTextReaderNextSibling w/o preparsed doc (Felix Bünemann),
+  Don't instruct user to run make when autogen.sh failed (林博仁(Buo-ren Lin)),
+  Run Travis ASan tests with "sudo: required" (Nick Wellnhofer),
+  Improve restoring of context size and position (Nick Wellnhofer),
+  Simplify and harden nodeset filtering (Nick Wellnhofer),
+  Avoid unnecessary backups of the context node (Nick Wellnhofer),
+  Fix inconsistency in xmlXPathIsInf (Nick Wellnhofer)
+
+   - Cleanups:
+
+
+
+v2.9.8: Mar 05 2018:
+   - Portability:
+  python: remove single use of _PyVerify_fd (Patrick Welche),
+  Build more test executables on Windows/MSVC (Nick Wellnhofer),
+  Stop including ansidecl.h (Nick Wellnhofer),
+  Fix libz and liblzma detection (Nick Wellnhofer),
+  Revert "Compile testapi with -Wno-unused-function" (Nick Wellnhofer)
+
+   - Bug Fixes:
+  Fix xmlParserEntityCheck (Nick Wellnhofer),
+  Halt parser in case of encoding error (Nick Wellnhofer),
+  Clear entity content in case of errors (Nick Wellnhofer),
+  Change calls to xmlCharEncInput to set flush false when not final call. Having flush incorrectly set to true causes errors for ICU. (Joel Hockey),
+  Fix buffer over-read in xmlParseNCNameComplex (Nick Wellnhofer),
+  Fix ICU library filenames on Windows/MSVC (Nick Wellnhofer),
+  Fix xmlXPathIsNaN broken by recent commit (Nick Wellnhofer),
+  Fix -Wenum-compare warnings (Nick Wellnhofer),
+  Fix callback signature in testapi.c (Nick Wellnhofer),
+  Fix unused parameter warning without ICU (Nick Wellnhofer),
+  Fix IO callback signatures (Nick Wellnhofer),
+  Fix misc callback signatures (Nick Wellnhofer),
+  Fix list callback signatures (Nick Wellnhofer),
+  Fix hash callback signatures (Nick Wellnhofer),
+  Refactor name and type signature for xmlNop (Vlad Tsyrklevich),
+  Fixed ICU to set flush correctly and provide pivot buffer. (Joel Hockey),
+  Skip EBCDIC tests if EBCDIC isn't supported (Nick Wellnhofer)
+
+   - Improvements:
+  Disable pointer-overflow UBSan checks under Travis (Nick Wellnhofer),
+  Improve handling of context input_id (Daniel Veillard),
+  Add resource file to Windows DLL (ccpaging),
+  Run Travis tests with -Werror (Nick Wellnhofer),
+  Build with "-Wall -Wextra" (Nick Wellnhofer),
+  Fix -Wtautological-pointer-compare warnings (Nick Wellnhofer),
+  Remove unused AC_CHECKs (Nick Wellnhofer),
+  Update information about contributing (Nick Wellnhofer),
+  Fix -Wmisleading-indentation warnings (Nick Wellnhofer),
+  Don't touch CFLAGS in configure.ac (Nick Wellnhofer),
+  Ignore function pointer cast warnings (Nick Wellnhofer),
+  Simplify XPath NaN, inf and -0 handling (Nick Wellnhofer),
+  Introduce xmlPosixStrdup and update xmlMemStrdup (Nick Wellnhofer),
+  Add test for ICU flush and pivot buffer (Nick Wellnhofer),
+  Compile testapi with -Wno-unused-function (Nick Wellnhofer)
+
+
+
+2.9.7: Nov 02 2017:
+   - Documentation:
+  xmlcatalog: refresh man page wrt. quering system catalog easily (Jan Pokorný)
+
+   - Portability:
+  Fix deprecated Travis compiler flag (Nick Wellnhofer),
+  Add declaration for DllMain (J. Peter Mugaas),
+  Fix preprocessor conditional in threads.h (J. Peter Mugaas),
+  Fix pointer comparison warnings on 64-bit Windows (J. Peter Mugaas),
+  Fix macro redefinition warning (J. Peter Mugaas),
+  Default to native threads on MinGW-w64 (Nick Wellnhofer),
+  Simplify Windows IO functions (Nick Wellnhofer),
+  Fix runtest on Windows (Nick Wellnhofer),
+  socklen_t is always int on Windows (Nick Wellnhofer),
+  Don't redefine socket error codes on Windows (Nick Wellnhofer),
+  Fix pointer/int cast warnings on 64-bit Windows (Nick Wellnhofer),
+  Fix Windows compiler warnings in xmlCanonicPath (Nick Wellnhofer)
+
+   - Bug Fixes:
+  xmlcatalog: restore ability to query system catalog easily (Jan Pokorný),
+  Fix comparison of nodesets to strings (Nick Wellnhofer)
+
+   - Improvements:
+  Add Makefile rules to rebuild HTML man pages (Nick Wellnhofer),
+  Fix mixed decls and code in timsort.h (Nick Wellnhofer),
+  Rework handling of return values in thread tests (Nick Wellnhofer),
+  Fix unused variable warnings in testrecurse (Nick Wellnhofer),
+  Fix -Wimplicit-fallthrough warnings (J. Peter Mugaas),
+  Upgrade timsort.h to latest revision (Nick Wellnhofer),
+  Increase warning level to /W3 under MSVC (Nick Wellnhofer),
+  Fix a couple of warnings in dict.c and threads.c (Nick Wellnhofer),
+  Update .gitignore for Windows (Nick Wellnhofer),
+  Fix unused variable warnings in nanohttp.c (Nick Wellnhofer),
+  Fix the Windows header mess (Nick Wellnhofer),
+  Don't include winsock2.h in xmllint.c (Nick Wellnhofer),
+  Remove generated file python/setup.py from version control (Nick Wellnhofer),
+  Use __linux__ macro in generated code (Nick Wellnhofer)
+
+
+
+v2.9.6: Oct 06 2017:
+   - Portability:
+  Change preprocessor OS tests to __linux__ (Nick Wellnhofer)
+
+   - Bug Fixes:
+  Fix XPath stack frame logic (Nick Wellnhofer),
+  Report undefined XPath variable error message (Nick Wellnhofer),
+  Fix regression with librsvg (Nick Wellnhofer),
+  Handle more invalid entity values in recovery mode (Nick Wellnhofer),
+  Fix structured validation errors (Nick Wellnhofer),
+  Fix memory leak in LZMA decompressor (Nick Wellnhofer),
+  Set memory limit for LZMA decompression (Nick Wellnhofer),
+  Handle illegal entity values in recovery mode (Nick Wellnhofer),
+  Fix debug dump of streaming XPath expressions (Nick Wellnhofer),
+  Fix memory leak in nanoftp (Nick Wellnhofer),
+  Fix memory leaks in SAX1 parser (Nick Wellnhofer)
+
+
+
+v2.9.5: Sep 04 2017:
+   - Security:
+  Detect infinite recursion in parameter entities (Nick Wellnhofer),
+  Fix handling of parameter-entity references (Nick Wellnhofer),
+  Disallow namespace nodes in XPointer ranges (Nick Wellnhofer),
+  Fix XPointer paths beginning with range-to (Nick Wellnhofer)
+
+   - Documentation:
+  Documentation fixes (Nick Wellnhofer),
+  Spelling and grammar fixes (Nick Wellnhofer)
+
+   - Portability:
+  Adding README.zOS to list of extra files for the release (Daniel Veillard),
+  Description of work needed to compile on zOS (Stéphane Michaut),
+  Porting libxml2 on zOS encoding of code (Stéphane Michaut),
+  small changes for OS/400 (Patrick Monnerat),
+  relaxng.c, xmlschemas.c: Fix build on pre-C99 compilers (Chun-wei Fan)
+
+   - Bug Fixes:
+  Problem resolving relative URIs (Daniel Veillard),
+  Fix unwanted warnings when switching encodings (Nick Wellnhofer),
+  Fix signature of xmlSchemaAugmentImportedIDC (Daniel Veillard),
+  Heap-buffer-overflow read of size 1 in xmlFAParsePosCharGroup (David Kilzer),
+  Fix NULL pointer deref in xmlFAParseCharClassEsc (Nick Wellnhofer),
+  Fix infinite loops with push parser in recovery mode (Nick Wellnhofer),
+  Send xmllint usage error to stderr (Nick Wellnhofer),
+  Fix NULL deref in xmlParseExternalEntityPrivate (Nick Wellnhofer),
+  Make sure not to call IS_BLANK_CH when parsing the DTD (Nick Wellnhofer),
+  Fix xmlHaltParser (Nick Wellnhofer),
+  Fix pathological performance when outputting charrefs (Nick Wellnhofer),
+  Fix invalid-source-encoding warnings in testWriter.c (Nick Wellnhofer),
+  Fix duplicate SAX callbacks for entity content (David Kilzer),
+  Treat URIs with scheme as absolute in C14N (Nick Wellnhofer),
+  Fix copy-paste errors in error messages (Nick Wellnhofer),
+  Fix sanity check in htmlParseNameComplex (Nick Wellnhofer),
+  Fix potential infinite loop in xmlStringLenDecodeEntities (Nick Wellnhofer),
+  Reset parser input pointers on encoding failure (Nick Wellnhofer),
+  Fix memory leak in xmlParseEntityDecl error path (Nick Wellnhofer),
+  Fix xmlBuildRelativeURI for URIs starting with './' (Nick Wellnhofer),
+  Fix type confusion in xmlValidateOneNamespace (Nick Wellnhofer),
+  Fix memory leak in xmlStringLenGetNodeList (Nick Wellnhofer),
+  Fix NULL pointer deref in xmlDumpElementContent (Daniel Veillard),
+  Fix memory leak in xmlBufAttrSerializeTxtContent (Nick Wellnhofer),
+  Stop parser on unsupported encodings (Nick Wellnhofer),
+  Check for integer overflow in memory debug code (Nick Wellnhofer),
+  Fix buffer size checks in xmlSnprintfElementContent (Nick Wellnhofer),
+  Avoid reparsing in xmlParseStartTag2 (Nick Wellnhofer),
+  Fix undefined behavior in xmlRegExecPushStringInternal (Nick Wellnhofer),
+  Check XPath exponents for overflow (Nick Wellnhofer),
+  Check for overflow in xmlXPathIsPositionalPredicate (Nick Wellnhofer),
+  Fix spurious error message (Nick Wellnhofer),
+  Fix memory leak in xmlCanonicPath (Nick Wellnhofer),
+  Fix memory leak in xmlXPathCompareNodeSetValue (Nick Wellnhofer),
+  Fix memory leak in pattern error path (Nick Wellnhofer),
+  Fix memory leak in parser error path (Nick Wellnhofer),
+  Fix memory leaks in XPointer error paths (Nick Wellnhofer),
+  Fix memory leak in xmlXPathNodeSetMergeAndClear (Nick Wellnhofer),
+  Fix memory leak in XPath filter optimizations (Nick Wellnhofer),
+  Fix memory leaks in XPath error paths (Nick Wellnhofer),
+  Do not leak the new CData node if adding fails (David Tardon),
+  Prevent unwanted external entity reference (Neel Mehta),
+  Increase buffer space for port in HTTP redirect support (Daniel Veillard),
+  Fix more NULL pointer derefs in xpointer.c (Nick Wellnhofer),
+  Avoid function/data pointer conversion in xpath.c (Nick Wellnhofer),
+  Fix format string warnings (Nick Wellnhofer),
+  Disallow namespace nodes in XPointer points (Nick Wellnhofer),
+  Fix comparison with root node in xmlXPathCmpNodes (Nick Wellnhofer),
+  Fix attribute decoding during XML schema validation (Alex Henrie),
+  Fix NULL pointer deref in XPointer range-to (Nick Wellnhofer)
+
+   - Improvements:
+  Updating the spec file to reflect Fedora 24 (Daniel Veillard),
+  Add const in five places to move 1 KiB to .rdata (Bruce Dawson),
+  Fix missing part of comment for function xmlXPathEvalExpression() (Daniel Veillard),
+  Get rid of "blanks wrapper" for parameter entities (Nick Wellnhofer),
+  Simplify handling of parameter entity references (Nick Wellnhofer),
+  Deduplicate code in encoding.c (Nick Wellnhofer),
+  Make HTML parser functions take const pointers (Nick Wellnhofer),
+  Build test programs only when needed (Nick Wellnhofer),
+  Fix doc/examples/index.py (Nick Wellnhofer),
+  Fix compiler warnings in threads.c (Nick Wellnhofer),
+  Fix empty-body warning in nanohttp.c (Nick Wellnhofer),
+  Fix cast-align warnings (Nick Wellnhofer),
+  Fix unused-parameter warnings (Nick Wellnhofer),
+  Rework entity boundary checks (Nick Wellnhofer),
+  Don't switch encoding for internal parameter entities (Nick Wellnhofer),
+  Merge duplicate code paths handling PE references (Nick Wellnhofer),
+  Test SAX2 callbacks with entity substitution (Nick Wellnhofer),
+  Support catalog and threads tests under --without-sax1 (Nick Wellnhofer),
+  Misc fixes for 'make tests' (Nick Wellnhofer),
+  Initialize keepBlanks in HTML parser (Nick Wellnhofer),
+  Add test cases for bug 758518 (David Kilzer),
+  Fix compiler warning in htmlParseElementInternal (Nick Wellnhofer),
+  Remove useless check in xmlParseAttributeListDecl (Nick Wellnhofer),
+  Allow zero sized memory input buffers (Nick Wellnhofer),
+  Add TODO comment in xmlSwitchEncoding (Nick Wellnhofer),
+  Check for integer overflow in xmlXPathFormatNumber (Nick Wellnhofer),
+  Make Travis print UBSan stacktraces (Nick Wellnhofer),
+  Add .travis.yml (Nick Wellnhofer),
+  Fix expected error output in Python tests (Nick Wellnhofer),
+  Simplify control flow in xmlParseStartTag2 (Nick Wellnhofer),
+  Disable LeakSanitizer when running API tests (Nick Wellnhofer),
+  Avoid out-of-bound array access in API tests (Nick Wellnhofer),
+  Avoid spurious UBSan errors in parser.c (Nick Wellnhofer),
+  Parse small XPath numbers more accurately (Nick Wellnhofer),
+  Rework XPath rounding functions (Nick Wellnhofer),
+  Fix white space in test output (Nick Wellnhofer),
+  Fix axis traversal from attribute and namespace nodes (Nick Wellnhofer),
+  Check for trailing characters in XPath expressions earlier (Nick Wellnhofer),
+  Rework final handling of XPath results (Nick Wellnhofer),
+  Make xmlXPathEvalExpression call xmlXPathEval (Nick Wellnhofer),
+  Remove unused variables (Nick Wellnhofer),
+  Don't print generic error messages in XPath tests (Nick Wellnhofer)
+
+   - Cleanups:
+  Fix a couple of misleading indentation errors (Daniel Veillard),
+  Remove unnecessary calls to xmlPopInput (Nick Wellnhofer)
+
+
+
+2.9.4: May 23 2016:
+   - Security:
+  More format string warnings with possible format string vulnerability (David Kilzer),
+  Avoid building recursive entities (Daniel Veillard),
+  Heap-based buffer overread in htmlCurrentChar (Pranjal Jumde),
+  Heap-based buffer-underreads due to xmlParseName (David Kilzer),
+  Heap use-after-free in xmlSAX2AttributeNs (Pranjal Jumde),
+  Heap use-after-free in htmlParsePubidLiteral and htmlParseSystemiteral (Pranjal Jumde),
+  Fix some format string warnings with possible format string vulnerability (David Kilzer),
+  Detect change of encoding when parsing HTML names (Hugh Davenport),
+  Fix inappropriate fetch of entities content (Daniel Veillard),
+  Bug 759398: Heap use-after-free in xmlDictComputeFastKey <https://bugzilla.gnome.org/show_bug.cgi?id=759398> (Pranjal Jumde),
+  Bug 758605: Heap-based buffer overread in xmlDictAddString <https://bugzilla.gnome.org/show_bug.cgi?id=758605> (Pranjal Jumde),
+  Bug 758588: Heap-based buffer overread in xmlParserPrintFileContextInternal <https://bugzilla.gnome.org/show_bug.cgi?id=758588> (David Kilzer),
+  Bug 757711: heap-buffer-overflow in xmlFAParsePosCharGroup <https://bugzilla.gnome.org/show_bug.cgi?id=757711> (Pranjal Jumde),
+  Add missing increments of recursion depth counter to XML parser. (Peter Simons)
+
+   - Documentation:
+  Fix typo: s{ ec -> cr }cipt (Jan Pokorný),
+  Fix typos: dictio{ nn -> n }ar{y,ies} (Jan Pokorný),
+  Fix typos: PATH_{ SEAPARATOR -> SEPARATOR } (Jan Pokorný),
+  Correct a typo. (Shlomi Fish)
+
+   - Portability:
+  Correct the usage of LDFLAGS (Mattias Hansson),
+  Revert the use of SAVE_LDFLAGS in configure.ac (Mattias Hansson),
+  libxml2 hardcodes -L/lib in zlib/lzma tests which breaks cross-compiles (Mike Frysinger),
+  Fix apibuild for a recently added construct (Daniel Veillard),
+  Use pkg-config to locate zlib when possible (Stewart Brodie),
+  Use pkg-config to locate ICU when possible (Stewart Brodie),
+  Portability to non C99 compliant compilers (Patrick Monnerat),
+  dict.h: Move xmlDictPtr definition before includes to allow direct inclusion. (Patrick Monnerat),
+  os400: tell about xmllint and xmlcatalog in README400. (Patrick Monnerat),
+  os400: properly process SGML add in XMLCATALOG command. (Patrick Monnerat),
+  os400: implement CL command XMLCATALOG. (Patrick Monnerat),
+  os400: compile and install program xmlcatalog (qshell-only). (Patrick Monnerat),
+  os400: expand tabs in sources, strip trailing blanks. (Patrick Monnerat),
+  os400: implement CL command XMLLINT. (Patrick Monnerat),
+  os400: compile and install program xmllint (qshell-only). (Patrick Monnerat),
+  os400: initscript make_module(): Use options instead of positional parameters. (Patrick Monnerat),
+  os400: c14n.rpgle: allow *omit for nullable reference parameters. (Patrick Monnerat),
+  os400: use like() for double type. (Patrick Monnerat),
+  os400: use like() for int type. (Patrick Monnerat),
+  os400: use like() for unsigned int type. (Patrick Monnerat),
+  os400: use like() for enum types. (Patrick Monnerat),
+  Add xz to xml2-config --libs output (Baruch Siach),
+  Bug 760190: configure.ac should be able to build --with-icu without icu-config tool <https://bugzilla.gnome.org/show_bug.cgi?id=760190> (David Kilzer),
+  win32\VC10\config.h and VS 2015 (Bruce Dawson),
+  Add configure maintainer mode (orzen)
+
+   - Bug Fixes:
+  Avoid an out of bound access when serializing malformed strings (Daniel Veillard),
+  Unsigned addition may overflow in xmlMallocAtomicLoc() (David Kilzer),
+  Integer signed/unsigned type mismatch in xmlParserInputGrow() (David Kilzer),
+  Bug 763071: heap-buffer-overflow in xmlStrncat <https://bugzilla.gnome.org/show_bug.cgi?id=763071> (Pranjal Jumde),
+  Integer overflow parsing port number in URI (Michael Paddon),
+  Fix an error with regexp on nullable counted char transition (Daniel Veillard),
+  Fix memory leak with XPath namespace nodes (Nick Wellnhofer),
+  Fix namespace axis traversal (Nick Wellnhofer),
+      Fix null pointer deref in docs with no root element (Hugh Davenport),
+  Fix XSD validation of URIs with ampersands (Alex Henrie),
+  xmlschemastypes.c: accept endOfDayFrag Times set to "24:00:00" mean "end of day" and should not cause an error. (Patrick Monnerat),
+  xmlcatalog: flush stdout before interactive shell input. (Patrick Monnerat),
+  xmllint: flush stdout before interactive shell input. (Patrick Monnerat),
+  Don't recurse into OP_VALUEs in xmlXPathOptimizeExpression (Nick Wellnhofer),
+  Fix namespace::node() XPath expression (Nick Wellnhofer),
+  Fix OOB write in xmlXPathEmptyNodeSet (Nick Wellnhofer),
+  Fix parsing of NCNames in XPath (Nick Wellnhofer),
+  Fix OOB read with invalid UTF-8 in xmlUTF8Strsize (Nick Wellnhofer),
+  Do normalize string-based datatype value in RelaxNG facet checking (Audric Schiltknecht),
+  Bug 760921: REGRESSION (8eb55d78): doc/examples/io1 test fails after fix for "xmlSaveUri() incorrectly recomposes URIs with rootless paths" <https://bugzilla.gnome.org/show_bug.cgi?id=760921> (David Kilzer),
+  Bug 760861: REGRESSION (bf9c1dad): Missing results for test/schemas/regexp-char-ref_[01].xsd <https://bugzilla.gnome.org/show_bug.cgi?id=760861> (David Kilzer),
+  error.c: *input->cur == 0 does not mean no error (Pavel Raiskup),
+  Add missing RNG test files (David Kilzer),
+  Bug 760183: REGRESSION (v2.9.3): XML push parser fails with bogus UTF-8 encoding error when multi-byte character in large CDATA section is split across buffer <https://bugzilla.gnome.org/show_bug.cgi?id=760183> (David Kilzer),
+  Bug 758572: ASAN crash in make check <https://bugzilla.gnome.org/show_bug.cgi?id=758572> (David Kilzer),
+  Bug 721158: Missing ICU string when doing --version on xmllint <https://bugzilla.gnome.org/show_bug.cgi?id=721158> (David Kilzer),
+  python 3: libxml2.c wrappers create Unicode str already (Michael Stahl),
+  Add autogen.sh to distrib (orzen),
+  Heap-based buffer overread in xmlNextChar (Daniel Veillard)
+
+   - Improvements:
+  Add more debugging info to runtest (Daniel Veillard),
+  Implement "runtest -u" mode (David Kilzer),
+  Add a make rule to rebuild for ASAN (Daniel Veillard)
+
+
+
+v2.9.3: Nov 20 2015:
+   - Security:
+  CVE-2015-8242 Buffer overead with HTML parser in push mode (Hugh Davenport),
+  CVE-2015-7500 Fix memory access error due to incorrect entities boundaries (Daniel Veillard),
+  CVE-2015-7499-2 Detect incoherency on GROW (Daniel Veillard),
+  CVE-2015-7499-1 Add xmlHaltParser() to stop the parser (Daniel Veillard),
+  CVE-2015-5312 Another entity expansion issue (David Drysdale),
+  CVE-2015-7497 Avoid an heap buffer overflow in xmlDictComputeFastQKey (David Drysdale),
+  CVE-2015-7498 Avoid processing entities after encoding conversion failures (Daniel Veillard),
+  CVE-2015-8035 Fix XZ compression support loop (Daniel Veillard),
+  CVE-2015-7942-2 Fix an error in previous Conditional section patch (Daniel Veillard),
+  CVE-2015-7942 Another variation of overflow in Conditional sections (Daniel Veillard),
+  CVE-2015-1819 Enforce the reader to run in constant memory (Daniel Veillard)
+  CVE-2015-7941_2 Cleanup conditional section error handling (Daniel Veillard),
+  CVE-2015-7941_1 Stop parsing on entities boundaries errors (Daniel Veillard),
+
+   - Documentation:
+  Correct spelling of "calling" (Alex Henrie),
+  Fix a small error in xmllint --format description (Fabien Degomme),
+  Avoid XSS on the search of xmlsoft.org (Daniel Veillard)
+
+   - Portability:
+  threads: use forward declarations only for glibc (Michael Heimpold),
+  Update Win32 configure.js to search for configure.ac (Daniel Veillard)
+
+   - Bug Fixes:
+  Bug on creating new stream from entity (Daniel Veillard),
+  Fix some loop issues embedding NEXT (Daniel Veillard),
+  Do not print error context when there is none (Daniel Veillard),
+  Avoid extra processing of MarkupDecl when EOF (Hugh Davenport),
+  Fix parsing short unclosed comment uninitialized access (Daniel Veillard),
+  Add missing Null check in xmlParseExternalEntityPrivate (Gaurav Gupta),
+  Fix a bug in CData error handling in the push parser (Daniel Veillard),
+  Fix a bug on name parsing at the end of current input buffer (Daniel Veillard),
+  Fix the spurious ID already defined error (Daniel Veillard),
+  Fix previous change to node sort order (Nick Wellnhofer),
+  Fix a self assignment issue raised by clang (Scott Graham),
+  Fail parsing early on if encoding conversion failed (Daniel Veillard),
+  Do not process encoding values if the declaration if broken (Daniel Veillard),
+  Silence clang's -Wunknown-attribute (Michael Catanzaro),
+  xmlMemUsed is not thread-safe (Martin von Gagern),
+  Fix support for except in nameclasses (Daniel Veillard),
+  Fix order of root nodes (Nick Wellnhofer),
+  Allow attributes on descendant-or-self axis (Nick Wellnhofer),
+  Fix the fix to Windows locking (Steve Nairn),
+  Fix timsort invariant loop re: Envisage article (Christopher Swenson),
+  Don't add IDs in xmlSetTreeDoc (Nick Wellnhofer),
+  Account for ID attributes in xmlSetTreeDoc (Nick Wellnhofer),
+  Remove various unused value assignments (Philip Withnall),
+  Fix missing entities after CVE-2014-3660 fix (Daniel Veillard),
+  Revert "Missing initialization for the catalog module" (Daniel Veillard)
+
+   - Improvements:
+  Reuse xmlHaltParser() where it makes sense (Daniel Veillard),
+  xmlStopParser reset errNo (Daniel Veillard),
+  Reenable xz support by default (Daniel Veillard),
+  Recover unescaped less-than character in HTML recovery parsing (Daniel Veillard),
+  Allow HTML serializer to output HTML5 DOCTYPE (Shaun McCance),
+  Regression test for bug #695699 (Nick Wellnhofer),
+  Add a couple of XPath tests (Nick Wellnhofer),
+  Add Python 3 rpm subpackage (Tomas Radej),
+  libxml2-config.cmake.in: update include directories (Samuel Martin),
+  Adding example from bugs 738805 to regression tests (Daniel Veillard)
+
+   - Cleanups:
+
+
+
 2.9.2: Oct 16 2014:
    - Security:
   Fix for CVE-2014-3660 billion laugh variant (Daniel Veillard),
@@ -845,7 +1288,7 @@ Gansterer),
    - Improvement: switch parser to XML-1.0 5th edition, add parsing flags
       for old versions, switch URI parsing to RFC 3986,
       add xmlSchemaValidCtxtGetParserCtxt (Holger Kaelberer),
-      new hashing functions for dictionaries (based on Stefan Behnel work),
+      new hashing functions for dictionnaries (based on Stefan Behnel work),
       improve handling of misplaced html/head/body in HTML parser, better
       regression test tools and code coverage display, better algorithms
       to detect various versions of the billion laughts attacks, make
@@ -955,7 +1398,7 @@ Gansterer),
       on Windows (Igor Zlatkovic), htmlCtxtReset fix (Michael Day), XPath
       principal node of axis bug, HTML serialization of some codepoint
       (Steven Rainwater), user data propagation in XInclude (Michael Day),
-      standalone and XML decl detection (Michael Day), Python id ouptut
+      standalone and XML decl detection (Michael Day), Python id output
       for some id, fix the big python string memory leak, URI parsing fixes
       (StÃ©phane Bidoul and William), long comments parsing bug (William),
       concurrent threads initialization (Ted Phelps), invalid char
@@ -967,7 +1410,7 @@ Gansterer),
       min occurs of 0 (William), HTML script/style parsing (Mike Day)
    - Improvement: make xmlTextReaderSetup() public
    - Compilation and postability: fix a missing include problem (William),
-      __ss_familly on AIX again (BjÃ¶rn Wiberg), compilation without zlib
+      __ss_family on AIX again (BjÃ¶rn Wiberg), compilation without zlib
       (Michael Day), catalog patch for Win32 (Christian Ehrlicher),
       Windows CE fixes (Andreas Stricke)
    - Various CVS to SVN infrastructure changes
@@ -1006,7 +1449,7 @@ Gansterer),
       fix attribute serialization in writer (Rob Richards), PHP4 DTD validation
       crasher, parser safety patch (Ben Darnell), _private context propagation
       when parsing entities (with Michael Day), fix entities behaviour when 
-      using SAX, URI to file path fix (Mikhail Zabaluev), disapearing validity
+      using SAX, URI to file path fix (Mikhail Zabaluev), disappearing validity
       context, arg error in SAX callback (Mike Hommey), fix mixed-content
       autodetect when using --noblanks, fix xmlIOParseDTD error handling,
       fix bug in xmlSplitQName on special Names, fix Relax-NG element content
@@ -1090,7 +1533,7 @@ Do not use or package 2.6.25
     split problem (William), issues with non-namespaced attributes in
     xmlAddChild() xmlAddNextSibling() and xmlAddPrevSibling() (Rob Richards),
     HTML parsing of script, Python must not output to stdout (Nic Ferrier),
-    exclusive C14N namespace visibility (Aleksey Sanin), XSD dataype
+    exclusive C14N namespace visibility (Aleksey Sanin), XSD datatype
     totalDigits bug (Kasimier Buchcik), error handling when writing to an
     xmlBuffer (Rob Richards), runtest schemas error not reported (Hisashi
     Fujinaka), signed/unsigned problem in date/time code (Albert Chin), fix
@@ -1099,7 +1542,7 @@ Do not use or package 2.6.25
     (Gary Coady), regexp bug affecting schemas (Kasimier), configuration of
     runtime debugging (Kasimier), xmlNodeBufGetContent bug on entity refs
     (Oleksandr Kononenko), xmlRegExecPushString2 bug (Sreeni Nair),
-    compilation and build fixes (Michael Day), removed dependancies on
+    compilation and build fixes (Michael Day), removed dependencies on
     xmlSchemaValidError (Kasimier), bug with <xml:foo/>, more XPath
     pattern based evaluation fixes (Kasimier)
    - improvements: XSD Schemas redefinitions/restrictions (Kasimier
@@ -1144,7 +1587,7 @@ Do not use or package 2.6.25
     foreign namespaces handling, XML Schemas facet comparison (Kupriyanov
     Anatolij), xmlSchemaPSimpleTypeErr error report (Kasimier Buchcik), xml:
     namespace ahndling in Schemas (Kasimier), empty model group in Schemas
-    (Kasimier), wilcard in Schemas (Kasimier), URI composition (William),
+    (Kasimier), wildcard in Schemas (Kasimier), URI composition (William),
     xs:anyType in Schemas (Kasimier), Python resolver emmitting error
     messages directly, Python xmlAttr.parent (Jakub Piotr Clapa), trying to
     fix the file path/URI conversion, xmlTextReaderGetAttribute fix (Rob
@@ -1231,7 +1674,7 @@ Do not use or package 2.6.25
     Bakefile support (Francesco Montorsi), Windows compilation (Joel Reed),
     some gcc4 fixes, HP-UX portability fixes (Rick Jones).
    - bug fixes: xmlSchemaElementDump namespace (Kasimier Buchcik), push and
-    xmlreader stopping on non-fatal errors, thread support for dictionaries
+    xmlreader stopping on non-fatal errors, thread support for dictionnaries
     reference counting (Gary Coady), internal subset and push problem, URL
     saved in xmlCopyDoc, various schemas bug fixes (Kasimier), Python paths
     fixup (Stephane Bidoul), xmlGetNodePath and namespaces, xmlSetNsProp fix
@@ -1318,7 +1761,7 @@ Do not use or package 2.6.25
     Buchcik), XInclude testing, Notation serialization, UTF8ToISO8859x
     transcoding (Mark Itzcovitz), lots of XML Schemas cleanup and fixes
     (Kasimier), ChangeLog cleanup (Stepan Kasal), memory fixes (Mark Vakoc),
-    handling of failed realloc(), out of bound array adressing in Schemas
+    handling of failed realloc(), out of bound array addressing in Schemas
     date handling, Python space/tabs cleanups (Malcolm Tredinnick), NMTOKENS
     E20 validation fix (Malcolm),
    - improvements: added W3C XML Schemas testsuite (Kasimier Buchcik), add
@@ -1335,7 +1778,7 @@ Do not use or package 2.6.25
     (Kasimier Buchcik), Schemas validation crash, xmlCheckUTF8 (William Brack
     and Julius Mittenzwei), Schemas facet check (Kasimier), default namespace
     problem (William), Schemas hexbinary empty values, encoding error could
-    genrate a serialization loop.
+    generate a serialization loop.
    - Improvements: Schemas validity improvements (Kasimier), added --path
     and --load-trace options to xmllint
    - documentation: tutorial update (John Fleck)
@@ -1482,7 +1925,7 @@ Do not use or package 2.6.25
     William) reported by Yuuichi Teranishi
    - bugfixes: make test and path issues, xmlWriter attribute serialization
     (William Brack), xmlWriter indentation (William), schemas validation
-    (Eric Haszlakiewicz), XInclude dictionaries issues (William and Oleg
+    (Eric Haszlakiewicz), XInclude dictionnaries issues (William and Oleg
     Paraschenko), XInclude empty fallback (William), HTML warnings (William),
     XPointer in XInclude (William), Python namespace serialization,
     isolat1ToUTF8 bound error (Alfred Mickautsch), output of parameter
@@ -1493,7 +1936,7 @@ Do not use or package 2.6.25
     --with-minimum configuration.
    - XInclude: allow the 2001 namespace without warning.
    - Documentation: missing example/index.html (John Fleck), version
-    dependancies (John Fleck)
+    dependencies (John Fleck)
    - reader API: structured error reporting (Steve Ball)
    - Windows compilation: mingw, msys (Mikhail Grushinskiy), function
     prototype (Cameron Johnson), MSVC6 compiler warnings, _WINSOCKAPI_
@@ -1503,7 +1946,7 @@ Do not use or package 2.6.25
 
 
 2.6.5: Jan 25 2004:
-   - Bugfixes: dictionaries for schemas (William Brack), regexp segfault
+   - Bugfixes: dictionnaries for schemas (William Brack), regexp segfault
     (William), xs:all problem (William), a number of XPointer bugfixes
     (William), xmllint error go to stderr, DTD validation problem with
     namespace, memory leak (William), SAX1 cleanup and minimal options fixes
@@ -1627,7 +2070,7 @@ Do not use or package 2.6.25
     intercepted at a structured level, with precise information
   available.
    - New simpler and more generic XML and HTML parser APIs, allowing to
-    easilly modify the parsing options and reuse parser context for multiple
+    easily modify the parsing options and reuse parser context for multiple
     consecutive documents.
    - Similar new APIs for the xmlReader, for options and reuse, provided new
     functions to access content as const strings, use them for Python

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/README
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/README
@@ -8,6 +8,7 @@ This code is released under the MIT Licence see the Copyright file.
 
 To build on an Unixised setup:
    ./configure ; make ; make install
+   if the ./configure file does not exist, run ./autogen.sh instead.
 To build on Windows:
    see instructions on win32/Readme.txt
 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/README.zOS
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/README.zOS
@@ -7,7 +7,7 @@ Notes for compiling on zOS:
 
 - since the name of files (or qualifier) in PDS are limited to 8 I had to
   rename xmlschemas.c and xmlschemastypes.c in (resp.) xmlsche.c xmlschet.c
-  (and I had to modify all occurences of these files accordingly in the
+  (and I had to modify all occurrences of these files accordingly in the
   rest of the Makefile !!!).
 
 - in order to copy objects to PDS, I had the cp command at line 860

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/SAX2.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/SAX2.c
@@ -40,7 +40,7 @@
  * TODO:
  *
  * macro to flag unimplemented blocks
- * XML_CATALOG_PREFER user env to select between system/public prefered
+ * XML_CATALOG_PREFER user env to select between system/public preferred
  * option. C.f. Richard Tobin <richard@cogsci.ed.ac.uk>
  *> Just FYI, I am using an environment variable XML_CATALOG_PREFER with
  *> values "system" and "public".  I have made the default be "system" to
@@ -1512,8 +1512,8 @@ process_external_subset:
     attr = elemDecl->attributes;
     while (attr != NULL) {
         /*
-         * Make sure that attributes redefinition occuring in the
-         * internal subset are not overriden by definitions in the
+         * Make sure that attributes redefinition occurring in the
+         * internal subset are not overridden by definitions in the
          * external subset.
          */
         if (attr->defaultValue != NULL) {
@@ -1668,6 +1668,8 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
     if (nodePush(ctxt, ret) < 0) {
         xmlUnlinkNode(ret);
         xmlFreeNode(ret);
+        if (prefix != NULL)
+            xmlFree(prefix);
         return;
     }
 
@@ -1734,8 +1736,8 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
     }
 
     /*
-     * set the namespace node, making sure that if the default namspace
-     * is unbound on a parent we simply kee it NULL
+     * set the namespace node, making sure that if the default namespace
+     * is unbound on a parent we simply keep it NULL
      */
     if ((ns != NULL) && (ns->href != NULL) &&
     ((ns->href[0] != 0) || (ns->prefix != NULL)))
@@ -2010,7 +2012,7 @@ xmlSAX2AttributeNs(xmlParserCtxtPtr ctxt,
     else
         ret->name = xmlStrdup(localname);
 
-        /* link at the end to preserv order, TODO speed up with a last */
+        /* link at the end to preserve order, TODO speed up with a last */
     if (ctxt->node->properties == NULL) {
         ctxt->node->properties = ret;
     } else {
@@ -2102,7 +2104,7 @@ xmlSAX2AttributeNs(xmlParserCtxtPtr ctxt,
         } else {
             /*
          * dup now contains a string of the flattened attribute
-         * content with entities substitued. Check if we need to
+         * content with entities substituted. Check if we need to
          * apply an extra layer of normalization.
          * It need to be done twice ... it's an extra burden related
          * to the ability to keep references in attributes
@@ -2135,7 +2137,7 @@ xmlSAX2AttributeNs(xmlParserCtxtPtr ctxt,
         }
     } else {
         /*
-         * if entities already have been substitued, then
+         * if entities already have been substituted, then
          * the attribute as passed is already normalized
          */
         dup = xmlStrndup(value, valueend - value);
@@ -2398,7 +2400,7 @@ xmlSAX2StartElementNs(void *ctx,
     if (nb_attributes > 0) {
         for (j = 0,i = 0;i < nb_attributes;i++,j+=5) {
         /*
-         * Handle the rare case of an undefined atribute prefix
+         * Handle the rare case of an undefined attribute prefix
          */
         if ((attributes[j+1] != NULL) && (attributes[j+2] == NULL)) {
         if (ctxt->dictNames) {
@@ -2584,7 +2586,7 @@ xmlSAX2Characters(void *ctx, const xmlChar *ch, int len)
          * The whole point of maintaining nodelen and nodemem,
          * xmlTextConcat is too costly, i.e. compute length,
          * reallocate a new buffer, move data, append ch. Here
-         * We try to minimaze realloc() uses and avoid copying
+         * We try to minimize realloc() uses and avoid copying
          * and recomputing length over and over.
          */
         if (lastChild->content == (xmlChar *)&(lastChild->properties)) {

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/aclocal.m4
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/aclocal.m4
@@ -21,7 +21,7 @@ If you have problems, you may need to regenerate the build system entirely.
 To do so, use the procedure documented by the package, typically 'autoreconf'.])])
 
 # pkg.m4 - Macros to locate and utilise pkg-config.   -*- Autoconf -*-
-# serial 12 (pkg-config-0.29.2)
+# serial 11 (pkg-config-0.29.1)
 
 dnl Copyright © 2004 Scott James Remnant <scott@netsplit.com>.
 dnl Copyright © 2012-2015 Dan Nicholson <dbn.lists@gmail.com>
@@ -63,7 +63,7 @@ dnl
 dnl See the "Since" comment for each macro you use to see what version
 dnl of the macros you require.
 m4_defun([PKG_PREREQ],
-[m4_define([PKG_MACROS_VERSION], [0.29.2])
+[m4_define([PKG_MACROS_VERSION], [0.29.1])
 m4_if(m4_version_compare(PKG_MACROS_VERSION, [$1]), -1,
     [m4_fatal([pkg.m4 version $1 or higher is required but ]PKG_MACROS_VERSION[ found])])
 ])dnl PKG_PREREQ
@@ -164,7 +164,7 @@ AC_ARG_VAR([$1][_CFLAGS], [C compiler flags for $1, overriding pkg-config])dnl
 AC_ARG_VAR([$1][_LIBS], [linker flags for $1, overriding pkg-config])dnl
 
 pkg_failed=no
-AC_MSG_CHECKING([for $2])
+AC_MSG_CHECKING([for $1])
 
 _PKG_CONFIG([$1][_CFLAGS], [cflags], [$2])
 _PKG_CONFIG([$1][_LIBS], [libs], [$2])
@@ -295,6 +295,74 @@ AS_VAR_COPY([$1], [pkg_cv_][$1])
 
 AS_VAR_IF([$1], [""], [$5], [$4])dnl
 ])dnl PKG_CHECK_VAR
+
+dnl PKG_WITH_MODULES(VARIABLE-PREFIX, MODULES,
+dnl   [ACTION-IF-FOUND],[ACTION-IF-NOT-FOUND],
+dnl   [DESCRIPTION], [DEFAULT])
+dnl ------------------------------------------
+dnl
+dnl Prepare a "--with-" configure option using the lowercase
+dnl [VARIABLE-PREFIX] name, merging the behaviour of AC_ARG_WITH and
+dnl PKG_CHECK_MODULES in a single macro.
+AC_DEFUN([PKG_WITH_MODULES],
+[
+m4_pushdef([with_arg], m4_tolower([$1]))
+
+m4_pushdef([description],
+           [m4_default([$5], [build with ]with_arg[ support])])
+
+m4_pushdef([def_arg], [m4_default([$6], [auto])])
+m4_pushdef([def_action_if_found], [AS_TR_SH([with_]with_arg)=yes])
+m4_pushdef([def_action_if_not_found], [AS_TR_SH([with_]with_arg)=no])
+
+m4_case(def_arg,
+            [yes],[m4_pushdef([with_without], [--without-]with_arg)],
+            [m4_pushdef([with_without],[--with-]with_arg)])
+
+AC_ARG_WITH(with_arg,
+     AS_HELP_STRING(with_without, description[ @<:@default=]def_arg[@:>@]),,
+    [AS_TR_SH([with_]with_arg)=def_arg])
+
+AS_CASE([$AS_TR_SH([with_]with_arg)],
+            [yes],[PKG_CHECK_MODULES([$1],[$2],$3,$4)],
+            [auto],[PKG_CHECK_MODULES([$1],[$2],
+                                        [m4_n([def_action_if_found]) $3],
+                                        [m4_n([def_action_if_not_found]) $4])])
+
+m4_popdef([with_arg])
+m4_popdef([description])
+m4_popdef([def_arg])
+
+])dnl PKG_WITH_MODULES
+
+dnl PKG_HAVE_WITH_MODULES(VARIABLE-PREFIX, MODULES,
+dnl   [DESCRIPTION], [DEFAULT])
+dnl -----------------------------------------------
+dnl
+dnl Convenience macro to trigger AM_CONDITIONAL after PKG_WITH_MODULES
+dnl check._[VARIABLE-PREFIX] is exported as make variable.
+AC_DEFUN([PKG_HAVE_WITH_MODULES],
+[
+PKG_WITH_MODULES([$1],[$2],,,[$3],[$4])
+
+AM_CONDITIONAL([HAVE_][$1],
+               [test "$AS_TR_SH([with_]m4_tolower([$1]))" = "yes"])
+])dnl PKG_HAVE_WITH_MODULES
+
+dnl PKG_HAVE_DEFINE_WITH_MODULES(VARIABLE-PREFIX, MODULES,
+dnl   [DESCRIPTION], [DEFAULT])
+dnl ------------------------------------------------------
+dnl
+dnl Convenience macro to run AM_CONDITIONAL and AC_DEFINE after
+dnl PKG_WITH_MODULES check. HAVE_[VARIABLE-PREFIX] is exported as make
+dnl and preprocessor variable.
+AC_DEFUN([PKG_HAVE_DEFINE_WITH_MODULES],
+[
+PKG_HAVE_WITH_MODULES([$1],[$2],[$3],[$4])
+
+AS_IF([test "$AS_TR_SH([with_]m4_tolower([$1]))" = "yes"],
+        [AC_DEFINE([HAVE_][$1], 1, [Enable ]m4_tolower([$1])[ support])])
+])dnl PKG_HAVE_DEFINE_WITH_MODULES
 
 # Copyright (C) 2002-2018 Free Software Foundation, Inc.
 #

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/buf.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/buf.c
@@ -1,7 +1,7 @@
 /*
  * buf.c: memory buffers for libxml2
  *
- * new buffer structures and entry points to simplify the maintainance
+ * new buffer structures and entry points to simplify the maintenance
  * of libxml2 and ensure we keep good control over memory allocations
  * and stay 64 bits clean.
  * The new entry point use the xmlBufPtr opaque structure and
@@ -396,7 +396,7 @@ xmlBufShrink(xmlBufPtr buf, size_t len) {
         ((buf->alloc == XML_BUFFER_ALLOC_IO) && (buf->contentIO != NULL))) {
     /*
      * we just move the content pointer, but also make sure
-     * the perceived buffer size has shrinked accordingly
+     * the perceived buffer size has shrunk accordingly
      */
         buf->content += len;
     buf->size -= len;
@@ -958,7 +958,7 @@ xmlBufAddHead(xmlBufPtr buf, const xmlChar *str, int len) {
 
     if (start_buf > (unsigned int) len) {
         /*
-         * We can add it in the space previously shrinked
+         * We can add it in the space previously shrunk
          */
         buf->content -= len;
             memmove(&buf->content[0], str, len);
@@ -1204,10 +1204,10 @@ xmlBufferPtr
 xmlBufBackToBuffer(xmlBufPtr buf) {
     xmlBufferPtr ret;
 
-    if ((buf == NULL) || (buf->error))
+    if (buf == NULL)
         return(NULL);
     CHECK_COMPAT(buf)
-    if (buf->buffer == NULL) {
+    if ((buf->error) || (buf->buffer == NULL)) {
         xmlBufFree(buf);
         return(NULL);
     }
@@ -1307,7 +1307,7 @@ xmlBufGetInputBase(xmlBufPtr buf, xmlParserInputPtr input) {
     CHECK_COMPAT(buf)
     base = input->base - buf->content;
     /*
-     * We could do some pointer arythmetic checks but that's probably
+     * We could do some pointer arithmetic checks but that's probably
      * sufficient.
      */
     if (base > buf->size) {

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/configure.ac
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/configure.ac
@@ -9,7 +9,7 @@ AC_CANONICAL_HOST
 
 LIBXML_MAJOR_VERSION=2
 LIBXML_MINOR_VERSION=9
-LIBXML_MICRO_VERSION=9
+LIBXML_MICRO_VERSION=10
 LIBXML_MICRO_VERSION_SUFFIX=
 LIBXML_VERSION=$LIBXML_MAJOR_VERSION.$LIBXML_MINOR_VERSION.$LIBXML_MICRO_VERSION$LIBXML_MICRO_VERSION_SUFFIX
 LIBXML_VERSION_INFO=`expr $LIBXML_MAJOR_VERSION + $LIBXML_MINOR_VERSION`:$LIBXML_MICRO_VERSION:$LIBXML_MINOR_VERSION
@@ -217,7 +217,7 @@ fi
 AM_CONDITIONAL([REBUILD_DOCS], [test "$enable_rebuild_docs" = "yes" -o "$USER" = "veillard"])
 
 dnl
-dnl hard dependancies on options
+dnl hard dependencies on options
 dnl
 if test "$with_schemas" = "yes"
 then
@@ -396,7 +396,7 @@ else
         # Try pkg-config first so that static linking works.
         PKG_CHECK_MODULES([Z],[zlib],
             [WITH_ZLIB=1],
-            [ ])
+            [:])
     fi
 
     if test "$WITH_ZLIB" = "0"; then
@@ -435,7 +435,7 @@ else
         # Try pkg-config first so that static linking works.
         PKG_CHECK_MODULES([LZMA],[liblzma],
             [WITH_LZMA=1],
-            [ ])
+            [:])
     fi
 
     # If pkg-config failed, fall back to AC_CHECK_LIB. This
@@ -771,7 +771,7 @@ else
     # warnings we'd like to see
     EXTRA_CFLAGS="${EXTRA_CFLAGS} -pedantic -Wall -Wextra -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Waggregate-return -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Winline -Wredundant-decls"
     # warnings we'd like to supress
-    EXTRA_CFLAGS="${EXTRA_CFLAGS} -Wno-long-long -Wno-format-extra-args -Wno-array-bounds"
+    EXTRA_CFLAGS="${EXTRA_CFLAGS} -Wno-long-long -Wno-format-extra-args"
     case "${host}" in
           alpha*-*-linux* )
 	       EXTRA_CFLAGS="${EXTRA_CFLAGS} -mieee"
@@ -1533,7 +1533,8 @@ else
         WITH_ICU=1
     fi
 fi
-XML_LIBS="-lxml2 $Z_LIBS $LZMA_LIBS $THREAD_LIBS $ICONV_LIBS $ICU_LIBS $M_LIBS $LIBS"
+XML_LIBS="-lxml2"
+XML_PRIVATE_LIBS="$Z_LIBS $LZMA_LIBS $THREAD_LIBS $ICONV_LIBS $ICU_LIBS $M_LIBS $LIBS"
 XML_LIBTOOLLIBS="libxml2.la"
 AC_SUBST(WITH_ICU)
 
@@ -1620,7 +1621,14 @@ case "$host" in
  WIN32_EXTRA_LDFLAGS="-no-undefined"
  if test "${PYTHON}" != ""
  then
+   case "$host" in
+     *-w64-mingw*)
+       WIN32_EXTRA_PYTHON_LIBADD="-shrext .pyd -L${pythondir}/../../lib -lpython${PYTHON_VERSION}"
+       ;;
+     *)
    WIN32_EXTRA_PYTHON_LIBADD="-L${pythondir}/../../libs -lpython$(echo ${PYTHON_VERSION} | tr -d .)"
+       ;;
+   esac
  fi
  ;;
  *-*-cygwin*)
@@ -1671,6 +1679,7 @@ AC_SUBST(XML_CFLAGS)
 
 AC_SUBST(XML_LIBDIR)
 AC_SUBST(XML_LIBS)
+AC_SUBST(XML_PRIVATE_LIBS)
 AC_SUBST(XML_LIBTOOLLIBS)
 AC_SUBST(ICONV_LIBS)
 AC_SUBST(ICU_LIBS)

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/dict.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/dict.c
@@ -38,7 +38,8 @@
  *  list we will use the BigKey algo as soon as the hash size grows
  *  over MIN_DICT_SIZE so this actually works
  */
-#if defined(HAVE_RAND) && defined(HAVE_SRAND) && defined(HAVE_TIME)
+#if defined(HAVE_RAND) && defined(HAVE_SRAND) && defined(HAVE_TIME) && \
+    !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 #define DICT_RANDOMIZATION
 #endif
 
@@ -371,6 +372,9 @@ found_pool:
  * http://burtleburtle.net/bob/hash/doobs.html
  */
 
+#ifdef __clang__
+ATTRIBUTE_NO_SANITIZE("unsigned-integer-overflow")
+#endif
 static uint32_t
 xmlDictComputeBigKey(const xmlChar* data, int namelen, int seed) {
     uint32_t hash;
@@ -403,6 +407,9 @@ xmlDictComputeBigKey(const xmlChar* data, int namelen, int seed) {
  *
  * Neither of the two strings must be NULL.
  */
+#ifdef __clang__
+ATTRIBUTE_NO_SANITIZE("unsigned-integer-overflow")
+#endif
 static unsigned long
 xmlDictComputeBigQKey(const xmlChar *prefix, int plen,
                       const xmlChar *name, int len, int seed)
@@ -727,7 +734,7 @@ xmlDictGrow(xmlDictPtr dict, size_t size) {
         dict->dict[key].next = entry;
         } else {
             /*
-         * we don't have much ways to alert from herei
+         * we don't have much ways to alert from here
          * result is losing an entry and unicity guarantee
          */
             ret = -1;
@@ -1202,7 +1209,7 @@ xmlDictQLookup(xmlDictPtr dict, const xmlChar *prefix, const xmlChar *name) {
  * @dict: the dictionary
  * @str: the string
  *
- * check if a string is owned by the disctionary
+ * check if a string is owned by the dictionary
  *
  * Returns 1 if true, 0 if false and -1 in case of error
  * -1 in case of error

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/elfgcchack.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/elfgcchack.h
@@ -4312,6 +4312,16 @@ extern __typeof (xmlHashCreateDict) xmlHashCreateDict__internal_alias __attribut
 #endif
 
 #ifdef bottom_hash
+#undef xmlHashDefaultDeallocator
+extern __typeof (xmlHashDefaultDeallocator) xmlHashDefaultDeallocator __attribute((alias("xmlHashDefaultDeallocator__internal_alias")));
+#else
+#ifndef xmlHashDefaultDeallocator
+extern __typeof (xmlHashDefaultDeallocator) xmlHashDefaultDeallocator__internal_alias __attribute((visibility("hidden")));
+#define xmlHashDefaultDeallocator xmlHashDefaultDeallocator__internal_alias
+#endif
+#endif
+
+#ifdef bottom_hash
 #undef xmlHashFree
 extern __typeof (xmlHashFree) xmlHashFree __attribute((alias("xmlHashFree__internal_alias")));
 #else

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/enc.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/enc.h
@@ -1,7 +1,7 @@
 /*
  * Summary: Internal Interfaces for encoding in libxml2
  * Description: this module describes a few interfaces which were
- *              addded along with the API changes in 2.9.0
+ *              added along with the API changes in 2.9.0
  *              those are private routines at this point
  *
  * Copy: See Copyright for the status of this software.

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/encoding.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/encoding.c
@@ -1795,7 +1795,7 @@ xmlFindCharEncodingHandler(const char *name) {
  *
  * The value of @inlen after return is the number of octets consumed
  *     as the return value is positive, else unpredictable.
- * The value of @outlen after return is the number of ocetes consumed.
+ * The value of @outlen after return is the number of octets consumed.
  */
 static int
 xmlIconvWrapper(iconv_t cd, unsigned char *out, int *outlen,
@@ -1863,7 +1863,7 @@ xmlIconvWrapper(iconv_t cd, unsigned char *out, int *outlen,
  *
  * The value of @inlen after return is the number of octets consumed
  *     as the return value is positive, else unpredictable.
- * The value of @outlen after return is the number of ocetes consumed.
+ * The value of @outlen after return is the number of octets consumed.
  */
 static int
 xmlUconvWrapper(uconv_t *cd, int toUnicode, unsigned char *out, int *outlen,
@@ -1972,7 +1972,7 @@ xmlEncOutputChunk(xmlCharEncodingHandler *handler, unsigned char *out,
 
 /**
  * xmlCharEncFirstLineInt:
- * @handler:    char enconding transformation data structure
+ * @handler:    char encoding transformation data structure
  * @out:  an xmlBuffer for the output.
  * @in:  an xmlBuffer for the input
  * @len:  number of bytes to convert for the first line, or -1
@@ -2059,7 +2059,7 @@ xmlCharEncFirstLineInt(xmlCharEncodingHandler *handler, xmlBufferPtr out,
 
 /**
  * xmlCharEncFirstLine:
- * @handler:    char enconding transformation data structure
+ * @handler:    char encoding transformation data structure
  * @out:  an xmlBuffer for the output.
  * @in:  an xmlBuffer for the input
  *
@@ -2546,7 +2546,7 @@ retry:
 
 /**
  * xmlCharEncOutFunc:
- * @handler:    char enconding transformation data structure
+ * @handler:    char encoding transformation data structure
  * @out:  an xmlBuffer for the output.
  * @in:  an xmlBuffer for the input
  *
@@ -2710,7 +2710,7 @@ retry:
 
 /**
  * xmlCharEncCloseFunc:
- * @handler:    char enconding transformation data structure
+ * @handler:    char encoding transformation data structure
  *
  * Generic front-end for encoding handler close function
  *
@@ -2811,7 +2811,7 @@ xmlByteConsumed(xmlParserCtxtPtr ctxt) {
     xmlCharEncodingHandler * handler = in->buf->encoder;
         /*
      * Encoding conversion, compute the number of unused original
-     * bytes from the input not consumed and substract that from
+     * bytes from the input not consumed and subtract that from
      * the raw consumed value, this is not a cheap operation
      */
         if (in->end - in->cur > 0) {
@@ -2860,7 +2860,7 @@ xmlByteConsumed(xmlParserCtxtPtr ctxt) {
  * Returns 0 if success, -2 if the transcoding fails, or -1 otherwise
  * The value of @inlen after return is the number of octets consumed
  *     as the return value is positive, else unpredictable.
- * The value of @outlen after return is the number of ocetes consumed.
+ * The value of @outlen after return is the number of octets consumed.
  */
 static int
 UTF8ToISO8859x(unsigned char* out, int *outlen,
@@ -2976,7 +2976,7 @@ UTF8ToISO8859x(unsigned char* out, int *outlen,
  * block of chars out.
  * Returns 0 if success, or -1 otherwise
  * The value of @inlen after return is the number of octets consumed
- * The value of @outlen after return is the number of ocetes produced.
+ * The value of @outlen after return is the number of octets produced.
  */
 static int
 ISO8859xToUTF8(unsigned char* out, int *outlen,

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/entities.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/entities.c
@@ -148,7 +148,7 @@ xmlFreeEntity(xmlEntityPtr entity)
 /*
  * xmlCreateEntity:
  *
- * internal routine doing the entity node strutures allocations
+ * internal routine doing the entity node structures allocations
  */
 static xmlEntityPtr
 xmlCreateEntity(xmlDictPtr dict, const xmlChar *name, int type,
@@ -398,7 +398,7 @@ xmlAddDocEntity(xmlDocPtr doc, const xmlChar *name, int type,
  *
  * Create a new entity, this differs from xmlAddDocEntity() that if
  * the document is NULL or has no internal subset defined, then an
- * unlinked entity structure will be returned, it is then the responsability
+ * unlinked entity structure will be returned, it is then the responsibility
  * of the caller to link it to the document later or free it when not needed
  * anymore.
  *
@@ -548,7 +548,7 @@ xmlGetDocEntity(const xmlDoc *doc, const xmlChar *name) {
  * xmlEncodeEntitiesInternal:
  * @doc:  the document containing the string
  * @input:  A string to convert to XML.
- * @attr: are we handling an atrbute value
+ * @attr: are we handling an attribute value
  *
  * Do a global encoding of a string, replacing the predefined entities
  * and non ASCII values with their entities and CharRef counterparts.

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/error.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/error.c
@@ -238,7 +238,7 @@ xmlParserPrintFileContext(xmlParserInputPtr input) {
  * @ctx: the parser context or NULL
  * @str: the formatted error message
  *
- * Report an erro with its context, replace the 4 old error/warning
+ * Report an error with its context, replace the 4 old error/warning
  * routines.
  */
 static void
@@ -631,7 +631,7 @@ __xmlRaiseError(xmlStructuredErrorFunc schannel,
     (channel == xmlParserValidityError) ||
     (channel == xmlParserValidityWarning))
     xmlReportError(to, ctxt, str, NULL, NULL);
-    else if ((channel == (xmlGenericErrorFunc) fprintf) ||
+    else if (((void(*)(void)) channel == (void(*)(void)) fprintf) ||
              (channel == xmlGenericErrorDefaultFunc))
     xmlReportError(to, ctxt, str, channel, data);
     else

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/globals.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/globals.c
@@ -107,7 +107,7 @@ xmlMallocFunc xmlMalloc = malloc;
  * @size:  the size requested in bytes
  *
  * The variable holding the libxml malloc() implementation for atomic
- * data (i.e. blocks not containings pointers), useful when using a
+ * data (i.e. blocks not containing pointers), useful when using a
  * garbage collecting allocator.
  *
  * Returns a pointer to the newly allocated block or NULL in case of error
@@ -260,7 +260,7 @@ static int xmlPedanticParserDefaultValueThrDef = 0;
  * Global setting, indicate that the parser should store the line number
  * in the content field of elements in the DOM tree.
  * Disabled by default since this may not be safe for old classes of
- * applicaton.
+ * application.
  */
 int xmlLineNumbersDefaultValue = 0;
 static int xmlLineNumbersDefaultValueThrDef = 0;
@@ -361,7 +361,7 @@ static const char *xmlTreeIndentStringThrDef = "  ";
  * xmlSaveNoEmptyTags:
  *
  * Global setting, asking the serializer to not output empty tags
- * as <empty/> but <empty></empty>. those two forms are undistinguishable
+ * as <empty/> but <empty></empty>. those two forms are indistinguishable
  * once parsed.
  * Disabled by default
  */

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/hash.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/hash.c
@@ -33,7 +33,8 @@
  * it seems that having hash randomization might be a good idea
  * when using XML with untrusted data
  */
-#if defined(HAVE_RAND) && defined(HAVE_SRAND) && defined(HAVE_TIME)
+#if defined(HAVE_RAND) && defined(HAVE_SRAND) && defined(HAVE_TIME) && \
+    !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 #define HASH_RANDOMIZATION
 #endif
 
@@ -78,6 +79,9 @@ struct _xmlHashTable {
  * xmlHashComputeKey:
  * Calculate the hash key
  */
+#ifdef __clang__
+ATTRIBUTE_NO_SANITIZE("unsigned-integer-overflow")
+#endif
 static unsigned long
 xmlHashComputeKey(xmlHashTablePtr table, const xmlChar *name,
               const xmlChar *name2, const xmlChar *name3) {
@@ -108,6 +112,9 @@ xmlHashComputeKey(xmlHashTablePtr table, const xmlChar *name,
     return (value % table->size);
 }
 
+#ifdef __clang__
+ATTRIBUTE_NO_SANITIZE("unsigned-integer-overflow")
+#endif
 static unsigned long
 xmlHashComputeQKey(xmlHashTablePtr table,
            const xmlChar *prefix, const xmlChar *name,

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/c14n.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/c14n.h
@@ -28,17 +28,17 @@ extern "C" {
 #include <libxml/xpath.h>
 
 /*
- * XML Canonicazation
+ * XML Canonicalization
  * http://www.w3.org/TR/xml-c14n
  *
- * Exclusive XML Canonicazation
+ * Exclusive XML Canonicalization
  * http://www.w3.org/TR/xml-exc-c14n
  *
  * Canonical form of an XML document could be created if and only if
  *  a) default attributes (if any) are added to all nodes
  *  b) all character and parsed entity references are resolved
- * In order to achive this in libxml2 the document MUST be loaded with
- * following global setings:
+ * In order to achieve this in libxml2 the document MUST be loaded with
+ * following global settings:
  *
  *    xmlLoadExtDtdDefaultValue = XML_DETECT_IDS | XML_COMPLETE_ATTRS;
  *    xmlSubstituteEntitiesDefault(1);
@@ -59,7 +59,7 @@ extern "C" {
  *
  */
 typedef enum {
-    XML_C14N_1_0            = 0,    /* Origianal C14N 1.0 spec */
+    XML_C14N_1_0            = 0,    /* Original C14N 1.0 spec */
     XML_C14N_EXCLUSIVE_1_0  = 1,    /* Exclusive C14N 1.0 spec */
     XML_C14N_1_1            = 2     /* C14N 1.1 spec */
 } xmlC14NMode;
@@ -96,7 +96,7 @@ XMLPUBFUN int XMLCALL
 /**
  * xmlC14NIsVisibleCallback:
  * @user_data: user data
- * @node: the curent node
+ * @node: the current node
  * @parent: the parent node
  *
  * Signature for a C14N callback on visible nodes

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/catalog.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/catalog.h
@@ -39,7 +39,7 @@ extern "C" {
 /**
  * XML_CATALOG_PI:
  *
- * The specific XML Catalog Processing Instuction name.
+ * The specific XML Catalog Processing Instruction name.
  */
 #define XML_CATALOG_PI                      \
     (const xmlChar *) "oasis-xml-catalog"

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/dict.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/dict.h
@@ -11,25 +11,18 @@
 #ifndef __XML_DICT_H__
 #define __XML_DICT_H__
 
+#include <stddef.h>
+#include <libxml/xmlversion.h>
+
 #ifdef __cplusplus
-#define __XML_EXTERNC   extern "C"
-#else
-#define __XML_EXTERNC
+extern "C" {
 #endif
 
 /*
  * The dictionary.
  */
-__XML_EXTERNC typedef struct _xmlDict xmlDict;
-__XML_EXTERNC typedef xmlDict *xmlDictPtr;
-
-#include <limits.h>
-#include <libxml/xmlversion.h>
-#include <libxml/tree.h>
-
-#ifdef __cplusplus
-extern "C" {
-#endif
+typedef struct _xmlDict xmlDict;
+typedef xmlDict *xmlDictPtr;
 
 /*
  * Initializer

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/hash.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/hash.h
@@ -80,7 +80,7 @@ typedef void *(*xmlHashCopier)(void *payload, const xmlChar *name);
 /**
  * xmlHashScanner:
  * @payload:  the data in the hash
- * @data:  extra scannner data
+ * @data:  extra scanner data
  * @name:  the name associated
  *
  * Callback when scanning data in a hash with the simple scanner.
@@ -89,7 +89,7 @@ typedef void (*xmlHashScanner)(void *payload, void *data, const xmlChar *name);
 /**
  * xmlHashScannerFull:
  * @payload:  the data in the hash
- * @data:  extra scannner data
+ * @data:  extra scanner data
  * @name:  the name associated
  * @name2:  the second name associated
  * @name3:  the third name associated

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/parser.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/parser.h
@@ -283,11 +283,11 @@ struct _xmlParserCtxt {
     void *            *pushTab;       /* array of data for push */
     xmlHashTablePtr    attsDefault;   /* defaulted attributes if any */
     xmlHashTablePtr    attsSpecial;   /* non-CDATA attributes if any */
-    int                nsWellFormed;  /* is the document XML Nanespace okay */
+    int                nsWellFormed;  /* is the document XML Namespace okay */
     int                options;       /* Extra options */
 
     /*
-     * Those fields are needed only for treaming parsing so far
+     * Those fields are needed only for streaming parsing so far
      */
     int               dictNames;    /* Use dictionary names for the tree */
     int               freeElemsNr;  /* number of freed element nodes */
@@ -1097,7 +1097,7 @@ typedef enum {
     XML_PARSE_PEDANTIC  = 1<<7, /* pedantic error reporting */
     XML_PARSE_NOBLANKS  = 1<<8, /* remove blank nodes */
     XML_PARSE_SAX1  = 1<<9, /* use the SAX1 interface internally */
-    XML_PARSE_XINCLUDE  = 1<<10,/* Implement XInclude substitition  */
+    XML_PARSE_XINCLUDE  = 1<<10,/* Implement XInclude substitution  */
     XML_PARSE_NONET = 1<<11,/* Forbid network access */
     XML_PARSE_NODICT    = 1<<12,/* Do not reuse the context dictionary */
     XML_PARSE_NSCLEAN   = 1<<13,/* remove redundant namespaces declarations */
@@ -1191,7 +1191,7 @@ XMLPUBFUN xmlDocPtr XMLCALL
 /**
  * xmlFeature:
  *
- * Used to examine the existance of features that can be enabled
+ * Used to examine the existence of features that can be enabled
  * or disabled at compile-time.
  * They used to be called XML_FEATURE_xxx but this clashed with Expat
  */

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/parserInternals.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/parserInternals.h
@@ -43,7 +43,7 @@ XMLPUBVAR unsigned int xmlParserMaxDepth;
 /**
  * XML_MAX_NAME_LENGTH:
  *
- * Maximum size allowed for a markup identitier
+ * Maximum size allowed for a markup identifier.
  * This is not a limitation of the parser but a safety boundary feature,
  * use XML_PARSE_HUGE option to override it.
  * Note that with the use of parsing dictionaries overriding the limit

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/schemasInternals.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/schemasInternals.h
@@ -321,13 +321,13 @@ struct _xmlSchemaWildcard {
 /**
  * XML_SCHEMAS_ATTRGROUP_WILDCARD_BUILDED:
  *
- * The attribute wildcard has been already builded.
+ * The attribute wildcard has been built.
  */
 #define XML_SCHEMAS_ATTRGROUP_WILDCARD_BUILDED 1 << 0
 /**
  * XML_SCHEMAS_ATTRGROUP_GLOBAL:
  *
- * The attribute wildcard has been already builded.
+ * The attribute group has been defined.
  */
 #define XML_SCHEMAS_ATTRGROUP_GLOBAL 1 << 1
 /**
@@ -725,7 +725,7 @@ struct _xmlSchemaType {
 /**
  * XML_SCHEMAS_ELEM_BLOCK_SUBSTITUTION:
  *
- * disallowed substitutions: "substituion"
+ * disallowed substitutions: "substitution"
  */
 #define XML_SCHEMAS_ELEM_BLOCK_SUBSTITUTION        1 << 13
 /**
@@ -789,7 +789,7 @@ struct _xmlSchemaElement {
     xmlRegexpPtr contModel; /* Obsolete for WXS, maybe used for RelaxNG */
     xmlSchemaContentType contentType;
     const xmlChar *refPrefix; /* Deprecated; not used */
-    xmlSchemaValPtr defVal; /* The compiled value contraint. */
+    xmlSchemaValPtr defVal; /* The compiled value constraint. */
     void *idcs; /* The identity-constraint defs */
 };
 
@@ -881,7 +881,7 @@ struct _xmlSchemaNotation {
 /**
  * XML_SCHEMAS_FINAL_DEFAULT_LIST:
  *
- * the cshema has "list" in the set of finalDefault.
+ * the schema has "list" in the set of finalDefault.
  */
 #define XML_SCHEMAS_FINAL_DEFAULT_LIST            1 << 4
 /**
@@ -942,7 +942,7 @@ struct _xmlSchema {
     xmlDictPtr      dict;
     void *includes;     /* the includes, this is opaque for now */
     int preserve;        /* whether to free the document */
-    int counter; /* used to give ononymous components unique names */
+    int counter; /* used to give anonymous components unique names */
     xmlHashTablePtr idcDef; /* All identity-constraint defs. */
     void *volatiles; /* Obsolete */
 };

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/tree.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/tree.h
@@ -527,7 +527,7 @@ struct _xmlNode {
  * xmlDocProperty
  *
  * Set of properties of the document as found by the parser
- * Some of them are linked to similary named xmlParserOption
+ * Some of them are linked to similarly named xmlParserOption
  */
 typedef enum {
     XML_DOC_WELLFORMED      = 1<<0, /* document is XML well formed */

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/xlink.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/xlink.h
@@ -26,7 +26,7 @@ extern "C" {
  *       of namespaces. If "foo" is the prefix for "http://foo.com/"
  *       then the link detection layer will expand role="foo:myrole"
  *       to "http://foo.com/:myrole".
- * NOTE: the link detection layer will expand URI-Refences found on
+ * NOTE: the link detection layer will expand URI-References found on
  *       href attributes by using the base mechanism if found.
  */
 typedef xmlChar *xlinkHRef;

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/xmlIO.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/xmlIO.h
@@ -27,7 +27,7 @@ extern "C" {
  * @filename: the filename or URI
  *
  * Callback used in the I/O Input API to detect if the current handler
- * can provide input fonctionnalities for this resource.
+ * can provide input functionality for this resource.
  *
  * Returns 1 if yes and 0 if another Input module should be used
  */
@@ -73,7 +73,7 @@ typedef int (XMLCALL *xmlInputCloseCallback) (void * context);
  * @filename: the filename or URI
  *
  * Callback used in the I/O Output API to detect if the current handler
- * can provide output fonctionnalities for this resource.
+ * can provide output functionality for this resource.
  *
  * Returns 1 if yes and 0 if another Output module should be used
  */

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/xmlerror.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/xmlerror.h
@@ -837,7 +837,7 @@ typedef enum {
  * xmlGenericErrorFunc:
  * @ctx:  a parsing context
  * @msg:  the message
- * @...:  the extra arguments of the varags to format the message
+ * @...:  the extra arguments of the varargs to format the message
  *
  * Signature of the function to use when there is an error and
  * no parsing or validity context available .

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/xmlexports.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/xmlexports.h
@@ -73,9 +73,6 @@
     #define XMLCALL __cdecl
   #endif
   #define XMLCDECL __cdecl
-  #if !defined _REENTRANT
-    #define _REENTRANT
-  #endif
 #endif
 
 /* Windows platform with Borland compiler */
@@ -97,9 +94,6 @@
   #endif
   #define XMLCALL __cdecl
   #define XMLCDECL __cdecl
-  #if !defined _REENTRANT
-    #define _REENTRANT
-  #endif
 #endif
 
 /* Windows platform with GNU compiler (Mingw) */
@@ -126,9 +120,6 @@
   #endif
   #define XMLCALL __cdecl
   #define XMLCDECL __cdecl
-  #if !defined _REENTRANT
-    #define _REENTRANT
-  #endif
 #endif
 
 /* Cygwin platform (does not define _WIN32), GNU compiler */

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/xmlversion.h.in
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/xmlversion.h.in
@@ -91,10 +91,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * Whether the thread support is configured in
  */
 #if @WITH_THREADS@
-#if defined(_REENTRANT) || defined(__MT__) || \
-    (defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE - 0 >= 199506L))
 #define LIBXML_THREAD_ENABLED
-#endif
 #endif
 
 /**
@@ -353,8 +350,10 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * LIBXML_EXPR_ENABLED:
  *
  * Whether the formal expressions interfaces are compiled in
+ *
+ * This code is unused and disabled unconditionally for now.
  */
-#if @WITH_SCHEMAS@
+#if 0
 #define LIBXML_EXPR_ENABLED
 #endif
 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/xpath.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/libxml/xpath.h
@@ -70,7 +70,9 @@ typedef enum {
     XPATH_INVALID_CHAR_ERROR,
     XPATH_INVALID_CTXT,
     XPATH_STACK_ERROR,
-    XPATH_FORBID_VARIABLE_ERROR
+    XPATH_FORBID_VARIABLE_ERROR,
+    XPATH_OP_LIMIT_EXCEEDED,
+    XPATH_RECURSION_LIMIT_EXCEEDED
 } xmlXPathError;
 
 /*
@@ -82,7 +84,7 @@ struct _xmlNodeSet {
     int nodeNr;         /* number of nodes in the set */
     int nodeMax;        /* size of the array as allocated */
     xmlNodePtr *nodeTab;    /* array of nodes in no particular order */
-    /* @@ with_ns to check wether namespace nodes should be looked at @@ */
+    /* @@ with_ns to check whether namespace nodes should be looked at @@ */
 };
 
 /*
@@ -352,6 +354,13 @@ struct _xmlXPathContext {
 
     /* Cache for reusal of XPath objects */
     void *cache;
+
+    /* Resource limits */
+    unsigned long opLimit;
+    unsigned long opCount;
+    int depth;
+    int maxDepth;
+    int maxParserDepth;
 };
 
 /*

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/win32config.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/win32config.h
@@ -38,7 +38,7 @@
 #if defined(_MSC_VER) || defined(__BORLANDC__)
 /* MS C-runtime has functions which can be used in order to determine if
    a given floating-point variable contains NaN, (+-)INF. These are
-   preferred, because floating-point technology is considered propriatary
+   preferred, because floating-point technology is considered proprietary
    by MS and we can assume that their functions know more about their
    oddities than we do. */
 #include <float.h>

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/wsockcompat.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/include/wsockcompat.h
@@ -11,6 +11,11 @@
 #include <errno.h>
 #include <winsock2.h>
 
+/* Fix for old MinGW. */
+#ifndef _WINSOCKAPI_
+#define _WINSOCKAPI_
+#endif
+
 /* the following is a workaround a problem for 'inline' keyword in said
    header when compiled with Borland C++ 6 */
 #if defined(__BORLANDC__) && !defined(__cplusplus)

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/libxml.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/libxml.h
@@ -34,7 +34,7 @@
 /*
  * Currently supported platforms use either autoconf or
  * copy to config.h own "preset" configuration file.
- * As result ifdef HAVE_CONFIG_H is omited here.
+ * As result ifdef HAVE_CONFIG_H is omitted here.
  */
 #include "config.h"
 #include <libxml/xmlversion.h>
@@ -53,7 +53,7 @@ int vfprintf(FILE *, const char *, va_list);
 /**
  * TRIO_REPLACE_STDIO:
  *
- * This macro is defined if teh trio string formatting functions are to
+ * This macro is defined if the trio string formatting functions are to
  * be used instead of the default stdio ones.
  */
 #define TRIO_REPLACE_STDIO
@@ -70,6 +70,13 @@ int vfprintf(FILE *, const char *, va_list);
 #else
 #define XML_IGNORE_PEDANTIC_WARNINGS
 #define XML_POP_WARNINGS
+#endif
+
+#if defined(__clang__) || \
+    (defined(__GNUC__) && (__GNUC__ >= 8))
+#define ATTRIBUTE_NO_SANITIZE(arg) __attribute__((no_sanitize(arg)))
+#else
+#define ATTRIBUTE_NO_SANITIZE(arg)
 #endif
 
 /*

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/libxml.spec.in
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/libxml.spec.in
@@ -128,7 +128,8 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/doc/libxml2-python-%{version}/*
 gzip -9 -c doc/libxml2-api.xml > doc/libxml2-api.xml.gz
 
 %check
-make runtests
+#disabling python tests from rpm build as broken in Fedora 30
+make PYTHON_SUBDIR="" runtests
 
 %clean
 rm -fr %{buildroot}

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/libxml2.spec
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/libxml2.spec
@@ -2,7 +2,7 @@
 
 Summary: Library providing XML and HTML support
 Name: libxml2
-Version: 2.9.9
+Version: 2.9.10
 Release: 1%{?dist}%{?extra_release}
 License: MIT
 Group: Development/Libraries
@@ -128,7 +128,8 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/doc/libxml2-python-%{version}/*
 gzip -9 -c doc/libxml2-api.xml > doc/libxml2-api.xml.gz
 
 %check
-make runtests
+#disabling python tests from rpm build as broken in Fedora 30
+make PYTHON_SUBDIR="" runtests
 
 %clean
 rm -fr %{buildroot}
@@ -203,6 +204,6 @@ rm -fr %{buildroot}
 %endif # with_python3
 
 %changelog
-* Mon Jan  7 2019 Daniel Veillard <veillard@redhat.com>
-- upstream release 2.9.9 see http://xmlsoft.org/news.html
+* Thu Feb 20 2020 Daniel Veillard <veillard@redhat.com>
+- upstream release 2.9.10 see http://xmlsoft.org/news.html
 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/libxml2.syms
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/libxml2.syms
@@ -2070,27 +2070,27 @@ LIBXML2_2.6.21 {
   xmlAutomataNewNegTrans;
 
 # xmlregexp
-  emptyExp; # variable
-  forbiddenExp; # variable
-  xmlExpCtxtNbCons;
-  xmlExpCtxtNbNodes;
-  xmlExpDump;
-  xmlExpExpDerive;
-  xmlExpFreeCtxt;
-  xmlExpFree;
-  xmlExpGetLanguage;
-  xmlExpGetStart;
-  xmlExpIsNillable;
-  xmlExpMaxToken;
-  xmlExpNewAtom;
-  xmlExpNewCtxt;
-  xmlExpNewOr;
-  xmlExpNewRange;
-  xmlExpNewSeq;
-  xmlExpParse;
-  xmlExpRef;
-  xmlExpStringDerive;
-  xmlExpSubsume;
+# emptyExp; removed in 2.9.10
+# forbiddenExp; removed in 2.9.10
+# xmlExpCtxtNbCons; removed in 2.9.10
+# xmlExpCtxtNbNodes; removed in 2.9.10
+# xmlExpDump; removed in 2.9.10
+# xmlExpExpDerive; removed in 2.9.10
+# xmlExpFreeCtxt; removed in 2.9.10
+# xmlExpFree; removed in 2.9.10
+# xmlExpGetLanguage; removed in 2.9.10
+# xmlExpGetStart; removed in 2.9.10
+# xmlExpIsNillable; removed in 2.9.10
+# xmlExpMaxToken; removed in 2.9.10
+# xmlExpNewAtom; removed in 2.9.10
+# xmlExpNewCtxt; removed in 2.9.10
+# xmlExpNewOr; removed in 2.9.10
+# xmlExpNewRange; removed in 2.9.10
+# xmlExpNewSeq; removed in 2.9.10
+# xmlExpParse; removed in 2.9.10
+# xmlExpRef; removed in 2.9.10
+# xmlExpStringDerive; removed in 2.9.10
+# xmlExpSubsume; removed in 2.9.10
 
 # parser
   xmlHasFeature;

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/nanohttp.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/nanohttp.c
@@ -1143,12 +1143,12 @@ xmlNanoHTTPConnectHost(const char *host, int port)
 
         switch (h_errno) {
         case HOST_NOT_FOUND:
-            h_err_txt = "Authoritive host not found";
+            h_err_txt = "Authoritative host not found";
             break;
 
         case TRY_AGAIN:
             h_err_txt =
-            "Non-authoritive host not found or server failure.";
+            "Non-authoritative host not found or server failure.";
             break;
 
         case NO_RECOVERY:

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/parser.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/parser.c
@@ -96,6 +96,12 @@ xmlCreateEntityParserCtxtInternal(const xmlChar *URL, const xmlChar *ID,
 
 static void xmlHaltParser(xmlParserCtxtPtr ctxt);
 
+static int
+xmlParseElementStart(xmlParserCtxtPtr ctxt);
+
+static void
+xmlParseElementEnd(xmlParserCtxtPtr ctxt);
+
 /************************************************************************
  *                                  *
  *  Arbitrary limits set in the parser. See XML_PARSE_HUGE      *
@@ -108,7 +114,7 @@ static void xmlHaltParser(xmlParserCtxtPtr ctxt);
 /*
  * XML_PARSER_NON_LINEAR is the threshold where the ratio of parsed entity
  *    replacement over the size in byte of the input indicates that you have
- *    and eponential behaviour. A value of 10 correspond to at least 3 entity
+ *    and exponential behaviour. A value of 10 correspond to at least 3 entity
  *    replacement per byte of input.
  */
 #define XML_PARSER_NON_LINEAR 10
@@ -140,7 +146,7 @@ xmlParserEntityCheck(xmlParserCtxtPtr ctxt, size_t size,
     if ((ent != NULL) && (ent->etype != XML_INTERNAL_PREDEFINED_ENTITY) &&
     (ent->content != NULL) && (ent->checked == 0) &&
     (ctxt->errNo != XML_ERR_ENTITY_LOOP)) {
-    unsigned long oldnbent = ctxt->nbentities;
+    unsigned long oldnbent = ctxt->nbentities, diff;
     xmlChar *rep;
 
     ent->checked = 1;
@@ -153,7 +159,10 @@ xmlParserEntityCheck(xmlParserCtxtPtr ctxt, size_t size,
         ent->content[0] = 0;
     }
 
-    ent->checked = (ctxt->nbentities - oldnbent + 1) * 2;
+        diff = ctxt->nbentities - oldnbent + 1;
+        if (diff > INT_MAX / 2)
+            diff = INT_MAX / 2;
+    ent->checked = diff * 2;
     if (rep != NULL) {
         if (xmlStrchr(rep, '<'))
         ent->checked |= 1;
@@ -1060,7 +1069,7 @@ xmlHasFeature(xmlFeature feature)
  * xmlDetectSAX2:
  * @ctxt:  an XML parser context
  *
- * Do the SAX2 detection and specific intialization
+ * Do the SAX2 detection and specific initialization
  */
 static void
 xmlDetectSAX2(xmlParserCtxtPtr ctxt) {
@@ -1392,7 +1401,7 @@ xmlCleanSpecialAttr(xmlParserCtxtPtr ctxt)
  * [37] UserCode ::= ('x' | 'X') '-' ([a-z] | [A-Z])+
  * [38] Subcode ::= ([a-z] | [A-Z])+
  *
- * The current REC reference the sucessors of RFC 1766, currently 5646
+ * The current REC reference the successors of RFC 1766, currently 5646
  *
  * http://www.rfc-editor.org/rfc/rfc5646.txt
  * langtag       = language
@@ -1819,7 +1828,6 @@ nodePop(xmlParserCtxtPtr ctxt)
     return (ret);
 }
 
-#ifdef LIBXML_PUSH_ENABLED
 /**
  * nameNsPush:
  * @ctxt:  an XML parser context
@@ -1855,6 +1863,11 @@ nameNsPush(xmlParserCtxtPtr ctxt, const xmlChar * value,
         goto mem_error;
         }
     ctxt->pushTab = tmp2;
+    } else if (ctxt->pushTab == NULL) {
+        ctxt->pushTab = (void **) xmlMalloc(ctxt->nameMax * 3 *
+                                            sizeof(ctxt->pushTab[0]));
+        if (ctxt->pushTab == NULL)
+            goto mem_error;
     }
     ctxt->nameTab[ctxt->nameNr] = value;
     ctxt->name = value;
@@ -1866,6 +1879,7 @@ mem_error:
     xmlErrMemory(ctxt, NULL);
     return (-1);
 }
+#ifdef LIBXML_PUSH_ENABLED
 /**
  * nameNsPop:
  * @ctxt: an XML parser context
@@ -2075,11 +2089,11 @@ static void xmlSHRINK (xmlParserCtxtPtr ctxt) {
     xmlGROW (ctxt);
 
 static void xmlGROW (xmlParserCtxtPtr ctxt) {
-    unsigned long curEnd = ctxt->input->end - ctxt->input->cur;
-    unsigned long curBase = ctxt->input->cur - ctxt->input->base;
+    ptrdiff_t curEnd = ctxt->input->end - ctxt->input->cur;
+    ptrdiff_t curBase = ctxt->input->cur - ctxt->input->base;
 
-    if (((curEnd > (unsigned long) XML_MAX_LOOKUP_LIMIT) ||
-         (curBase > (unsigned long) XML_MAX_LOOKUP_LIMIT)) &&
+    if (((curEnd > XML_MAX_LOOKUP_LIMIT) ||
+         (curBase > XML_MAX_LOOKUP_LIMIT)) &&
          ((ctxt->input->buf) &&
           (ctxt->input->buf->readcallback != xmlInputReadCallbackNop)) &&
         ((ctxt->options & XML_PARSE_HUGE) == 0)) {
@@ -2281,9 +2295,8 @@ xmlPushInput(xmlParserCtxtPtr ctxt, xmlParserInputPtr input) {
  */
 int
 xmlParseCharRef(xmlParserCtxtPtr ctxt) {
-    unsigned int val = 0;
+    int val = 0;
     int count = 0;
-    unsigned int outofrange = 0;
 
     /*
      * Using RAW/CUR/NEXT is okay since we are working on ASCII range here
@@ -2310,8 +2323,8 @@ xmlParseCharRef(xmlParserCtxtPtr ctxt) {
         val = 0;
         break;
         }
-        if (val > 0x10FFFF)
-            outofrange = val;
+        if (val > 0x110000)
+            val = 0x110000;
 
         NEXT;
         count++;
@@ -2339,8 +2352,8 @@ xmlParseCharRef(xmlParserCtxtPtr ctxt) {
         val = 0;
         break;
         }
-        if (val > 0x10FFFF)
-            outofrange = val;
+        if (val > 0x110000)
+            val = 0x110000;
 
         NEXT;
         count++;
@@ -2360,7 +2373,11 @@ xmlParseCharRef(xmlParserCtxtPtr ctxt) {
      * Characters referred to using character references must match the
      * production for Char.
      */
-    if ((IS_CHAR(val) && (outofrange == 0))) {
+    if (val >= 0x110000) {
+        xmlFatalErrMsgInt(ctxt, XML_ERR_INVALID_CHAR,
+                "xmlParseCharRef: character reference out of bounds\n",
+            val);
+    } else if (IS_CHAR(val)) {
         return(val);
     } else {
         xmlFatalErrMsgInt(ctxt, XML_ERR_INVALID_CHAR,
@@ -2392,8 +2409,7 @@ static int
 xmlParseStringCharRef(xmlParserCtxtPtr ctxt, const xmlChar **str) {
     const xmlChar *ptr;
     xmlChar cur;
-    unsigned int val = 0;
-    unsigned int outofrange = 0;
+    int val = 0;
 
     if ((str == NULL) || (*str == NULL)) return(0);
     ptr = *str;
@@ -2413,8 +2429,8 @@ xmlParseStringCharRef(xmlParserCtxtPtr ctxt, const xmlChar **str) {
         val = 0;
         break;
         }
-        if (val > 0x10FFFF)
-            outofrange = val;
+        if (val > 0x110000)
+            val = 0x110000;
 
         ptr++;
         cur = *ptr;
@@ -2432,8 +2448,8 @@ xmlParseStringCharRef(xmlParserCtxtPtr ctxt, const xmlChar **str) {
         val = 0;
         break;
         }
-        if (val > 0x10FFFF)
-            outofrange = val;
+        if (val > 0x110000)
+            val = 0x110000;
 
         ptr++;
         cur = *ptr;
@@ -2451,7 +2467,11 @@ xmlParseStringCharRef(xmlParserCtxtPtr ctxt, const xmlChar **str) {
      * Characters referred to using character references must match the
      * production for Char.
      */
-    if ((IS_CHAR(val) && (outofrange == 0))) {
+    if (val >= 0x110000) {
+        xmlFatalErrMsgInt(ctxt, XML_ERR_INVALID_CHAR,
+                "xmlParseStringCharRef: character reference out of bounds\n",
+                val);
+    } else if (IS_CHAR(val)) {
         return(val);
     } else {
         xmlFatalErrMsgInt(ctxt, XML_ERR_INVALID_CHAR,
@@ -2702,7 +2722,7 @@ xmlStringLenDecodeEntities(xmlParserCtxtPtr ctxt, const xmlChar *str, int len,
             /*
              * Note: external parsed entities will not be loaded,
              * it is not required for a non-validating parser to
-             * complete external PEreferences coming from the
+             * complete external PEReferences coming from the
              * internal subset
              */
             if (((ctxt->options & XML_PARSE_NOENT) != 0) ||
@@ -3366,7 +3386,7 @@ xmlParseNCNameComplex(xmlParserCtxtPtr ctxt) {
         /*
          * when shrinking to extend the buffer we really need to preserve
          * the part of the name we already parsed. Hence rolling back
-         * by current lenght.
+         * by current length.
          */
         ctxt->input->cur -= l;
         GROW;
@@ -3835,7 +3855,7 @@ error:
  * xmlParseAttValueComplex:
  * @ctxt:  an XML parser context
  * @len:   the resulting attribute len
- * @normalize:  wether to apply the inner normalization
+ * @normalize:  whether to apply the inner normalization
  *
  * parse a value for an attribute, this is the fallback function
  * of xmlParseAttValue() when the attribute parsing requires handling
@@ -3984,14 +4004,17 @@ xmlParseAttValueComplex(xmlParserCtxtPtr ctxt, int *attlen, int normalize) {
              */
             if ((ent->etype != XML_INTERNAL_PREDEFINED_ENTITY) &&
             (ent->content != NULL) && (ent->checked == 0)) {
-            unsigned long oldnbent = ctxt->nbentities;
+            unsigned long oldnbent = ctxt->nbentities, diff;
 
             ++ctxt->depth;
             rep = xmlStringDecodeEntities(ctxt, ent->content,
                           XML_SUBSTITUTE_REF, 0, 0, 0);
             --ctxt->depth;
 
-            ent->checked = (ctxt->nbentities - oldnbent + 1) * 2;
+                        diff = ctxt->nbentities - oldnbent + 1;
+                        if (diff > INT_MAX / 2)
+                            diff = INT_MAX / 2;
+                        ent->checked = diff * 2;
             if (rep != NULL) {
                 if (xmlStrchr(rep, '<'))
                     ent->checked |= 1;
@@ -4059,7 +4082,7 @@ xmlParseAttValueComplex(xmlParserCtxtPtr ctxt, int *attlen, int normalize) {
 
     /*
      * There we potentially risk an overflow, don't allow attribute value of
-     * length more than INT_MAX it is a very reasonnable assumption !
+     * length more than INT_MAX it is a very reasonable assumption !
      */
     if (len >= INT_MAX) {
         xmlFatalErrMsg(ctxt, XML_ERR_ATTRIBUTE_NOT_FINISHED,
@@ -4664,7 +4687,7 @@ xmlParseExternalID(xmlParserCtxtPtr ctxt, xmlChar **publicID, int strict) {
  * xmlParseCommentComplex:
  * @ctxt:  an XML parser context
  * @buf:  the already parsed part of the buffer
- * @len:  number of bytes filles in the buffer
+ * @len:  number of bytes in the buffer
  * @size:  allocated size of the buffer
  *
  * Skip an XML (SGML) comment <!-- .... -->
@@ -4955,6 +4978,10 @@ get_more:
         } else
             xmlFatalErrMsgStr(ctxt, XML_ERR_HYPHEN_IN_COMMENT,
                               "Double hyphen within comment\n", NULL);
+                if (ctxt->instate == XML_PARSER_EOF) {
+                    xmlFree(buf);
+                    return;
+                }
         in++;
         ctxt->input->col++;
         }
@@ -5085,7 +5112,7 @@ error:
  *
  * [16] PI ::= '<?' PITarget (S (Char* - (Char* '?>' Char*)))? '?>'
  *
- * The processing is transfered to SAX once parsed.
+ * The processing is transferred to SAX once parsed.
  */
 
 void
@@ -5501,7 +5528,7 @@ xmlParseEntityDecl(xmlParserCtxtPtr ctxt) {
                     literal, URI, NULL);
             /*
              * For expat compatibility in SAX mode.
-             * assuming the entity repalcement was asked for
+             * assuming the entity replacement was asked for
              */
             if ((ctxt->replaceEntities != 0) &&
             ((ctxt->myDoc == NULL) ||
@@ -6611,149 +6638,143 @@ xmlParseElementDecl(xmlParserCtxtPtr ctxt) {
 
 static void
 xmlParseConditionalSections(xmlParserCtxtPtr ctxt) {
+    int *inputIds = NULL;
+    size_t inputIdsSize = 0;
+    size_t depth = 0;
+
+    while (ctxt->instate != XML_PARSER_EOF) {
+        if ((RAW == '<') && (NXT(1) == '!') && (NXT(2) == '[')) {
     int id = ctxt->input->id;
 
     SKIP(3);
     SKIP_BLANKS;
+
     if (CMP7(CUR_PTR, 'I', 'N', 'C', 'L', 'U', 'D', 'E')) {
     SKIP(7);
     SKIP_BLANKS;
     if (RAW != '[') {
         xmlFatalErr(ctxt, XML_ERR_CONDSEC_INVALID, NULL);
         xmlHaltParser(ctxt);
-        return;
-    } else {
+                    goto error;
+                }
         if (ctxt->input->id != id) {
         xmlFatalErrMsg(ctxt, XML_ERR_ENTITY_BOUNDARY,
-                           "All markup of the conditional section is not"
-                               " in the same entity\n");
+                                   "All markup of the conditional section is"
+                                   " not in the same entity\n");
         }
         NEXT;
-    }
-    if (xmlParserDebugEntities) {
-        if ((ctxt->input != NULL) && (ctxt->input->filename))
-        xmlGenericError(xmlGenericErrorContext,
-            "%s(%d): ", ctxt->input->filename,
-            ctxt->input->line);
-        xmlGenericError(xmlGenericErrorContext,
-            "Entering INCLUDE Conditional Section\n");
-    }
 
-        SKIP_BLANKS;
-        GROW;
-    while (((RAW != 0) && ((RAW != ']') || (NXT(1) != ']') ||
-            (NXT(2) != '>'))) && (ctxt->instate != XML_PARSER_EOF)) {
-        const xmlChar *check = CUR_PTR;
-        unsigned int cons = ctxt->input->consumed;
+                if (inputIdsSize <= depth) {
+                    int *tmp;
 
-        if ((RAW == '<') && (NXT(1) == '!') && (NXT(2) == '[')) {
-        xmlParseConditionalSections(ctxt);
-        } else
-        xmlParseMarkupDecl(ctxt);
-
-            SKIP_BLANKS;
-            GROW;
-
-        if ((CUR_PTR == check) && (cons == ctxt->input->consumed)) {
-        xmlFatalErr(ctxt, XML_ERR_EXT_SUBSET_NOT_FINISHED, NULL);
-        xmlHaltParser(ctxt);
-        break;
+                    inputIdsSize = (inputIdsSize == 0 ? 4 : inputIdsSize * 2);
+                    tmp = (int *) xmlRealloc(inputIds,
+                            inputIdsSize * sizeof(int));
+                    if (tmp == NULL) {
+                        xmlErrMemory(ctxt, NULL);
+                        goto error;
         }
+                    inputIds = tmp;
     }
-    if (xmlParserDebugEntities) {
-        if ((ctxt->input != NULL) && (ctxt->input->filename))
-        xmlGenericError(xmlGenericErrorContext,
-            "%s(%d): ", ctxt->input->filename,
-            ctxt->input->line);
-        xmlGenericError(xmlGenericErrorContext,
-            "Leaving INCLUDE Conditional Section\n");
-    }
-
+                inputIds[depth] = id;
+                depth++;
     } else if (CMP6(CUR_PTR, 'I', 'G', 'N', 'O', 'R', 'E')) {
     int state;
     xmlParserInputState instate;
-    int depth = 0;
+                size_t ignoreDepth = 0;
 
     SKIP(6);
     SKIP_BLANKS;
     if (RAW != '[') {
         xmlFatalErr(ctxt, XML_ERR_CONDSEC_INVALID, NULL);
         xmlHaltParser(ctxt);
-        return;
-    } else {
+                    goto error;
+                }
         if (ctxt->input->id != id) {
         xmlFatalErrMsg(ctxt, XML_ERR_ENTITY_BOUNDARY,
-                           "All markup of the conditional section is not"
-                               " in the same entity\n");
+                                   "All markup of the conditional section is"
+                                   " not in the same entity\n");
         }
         NEXT;
-    }
-    if (xmlParserDebugEntities) {
-        if ((ctxt->input != NULL) && (ctxt->input->filename))
-        xmlGenericError(xmlGenericErrorContext,
-            "%s(%d): ", ctxt->input->filename,
-            ctxt->input->line);
-        xmlGenericError(xmlGenericErrorContext,
-            "Entering IGNORE Conditional Section\n");
-    }
 
     /*
-     * Parse up to the end of the conditional section
-     * But disable SAX event generating DTD building in the meantime
+                 * Parse up to the end of the conditional section but disable
+                 * SAX event generating DTD building in the meantime
      */
     state = ctxt->disableSAX;
     instate = ctxt->instate;
     if (ctxt->recovery == 0) ctxt->disableSAX = 1;
     ctxt->instate = XML_PARSER_IGNORE;
 
-    while (((depth >= 0) && (RAW != 0)) &&
-               (ctxt->instate != XML_PARSER_EOF)) {
+                while (RAW != 0) {
       if ((RAW == '<') && (NXT(1) == '!') && (NXT(2) == '[')) {
-        depth++;
         SKIP(3);
-        continue;
+                        ignoreDepth++;
+                        /* Check for integer overflow */
+                        if (ignoreDepth == 0) {
+                            xmlErrMemory(ctxt, NULL);
+                            goto error;
       }
-      if ((RAW == ']') && (NXT(1) == ']') && (NXT(2) == '>')) {
-        if (--depth >= 0) SKIP(3);
-        continue;
-      }
+                    } else if ((RAW == ']') && (NXT(1) == ']') &&
+                               (NXT(2) == '>')) {
+                        if (ignoreDepth == 0)
+                            break;
+                        SKIP(3);
+                        ignoreDepth--;
+                    } else {
       NEXT;
-      continue;
+                    }
     }
 
     ctxt->disableSAX = state;
     ctxt->instate = instate;
 
-    if (xmlParserDebugEntities) {
-        if ((ctxt->input != NULL) && (ctxt->input->filename))
-        xmlGenericError(xmlGenericErrorContext,
-            "%s(%d): ", ctxt->input->filename,
-            ctxt->input->line);
-        xmlGenericError(xmlGenericErrorContext,
-            "Leaving IGNORE Conditional Section\n");
+        if (RAW == 0) {
+            xmlFatalErr(ctxt, XML_ERR_CONDSEC_NOT_FINISHED, NULL);
+                    goto error;
     }
-
+                if (ctxt->input->id != id) {
+                    xmlFatalErrMsg(ctxt, XML_ERR_ENTITY_BOUNDARY,
+                                   "All markup of the conditional section is"
+                                   " not in the same entity\n");
+                }
+                SKIP(3);
     } else {
     xmlFatalErr(ctxt, XML_ERR_CONDSEC_INVALID_KEYWORD, NULL);
     xmlHaltParser(ctxt);
-    return;
+                goto error;
     }
-
-    if (RAW == 0)
-        SHRINK;
-
-    if (RAW == 0) {
-    xmlFatalErr(ctxt, XML_ERR_CONDSEC_NOT_FINISHED, NULL);
-    } else {
-    if (ctxt->input->id != id) {
+        } else if ((depth > 0) &&
+                   (RAW == ']') && (NXT(1) == ']') && (NXT(2) == '>')) {
+            depth--;
+            if (ctxt->input->id != inputIds[depth]) {
         xmlFatalErrMsg(ctxt, XML_ERR_ENTITY_BOUNDARY,
-                       "All markup of the conditional section is not in"
-                           " the same entity\n");
+                               "All markup of the conditional section is not"
+                               " in the same entity\n");
     }
-    if ((ctxt-> instate != XML_PARSER_EOF) &&
-        ((ctxt->input->cur + 3) <= ctxt->input->end))
         SKIP(3);
+        } else {
+            const xmlChar *check = CUR_PTR;
+            unsigned int cons = ctxt->input->consumed;
+
+            xmlParseMarkupDecl(ctxt);
+
+            if ((CUR_PTR == check) && (cons == ctxt->input->consumed)) {
+                xmlFatalErr(ctxt, XML_ERR_EXT_SUBSET_NOT_FINISHED, NULL);
+                xmlHaltParser(ctxt);
+                goto error;
+            }
     }
+
+        if (depth == 0)
+            break;
+
+        SKIP_BLANKS;
+        GROW;
+    }
+
+error:
+    xmlFree(inputIds);
 }
 
 /**
@@ -6810,20 +6831,10 @@ xmlParseMarkupDecl(xmlParserCtxtPtr ctxt) {
 
     /*
      * detect requirement to exit there and act accordingly
-     * and avoid having instate overriden later on
+     * and avoid having instate overridden later on
      */
     if (ctxt->instate == XML_PARSER_EOF)
         return;
-
-    /*
-     * Conditional sections are allowed from entities included
-     * by PE References in the internal subset.
-     */
-    if ((ctxt->external == 0) && (ctxt->inputNr > 1)) {
-        if ((RAW == '<') && (NXT(1) == '!') && (NXT(2) == '[')) {
-        xmlParseConditionalSections(ctxt);
-    }
-    }
 
     ctxt->instate = XML_PARSER_DTD;
 }
@@ -7009,7 +7020,7 @@ xmlParseReference(xmlParserCtxtPtr ctxt) {
      */
     if (NXT(1) == '#') {
     int i = 0;
-    xmlChar out[10];
+    xmlChar out[16];
     int hex = NXT(2);
     int value = xmlParseCharRef(ctxt);
 
@@ -7086,7 +7097,7 @@ xmlParseReference(xmlParserCtxtPtr ctxt) {
          ((ent->children == NULL) && (ctxt->options & XML_PARSE_NOENT))) &&
         ((ent->etype != XML_EXTERNAL_GENERAL_PARSED_ENTITY) ||
          (ctxt->options & (XML_PARSE_NOENT | XML_PARSE_DTDVALID)))) {
-    unsigned long oldnbent = ctxt->nbentities;
+    unsigned long oldnbent = ctxt->nbentities, diff;
 
     /*
      * This is a bit hackish but this seems the best
@@ -7127,7 +7138,10 @@ xmlParseReference(xmlParserCtxtPtr ctxt) {
      * Store the number of entities needing parsing for this entity
      * content and do checkings
      */
-    ent->checked = (ctxt->nbentities - oldnbent + 1) * 2;
+        diff = ctxt->nbentities - oldnbent + 1;
+        if (diff > INT_MAX / 2)
+            diff = INT_MAX / 2;
+        ent->checked = diff * 2;
     if ((ent->content != NULL) && (xmlStrchr(ent->content, '<')))
         ent->checked |= 1;
     if (ret == XML_ERR_ENTITY_LOOP) {
@@ -7675,7 +7689,7 @@ xmlParseStringEntityRef(xmlParserCtxtPtr ctxt, const xmlChar ** str) {
     }
 
     /*
-     * Increate the number of entity references parsed
+     * Increase the number of entity references parsed
      */
     ctxt->nbentities++;
 
@@ -7851,7 +7865,7 @@ xmlParsePEReference(xmlParserCtxtPtr ctxt)
     NEXT;
 
     /*
-     * Increate the number of entity references parsed
+     * Increase the number of entity references parsed
      */
     ctxt->nbentities++;
 
@@ -8117,7 +8131,7 @@ xmlParseStringPEReference(xmlParserCtxtPtr ctxt, const xmlChar **str) {
     ptr++;
 
     /*
-     * Increate the number of entity references parsed
+     * Increase the number of entity references parsed
      */
     ctxt->nbentities++;
 
@@ -8284,6 +8298,15 @@ xmlParseInternalSubset(xmlParserCtxtPtr ctxt) {
         SKIP_BLANKS;
         xmlParseMarkupDecl(ctxt);
         xmlParsePEReference(ctxt);
+
+            /*
+             * Conditional sections are allowed from external entities included
+             * by PE References in the internal subset.
+             */
+            if ((ctxt->inputNr > 1) && (ctxt->input->filename != NULL) &&
+                (RAW == '<') && (NXT(1) == '!') && (NXT(2) == '[')) {
+                xmlParseConditionalSections(ctxt);
+            }
 
         if ((CUR_PTR == check) && (cons == ctxt->input->consumed)) {
         xmlFatalErr(ctxt, XML_ERR_INTERNAL_ERROR,
@@ -8713,12 +8736,16 @@ xmlParseQName(xmlParserCtxtPtr ctxt, const xmlChar **prefix) {
     if (l == NULL) {
         xmlChar *tmp;
 
+            if (ctxt->instate == XML_PARSER_EOF)
+                return(NULL);
             xmlNsErr(ctxt, XML_NS_ERR_QNAME,
                  "Failed to parse QName '%s:'\n", p, NULL, NULL);
         l = xmlParseNmtoken(ctxt);
-        if (l == NULL)
+        if (l == NULL) {
+                if (ctxt->instate == XML_PARSER_EOF)
+                    return(NULL);
         tmp = xmlBuildQName(BAD_CAST "", p, NULL, 0);
-        else {
+            } else {
         tmp = xmlBuildQName(l, p, NULL, 0);
         xmlFree((char *)l);
         }
@@ -8741,6 +8768,8 @@ xmlParseQName(xmlParserCtxtPtr ctxt, const xmlChar **prefix) {
         *prefix = p;
         return(l);
         }
+            if (ctxt->instate == XML_PARSER_EOF)
+                return(NULL);
         tmp = xmlBuildQName(BAD_CAST "", l, NULL, 0);
         l = xmlDictLookup(ctxt->dict, tmp, -1);
         if (tmp != NULL) xmlFree(tmp);
@@ -8840,6 +8869,18 @@ xmlParseQNameAndCompare(xmlParserCtxtPtr ctxt, xmlChar const *name,
  *     caller if it was copied, this can be detected by val[*len] == 0.
  */
 
+#define GROW_PARSE_ATT_VALUE_INTERNAL(ctxt, in, start, end) \
+    const xmlChar *oldbase = ctxt->input->base;\
+    GROW;\
+    if (ctxt->instate == XML_PARSER_EOF)\
+        return(NULL);\
+    if (oldbase != ctxt->input->base) {\
+        ptrdiff_t delta = ctxt->input->base - oldbase;\
+        start = start + delta;\
+        in = in + delta;\
+    }\
+    end = ctxt->input->end;
+
 static xmlChar *
 xmlParseAttValueInternal(xmlParserCtxtPtr ctxt, int *len, int *alloc,
                          int normalize)
@@ -8869,14 +8910,7 @@ xmlParseAttValueInternal(xmlParserCtxtPtr ctxt, int *len, int *alloc,
     end = ctxt->input->end;
     start = in;
     if (in >= end) {
-        const xmlChar *oldbase = ctxt->input->base;
-    GROW;
-    if (oldbase != ctxt->input->base) {
-        long delta = ctxt->input->base - oldbase;
-        start = start + delta;
-        in = in + delta;
-    }
-    end = ctxt->input->end;
+        GROW_PARSE_ATT_VALUE_INTERNAL(ctxt, in, start, end)
     }
     if (normalize) {
         /*
@@ -8893,16 +8927,7 @@ xmlParseAttValueInternal(xmlParserCtxtPtr ctxt, int *len, int *alloc,
         in++;
         start = in;
         if (in >= end) {
-        const xmlChar *oldbase = ctxt->input->base;
-        GROW;
-                if (ctxt->instate == XML_PARSER_EOF)
-                    return(NULL);
-        if (oldbase != ctxt->input->base) {
-            long delta = ctxt->input->base - oldbase;
-            start = start + delta;
-            in = in + delta;
-        }
-        end = ctxt->input->end;
+                GROW_PARSE_ATT_VALUE_INTERNAL(ctxt, in, start, end)
                 if (((in - start) > XML_MAX_TEXT_LENGTH) &&
                     ((ctxt->options & XML_PARSE_HUGE) == 0)) {
                     xmlFatalErrMsg(ctxt, XML_ERR_ATTRIBUTE_NOT_FINISHED,
@@ -8916,16 +8941,7 @@ xmlParseAttValueInternal(xmlParserCtxtPtr ctxt, int *len, int *alloc,
         col++;
         if ((*in++ == 0x20) && (*in == 0x20)) break;
         if (in >= end) {
-        const xmlChar *oldbase = ctxt->input->base;
-        GROW;
-                if (ctxt->instate == XML_PARSER_EOF)
-                    return(NULL);
-        if (oldbase != ctxt->input->base) {
-            long delta = ctxt->input->base - oldbase;
-            start = start + delta;
-            in = in + delta;
-        }
-        end = ctxt->input->end;
+                GROW_PARSE_ATT_VALUE_INTERNAL(ctxt, in, start, end)
                 if (((in - start) > XML_MAX_TEXT_LENGTH) &&
                     ((ctxt->options & XML_PARSE_HUGE) == 0)) {
                     xmlFatalErrMsg(ctxt, XML_ERR_ATTRIBUTE_NOT_FINISHED,
@@ -8954,7 +8970,7 @@ xmlParseAttValueInternal(xmlParserCtxtPtr ctxt, int *len, int *alloc,
                 if (ctxt->instate == XML_PARSER_EOF)
                     return(NULL);
         if (oldbase != ctxt->input->base) {
-            long delta = ctxt->input->base - oldbase;
+            ptrdiff_t delta = ctxt->input->base - oldbase;
             start = start + delta;
             in = in + delta;
             last = last + delta;
@@ -8981,16 +8997,7 @@ xmlParseAttValueInternal(xmlParserCtxtPtr ctxt, int *len, int *alloc,
         in++;
         col++;
         if (in >= end) {
-        const xmlChar *oldbase = ctxt->input->base;
-        GROW;
-                if (ctxt->instate == XML_PARSER_EOF)
-                    return(NULL);
-        if (oldbase != ctxt->input->base) {
-            long delta = ctxt->input->base - oldbase;
-            start = start + delta;
-            in = in + delta;
-        }
-        end = ctxt->input->end;
+                GROW_PARSE_ATT_VALUE_INTERNAL(ctxt, in, start, end)
                 if (((in - start) > XML_MAX_TEXT_LENGTH) &&
                     ((ctxt->options & XML_PARSE_HUGE) == 0)) {
                     xmlFatalErrMsg(ctxt, XML_ERR_ATTRIBUTE_NOT_FINISHED,
@@ -9084,7 +9091,7 @@ xmlParseAttribute2(xmlParserCtxtPtr ctxt,
     if (normalize) {
         /*
          * Sometimes a second normalisation pass for spaces is needed
-         * but that only happens if charrefs or entities refernces
+         * but that only happens if charrefs or entities references
          * have been used in the attribute value, i.e. the attribute
          * value have been extracted in an allocated string already.
          */
@@ -9247,7 +9254,8 @@ xmlParseStartTag2(xmlParserCtxtPtr ctxt, const xmlChar **pref,
                 xmlErrMemory(ctxt, "dictionary allocation failure");
                 if ((attvalue != NULL) && (alloc != 0))
                     xmlFree(attvalue);
-                return(NULL);
+                localname = NULL;
+                goto done;
             }
             if (*URL != 0) {
                 uri = xmlParseURI((const char *) URL);
@@ -9497,7 +9505,8 @@ next_attr:
 
             if ((atts == NULL) || (nbatts + 5 > maxatts)) {
             if (xmlCtxtGrowAttrs(ctxt, nbatts + 5) < 0) {
-                return(NULL);
+                            localname = NULL;
+                            goto done;
             }
             maxatts = ctxt->maxatts;
             atts = ctxt->atts;
@@ -9807,9 +9816,10 @@ xmlParseCDSect(xmlParserCtxtPtr ctxt) {
 
 void
 xmlParseContent(xmlParserCtxtPtr ctxt) {
+    int nameNr = ctxt->nameNr;
+
     GROW;
     while ((RAW != 0) &&
-       ((RAW != '<') || (NXT(1) != '/')) &&
        (ctxt->instate != XML_PARSER_EOF)) {
     const xmlChar *test = CUR_PTR;
     unsigned int cons = ctxt->input->consumed;
@@ -9843,7 +9853,13 @@ xmlParseContent(xmlParserCtxtPtr ctxt) {
      * Fourth case :  a sub-element.
      */
     else if (*cur == '<') {
-        xmlParseElement(ctxt);
+            if (NXT(1) == '/') {
+                if (ctxt->nameNr <= nameNr)
+                    break;
+            xmlParseElementEnd(ctxt);
+            } else {
+            xmlParseElementStart(ctxt);
+            }
     }
 
     /*
@@ -9878,7 +9894,7 @@ xmlParseContent(xmlParserCtxtPtr ctxt) {
  * xmlParseElement:
  * @ctxt:  an XML parser context
  *
- * parse an XML element, this is highly recursive
+ * parse an XML element
  *
  * [39] element ::= EmptyElemTag | STag content ETag
  *
@@ -9890,6 +9906,23 @@ xmlParseContent(xmlParserCtxtPtr ctxt) {
 
 void
 xmlParseElement(xmlParserCtxtPtr ctxt) {
+    if (xmlParseElementStart(ctxt) != 0)
+        return;
+    xmlParseContent(ctxt);
+    if (ctxt->instate == XML_PARSER_EOF)
+    return;
+    xmlParseElementEnd(ctxt);
+}
+
+/**
+ * xmlParseElementStart:
+ * @ctxt:  an XML parser context
+ *
+ * Parse the start of an XML element. Returns -1 in case of error, 0 if an
+ * opening tag was parsed, 1 if an empty element was parsed.
+ */
+static int
+xmlParseElementStart(xmlParserCtxtPtr ctxt) {
     const xmlChar *name;
     const xmlChar *prefix = NULL;
     const xmlChar *URI = NULL;
@@ -9904,7 +9937,7 @@ xmlParseElement(xmlParserCtxtPtr ctxt) {
          "Excessive depth in document: %d use XML_PARSE_HUGE option\n",
               xmlParserMaxDepth);
     xmlHaltParser(ctxt);
-    return;
+    return(-1);
     }
 
     /* Capture start position */
@@ -9931,12 +9964,17 @@ xmlParseElement(xmlParserCtxtPtr ctxt) {
     name = xmlParseStartTag(ctxt);
 #endif /* LIBXML_SAX1_ENABLED */
     if (ctxt->instate == XML_PARSER_EOF)
-    return;
+    return(-1);
     if (name == NULL) {
     spacePop(ctxt);
-        return;
+        return(-1);
     }
+    if (ctxt->sax2)
+        nameNsPush(ctxt, name, prefix, URI, ctxt->nsNr - nsNr);
+#ifdef LIBXML_SAX1_ENABLED
+    else
     namePush(ctxt, name);
+#endif /* LIBXML_SAX1_ENABLED */
     ret = ctxt->node;
 
 #ifdef LIBXML_VALID_ENABLED
@@ -9977,7 +10015,7 @@ xmlParseElement(xmlParserCtxtPtr ctxt) {
        node_info.node = ret;
        xmlParserAddNodeInfo(ctxt, &node_info);
     }
-    return;
+    return(1);
     }
     if (RAW == '>') {
         NEXT1;
@@ -10005,41 +10043,39 @@ xmlParseElement(xmlParserCtxtPtr ctxt) {
        node_info.node = ret;
        xmlParserAddNodeInfo(ctxt, &node_info);
     }
-    return;
+    return(-1);
     }
 
-    /*
-     * Parse the content of the element:
-     */
-    xmlParseContent(ctxt);
-    if (ctxt->instate == XML_PARSER_EOF)
-    return;
-    if (!IS_BYTE_CHAR(RAW)) {
-        xmlFatalErrMsgStrIntStr(ctxt, XML_ERR_TAG_NOT_FINISHED,
-     "Premature end of data in tag %s line %d\n",
-                        name, line, NULL);
+    return(0);
+}
 
-    /*
-     * end of parsing of this node.
+/**
+ * xmlParseElementEnd:
+ * @ctxt:  an XML parser context
+ *
+ * Parse the end of an XML element.
      */
-    nodePop(ctxt);
-    namePop(ctxt);
-    spacePop(ctxt);
-    if (nsNr != ctxt->nsNr)
-        nsPop(ctxt, ctxt->nsNr - nsNr);
+static void
+xmlParseElementEnd(xmlParserCtxtPtr ctxt) {
+    xmlParserNodeInfo node_info;
+    xmlNodePtr ret = ctxt->node;
+
+    if (ctxt->nameNr <= 0)
     return;
-    }
 
     /*
      * parse the end of tag: '</' should be here.
      */
     if (ctxt->sax2) {
-    xmlParseEndTag2(ctxt, prefix, URI, line, ctxt->nsNr - nsNr, tlen);
+        const xmlChar *prefix = ctxt->pushTab[ctxt->nameNr * 3 - 3];
+        const xmlChar *URI = ctxt->pushTab[ctxt->nameNr * 3 - 2];
+        int nsNr = (ptrdiff_t) ctxt->pushTab[ctxt->nameNr * 3 - 1];
+    xmlParseEndTag2(ctxt, prefix, URI, 0, nsNr, 0);
     namePop(ctxt);
     }
 #ifdef LIBXML_SAX1_ENABLED
       else
-    xmlParseEndTag1(ctxt, line);
+    xmlParseEndTag1(ctxt, 0);
 #endif /* LIBXML_SAX1_ENABLED */
 
     /*
@@ -10281,7 +10317,7 @@ xmlParseEncodingDecl(xmlParserCtxtPtr ctxt) {
     }
 
     /*
-     * UTF-16 encoding stwich has already taken place at this stage,
+     * UTF-16 encoding switch has already taken place at this stage,
      * more over the little-endian/big-endian selection is already done
      */
         if ((encoding != NULL) &&
@@ -11164,7 +11200,7 @@ xmlParseTryOrFinish(xmlParserCtxtPtr ctxt, int terminate) {
     else {
         /*
          * If we are operating on converted input, try to flush
-         * remainng chars to avoid them stalling in the non-converted
+         * remaining chars to avoid them stalling in the non-converted
          * buffer. But do not do this in document start where
          * encoding="..." may not have been read and we work on a
          * guessed encoding.
@@ -12356,13 +12392,6 @@ xmlCreatePushParserCtxt(xmlSAXHandlerPtr sax, void *user_data,
     return(NULL);
     }
     ctxt->dictNames = 1;
-    ctxt->pushTab = (void **) xmlMalloc(ctxt->nameMax * 3 * sizeof(xmlChar *));
-    if (ctxt->pushTab == NULL) {
-        xmlErrMemory(ctxt, NULL);
-    xmlFreeParserInputBuffer(buf);
-    xmlFreeParserCtxt(ctxt);
-    return(NULL);
-    }
     if (sax != NULL) {
 #ifdef LIBXML_SAX1_ENABLED
     if (ctxt->sax != (xmlSAXHandlerPtr) &xmlDefaultSAXHandler)
@@ -13898,6 +13927,7 @@ xmlParseBalancedChunkMemoryRecover(xmlDocPtr doc, xmlSAXHandlerPtr sax,
     xmlFreeParserCtxt(ctxt);
     newDoc->intSubset = NULL;
     newDoc->extSubset = NULL;
+    if(doc != NULL)
     newDoc->oldNs = NULL;
     xmlFreeDoc(newDoc);
 
@@ -14006,6 +14036,10 @@ xmlCreateEntityParserCtxtInternal(const xmlChar *URL, const xmlChar *ID,
      */
     ctxt->input_id = pctx->input_id + 1;
     }
+
+    /* Don't read from stdin. */
+    if (xmlStrcmp(URL, BAD_CAST "-") == 0)
+        URL = BAD_CAST "./-";
 
     uri = xmlBuildURI(URL, base);
 
@@ -14938,16 +14972,6 @@ xmlCtxtResetPush(xmlParserCtxtPtr ctxt, const char *chunk,
     }
 
     xmlCtxtReset(ctxt);
-
-    if (ctxt->pushTab == NULL) {
-        ctxt->pushTab = (void **) xmlMalloc(ctxt->nameMax * 3 *
-                                        sizeof(xmlChar *));
-        if (ctxt->pushTab == NULL) {
-        xmlErrMemory(ctxt, NULL);
-            xmlFreeParserInputBuffer(buf);
-            return(1);
-        }
-    }
 
     if (filename == NULL) {
         ctxt->directory = NULL;

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/parser.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/parser.c
@@ -2646,7 +2646,8 @@ xmlStringLenDecodeEntities(xmlParserCtxtPtr ctxt, const xmlChar *str, int len,
     else
         c = 0;
     while ((c != 0) && (c != end) && /* non input consuming loop */
-       (c != end2) && (c != end3)) {
+           (c != end2) && (c != end3) &&
+           (ctxt->instate != XML_PARSER_EOF)) {
 
     if (c == 0) break;
         if ((c == '&') && (str[1] == '#')) {

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/parserInternals.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/parserInternals.c
@@ -703,7 +703,7 @@ encoding_error:
     /*
      * An encoding problem may arise from a truncated input buffer
      * splitting a character in the middle. In that case do not raise
-     * an error but return 0 to endicate an end of stream problem
+     * an error but return 0 to indicate an end of stream problem
      */
     if (ctxt->input->end - ctxt->input->cur < 4) {
     *len = 0;
@@ -816,7 +816,7 @@ encoding_error:
     /*
      * An encoding problem may arise from a truncated input buffer
      * splitting a character in the middle. In that case do not raise
-     * an error but return 0 to endicate an end of stream problem
+     * an error but return 0 to indicate an end of stream problem
      */
     if ((ctxt == NULL) || (ctxt->input == NULL) ||
         (ctxt->input->end - ctxt->input->cur < 4)) {
@@ -1093,7 +1093,7 @@ xmlSwitchEncoding(xmlParserCtxtPtr ctxt, xmlCharEncoding enc)
     }
     }
     /*
-     * TODO: We could recover from errors in external entites if we
+     * TODO: We could recover from errors in external entities if we
      * didn't stop the parser. But most callers of this function don't
      * check the return value.
      */
@@ -1138,7 +1138,7 @@ xmlSwitchInputEncodingInt(xmlParserCtxtPtr ctxt, xmlParserInputPtr input,
     if (input->buf != NULL) {
         if (input->buf->encoder != NULL) {
             /*
-             * Check in case the auto encoding detetection triggered
+             * Check in case the auto encoding detection triggered
              * in already.
              */
             if (input->buf->encoder == handler)

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/pattern.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/pattern.c
@@ -1,5 +1,5 @@
 /*
- * pattern.c: Implemetation of selectors for nodes
+ * pattern.c: Implementation of selectors for nodes
  *
  * Reference:
  *   http://www.w3.org/TR/2001/REC-xmlschema-1-20010502/
@@ -55,7 +55,7 @@
 /*
 * NOTE: Those private flags (XML_STREAM_xxx) are used
 *   in _xmlStreamCtxt->flag. They extend the public
-*   xmlPatternFlags, so be carefull not to interfere with the
+*   xmlPatternFlags, so be careful not to interfere with the
 *   reserved values for xmlPatternFlags.
 */
 #define XML_STREAM_FINAL_IS_ANY_NODE 1<<14
@@ -229,13 +229,16 @@ xmlNewPattern(void) {
  */
 void
 xmlFreePattern(xmlPatternPtr comp) {
+    xmlFreePatternList(comp);
+}
+
+static void
+xmlFreePatternInternal(xmlPatternPtr comp) {
     xmlStepOpPtr op;
     int i;
 
     if (comp == NULL)
     return;
-    if (comp->next != NULL)
-        xmlFreePattern(comp->next);
     if (comp->stream != NULL)
         xmlFreeStreamComp(comp->stream);
     if (comp->pattern != NULL)
@@ -273,7 +276,7 @@ xmlFreePatternList(xmlPatternPtr comp) {
     cur = comp;
     comp = comp->next;
     cur->next = NULL;
-    xmlFreePattern(cur);
+    xmlFreePatternInternal(cur);
     }
 }
 
@@ -742,7 +745,7 @@ rollback:
  * xmlPatScanLiteral:
  * @ctxt:  the XPath Parser context
  *
- * Parse an XPath Litteral:
+ * Parse an XPath Literal:
  *
  * [29] Literal ::= '"' [^"]* '"'
  *                | "'" [^']* "'"
@@ -1973,7 +1976,7 @@ xmlStreamPushInternal(xmlStreamCtxtPtr stream,
         } else {
         /*
         * If there are "//", then we need to process every "//"
-        * occuring in the states, plus any other state for this
+        * occurring in the states, plus any other state for this
         * level.
         */
         stepNr = stream->states[2 * i];

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/save.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/save.h
@@ -1,7 +1,7 @@
 /*
  * Summary: Internal Interfaces for saving in libxml2
  * Description: this module describes a few interfaces which were
- *              addded along with the API changes in 2.9.0
+ *              added along with the API changes in 2.9.0
  *              those are private routines at this point
  *
  * Copy: See Copyright for the status of this software.
@@ -25,8 +25,9 @@ void xmlBufDumpNotationTable(xmlBufPtr buf, xmlNotationTablePtr table);
 void xmlBufDumpElementDecl(xmlBufPtr buf, xmlElementPtr elem);
 void xmlBufDumpAttributeDecl(xmlBufPtr buf, xmlAttributePtr attr);
 void xmlBufDumpEntityDecl(xmlBufPtr buf, xmlEntityPtr ent);
-xmlChar *xmlEncodeAttributeEntities(xmlDocPtr doc, const xmlChar *input);
 #endif
+
+xmlChar *xmlEncodeAttributeEntities(xmlDocPtr doc, const xmlChar *input);
 
 #ifdef __cplusplus
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/threads.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/threads.c
@@ -82,7 +82,7 @@ static int libxml_is_threaded = 1;
 
 /*
  * TODO: this module still uses malloc/free and not xmlMalloc/xmlFree
- *       to avoid some crazyness since xmlMalloc/xmlFree may actually
+ *       to avoid some craziness since xmlMalloc/xmlFree may actually
  *       be hosted on allocated blocks needing them for the allocation ...
  */
 
@@ -239,7 +239,7 @@ xmlMutexLock(xmlMutexPtr tok)
     if (acquire_sem(tok->sem) != B_NO_ERROR) {
 #ifdef DEBUG_THREADS
         xmlGenericError(xmlGenericErrorContext,
-                        "xmlMutexLock():BeOS:Couldn't aquire semaphore\n");
+                        "xmlMutexLock():BeOS:Couldn't acquire semaphore\n");
 #endif
     }
     tok->tid = find_thread(NULL);

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/timsort.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/timsort.h
@@ -59,7 +59,7 @@ typedef unsigned __int64 uint64_t;
 #define SORT_SWAP(x,y) {SORT_TYPE __SORT_SWAP_t = (x); (x) = (y); (y) = __SORT_SWAP_t;}
 
 
-/* Common, type-agnosting functions and constants that we don't want to declare twice. */
+/* Common, type-agnostic functions and constants that we don't want to declare twice. */
 #ifndef SORT_COMMON_H
 #define SORT_COMMON_H
 
@@ -74,7 +74,7 @@ typedef unsigned __int64 uint64_t;
 static int compute_minrun(const uint64_t);
 
 #ifndef CLZ
-#ifdef __GNUC__
+#if defined(__GNUC__) && ((__GNUC__ == 3 && __GNUC_MINOR__ >= 4) || (__GNUC__ > 3))
 #define CLZ __builtin_clzll
 #else
 
@@ -404,7 +404,8 @@ static void TIM_SORT_MERGE(SORT_TYPE *dst, const TIM_SORT_RUN_T *stack, const in
     j = curr + A;
     k = curr + A + B;
 
-    while (k-- > curr) {
+    while (k > curr) {
+      k--;
       if ((i > 0) && (j > curr)) {
         if (SORT_CMP(dst[j - 1], storage[i - 1]) > 0) {
           dst[k] = dst[--j];

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/tree.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/tree.c
@@ -59,7 +59,7 @@ int __xmlRegisterCallbacks = 0;
  ************************************************************************/
 
 static xmlNsPtr
-xmlNewReconciliedNs(xmlDocPtr doc, xmlNodePtr tree, xmlNsPtr ns);
+xmlNewReconciledNs(xmlDocPtr doc, xmlNodePtr tree, xmlNsPtr ns);
 
 static xmlChar* xmlGetPropNodeValueInternal(const xmlAttr *prop);
 
@@ -181,7 +181,7 @@ xmlGetEntityFromDtd(const xmlDtd *dtd, const xmlChar *name) {
  * @dtd:  A pointer to the DTD to search
  * @name:  The entity name
  *
- * Do an entity lookup in the DTD pararmeter entity hash table and
+ * Do an entity lookup in the DTD parameter entity hash table and
  * return the corresponding entity, if found.
  *
  * Returns A pointer to the entity structure or NULL if not found.
@@ -2950,7 +2950,7 @@ xmlNewChild(xmlNodePtr parent, xmlNsPtr ns,
  * Add a new attribute after @prev using @cur as base attribute.
  * When inserting before @cur, @prev is passed as @cur->prev.
  * When inserting after @cur, @prev is passed as @cur.
- * If an existing attribute is found it is detroyed prior to adding @prop.
+ * If an existing attribute is found it is destroyed prior to adding @prop.
  *
  * Returns the attribute being inserted or NULL in case of error.
  */
@@ -3664,7 +3664,9 @@ xmlNextElementSibling(xmlNodePtr node) {
 void
 xmlFreeNodeList(xmlNodePtr cur) {
     xmlNodePtr next;
+    xmlNodePtr parent;
     xmlDictPtr dict = NULL;
+    size_t depth = 0;
 
     if (cur == NULL) return;
     if (cur->type == XML_NAMESPACE_DECL) {
@@ -3680,16 +3682,21 @@ xmlFreeNodeList(xmlNodePtr cur) {
     return;
     }
     if (cur->doc != NULL) dict = cur->doc->dict;
-    while (cur != NULL) {
+    while (1) {
+        while ((cur->children != NULL) &&
+               (cur->type != XML_DTD_NODE) &&
+               (cur->type != XML_ENTITY_REF_NODE)) {
+            cur = cur->children;
+            depth += 1;
+        }
+
         next = cur->next;
+        parent = cur->parent;
     if (cur->type != XML_DTD_NODE) {
 
         if ((__xmlRegisterCallbacks) && (xmlDeregisterNodeDefaultValue))
         xmlDeregisterNodeDefaultValue(cur);
 
-        if ((cur->children != NULL) &&
-        (cur->type != XML_ENTITY_REF_NODE))
-        xmlFreeNodeList(cur->children);
         if (((cur->type == XML_ELEMENT_NODE) ||
          (cur->type == XML_XINCLUDE_START) ||
          (cur->type == XML_XINCLUDE_END)) &&
@@ -3720,7 +3727,16 @@ xmlFreeNodeList(xmlNodePtr cur) {
         DICT_FREE(cur->name)
         xmlFree(cur);
     }
+
+        if (next != NULL) {
     cur = next;
+        } else {
+            if ((depth == 0) || (parent == NULL))
+                break;
+            depth -= 1;
+            cur = parent;
+            cur->children = NULL;
+        }
     }
 }
 
@@ -4050,7 +4066,7 @@ xmlCopyPropInternal(xmlDocPtr doc, xmlNodePtr target, xmlAttrPtr cur) {
       } else {
         /*
          * we have to find something appropriate here since
-         * we cant be sure, that the namespce we found is identified
+         * we cant be sure, that the namespace we found is identified
          * by the prefix
          */
         if (xmlStrEqual(ns->href, cur->ns->href)) {
@@ -4058,10 +4074,10 @@ xmlCopyPropInternal(xmlDocPtr doc, xmlNodePtr target, xmlAttrPtr cur) {
           ret->ns = ns;
         } else {
           /*
-           * we are in trouble: we need a new reconcilied namespace.
+           * we are in trouble: we need a new reconciled namespace.
            * This is expensive
            */
-          ret->ns = xmlNewReconciliedNs(target->doc, target, cur->ns);
+          ret->ns = xmlNewReconciledNs(target->doc, target, cur->ns);
         }
       }
 
@@ -4154,8 +4170,8 @@ xmlCopyPropList(xmlNodePtr target, xmlAttrPtr cur) {
  * say RPM:Copyright without changing the namespace pointer to
  * something else can produce stale links. One way to do it is
  * to keep a reference counter but this doesn't work as soon
- * as one move the element or the subtree out of the scope of
- * the existing namespace. The actual solution seems to add
+ * as one moves the element or the subtree out of the scope of
+ * the existing namespace. The actual solution seems to be to add
  * a copy of the namespace at the top of the copied tree if
  * not available in the subtree.
  * Hence two functions, the public front-end call the inner ones
@@ -4280,7 +4296,7 @@ xmlStaticCopyNode(xmlNodePtr node, xmlDocPtr doc, xmlNodePtr parent,
         while (root->parent != NULL) root = root->parent;
         ret->ns = xmlNewNs(root, ns->href, ns->prefix);
         } else {
-            ret->ns = xmlNewReconciliedNs(doc, ret, node->ns);
+            ret->ns = xmlNewReconciledNs(doc, ret, node->ns);
         }
     } else {
         /*
@@ -4719,7 +4735,7 @@ xmlGetNodePath(const xmlNode *node)
 
             /*
              * Thumbler index computation
-         * TODO: the ocurence test seems bogus for namespaced names
+         * TODO: the occurrence test seems bogus for namespaced names
              */
             tmp = cur->prev;
             while (tmp != NULL) {
@@ -6214,7 +6230,7 @@ xmlSearchNsByHref(xmlDocPtr doc, xmlNodePtr node, const xmlChar * href)
 }
 
 /**
- * xmlNewReconciliedNs:
+ * xmlNewReconciledNs:
  * @doc:  the document
  * @tree:  a node expected to hold the new namespace
  * @ns:  the original namespace
@@ -6227,7 +6243,7 @@ xmlSearchNsByHref(xmlDocPtr doc, xmlNodePtr node, const xmlChar * href)
  * Returns the (new) namespace definition or NULL in case of error
  */
 static xmlNsPtr
-xmlNewReconciliedNs(xmlDocPtr doc, xmlNodePtr tree, xmlNsPtr ns) {
+xmlNewReconciledNs(xmlDocPtr doc, xmlNodePtr tree, xmlNsPtr ns) {
     xmlNsPtr def;
     xmlChar prefix[50];
     int counter = 1;
@@ -6235,14 +6251,14 @@ xmlNewReconciliedNs(xmlDocPtr doc, xmlNodePtr tree, xmlNsPtr ns) {
     if ((tree == NULL) || (tree->type != XML_ELEMENT_NODE)) {
 #ifdef DEBUG_TREE
         xmlGenericError(xmlGenericErrorContext,
-        "xmlNewReconciliedNs : tree == NULL\n");
+        "xmlNewReconciledNs : tree == NULL\n");
 #endif
     return(NULL);
     }
     if ((ns == NULL) || (ns->type != XML_NAMESPACE_DECL)) {
 #ifdef DEBUG_TREE
         xmlGenericError(xmlGenericErrorContext,
-        "xmlNewReconciliedNs : ns == NULL\n");
+        "xmlNewReconciledNs : ns == NULL\n");
 #endif
     return(NULL);
     }
@@ -6344,7 +6360,7 @@ xmlReconciliateNs(xmlDocPtr doc, xmlNodePtr tree) {
             /*
          * OK we need to recreate a new namespace definition
          */
-        n = xmlNewReconciliedNs(doc, tree, node->ns);
+        n = xmlNewReconciledNs(doc, tree, node->ns);
         if (n != NULL) { /* :-( what if else ??? */
             /*
              * check if we need to grow the cache buffers.
@@ -6373,7 +6389,7 @@ xmlReconciliateNs(xmlDocPtr doc, xmlNodePtr tree) {
         }
     }
     /*
-     * now check for namespace hold by attributes on the node.
+     * now check for namespace held by attributes on the node.
      */
     if (node->type == XML_ELEMENT_NODE) {
         attr = node->properties;
@@ -6408,7 +6424,7 @@ xmlReconciliateNs(xmlDocPtr doc, xmlNodePtr tree) {
             /*
              * OK we need to recreate a new namespace definition
              */
-            n = xmlNewReconciliedNs(doc, tree, attr->ns);
+            n = xmlNewReconciledNs(doc, tree, attr->ns);
             if (n != NULL) { /* :-( what if else ??? */
                 /*
                  * check if we need to grow the cache buffers.
@@ -7961,7 +7977,7 @@ xmlDOMWrapNsMapAddItem(xmlNsMapPtr *nsmap, int position,
 * Creates or reuses an xmlNs struct on doc->oldNs with
 * the given prefix and namespace name.
 *
-* Returns the aquired ns struct or NULL in case of an API
+* Returns the acquired ns struct or NULL in case of an API
 *         or internal error.
 */
 static xmlNsPtr
@@ -8575,7 +8591,7 @@ ns_next_prefix:
 }
 
 /*
-* xmlDOMWrapNSNormAquireNormalizedNs:
+* xmlDOMWrapNSNormAcquireNormalizedNs:
 * @doc: the doc
 * @elem: the element-node to declare namespaces on
 * @ns: the ns-struct to use for the search
@@ -8594,7 +8610,7 @@ ns_next_prefix:
 * Returns 0 if succeeded, -1 otherwise and on API/internal errors.
 */
 static int
-xmlDOMWrapNSNormAquireNormalizedNs(xmlDocPtr doc,
+xmlDOMWrapNSNormAcquireNormalizedNs(xmlDocPtr doc,
                    xmlNodePtr elem,
                    xmlNsPtr ns,
                    xmlNsPtr *retNs,
@@ -8893,9 +8909,9 @@ next_ns_decl:
             }
         }
         /*
-        * Aquire a normalized ns-decl and add it to the map.
+        * Acquire a normalized ns-decl and add it to the map.
         */
-        if (xmlDOMWrapNSNormAquireNormalizedNs(doc, curElem,
+        if (xmlDOMWrapNSNormAcquireNormalizedNs(doc, curElem,
             cur->ns, &ns,
             &nsMap, depth,
             ancestorsOnly,
@@ -9033,7 +9049,7 @@ xmlDOMWrapAdoptBranch(xmlDOMWrapCtxtPtr ctxt,
     nsMap = (xmlNsMapPtr) ctxt->namespaceMap;
     /*
     * Disable search for ns-decls in the parent-axis of the
-    * desination element, if:
+    * destination element, if:
     * 1) there's no destination parent
     * 2) custom ns-reference handling is used
     */
@@ -9178,9 +9194,9 @@ xmlDOMWrapAdoptBranch(xmlDOMWrapCtxtPtr ctxt,
             cur->ns = ns;
         } else {
             /*
-            * Aquire a normalized ns-decl and add it to the map.
+            * Acquire a normalized ns-decl and add it to the map.
             */
-            if (xmlDOMWrapNSNormAquireNormalizedNs(destDoc,
+            if (xmlDOMWrapNSNormAcquireNormalizedNs(destDoc,
             /* ns-decls on curElem or on destDoc->oldNs */
             destParent ? curElem : NULL,
             cur->ns, &ns,
@@ -9234,7 +9250,7 @@ ns_end:
         goto leave_node;
         case XML_ENTITY_REF_NODE:
         /*
-        * Remove reference to the entitity-node.
+        * Remove reference to the entity-node.
         */
         cur->content = NULL;
         cur->children = NULL;
@@ -9468,7 +9484,7 @@ xmlDOMWrapCloneNode(xmlDOMWrapCtxtPtr ctxt,
         }
         memset(clone, 0, sizeof(xmlNode));
         /*
-        * Set hierachical links.
+        * Set hierarchical links.
         */
         if (resultClone != NULL) {
             clone->parent = parentClone;
@@ -9492,7 +9508,7 @@ xmlDOMWrapCloneNode(xmlDOMWrapCtxtPtr ctxt,
         }
         memset(clone, 0, sizeof(xmlAttr));
         /*
-        * Set hierachical links.
+        * Set hierarchical links.
         * TODO: Change this to add to the end of attributes.
         */
         if (resultClone != NULL) {
@@ -9720,9 +9736,9 @@ xmlDOMWrapCloneNode(xmlDOMWrapCtxtPtr ctxt,
         clone->ns = ns;
     } else {
         /*
-        * Aquire a normalized ns-decl and add it to the map.
+        * Acquire a normalized ns-decl and add it to the map.
         */
-        if (xmlDOMWrapNSNormAquireNormalizedNs(destDoc,
+        if (xmlDOMWrapNSNormAcquireNormalizedNs(destDoc,
         /* ns-decls on curElem or on destDoc->oldNs */
         destParent ? curElem : NULL,
         cur->ns, &ns,
@@ -9959,7 +9975,7 @@ xmlDOMWrapAdoptAttr(xmlDOMWrapCtxtPtr ctxt,
         break;
         case XML_ENTITY_REF_NODE:
         /*
-        * Remove reference to the entitity-node.
+        * Remove reference to the entity-node.
         */
         cur->content = NULL;
         cur->children = NULL;
@@ -10097,7 +10113,7 @@ xmlDOMWrapAdoptNode(xmlDOMWrapCtxtPtr ctxt,
             break;
         case XML_ENTITY_REF_NODE:
         /*
-        * Remove reference to the entitity-node.
+        * Remove reference to the entity-node.
         */
         node->content = NULL;
         node->children = NULL;

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/trionan.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/trionan.c
@@ -92,7 +92,7 @@
 
 /*
  * In ANSI/IEEE 754-1985 64-bits double format numbers have the
- * following properties (amoungst others)
+ * following properties (amongst others)
  *
  *   o FLT_RADIX == 2: binary encoding
  *   o DBL_MAX_EXP == 1024: 11 bits exponent, where one bit is used

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/uri.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/uri.c
@@ -22,7 +22,7 @@
  * MAX_URI_LENGTH:
  *
  * The definition of the URI regexp in the above RFC has no size limit
- * In practice they are usually relativey short except for the
+ * In practice they are usually relatively short except for the
  * data URI scheme as defined in RFC 2397. Even for data URI the usual
  * maximum size before hitting random practical limits is around 64 KB
  * and 4KB is usually a maximum admitted limit for proper operations.
@@ -325,16 +325,18 @@ static int
 xmlParse3986Port(xmlURIPtr uri, const char **str)
 {
     const char *cur = *str;
-    unsigned port = 0; /* unsigned for defined overflow behavior */
+    int port = 0;
 
     if (ISA_DIGIT(cur)) {
     while (ISA_DIGIT(cur)) {
         port = port * 10 + (*cur - '0');
+            if (port > 99999999)
+                port = 99999999;
 
         cur++;
     }
     if (uri != NULL)
-        uri->port = port & INT_MAX; /* port value modulo INT_MAX+1 */
+        uri->port = port;
     *str = cur;
     return(0);
     }
@@ -436,7 +438,7 @@ xmlParse3986Host(xmlURIPtr uri, const char **str)
 
     host = cur;
     /*
-     * IPv6 and future adressing scheme are enclosed between brackets
+     * IPv6 and future addressing scheme are enclosed between brackets
      */
     if (*cur == '[') {
         cur++;
@@ -1456,7 +1458,7 @@ xmlNormalizeURIPath(char *path) {
               goto done_cd;
         (out++)[0] = (cur++)[0];
     }
-    /* nomalize // */
+    /* normalize // */
     while ((cur[0] == '/') && (cur[1] == '/'))
         cur++;
 
@@ -2150,7 +2152,7 @@ done:
  *     http://site1.com/docs/pic1.gif   http://site1.com/docs/pic1.gif
  *
  *
- * Note: if the URI reference is really wierd or complicated, it may be
+ * Note: if the URI reference is really weird or complicated, it may be
  *       worthwhile to first convert it into a "nice" one by calling
  *       xmlBuildURI (using 'base') before calling this routine,
  *       since this routine (for reasonable efficiency) assumes URI has
@@ -2461,7 +2463,7 @@ path_processing:
     /* allocate space for leading '/' + path + string terminator */
     uri->path = xmlMallocAtomic(len + 2);
     if (uri->path == NULL) {
-        xmlFreeURI(uri);    /* Guard agains 'out of memory' */
+        xmlFreeURI(uri);    /* Guard against 'out of memory' */
         return(NULL);
     }
     /* Put in leading '/' plus path */
@@ -2476,7 +2478,7 @@ path_processing:
     }
     p = uri->path;
     }
-    /* Now change all occurences of '\' to '/' */
+    /* Now change all occurrences of '\' to '/' */
     while (*p != '\0') {
     if (*p == '\\')
         *p = '/';
@@ -2526,7 +2528,7 @@ xmlPathToURI(const xmlChar *path)
         return(NULL);
 #if defined(_WIN32) && !defined(__CYGWIN__)
     /* xmlCanonicPath can return an URI on Windows (is that the intended behaviour?)
-       If 'cal' is a valid URI allready then we are done here, as continuing would make
+       If 'cal' is a valid URI already then we are done here, as continuing would make
        it invalid. */
     if ((uri = xmlParseURI((const char *) cal)) != NULL) {
     xmlFreeURI(uri);

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/valid.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/valid.c
@@ -1099,14 +1099,22 @@ xmlCopyElementContent(xmlElementContentPtr cur) {
  */
 void
 xmlFreeDocElementContent(xmlDocPtr doc, xmlElementContentPtr cur) {
-    xmlElementContentPtr next;
     xmlDictPtr dict = NULL;
+    size_t depth = 0;
 
+    if (cur == NULL)
+        return;
     if (doc != NULL)
         dict = doc->dict;
 
-    while (cur != NULL) {
-        next = cur->c2;
+    while (1) {
+        xmlElementContentPtr parent;
+
+        while ((cur->c1 != NULL) || (cur->c2 != NULL)) {
+            cur = (cur->c1 != NULL) ? cur->c1 : cur->c2;
+            depth += 1;
+        }
+
     switch (cur->type) {
         case XML_ELEMENT_CONTENT_PCDATA:
         case XML_ELEMENT_CONTENT_ELEMENT:
@@ -1119,7 +1127,6 @@ xmlFreeDocElementContent(xmlDocPtr doc, xmlElementContentPtr cur) {
             NULL);
         return;
     }
-    if (cur->c1 != NULL) xmlFreeDocElementContent(doc, cur->c1);
     if (dict) {
         if ((cur->name != NULL) && (!xmlDictOwns(dict, cur->name)))
             xmlFree((xmlChar *) cur->name);
@@ -1129,8 +1136,23 @@ xmlFreeDocElementContent(xmlDocPtr doc, xmlElementContentPtr cur) {
         if (cur->name != NULL) xmlFree((xmlChar *) cur->name);
         if (cur->prefix != NULL) xmlFree((xmlChar *) cur->prefix);
     }
+        parent = cur->parent;
+        if ((depth == 0) || (parent == NULL)) {
+            xmlFree(cur);
+            break;
+        }
+        if (cur == parent->c1)
+            parent->c1 = NULL;
+        else
+            parent->c2 = NULL;
     xmlFree(cur);
-    cur = next;
+
+        if (parent->c2 != NULL) {
+        cur = parent->c2;
+        } else {
+            depth -= 1;
+            cur = parent;
+        }
     }
 }
 
@@ -1148,81 +1170,102 @@ xmlFreeElementContent(xmlElementContentPtr cur) {
 
 #ifdef LIBXML_OUTPUT_ENABLED
 /**
+ * xmlDumpElementOccur:
+ * @buf:  An XML buffer
+ * @cur:  An element table
+ *
+ * Dump the occurence operator of an element.
+ */
+static void
+xmlDumpElementOccur(xmlBufferPtr buf, xmlElementContentPtr cur) {
+    switch (cur->ocur) {
+        case XML_ELEMENT_CONTENT_ONCE:
+            break;
+        case XML_ELEMENT_CONTENT_OPT:
+            xmlBufferWriteChar(buf, "?");
+            break;
+        case XML_ELEMENT_CONTENT_MULT:
+            xmlBufferWriteChar(buf, "*");
+            break;
+        case XML_ELEMENT_CONTENT_PLUS:
+            xmlBufferWriteChar(buf, "+");
+            break;
+    }
+}
+
+/**
  * xmlDumpElementContent:
  * @buf:  An XML buffer
  * @content:  An element table
- * @glob: 1 if one must print the englobing parenthesis, 0 otherwise
  *
  * This will dump the content of the element table as an XML DTD definition
  */
 static void
-xmlDumpElementContent(xmlBufferPtr buf, xmlElementContentPtr content, int glob) {
+xmlDumpElementContent(xmlBufferPtr buf, xmlElementContentPtr content) {
+    xmlElementContentPtr cur;
+
     if (content == NULL) return;
 
-    if (glob) xmlBufferWriteChar(buf, "(");
-    switch (content->type) {
+    xmlBufferWriteChar(buf, "(");
+    cur = content;
+
+    do {
+        if (cur == NULL) return;
+
+        switch (cur->type) {
         case XML_ELEMENT_CONTENT_PCDATA:
             xmlBufferWriteChar(buf, "#PCDATA");
         break;
     case XML_ELEMENT_CONTENT_ELEMENT:
-        if (content->prefix != NULL) {
-        xmlBufferWriteCHAR(buf, content->prefix);
+                if (cur->prefix != NULL) {
+                    xmlBufferWriteCHAR(buf, cur->prefix);
         xmlBufferWriteChar(buf, ":");
         }
-        xmlBufferWriteCHAR(buf, content->name);
+                xmlBufferWriteCHAR(buf, cur->name);
         break;
     case XML_ELEMENT_CONTENT_SEQ:
-        if ((content->c1 != NULL) &&
-            ((content->c1->type == XML_ELEMENT_CONTENT_OR) ||
-             (content->c1->type == XML_ELEMENT_CONTENT_SEQ)))
-        xmlDumpElementContent(buf, content->c1, 1);
-        else
-        xmlDumpElementContent(buf, content->c1, 0);
-            xmlBufferWriteChar(buf, " , ");
-        if ((content->c2 != NULL) &&
-            ((content->c2->type == XML_ELEMENT_CONTENT_OR) ||
-             ((content->c2->type == XML_ELEMENT_CONTENT_SEQ) &&
-          (content->c2->ocur != XML_ELEMENT_CONTENT_ONCE))))
-        xmlDumpElementContent(buf, content->c2, 1);
-        else
-        xmlDumpElementContent(buf, content->c2, 0);
-        break;
     case XML_ELEMENT_CONTENT_OR:
-        if ((content->c1 != NULL) &&
-            ((content->c1->type == XML_ELEMENT_CONTENT_OR) ||
-             (content->c1->type == XML_ELEMENT_CONTENT_SEQ)))
-        xmlDumpElementContent(buf, content->c1, 1);
-        else
-        xmlDumpElementContent(buf, content->c1, 0);
-            xmlBufferWriteChar(buf, " | ");
-        if ((content->c2 != NULL) &&
-            ((content->c2->type == XML_ELEMENT_CONTENT_SEQ) ||
-             ((content->c2->type == XML_ELEMENT_CONTENT_OR) &&
-          (content->c2->ocur != XML_ELEMENT_CONTENT_ONCE))))
-        xmlDumpElementContent(buf, content->c2, 1);
-        else
-        xmlDumpElementContent(buf, content->c2, 0);
-        break;
+                if ((cur != content) &&
+                    (cur->parent != NULL) &&
+                    ((cur->type != cur->parent->type) ||
+                     (cur->ocur != XML_ELEMENT_CONTENT_ONCE)))
+                    xmlBufferWriteChar(buf, "(");
+                cur = cur->c1;
+                continue;
     default:
         xmlErrValid(NULL, XML_ERR_INTERNAL_ERROR,
-            "Internal: ELEMENT content corrupted invalid type\n",
+                        "Internal: ELEMENT cur corrupted invalid type\n",
             NULL);
     }
-    if (glob)
+
+        while (cur != content) {
+            xmlElementContentPtr parent = cur->parent;
+
+            if (parent == NULL) return;
+
+            if (((cur->type == XML_ELEMENT_CONTENT_OR) ||
+                 (cur->type == XML_ELEMENT_CONTENT_SEQ)) &&
+                ((cur->type != parent->type) ||
+                 (cur->ocur != XML_ELEMENT_CONTENT_ONCE)))
         xmlBufferWriteChar(buf, ")");
-    switch (content->ocur) {
-        case XML_ELEMENT_CONTENT_ONCE:
-        break;
-        case XML_ELEMENT_CONTENT_OPT:
-        xmlBufferWriteChar(buf, "?");
-        break;
-        case XML_ELEMENT_CONTENT_MULT:
-        xmlBufferWriteChar(buf, "*");
-        break;
-        case XML_ELEMENT_CONTENT_PLUS:
-        xmlBufferWriteChar(buf, "+");
+            xmlDumpElementOccur(buf, cur);
+
+            if (cur == parent->c1) {
+                if (parent->type == XML_ELEMENT_CONTENT_SEQ)
+                    xmlBufferWriteChar(buf, " , ");
+                else if (parent->type == XML_ELEMENT_CONTENT_OR)
+                    xmlBufferWriteChar(buf, " | ");
+
+                cur = parent->c2;
         break;
     }
+
+            cur = parent;
+        }
+    } while (cur != content);
+
+    xmlBufferWriteChar(buf, ")");
+    xmlDumpElementOccur(buf, content);
 }
 
 /**
@@ -1703,7 +1746,7 @@ xmlDumpElementDecl(xmlBufferPtr buf, xmlElementPtr elem) {
         }
         xmlBufferWriteCHAR(buf, elem->name);
         xmlBufferWriteChar(buf, " ");
-        xmlDumpElementContent(buf, elem->content, 1);
+        xmlDumpElementContent(buf, elem->content);
         xmlBufferWriteChar(buf, ">\n");
         break;
     case XML_ELEMENT_TYPE_ELEMENT:
@@ -1714,7 +1757,7 @@ xmlDumpElementDecl(xmlBufferPtr buf, xmlElementPtr elem) {
         }
         xmlBufferWriteCHAR(buf, elem->name);
         xmlBufferWriteChar(buf, " ");
-        xmlDumpElementContent(buf, elem->content, 1);
+        xmlDumpElementContent(buf, elem->content);
         xmlBufferWriteChar(buf, ">\n");
         break;
     default:
@@ -2640,7 +2683,7 @@ xmlAddID(xmlValidCtxtPtr ctxt, xmlDocPtr doc, const xmlChar *value,
     ret->doc = doc;
     if ((ctxt != NULL) && (ctxt->vstateNr != 0)) {
     /*
-     * Operating in streaming mode, attr is gonna disapear
+     * Operating in streaming mode, attr is gonna disappear
      */
     if (doc->dict != NULL)
         ret->name = xmlDictLookup(doc->dict, attr->name, -1);
@@ -2968,7 +3011,7 @@ xmlAddRef(xmlValidCtxtPtr ctxt, xmlDocPtr doc, const xmlChar *value,
     ret->value = xmlStrdup(value);
     if ((ctxt != NULL) && (ctxt->vstateNr != 0)) {
     /*
-     * Operating in streaming mode, attr is gonna disapear
+     * Operating in streaming mode, attr is gonna disappear
      */
     ret->name = xmlStrdup(attr->name);
     ret->attr = NULL;

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/win32/Makefile.bcb
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/win32/Makefile.bcb
@@ -225,9 +225,7 @@ UTILS = $(BINDIR)\xmllint.exe\
 	$(BINDIR)\testlimits.exe
 
 
-!if "$(WITH_THREADS)" == "yes" || "$(WITH_THREADS)" == "ctls" || "$(WITH_THREADS)" == "native"
-UTILS = $(UTILS) $(BINDIR)\testThreadsWin32.exe
-!else if "$(WITH_THREADS)" == "posix"
+!if "$(WITH_THREADS)" != "no"
 UTILS = $(UTILS) $(BINDIR)\testThreads.exe
 !endif
 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/win32/Makefile.mingw
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/win32/Makefile.mingw
@@ -220,16 +220,7 @@ UTILS = $(BINDIR)/xmllint.exe\
 	$(BINDIR)/testapi.exe\
 	$(BINDIR)/testlimits.exe
 
-ifeq ($(WITH_THREADS),yes)
-UTILS += $(BINDIR)/testThreadsWin32.exe
-endif
-ifeq ($(WITH_THREADS),ctls) 
-UTILS += $(BINDIR)/testThreadsWin32.exe
-endif
-ifeq ($(WITH_THREADS),native)
-UTILS += $(BINDIR)/testThreadsWin32.exe
-endif
-ifeq ($(WITH_THREADS),posix)
+ifneq ($(WITH_THREADS),no)
 UTILS += $(BINDIR)/testThreads.exe
 endif
 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/win32/Makefile.msvc
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/win32/Makefile.msvc
@@ -274,9 +274,7 @@ UTILS = $(BINDIR)\xmllint.exe\
 	$(BINDIR)\testlimits.exe\
 	$(BINDIR)\testrecurse.exe
 	
-!if "$(WITH_THREADS)" == "yes" || "$(WITH_THREADS)" == "ctls" || "$(WITH_THREADS)" == "native"
-UTILS = $(UTILS) $(BINDIR)\testThreadsWin32.exe
-!else if "$(WITH_THREADS)" == "posix"
+!if "$(WITH_THREADS)" != "no"
 UTILS = $(UTILS) $(BINDIR)\testThreads.exe
 !endif
 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/win32/configure.js
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/win32/configure.js
@@ -172,7 +172,7 @@ function usage()
 	WScript.Echo(txt);
 }
 
-/* Discovers the version we are working with by reading the apropriate
+/* Discovers the version we are working with by reading the appropriate
    configuration file. Despite its name, this also writes the configuration
    file included by our makefile. */
 function discoverVersion()

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/win32/libxml2.def.src
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/win32/libxml2.def.src
@@ -945,6 +945,7 @@ xmlHashAddEntry3
 xmlHashCopy
 xmlHashCreate
 xmlHashCreateDict
+xmlHashDefaultDeallocator
 xmlHashFree
 xmlHashLookup
 xmlHashLookup2

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xml2-config.1
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xml2-config.1
@@ -16,6 +16,7 @@ Print the currently installed version of \fIGNOME-XML\fP on the standard output.
 .TP 8
 .B  \-\-libs
 Print the linker flags that are necessary to link a \fIGNOME-XML\fP program.
+Add \-\-dynamic after --libs to print only shared library linking information.
 .TP 8
 .B  \-\-cflags
 Print the compiler flags that are necessary to compile a \fIGNOME-XML\fP program.

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xml2Conf.sh.in
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xml2Conf.sh.in
@@ -2,7 +2,7 @@
 # Configuration file for using the XML library in GNOME applications
 #
 XML2_LIBDIR="@XML_LIBDIR@"
-XML2_LIBS="@XML_LIBS@"
+XML2_LIBS="@XML_LIBS@ @XML_PRIVATE_LIBS@"
 XML2_INCLUDEDIR="@XML_INCLUDEDIR@"
 MODULE_VERSION="xml2-@VERSION@"
 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xmlreader.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xmlreader.c
@@ -238,6 +238,8 @@ xmlFreeID(xmlIDPtr id) {
 
     if (id->value != NULL)
     DICT_FREE(id->value)
+    if (id->name != NULL)
+    DICT_FREE(id->name)
     xmlFree(id);
 }
 
@@ -271,6 +273,7 @@ xmlTextReaderRemoveID(xmlDocPtr doc, xmlAttrPtr attr) {
     return(-1);
     }
     id->name = attr->name;
+    attr->name = NULL;
     id->attr = NULL;
     return(0);
 }
@@ -345,7 +348,9 @@ xmlTextReaderFreePropList(xmlTextReaderPtr reader, xmlAttrPtr cur) {
 static void
 xmlTextReaderFreeNodeList(xmlTextReaderPtr reader, xmlNodePtr cur) {
     xmlNodePtr next;
+    xmlNodePtr parent;
     xmlDictPtr dict;
+    size_t depth = 0;
 
     if ((reader != NULL) && (reader->ctxt != NULL))
     dict = reader->ctxt->dict;
@@ -361,17 +366,20 @@ xmlTextReaderFreeNodeList(xmlTextReaderPtr reader, xmlNodePtr cur) {
     xmlFreeDoc((xmlDocPtr) cur);
     return;
     }
-    while (cur != NULL) {
+    while (1) {
+        while ((cur->type != XML_DTD_NODE) &&
+               (cur->type != XML_ENTITY_REF_NODE) &&
+               (cur->children != NULL) &&
+               (cur->children->parent == cur)) {
+            cur = cur->children;
+            depth += 1;
+        }
+
         next = cur->next;
+        parent = cur->parent;
+
     /* unroll to speed up freeing the document */
     if (cur->type != XML_DTD_NODE) {
-
-        if ((cur->children != NULL) &&
-        (cur->type != XML_ENTITY_REF_NODE)) {
-        if (cur->children->parent == cur)
-            xmlTextReaderFreeNodeList(reader, cur->children);
-        cur->children = NULL;
-        }
 
         if ((__xmlRegisterCallbacks) && (xmlDeregisterNodeDefaultValue))
         xmlDeregisterNodeDefaultValue(cur);
@@ -411,7 +419,16 @@ xmlTextReaderFreeNodeList(xmlTextReaderPtr reader, xmlNodePtr cur) {
         xmlFree(cur);
         }
     }
+
+        if (next != NULL) {
     cur = next;
+        } else {
+            if ((depth == 0) || (parent == NULL))
+                break;
+            depth -= 1;
+            cur = parent;
+            cur->children = NULL;
+        }
     }
 }
 
@@ -983,7 +1000,6 @@ xmlTextReaderValidatePush(xmlTextReaderPtr reader ATTRIBUTE_UNUSED) {
          */
         node = xmlTextReaderExpand(reader);
         if (node == NULL) {
-printf("Expand failed !\n");
             ret = -1;
         } else {
         ret = xmlRelaxNGValidateFullElement(reader->rngValidCtxt,
@@ -1095,7 +1111,7 @@ xmlTextReaderValidateEntity(xmlTextReaderPtr reader) {
     do {
     if (node->type == XML_ENTITY_REF_NODE) {
         /*
-         * Case where the underlying tree is not availble, lookup the entity
+         * Case where the underlying tree is not available, lookup the entity
          * and walk it.
          */
         if ((node->children == NULL) && (ctxt->sax != NULL) &&
@@ -1112,11 +1128,11 @@ xmlTextReaderValidateEntity(xmlTextReaderPtr reader) {
         continue;
         } else {
         /*
-         * The error has probably be raised already.
+         * The error has probably been raised already.
          */
         if (node == oldnode)
             break;
-        node = node->next;
+                goto skip_children;
         }
 #ifdef LIBXML_REGEXP_ENABLED
     } else if (node->type == XML_ELEMENT_NODE) {
@@ -1138,6 +1154,7 @@ xmlTextReaderValidateEntity(xmlTextReaderPtr reader) {
     } else if (node->type == XML_ELEMENT_NODE) {
         xmlTextReaderValidatePop(reader);
     }
+skip_children:
     if (node->next != NULL) {
         node = node->next;
         continue;
@@ -1357,7 +1374,7 @@ get_next_node:
 
     /*
      * If we are not backtracking on ancestors or examined nodes,
-     * that the parser didn't finished or that we arent at the end
+     * that the parser didn't finished or that we aren't at the end
      * of stream, continue processing.
      */
     while ((reader->node != NULL) && (reader->node->next == NULL) &&
@@ -1548,7 +1565,7 @@ node_found:
     (reader->node->type == XML_ENTITY_REF_NODE) &&
     (reader->ctxt != NULL) && (reader->ctxt->replaceEntities == 1)) {
     /*
-     * Case where the underlying tree is not availble, lookup the entity
+     * Case where the underlying tree is not available, lookup the entity
      * and walk it.
      */
     if ((reader->node->children == NULL) && (reader->ctxt->sax != NULL) &&
@@ -1713,6 +1730,8 @@ xmlTextReaderReadInnerXml(xmlTextReaderPtr reader ATTRIBUTE_UNUSED)
     }
     doc = reader->node->doc;
     buff = xmlBufferCreate();
+    if (buff == NULL)
+        return NULL;
     for (cur_node = reader->node->children; cur_node != NULL;
          cur_node = cur_node->next) {
         /* XXX: Why is the node copied? */
@@ -1755,11 +1774,11 @@ xmlTextReaderReadOuterXml(xmlTextReaderPtr reader ATTRIBUTE_UNUSED)
     xmlBufferPtr buff;
     xmlDocPtr doc;
 
-    node = reader->node;
-    doc = node->doc;
     if (xmlTextReaderExpand(reader) == NULL) {
         return NULL;
     }
+    node = reader->node;
+    doc = node->doc;
     /* XXX: Why is the node copied? */
     if (node->type == XML_DTD_NODE) {
         node = (xmlNodePtr) xmlCopyDtd((xmlDtdPtr) node);
@@ -2262,16 +2281,20 @@ xmlFreeTextReader(xmlTextReaderPtr reader) {
     if (reader->ctxt != NULL) {
         if (reader->dict == reader->ctxt->dict)
         reader->dict = NULL;
+    if ((reader->ctxt->vctxt.vstateTab != NULL) &&
+        (reader->ctxt->vctxt.vstateMax > 0)){
+#ifdef LIBXML_REGEXP_ENABLED
+            while (reader->ctxt->vctxt.vstateNr > 0)
+                xmlValidatePopElement(&reader->ctxt->vctxt, NULL, NULL, NULL);
+#endif
+        xmlFree(reader->ctxt->vctxt.vstateTab);
+        reader->ctxt->vctxt.vstateTab = NULL;
+        reader->ctxt->vctxt.vstateMax = 0;
+    }
     if (reader->ctxt->myDoc != NULL) {
         if (reader->preserve == 0)
         xmlTextReaderFreeDoc(reader, reader->ctxt->myDoc);
         reader->ctxt->myDoc = NULL;
-    }
-    if ((reader->ctxt->vctxt.vstateTab != NULL) &&
-        (reader->ctxt->vctxt.vstateMax > 0)){
-        xmlFree(reader->ctxt->vctxt.vstateTab);
-        reader->ctxt->vctxt.vstateTab = NULL;
-        reader->ctxt->vctxt.vstateMax = 0;
     }
     if (reader->allocs & XML_TEXTREADER_CTXT)
         xmlFreeParserCtxt(reader->ctxt);
@@ -2500,7 +2523,7 @@ xmlTextReaderGetAttributeNs(xmlTextReaderPtr reader, const xmlChar *localName,
  * parser, set its state to End Of File and return the input stream with
  * what is left that the parser did not use.
  *
- * The implementation is not good, the parser certainly procgressed past
+ * The implementation is not good, the parser certainly progressed past
  * what's left in reader->input, and there is an allocation problem. Best
  * would be to rewrite it differently.
  *
@@ -2882,8 +2905,8 @@ xmlTextReaderMoveToElement(xmlTextReaderPtr reader) {
  *
  * Parses an attribute value into one or more Text and EntityReference nodes.
  *
- * Returns 1 in case of success, 0 if the reader was not positionned on an
- *         ttribute node or all the attribute values have been read, or -1
+ * Returns 1 in case of success, 0 if the reader was not positioned on an
+ *         attribute node or all the attribute values have been read, or -1
  *         in case of error.
  */
 int
@@ -3920,7 +3943,7 @@ xmlTextReaderGetParserColumnNumber(xmlTextReaderPtr reader)
  * xmlTextReaderCurrentNode:
  * @reader:  the xmlTextReaderPtr used
  *
- * Hacking interface allowing to get the xmlNodePtr correponding to the
+ * Hacking interface allowing to get the xmlNodePtr corresponding to the
  * current node being accessed by the xmlTextReader. This is dangerous
  * because the underlying node may be destroyed on the next Reads.
  *
@@ -4032,7 +4055,7 @@ xmlTextReaderPreservePattern(xmlTextReaderPtr reader, const xmlChar *pattern,
  * xmlTextReaderCurrentDoc:
  * @reader:  the xmlTextReaderPtr used
  *
- * Hacking interface allowing to get the xmlDocPtr correponding to the
+ * Hacking interface allowing to get the xmlDocPtr corresponding to the
  * current document being accessed by the xmlTextReader.
  * NOTE: as a result of this call, the reader will not destroy the
  *       associated XML document and calling xmlFreeDoc() on the result
@@ -4135,11 +4158,11 @@ xmlTextReaderValidityStructuredRelay(void *userData, xmlErrorPtr error)
  *
  * Use RelaxNG to validate the document as it is processed.
  * Activation is only possible before the first Read().
- * if @schema is NULL, then RelaxNG validation is desactivated.
+ * if @schema is NULL, then RelaxNG validation is deactivated.
  @ The @schema should not be freed until the reader is deallocated
  * or its use has been deactivated.
  *
- * Returns 0 in case the RelaxNG validation could be (des)activated and
+ * Returns 0 in case the RelaxNG validation could be (de)activated and
  *         -1 in case of error.
  */
 int
@@ -4199,7 +4222,7 @@ xmlTextReaderRelaxNGSetSchema(xmlTextReaderPtr reader, xmlRelaxNGPtr schema) {
  *
  * Internal locator function for the readers
  *
- * Returns 0 in case the Schema validation could be (des)activated and
+ * Returns 0 in case the Schema validation could be (de)activated and
  *         -1 in case of error.
  */
 static int
@@ -4252,11 +4275,11 @@ xmlTextReaderLocator(void *ctx, const char **file, unsigned long *line) {
  *
  * Use XSD Schema to validate the document as it is processed.
  * Activation is only possible before the first Read().
- * if @schema is NULL, then Schema validation is desactivated.
- @ The @schema should not be freed until the reader is deallocated
+ * if @schema is NULL, then Schema validation is deactivated.
+ * The @schema should not be freed until the reader is deallocated
  * or its use has been deactivated.
  *
- * Returns 0 in case the Schema validation could be (des)activated and
+ * Returns 0 in case the Schema validation could be (de)activated and
  *         -1 in case of error.
  */
 int

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xmlsave.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xmlsave.c
@@ -1,5 +1,5 @@
 /*
- * xmlsave.c: Implemetation of the document serializer
+ * xmlsave.c: Implementation of the document serializer
  *
  * See Copyright for the status of this software.
  *
@@ -83,7 +83,6 @@ struct _xmlSaveCtxt {
     const xmlChar *encoding;
     xmlCharEncodingHandlerPtr handler;
     xmlOutputBufferPtr buf;
-    xmlDocPtr doc;
     int options;
     int level;
     int format;
@@ -356,7 +355,7 @@ xmlSaveCtxtInit(xmlSaveCtxtPtr ctxt)
 /**
  * xmlFreeSaveCtxt:
  *
- * Free a saving context, destroying the ouptut in any remaining buffer
+ * Free a saving context, destroying the output in any remaining buffer
  */
 static void
 xmlFreeSaveCtxt(xmlSaveCtxtPtr ctxt)
@@ -707,7 +706,6 @@ static void
 xmlDtdDumpOutput(xmlSaveCtxtPtr ctxt, xmlDtdPtr dtd) {
     xmlOutputBufferPtr buf;
     int format, level;
-    xmlDocPtr doc;
 
     if (dtd == NULL) return;
     if ((ctxt == NULL) || (ctxt->buf == NULL))
@@ -742,14 +740,11 @@ xmlDtdDumpOutput(xmlSaveCtxtPtr ctxt, xmlDtdPtr dtd) {
     }
     format = ctxt->format;
     level = ctxt->level;
-    doc = ctxt->doc;
     ctxt->format = 0;
     ctxt->level = -1;
-    ctxt->doc = dtd->doc;
     xmlNodeListDumpOutput(ctxt, dtd->children);
     ctxt->format = format;
     ctxt->level = level;
-    ctxt->doc = doc;
     xmlOutputBufferWrite(buf, 2, "]>");
 }
 
@@ -2191,9 +2186,9 @@ xmlAttrSerializeTxtContent(xmlBufferPtr buf, xmlDocPtr doc,
  *
  * Dump an XML node, recursive behaviour,children are printed too.
  * Note that @format = 1 provide node indenting only if xmlIndentTreeOutput = 1
- * or xmlKeepBlanksDefault(0) was called
+ * or xmlKeepBlanksDefault(0) was called.
  * Since this is using xmlBuffer structures it is limited to 2GB and somehow
- * deprecated, use xmlBufNodeDump() instead.
+ * deprecated, use xmlNodeDumpOutput() instead.
  *
  * Returns the number of bytes written to the buffer or -1 in case of error
  */
@@ -2360,7 +2355,6 @@ xmlNodeDumpOutput(xmlOutputBufferPtr buf, xmlDocPtr doc, xmlNodePtr cur,
         encoding = "UTF-8";
 
     memset(&ctxt, 0, sizeof(ctxt));
-    ctxt.doc = doc;
     ctxt.buf = buf;
     ctxt.level = level;
     ctxt.format = format ? 1 : 0;
@@ -2446,7 +2440,6 @@ xmlDocDumpFormatMemoryEnc(xmlDocPtr out_doc, xmlChar **doc_txt_ptr,
     }
 
     memset(&ctxt, 0, sizeof(ctxt));
-    ctxt.doc = out_doc;
     ctxt.buf = out_buff;
     ctxt.level = 0;
     ctxt.format = format ? 1 : 0;
@@ -2565,7 +2558,6 @@ xmlDocFormatDump(FILE *f, xmlDocPtr cur, int format) {
     buf = xmlOutputBufferCreateFile(f, handler);
     if (buf == NULL) return(-1);
     memset(&ctxt, 0, sizeof(ctxt));
-    ctxt.doc = cur;
     ctxt.buf = buf;
     ctxt.level = 0;
     ctxt.format = format ? 1 : 0;
@@ -2596,7 +2588,7 @@ xmlDocDump(FILE *f, xmlDocPtr cur) {
  * xmlSaveFileTo:
  * @buf:  an output I/O buffer
  * @cur:  the document
- * @encoding:  the encoding if any assuming the I/O layer handles the trancoding
+ * @encoding:  the encoding if any assuming the I/O layer handles the transcoding
  *
  * Dump an XML document to an I/O buffer.
  * Warning ! This call xmlOutputBufferClose() on buf which is not available
@@ -2615,7 +2607,6 @@ xmlSaveFileTo(xmlOutputBufferPtr buf, xmlDocPtr cur, const char *encoding) {
     return(-1);
     }
     memset(&ctxt, 0, sizeof(ctxt));
-    ctxt.doc = cur;
     ctxt.buf = buf;
     ctxt.level = 0;
     ctxt.format = 0;
@@ -2631,7 +2622,7 @@ xmlSaveFileTo(xmlOutputBufferPtr buf, xmlDocPtr cur, const char *encoding) {
  * xmlSaveFormatFileTo:
  * @buf:  an output I/O buffer
  * @cur:  the document
- * @encoding:  the encoding if any assuming the I/O layer handles the trancoding
+ * @encoding:  the encoding if any assuming the I/O layer handles the transcoding
  * @format: should formatting spaces been added
  *
  * Dump an XML document to an I/O buffer.
@@ -2655,7 +2646,6 @@ xmlSaveFormatFileTo(xmlOutputBufferPtr buf, xmlDocPtr cur,
     return(-1);
     }
     memset(&ctxt, 0, sizeof(ctxt));
-    ctxt.doc = cur;
     ctxt.buf = buf;
     ctxt.level = 0;
     ctxt.format = format ? 1 : 0;
@@ -2710,7 +2700,6 @@ xmlSaveFormatFileEnc( const char * filename, xmlDocPtr cur,
     buf = xmlOutputBufferCreateFilename(filename, handler, cur->compression);
     if (buf == NULL) return(-1);
     memset(&ctxt, 0, sizeof(ctxt));
-    ctxt.doc = cur;
     ctxt.buf = buf;
     ctxt.level = 0;
     ctxt.format = format ? 1 : 0;

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xmlwriter.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xmlwriter.c
@@ -541,8 +541,8 @@ xmlTextWriterStartDocument(xmlTextWriterPtr writer, const char *version,
     if (encoding != NULL) {
         encoder = xmlFindCharEncodingHandler(encoding);
         if (encoder == NULL) {
-            xmlWriterErrMsg(writer, XML_ERR_NO_MEMORY,
-                            "xmlTextWriterStartDocument : out of memory!\n");
+            xmlWriterErrMsg(writer, XML_ERR_UNSUPPORTED_ENCODING,
+                            "xmlTextWriterStartDocument : unsupported encoding\n");
             return -1;
         }
     }
@@ -801,7 +801,7 @@ xmlTextWriterStartComment(xmlTextWriterPtr writer)
  * xmlTextWriterEndComment:
  * @writer:  the xmlTextWriterPtr
  *
- * End the current xml coment.
+ * End the current xml comment.
  *
  * Returns the bytes written (may be 0 because of buffering) or -1 in case of error
  */

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xpath.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xpath.c
@@ -343,7 +343,7 @@ xmlXPathCmpNodesExt(xmlNodePtr node1, xmlNodePtr node2) {
     }
 
     /*
-     * Speedup using document order if availble.
+     * Speedup using document order if available.
      */
     if ((node1->type == XML_ELEMENT_NODE) &&
     (node2->type == XML_ELEMENT_NODE) &&
@@ -411,7 +411,7 @@ turtle_comparison:
     if (node1 == node2->next)
     return(-1);
     /*
-     * Speedup using document order if availble.
+     * Speedup using document order if available.
      */
     if ((node1->type == XML_ELEMENT_NODE) &&
     (node2->type == XML_ELEMENT_NODE) &&
@@ -435,7 +435,7 @@ turtle_comparison:
 #endif /* XP_OPTIMIZED_NON_ELEM_COMPARISON */
 
 /*
- * Wrapper for the Timsort argorithm from timsort.h
+ * Wrapper for the Timsort algorithm from timsort.h
  */
 #ifdef WITH_TIM_SORT
 #define SORT_NAME libxml_domnode
@@ -610,6 +610,8 @@ static const char *xmlXPathErrorMessages[] = {
     "Invalid or incomplete context\n",
     "Stack usage error\n",
     "Forbidden variable\n",
+    "Operation limit exceeded\n",
+    "Recursion limit exceeded\n",
     "?? Unknown error ??\n" /* Must be last in the list! */
 };
 #define MAXERRNO ((int)(sizeof(xmlXPathErrorMessages) / \
@@ -625,6 +627,7 @@ static void
 xmlXPathErrMemory(xmlXPathContextPtr ctxt, const char *extra)
 {
     if (ctxt != NULL) {
+        xmlResetError(&ctxt->lastError);
         if (extra) {
             xmlChar buf[200];
 
@@ -746,6 +749,32 @@ xmlXPatherror(xmlXPathParserContextPtr ctxt, const char *file ATTRIBUTE_UNUSED,
               int line ATTRIBUTE_UNUSED, int no) {
     xmlXPathErr(ctxt, no);
 }
+
+/**
+ * xmlXPathCheckOpLimit:
+ * @ctxt:  the XPath Parser context
+ * @opCount:  the number of operations to be added
+ *
+ * Adds opCount to the running total of operations and returns -1 if the
+ * operation limit is exceeded. Returns 0 otherwise.
+ */
+static int
+xmlXPathCheckOpLimit(xmlXPathParserContextPtr ctxt, unsigned long opCount) {
+    xmlXPathContextPtr xpctxt = ctxt->context;
+
+    if ((opCount > xpctxt->opLimit) ||
+        (xpctxt->opCount > xpctxt->opLimit - opCount)) {
+        xpctxt->opCount = xpctxt->opLimit;
+        xmlXPathErr(ctxt, XPATH_OP_LIMIT_EXCEEDED);
+        return(-1);
+    }
+
+    xpctxt->opCount += opCount;
+    return(0);
+}
+
+#define OP_LIMIT_EXCEEDED(ctxt, n) \
+    ((ctxt->context->opLimit != 0) && (xmlXPathCheckOpLimit(ctxt, n) < 0))
 
 /************************************************************************
  *                                  *
@@ -1076,14 +1105,15 @@ xmlXPathFreeCompExpr(xmlXPathCompExprPtr comp)
  * Returns -1 in case of failure, the index otherwise
  */
 static int
-xmlXPathCompExprAdd(xmlXPathCompExprPtr comp, int ch1, int ch2,
+xmlXPathCompExprAdd(xmlXPathParserContextPtr ctxt, int ch1, int ch2,
    xmlXPathOp op, int value,
    int value2, int value3, void *value4, void *value5) {
+    xmlXPathCompExprPtr comp = ctxt->comp;
     if (comp->nbStep >= comp->maxStep) {
     xmlXPathStepOp *real;
 
         if (comp->maxStep >= XPATH_MAX_STEPS) {
-        xmlXPathErrMemory(NULL, "adding step\n");
+        xmlXPathPErrMemory(ctxt, "adding step\n");
         return(-1);
         }
     comp->maxStep *= 2;
@@ -1091,7 +1121,7 @@ xmlXPathCompExprAdd(xmlXPathCompExprPtr comp, int ch1, int ch2,
                               comp->maxStep * sizeof(xmlXPathStepOp));
     if (real == NULL) {
         comp->maxStep /= 2;
-        xmlXPathErrMemory(NULL, "adding step\n");
+        xmlXPathPErrMemory(ctxt, "adding step\n");
         return(-1);
     }
     comp->steps = real;
@@ -1153,20 +1183,20 @@ xmlXPathCompSwap(xmlXPathStepOpPtr op) {
 }
 
 #define PUSH_FULL_EXPR(op, op1, op2, val, val2, val3, val4, val5)   \
-    xmlXPathCompExprAdd(ctxt->comp, (op1), (op2),           \
+    xmlXPathCompExprAdd(ctxt, (op1), (op2),         \
                     (op), (val), (val2), (val3), (val4), (val5))
 #define PUSH_LONG_EXPR(op, val, val2, val3, val4, val5)         \
-    xmlXPathCompExprAdd(ctxt->comp, ctxt->comp->last, -1,       \
+    xmlXPathCompExprAdd(ctxt, ctxt->comp->last, -1,     \
                     (op), (val), (val2), (val3), (val4), (val5))
 
 #define PUSH_LEAVE_EXPR(op, val, val2)                  \
-xmlXPathCompExprAdd(ctxt->comp, -1, -1, (op), (val), (val2), 0 ,NULL ,NULL)
+xmlXPathCompExprAdd(ctxt, -1, -1, (op), (val), (val2), 0 ,NULL ,NULL)
 
 #define PUSH_UNARY_EXPR(op, ch, val, val2)              \
-xmlXPathCompExprAdd(ctxt->comp, (ch), -1, (op), (val), (val2), 0 ,NULL ,NULL)
+xmlXPathCompExprAdd(ctxt, (ch), -1, (op), (val), (val2), 0 ,NULL ,NULL)
 
 #define PUSH_BINARY_EXPR(op, ch1, ch2, val, val2)           \
-xmlXPathCompExprAdd(ctxt->comp, (ch1), (ch2), (op),         \
+xmlXPathCompExprAdd(ctxt, (ch1), (ch2), (op),           \
             (val), (val2), 0 ,NULL ,NULL)
 
 /************************************************************************
@@ -2226,7 +2256,7 @@ xmlXPathFreeCache(xmlXPathContextCachePtr cache)
  *
  * @ctxt:  the XPath context
  * @active: enables/disables (creates/frees) the cache
- * @value: a value with semantics dependant on @options
+ * @value: a value with semantics dependent on @options
  * @options: options (currently only the value 0 is used)
  *
  * Creates/frees an object cache on the XPath context.
@@ -2386,7 +2416,7 @@ xmlXPathCacheNewNodeSet(xmlXPathContextPtr ctxt, xmlNodePtr val)
     {
         xmlXPathObjectPtr ret;
         /*
-        * Use the nodset-cache.
+        * Use the nodeset-cache.
         */
         ret = (xmlXPathObjectPtr)
         cache->nodesetObjs->items[--cache->nodesetObjs->number];
@@ -2396,6 +2426,7 @@ xmlXPathCacheNewNodeSet(xmlXPathContextPtr ctxt, xmlNodePtr val)
         if ((ret->nodesetval->nodeMax == 0) ||
             (val->type == XML_NAMESPACE_DECL))
         {
+                    /* TODO: Check memory error. */
             xmlXPathNodeSetAddUnique(ret->nodesetval, val);
         } else {
             ret->nodesetval->nodeTab[0] = val;
@@ -2842,29 +2873,36 @@ valuePop(xmlXPathParserContextPtr ctxt)
  * @ctxt:  an XPath evaluation context
  * @value:  the XPath object
  *
- * Pushes a new XPath object on top of the value stack
+ * Pushes a new XPath object on top of the value stack. If value is NULL,
+ * a memory error is recorded in the parser context.
  *
- * returns the number of items on the value stack
+ * Returns the number of items on the value stack, or -1 in case of error.
  */
 int
 valuePush(xmlXPathParserContextPtr ctxt, xmlXPathObjectPtr value)
 {
-    if ((ctxt == NULL) || (value == NULL)) return(-1);
+    if (ctxt == NULL) return(-1);
+    if (value == NULL) {
+        /*
+         * A NULL value typically indicates that a memory allocation failed,
+         * so we set ctxt->error here to propagate the error.
+         */
+    ctxt->error = XPATH_MEMORY_ERROR;
+        return(-1);
+    }
     if (ctxt->valueNr >= ctxt->valueMax) {
         xmlXPathObjectPtr *tmp;
 
         if (ctxt->valueMax >= XPATH_MAX_STACK_DEPTH) {
-            xmlXPathErrMemory(NULL, "XPath stack depth limit reached\n");
-            ctxt->error = XPATH_MEMORY_ERROR;
-            return (0);
+            xmlXPathPErrMemory(ctxt, "XPath stack depth limit reached\n");
+            return (-1);
         }
         tmp = (xmlXPathObjectPtr *) xmlRealloc(ctxt->valueTab,
                                              2 * ctxt->valueMax *
                                              sizeof(ctxt->valueTab[0]));
         if (tmp == NULL) {
-            xmlXPathErrMemory(NULL, "pushing value\n");
-            ctxt->error = XPATH_MEMORY_ERROR;
-            return (0);
+            xmlXPathPErrMemory(ctxt, "pushing value\n");
+            return (-1);
         }
         ctxt->valueMax *= 2;
     ctxt->valueTab = tmp;
@@ -3320,7 +3358,7 @@ xmlXPathCmpNodes(xmlNodePtr node1, xmlNodePtr node2) {
     return(-1);
 
     /*
-     * Speedup using document order if availble.
+     * Speedup using document order if available.
      */
     if ((node1->type == XML_ELEMENT_NODE) &&
     (node2->type == XML_ELEMENT_NODE) &&
@@ -3383,7 +3421,7 @@ xmlXPathCmpNodes(xmlNodePtr node1, xmlNodePtr node2) {
     if (node1 == node2->next)
     return(-1);
     /*
-     * Speedup using document order if availble.
+     * Speedup using document order if available.
      */
     if ((node1->type == XML_ELEMENT_NODE) &&
     (node2->type == XML_ELEMENT_NODE) &&
@@ -3547,42 +3585,12 @@ xmlXPathNodeSetCreate(xmlNodePtr val) {
     if (val->type == XML_NAMESPACE_DECL) {
         xmlNsPtr ns = (xmlNsPtr) val;
 
+            /* TODO: Check memory error. */
         ret->nodeTab[ret->nodeNr++] =
         xmlXPathNodeSetDupNs((xmlNodePtr) ns->next, ns);
     } else
         ret->nodeTab[ret->nodeNr++] = val;
     }
-    return(ret);
-}
-
-/**
- * xmlXPathNodeSetCreateSize:
- * @size:  the initial size of the set
- *
- * Create a new xmlNodeSetPtr of type double and of value @val
- *
- * Returns the newly created object.
- */
-static xmlNodeSetPtr
-xmlXPathNodeSetCreateSize(int size) {
-    xmlNodeSetPtr ret;
-
-    ret = (xmlNodeSetPtr) xmlMalloc(sizeof(xmlNodeSet));
-    if (ret == NULL) {
-        xmlXPathErrMemory(NULL, "creating nodeset\n");
-    return(NULL);
-    }
-    memset(ret, 0 , (size_t) sizeof(xmlNodeSet));
-    if (size < XML_NODESET_DEFAULT)
-    size = XML_NODESET_DEFAULT;
-    ret->nodeTab = (xmlNodePtr *) xmlMalloc(size * sizeof(xmlNodePtr));
-    if (ret->nodeTab == NULL) {
-    xmlXPathErrMemory(NULL, "creating nodeset\n");
-    xmlFree(ret);
-    return(NULL);
-    }
-    memset(ret->nodeTab, 0 , size * (size_t) sizeof(xmlNodePtr));
-    ret->nodeMax = size;
     return(ret);
 }
 
@@ -3684,6 +3692,7 @@ xmlXPathNodeSetAddNs(xmlNodeSetPtr cur, xmlNodePtr node, xmlNsPtr ns) {
         cur->nodeMax *= 2;
     cur->nodeTab = temp;
     }
+    /* TODO: Check memory error. */
     cur->nodeTab[cur->nodeNr++] = xmlXPathNodeSetDupNs(node, ns);
     return(0);
 }
@@ -3742,6 +3751,7 @@ xmlXPathNodeSetAdd(xmlNodeSetPtr cur, xmlNodePtr val) {
     if (val->type == XML_NAMESPACE_DECL) {
     xmlNsPtr ns = (xmlNsPtr) val;
 
+        /* TODO: Check memory error. */
     cur->nodeTab[cur->nodeNr++] =
         xmlXPathNodeSetDupNs((xmlNodePtr) ns->next, ns);
     } else
@@ -3796,6 +3806,7 @@ xmlXPathNodeSetAddUnique(xmlNodeSetPtr cur, xmlNodePtr val) {
     if (val->type == XML_NAMESPACE_DECL) {
     xmlNsPtr ns = (xmlNsPtr) val;
 
+        /* TODO: Check memory error. */
     cur->nodeTab[cur->nodeNr++] =
         xmlXPathNodeSetDupNs((xmlNodePtr) ns->next, ns);
     } else
@@ -3830,7 +3841,7 @@ xmlXPathNodeSetMerge(xmlNodeSetPtr val1, xmlNodeSetPtr val2) {
     *  xmlXPathNodeSetDupNs() to the set; thus a pure
     *  memcpy is not possible.
     *  If there was a flag on the nodesetval, indicating that
-    *  some temporary nodes are in, that would be helpfull.
+    *  some temporary nodes are in, that would be helpful.
     */
     /*
     * Optimization: Create an equally sized node-set
@@ -3912,6 +3923,7 @@ xmlXPathNodeSetMerge(xmlNodeSetPtr val1, xmlNodeSetPtr val2) {
     if (n2->type == XML_NAMESPACE_DECL) {
         xmlNsPtr ns = (xmlNsPtr) n2;
 
+            /* TODO: Check memory error. */
         val1->nodeTab[val1->nodeNr++] =
         xmlXPathNodeSetDupNs((xmlNodePtr) ns->next, ns);
     } else
@@ -3926,48 +3938,22 @@ xmlXPathNodeSetMerge(xmlNodeSetPtr val1, xmlNodeSetPtr val2) {
  * xmlXPathNodeSetMergeAndClear:
  * @set1:  the first NodeSet or NULL
  * @set2:  the second NodeSet
- * @hasSet2NsNodes: 1 if set2 contains namespaces nodes
  *
- * Merges two nodesets, all nodes from @set2 are added to @set1
- * if @set1 is NULL, a new set is created and copied from @set2.
+ * Merges two nodesets, all nodes from @set2 are added to @set1.
  * Checks for duplicate nodes. Clears set2.
  *
  * Returns @set1 once extended or NULL in case of error.
  */
 static xmlNodeSetPtr
-xmlXPathNodeSetMergeAndClear(xmlNodeSetPtr set1, xmlNodeSetPtr set2,
-                 int hasNullEntries)
+xmlXPathNodeSetMergeAndClear(xmlNodeSetPtr set1, xmlNodeSetPtr set2)
 {
-    if ((set1 == NULL) && (hasNullEntries == 0)) {
-    /*
-    * Note that doing a memcpy of the list, namespace nodes are
-    * just assigned to set1, since set2 is cleared anyway.
-    */
-    set1 = xmlXPathNodeSetCreateSize(set2->nodeNr);
-    if (set1 == NULL)
-        return(NULL);
-    if (set2->nodeNr != 0) {
-        memcpy(set1->nodeTab, set2->nodeTab,
-        set2->nodeNr * sizeof(xmlNodePtr));
-        set1->nodeNr = set2->nodeNr;
-    }
-    } else {
+{
     int i, j, initNbSet1;
     xmlNodePtr n1, n2;
-
-    if (set1 == NULL)
-            set1 = xmlXPathNodeSetCreate(NULL);
-        if (set1 == NULL)
-            return (NULL);
 
     initNbSet1 = set1->nodeNr;
     for (i = 0;i < set2->nodeNr;i++) {
         n2 = set2->nodeTab[i];
-        /*
-        * Skip NULLed entries.
-        */
-        if (n2 == NULL)
-        continue;
         /*
         * Skip duplicates.
         */
@@ -4033,49 +4019,21 @@ skip_node:
  * xmlXPathNodeSetMergeAndClearNoDupls:
  * @set1:  the first NodeSet or NULL
  * @set2:  the second NodeSet
- * @hasSet2NsNodes: 1 if set2 contains namespaces nodes
  *
- * Merges two nodesets, all nodes from @set2 are added to @set1
- * if @set1 is NULL, a new set is created and copied from @set2.
- * Doesn't chack for duplicate nodes. Clears set2.
+ * Merges two nodesets, all nodes from @set2 are added to @set1.
+ * Doesn't check for duplicate nodes. Clears set2.
  *
  * Returns @set1 once extended or NULL in case of error.
  */
 static xmlNodeSetPtr
-xmlXPathNodeSetMergeAndClearNoDupls(xmlNodeSetPtr set1, xmlNodeSetPtr set2,
-                    int hasNullEntries)
+xmlXPathNodeSetMergeAndClearNoDupls(xmlNodeSetPtr set1, xmlNodeSetPtr set2)
 {
-    if (set2 == NULL)
-    return(set1);
-    if ((set1 == NULL) && (hasNullEntries == 0)) {
-    /*
-    * Note that doing a memcpy of the list, namespace nodes are
-    * just assigned to set1, since set2 is cleared anyway.
-    */
-    set1 = xmlXPathNodeSetCreateSize(set2->nodeNr);
-    if (set1 == NULL)
-        return(NULL);
-    if (set2->nodeNr != 0) {
-        memcpy(set1->nodeTab, set2->nodeTab,
-        set2->nodeNr * sizeof(xmlNodePtr));
-        set1->nodeNr = set2->nodeNr;
-    }
-    } else {
+{
     int i;
     xmlNodePtr n2;
 
-    if (set1 == NULL)
-        set1 = xmlXPathNodeSetCreate(NULL);
-        if (set1 == NULL)
-            return (NULL);
-
     for (i = 0;i < set2->nodeNr;i++) {
         n2 = set2->nodeTab[i];
-        /*
-        * Skip NULLed entries.
-        */
-        if (n2 == NULL)
-        continue;
         if (set1->nodeMax == 0) {
         set1->nodeTab = (xmlNodePtr *) xmlMalloc(
             XML_NODESET_DEFAULT * sizeof(xmlNodePtr));
@@ -4346,6 +4304,7 @@ xmlXPathNewNodeSet(xmlNodePtr val) {
     memset(ret, 0 , (size_t) sizeof(xmlXPathObject));
     ret->type = XPATH_NODESET;
     ret->boolval = 0;
+    /* TODO: Check memory error. */
     ret->nodesetval = xmlXPathNodeSetCreate(val);
     /* @@ with_ns to check whether namespace nodes should be looked at @@ */
 #ifdef XP_DEBUG_OBJ_USAGE
@@ -4406,6 +4365,7 @@ xmlXPathNewNodeSetList(xmlNodeSetPtr val)
         ret = xmlXPathNewNodeSet(val->nodeTab[0]);
         if (ret) {
             for (i = 1; i < val->nodeNr; ++i) {
+                /* TODO: Propagate memory error. */
                 if (xmlXPathNodeSetAddUnique(ret->nodesetval, val->nodeTab[i])
             < 0) break;
         }
@@ -4477,6 +4437,7 @@ xmlXPathDifference (xmlNodeSetPtr nodes1, xmlNodeSetPtr nodes2) {
     if (xmlXPathNodeSetIsEmpty(nodes2))
     return(nodes1);
 
+    /* TODO: Check memory error. */
     ret = xmlXPathNodeSetCreate(NULL);
     if (xmlXPathNodeSetIsEmpty(nodes1))
     return(ret);
@@ -4486,6 +4447,7 @@ xmlXPathDifference (xmlNodeSetPtr nodes1, xmlNodeSetPtr nodes2) {
     for (i = 0; i < l1; i++) {
     cur = xmlXPathNodeSetItem(nodes1, i);
     if (!xmlXPathNodeSetContains(nodes2, cur)) {
+            /* TODO: Propagate memory error. */
         if (xmlXPathNodeSetAddUnique(ret, cur) < 0)
             break;
     }
@@ -4522,6 +4484,7 @@ xmlXPathIntersection (xmlNodeSetPtr nodes1, xmlNodeSetPtr nodes2) {
     for (i = 0; i < l1; i++) {
     cur = xmlXPathNodeSetItem(nodes1, i);
     if (xmlXPathNodeSetContains(nodes2, cur)) {
+            /* TODO: Propagate memory error. */
         if (xmlXPathNodeSetAddUnique(ret, cur) < 0)
             break;
     }
@@ -4560,6 +4523,7 @@ xmlXPathDistinctSorted (xmlNodeSetPtr nodes) {
     strval = xmlXPathCastNodeToString(cur);
     if (xmlHashLookup(hash, strval) == NULL) {
         xmlHashAddEntry(hash, strval, strval);
+            /* TODO: Propagate memory error. */
         if (xmlXPathNodeSetAddUnique(ret, cur) < 0)
             break;
     } else {
@@ -4653,6 +4617,7 @@ xmlXPathNodeLeadingSorted (xmlNodeSetPtr nodes, xmlNodePtr node) {
     cur = xmlXPathNodeSetItem(nodes, i);
     if (cur == node)
         break;
+        /* TODO: Propagate memory error. */
     if (xmlXPathNodeSetAddUnique(ret, cur) < 0)
         break;
     }
@@ -4758,6 +4723,7 @@ xmlXPathNodeTrailingSorted (xmlNodeSetPtr nodes, xmlNodePtr node) {
     cur = xmlXPathNodeSetItem(nodes, i);
     if (cur == node)
         break;
+        /* TODO: Propagate memory error. */
     if (xmlXPathNodeSetAddUnique(ret, cur) < 0)
         break;
     }
@@ -5457,6 +5423,7 @@ xmlXPathObjectCopy(xmlXPathObjectPtr val) {
         break;
 #endif
     case XPATH_NODESET:
+            /* TODO: Check memory error. */
         ret->nodesetval = xmlXPathNodeSetMerge(NULL, val->nodesetval);
         /* Do not deallocate the copied tree value */
         ret->boolval = 0;
@@ -5944,7 +5911,7 @@ xmlXPathCastToNumber(xmlXPathObjectPtr val) {
     return(NAN);
     switch (val->type) {
     case XPATH_UNDEFINED:
-#ifdef DEGUB_EXPR
+#ifdef DEBUG_EXPR
     xmlGenericError(xmlGenericErrorContext, "NUMBER: undefined\n");
 #endif
     ret = NAN;
@@ -6152,6 +6119,9 @@ xmlXPathNewContext(xmlDocPtr doc) {
 
     ret->contextSize = -1;
     ret->proximityPosition = -1;
+
+    ret->maxDepth = INT_MAX;
+    ret->maxParserDepth = INT_MAX;
 
 #ifdef XP_DEFAULT_CACHE_ON
     if (xmlXPathContextSetCache(ret, 1, -1, 0) == -1) {
@@ -6643,6 +6613,7 @@ xmlXPathCompareNodeSets(int inf, int strict,
 
     values2 = (double *) xmlMalloc(ns2->nodeNr * sizeof(double));
     if (values2 == NULL) {
+        /* TODO: Propagate memory error. */
         xmlXPathErrMemory(NULL, "comparing nodesets\n");
     xmlXPathFreeObject(arg1);
     xmlXPathFreeObject(arg2);
@@ -6903,11 +6874,13 @@ xmlXPathEqualNodeSets(xmlXPathObjectPtr arg1, xmlXPathObjectPtr arg2, int neq) {
 
     values1 = (xmlChar **) xmlMalloc(ns1->nodeNr * sizeof(xmlChar *));
     if (values1 == NULL) {
+        /* TODO: Propagate memory error. */
         xmlXPathErrMemory(NULL, "comparing nodesets\n");
     return(0);
     }
     hashs1 = (unsigned int *) xmlMalloc(ns1->nodeNr * sizeof(unsigned int));
     if (hashs1 == NULL) {
+        /* TODO: Propagate memory error. */
         xmlXPathErrMemory(NULL, "comparing nodesets\n");
     xmlFree(values1);
     return(0);
@@ -6915,6 +6888,7 @@ xmlXPathEqualNodeSets(xmlXPathObjectPtr arg1, xmlXPathObjectPtr arg2, int neq) {
     memset(values1, 0, ns1->nodeNr * sizeof(xmlChar *));
     values2 = (xmlChar **) xmlMalloc(ns2->nodeNr * sizeof(xmlChar *));
     if (values2 == NULL) {
+        /* TODO: Propagate memory error. */
         xmlXPathErrMemory(NULL, "comparing nodesets\n");
     xmlFree(hashs1);
     xmlFree(values1);
@@ -6922,6 +6896,7 @@ xmlXPathEqualNodeSets(xmlXPathObjectPtr arg1, xmlXPathObjectPtr arg2, int neq) {
     }
     hashs2 = (unsigned int *) xmlMalloc(ns2->nodeNr * sizeof(unsigned int));
     if (hashs2 == NULL) {
+        /* TODO: Propagate memory error. */
         xmlXPathErrMemory(NULL, "comparing nodesets\n");
     xmlFree(hashs1);
     xmlFree(values1);
@@ -7551,6 +7526,7 @@ xmlXPathMultValues(xmlXPathParserContextPtr ctxt) {
  * The numeric operators convert their operands to numbers as if
  * by calling the number function.
  */
+ATTRIBUTE_NO_SANITIZE("float-divide-by-zero")
 void
 xmlXPathDivValues(xmlXPathParserContextPtr ctxt) {
     xmlXPathObjectPtr arg;
@@ -7623,7 +7599,7 @@ typedef xmlNodePtr (*xmlXPathTraversalFunctionExt)
  * Used for merging node sets in xmlXPathCollectAndTest().
  */
 typedef xmlNodeSetPtr (*xmlXPathNodeSetMergeFunction)
-            (xmlNodeSetPtr, xmlNodeSetPtr, int);
+            (xmlNodeSetPtr, xmlNodeSetPtr);
 
 
 /**
@@ -8562,28 +8538,9 @@ xmlXPathCountFunction(xmlXPathParserContextPtr ctxt, int nargs) {
 
     if ((cur == NULL) || (cur->nodesetval == NULL))
     valuePush(ctxt, xmlXPathCacheNewFloat(ctxt->context, (double) 0));
-    else if ((cur->type == XPATH_NODESET) || (cur->type == XPATH_XSLT_TREE)) {
+    else
     valuePush(ctxt, xmlXPathCacheNewFloat(ctxt->context,
         (double) cur->nodesetval->nodeNr));
-    } else {
-    if ((cur->nodesetval->nodeNr != 1) ||
-        (cur->nodesetval->nodeTab == NULL)) {
-        valuePush(ctxt, xmlXPathCacheNewFloat(ctxt->context, (double) 0));
-    } else {
-        xmlNodePtr tmp;
-        int i = 0;
-
-        tmp = cur->nodesetval->nodeTab[0];
-        if ((tmp != NULL) && (tmp->type != XML_NAMESPACE_DECL)) {
-        tmp = tmp->children;
-        while (tmp != NULL) {
-            tmp = tmp->next;
-            i++;
-        }
-        }
-        valuePush(ctxt, xmlXPathCacheNewFloat(ctxt->context, (double) i));
-    }
-    }
     xmlXPathReleaseObject(ctxt->context, cur);
 }
 
@@ -8621,7 +8578,7 @@ xmlXPathGetElementsByIds (xmlDocPtr doc, const xmlChar *ids) {
          * We used to check the fact that the value passed
          * was an NCName, but this generated much troubles for
          * me and Aleksey Sanin, people blatantly violated that
-         * constaint, like Visa3D spec.
+         * constraint, like Visa3D spec.
          * if (xmlValidateNCName(ID, 1) == 0)
          */
         attr = xmlGetID(doc, ID);
@@ -8632,6 +8589,7 @@ xmlXPathGetElementsByIds (xmlDocPtr doc, const xmlChar *ids) {
             elem = (xmlNodePtr) attr;
         else
             elem = NULL;
+                /* TODO: Check memory error. */
         if (elem != NULL)
             xmlXPathNodeSetAdd(ret, elem);
         }
@@ -8675,18 +8633,15 @@ xmlXPathIdFunction(xmlXPathParserContextPtr ctxt, int nargs) {
     xmlNodeSetPtr ns;
     int i;
 
+        /* TODO: Check memory error. */
     ret = xmlXPathNodeSetCreate(NULL);
-        /*
-         * FIXME -- in an out-of-memory condition this will behave badly.
-         * The solution is not clear -- we already popped an item from
-         * ctxt, so the object is in a corrupt state.
-         */
 
     if (obj->nodesetval != NULL) {
         for (i = 0; i < obj->nodesetval->nodeNr; i++) {
         tokens =
             xmlXPathCastNodeToString(obj->nodesetval->nodeTab[i]);
         ns = xmlXPathGetElementsByIds(ctxt->context->doc, tokens);
+                /* TODO: Check memory error. */
         ret = xmlXPathNodeSetMerge(ret, ns);
         xmlXPathFreeNodeSet(ns);
         if (tokens != NULL)
@@ -8698,6 +8653,7 @@ xmlXPathIdFunction(xmlXPathParserContextPtr ctxt, int nargs) {
     return;
     }
     obj = xmlXPathCacheConvertString(ctxt->context, obj);
+    if (obj == NULL) return;
     ret = xmlXPathGetElementsByIds(ctxt->context->doc, obj->stringval);
     valuePush(ctxt, xmlXPathCacheWrapNodeSet(ctxt->context, ret));
     xmlXPathReleaseObject(ctxt->context, obj);
@@ -9135,8 +9091,7 @@ void
 xmlXPathSubstringFunction(xmlXPathParserContextPtr ctxt, int nargs) {
     xmlXPathObjectPtr str, start, len;
     double le=0, in;
-    int i, l, m;
-    xmlChar *ret;
+    int i = 1, j = INT_MAX;
 
     if (nargs < 2) {
     CHECK_ARITY(2);
@@ -9163,67 +9118,42 @@ xmlXPathSubstringFunction(xmlXPathParserContextPtr ctxt, int nargs) {
     CAST_TO_STRING;
     CHECK_TYPE(XPATH_STRING);
     str = valuePop(ctxt);
-    m = xmlUTF8Strlen((const unsigned char *)str->stringval);
 
-    /*
-     * If last pos not present, calculate last position
-    */
-    if (nargs != 3) {
-    le = (double)m;
-    if (in < 1.0)
-        in = 1.0;
-    }
-
-    /* Need to check for the special cases where either
-     * the index is NaN, the length is NaN, or both
-     * arguments are infinity (relying on Inf + -Inf = NaN)
-     */
-    if (!xmlXPathIsInf(in) && !xmlXPathIsNaN(in + le)) {
-        /*
-         * To meet the requirements of the spec, the arguments
-     * must be converted to integer format before
-     * initial index calculations are done
-         *
-         * First we go to integer form, rounding up
-     * and checking for special cases
-         */
+    if (!(in < INT_MAX)) { /* Logical NOT to handle NaNs */
+        i = INT_MAX;
+    } else if (in >= 1.0) {
         i = (int) in;
-        if (((double)i)+0.5 <= in) i++;
-
-    if (xmlXPathIsInf(le) == 1) {
-        l = m;
-        if (i < 1)
-        i = 1;
-    }
-    else if (xmlXPathIsInf(le) == -1 || le < 0.0)
-        l = 0;
-    else {
-        l = (int) le;
-        if (((double)l)+0.5 <= le) l++;
+        if (in - floor(in) >= 0.5)
+            i += 1;
     }
 
-    /* Now we normalize inidices */
-        i -= 1;
-        l += i;
-        if (i < 0)
-            i = 0;
-        if (l > m)
-            l = m;
+    if (nargs == 3) {
+        double rin, rle, end;
 
-        /* number of chars to copy */
-        l -= i;
+        rin = floor(in);
+        if (in - rin >= 0.5)
+            rin += 1.0;
 
-        ret = xmlUTF8Strsub(str->stringval, i, l);
+        rle = floor(le);
+        if (le - rle >= 0.5)
+            rle += 1.0;
+
+        end = rin + rle;
+        if (!(end >= 1.0)) { /* Logical NOT to handle NaNs */
+            j = 1;
+        } else if (end < INT_MAX) {
+            j = (int)end;
     }
-    else {
-        ret = NULL;
     }
-    if (ret == NULL)
-    valuePush(ctxt, xmlXPathCacheNewCString(ctxt->context, ""));
-    else {
+
+    if (i < j) {
+        xmlChar *ret = xmlUTF8Strsub(str->stringval, i - 1, j - i);
     valuePush(ctxt, xmlXPathCacheNewString(ctxt->context, ret));
     xmlFree(ret);
+    } else {
+    valuePush(ctxt, xmlXPathCacheNewCString(ctxt->context, ""));
     }
+
     xmlXPathReleaseObject(ctxt->context, str);
 }
 
@@ -9682,7 +9612,12 @@ xmlXPathCeilingFunction(xmlXPathParserContextPtr ctxt, int nargs) {
     CAST_TO_NUMBER;
     CHECK_TYPE(XPATH_NUMBER);
 
+#ifdef _AIX
+    /* Work around buggy ceil() function on AIX */
+    ctxt->value->floatval = copysign(ceil(ctxt->value->floatval), ctxt->value->floatval);
+#else
     ctxt->value->floatval = ceil(ctxt->value->floatval);
+#endif
 }
 
 /**
@@ -9999,15 +9934,19 @@ xmlXPathParseNameComplex(xmlXPathParserContextPtr ctxt, int qualified) {
            (IS_COMBINING(c)) ||
            (IS_EXTENDER(c))) {
         if (len + 10 > max) {
+                    xmlChar *tmp;
                     if (max > XML_MAX_NAME_LENGTH) {
+                        xmlFree(buffer);
                         XP_ERRORNULL(XPATH_EXPR_ERROR);
                     }
             max *= 2;
-            buffer = (xmlChar *) xmlRealloc(buffer,
+            tmp = (xmlChar *) xmlRealloc(buffer,
                                         max * sizeof(xmlChar));
-            if (buffer == NULL) {
+            if (tmp == NULL) {
+                        xmlFree(buffer);
             XP_ERRORNULL(XPATH_MEMORY_ERROR);
             }
+                    buffer = tmp;
         }
         COPY_BUF(l,buffer,len,c);
         NEXTL(l);
@@ -10899,10 +10838,7 @@ xmlXPathCompRelationalExpr(xmlXPathParserContextPtr ctxt) {
     xmlXPathCompAdditiveExpr(ctxt);
     CHECK_ERROR;
     SKIP_BLANKS;
-    while ((CUR == '<') ||
-           (CUR == '>') ||
-           ((CUR == '<') && (NXT(1) == '=')) ||
-           ((CUR == '>') && (NXT(1) == '='))) {
+    while ((CUR == '<') || (CUR == '>')) {
     int inf, strict;
     int op1 = ctxt->comp->last;
 
@@ -10995,6 +10931,14 @@ xmlXPathCompAndExpr(xmlXPathParserContextPtr ctxt) {
  */
 static void
 xmlXPathCompileExpr(xmlXPathParserContextPtr ctxt, int sort) {
+    xmlXPathContextPtr xpctxt = ctxt->context;
+
+    if (xpctxt != NULL) {
+        if (xpctxt->depth >= xpctxt->maxParserDepth)
+            XP_ERROR(XPATH_RECURSION_LIMIT_EXCEEDED);
+        xpctxt->depth += 1;
+    }
+
     xmlXPathCompAndExpr(ctxt);
     CHECK_ERROR;
     SKIP_BLANKS;
@@ -11016,6 +10960,9 @@ xmlXPathCompileExpr(xmlXPathParserContextPtr ctxt, int sort) {
     */
     PUSH_UNARY_EXPR(XPATH_OP_SORT, ctxt->comp->last , 0, 0);
     }
+
+    if (xpctxt != NULL)
+        xpctxt->depth -= 1;
 }
 
 /**
@@ -11634,366 +11581,300 @@ xmlXPathDebugDumpStepAxis(xmlXPathStepOpPtr op,
 }
 #endif /* DEBUG_STEP */
 
-static int
-xmlXPathCompOpEvalPredicate(xmlXPathParserContextPtr ctxt,
-                xmlXPathStepOpPtr op,
+/**
+ * xmlXPathNodeSetFilter:
+ * @ctxt:  the XPath Parser context
+ * @set: the node set to filter
+ * @filterOpIndex: the index of the predicate/filter op
+ * @minPos: minimum position in the filtered set (1-based)
+ * @maxPos: maximum position in the filtered set (1-based)
+ * @hasNsNodes: true if the node set may contain namespace nodes
+ *
+ * Filter a node set, keeping only nodes for which the predicate expression
+ * matches. Afterwards, keep only nodes between minPos and maxPos in the
+ * filtered result.
+ */
+static void
+xmlXPathNodeSetFilter(xmlXPathParserContextPtr ctxt,
                 xmlNodeSetPtr set,
-                int contextSize,
+              int filterOpIndex,
+                      int minPos, int maxPos,
                 int hasNsNodes)
 {
-    if (op->ch1 != -1) {
-    xmlXPathCompExprPtr comp = ctxt->comp;
-    /*
-    * Process inner predicates first.
-    */
-    if (comp->steps[op->ch1].op != XPATH_OP_PREDICATE) {
-        /*
-        * TODO: raise an internal error.
-        */
-    }
-    contextSize = xmlXPathCompOpEvalPredicate(ctxt,
-        &comp->steps[op->ch1], set, contextSize, hasNsNodes);
-    CHECK_ERROR0;
-    if (contextSize <= 0)
-        return(0);
-    }
-    if (op->ch2 != -1) {
-    xmlXPathContextPtr xpctxt = ctxt->context;
-    xmlNodePtr contextNode, oldContextNode;
-    xmlDocPtr oldContextDoc;
-        int oldcs, oldpp;
-    int i, res, contextPos = 0, newContextSize;
-    xmlXPathStepOpPtr exprOp;
-    xmlXPathObjectPtr contextObj = NULL, exprRes = NULL;
+    xmlXPathContextPtr xpctxt;
+    xmlNodePtr oldnode;
+    xmlDocPtr olddoc;
+    xmlXPathStepOpPtr filterOp;
+    int oldcs, oldpp;
+    int i, j, pos;
 
-#ifdef LIBXML_XPTR_ENABLED
-    /*
-    * URGENT TODO: Check the following:
-    *  We don't expect location sets if evaluating prediates, right?
-    *  Only filters should expect location sets, right?
-    */
-#endif
-    /*
-    * SPEC XPath 1.0:
-    *  "For each node in the node-set to be filtered, the
-    *  PredicateExpr is evaluated with that node as the
-    *  context node, with the number of nodes in the
-    *  node-set as the context size, and with the proximity
-    *  position of the node in the node-set with respect to
-    *  the axis as the context position;"
-    * @oldset is the node-set" to be filtered.
-    *
-    * SPEC XPath 1.0:
-    *  "only predicates change the context position and
-    *  context size (see [2.4 Predicates])."
-    * Example:
-    *   node-set  context pos
-    *    nA         1
-    *    nB         2
-    *    nC         3
-    *   After applying predicate [position() > 1] :
-    *   node-set  context pos
-    *    nB         1
-    *    nC         2
-    */
-    oldContextNode = xpctxt->node;
-    oldContextDoc = xpctxt->doc;
-        oldcs = xpctxt->contextSize;
-        oldpp = xpctxt->proximityPosition;
-    /*
-    * Get the expression of this predicate.
-    */
-    exprOp = &ctxt->comp->steps[op->ch2];
-    newContextSize = 0;
-    for (i = 0; i < set->nodeNr; i++) {
-        if (set->nodeTab[i] == NULL)
-        continue;
+    if ((set == NULL) || (set->nodeNr == 0))
+        return;
 
-        contextNode = set->nodeTab[i];
-        xpctxt->node = contextNode;
-        xpctxt->contextSize = contextSize;
-        xpctxt->proximityPosition = ++contextPos;
-
-        /*
-        * Also set the xpath document in case things like
-        * key() are evaluated in the predicate.
-        */
-        if ((contextNode->type != XML_NAMESPACE_DECL) &&
-        (contextNode->doc != NULL))
-        xpctxt->doc = contextNode->doc;
-        /*
-        * Evaluate the predicate expression with 1 context node
-        * at a time; this node is packaged into a node set; this
-        * node set is handed over to the evaluation mechanism.
-        */
-        if (contextObj == NULL)
-        contextObj = xmlXPathCacheNewNodeSet(xpctxt, contextNode);
-        else {
-        if (xmlXPathNodeSetAddUnique(contextObj->nodesetval,
-            contextNode) < 0) {
-            ctxt->error = XPATH_MEMORY_ERROR;
-            goto evaluation_exit;
-        }
-        }
-
-        valuePush(ctxt, contextObj);
-
-        res = xmlXPathCompOpEvalToBoolean(ctxt, exprOp, 1);
-
-        if ((ctxt->error != XPATH_EXPRESSION_OK) || (res == -1)) {
-        xmlXPathNodeSetClear(set, hasNsNodes);
-        newContextSize = 0;
-        goto evaluation_exit;
-        }
-
-        if (res != 0) {
-        newContextSize++;
-        } else {
-        /*
-        * Remove the entry from the initial node set.
-        */
-        set->nodeTab[i] = NULL;
-        if (contextNode->type == XML_NAMESPACE_DECL)
-            xmlXPathNodeSetFreeNs((xmlNsPtr) contextNode);
-        }
-        if (ctxt->value == contextObj) {
-        /*
-        * Don't free the temporary XPath object holding the
-        * context node, in order to avoid massive recreation
-        * inside this loop.
-        */
-        valuePop(ctxt);
-        xmlXPathNodeSetClear(contextObj->nodesetval, hasNsNodes);
-        } else {
-        /*
-        * TODO: The object was lost in the evaluation machinery.
-        *  Can this happen? Maybe in internal-error cases.
-        */
-        contextObj = NULL;
-        }
-    }
-
-    if (contextObj != NULL) {
-        if (ctxt->value == contextObj)
-        valuePop(ctxt);
-        xmlXPathReleaseObject(xpctxt, contextObj);
-    }
-evaluation_exit:
-    if (exprRes != NULL)
-        xmlXPathReleaseObject(ctxt->context, exprRes);
-    /*
-    * Reset/invalidate the context.
-    */
-    xpctxt->node = oldContextNode;
-    xpctxt->doc = oldContextDoc;
-    xpctxt->contextSize = oldcs;
-    xpctxt->proximityPosition = oldpp;
-    return(newContextSize);
-    }
-    return(contextSize);
-}
-
-static int
-xmlXPathCompOpEvalPositionalPredicate(xmlXPathParserContextPtr ctxt,
-                      xmlXPathStepOpPtr op,
-                      xmlNodeSetPtr set,
-                      int contextSize,
-                      int minPos,
-                      int maxPos,
-                      int hasNsNodes)
-{
-    if (op->ch1 != -1) {
-    xmlXPathCompExprPtr comp = ctxt->comp;
-    if (comp->steps[op->ch1].op != XPATH_OP_PREDICATE) {
-        /*
-        * TODO: raise an internal error.
-        */
-    }
-    contextSize = xmlXPathCompOpEvalPredicate(ctxt,
-        &comp->steps[op->ch1], set, contextSize, hasNsNodes);
-    CHECK_ERROR0;
-    if (contextSize <= 0)
-        return(0);
-    }
     /*
     * Check if the node set contains a sufficient number of nodes for
     * the requested range.
     */
-    if (contextSize < minPos) {
-    xmlXPathNodeSetClear(set, hasNsNodes);
-    return(0);
+    if (set->nodeNr < minPos) {
+        xmlXPathNodeSetClear(set, hasNsNodes);
+        return;
     }
-    if (op->ch2 == -1) {
-    /*
-    * TODO: Can this ever happen?
-    */
-    return (contextSize);
-    } else {
-    xmlDocPtr oldContextDoc;
-        int oldcs, oldpp;
-    int i, pos = 0, newContextSize = 0, contextPos = 0, res;
-    xmlXPathStepOpPtr exprOp;
-    xmlXPathObjectPtr contextObj = NULL, exprRes = NULL;
-    xmlNodePtr oldContextNode, contextNode = NULL;
-    xmlXPathContextPtr xpctxt = ctxt->context;
-        int frame;
+
+    xpctxt = ctxt->context;
+    oldnode = xpctxt->node;
+    olddoc = xpctxt->doc;
+    oldcs = xpctxt->contextSize;
+    oldpp = xpctxt->proximityPosition;
+    filterOp = &ctxt->comp->steps[filterOpIndex];
+
+    xpctxt->contextSize = set->nodeNr;
+
+    for (i = 0, j = 0, pos = 1; i < set->nodeNr; i++) {
+        xmlNodePtr node = set->nodeTab[i];
+        int res;
+
+        xpctxt->node = node;
+        xpctxt->proximityPosition = i + 1;
+
+        /*
+        * Also set the xpath document in case things like
+        * key() are evaluated in the predicate.
+        *
+        * TODO: Get real doc for namespace nodes.
+        */
+        if ((node->type != XML_NAMESPACE_DECL) &&
+            (node->doc != NULL))
+            xpctxt->doc = node->doc;
+
+        res = xmlXPathCompOpEvalToBoolean(ctxt, filterOp, 1);
+
+        if (ctxt->error != XPATH_EXPRESSION_OK)
+            goto exit;
+        if (res < 0) {
+            /* Shouldn't happen */
+            xmlXPathErr(ctxt, XPATH_EXPR_ERROR);
+            goto exit;
+    }
+
+        if ((res != 0) && ((pos >= minPos) && (pos <= maxPos))) {
+            if (i != j) {
+                set->nodeTab[j] = node;
+                set->nodeTab[i] = NULL;
+            }
+
+            j += 1;
+        } else {
+            /* Remove the entry from the initial node set. */
+            set->nodeTab[i] = NULL;
+            if (node->type == XML_NAMESPACE_DECL)
+                xmlXPathNodeSetFreeNs((xmlNsPtr) node);
+        }
+
+        if (res != 0) {
+            if (pos == maxPos) {
+                /* Clear remaining nodes and exit loop. */
+                if (hasNsNodes) {
+                    for (i++; i < set->nodeNr; i++) {
+                        node = set->nodeTab[i];
+                        if ((node != NULL) &&
+                            (node->type == XML_NAMESPACE_DECL))
+                            xmlXPathNodeSetFreeNs((xmlNsPtr) node);
+                    }
+                }
+                break;
+            }
+
+            pos += 1;
+        }
+    }
+
+    set->nodeNr = j;
+
+    /* If too many elements were removed, shrink table to preserve memory. */
+    if ((set->nodeMax > XML_NODESET_DEFAULT) &&
+        (set->nodeNr < set->nodeMax / 2)) {
+        xmlNodePtr *tmp;
+        int nodeMax = set->nodeNr;
+
+        if (nodeMax < XML_NODESET_DEFAULT)
+            nodeMax = XML_NODESET_DEFAULT;
+        tmp = (xmlNodePtr *) xmlRealloc(set->nodeTab,
+                nodeMax * sizeof(xmlNodePtr));
+        if (tmp == NULL) {
+            xmlXPathPErrMemory(ctxt, "shrinking nodeset\n");
+        } else {
+            set->nodeTab = tmp;
+            set->nodeMax = nodeMax;
+        }
+    }
+
+exit:
+    xpctxt->node = oldnode;
+    xpctxt->doc = olddoc;
+    xpctxt->contextSize = oldcs;
+    xpctxt->proximityPosition = oldpp;
+    }
 
 #ifdef LIBXML_XPTR_ENABLED
-        /*
-        * URGENT TODO: Check the following:
-        *  We don't expect location sets if evaluating prediates, right?
-        *  Only filters should expect location sets, right?
+/**
+ * xmlXPathLocationSetFilter:
+ * @ctxt:  the XPath Parser context
+ * @locset: the location set to filter
+ * @filterOpIndex: the index of the predicate/filter op
+ * @minPos: minimum position in the filtered set (1-based)
+ * @maxPos: maximum position in the filtered set (1-based)
+    *
+ * Filter a location set, keeping only nodes for which the predicate
+ * expression matches. Afterwards, keep only nodes between minPos and maxPos
+ * in the filtered result.
     */
-#endif /* LIBXML_XPTR_ENABLED */
+static void
+xmlXPathLocationSetFilter(xmlXPathParserContextPtr ctxt,
+                  xmlLocationSetPtr locset,
+                  int filterOpIndex,
+                          int minPos, int maxPos)
+{
+    xmlXPathContextPtr xpctxt;
+    xmlNodePtr oldnode;
+    xmlDocPtr olddoc;
+    xmlXPathStepOpPtr filterOp;
+    int oldcs, oldpp;
+    int i, j, pos;
 
-    /*
-    * Save old context.
-    */
-    oldContextNode = xpctxt->node;
-    oldContextDoc = xpctxt->doc;
+    if ((locset == NULL) || (locset->locNr == 0) || (filterOpIndex == -1))
+        return;
+
+    xpctxt = ctxt->context;
+    oldnode = xpctxt->node;
+    olddoc = xpctxt->doc;
         oldcs = xpctxt->contextSize;
         oldpp = xpctxt->proximityPosition;
-    /*
-    * Get the expression of this predicate.
-    */
-    exprOp = &ctxt->comp->steps[op->ch2];
-    for (i = 0; i < set->nodeNr; i++) {
-            xmlXPathObjectPtr tmp;
+    filterOp = &ctxt->comp->steps[filterOpIndex];
 
-        if (set->nodeTab[i] == NULL)
-        continue;
+    xpctxt->contextSize = locset->locNr;
 
-        contextNode = set->nodeTab[i];
+    for (i = 0, j = 0, pos = 1; i < locset->locNr; i++) {
+        xmlNodePtr contextNode = locset->locTab[i]->user;
+        int res;
+
         xpctxt->node = contextNode;
-        xpctxt->contextSize = contextSize;
-        xpctxt->proximityPosition = ++contextPos;
+        xpctxt->proximityPosition = i + 1;
 
         /*
-        * Initialize the new set.
         * Also set the xpath document in case things like
-        * key() evaluation are attempted on the predicate
+        * key() are evaluated in the predicate.
+        *
+        * TODO: Get real doc for namespace nodes.
         */
         if ((contextNode->type != XML_NAMESPACE_DECL) &&
         (contextNode->doc != NULL))
         xpctxt->doc = contextNode->doc;
-        /*
-        * Evaluate the predicate expression with 1 context node
-        * at a time; this node is packaged into a node set; this
-        * node set is handed over to the evaluation mechanism.
-        */
-        if (contextObj == NULL)
-        contextObj = xmlXPathCacheNewNodeSet(xpctxt, contextNode);
-        else {
-        if (xmlXPathNodeSetAddUnique(contextObj->nodesetval,
-            contextNode) < 0) {
-            ctxt->error = XPATH_MEMORY_ERROR;
-            goto evaluation_exit;
-        }
+
+        res = xmlXPathCompOpEvalToBoolean(ctxt, filterOp, 1);
+
+        if (ctxt->error != XPATH_EXPRESSION_OK)
+            goto exit;
+        if (res < 0) {
+            /* Shouldn't happen */
+            xmlXPathErr(ctxt, XPATH_EXPR_ERROR);
+            goto exit;
         }
 
-        valuePush(ctxt, contextObj);
-            frame = xmlXPathSetFrame(ctxt);
-        res = xmlXPathCompOpEvalToBoolean(ctxt, exprOp, 1);
-            xmlXPathPopFrame(ctxt, frame);
-            tmp = valuePop(ctxt);
-
-        if ((ctxt->error != XPATH_EXPRESSION_OK) || (res == -1)) {
-                while (tmp != contextObj) {
-                    /*
-                     * Free up the result
-                     * then pop off contextObj, which will be freed later
-                     */
-                    xmlXPathReleaseObject(xpctxt, tmp);
-                    tmp = valuePop(ctxt);
-                }
-        goto evaluation_error;
+        if ((res != 0) && ((pos >= minPos) && (pos <= maxPos))) {
+            if (i != j) {
+                locset->locTab[j] = locset->locTab[i];
+                locset->locTab[i] = NULL;
         }
-            /* push the result back onto the stack */
-            valuePush(ctxt, tmp);
 
-        if (res)
-        pos++;
-
-        if (res && (pos >= minPos) && (pos <= maxPos)) {
-        /*
-        * Fits in the requested range.
-        */
-        newContextSize++;
-        if (minPos == maxPos) {
-            /*
-            * Only 1 node was requested.
-            */
-            if (contextNode->type == XML_NAMESPACE_DECL) {
-            /*
-            * As always: take care of those nasty
-            * namespace nodes.
-            */
-            set->nodeTab[i] = NULL;
-            }
-            xmlXPathNodeSetClear(set, hasNsNodes);
-            set->nodeNr = 1;
-            set->nodeTab[0] = contextNode;
-            goto evaluation_exit;
-        }
-        if (pos == maxPos) {
-            /*
-            * We are done.
-            */
-            xmlXPathNodeSetClearFromPos(set, i +1, hasNsNodes);
-            goto evaluation_exit;
-        }
+            j += 1;
         } else {
-        /*
-        * Remove the entry from the initial node set.
-        */
-        set->nodeTab[i] = NULL;
-        if (contextNode->type == XML_NAMESPACE_DECL)
-            xmlXPathNodeSetFreeNs((xmlNsPtr) contextNode);
+            /* Remove the entry from the initial location set. */
+            xmlXPathFreeObject(locset->locTab[i]);
+            locset->locTab[i] = NULL;
         }
-        if (exprRes != NULL) {
-        xmlXPathReleaseObject(ctxt->context, exprRes);
-        exprRes = NULL;
+
+        if (res != 0) {
+            if (pos == maxPos) {
+                /* Clear remaining nodes and exit loop. */
+                for (i++; i < locset->locNr; i++) {
+                    xmlXPathFreeObject(locset->locTab[i]);
         }
-        if (ctxt->value == contextObj) {
-        /*
-        * Don't free the temporary XPath object holding the
-        * context node, in order to avoid massive recreation
-        * inside this loop.
-        */
-        valuePop(ctxt);
-        xmlXPathNodeSetClear(contextObj->nodesetval, hasNsNodes);
+                break;
+    }
+
+            pos += 1;
+    }
+}
+
+    locset->locNr = j;
+
+    /* If too many elements were removed, shrink table to preserve memory. */
+    if ((locset->locMax > XML_NODESET_DEFAULT) &&
+        (locset->locNr < locset->locMax / 2)) {
+        xmlXPathObjectPtr *tmp;
+        int locMax = locset->locNr;
+
+        if (locMax < XML_NODESET_DEFAULT)
+            locMax = XML_NODESET_DEFAULT;
+        tmp = (xmlXPathObjectPtr *) xmlRealloc(locset->locTab,
+                locMax * sizeof(xmlXPathObjectPtr));
+        if (tmp == NULL) {
+            xmlXPathPErrMemory(ctxt, "shrinking locset\n");
         } else {
-        /*
-        * The object was lost in the evaluation machinery.
-        * Can this happen? Maybe in case of internal-errors.
-        */
-        contextObj = NULL;
+            locset->locTab = tmp;
+            locset->locMax = locMax;
         }
-    }
-    goto evaluation_exit;
+        }
 
-evaluation_error:
-    xmlXPathNodeSetClear(set, hasNsNodes);
-    newContextSize = 0;
-
-evaluation_exit:
-    if (contextObj != NULL) {
-        if (ctxt->value == contextObj)
-        valuePop(ctxt);
-        xmlXPathReleaseObject(xpctxt, contextObj);
-    }
-    if (exprRes != NULL)
-        xmlXPathReleaseObject(ctxt->context, exprRes);
-    /*
-    * Reset/invalidate the context.
-    */
-    xpctxt->node = oldContextNode;
-    xpctxt->doc = oldContextDoc;
+exit:
+    xpctxt->node = oldnode;
+    xpctxt->doc = olddoc;
     xpctxt->contextSize = oldcs;
     xpctxt->proximityPosition = oldpp;
-    return(newContextSize);
+        }
+#endif /* LIBXML_XPTR_ENABLED */
+
+/**
+ * xmlXPathCompOpEvalPredicate:
+ * @ctxt:  the XPath Parser context
+ * @op: the predicate op
+ * @set: the node set to filter
+ * @minPos: minimum position in the filtered set (1-based)
+ * @maxPos: maximum position in the filtered set (1-based)
+ * @hasNsNodes: true if the node set may contain namespace nodes
+ *
+ * Filter a node set, keeping only nodes for which the sequence of predicate
+ * expressions matches. Afterwards, keep only nodes between minPos and maxPos
+ * in the filtered result.
+        */
+static void
+xmlXPathCompOpEvalPredicate(xmlXPathParserContextPtr ctxt,
+                xmlXPathStepOpPtr op,
+                xmlNodeSetPtr set,
+                            int minPos, int maxPos,
+                int hasNsNodes)
+{
+    if (op->ch1 != -1) {
+    xmlXPathCompExprPtr comp = ctxt->comp;
+        /*
+    * Process inner predicates first.
+        */
+    if (comp->steps[op->ch1].op != XPATH_OP_PREDICATE) {
+            xmlGenericError(xmlGenericErrorContext,
+                "xmlXPathCompOpEvalPredicate: Expected a predicate\n");
+            XP_ERROR(XPATH_INVALID_OPERAND);
+        }
+        if (ctxt->context->depth >= ctxt->context->maxDepth)
+            XP_ERROR(XPATH_RECURSION_LIMIT_EXCEEDED);
+        ctxt->context->depth += 1;
+    xmlXPathCompOpEvalPredicate(ctxt, &comp->steps[op->ch1], set,
+                                    1, set->nodeNr, hasNsNodes);
+        ctxt->context->depth -= 1;
+    CHECK_ERROR;
     }
-    return(contextSize);
+
+    if (op->ch2 != -1)
+        xmlXPathNodeSetFilter(ctxt, set, op->ch2, minPos, maxPos, hasNsNodes);
 }
 
 static int
@@ -12013,7 +11894,7 @@ xmlXPathIsPositionalPredicate(xmlXPathParserContextPtr ctxt,
     * 1) For predicates (XPATH_OP_PREDICATE):
     *    - an inner predicate operator
     * 2) For filters (XPATH_OP_FILTER):
-    *    - an inner filter operater OR
+    *    - an inner filter operator OR
     *    - an expression selecting the node set.
     *      E.g. "key('a', 'b')" or "(//foo | //bar)".
     */
@@ -12111,7 +11992,7 @@ xmlXPathNodeCollectAndTest(xmlXPathParserContextPtr ctxt,
     /* First predicate operator */
     xmlXPathStepOpPtr predOp;
     int maxPos; /* The requested position() (when a "[n]" predicate) */
-    int hasPredicateRange, hasAxisRange, pos, size, newSize;
+    int hasPredicateRange, hasAxisRange, pos;
     int breakOnFirstHit;
 
     xmlXPathTraversalFunction next = NULL;
@@ -12304,6 +12185,7 @@ xmlXPathNodeCollectAndTest(xmlXPathParserContextPtr ctxt,
     if (seq == NULL) {
         seq = xmlXPathNodeSetCreate(NULL);
         if (seq == NULL) {
+                /* TODO: Propagate memory error. */
         total = 0;
         goto error;
         }
@@ -12315,6 +12197,9 @@ xmlXPathNodeCollectAndTest(xmlXPathParserContextPtr ctxt,
     cur = NULL;
     hasNsNodes = 0;
         do {
+            if (OP_LIMIT_EXCEEDED(ctxt, 1))
+                goto error;
+
             cur = next(ctxt, cur);
             if (cur == NULL)
                 break;
@@ -12522,7 +12407,8 @@ axis_range_end: /* ----------------------------------------------------- */
         outSeq = seq;
         seq = NULL;
     } else
-        outSeq = mergeAndClear(outSeq, seq, 0);
+            /* TODO: Check memory error. */
+        outSeq = mergeAndClear(outSeq, seq);
     /*
     * Break if only a true/false result was requested.
     */
@@ -12539,7 +12425,8 @@ first_hit: /* ---------------------------------------------------------- */
         outSeq = seq;
         seq = NULL;
     } else
-        outSeq = mergeAndClear(outSeq, seq, 0);
+            /* TODO: Check memory error. */
+        outSeq = mergeAndClear(outSeq, seq);
     break;
 
 #ifdef DEBUG_STEP
@@ -12583,51 +12470,20 @@ apply_predicates: /* --------------------------------------------------- */
         * For the moment, I'll try to solve this with a recursive
         * function: xmlXPathCompOpEvalPredicate().
         */
-        size = seq->nodeNr;
         if (hasPredicateRange != 0)
-        newSize = xmlXPathCompOpEvalPositionalPredicate(ctxt,
-            predOp, seq, size, maxPos, maxPos, hasNsNodes);
+        xmlXPathCompOpEvalPredicate(ctxt, predOp, seq, maxPos, maxPos,
+                        hasNsNodes);
         else
-        newSize = xmlXPathCompOpEvalPredicate(ctxt,
-            predOp, seq, size, hasNsNodes);
+        xmlXPathCompOpEvalPredicate(ctxt, predOp, seq, 1, seq->nodeNr,
+                        hasNsNodes);
 
         if (ctxt->error != XPATH_EXPRESSION_OK) {
         total = 0;
         goto error;
         }
-        /*
-        * Add the filtered set of nodes to the result node set.
-        */
-        if (newSize == 0) {
-        /*
-        * The predicates filtered all nodes out.
-        */
-        xmlXPathNodeSetClear(seq, hasNsNodes);
-        } else if (seq->nodeNr > 0) {
-        /*
-        * Add to result set.
-        */
-        if (outSeq == NULL) {
-            if (size != newSize) {
-            /*
-            * We need to merge and clear here, since
-            * the sequence will contained NULLed entries.
-            */
-            outSeq = mergeAndClear(NULL, seq, 1);
-            } else {
-            outSeq = seq;
-            seq = NULL;
-            }
-        } else
-            outSeq = mergeAndClear(outSeq, seq,
-            (size != newSize) ? 1: 0);
-        /*
-        * Break if only a true/false result was requested.
-        */
-        if (toBool)
-            break;
         }
-        } else if (seq->nodeNr > 0) {
+
+        if (seq->nodeNr > 0) {
         /*
         * Add to result set.
         */
@@ -12635,8 +12491,12 @@ apply_predicates: /* --------------------------------------------------- */
         outSeq = seq;
         seq = NULL;
         } else {
-        outSeq = mergeAndClear(outSeq, seq, 0);
+                /* TODO: Check memory error. */
+        outSeq = mergeAndClear(outSeq, seq);
         }
+
+            if (toBool)
+                break;
     }
     }
 
@@ -12655,14 +12515,14 @@ error:
     xmlXPathReleaseObject(xpctxt, obj);
 
     /*
-    * Ensure we return at least an emtpy set.
+    * Ensure we return at least an empty set.
     */
     if (outSeq == NULL) {
     if ((seq != NULL) && (seq->nodeNr == 0))
         outSeq = seq;
     else
+            /* TODO: Check memory error. */
         outSeq = xmlXPathNodeSetCreate(NULL);
-        /* XXX what if xmlXPathNodeSetCreate returned NULL here? */
     }
     if ((seq != NULL) && (seq != outSeq)) {
      xmlXPathFreeNodeSet(seq);
@@ -12718,10 +12578,15 @@ xmlXPathCompOpEvalFirst(xmlXPathParserContextPtr ctxt,
     xmlXPathObjectPtr arg1, arg2;
 
     CHECK_ERROR0;
+    if (OP_LIMIT_EXCEEDED(ctxt, 1))
+        return(0);
+    if (ctxt->context->depth >= ctxt->context->maxDepth)
+        XP_ERROR0(XPATH_RECURSION_LIMIT_EXCEEDED);
+    ctxt->context->depth += 1;
     comp = ctxt->comp;
     switch (op->op) {
         case XPATH_OP_END:
-            return (0);
+            break;
         case XPATH_OP_UNION:
             total =
                 xmlXPathCompOpEvalFirst(ctxt, &comp->steps[op->ch1],
@@ -12735,11 +12600,11 @@ xmlXPathCompOpEvalFirst(xmlXPathParserContextPtr ctxt,
                  * limit tree traversing to first node in the result
                  */
         /*
-        * OPTIMIZE TODO: This implicitely sorts
+        * OPTIMIZE TODO: This implicitly sorts
         *  the result, even if not needed. E.g. if the argument
         *  of the count() function, no sorting is needed.
         * OPTIMIZE TODO: How do we know if the node-list wasn't
-        *  aready sorted?
+        *  already sorted?
         */
         if (ctxt->value->nodesetval->nodeNr > 1)
             xmlXPathNodeSetSort(ctxt->value->nodesetval);
@@ -12758,7 +12623,19 @@ xmlXPathCompOpEvalFirst(xmlXPathParserContextPtr ctxt,
             xmlXPathReleaseObject(ctxt->context, arg2);
                 XP_ERROR0(XPATH_INVALID_TYPE);
             }
+            if ((ctxt->context->opLimit != 0) &&
+                (((arg1->nodesetval != NULL) &&
+                  (xmlXPathCheckOpLimit(ctxt,
+                                        arg1->nodesetval->nodeNr) < 0)) ||
+                 ((arg2->nodesetval != NULL) &&
+                  (xmlXPathCheckOpLimit(ctxt,
+                                        arg2->nodesetval->nodeNr) < 0)))) {
+            xmlXPathReleaseObject(ctxt->context, arg1);
+            xmlXPathReleaseObject(ctxt->context, arg2);
+                break;
+            }
 
+            /* TODO: Check memory error. */
             arg1->nodesetval = xmlXPathNodeSetMerge(arg1->nodesetval,
                                                     arg2->nodesetval);
             valuePush(ctxt, arg1);
@@ -12766,10 +12643,11 @@ xmlXPathCompOpEvalFirst(xmlXPathParserContextPtr ctxt,
             /* optimizer */
         if (total > cur)
         xmlXPathCompSwap(op);
-            return (total + cur);
+            total += cur;
+            break;
         case XPATH_OP_ROOT:
             xmlXPathRoot(ctxt);
-            return (0);
+            break;
         case XPATH_OP_NODE:
             if (op->ch1 != -1)
                 total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
@@ -12779,22 +12657,22 @@ xmlXPathCompOpEvalFirst(xmlXPathParserContextPtr ctxt,
         CHECK_ERROR0;
         valuePush(ctxt, xmlXPathCacheNewNodeSet(ctxt->context,
         ctxt->context->node));
-            return (total);
+            break;
         case XPATH_OP_COLLECT:{
                 if (op->ch1 == -1)
-                    return (total);
+                    break;
 
                 total = xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
         CHECK_ERROR0;
 
                 total += xmlXPathNodeCollectAndTest(ctxt, op, first, NULL, 0);
-                return (total);
+                break;
             }
         case XPATH_OP_VALUE:
             valuePush(ctxt,
                       xmlXPathCacheObjectCopy(ctxt->context,
             (xmlXPathObjectPtr) op->value4));
-            return (0);
+            break;
         case XPATH_OP_SORT:
             if (op->ch1 != -1)
                 total +=
@@ -12806,15 +12684,19 @@ xmlXPathCompOpEvalFirst(xmlXPathParserContextPtr ctxt,
                 && (ctxt->value->nodesetval != NULL)
         && (ctxt->value->nodesetval->nodeNr > 1))
                 xmlXPathNodeSetSort(ctxt->value->nodesetval);
-            return (total);
+            break;
 #ifdef XP_OPTIMIZED_FILTER_FIRST
     case XPATH_OP_FILTER:
                 total += xmlXPathCompOpEvalFilterFirst(ctxt, op, first);
-            return (total);
+            break;
 #endif
         default:
-            return (xmlXPathCompOpEval(ctxt, op));
+            total += xmlXPathCompOpEval(ctxt, op);
+            break;
     }
+
+    ctxt->context->depth -= 1;
+    return(total);
 }
 
 /**
@@ -12837,10 +12719,15 @@ xmlXPathCompOpEvalLast(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op,
     xmlXPathObjectPtr arg1, arg2;
 
     CHECK_ERROR0;
+    if (OP_LIMIT_EXCEEDED(ctxt, 1))
+        return(0);
+    if (ctxt->context->depth >= ctxt->context->maxDepth)
+        XP_ERROR0(XPATH_RECURSION_LIMIT_EXCEEDED);
+    ctxt->context->depth += 1;
     comp = ctxt->comp;
     switch (op->op) {
         case XPATH_OP_END:
-            return (0);
+            break;
         case XPATH_OP_UNION:
             total =
                 xmlXPathCompOpEvalLast(ctxt, &comp->steps[op->ch1], last);
@@ -12876,7 +12763,19 @@ xmlXPathCompOpEvalLast(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op,
             xmlXPathReleaseObject(ctxt->context, arg2);
                 XP_ERROR0(XPATH_INVALID_TYPE);
             }
+            if ((ctxt->context->opLimit != 0) &&
+                (((arg1->nodesetval != NULL) &&
+                  (xmlXPathCheckOpLimit(ctxt,
+                                        arg1->nodesetval->nodeNr) < 0)) ||
+                 ((arg2->nodesetval != NULL) &&
+                  (xmlXPathCheckOpLimit(ctxt,
+                                        arg2->nodesetval->nodeNr) < 0)))) {
+            xmlXPathReleaseObject(ctxt->context, arg1);
+            xmlXPathReleaseObject(ctxt->context, arg2);
+                break;
+            }
 
+            /* TODO: Check memory error. */
             arg1->nodesetval = xmlXPathNodeSetMerge(arg1->nodesetval,
                                                     arg2->nodesetval);
             valuePush(ctxt, arg1);
@@ -12884,10 +12783,11 @@ xmlXPathCompOpEvalLast(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op,
             /* optimizer */
         if (total > cur)
         xmlXPathCompSwap(op);
-            return (total + cur);
+            total += cur;
+            break;
         case XPATH_OP_ROOT:
             xmlXPathRoot(ctxt);
-            return (0);
+            break;
         case XPATH_OP_NODE:
             if (op->ch1 != -1)
                 total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
@@ -12897,22 +12797,22 @@ xmlXPathCompOpEvalLast(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op,
         CHECK_ERROR0;
         valuePush(ctxt, xmlXPathCacheNewNodeSet(ctxt->context,
         ctxt->context->node));
-            return (total);
+            break;
         case XPATH_OP_COLLECT:{
                 if (op->ch1 == -1)
-                    return (0);
+                    break;
 
                 total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
         CHECK_ERROR0;
 
                 total += xmlXPathNodeCollectAndTest(ctxt, op, NULL, last, 0);
-                return (total);
+                break;
             }
         case XPATH_OP_VALUE:
             valuePush(ctxt,
                       xmlXPathCacheObjectCopy(ctxt->context,
             (xmlXPathObjectPtr) op->value4));
-            return (0);
+            break;
         case XPATH_OP_SORT:
             if (op->ch1 != -1)
                 total +=
@@ -12924,10 +12824,14 @@ xmlXPathCompOpEvalLast(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op,
                 && (ctxt->value->nodesetval != NULL)
         && (ctxt->value->nodesetval->nodeNr > 1))
                 xmlXPathNodeSetSort(ctxt->value->nodesetval);
-            return (total);
+            break;
         default:
-            return (xmlXPathCompOpEval(ctxt, op));
+            total += xmlXPathCompOpEval(ctxt, op);
+            break;
     }
+
+    ctxt->context->depth -= 1;
+    return (total);
 }
 
 #ifdef XP_OPTIMIZED_FILTER_FIRST
@@ -12937,13 +12841,7 @@ xmlXPathCompOpEvalFilterFirst(xmlXPathParserContextPtr ctxt,
 {
     int total = 0;
     xmlXPathCompExprPtr comp;
-    xmlXPathObjectPtr res;
-    xmlXPathObjectPtr obj;
-    xmlNodeSetPtr oldset;
-    xmlNodePtr oldnode;
-    xmlDocPtr oldDoc;
-    int oldcs, oldpp;
-    int i;
+    xmlNodeSetPtr set;
 
     CHECK_ERROR0;
     comp = ctxt->comp;
@@ -12994,208 +12892,30 @@ xmlXPathCompOpEvalFilterFirst(xmlXPathParserContextPtr ctxt,
     return (total);
 
 #ifdef LIBXML_XPTR_ENABLED
-    /*
+        /*
     * Hum are we filtering the result of an XPointer expression
-    */
+        */
     if (ctxt->value->type == XPATH_LOCATIONSET) {
-    xmlXPathObjectPtr tmp = NULL;
-    xmlLocationSetPtr newlocset = NULL;
-    xmlLocationSetPtr oldlocset;
+        xmlLocationSetPtr locset = ctxt->value->user;
 
-    /*
-    * Extract the old locset, and then evaluate the result of the
-    * expression for all the element in the locset. use it to grow
-    * up a new locset.
-    */
-    CHECK_TYPE0(XPATH_LOCATIONSET);
-
-    if ((ctxt->value->user == NULL) ||
-            (((xmlLocationSetPtr) ctxt->value->user)->locNr == 0))
-        return (total);
-
-    obj = valuePop(ctxt);
-    oldlocset = obj->user;
-        oldnode = ctxt->context->node;
-        oldcs = ctxt->context->contextSize;
-        oldpp = ctxt->context->proximityPosition;
-
-    newlocset = xmlXPtrLocationSetCreate(NULL);
-
-    for (i = 0; i < oldlocset->locNr; i++) {
-        /*
-        * Run the evaluation with a node list made of a
-        * single item in the nodelocset.
-        */
-        ctxt->context->node = oldlocset->locTab[i]->user;
-        ctxt->context->contextSize = oldlocset->locNr;
-        ctxt->context->proximityPosition = i + 1;
-        if (tmp == NULL) {
-        tmp = xmlXPathCacheNewNodeSet(ctxt->context,
-            ctxt->context->node);
-        } else {
-        if (xmlXPathNodeSetAddUnique(tmp->nodesetval,
-                                     ctxt->context->node) < 0) {
-            ctxt->error = XPATH_MEMORY_ERROR;
-        }
-        }
-        valuePush(ctxt, tmp);
-        if (op->ch2 != -1)
-        total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch2]);
-        if (ctxt->error != XPATH_EXPRESSION_OK) {
-                xmlXPtrFreeLocationSet(newlocset);
-                goto xptr_error;
-        }
-        /*
-        * The result of the evaluation need to be tested to
-        * decided whether the filter succeeded or not
-        */
-        res = valuePop(ctxt);
-        if (xmlXPathEvaluatePredicateResult(ctxt, res)) {
-        xmlXPtrLocationSetAdd(newlocset,
-            xmlXPathCacheObjectCopy(ctxt->context,
-            oldlocset->locTab[i]));
-        }
-        /*
-        * Cleanup
-        */
-        if (res != NULL) {
-        xmlXPathReleaseObject(ctxt->context, res);
-        }
-        if (ctxt->value == tmp) {
-        valuePop(ctxt);
-        xmlXPathNodeSetClear(tmp->nodesetval, 1);
-        /*
-        * REVISIT TODO: Don't create a temporary nodeset
-        * for everly iteration.
-        */
-        /* OLD: xmlXPathFreeObject(res); */
-        } else
-        tmp = NULL;
-        /*
-        * Only put the first node in the result, then leave.
-        */
-        if (newlocset->locNr > 0) {
-        *first = (xmlNodePtr) oldlocset->locTab[i]->user;
-        break;
-        }
+        if (locset != NULL) {
+            xmlXPathLocationSetFilter(ctxt, locset, op->ch2, 1, 1);
+            if (locset->locNr > 0)
+                *first = (xmlNodePtr) locset->locTab[0]->user;
     }
-    if (tmp != NULL) {
-        xmlXPathReleaseObject(ctxt->context, tmp);
-    }
-    /*
-    * The result is used as the new evaluation locset.
-    */
-    valuePush(ctxt, xmlXPtrWrapLocationSet(newlocset));
-xptr_error:
-    xmlXPathReleaseObject(ctxt->context, obj);
-    ctxt->context->node = oldnode;
-    ctxt->context->contextSize = oldcs;
-    ctxt->context->proximityPosition = oldpp;
+
     return (total);
     }
 #endif /* LIBXML_XPTR_ENABLED */
 
-    /*
-    * Extract the old set, and then evaluate the result of the
-    * expression for all the element in the set. use it to grow
-    * up a new set.
-    */
     CHECK_TYPE0(XPATH_NODESET);
-
-    if ((ctxt->value->nodesetval != NULL) &&
-        (ctxt->value->nodesetval->nodeNr != 0)) {
-    xmlNodeSetPtr newset;
-    xmlXPathObjectPtr tmp = NULL;
-
-        obj = valuePop(ctxt);
-        oldset = obj->nodesetval;
-        oldnode = ctxt->context->node;
-        oldDoc = ctxt->context->doc;
-        oldcs = ctxt->context->contextSize;
-        oldpp = ctxt->context->proximityPosition;
-
-    /*
-    * Initialize the new set.
-    * Also set the xpath document in case things like
-    * key() evaluation are attempted on the predicate
-    */
-    newset = xmlXPathNodeSetCreate(NULL);
-        /* XXX what if xmlXPathNodeSetCreate returned NULL? */
-
-    for (i = 0; i < oldset->nodeNr; i++) {
-        /*
-        * Run the evaluation with a node list made of
-        * a single item in the nodeset.
-        */
-        ctxt->context->node = oldset->nodeTab[i];
-        if ((oldset->nodeTab[i]->type != XML_NAMESPACE_DECL) &&
-        (oldset->nodeTab[i]->doc != NULL))
-        ctxt->context->doc = oldset->nodeTab[i]->doc;
-        if (tmp == NULL) {
-        tmp = xmlXPathCacheNewNodeSet(ctxt->context,
-            ctxt->context->node);
-        } else {
-        if (xmlXPathNodeSetAddUnique(tmp->nodesetval,
-                                     ctxt->context->node) < 0) {
-            ctxt->error = XPATH_MEMORY_ERROR;
-        }
-        }
-        valuePush(ctxt, tmp);
-        ctxt->context->contextSize = oldset->nodeNr;
-        ctxt->context->proximityPosition = i + 1;
-        if (op->ch2 != -1)
-        total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch2]);
-        if (ctxt->error != XPATH_EXPRESSION_OK) {
-        xmlXPathFreeNodeSet(newset);
-                goto error;
-        }
-        /*
-        * The result of the evaluation needs to be tested to
-        * decide whether the filter succeeded or not
-        */
-        res = valuePop(ctxt);
-        if (xmlXPathEvaluatePredicateResult(ctxt, res)) {
-        if (xmlXPathNodeSetAdd(newset, oldset->nodeTab[i]) < 0)
-            ctxt->error = XPATH_MEMORY_ERROR;
-        }
-        /*
-        * Cleanup
-        */
-        if (res != NULL) {
-        xmlXPathReleaseObject(ctxt->context, res);
-        }
-        if (ctxt->value == tmp) {
-        valuePop(ctxt);
-        /*
-        * Don't free the temporary nodeset
-        * in order to avoid massive recreation inside this
-        * loop.
-        */
-        xmlXPathNodeSetClear(tmp->nodesetval, 1);
-        } else
-        tmp = NULL;
-        /*
-        * Only put the first node in the result, then leave.
-        */
-        if (newset->nodeNr > 0) {
-        *first = *(newset->nodeTab);
-        break;
-        }
+    set = ctxt->value->nodesetval;
+    if (set != NULL) {
+        xmlXPathNodeSetFilter(ctxt, set, op->ch2, 1, 1, 1);
+        if (set->nodeNr > 0)
+            *first = set->nodeTab[0];
     }
-    if (tmp != NULL) {
-        xmlXPathReleaseObject(ctxt->context, tmp);
-    }
-    /*
-    * The result is used as the new evaluation set.
-    */
-    valuePush(ctxt, xmlXPathCacheWrapNodeSet(ctxt->context, newset));
-error:
-    xmlXPathReleaseObject(ctxt->context, obj);
-    ctxt->context->node = oldnode;
-    ctxt->context->doc = oldDoc;
-    ctxt->context->contextSize = oldcs;
-    ctxt->context->proximityPosition = oldpp;
-    }
+
     return(total);
 }
 #endif /* XP_OPTIMIZED_FILTER_FIRST */
@@ -13217,44 +12937,49 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
     xmlXPathObjectPtr arg1, arg2;
 
     CHECK_ERROR0;
+    if (OP_LIMIT_EXCEEDED(ctxt, 1))
+        return(0);
+    if (ctxt->context->depth >= ctxt->context->maxDepth)
+        XP_ERROR0(XPATH_RECURSION_LIMIT_EXCEEDED);
+    ctxt->context->depth += 1;
     comp = ctxt->comp;
     switch (op->op) {
         case XPATH_OP_END:
-            return (0);
+            break;
         case XPATH_OP_AND:
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
         CHECK_ERROR0;
             xmlXPathBooleanFunction(ctxt, 1);
             if ((ctxt->value == NULL) || (ctxt->value->boolval == 0))
-                return (total);
+                break;
             arg2 = valuePop(ctxt);
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch2]);
         if (ctxt->error) {
         xmlXPathFreeObject(arg2);
-        return(0);
+        break;
         }
             xmlXPathBooleanFunction(ctxt, 1);
             if (ctxt->value != NULL)
                 ctxt->value->boolval &= arg2->boolval;
         xmlXPathReleaseObject(ctxt->context, arg2);
-            return (total);
+            break;
         case XPATH_OP_OR:
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
         CHECK_ERROR0;
             xmlXPathBooleanFunction(ctxt, 1);
             if ((ctxt->value == NULL) || (ctxt->value->boolval == 1))
-                return (total);
+                break;
             arg2 = valuePop(ctxt);
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch2]);
         if (ctxt->error) {
         xmlXPathFreeObject(arg2);
-        return(0);
+        break;
         }
             xmlXPathBooleanFunction(ctxt, 1);
             if (ctxt->value != NULL)
                 ctxt->value->boolval |= arg2->boolval;
         xmlXPathReleaseObject(ctxt->context, arg2);
-            return (total);
+            break;
         case XPATH_OP_EQUAL:
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
         CHECK_ERROR0;
@@ -13265,7 +12990,7 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
         else
         equal = xmlXPathNotEqualValues(ctxt);
         valuePush(ctxt, xmlXPathCacheNewBoolean(ctxt->context, equal));
-            return (total);
+            break;
         case XPATH_OP_CMP:
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
         CHECK_ERROR0;
@@ -13273,7 +12998,7 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
         CHECK_ERROR0;
             ret = xmlXPathCompareValues(ctxt, op->value, op->value2);
         valuePush(ctxt, xmlXPathCacheNewBoolean(ctxt->context, ret));
-            return (total);
+            break;
         case XPATH_OP_PLUS:
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
         CHECK_ERROR0;
@@ -13291,7 +13016,7 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                 CAST_TO_NUMBER;
                 CHECK_TYPE0(XPATH_NUMBER);
             }
-            return (total);
+            break;
         case XPATH_OP_MULT:
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
         CHECK_ERROR0;
@@ -13303,7 +13028,7 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                 xmlXPathDivValues(ctxt);
             else if (op->value == 2)
                 xmlXPathModValues(ctxt);
-            return (total);
+            break;
         case XPATH_OP_UNION:
             total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
         CHECK_ERROR0;
@@ -13318,21 +13043,33 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
             xmlXPathReleaseObject(ctxt->context, arg2);
                 XP_ERROR0(XPATH_INVALID_TYPE);
             }
+            if ((ctxt->context->opLimit != 0) &&
+                (((arg1->nodesetval != NULL) &&
+                  (xmlXPathCheckOpLimit(ctxt,
+                                        arg1->nodesetval->nodeNr) < 0)) ||
+                 ((arg2->nodesetval != NULL) &&
+                  (xmlXPathCheckOpLimit(ctxt,
+                                        arg2->nodesetval->nodeNr) < 0)))) {
+            xmlXPathReleaseObject(ctxt->context, arg1);
+            xmlXPathReleaseObject(ctxt->context, arg2);
+                break;
+            }
 
         if ((arg1->nodesetval == NULL) ||
         ((arg2->nodesetval != NULL) &&
          (arg2->nodesetval->nodeNr != 0)))
         {
+                /* TODO: Check memory error. */
         arg1->nodesetval = xmlXPathNodeSetMerge(arg1->nodesetval,
                             arg2->nodesetval);
         }
 
             valuePush(ctxt, arg1);
         xmlXPathReleaseObject(ctxt->context, arg2);
-            return (total);
+            break;
         case XPATH_OP_ROOT:
             xmlXPathRoot(ctxt);
-            return (total);
+            break;
         case XPATH_OP_NODE:
             if (op->ch1 != -1)
                 total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
@@ -13342,22 +13079,22 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
         CHECK_ERROR0;
         valuePush(ctxt, xmlXPathCacheNewNodeSet(ctxt->context,
         ctxt->context->node));
-            return (total);
+            break;
         case XPATH_OP_COLLECT:{
                 if (op->ch1 == -1)
-                    return (total);
+                    break;
 
                 total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
         CHECK_ERROR0;
 
                 total += xmlXPathNodeCollectAndTest(ctxt, op, NULL, NULL, 0);
-                return (total);
+                break;
             }
         case XPATH_OP_VALUE:
             valuePush(ctxt,
                       xmlXPathCacheObjectCopy(ctxt->context,
             (xmlXPathObjectPtr) op->value4));
-            return (total);
+            break;
         case XPATH_OP_VARIABLE:{
         xmlXPathObjectPtr val;
 
@@ -13378,7 +13115,7 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
             "xmlXPathCompOpEval: variable %s bound to undefined prefix %s\n",
                                     (char *) op->value4, (char *)op->value5);
                         ctxt->error = XPATH_UNDEF_PREFIX_ERROR;
-                        return (total);
+                        break;
                     }
             val = xmlXPathVariableLookupNS(ctxt->context,
                                                        op->value4, URI);
@@ -13386,7 +13123,7 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
             XP_ERROR0(XPATH_UNDEF_VARIABLE_ERROR);
                     valuePush(ctxt, val);
                 }
-                return (total);
+                break;
             }
         case XPATH_OP_FUNCTION:{
                 xmlXPathFunction func;
@@ -13400,7 +13137,7 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                         xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
                     if (ctxt->error != XPATH_EXPRESSION_OK) {
                         xmlXPathPopFrame(ctxt, frame);
-                        return (total);
+                        break;
                     }
                 }
         if (ctxt->valueNr < ctxt->valueFrame + op->value) {
@@ -13408,7 +13145,7 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                 "xmlXPathCompOpEval: parameter error\n");
             ctxt->error = XPATH_INVALID_OPERAND;
                     xmlXPathPopFrame(ctxt, frame);
-            return (total);
+            break;
         }
         for (i = 0; i < op->value; i++) {
             if (ctxt->valueTab[(ctxt->valueNr - 1) - i] == NULL) {
@@ -13416,7 +13153,7 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                 "xmlXPathCompOpEval: parameter error\n");
             ctxt->error = XPATH_INVALID_OPERAND;
                         xmlXPathPopFrame(ctxt, frame);
-            return (total);
+            break;
             }
                 }
                 if (op->cache != NULL)
@@ -13436,7 +13173,7 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                                     (char *)op->value4, (char *)op->value5);
                             xmlXPathPopFrame(ctxt, frame);
                             ctxt->error = XPATH_UNDEF_PREFIX_ERROR;
-                            return (total);
+                            break;
                         }
                         func = xmlXPathFunctionLookupNS(ctxt->context,
                                                         op->value4, URI);
@@ -13457,8 +13194,11 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                 func(ctxt, op->value);
                 ctxt->context->function = oldFunc;
                 ctxt->context->functionURI = oldFuncURI;
+                if ((ctxt->error == XPATH_EXPRESSION_OK) &&
+                    (ctxt->valueNr != ctxt->valueFrame + 1))
+                    XP_ERROR0(XPATH_STACK_ERROR);
                 xmlXPathPopFrame(ctxt, frame);
-                return (total);
+                break;
             }
         case XPATH_OP_ARG:
             if (op->ch1 != -1) {
@@ -13469,17 +13209,10 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                 total += xmlXPathCompOpEval(ctxt, &comp->steps[op->ch2]);
             CHECK_ERROR0;
         }
-            return (total);
+            break;
         case XPATH_OP_PREDICATE:
         case XPATH_OP_FILTER:{
-                xmlXPathObjectPtr res;
-                xmlXPathObjectPtr obj, tmp;
-                xmlNodeSetPtr newset = NULL;
-                xmlNodeSetPtr oldset;
-                xmlNodePtr oldnode;
-        xmlDocPtr oldDoc;
-                int oldcs, oldpp;
-                int i;
+                xmlNodeSetPtr set;
 
                 /*
                  * Optimization for ()[1] selection i.e. the first elem
@@ -13491,7 +13224,7 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
             *  will result in an ordered list if we have an
             *  XPATH_OP_FILTER?
             *  What about an additional field or flag on
-            *  xmlXPathObject like @sorted ? This way we wouln'd need
+            *  xmlXPathObject like @sorted ? This way we wouldn't need
             *  to assume anything, so it would be more robust and
             *  easier to optimize.
             */
@@ -13523,7 +13256,7 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                             (ctxt->value->nodesetval->nodeNr > 1))
                             xmlXPathNodeSetClearFromPos(ctxt->value->nodesetval,
                                                         1, 1);
-                        return (total);
+                        break;
                     }
                 }
                 /*
@@ -13558,7 +13291,7 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                             (ctxt->value->nodesetval->nodeTab != NULL) &&
                             (ctxt->value->nodesetval->nodeNr > 1))
                             xmlXPathNodeSetKeepLast(ctxt->value->nodesetval);
-                        return (total);
+                        break;
                     }
                 }
         /*
@@ -13577,224 +13310,28 @@ xmlXPathCompOpEval(xmlXPathParserContextPtr ctxt, xmlXPathStepOpPtr op)
                         xmlXPathCompOpEval(ctxt, &comp->steps[op->ch1]);
         CHECK_ERROR0;
                 if (op->ch2 == -1)
-                    return (total);
+                    break;
                 if (ctxt->value == NULL)
-                    return (total);
+                    break;
 
 #ifdef LIBXML_XPTR_ENABLED
                 /*
                  * Hum are we filtering the result of an XPointer expression
                  */
                 if (ctxt->value->type == XPATH_LOCATIONSET) {
-                    xmlLocationSetPtr newlocset = NULL;
-                    xmlLocationSetPtr oldlocset;
-
-                    /*
-                     * Extract the old locset, and then evaluate the result of the
-                     * expression for all the element in the locset. use it to grow
-                     * up a new locset.
-                     */
-                    CHECK_TYPE0(XPATH_LOCATIONSET);
-
-                    if ((ctxt->value->user == NULL) ||
-                        (((xmlLocationSetPtr) ctxt->value->user)->locNr == 0))
-                        return (total);
-
-                    obj = valuePop(ctxt);
-                    oldlocset = obj->user;
-                    oldnode = ctxt->context->node;
-                    oldcs = ctxt->context->contextSize;
-                    oldpp = ctxt->context->proximityPosition;
-
-                    newlocset = xmlXPtrLocationSetCreate(NULL);
-
-                    for (i = 0; i < oldlocset->locNr; i++) {
-                        /*
-                         * Run the evaluation with a node list made of a
-                         * single item in the nodelocset.
-                         */
-                        ctxt->context->node = oldlocset->locTab[i]->user;
-                        ctxt->context->contextSize = oldlocset->locNr;
-                        ctxt->context->proximityPosition = i + 1;
-            tmp = xmlXPathCacheNewNodeSet(ctxt->context,
-                ctxt->context->node);
-                        valuePush(ctxt, tmp);
-
-                        if (op->ch2 != -1)
-                            total +=
-                                xmlXPathCompOpEval(ctxt,
-                                                   &comp->steps[op->ch2]);
-            if (ctxt->error != XPATH_EXPRESSION_OK) {
-                            xmlXPtrFreeLocationSet(newlocset);
-                            goto filter_xptr_error;
-            }
-
-                        /*
-                         * The result of the evaluation need to be tested to
-                         * decided whether the filter succeeded or not
-                         */
-                        res = valuePop(ctxt);
-                        if (xmlXPathEvaluatePredicateResult(ctxt, res)) {
-                            xmlXPtrLocationSetAdd(newlocset,
-                                                  xmlXPathObjectCopy
-                                                  (oldlocset->locTab[i]));
-                        }
-
-                        /*
-                         * Cleanup
-                         */
-                        if (res != NULL) {
-                xmlXPathReleaseObject(ctxt->context, res);
-            }
-                        if (ctxt->value == tmp) {
-                            res = valuePop(ctxt);
-                xmlXPathReleaseObject(ctxt->context, res);
-                        }
-                    }
-
-                    /*
-                     * The result is used as the new evaluation locset.
-                     */
-                    valuePush(ctxt, xmlXPtrWrapLocationSet(newlocset));
-filter_xptr_error:
-            xmlXPathReleaseObject(ctxt->context, obj);
-                    ctxt->context->node = oldnode;
-                    ctxt->context->contextSize = oldcs;
-                    ctxt->context->proximityPosition = oldpp;
-                    return (total);
+                    xmlLocationSetPtr locset = ctxt->value->user;
+                    xmlXPathLocationSetFilter(ctxt, locset, op->ch2,
+                                              1, locset->locNr);
+                    break;
                 }
 #endif /* LIBXML_XPTR_ENABLED */
 
-                /*
-                 * Extract the old set, and then evaluate the result of the
-                 * expression for all the element in the set. use it to grow
-                 * up a new set.
-                 */
                 CHECK_TYPE0(XPATH_NODESET);
-
-                if ((ctxt->value->nodesetval != NULL) &&
-                    (ctxt->value->nodesetval->nodeNr != 0)) {
-                    obj = valuePop(ctxt);
-                    oldset = obj->nodesetval;
-                    oldnode = ctxt->context->node;
-                    oldDoc = ctxt->context->doc;
-                    oldcs = ctxt->context->contextSize;
-                    oldpp = ctxt->context->proximityPosition;
-            tmp = NULL;
-                    /*
-                     * Initialize the new set.
-             * Also set the xpath document in case things like
-             * key() evaluation are attempted on the predicate
-                     */
-                    newset = xmlXPathNodeSetCreate(NULL);
-            /*
-            * SPEC XPath 1.0:
-            *  "For each node in the node-set to be filtered, the
-            *  PredicateExpr is evaluated with that node as the
-            *  context node, with the number of nodes in the
-            *  node-set as the context size, and with the proximity
-            *  position of the node in the node-set with respect to
-            *  the axis as the context position;"
-            * @oldset is the node-set" to be filtered.
-            *
-            * SPEC XPath 1.0:
-            *  "only predicates change the context position and
-            *  context size (see [2.4 Predicates])."
-            * Example:
-            *   node-set  context pos
-            *    nA         1
-            *    nB         2
-            *    nC         3
-            *   After applying predicate [position() > 1] :
-            *   node-set  context pos
-            *    nB         1
-            *    nC         2
-            *
-            * removed the first node in the node-set, then
-            * the context position of the
-            */
-                    for (i = 0; i < oldset->nodeNr; i++) {
-                        /*
-                         * Run the evaluation with a node list made of
-                         * a single item in the nodeset.
-                         */
-                        ctxt->context->node = oldset->nodeTab[i];
-            if ((oldset->nodeTab[i]->type != XML_NAMESPACE_DECL) &&
-                (oldset->nodeTab[i]->doc != NULL))
-                    ctxt->context->doc = oldset->nodeTab[i]->doc;
-            if (tmp == NULL) {
-                tmp = xmlXPathCacheNewNodeSet(ctxt->context,
-                ctxt->context->node);
-            } else {
-                if (xmlXPathNodeSetAddUnique(tmp->nodesetval,
-                               ctxt->context->node) < 0) {
-                ctxt->error = XPATH_MEMORY_ERROR;
-                }
-            }
-                        valuePush(ctxt, tmp);
-                        ctxt->context->contextSize = oldset->nodeNr;
-                        ctxt->context->proximityPosition = i + 1;
-            /*
-            * Evaluate the predicate against the context node.
-            * Can/should we optimize position() predicates
-            * here (e.g. "[1]")?
-            */
-                        if (op->ch2 != -1)
-                            total +=
-                                xmlXPathCompOpEval(ctxt,
-                                                   &comp->steps[op->ch2]);
-            if (ctxt->error != XPATH_EXPRESSION_OK) {
-                xmlXPathFreeNodeSet(newset);
-                            goto filter_error;
-            }
-
-                        /*
-                         * The result of the evaluation needs to be tested to
-                         * decide whether the filter succeeded or not
-                         */
-            /*
-            * OPTIMIZE TODO: Can we use
-            * xmlXPathNodeSetAdd*Unique()* instead?
-            */
-                        res = valuePop(ctxt);
-                        if (xmlXPathEvaluatePredicateResult(ctxt, res)) {
-                            if (xmlXPathNodeSetAdd(newset, oldset->nodeTab[i])
-                    < 0)
-                ctxt->error = XPATH_MEMORY_ERROR;
-                        }
-
-                        /*
-                         * Cleanup
-                         */
-                        if (res != NULL) {
-                xmlXPathReleaseObject(ctxt->context, res);
-            }
-                        if (ctxt->value == tmp) {
-                            valuePop(ctxt);
-                xmlXPathNodeSetClear(tmp->nodesetval, 1);
-                /*
-                * Don't free the temporary nodeset
-                * in order to avoid massive recreation inside this
-                * loop.
-                */
-                        } else
-                tmp = NULL;
-                    }
-            if (tmp != NULL)
-            xmlXPathReleaseObject(ctxt->context, tmp);
-                    /*
-                     * The result is used as the new evaluation set.
-                     */
-            valuePush(ctxt,
-            xmlXPathCacheWrapNodeSet(ctxt->context, newset));
-filter_error:
-            xmlXPathReleaseObject(ctxt->context, obj);
-            ctxt->context->node = oldnode;
-            ctxt->context->doc = oldDoc;
-                    ctxt->context->contextSize = oldcs;
-                    ctxt->context->proximityPosition = oldpp;
-                }
-                return (total);
+                set = ctxt->value->nodesetval;
+                if (set != NULL)
+                    xmlXPathNodeSetFilter(ctxt, set, op->ch2,
+                                          1, set->nodeNr, 1);
+                break;
             }
         case XPATH_OP_SORT:
             if (op->ch1 != -1)
@@ -13807,7 +13344,7 @@ filter_error:
         {
                 xmlXPathNodeSetSort(ctxt->value->nodesetval);
         }
-            return (total);
+            break;
 #ifdef LIBXML_XPTR_ENABLED
         case XPATH_OP_RANGETO:{
                 xmlXPathObjectPtr range;
@@ -13830,7 +13367,7 @@ filter_error:
                     XP_ERROR0(XPATH_INVALID_OPERAND);
                 }
                 if (op->ch2 == -1)
-                    return (total);
+                    break;
 
                 if (ctxt->value->type == XPATH_LOCATIONSET) {
                     /*
@@ -13842,7 +13379,7 @@ filter_error:
 
                     if ((ctxt->value->user == NULL) ||
                         (((xmlLocationSetPtr) ctxt->value->user)->locNr == 0))
-                        return (total);
+                        break;
 
                     obj = valuePop(ctxt);
                     oldlocset = obj->user;
@@ -13964,13 +13501,17 @@ rangeto_error:
                 ctxt->context->node = oldnode;
                 ctxt->context->contextSize = oldcs;
                 ctxt->context->proximityPosition = oldpp;
-                return (total);
+                break;
             }
 #endif /* LIBXML_XPTR_ENABLED */
-    }
+        default:
     xmlGenericError(xmlGenericErrorContext,
                     "XPath: unknown precompiled operation %d\n", op->op);
     ctxt->error = XPATH_INVALID_OPERAND;
+            break;
+    }
+
+    ctxt->context->depth -= 1;
     return (total);
 }
 
@@ -13990,6 +13531,8 @@ xmlXPathCompOpEvalToBoolean(xmlXPathParserContextPtr ctxt,
     xmlXPathObjectPtr resObj = NULL;
 
 start:
+    if (OP_LIMIT_EXCEEDED(ctxt, 1))
+        return(0);
     /* comp = ctxt->comp; */
     switch (op->op) {
         case XPATH_OP_END:
@@ -14116,12 +13659,14 @@ xmlXPathRunStreamEval(xmlXPathContextPtr ctxt, xmlPatternPtr comp,
         /* Select "/" */
         if (toBool)
         return(1);
+            /* TODO: Check memory error. */
         xmlXPathNodeSetAddUnique((*resultSeq)->nodesetval,
                              (xmlNodePtr) ctxt->doc);
     } else {
         /* Select "self::node()" */
         if (toBool)
         return(1);
+            /* TODO: Check memory error. */
         xmlXPathNodeSetAddUnique((*resultSeq)->nodesetval, ctxt->node);
     }
     }
@@ -14182,6 +13727,7 @@ xmlXPathRunStreamEval(xmlXPathContextPtr ctxt, xmlPatternPtr comp,
     } else if (ret == 1) {
         if (toBool)
         goto return_1;
+            /* TODO: Check memory error. */
         xmlXPathNodeSetAddUnique((*resultSeq)->nodesetval, cur);
     }
     }
@@ -14189,6 +13735,16 @@ xmlXPathRunStreamEval(xmlXPathContextPtr ctxt, xmlPatternPtr comp,
     goto scan_children;
 next_node:
     do {
+        if (ctxt->opLimit != 0) {
+            if (ctxt->opCount >= ctxt->opLimit) {
+                xmlGenericError(xmlGenericErrorContext,
+                        "XPath operation limit exceeded\n");
+                xmlFreeStreamCtxt(patstream);
+                return(-1);
+            }
+            ctxt->opCount++;
+        }
+
         nb_nodes++;
 
     switch (cur->type) {
@@ -14311,6 +13867,8 @@ xmlXPathRunEval(xmlXPathParserContextPtr ctxt, int toBool)
 
     if ((ctxt == NULL) || (ctxt->comp == NULL))
     return(-1);
+
+    ctxt->context->depth = 0;
 
     if (ctxt->valueTab == NULL) {
     /* Allocate the value stack */
@@ -14498,7 +14056,7 @@ xmlXPathTryStreamCompile(xmlXPathContextPtr ctxt, const xmlChar *str) {
 
     /*
      * We don't try to handle expressions using the verbose axis
-     * specifiers ("::"), just the simplied form at this point.
+     * specifiers ("::"), just the simplified form at this point.
      * Additionally, if there is no list of namespaces available and
      *  there's a ":" in the expression, indicating a prefixed QName,
      *  then we won't try to compile either. xmlPatterncompile() needs
@@ -14552,8 +14110,12 @@ xmlXPathTryStreamCompile(xmlXPathContextPtr ctxt, const xmlChar *str) {
 #endif /* XPATH_STREAMING */
 
 static void
-xmlXPathOptimizeExpression(xmlXPathCompExprPtr comp, xmlXPathStepOpPtr op)
+xmlXPathOptimizeExpression(xmlXPathParserContextPtr pctxt,
+                           xmlXPathStepOpPtr op)
 {
+    xmlXPathCompExprPtr comp = pctxt->comp;
+    xmlXPathContextPtr ctxt;
+
     /*
     * Try to rewrite "descendant-or-self::node()/foo" to an optimized
     * internal representation.
@@ -14609,10 +14171,18 @@ xmlXPathOptimizeExpression(xmlXPathCompExprPtr comp, xmlXPathStepOpPtr op)
         return;
 
     /* Recurse */
+    ctxt = pctxt->context;
+    if (ctxt != NULL) {
+        if (ctxt->depth >= ctxt->maxDepth)
+            return;
+        ctxt->depth += 1;
+    }
     if (op->ch1 != -1)
-        xmlXPathOptimizeExpression(comp, &comp->steps[op->ch1]);
+        xmlXPathOptimizeExpression(pctxt, &comp->steps[op->ch1]);
     if (op->ch2 != -1)
-    xmlXPathOptimizeExpression(comp, &comp->steps[op->ch2]);
+    xmlXPathOptimizeExpression(pctxt, &comp->steps[op->ch2]);
+    if (ctxt != NULL)
+        ctxt->depth -= 1;
 }
 
 /**
@@ -14641,6 +14211,8 @@ xmlXPathCtxtCompile(xmlXPathContextPtr ctxt, const xmlChar *str) {
     pctxt = xmlXPathNewParserContext(str, ctxt);
     if (pctxt == NULL)
         return NULL;
+    if (ctxt != NULL)
+        ctxt->depth = 0;
     xmlXPathCompileExpr(pctxt, 1);
 
     if( pctxt->error != XPATH_EXPRESSION_OK )
@@ -14660,6 +14232,11 @@ xmlXPathCtxtCompile(xmlXPathContextPtr ctxt, const xmlChar *str) {
     comp = NULL;
     } else {
     comp = pctxt->comp;
+    if ((comp->nbStep > 1) && (comp->last >= 0)) {
+            if (ctxt != NULL)
+                ctxt->depth = 0;
+        xmlXPathOptimizeExpression(pctxt, &comp->steps[comp->last]);
+    }
     pctxt->comp = NULL;
     }
     xmlXPathFreeParserContext(pctxt);
@@ -14670,9 +14247,6 @@ xmlXPathCtxtCompile(xmlXPathContextPtr ctxt, const xmlChar *str) {
     comp->string = xmlStrdup(str);
     comp->nb = 0;
 #endif
-    if ((comp->nbStep > 1) && (comp->last >= 0)) {
-        xmlXPathOptimizeExpression(comp, &comp->steps[comp->last]);
-    }
     }
     return(comp);
 }
@@ -14829,6 +14403,8 @@ xmlXPathEvalExpr(xmlXPathParserContextPtr ctxt) {
     } else
 #endif
     {
+        if (ctxt->context != NULL)
+            ctxt->context->depth = 0;
     xmlXPathCompileExpr(ctxt, 1);
         CHECK_ERROR;
 
@@ -14836,9 +14412,12 @@ xmlXPathEvalExpr(xmlXPathParserContextPtr ctxt) {
         if (*ctxt->cur != 0)
             XP_ERROR(XPATH_EXPR_ERROR);
 
-    if ((ctxt->comp->nbStep > 1) && (ctxt->comp->last >= 0))
-        xmlXPathOptimizeExpression(ctxt->comp,
+    if ((ctxt->comp->nbStep > 1) && (ctxt->comp->last >= 0)) {
+            if (ctxt->context != NULL)
+                ctxt->context->depth = 0;
+        xmlXPathOptimizeExpression(ctxt,
         &ctxt->comp->steps[ctxt->comp->last]);
+    }
     }
 
     xmlXPathRunEval(ctxt, 0);

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xzlib.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xzlib.h
@@ -1,5 +1,5 @@
 /**
- * xzlib.h: header for the front end for the transparent suport of lzma
+ * xzlib.h: header for the front end for the transparent support of lzma
  *          compression at the I/O layer
  *
  * See Copyright for the status of this software.

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/win32/config.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/win32/config.h
@@ -37,7 +37,7 @@
 #if defined(_MSC_VER) || defined(__BORLANDC__)
 /* MS C-runtime has functions which can be used in order to determine if
    a given floating-point variable contains NaN, (+-)INF. These are
-   preferred, because floating-point technology is considered propriatary
+   preferred, because floating-point technology is considered proprietary
    by MS and we can assume that their functions know more about their
    oddities than we do. */
 #include <float.h>

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/win32/include/libxml/xmlversion.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/win32/include/libxml/xmlversion.h
@@ -29,21 +29,21 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.9.9"
+#define LIBXML_DOTTED_VERSION "2.9.10"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 20909
+#define LIBXML_VERSION 20910
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "20909"
+#define LIBXML_VERSION_STRING "20910"
 
 /**
  * LIBXML_VERSION_EXTRA:
@@ -58,7 +58,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(20909);
+#define LIBXML_TEST_VERSION xmlCheckVersion(20910);
 
 #ifndef VMS
 #if 0
@@ -91,10 +91,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * Whether the thread support is configured in
  */
 #if 1
-#if defined(_REENTRANT) || defined(__MT__) || \
-    (defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE - 0 >= 199506L))
 #define LIBXML_THREAD_ENABLED
-#endif
 #endif
 
 /**
@@ -353,6 +350,8 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * LIBXML_EXPR_ENABLED:
  *
  * Whether the formal expressions interfaces are compiled in
+ *
+ * This code is unused and disabled unconditionally for now.
  */
 #if 0
 #define LIBXML_EXPR_ENABLED


### PR DESCRIPTION
We currently use libxml2 version 2.9.9. We should update to the latest stable release 2.9.10.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8237889](https://bugs.openjdk.java.net/browse/JDK-8237889): Update libxml2 to version 2.9.10


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/120/head:pull/120`
`$ git checkout pull/120`
