### PR TITLE
8240265: iOS: Unnecessary logging on pinch gestures

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosGestureSupport.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosGestureSupport.java
@@ -93,7 +93,6 @@ final class IosGestureSupport {
     public static void magnifyGesturePerformed(View view, int modifiers, int x,
                                                int y, int xAbs, int yAbs,
                                                float scale) {
-        System.out.println(scale);
         gestures.handleDeltaZooming(view, modifiers, isDirect, false, x, y, xAbs,
                                     yAbs, scale, View.GESTURE_NO_DOUBLE_VALUE);
     }


### PR DESCRIPTION
This PR removes unnecessary logging of the scale value during a pinch gesture on iOS
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240265](https://bugs.openjdk.java.net/browse/JDK-8240265): iOS: Unnecessary logging on pinch gestures 


### Reviewers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/131/head:pull/131`
`$ git checkout pull/131`
