### PR TITLE
8236832: [macos 10.15] JavaFX Application hangs on video play on Cata…

### DIFF
--- a/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFAudioProcessor.mm
+++ b/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFAudioProcessor.mm
@@ -279,4 +279,8 @@ void ProcessAudioTap(MTAudioProcessingTapRef tapRef,
             return;
         }
     }
+
+    if (context->audioSpectrum != nullptr) {
+        context->audioSpectrum.get()->SetFirstBufferDelivered(true);
+    }
 }

--- a/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFAudioSpectrumUnit.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFAudioSpectrumUnit.cpp
@@ -41,6 +41,7 @@ AVFAudioSpectrumUnit::AVFAudioSpectrumUnit() : mSpectrumCallbackProc(NULL),
                                                mMaxFrames(0),
                                                mSamplesPerInterval(0),
                                                mRebuildCrunch(true),
+                                               mFirstBufferDelivered(false),
                                                mSpectrumElement(NULL),
                                                mSpectrum(NULL) {
     mMixBuffer.mNumberBuffers = 1;
@@ -191,7 +192,8 @@ void AVFAudioSpectrumUnit::UpdateBands(int size, const float* magnitudes, const 
     // Call our listener to dispatch the spectrum event
     if (mSpectrumCallbackProc) {
         double duration = (double) mSamplesPerInterval / (double) 44100;
-        mSpectrumCallbackProc(mSpectrumCallbackContext, duration);
+        double timestamp = mFirstBufferDelivered ? -1.0 : 0.0;
+        mSpectrumCallbackProc(mSpectrumCallbackContext, duration, timestamp);
     }
 
     unlockBands();
@@ -212,6 +214,10 @@ void AVFAudioSpectrumUnit::SetMaxFrames(UInt32 maxFrames) {
 void AVFAudioSpectrumUnit::SetSpectrumCallbackProc(AVFSpectrumUnitCallbackProc proc, void *context) {
     mSpectrumCallbackProc = proc;
     mSpectrumCallbackContext = context;
+}
+
+void AVFAudioSpectrumUnit::SetFirstBufferDelivered(bool isFirstBufferDelivered) {
+    mFirstBufferDelivered = isFirstBufferDelivered;
 }
 
 static gboolean PostMessageCallback(GstElement * element, GstMessage * message) {

--- a/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFAudioSpectrumUnit.h
+++ b/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFAudioSpectrumUnit.h
@@ -49,7 +49,8 @@
  * timeStamp: the beginning time in seconds of the sample period (from beginning of stream)
  * duration: the length of time in seconds of the sample period
  */
-typedef void (*AVFSpectrumUnitCallbackProc)(void *callbackContext, double duration);
+typedef void (*AVFSpectrumUnitCallbackProc)(void *callbackContext, double duration,
+                                            double timestamp);
 
 class AVFAudioSpectrumUnit : public CAudioSpectrum {
 public:
@@ -80,6 +81,7 @@ public:
     void SetChannels(UInt32 count);
     void SetMaxFrames(UInt32 maxFrames);
     void SetSpectrumCallbackProc(AVFSpectrumUnitCallbackProc proc, void *context);
+    void SetFirstBufferDelivered(bool isFirstBufferDelivered);
 
 private:
     AVFSpectrumUnitCallbackProc mSpectrumCallbackProc;
@@ -102,6 +104,7 @@ private:
     UInt32 mSamplesPerInterval;
 
     bool mRebuildCrunch;
+    bool mFirstBufferDelivered;
 
     // GStreamer
     GstElement *mSpectrumElement;

--- a/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFMediaPlayer.mm
+++ b/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFMediaPlayer.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ static void append_log(NSMutableString *s, NSString *fmt, ...) {
 
 @implementation AVFMediaPlayer
 
-static void SpectrumCallbackProc(void *context, double duration);
+static void SpectrumCallbackProc(void *context, double duration, double timestamp);
 
 static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink,
                                     const CVTimeStamp *inNow,
@@ -651,19 +651,21 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink,
     eventHandler->SendNewFrameEvent(frame);
 }
 
-- (void) sendSpectrumEventDuration:(double)duration {
+- (void) sendSpectrumEventDuration:(double)duration timestamp:(double)timestamp {
     if (eventHandler) {
-        double timestamp = self.currentTime;
+        if (timestamp < 0) {
+            timestamp = self.currentTime;
+        }
         eventHandler->SendAudioSpectrumEvent(timestamp, duration);
     }
 }
 
 @end
 
-static void SpectrumCallbackProc(void *context, double duration) {
+static void SpectrumCallbackProc(void *context, double duration, double timestamp) {
     if (context) {
         AVFMediaPlayer *player = (__bridge AVFMediaPlayer*)context;
-        [player sendSpectrumEventDuration:duration];
+        [player sendSpectrumEventDuration:duration timestamp:timestamp];
     }
 }
 


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8236832

- This issue most likely caused by changes in AVFoundation APIs on macOS 10.15.
- Getting currentTime from AVPlayer was blocked if it is done from ProcessAudioTap callback (used for spectrum, equalizer and volume) on first call. If we reading currentTime after first callback returns, then it will not block. Fixed by not reading currentTime on first call and default it 0.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8236832](https://bugs.openjdk.java.net/browse/JDK-8236832): [macos 10.15] JavaFX Application hangs on video play on Catalina


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Guru Hb ([ghb](@guruhb) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/126/head:pull/126`
`$ git checkout pull/126`
