### PR TITLE
8236685: [macOs] Remove obsolete file dialog subclasses

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.h
@@ -60,6 +60,4 @@
 
 + (BOOL)syncRenderingDisabled;
 
-+ (BOOL)isSandboxed;
-
 @end

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -755,44 +755,6 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
     return disableSyncRendering;
 }
 
-+ (BOOL)isSandboxed
-{
-    static int isSandboxed = -1;
-
-    if (isSandboxed == -1) {
-        isSandboxed = 0;
-
-        NSBundle *mainBundle = [NSBundle mainBundle];
-        NSURL *url = [mainBundle bundleURL];
-        SecStaticCodeRef staticCodeRef = NULL;
-        SecStaticCodeCreateWithPath((CFURLRef)url, kSecCSDefaultFlags, &staticCodeRef);
-
-        if (staticCodeRef) {
-            // Check if the app is signed
-            OSStatus res_signed = SecStaticCodeCheckValidityWithErrors(staticCodeRef, kSecCSBasicValidateOnly, NULL, NULL);
-            if (res_signed == errSecSuccess) {
-                // It is signed, now check if it's sandboxed
-                SecRequirementRef sandboxRequirementRef = NULL;
-                SecRequirementCreateWithString(CFSTR("entitlement[\"com.apple.security.app-sandbox\"] exists"), kSecCSDefaultFlags, &sandboxRequirementRef);
-
-                if (sandboxRequirementRef) {
-                    OSStatus res_sandboxed = SecStaticCodeCheckValidityWithErrors(staticCodeRef, kSecCSBasicValidateOnly, sandboxRequirementRef, NULL);
-                    if (res_sandboxed == errSecSuccess) {
-                        // Yep, sandboxed
-                        isSandboxed = 1;
-                    }
-
-                    CFRelease(sandboxRequirementRef);
-                }
-            }
-
-            CFRelease(staticCodeRef);
-        }
-    }
-
-    return isSandboxed == 1 ? YES : NO;
-}
-
 @end
 
 #pragma mark --- JNI

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassDialogs.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassDialogs.m
@@ -38,84 +38,6 @@
     #define LOG(MSG, ...) GLASS_LOG(MSG, ## __VA_ARGS__);
 #endif
 
