### PR TITLE
8185887: TableRowSkinBase fails to correctly virtualize cells in horizontal direction

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -835,11 +835,9 @@ public class TreeTableView<S> extends Control {
 
             // update the lastKnownColumnIndex map
             lastKnownColumnIndex.clear();
-            for (TreeTableColumn<S,?> tc : getColumns()) {
-                int index = getVisibleLeafIndex(tc);
-                if (index > -1) {
-                    lastKnownColumnIndex.put(tc, index);
-                }
+            ObservableList<TreeTableColumn<S,?>> visibleLeafColumns = getVisibleLeafColumns();
+            for( int index =0, max = visibleLeafColumns.size(); index<max; index++) {
+                lastKnownColumnIndex.put(visibleLeafColumns.get(index), index);
             }
         }
     };
@@ -1790,6 +1788,11 @@ public class TreeTableView<S> extends Control {
      * visible leaf columns
      */
     public int getVisibleLeafIndex(TreeTableColumn<S,?> column) {
+        final int indexHint = this.lastKnownColumnIndex.getOrDefault(column, -1);
+        if (indexHint >= 0 && indexHint < getVisibleLeafColumns().size() &&
+            getVisibleLeafColumns().get(indexHint) == column) {
+            return indexHint;
+        }
         return getVisibleLeafColumns().indexOf(column);
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,9 +37,11 @@ import javafx.beans.property.ObjectProperty;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.collections.WeakListChangeListener;
+import javafx.collections.transformation.FilteredList;
 import javafx.css.StyleOrigin;
 import javafx.css.StyleableObjectProperty;
 import javafx.geometry.Insets;
+import javafx.geometry.Orientation;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.Parent;
@@ -135,7 +137,6 @@ public abstract class TableRowSkinBase<T,
 
     double fixedCellSize;
     boolean fixedCellSizeEnabled;
-
 
 
     /***************************************************************************
@@ -257,7 +258,8 @@ public abstract class TableRowSkinBase<T,
         if (cellsMap.isEmpty()) return;
 
         ObservableList<? extends TableColumnBase> visibleLeafColumns = getVisibleLeafColumns();
-        if (visibleLeafColumns.isEmpty()) {
+        final int visibleLeafColumnsSize =  visibleLeafColumns.size();
+        if (visibleLeafColumnsSize==0) {
             super.layoutChildren(x,y,w,h);
             return;
         }
@@ -306,9 +308,8 @@ public abstract class TableRowSkinBase<T,
                         // earlier rows to update themselves to take into account
                         // this increased indentation.
                         final VirtualFlow<C> flow = getVirtualFlow();
-                        final int thisIndex = getSkinnable().getIndex();
-                        for (int i = 0; i < flow.cells.size(); i++) {
-                            C cell = flow.cells.get(i);
+                        for (int i = 0, max = flow.getCellCount(); i < max; i++) {
+                            C cell = flow.getCell(i);
                             if (cell == null || cell.isEmpty()) continue;
                             cell.requestLayout();
                             cell.layout();
@@ -326,7 +327,6 @@ public abstract class TableRowSkinBase<T,
         double height;
 
         final double verticalPadding = snappedTopInset() + snappedBottomInset();
-        final double horizontalPadding = snappedLeftInset() + snappedRightInset();
         final double controlHeight = control.getHeight();
 
         /**
@@ -339,45 +339,79 @@ public abstract class TableRowSkinBase<T,
         int index = control.getIndex();
         if (index < 0/* || row >= itemsProperty().get().size()*/) return;
 
+        int firstVisibleColumnIndex = -1;
+        int lastVisibleColumnIndex = -1;
+        final VirtualFlow<?> virtualFlow = getVirtualFlow();
+        final double scrollX = virtualFlow == null ? 0.0 : virtualFlow.getHbar().getValue();
+        final Insets padding = getSkinnable().getPadding();
+        final double vfWidth = virtualFlow == null ? 0.0:virtualFlow.getWidth();
+        final double headerWidth = vfWidth - (padding.getLeft() + padding.getRight());
+        for (int column = 0, max = cells.size(); column < max; column++) {
+            R tableCell = cells.get(column);
+
+            TableColumnBase<T, ?> col = getTableColumn(tableCell);
+            if (col == null || !col.isVisible()) {
+                continue;
+            }
+
+            // work out where this column header is, and it's width (start -> end)
+            double start = 0;
+            for (int i = 0; i < visibleLeafColumnsSize; i++) {
+                TableColumnBase<?,?> c = visibleLeafColumns.get(i);
+                if (c.equals(col)) break;
+                start += snapSizeX(c.getWidth());
+            }
+            double end = start + col.getWidth();
+            // determine the width of the table
+
+            final boolean visible = isOverlap(start, end, scrollX, headerWidth + scrollX);
+            if(visible) {
+                if(firstVisibleColumnIndex == -1) {
+                    firstVisibleColumnIndex = column;
+                }
+                lastVisibleColumnIndex = column;
+            }else if( firstVisibleColumnIndex != -1 ) {
+                break;
+            }
+        }
+
+        final ObservableList<Node> children = getChildren();
+        if(fixedCellSizeEnabled) {
+            for (int column = 0, max = cells.size(); column < max; column++) {
+                R tableCell = cells.get(column);
+                final boolean isVisible = firstVisibleColumnIndex <= column && column <= lastVisibleColumnIndex;
+                if (isVisible ) {
+                    if(tableCell.getParent()==null){
+                        children.add(tableCell);
+                    }
+                }else{
+                    // we only add/remove to the scenegraph if the fixed cell
+                    // length support is enabled - otherwise we keep all
+                    // TableCells in the scenegraph
+                    children.remove(tableCell);
+                }
+            }
+        }
+
+        // Added for RT-32700, and then updated for RT-34074.
+        // We change the alignment from CENTER_LEFT to TOP_LEFT if the
+        // height of the row is greater than the default size, and if
+        // the alignment is the default alignment.
+        // What I would rather do is only change the alignment if the
+        // alignment has not been manually changed, but for now this will
+        // do.
+        final boolean centreContent = h <= 24.0;
+
+        double layoutY = snappedTopInset();
+        final double snapSizeYVerticalPadding = snapSizeY(verticalPadding);
+
         for (int column = 0, max = cells.size(); column < max; column++) {
             R tableCell = cells.get(column);
             TableColumnBase<T, ?> tableColumn = getTableColumn(tableCell);
 
-            boolean isVisible = true;
-            if (fixedCellSizeEnabled) {
-                // we determine if the cell is visible, and if not we have the
-                // ability to take it out of the scenegraph to help improve
-                // performance. However, we only do this when there is a
-                // fixed cell length specified in the TableView. This is because
-                // when we have a fixed cell length it is possible to know with
-                // certainty the height of each TableCell - it is the fixed value
-                // provided by the developer, and this means that we do not have
-                // to concern ourselves with the possibility that the height
-                // may be variable and / or dynamic.
-                isVisible = isColumnPartiallyOrFullyVisible(tableColumn);
-
-                height = fixedCellSize;
-            } else {
-                height = Math.max(controlHeight, tableCell.prefHeight(-1));
-                height = snapSizeY(height) - snapSizeY(verticalPadding);
-            }
-
-            if (isVisible) {
-                if (fixedCellSizeEnabled && tableCell.getParent() == null) {
-                    getChildren().add(tableCell);
-                }
-
-                width = tableCell.prefWidth(height) - snapSizeX(horizontalPadding);
-
-                // Added for RT-32700, and then updated for RT-34074.
-                // We change the alignment from CENTER_LEFT to TOP_LEFT if the
-                // height of the row is greater than the default size, and if
-                // the alignment is the default alignment.
-                // What I would rather do is only change the alignment if the
-                // alignment has not been manually changed, but for now this will
-                // do.
-                final boolean centreContent = h <= 24.0;
-
+            boolean isVisible = firstVisibleColumnIndex <= column && column <= lastVisibleColumnIndex;
+            width = snapSizeX(tableColumn.getWidth());
+            if (isVisible || isOverlap(tableCell.getLayoutX(), tableCell.getLayoutX()+width, scrollX, headerWidth + scrollX)) {
                 // if the style origin is null then the property has not been
                 // set (or it has been reset to its default), which means that
                 // we can set it without overwriting someone elses settings.
@@ -429,27 +463,35 @@ public abstract class TableRowSkinBase<T,
                         }
                     }
                 }
+
+                if (fixedCellSizeEnabled) {
+                    // we determine if the cell is visible, and if not we have the
+                    // ability to take it out of the scenegraph to help improve
+                    // performance. However, we only do this when there is a
+                    // fixed cell length specified in the TableView. This is because
+                    // when we have a fixed cell length it is possible to know with
+                    // certainty the height of each TableCell - it is the fixed value
+                    // provided by the developer, and this means that we do not have
+                    // to concern ourselves with the possibility that the height
+                    // may be variable and / or dynamic.
+
+                    height = fixedCellSize;
+                } else {
+                    height = Math.max(controlHeight, tableCell.prefHeight(-1));
+                    height = snapSizeY(height) - snapSizeYVerticalPadding;
+                }
+
                 ///////////////////////////////////////////
                 // further indentation code ends here
                 ///////////////////////////////////////////
-
-                tableCell.resize(width, height);
-                tableCell.relocate(x, snappedTopInset());
+                tableCell.resizeRelocate(x, layoutY, width, height);
 
                 // Request layout is here as (partial) fix for RT-28684.
                 // This does not appear to impact performance...
                 tableCell.requestLayout();
-            } else {
-                width = snapSizeX(tableCell.prefWidth(-1)) - snapSizeX(horizontalPadding);
-
-                if (fixedCellSizeEnabled) {
-                    // we only add/remove to the scenegraph if the fixed cell
-                    // length support is enabled - otherwise we keep all
-                    // TableCells in the scenegraph
-                    getChildren().remove(tableCell);
-                }
+            }else if(fixedCellSizeEnabled && lastVisibleColumnIndex<column){
+                break;
             }
