### PR TITLE
8239822: Intermittent unit test failures in RegionCSSTest

### DIFF
--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/StyleManagerTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/StyleManagerTest.java
@@ -41,6 +41,7 @@ import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.Paint;
 import javafx.scene.shape.Rectangle;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -62,14 +63,23 @@ public class StyleManagerTest {
     public StyleManagerTest() {
     }
 
-    @Before
-    public void setUp() {
+    private static void resetStyleManager() {
         StyleManagerShim sm = StyleManagerShim.getInstance();
         sm.userAgentStylesheetContainers_clear();
         sm.platformUserAgentStylesheetContainers_clear();
         sm.stylesheetContainerMap_clear();
         sm.cacheContainerMap_clear();
         sm.set_hasDefaultUserAgentStylesheet(false);
+    }
+
+    @Before
+    public void setUp() {
+        resetStyleManager();
+    }
+
+    @AfterClass
+    public static void cleanupOnce() {
+        resetStyleManager();
     }
 
     @Test

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/Node_cssStateTransition_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/Node_cssStateTransition_Test.java
@@ -41,6 +41,7 @@ import javafx.scene.paint.Paint;
 import javafx.scene.shape.Rectangle;
 import static org.junit.Assert.*;
 
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -49,14 +50,23 @@ public class Node_cssStateTransition_Test {
     public Node_cssStateTransition_Test() {
     }
 
-    @Before
-    public void setUp() {
+    private static void resetStyleManager() {
         StyleManager sm = StyleManager.getInstance();
         sm.userAgentStylesheetContainers.clear();
         sm.platformUserAgentStylesheetContainers.clear();
         sm.stylesheetContainerMap.clear();
         sm.cacheContainerMap.clear();
         sm.hasDefaultUserAgentStylesheet = false;
+    }
+
+    @Before
+    public void setUp() {
+        resetStyleManager();
+    }
+
+    @AfterClass
+    public static void cleanupOnce() {
+        resetStyleManager();
     }
 
     @Test

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/CssStyleHelperTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/CssStyleHelperTest.java
@@ -40,6 +40,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -49,19 +50,27 @@ public class CssStyleHelperTest {
     private Stage stage;
     private StackPane root;
 
-    @Before
-    public void setup() {
-        root = new StackPane();
-        scene = new Scene(root);
-        stage = new Stage();
-        stage.setScene(scene);
-
+    private static void initStyleManager() {
         StyleManager sm = StyleManager.getInstance();
         sm.userAgentStylesheetContainers.clear();
         sm.platformUserAgentStylesheetContainers.clear();
         sm.stylesheetContainerMap.clear();
         sm.cacheContainerMap.clear();
         sm.hasDefaultUserAgentStylesheet = false;
+    }
+
+    @Before
+    public void setup() {
+        root = new StackPane();
+        scene = new Scene(root);
+        stage = new Stage();
+        stage.setScene(scene);
+        initStyleManager();
+    }
+
+    @AfterClass
+    public static void cleanupOnce() {
+        initStyleManager();
     }
 
     @Test

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/CssStyleHelperTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/CssStyleHelperTest.java
@@ -50,7 +50,7 @@ public class CssStyleHelperTest {
     private Stage stage;
     private StackPane root;
 
-    private static void initStyleManager() {
+    private static void resetStyleManager() {
         StyleManager sm = StyleManager.getInstance();
         sm.userAgentStylesheetContainers.clear();
         sm.platformUserAgentStylesheetContainers.clear();
@@ -65,12 +65,12 @@ public class CssStyleHelperTest {
         scene = new Scene(root);
         stage = new Stage();
         stage.setScene(scene);
-        initStyleManager();
+        resetStyleManager();
     }
 
     @AfterClass
     public static void cleanupOnce() {
-        initStyleManager();
+        resetStyleManager();
     }
 
     @Test


### PR DESCRIPTION
This is a fix for an intermittent test failure affecting `test.javafx.scene.layout.RegionCSSTest`. This turns out to be a test bug in `test.javafx.scene.CssStyleHelperTest`, which was added as part of [JDK-8237469](https://bugs.openjdk.java.net/browse/JDK-8237469). RegionCSSTest is a victim of this bug.

Except for the systemTests project, all unit tests are run in the same JVM, so each test class must ensure that any modified global state is restored after the tests are run. The CssStyleHelperTest leaves a userAgentStyleSheet set, which is a global (per Application) attribute, so any subsequent tests will be run with that stylesheet set. If the last test that is run in CssStyleHelperTest sets a style sheet with `"-fx-background"` then it will cause assertion failures in 78 of the tests in RegionCSSTest. 

The fix is to cleanup the global userAgentStyleSheet, along with any other state that is set, in an  `@AfterClass` cleanup method.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8239822](https://bugs.openjdk.java.net/browse/JDK-8239822): Intermittent unit test failures in RegionCSSTest


### Reviewers
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/124/head:pull/124`
`$ git checkout pull/124`
