### PR TITLE
8236840: Memory leak when switching ButtonSkin

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ButtonSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ButtonSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,8 @@ package javafx.scene.control.skin;
 import com.sun.javafx.scene.NodeHelper;
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
 import com.sun.javafx.scene.control.skin.Utils;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.WeakChangeListener;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.ContextMenu;
@@ -78,6 +80,24 @@ public class ButtonSkin extends LabeledSkinBase<Button> {
         }
     };
 
+    ChangeListener<Scene> sceneChangeListener = (ov, oldScene, newScene) -> {
+        if (oldScene != null) {
+            if (getSkinnable().isDefaultButton()) {
+                setDefaultButton(oldScene, false);
+            }
+            if (getSkinnable().isCancelButton()) {
+                setCancelButton(oldScene, false);
+            }
+        }
+        if (newScene != null) {
+            if (getSkinnable().isDefaultButton()) {
+                setDefaultButton(newScene, true);
+            }
+            if (getSkinnable().isCancelButton()) {
+                setCancelButton(newScene, true);
+            }
+        }
+    };
 
 
     /***************************************************************************
@@ -124,24 +144,7 @@ public class ButtonSkin extends LabeledSkinBase<Button> {
                 }
             }
         });
-        control.sceneProperty().addListener((ov, oldScene, newScene) -> {
-            if (oldScene != null) {
-                if (getSkinnable().isDefaultButton()) {
-                    setDefaultButton(oldScene, false);
-                }
-                if (getSkinnable().isCancelButton()) {
-                    setCancelButton(oldScene, false);
-                }
-            }
-            if (newScene != null) {
-                if (getSkinnable().isDefaultButton()) {
-                    setDefaultButton(newScene, true);
-                }
-                if (getSkinnable().isCancelButton()) {
-                    setCancelButton(newScene, true);
-                }
-            }
-        });
+        control.sceneProperty().addListener(new WeakChangeListener<>(sceneChangeListener));
 
         // set visuals
         if (getSkinnable().isDefaultButton()) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ButtonSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ButtonSkin.java
@@ -175,6 +175,12 @@ public class ButtonSkin extends LabeledSkinBase<Button> {
 
     /** {@inheritDoc} */
     @Override public void dispose() {
+        if (getSkinnable().isDefaultButton()) {
+            setDefaultButton(false);
+        }
+        if (getSkinnable().isCancelButton()) {
+            setCancelButton(false);
+        }
         getSkinnable().sceneProperty().removeListener(weakSceneChangeListener);
         super.dispose();
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ButtonSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ButtonSkin.java
@@ -98,7 +98,7 @@ public class ButtonSkin extends LabeledSkinBase<Button> {
             }
         }
     };
-    WeakChangeListener<Scene> weakChangeListener = new WeakChangeListener<>(sceneChangeListener);
+    WeakChangeListener<Scene> weakSceneChangeListener = new WeakChangeListener<>(sceneChangeListener);
 
 
     /***************************************************************************
@@ -145,7 +145,7 @@ public class ButtonSkin extends LabeledSkinBase<Button> {
                 }
             }
         });
-        control.sceneProperty().addListener(weakChangeListener);
+        control.sceneProperty().addListener(weakSceneChangeListener);
 
         // set visuals
         if (getSkinnable().isDefaultButton()) {
@@ -175,7 +175,7 @@ public class ButtonSkin extends LabeledSkinBase<Button> {
 
     /** {@inheritDoc} */
     @Override public void dispose() {
-        getSkinnable().sceneProperty().removeListener(weakChangeListener);
+        getSkinnable().sceneProperty().removeListener(weakSceneChangeListener);
         super.dispose();
 
         if (behavior != null) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ButtonSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ButtonSkin.java
@@ -98,6 +98,7 @@ public class ButtonSkin extends LabeledSkinBase<Button> {
             }
         }
     };