-
             x += width;
         }
     }
@@ -540,20 +582,10 @@ public abstract class TableRowSkinBase<T,
             cells.add(cell);
         }
 
-        // update children of each row
         if (fixedCellSizeEnabled) {
-            // we leave the adding / removing up to the layoutChildren method mostly,
-            // but here we remove any children cells that refer to columns that are
-            // not visible
-            List<Node> toRemove = new ArrayList<>();
-            for (Node cell : getChildren()) {
-                if (! (cell instanceof IndexedCell)) continue;
-                if (!getTableColumn((R)cell).isVisible()) {
-                    toRemove.add(cell);
-                }
-            }
-            getChildren().removeAll(toRemove);
-        } else if (!fixedCellSizeEnabled && (resetChildren || cellsEmpty)) {
+            return;
+        }
+        if (resetChildren || cellsEmpty) {
             getChildren().setAll(cells);
         }
     }
@@ -571,11 +603,15 @@ public abstract class TableRowSkinBase<T,
 
     /** {@inheritDoc} */
     @Override protected double computePrefWidth(double height, double topInset, double rightInset, double bottomInset, double leftInset) {
-        double prefWidth = 0.0;
-        for (R cell : cells) {
-            prefWidth += cell.prefWidth(height);
+        double width = 0;
+        ObservableList<? extends TableColumnBase> visibleLeafColumns = getVisibleLeafColumns();
+        for (TableColumnBase<?,?> c: visibleLeafColumns) {
+            if( c.isVisible() ) {
+                width += snapSizeX(c.getWidth());
+            }
         }
-        return prefWidth;
+        final Insets padding = getSkinnable().getPadding();
+        return width + padding.getLeft() + padding.getRight();
     }
 
     /** {@inheritDoc} */
@@ -591,8 +627,9 @@ public abstract class TableRowSkinBase<T,
         // cells via CSS, where the desired height is less than the height
         // of the TableCells. Essentially, -fx-cell-size is given higher
         // precedence now
-        if (getCellSize() < DEFAULT_CELL_SIZE) {
-            return getCellSize();
+        final double cellSize = getCellSize();
+        if (cellSize < DEFAULT_CELL_SIZE) {
+            return cellSize;
         }
 
         // FIXME according to profiling, this method is slow and should
@@ -603,8 +640,7 @@ public abstract class TableRowSkinBase<T,
             final R tableCell = cells.get(i);
             prefHeight = Math.max(prefHeight, tableCell.prefHeight(-1));
         }
-        double ph = Math.max(prefHeight, Math.max(getCellSize(), getSkinnable().minHeight(-1)));
-
+        double ph = Math.max(prefHeight, Math.max(cellSize, getSkinnable().minHeight(-1)));
         return ph;
     }
 
