### PR TITLE
8240211: Stack overflow on Windows 32-bit can lead to crash

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/StackBounds.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/StackBounds.cpp
@@ -244,6 +244,9 @@ StackBounds StackBounds::currentThreadStackBoundsInternal()
 #endif
 #endif // NDEBUG
     void* bound = static_cast<char*>(endOfStack) + guardPage.RegionSize;
+#if PLATFORM(JAVA)
+    bound = static_cast<char*>(bound) + JAVA_RED_ZONE;
+#endif
     return StackBounds { origin, bound };
 }
 


### PR DESCRIPTION
Issue: The stack pointer is checked close to the stack limit during the last iteration of calling frameLoaded() and then, grows beyond the thread's stack range causing a stack overflow and crashes. This occurs as the stack grows by an amount larger than the reserved zone at the end of the stack.

Fix: Reduce the stack range visible to the thread in [StackBounds.cpp](https://github.com/openjdk/jfx/blob/master/modules/javafx.web/src/main/native/Source/WTF/wtf/StackBounds.cpp) similar to Mac and Linux. This causes the stack pointer check to throw a StackOverflowError during the last iteration.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240211](https://bugs.openjdk.java.net/browse/JDK-8240211): Stack overflow on Windows 32-bit can lead to crash


### Reviewers
 * Guru Hb ([ghb](@guruhb) - **Reviewer**)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/137/head:pull/137`
`$ git checkout pull/137`
