### PR TITLE
8240262: iOS refresh rate is capped to 30 Hz

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassViewGL.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassViewGL.m
@@ -217,8 +217,6 @@ static EAGLContext * ctx = nil;
             if ([currSysVer compare:reqSysVer options:NSNumericSearch] != NSOrderedAscending) {
                 displayLink = [[UIScreen mainScreen] displayLinkWithTarget:[GlassTimer getDelegate]
                                                                   selector:@selector(displayLinkUpdate:)];
-                // 1 is 60hz, 2 is 30 Hz, 3 is 20 Hz ...
-                [displayLink setFrameInterval:2];
                 [displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:NSDefaultRunLoopMode];
                 [displayLink addToRunLoop:[NSRunLoop currentRunLoop] forMode:UITrackingRunLoopMode];
                 GLASS_LOG("GlassViewGL: displayLink SET");


### PR DESCRIPTION
There is a hardcoded limit to refresh the glass view on iOS at a half rate of the native refresh rate. 

This PR removes that limit. 

Since the default value for `frameInterval ` is 1 (which implies refreshing at the same rate as allowed by the device), doing `setFrameInterval:1` is not necessary. What's more, this method is [deprecated](https://developer.apple.com/documentation/quartzcore/cadisplaylink/1621231-frameinterval?language=objc).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240262](https://bugs.openjdk.java.net/browse/JDK-8240262): iOS refresh rate is capped to 30 Hz


### Reviewers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/130/head:pull/130`
`$ git checkout pull/130`