@@ -621,8 +657,9 @@ public abstract class TableRowSkinBase<T,
         // cells via CSS, where the desired height is less than the height
         // of the TableCells. Essentially, -fx-cell-size is given higher
         // precedence now
-        if (getCellSize() < DEFAULT_CELL_SIZE) {
-            return getCellSize();
+        final double cellSize = getCellSize();
+        if (cellSize < DEFAULT_CELL_SIZE) {
+            return cellSize;
         }
 
         // FIXME according to profiling, this method is slow and should
@@ -663,27 +700,8 @@ public abstract class TableRowSkinBase<T,
      *                                                                         *
      **************************************************************************/
 
-    private boolean isColumnPartiallyOrFullyVisible(TableColumnBase col) {
-        if (col == null || !col.isVisible()) return false;
-
-        final VirtualFlow<?> virtualFlow = getVirtualFlow();
-        double scrollX = virtualFlow == null ? 0.0 : virtualFlow.getHbar().getValue();
-
-        // work out where this column header is, and it's width (start -> end)
-        double start = 0;
-        final ObservableList<? extends TableColumnBase> visibleLeafColumns = getVisibleLeafColumns();
-        for (int i = 0, max = visibleLeafColumns.size(); i < max; i++) {
-            TableColumnBase<?,?> c = visibleLeafColumns.get(i);
-            if (c.equals(col)) break;
-            start += c.getWidth();
-        }
-        double end = start + col.getWidth();
-
-        // determine the width of the table
-        final Insets padding = getSkinnable().getPadding();
-        double headerWidth = getSkinnable().getWidth() - padding.getLeft() + padding.getRight();
-
-        return (start >= scrollX || end > scrollX) && (start < (headerWidth + scrollX) || end <= (headerWidth + scrollX));
+    private static boolean isOverlap(double start, double end, double start2, double end2){
+        return (start<=end2 && end >= start2);
     }
 
     private void requestCellUpdate() {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
@@ -157,8 +157,24 @@ public abstract class TableRowSkinBase<T,
         getSkinnable().setPickOnBounds(false);
 
         recreateCells();
-        updateCells(true);
 
+        if(control instanceof TableRow){
+            TableRow tableRow = (TableRow)control;
+            TableView tableView = tableRow.getTableView();
+            if(tableView!=null){
+                fixedCellSize = tableView.getFixedCellSize();
+                fixedCellSizeEnabled = fixedCellSize >= 0;
+            }
+        }else if(control instanceof TreeTableRow){
+            TreeTableRow treeTableRow = (TreeTableRow)control;
+            TreeTableView treeTableView = treeTableRow.getTreeTableView();
+            if(treeTableView!=null){
+                fixedCellSize = treeTableView.getFixedCellSize();
+                fixedCellSizeEnabled = fixedCellSize >= 0;
+            }
+        }
+
+        updateCells(true);
         // init bindings
         // watches for any change in the leaf columns observableArrayList - this will indicate
         // that the column order has changed and that we should update the row
@@ -346,38 +362,27 @@ public abstract class TableRowSkinBase<T,
         final Insets padding = getSkinnable().getPadding();
         final double vfWidth = virtualFlow == null ? 0.0:virtualFlow.getWidth();
         final double headerWidth = vfWidth - (padding.getLeft() + padding.getRight());
-        for (int column = 0, max = cells.size(); column < max; column++) {
-            R tableCell = cells.get(column);
 
-            TableColumnBase<T, ?> col = getTableColumn(tableCell);
-            if (col == null || !col.isVisible()) {
-                continue;
-            }
-
-            // work out where this column header is, and it's width (start -> end)
-            double start = 0;
-            for (int i = 0; i < visibleLeafColumnsSize; i++) {
-                TableColumnBase<?,?> c = visibleLeafColumns.get(i);
-                if (c.equals(col)) break;
-                start += snapSizeX(c.getWidth());
-            }
-            double end = start + col.getWidth();
-            // determine the width of the table
-
+        double start = 0;
+        for (int i = 0; i < visibleLeafColumnsSize; i++) {
+            TableColumnBase<?,?> c = visibleLeafColumns.get(i);
+            double end = start + snapSizeX(c.getWidth());
             final boolean visible = isOverlap(start, end, scrollX, headerWidth + scrollX);
             if(visible) {
                 if(firstVisibleColumnIndex == -1) {
-                    firstVisibleColumnIndex = column;
+                    firstVisibleColumnIndex = i;
                 }
-                lastVisibleColumnIndex = column;
+                lastVisibleColumnIndex = i;
             }else if( firstVisibleColumnIndex != -1 ) {
                 break;
             }
+            start = end;
         }
 
         final ObservableList<Node> children = getChildren();
         if(fixedCellSizeEnabled) {
-            for (int column = 0, max = cells.size(); column < max; column++) {
+            final Set<R> removeCells = new HashSet<>();
+            for (int column = cells.size()-1; column >= 0; column--) {
                 R tableCell = cells.get(column);
                 final boolean isVisible = firstVisibleColumnIndex <= column && column <= lastVisibleColumnIndex;
                 if (isVisible ) {
@@ -388,9 +393,13 @@ public abstract class TableRowSkinBase<T,
                     // we only add/remove to the scenegraph if the fixed cell
                     // length support is enabled - otherwise we keep all
                     // TableCells in the scenegraph
-                    children.remove(tableCell);
+                    if(tableCell.getParent()!=null){
+                        removeCells.add(tableCell);
+                    }
                 }
             }
+            // Batch Remove
+            children.removeAll(removeCells);
         }
 
         // Added for RT-32700, and then updated for RT-34074.
@@ -558,8 +567,7 @@ public abstract class TableRowSkinBase<T,
         final int skinnableIndex = skinnable.getIndex();
         final List<? extends TableColumnBase/*<T,?>*/> visibleLeafColumns = getVisibleLeafColumns();
 
-        for (int i = 0, max = visibleLeafColumns.size(); i < max; i++) {
-            TableColumnBase<T,?> col = visibleLeafColumns.get(i);
+        for (TableColumnBase<T,?> col : visibleLeafColumns) {
 
             R cell = null;
             if (cellsMap.containsKey(col)) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ import javafx.scene.AccessibleAttribute;
 import javafx.scene.Node;
 import javafx.scene.control.Button;
 import javafx.scene.control.Control;
+import javafx.scene.control.ScrollBar;
 import javafx.scene.control.ResizeFeaturesBase;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
@@ -115,7 +116,11 @@ public class TableViewSkin<T> extends TableViewSkinBase<T, T, TableView<T>, Tabl
             }
         };
         flow.getVbar().addEventFilter(MouseEvent.MOUSE_PRESSED, ml);
-        flow.getHbar().addEventFilter(MouseEvent.MOUSE_PRESSED, ml);
+
+        final ScrollBar hbar = flow.getHbar();
+        hbar.addEventFilter(MouseEvent.MOUSE_PRESSED, ml);
+        hbar.valueProperty().addListener(o -> flow.requestCellLayout());
+        hbar.widthProperty().addListener(o -> flow.requestCellLayout());
 
         // init the behavior 'closures'
         behavior.setOnFocusPreviousRow(() -> onFocusAboveCell());

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkin.java
@@ -115,12 +115,13 @@ public class TableViewSkin<T> extends TableViewSkinBase<T, T, TableView<T>, Tabl
                 control.requestFocus();
             }
         };
-        flow.getVbar().addEventFilter(MouseEvent.MOUSE_PRESSED, ml);
 
         final ScrollBar hbar = flow.getHbar();
+        final ScrollBar vbar = flow.getVbar();
+        vbar.addEventFilter(MouseEvent.MOUSE_PRESSED, ml);
         hbar.addEventFilter(MouseEvent.MOUSE_PRESSED, ml);
-        hbar.valueProperty().addListener(o -> flow.requestCellLayout());
-        hbar.widthProperty().addListener(o -> flow.requestCellLayout());
+        vbar.heightProperty().addListener(o -> requestCellLayout());
+        hbar.widthProperty().addListener(o -> requestCellLayout());
 
         // init the behavior 'closures'
         behavior.setOnFocusPreviousRow(() -> onFocusAboveCell());
@@ -240,6 +241,10 @@ public class TableViewSkin<T> extends TableViewSkinBase<T, T, TableView<T>, Tabl
     /** {@inheritDoc} */
     @Override void horizontalScroll() {
         super.horizontalScroll();
+        requestCellLayout();
+    }
+
+    private void requestCellLayout(){
         if (getSkinnable().getFixedCellSize() > 0) {
             flow.requestCellLayout();
         }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableRowSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableRowSkin.java
@@ -220,19 +220,23 @@ public class TreeTableRowSkin<T> extends TableRowSkinBase<TreeItem<T>, TreeTable
 
     /** {@inheritDoc} */
     @Override protected void updateChildren() {
-        super.updateChildren();
-
-        updateDisclosureNodeAndGraphic();
-
-        if (childrenDirty) {
+        if (fixedCellSizeEnabled) {
+            updateDisclosureNodeAndGraphic();
+            super.updateChildren();
             childrenDirty = false;
-            if (cells.isEmpty()) {
-                getChildren().clear();
-            } else {
-                // TODO we can optimise this by only showing cells that are
-                // visible based on the table width and the amount of horizontal
-                // scrolling.
-                getChildren().addAll(cells);
+        } else {
+            super.updateChildren();
+            updateDisclosureNodeAndGraphic();
+            if (childrenDirty) {
+                childrenDirty = false;
+                if (cells.isEmpty()) {
+                    getChildren().clear();
+                } else {
+                    // TODO we can optimise this by only showing cells that are
+                    // visible based on the table width and the amount of horizontal
+                    // scrolling.
+                    getChildren().addAll(cells);
+                }
             }
         }
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableViewSkin.java
@@ -160,8 +160,12 @@ public class TreeTableViewSkin<T> extends TableViewSkinBase<T, TreeItem<T>, Tree
                 control.requestFocus();
             }
         };
-        flow.getVbar().addEventFilter(MouseEvent.MOUSE_PRESSED, ml);
-        flow.getHbar().addEventFilter(MouseEvent.MOUSE_PRESSED, ml);
+        final ScrollBar hbar = flow.getHbar();
+        final ScrollBar vbar = flow.getVbar();
+        vbar.addEventFilter(MouseEvent.MOUSE_PRESSED, ml);
+        hbar.addEventFilter(MouseEvent.MOUSE_PRESSED, ml);
+        vbar.heightProperty().addListener(o -> requestCellLayout());
+        hbar.widthProperty().addListener(o -> requestCellLayout());
 
         // init the behavior 'closures'
         behavior.setOnFocusPreviousRow(() -> onFocusAboveCell());
@@ -335,9 +339,7 @@ public class TreeTableViewSkin<T> extends TableViewSkinBase<T, TreeItem<T>, Tree
     /** {@inheritDoc} */
     @Override void horizontalScroll() {
         super.horizontalScroll();
-        if (getSkinnable().getFixedCellSize() > 0) {
-            flow.requestCellLayout();
-        }
+        requestCellLayout();
     }
 
     /** {@inheritDoc} */
@@ -362,6 +364,12 @@ public class TreeTableViewSkin<T> extends TableViewSkinBase<T, TreeItem<T>, Tree
             // requestRebuildCells();
         } else {
             needCellsReconfigured = true;
+        }
+    }
+
+    private void requestCellLayout(){
+        if (getSkinnable().getFixedCellSize() > 0) {
+            flow.requestCellLayout();
         }
     }
 }


### PR DESCRIPTION
If there are many columns, the current TableView will stall scrolling. Resolving this performance issue requires column virtualization. Virtualization mode is enabled when the row height is fixed by the following method.

`tableView.setFixedCellSize(height)`

This proposal includes a fix because the current code does not correctly implement column virtualization.

The improvement of this proposal can be seen in the following test program.

``` Java
import java.util.Arrays;
import java.util.Collections;

import javafx.animation.AnimationTimer;
import javafx.application.Application;
import javafx.beans.property.SimpleStringProperty;
import javafx.collections.ObservableList;
import javafx.scene.Scene;
import javafx.scene.control.Button;
import javafx.scene.control.TableColumn;
import javafx.scene.control.TableView;
import javafx.scene.layout.BorderPane;
import javafx.scene.layout.HBox;
import javafx.stage.Stage;

public class BigTableViewTest2 extends Application {
	private static final boolean USE_WIDTH_FIXED_SIZE = false;
	private static final boolean USE_HEIGHT_FIXED_SIZE = true;
//	private static final int COL_COUNT=30;
//	private static final int COL_COUNT=300;
//	private static final int COL_COUNT=600;
	private static final int COL_COUNT = 1000;
	private static final int ROW_COUNT = 1000;

	@Override
	public void start(final Stage primaryStage) throws Exception {
		final TableView<String[]> tableView = new TableView<>();

//	    tableView.setTableMenuButtonVisible(true); //too heavy
		if (USE_HEIGHT_FIXED_SIZE) {
			tableView.setFixedCellSize(24);
		}

		final ObservableList<TableColumn<String[], ?>> columns = tableView.getColumns();
		for (int i = 0; i < COL_COUNT; i++) {
			final TableColumn<String[], String> column = new TableColumn<>("Col" + i);
			final int colIndex = i;
			column.setCellValueFactory((cell) -> new SimpleStringProperty(cell.getValue()[colIndex]));
			columns.add(column);
			if (USE_WIDTH_FIXED_SIZE) {
				column.setPrefWidth(60);
				column.setMaxWidth(60);
				column.setMinWidth(60);
			}
		}

		final Button load = new Button("load");
		load.setOnAction(e -> {
			final ObservableList<String[]> items = tableView.getItems();
			items.clear();
			for (int i = 0; i < ROW_COUNT; i++) {
				final String[] rec = new String[COL_COUNT];
				for (int j = 0; j < rec.length; j++) {
					rec[j] = i + ":" + j;
				}
				items.add(rec);
			}
		});

		final Button reverse = new Button("reverse columns");
		reverse.setOnAction(e -> {
			final TableColumn<String[], ?>[] itemsArray = columns.toArray(new TableColumn[0]);
			Collections.reverse(Arrays.asList(itemsArray));
			tableView.getColumns().clear();
			tableView.getColumns().addAll(Arrays.asList(itemsArray));
		});

		final Button hide = new Button("hide % 10");
		hide.setOnAction(e -> {
			for (int i = 0, n = columns.size(); i < n; i++) {
				if (i % 10 == 0) {
					columns.get(i).setVisible(false);
				}
			}
		});

		final BorderPane root = new BorderPane(tableView);
		root.setTop(new HBox(8, load, reverse, hide));

		final Scene scene = new Scene(root, 800, 800);
		primaryStage.setScene(scene);
		primaryStage.show();
		this.prepareTimeline(scene);
	}

	public static void main(final String[] args) {
		Application.launch(args);
	}

	private void prepareTimeline(final Scene scene) {
		new AnimationTimer() {
			@Override
			public void handle(final long now) {
				final double fps = com.sun.javafx.perf.PerformanceTracker.getSceneTracker(scene).getInstantFPS();
				((Stage) scene.getWindow()).setTitle("FPS:" + (int) fps);
			}
		}.start();
	}
}
```

``` Java
import javafx.animation.AnimationTimer;
import javafx.application.Application;
import javafx.application.Platform;
import javafx.beans.property.ReadOnlyStringWrapper;
import javafx.scene.Scene;
import javafx.scene.control.TreeItem;
import javafx.scene.control.TreeTableColumn;
import javafx.scene.control.TreeTableColumn.CellDataFeatures;
import javafx.scene.control.TreeTableView;
import javafx.stage.Stage;

public class BigTreeTableViewTest extends Application {

	private static final boolean USE_HEIGHT_FIXED_SIZE = true;
//	private static final int COL_COUNT = 900;
	private static final int COL_COUNT = 800;
//	private static final int COL_COUNT = 600;
//	private static final int COL_COUNT = 500;
//	private static final int COL_COUNT = 400;
//	private static final int COL_COUNT = 300;
//	private static final int COL_COUNT = 200;
//	private static final int COL_COUNT = 100;

	public static void main(final String[] args) {
		Application.launch(args);
	}

	@Override
	public void start(final Stage stage) {
		final TreeItem<String> root = new TreeItem<>("Root");
		final TreeTableView<String> treeTableView = new TreeTableView<>(root);
		if (USE_HEIGHT_FIXED_SIZE) {
			treeTableView.setFixedCellSize(24);
		}
		treeTableView.setPrefWidth(800);
		treeTableView.setPrefHeight(500);
		stage.setWidth(800);
		stage.setHeight(500);

		Platform.runLater(() -> {
			for (int i = 0; i < 100; i++) {
				TreeItem<String> child = this.addNodes(root);
				child = this.addNodes(child);
				child = this.addNodes(child);
				child = this.addNodes(child);
			}
		});

		final TreeTableColumn<String, String>[] cols = new TreeTableColumn[COL_COUNT + 1];
		final TreeTableColumn<String, String> column = new TreeTableColumn<>("Column");
		column.setPrefWidth(150);
		column.setCellValueFactory(
				(final CellDataFeatures<String, String> p) -> new ReadOnlyStringWrapper(p.getValue().getValue()));
		cols[0] = column;

		for (int i = 0; i < COL_COUNT; i++) {
			final TreeTableColumn<String, String> col = new TreeTableColumn<>(Integer.toString(i));
			col.setPrefWidth(60);
			col.setCellValueFactory(val -> new ReadOnlyStringWrapper(val.getValue().getValue()+":"+val.getTreeTableColumn().getText()));
			cols[i + 1] = col;
		}
		treeTableView.getColumns().addAll(cols);

		final Scene scene = new Scene(treeTableView, 800, 500);
		stage.setScene(scene);
		stage.show();
		this.prepareTimeline(scene);
	}

	private TreeItem<String> addNodes(final TreeItem<String> parent) {

		final TreeItem<String>[] childNodes = new TreeItem[20];
		for (int i = 0; i < childNodes.length; i++) {
			childNodes[i] = new TreeItem<>("N" + i);
		}
		final TreeItem<String> root = new TreeItem<>("dir");
		root.setExpanded(true);
		root.getChildren().addAll(childNodes);
		parent.setExpanded(true);
		parent.getChildren().add(root);
		return root;
	}

	private void prepareTimeline(final Scene scene) {
		new AnimationTimer() {
			@Override
			public void handle(final long now) {
				final double fps = com.sun.javafx.perf.PerformanceTracker.getSceneTracker(scene).getInstantFPS();
				((Stage) scene.getWindow()).setTitle("FPS:" + (int) fps);
			}
		}.start();
	}

}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8185887](https://bugs.openjdk.org/browse/JDK-8185887): TableRowSkinBase fails to correctly virtualize cells in horizontal direction


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/125/head:pull/125` \
`$ git checkout pull/125`

Update a local copy of the PR: \
`$ git checkout pull/125` \
`$ git pull https://git.openjdk.org/jfx.git pull/125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 125`

View PR using the GUI difftool: \
`$ git pr show -t 125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/125.diff">https://git.openjdk.org/jfx/pull/125.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/125#issuecomment-608369779)