-static BOOL doPerformKeyEquivalent(NSEvent* theEvent, NSWindow* panel)
-{
-    NSResponder* responder = [panel firstResponder];
-    if ([responder isKindOfClass:[NSText class]])
-    {
-        NSText* text = (NSText*)responder;
-        if ([theEvent type] == NSKeyDown
-            && ([theEvent modifierFlags] & NSDeviceIndependentModifierFlagsMask) == NSCommandKeyMask)
-        {
-            NSRange range = [text selectedRange];
-            BOOL hasSelectedText = range.length > 0;
-            if ([theEvent keyCode] == 7 && hasSelectedText) // Cmd + X - Cut
-            {
-                [text cut:panel];
-                return true;
-            }
-            if ([theEvent keyCode] == 8 && hasSelectedText) // Cmd + C - Copy
-            {
-                [text copy:panel];
-                return true;
-            }
-            if ([theEvent keyCode] == 9) // Cmd + V - Paste
-            {
-                [text paste:panel];
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
-/*
- * Function to determine whether or not to use raw NSPanel classes
- * (either NSSavePanel or NSOpenPanel).
- *
- * Return: YES if we need to use the raw NSPanel classes; NO if we
- * can use the Glass subclasses
- */
-static BOOL useNSPanel()
-{
-    // As of macOS 10.15 all file dialogs are out of process, so we
-    // effectively can't subclass them.
-    if (@available(macOS 10.15, *)) {
-        return YES;
-    } else {
-        return [GlassApplication isSandboxed];
-    }
-}
-
-@interface GlassSavePanel : NSSavePanel
-@end
-
-@implementation GlassSavePanel
-
-- (BOOL)performKeyEquivalent:(NSEvent *)theEvent
-{
-    if (doPerformKeyEquivalent(theEvent, self)) {
-        return true;
-    }
-    return [super performKeyEquivalent:theEvent];
-}
-@end
-
-@interface GlassOpenPanel : NSOpenPanel
-@end
-
-@implementation GlassOpenPanel
-
-- (BOOL)performKeyEquivalent:(NSEvent *)theEvent
-{
-    if (doPerformKeyEquivalent(theEvent, self)) {
-        return true;
-    }
-    return [super performKeyEquivalent:theEvent];
-}
-@end
-
-
 #pragma mark --- Dispatcher
 
 @interface DialogDispatcher : NSObject
@@ -503,7 +425,7 @@ JNIEXPORT jobject JNICALL Java_com_sun_glass_ui_mac_MacCommonDialogs__1showFileO
     GLASS_ASSERT_MAIN_JAVA_THREAD(env);
     GLASS_POOL_ENTER;
     {
-        NSOpenPanel *panel = useNSPanel() ? [NSOpenPanel openPanel] : [GlassOpenPanel openPanel];
+        NSOpenPanel *panel = [NSOpenPanel openPanel];
         [panel setAllowsMultipleSelection:(jMultipleMode==JNI_TRUE)];
         [panel setTitle:[GlassHelper nsStringWithJavaString:jTitle withEnv:env]];
         NSString *folder = [GlassHelper nsStringWithJavaString:jFolder withEnv:env];
@@ -579,7 +501,7 @@ JNIEXPORT jobject JNICALL Java_com_sun_glass_ui_mac_MacCommonDialogs__1showFileS
     GLASS_ASSERT_MAIN_JAVA_THREAD(env);
     GLASS_POOL_ENTER;
     {
-        NSSavePanel *panel = useNSPanel() ? [NSSavePanel savePanel] : [GlassSavePanel savePanel];
+        NSSavePanel *panel = [NSSavePanel savePanel];
         [panel setTitle:[GlassHelper nsStringWithJavaString:jTitle withEnv:env]];
         NSString *folder = [GlassHelper nsStringWithJavaString:jFolder withEnv:env];
         if ([folder length] > 0)
@@ -651,7 +573,7 @@ JNIEXPORT jobject JNICALL Java_com_sun_glass_ui_mac_MacCommonDialogs__1showFolde
     GLASS_ASSERT_MAIN_JAVA_THREAD(env);
     GLASS_POOL_ENTER;
     {
-        NSOpenPanel *panel = useNSPanel() ? [NSOpenPanel openPanel] : [GlassOpenPanel openPanel];
+        NSOpenPanel *panel = [NSOpenPanel openPanel];
         [panel setTitle:[GlassHelper nsStringWithJavaString:jTitle withEnv:env]];
         NSString *folder = [GlassHelper nsStringWithJavaString:jFolder withEnv:env];
         if ([folder length] > 0)


### PR DESCRIPTION
This is a follow-on to [JDK-8234474](https://bugs.openjdk.java.net/browse/JDK-8234474).

This fix removes the custom subclasses of NSSavePanel and NSOpenPanel that are optionally used by the glass implementation of file open, directory open, and file save. These subclasses were originally added to provide support for keyboard shortcuts for Copy (CMD-C), Cut (CMD-X), and Paste (CMD-V) operations that the standard Apple dialogs do not support directly; applications can add their own support, but JavaFX is a library not an application.

Note that as of macOS 10.15, all file dialogs on Mac are run in a spearate process. Attempts to subclass NSSavePanel and NSOpenPanel are no longer supported. They are either ineffective (silently ignored) or else crash the application. As a result of the crashes that were happening in some environments, the fix for [JDK-8234474](https://bugs.openjdk.java.net/browse/JDK-8234474) uses the NSSavePanel and NSOpenPanel base classes directly when running on macOS 10.15 or later. The proposed fix for this follow-on issue, [JDK-8236685](https://bugs.openjdk.java.net/browse/JDK-8236685), will use NSSavePanel and NSOpenPanel directly on all versions of macOS.

Note that Copy, Cut, and Paste functionality are available with the menu before and after this fix. This only impacts the keyboard shortcuts.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8236685](https://bugs.openjdk.java.net/browse/JDK-8236685): [macOs] Remove obsolete file dialog subclasses


### Reviewers
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)
 * Phil Race ([prr](@prrace) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/135/head:pull/135`
`$ git checkout pull/135`
