### PR TITLE
8089828: RTL Orientation, the flag of a mnemonic is not placed under the mnemonic letter.

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/skin/Utils.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/skin/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -148,7 +148,7 @@ public class Utils {
     }
 
     public static Point2D computeMnemonicPosition(Font font, String text, int mnemonicIndex, double wrappingWidth,
-                                                  double lineSpacing) {
+                                                  double lineSpacing, boolean isRTL) {
         // Input validation
         if ((font == null) || (text == null) ||
             (mnemonicIndex < 0) || (mnemonicIndex > text.length())) {
@@ -165,8 +165,9 @@ public class Utils {
         int start = 0;
         int i = 0;
         int totalLines = layout.getLines().length;
+        int lineLength = 0;
         while (i < totalLines) {
-            int lineLength = layout.getLines()[i].getLength();
+            lineLength = layout.getLines()[i].getLength();
 
             if ((mnemonicIndex >= start) &&
                 (mnemonicIndex < (start + lineLength))) {
@@ -182,6 +183,10 @@ public class Utils {
         // in line numbered 'i'
         double lineHeight = layout.getBounds().getHeight() / totalLines;
         double x = Utils.computeTextWidth(font, text.substring(start, mnemonicIndex), 0);
+        if (isRTL) {
+            double lineWidth = Utils.computeTextWidth(font, text.substring(start, (start + lineLength - 1)), 0);
+            x = lineWidth - x;
+        }
 
         double y = (lineHeight * (i+1));
         // Adjust y offset for linespacing except for the last line.

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -580,7 +580,8 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
         if (containsMnemonic) {
             final Font font = text.getFont();
             String preSt = bindings.getText();
-            mnemonicPos = Utils.computeMnemonicPosition(font, preSt, bindings.getMnemonicIndex(), this.wrapWidth, labeled.getLineSpacing());
+            boolean isRTL = (labeledNode.getEffectiveNodeOrientation() == NodeOrientation.RIGHT_TO_LEFT);
+            mnemonicPos = Utils.computeMnemonicPosition(font, preSt, bindings.getMnemonicIndex(), this.wrapWidth, labeled.getLineSpacing(), isRTL);
             mnemonicWidth = Utils.computeTextWidth(font, preSt.substring(bindings.getMnemonicIndex(), bindings.getMnemonicIndex() + 1), 0);
             mnemonicHeight = Utils.computeTextHeight(font, "_", 0, text.getBoundsType());
         }

--- a/tests/manual/UI/ButtonMnemonicPositionTest.java
+++ b/tests/manual/UI/ButtonMnemonicPositionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tests/manual/UI/ButtonMnemonicPositionTest.java
+++ b/tests/manual/UI/ButtonMnemonicPositionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2020 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 import javafx.application.Application;
 import javafx.application.Platform;
+import javafx.geometry.NodeOrientation;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -40,7 +41,7 @@ public class ButtonMnemonicPositionTest extends Application {
         String str =
             "This test is to check mnemonic position is correctly shown " +
             "in a single and multi-line button.\n" +
-            "Test shows 4 buttons of varying widths one below another - " +
+            "Test shows 8 buttons of varying widths stacked in 2 groups of 4 buttons each - " +
             "The buttons are made up of a string consisting of A to Z English" +
             " characters\n"+
             "------------------------------------------------------\n"+
@@ -70,7 +71,7 @@ public class ButtonMnemonicPositionTest extends Application {
             new Label("------------------------------------------------------");
 
 
-        // Test buttons ---------------------------------------
+        // LTR Test buttons ---------------------------------------
         Button b1 = new Button("ABCDEFGHIJKLMNOPQRST_UVWXYZ");
         Button b2 = new Button("ABCDEFGHIJKLMNOPQRST_UVWXYZ");
         Button b3 = new Button("ABCDEFGHIJKLMNOPQRST_UVWXYZ");
@@ -85,12 +86,42 @@ public class ButtonMnemonicPositionTest extends Application {
         b4.setMaxWidth(60);
         b4.wrapTextProperty().setValue(true);
 
+        VBox LTRBox = new VBox();
+        LTRBox.setSpacing(10.0);
+        LTRBox.getChildren().addAll(b1, b2, b3, b4);
+
+        // RTL Test buttons ---------------------------------------
+        Button b5 = new Button("ABCDEFGHIJKLMNOPQRST_UVWXYZ");
+        Button b6 = new Button("ABCDEFGHIJKLMNOPQRST_UVWXYZ");
+        Button b7 = new Button("ABCDEFGHIJKLMNOPQRST_UVWXYZ");
+        Button b8 = new Button("ABCDEFGHIJKLMNOPQRST_UVWXYZ");
+
+        b5.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
+        b6.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
+        b6.setMaxWidth(130);
+        b6.wrapTextProperty().setValue(true);
+
+        b7.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
+        b7.setMaxWidth(85);
+        b7.wrapTextProperty().setValue(true);
+
+        b8.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
+        b8.setMaxWidth(60);
+        b8.wrapTextProperty().setValue(true);
+
+        VBox RTLBox = new VBox();
+        RTLBox.setSpacing(10.0);
+        RTLBox.getChildren().addAll(b5, b6, b7, b8);
+
+        HBox btnBox = new HBox();
+        btnBox.getChildren().addAll(LTRBox, RTLBox);
+
         VBox box = new VBox();
         box.setSpacing(10.0);
 
         Scene s = new Scene(box);
         box.getChildren().addAll(testInstructions, testBtnBox, lbl,
-                                 b1, b2, b3, b4);
+                                 btnBox);
         primaryStage.setScene(s);
         primaryStage.show();
     }


### PR DESCRIPTION
**Bug :**
https://bugs.openjdk.java.net/browse/JDK-8089828

**Root Cause :**
RIGHT_TO_LEFT NodeOrientation was not considered during mnemonic position calculation.

**Fix :**
Corrected code to consider RIGHT_TO_LEFT NodeOrientation while calculating mnemonic position.

**Testing :**
Existing manual test is modified to test RTL buttons as well.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8089828](https://bugs.openjdk.java.net/browse/JDK-8089828): RTL Orientation, the flag of a mnemonic is not placed under the mnemonic letter.


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/146/head:pull/146`
`$ git checkout pull/146`
