### PR TITLE
8240466: AppJSCallback* apps launched by ModuleLauncherTest intermittently hang

### DIFF
--- a/tests/system/src/testapp5/java/mymod/myapp5/AppJSCallbackExported.java
+++ b/tests/system/src/testapp5/java/mymod/myapp5/AppJSCallbackExported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,11 @@
 
 package myapp5;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import javafx.application.Application;
 import javafx.concurrent.Worker;
+import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
 import netscape.javascript.JSObject;
@@ -41,42 +44,79 @@ import static myapp5.Constants.*;
  */
 public class AppJSCallbackExported extends Application {
 
+    private static int callbackCount = -1;
+    private static final CountDownLatch launchLatch = new CountDownLatch(1);
+    private static final CountDownLatch contentLatch = new CountDownLatch(1);
+
     private final MyCallback callback = new MyCallback();
+    private WebEngine webEngine;
 
     /**
      * @param args the command line arguments
      */
     public static void main(String[] args) {
+        Thread thr = new Thread(() -> {
+            try {
+                Application.launch(args);
+            } catch (Throwable t) {
+                System.err.println("ERROR: caught unexpected exception: " + t);
+                t.printStackTrace(System.err);
+                System.exit(ERROR_UNEXPECTED_EXCEPTION);
+            }
+        });
+        thr.start();
+
+        // Wait for JavaFX runtime to startup and launch the application
+        waitForLatch(launchLatch, 10, "waiting for FX startup");
+
+        // Wait for the web content to be loaded
+        waitForLatch(contentLatch, 5, "loading web content");
+
+        // Test that the callback is as expected
         try {
-            Application.launch(args);
+            Util.assertEquals(1, callbackCount);
+            System.exit(ERROR_NONE);
         } catch (Throwable t) {
-            System.err.println("ERROR: caught unexpected exception: " + t);
             t.printStackTrace(System.err);
-            System.exit(ERROR_UNEXPECTED_EXCEPTION);
+            System.exit(ERROR_ASSERTION_FAILURE);
         }
     }
 
     @Override
     public void start(Stage stage) throws Exception {
         try {
-            final WebView webView = new WebView();
-            webView.getEngine().getLoadWorker().stateProperty().addListener((ov, o, n) -> {
+            launchLatch.countDown();
+            webEngine = new WebView().getEngine();
+            webEngine.getLoadWorker().stateProperty().addListener((ov, o, n) -> {
                 if (n == Worker.State.SUCCEEDED) {
                     try {
-                        final JSObject window = (JSObject) webView.getEngine().executeScript("window");
+                        final JSObject window = (JSObject) webEngine.executeScript("window");
                         Util.assertNotNull(window);
                         window.setMember("javaCallback", callback);
-                        webView.getEngine().executeScript("document.getElementById(\"mybtn1\").click()");
-                        Util.assertEquals(1, callback.getCount());
-                        System.exit(ERROR_NONE);
+                        webEngine.executeScript("document.getElementById(\"mybtn1\").click()");
+                        callbackCount = callback.getCount();
+                        contentLatch.countDown();
                     } catch (Throwable t) {
                         t.printStackTrace(System.err);
-                        System.exit(ERROR_ASSERTION_FAILURE);
+                        System.exit(ERROR_UNEXPECTED_EXCEPTION);
                     }
                 }
             });
-            webView.getEngine().loadContent(Util.content);
+            webEngine.loadContent(Util.content);
         } catch (Error | Exception ex) {
+            System.err.println("ERROR: caught unexpected exception: " + ex);
+            ex.printStackTrace(System.err);
+            System.exit(ERROR_UNEXPECTED_EXCEPTION);
+        }
+    }
+
+    public static void waitForLatch(CountDownLatch latch, int seconds, String msg) {
+        try {
+            if (!latch.await(seconds, TimeUnit.SECONDS)) {
+                System.err.println("Timeout: " + msg);
+                System.exit(ERROR_UNEXPECTED_EXCEPTION);
+            }
+        } catch (InterruptedException ex) {
             System.err.println("ERROR: caught unexpected exception: " + ex);
             ex.printStackTrace(System.err);
             System.exit(ERROR_UNEXPECTED_EXCEPTION);

--- a/tests/system/src/testapp5/java/mymod/myapp5/AppJSCallbackOpened.java
+++ b/tests/system/src/testapp5/java/mymod/myapp5/AppJSCallbackOpened.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,11 @@
 
 package myapp5;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import javafx.application.Application;
 import javafx.concurrent.Worker;
+import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
 import netscape.javascript.JSObject;
@@ -41,42 +44,79 @@ import static myapp5.Constants.*;
  */
 public class AppJSCallbackOpened extends Application {
 
+    private static int callbackCount = -1;
+    private static final CountDownLatch launchLatch = new CountDownLatch(1);
+    private static final CountDownLatch contentLatch = new CountDownLatch(1);
+
     private final MyCallback callback = new MyCallback();
+    private WebEngine webEngine;
 
     /**
      * @param args the command line arguments
      */
     public static void main(String[] args) {
+        Thread thr = new Thread(() -> {
+            try {
+                Application.launch(args);
+            } catch (Throwable t) {
+                System.err.println("ERROR: caught unexpected exception: " + t);
+                t.printStackTrace(System.err);
+                System.exit(ERROR_UNEXPECTED_EXCEPTION);
+            }
+        });
+        thr.start();
+
+        // Wait for JavaFX runtime to startup and launch the application
+        waitForLatch(launchLatch, 10, "waiting for FX startup");
+
+        // Wait for the web content to be loaded
+        waitForLatch(contentLatch, 5, "loading web content");
+
+        // Test that the callback is as expected
         try {
-            Application.launch(args);
+            Util.assertEquals(1, callbackCount);
+            System.exit(ERROR_NONE);
         } catch (Throwable t) {
-            System.err.println("ERROR: caught unexpected exception: " + t);
             t.printStackTrace(System.err);
-            System.exit(ERROR_UNEXPECTED_EXCEPTION);
+            System.exit(ERROR_ASSERTION_FAILURE);
         }
     }
 
     @Override
     public void start(Stage stage) throws Exception {
         try {
-            final WebView webView = new WebView();
-            webView.getEngine().getLoadWorker().stateProperty().addListener((ov, o, n) -> {
+            launchLatch.countDown();
+            webEngine = new WebView().getEngine();
+            webEngine.getLoadWorker().stateProperty().addListener((ov, o, n) -> {
                 if (n == Worker.State.SUCCEEDED) {
                     try {
-                        final JSObject window = (JSObject) webView.getEngine().executeScript("window");
+                        final JSObject window = (JSObject) webEngine.executeScript("window");
                         Util.assertNotNull(window);
                         window.setMember("javaCallback", callback);
-                        webView.getEngine().executeScript("document.getElementById(\"mybtn1\").click()");
-                        Util.assertEquals(1, callback.getCount());
-                        System.exit(ERROR_NONE);
+                        webEngine.executeScript("document.getElementById(\"mybtn1\").click()");
+                        callbackCount = callback.getCount();
+                        contentLatch.countDown();
                     } catch (Throwable t) {
                         t.printStackTrace(System.err);
-                        System.exit(ERROR_ASSERTION_FAILURE);
+                        System.exit(ERROR_UNEXPECTED_EXCEPTION);
                     }
                 }
             });
-            webView.getEngine().loadContent(Util.content);
+            webEngine.loadContent(Util.content);
         } catch (Error | Exception ex) {
+            System.err.println("ERROR: caught unexpected exception: " + ex);
+            ex.printStackTrace(System.err);
+            System.exit(ERROR_UNEXPECTED_EXCEPTION);
+        }
+    }
+
+    public static void waitForLatch(CountDownLatch latch, int seconds, String msg) {
+        try {
+            if (!latch.await(seconds, TimeUnit.SECONDS)) {
+                System.err.println("Timeout: " + msg);
+                System.exit(ERROR_UNEXPECTED_EXCEPTION);
+            }
+        } catch (InterruptedException ex) {
             System.err.println("ERROR: caught unexpected exception: " + ex);
             ex.printStackTrace(System.err);
             System.exit(ERROR_UNEXPECTED_EXCEPTION);

--- a/tests/system/src/testapp5/java/mymod/myapp5/AppJSCallbackQualExported.java
+++ b/tests/system/src/testapp5/java/mymod/myapp5/AppJSCallbackQualExported.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,11 @@
 
 package myapp5;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import javafx.application.Application;
 import javafx.concurrent.Worker;
+import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
 import netscape.javascript.JSObject;
@@ -41,42 +44,79 @@ import static myapp5.Constants.*;
  */
 public class AppJSCallbackQualExported extends Application {
 
+    private static int callbackCount = -1;
+    private static final CountDownLatch launchLatch = new CountDownLatch(1);
+    private static final CountDownLatch contentLatch = new CountDownLatch(1);
+
     private final MyCallback callback = new MyCallback();
+    private WebEngine webEngine;
 
     /**
      * @param args the command line arguments
      */
     public static void main(String[] args) {
+        Thread thr = new Thread(() -> {
+            try {
+                Application.launch(args);
+            } catch (Throwable t) {
+                System.err.println("ERROR: caught unexpected exception: " + t);
+                t.printStackTrace(System.err);
+                System.exit(ERROR_UNEXPECTED_EXCEPTION);
+            }
+        });
+        thr.start();
+
+        // Wait for JavaFX runtime to startup and launch the application
+        waitForLatch(launchLatch, 10, "waiting for FX startup");
+
+        // Wait for the web content to be loaded
+        waitForLatch(contentLatch, 5, "loading web content");
+
+        // Test that the callback is as expected
         try {
-            Application.launch(args);
+            Util.assertEquals(0, callbackCount);
+            System.exit(ERROR_NONE);
         } catch (Throwable t) {
-            System.err.println("ERROR: caught unexpected exception: " + t);
             t.printStackTrace(System.err);
-            System.exit(ERROR_UNEXPECTED_EXCEPTION);
+            System.exit(ERROR_ASSERTION_FAILURE);
         }
     }
 
     @Override
     public void start(Stage stage) throws Exception {
         try {
-            final WebView webView = new WebView();
-            webView.getEngine().getLoadWorker().stateProperty().addListener((ov, o, n) -> {
+            launchLatch.countDown();
+            webEngine = new WebView().getEngine();
+            webEngine.getLoadWorker().stateProperty().addListener((ov, o, n) -> {
                 if (n == Worker.State.SUCCEEDED) {
                     try {
-                        final JSObject window = (JSObject) webView.getEngine().executeScript("window");
+                        final JSObject window = (JSObject) webEngine.executeScript("window");
                         Util.assertNotNull(window);
                         window.setMember("javaCallback", callback);
-                        webView.getEngine().executeScript("document.getElementById(\"mybtn1\").click()");
-                        Util.assertEquals(0, callback.getCount());
-                        System.exit(ERROR_NONE);
+                        webEngine.executeScript("document.getElementById(\"mybtn1\").click()");
+                        callbackCount = callback.getCount();
+                        contentLatch.countDown();
                     } catch (Throwable t) {
                         t.printStackTrace(System.err);
-                        System.exit(ERROR_ASSERTION_FAILURE);
+                        System.exit(ERROR_UNEXPECTED_EXCEPTION);
                     }
                 }
             });
-            webView.getEngine().loadContent(Util.content);
+            webEngine.loadContent(Util.content);
         } catch (Error | Exception ex) {
+            System.err.println("ERROR: caught unexpected exception: " + ex);
+            ex.printStackTrace(System.err);
+            System.exit(ERROR_UNEXPECTED_EXCEPTION);
+        }
+    }
+
+    public static void waitForLatch(CountDownLatch latch, int seconds, String msg) {
+        try {
+            if (!latch.await(seconds, TimeUnit.SECONDS)) {
+                System.err.println("Timeout: " + msg);
+                System.exit(ERROR_UNEXPECTED_EXCEPTION);
+            }
+        } catch (InterruptedException ex) {
             System.err.println("ERROR: caught unexpected exception: " + ex);
             ex.printStackTrace(System.err);
             System.exit(ERROR_UNEXPECTED_EXCEPTION);

--- a/tests/system/src/testapp5/java/mymod/myapp5/AppJSCallbackQualOpened.java
+++ b/tests/system/src/testapp5/java/mymod/myapp5/AppJSCallbackQualOpened.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,11 @@
 
 package myapp5;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import javafx.application.Application;
 import javafx.concurrent.Worker;
+import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
 import netscape.javascript.JSObject;
@@ -41,42 +44,79 @@ import static myapp5.Constants.*;
  */
 public class AppJSCallbackQualOpened extends Application {
 
+    private static int callbackCount = -1;
+    private static final CountDownLatch launchLatch = new CountDownLatch(1);
+    private static final CountDownLatch contentLatch = new CountDownLatch(1);
+
     private final MyCallback callback = new MyCallback();
+    private WebEngine webEngine;
 
     /**
      * @param args the command line arguments
      */
     public static void main(String[] args) {
+        Thread thr = new Thread(() -> {
+            try {
+                Application.launch(args);
+            } catch (Throwable t) {
+                System.err.println("ERROR: caught unexpected exception: " + t);
+                t.printStackTrace(System.err);
+                System.exit(ERROR_UNEXPECTED_EXCEPTION);
+            }
+        });
+        thr.start();
+
+        // Wait for JavaFX runtime to startup and launch the application
+        waitForLatch(launchLatch, 10, "waiting for FX startup");
+
+        // Wait for the web content to be loaded
+        waitForLatch(contentLatch, 5, "loading web content");
+
+        // Test that the callback is as expected
         try {
-            Application.launch(args);
+            Util.assertEquals(1, callbackCount);
+            System.exit(ERROR_NONE);
         } catch (Throwable t) {
-            System.err.println("ERROR: caught unexpected exception: " + t);
             t.printStackTrace(System.err);
-            System.exit(ERROR_UNEXPECTED_EXCEPTION);
+            System.exit(ERROR_ASSERTION_FAILURE);
         }
     }
 
     @Override
     public void start(Stage stage) throws Exception {
         try {
-            final WebView webView = new WebView();
-            webView.getEngine().getLoadWorker().stateProperty().addListener((ov, o, n) -> {
+            launchLatch.countDown();
+            webEngine = new WebView().getEngine();
+            webEngine.getLoadWorker().stateProperty().addListener((ov, o, n) -> {
                 if (n == Worker.State.SUCCEEDED) {
                     try {
-                        final JSObject window = (JSObject) webView.getEngine().executeScript("window");
+                        final JSObject window = (JSObject) webEngine.executeScript("window");
                         Util.assertNotNull(window);
                         window.setMember("javaCallback", callback);
-                        webView.getEngine().executeScript("document.getElementById(\"mybtn1\").click()");
-                        Util.assertEquals(1, callback.getCount());
-                        System.exit(ERROR_NONE);
+                        webEngine.executeScript("document.getElementById(\"mybtn1\").click()");
+                        callbackCount = callback.getCount();
+                        contentLatch.countDown();
                     } catch (Throwable t) {
                         t.printStackTrace(System.err);
-                        System.exit(ERROR_ASSERTION_FAILURE);
+                        System.exit(ERROR_UNEXPECTED_EXCEPTION);
                     }
                 }
             });
-            webView.getEngine().loadContent(Util.content);
+            webEngine.loadContent(Util.content);
         } catch (Error | Exception ex) {
+            System.err.println("ERROR: caught unexpected exception: " + ex);
+            ex.printStackTrace(System.err);
+            System.exit(ERROR_UNEXPECTED_EXCEPTION);
+        }
+    }
+
+    public static void waitForLatch(CountDownLatch latch, int seconds, String msg) {
+        try {
+            if (!latch.await(seconds, TimeUnit.SECONDS)) {
+                System.err.println("Timeout: " + msg);
+                System.exit(ERROR_UNEXPECTED_EXCEPTION);
+            }
+        } catch (InterruptedException ex) {
             System.err.println("ERROR: caught unexpected exception: " + ex);
             ex.printStackTrace(System.err);
             System.exit(ERROR_UNEXPECTED_EXCEPTION);


### PR DESCRIPTION
While testing JavaFX using gradle 6.3-nightly and JDK 14, I ran into what turned out to be a latent test bug in the AppJSCallback* apps that are launched by ModuleLauncherTest. The launched apps construct a WebView instance, obtain a WebEngine instance from the WebView, add a state listener to the WebEngine, load the web content, and then return from the Application::start method. The WebView instance is held a local variable, and so is subject to garbage collection once it goes out of scope when the start method returns.

In addition, the test apps did not check for successful launching of the application or successful loading of the web content, which led to the test suite hanging (else it would have been a simple test failure).

Note that I don't know (nor care) what changed in JDK 14 to make this more likely to occur, but since the test itself is demonstrably wrong, it needs to be fixed.

The main part of the fix was to make the WebEngine an instance variable. In order to make the test more robust, I also modified it to launch the application in another thread, and having the main thread check that the application launched successfully and that the web content was loaded successfully, after which I did the assertion check for the correct number of callbacks.

The 5 different apps only differ from each other in the name of the class, the name of the package from which MyCallback is imported, and possibly the expected number of callbacks. I diffed AppJSCallbackExported.java against the other 4 test files and the diffs are essentially the same as they were before this change. Reviewers thus only need to review one of the tests in detail.

For example, here are the diffs between AppJSCallbackExported and AppJSCallbackUnexported:

```
$ diff .../AppJSCallbackExported.java .../AppJSCallbackUnexported.java

37c37
< import myapp5.pkg2.MyCallback;
---
> import myapp5.pkg1.MyCallback;
45c45
< public class AppJSCallbackExported extends Application {
---
> public class AppJSCallbackUnexported extends Application {
77c77
<             Util.assertEquals(1, callbackCount);
---
>             Util.assertEquals(0, callbackCount);
```
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240466](https://bugs.openjdk.java.net/browse/JDK-8240466): AppJSCallback* apps launched by ModuleLauncherTest intermittently hang


### Reviewers
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/134/head:pull/134`
`$ git checkout pull/134`