+    WeakChangeListener<Scene> weakChangeListener = new WeakChangeListener<>(sceneChangeListener);
 
 
     /***************************************************************************
@@ -144,7 +145,7 @@ public class ButtonSkin extends LabeledSkinBase<Button> {
                 }
             }
         });
-        control.sceneProperty().addListener(new WeakChangeListener<>(sceneChangeListener));
+        control.sceneProperty().addListener(weakChangeListener);
 
         // set visuals
         if (getSkinnable().isDefaultButton()) {
@@ -174,6 +175,7 @@ public class ButtonSkin extends LabeledSkinBase<Button> {
 
     /** {@inheritDoc} */
     @Override public void dispose() {
+        getSkinnable().sceneProperty().removeListener(weakChangeListener);
         super.dispose();
 
         if (behavior != null) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/ButtonSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/ButtonSkinTest.java
@@ -37,6 +37,8 @@ import javafx.scene.control.Button;
 import javafx.scene.Group;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.Mnemonic;
 import javafx.collections.ObservableList;
 import javafx.scene.input.KeyCombination;
@@ -199,9 +201,9 @@ public class ButtonSkinTest {
         skin = null;
 
         attemptGC(oldSkinRef);
-        assertNull("Old ButtonSkin should be GCed.", oldSkinRef.get());
-        assertNull("Default ButtonSkin should be GCed.", defSkinRef.get());
-        assertNotNull("Current ButtonSkin should NOT be GCed.", currSkinRef.get());
+        assertNull("Old ButtonSkin must be GCed.", oldSkinRef.get());
+        assertNull("Default ButtonSkin must be GCed.", defSkinRef.get());
+        assertNotNull("Current ButtonSkin must NOT be GCed.", currSkinRef.get());
     }
 
     @Test
@@ -221,9 +223,9 @@ public class ButtonSkinTest {
         skin = null;
 
         attemptGC(skinRef1);
-        assertNull("Unused ButtonSkin should be GCed.", skinRef1.get());
-        assertNull("Unused ButtonSkin should be GCed.", skinRef2.get());
-        assertNotNull("Default ButtonSkin should NOT be GCed.", defSkinRef.get());
+        assertNull("Unused ButtonSkin must be GCed.", skinRef1.get());
+        assertNull("Unused ButtonSkin must be GCed.", skinRef2.get());
+        assertNotNull("Default ButtonSkin must NOT be GCed.", defSkinRef.get());
     }
 
     @Test
@@ -237,8 +239,8 @@ public class ButtonSkinTest {
         skin = null;
 
         attemptGC(skinRef);
-        assertNull("Button should be GCed.", buttonRef.get());
-        assertNull("ButtonSkin should be GCed.", skinRef.get());
+        assertNull("Button must be GCed.", buttonRef.get());
+        assertNull("ButtonSkin must be GCed.", skinRef.get());
     }
 
     @Test
@@ -252,6 +254,44 @@ public class ButtonSkinTest {
 
         button.setSkin(new ButtonSkin1(button));
         root.getChildren().remove(button);
+    }
+
+    @Test
+    public void testDefaultButtonNullSkinReleased() {
+        Button button = new Button();
+        button.setDefaultButton(true);
+        Group root = new Group(button);
+        Scene scene = new Scene(root);
+        Stage stage = new Stage();
+        stage.setScene(scene);
+        stage.show();
+        WeakReference<ButtonSkin> defSkinRef = new WeakReference<>((ButtonSkin)button.getSkin());
+        KeyCodeCombination key = new KeyCodeCombination(KeyCode.ENTER);
+        assertNotNull(scene.getAccelerators().get(key));
+        button.setSkin(null);
+        assertNull(scene.getAccelerators().get(key));
+
+        attemptGC(defSkinRef);
+        assertNull("ButtonSkin must be GCed", defSkinRef.get());
+    }
+
+    @Test
+    public void testCancelButtonNullSkinReleased() {
+        Button button = new Button();
+        button.setCancelButton(true);
+        Group root = new Group(button);
+        Scene scene = new Scene(root);
+        Stage stage = new Stage();
+        stage.setScene(scene);
+        stage.show();
+        WeakReference<ButtonSkin> defSkinRef = new WeakReference<>((ButtonSkin)button.getSkin());
+        KeyCodeCombination key = new KeyCodeCombination(KeyCode.ESCAPE);
+        assertNotNull(scene.getAccelerators().get(key));
+        button.setSkin(null);
+        assertNull(scene.getAccelerators().get(key));
+
+        attemptGC(defSkinRef);
+        assertNull("ButtonSkin must be GCed", defSkinRef.get());
     }
 
     private void attemptGC(WeakReference<ButtonSkin> weakRef) {


### PR DESCRIPTION
ButtonSkin adds a `ChangeListener` to `Control.sceneProperty()` which results in leaking the `ButtonSkin` itself when the `Button`'s skin is changed to a new `ButtonSkin`. 
Using a `WeakChangeListener` instead of `ChangeListener` solves the issue.

Please take a look.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8236840](https://bugs.openjdk.java.net/browse/JDK-8236840): Memory leak when switching ButtonSkin


### Reviewers
 * Jeanette Winzenburg ([fastegal](@kleopatra) - Author)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/147/head:pull/147`
`$ git checkout pull/147`
