### PR TITLE
8241455: Memory leak on replacing selection/focusModel

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ChoiceBox.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ChoiceBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,9 +29,11 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ObjectPropertyBase;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ChangeListener;
+import javafx.beans.value.WeakChangeListener;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
+import javafx.collections.WeakListChangeListener;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyBooleanWrapper;
 import javafx.event.ActionEvent;
@@ -503,6 +505,9 @@ public class ChoiceBox<T> extends Control {
     // package for testing
     static class ChoiceBoxSelectionModel<T> extends SingleSelectionModel<T> {
         private final ChoiceBox<T> choiceBox;
+        private ChangeListener<ObservableList<T>> itemsObserver;
+        private ListChangeListener<T> itemsContentObserver;
+        private WeakListChangeListener<T> weakItemsContentObserver;
 
         public ChoiceBoxSelectionModel(final ChoiceBox<T> cb) {
             if (cb == null) {
@@ -520,7 +525,7 @@ public class ChoiceBox<T> extends Control {
              */
 
             // watching for changes to the items list content
-            final ListChangeListener<T> itemsContentObserver = c -> {
+            itemsContentObserver = c -> {
                 if (choiceBox.getItems() == null || choiceBox.getItems().isEmpty()) {
                     setSelectedIndex(-1);
                 } else if (getSelectedIndex() == -1 && getSelectedItem() != null) {
@@ -530,17 +535,18 @@ public class ChoiceBox<T> extends Control {
                     }
                 }
             };
+            weakItemsContentObserver = new WeakListChangeListener<>(itemsContentObserver);
             if (this.choiceBox.getItems() != null) {
-                this.choiceBox.getItems().addListener(itemsContentObserver);
+                this.choiceBox.getItems().addListener(weakItemsContentObserver);
             }
 
             // watching for changes to the items list
-            ChangeListener<ObservableList<T>> itemsObserver = (valueModel, oldList, newList) -> {
+            itemsObserver = (valueModel, oldList, newList) -> {
                 if (oldList != null) {
-                    oldList.removeListener(itemsContentObserver);
+                    oldList.removeListener(weakItemsContentObserver);
                 }
                 if (newList != null) {
-                    newList.addListener(itemsContentObserver);
+                    newList.addListener(weakItemsContentObserver);
                 }
                 setSelectedIndex(-1);
                 if (getSelectedItem() != null) {
@@ -550,7 +556,9 @@ public class ChoiceBox<T> extends Control {
                     }
                 }
             };
-            this.choiceBox.itemsProperty().addListener(itemsObserver);
+            // TBD: use pattern as f.i. in listView selectionModel (invalidationListener to really
+            // get all changes - including list of same content - of the list-valued property)
+            this.choiceBox.itemsProperty().addListener(new WeakChangeListener<>(itemsObserver));
         }
 
         // API Implementation

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TabPane.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TabPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.WritableValue;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
+import javafx.collections.WeakListChangeListener;
 import javafx.geometry.Side;
 import javafx.scene.AccessibleAttribute;
 import javafx.scene.AccessibleRole;
@@ -672,6 +673,8 @@ public class TabPane extends Control {
     static class TabPaneSelectionModel extends SingleSelectionModel<Tab> {
         private final TabPane tabPane;
 
+        private ListChangeListener<Tab> itemsContentObserver;
+
         public TabPaneSelectionModel(final TabPane t) {
             if (t == null) {
                 throw new NullPointerException("TabPane can not be null");
@@ -679,7 +682,7 @@ public class TabPane extends Control {
             this.tabPane = t;
 
             // watching for changes to the items list content
-            final ListChangeListener<Tab> itemsContentObserver = c -> {
+            itemsContentObserver = c -> {
                 while (c.next()) {
                     for (Tab tab : c.getRemoved()) {
                         if (tab != null && !tabPane.getTabs().contains(tab)) {
@@ -710,7 +713,7 @@ public class TabPane extends Control {
                 }
             };
             if (this.tabPane.getTabs() != null) {
-                this.tabPane.getTabs().addListener(itemsContentObserver);
+                this.tabPane.getTabs().addListener(new WeakListChangeListener<>(itemsContentObserver));
             }
         }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3406,12 +3406,13 @@ public class TreeTableView<S> extends Control {
             TreeTablePosition<S,?> pos = new TreeTablePosition<>(treeTableView, focusRow, null);
             setFocusedCell(pos);
 
-            treeTableView.showRootProperty().addListener(o -> {
+            showRootListener = obs -> {
                 if (isFocused(0)) {
                     focus(-1);
                     focus(0);
                 }
-            });
+            };
+            treeTableView.showRootProperty().addListener(new WeakInvalidationListener(showRootListener));
 
             focusedCellProperty().addListener(o -> {
                 treeTableView.notifyAccessibleAttributeChanged(AccessibleAttribute.FOCUS_ITEM);
@@ -3424,6 +3425,8 @@ public class TreeTableView<S> extends Control {
 
         private final WeakChangeListener<TreeItem<S>> weakRootPropertyListener =
                 new WeakChangeListener<>(rootPropertyListener);
+
+        private final InvalidationListener showRootListener;
 
         private void updateTreeEventListener(TreeItem<S> oldRoot, TreeItem<S> newRoot) {
             if (oldRoot != null && weakTreeItemListener != null) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,8 +58,6 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import javafx.event.Event;
 import javafx.event.EventHandler;
-
-import java.lang.ref.WeakReference;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -573,36 +571,4 @@ public class ChoiceBoxTest {
         assertTrue("onHiding event not received", onHidingPass);
         assertTrue("onHidden event not received", onHiddenPass);
     }
-
-    /**
-     * Memory leak on replacing selectionModel.
-     * https://bugs.openjdk.java.net/browse/JDK-8241455
-     */
-    @Test
-    public void testReplaceSelectionModelMemory() {
-        weakSmRef = new WeakReference<>(box.getSelectionModel());
-        SingleSelectionModel<String> replacingSm = ChoiceBoxShim.get_ChoiceBoxSelectionModel(box);
-        box.setSelectionModel(replacingSm);
-        attemptGC(10);
-        assertNull("selectionModel must be gc'ed", weakSmRef.get());
-    }
-
-    private WeakReference<SingleSelectionModel<?>> weakSmRef;
-    private void attemptGC(int n) {
-        // Attempt gc n times
-        for (int i = 0; i < n; i++) {
-            System.gc();
-            System.runFinalization();
-
-            if (weakSmRef.get() == null) {
-                break;
-            }
-            try {
-                Thread.sleep(500);
-            } catch (InterruptedException e) {
-               System.err.println("InterruptedException occurred during Thread.sleep()");
-            }
-        }
-    }
-
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,6 +58,8 @@ import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import javafx.event.Event;
 import javafx.event.EventHandler;
+
+import java.lang.ref.WeakReference;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -571,4 +573,36 @@ public class ChoiceBoxTest {
         assertTrue("onHiding event not received", onHidingPass);
         assertTrue("onHidden event not received", onHiddenPass);
     }
+
+    /**
+     * Memory leak on replacing selectionModel.
+     * https://bugs.openjdk.java.net/browse/JDK-8241455
+     */
+    @Test
+    public void testReplaceSelectionModelMemory() {
+        weakSmRef = new WeakReference<>(box.getSelectionModel());
+        SingleSelectionModel<String> replacingSm = ChoiceBoxShim.get_ChoiceBoxSelectionModel(box);
+        box.setSelectionModel(replacingSm);
+        attemptGC(10);
+        assertNull("selectionModel must be gc'ed", weakSmRef.get());
+    }
+
+    private WeakReference<SingleSelectionModel<?>> weakSmRef;
+    private void attemptGC(int n) {
+        // Attempt gc n times
+        for (int i = 0; i < n; i++) {
+            System.gc();
+            System.runFinalization();
+
+            if (weakSmRef.get() == null) {
+                break;
+            }
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+               System.err.println("InterruptedException occurred during Thread.sleep()");
+            }
+        }
+    }
+
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SelectionFocusModelMemoryTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SelectionFocusModelMemoryTest.java
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.control;
+
+import java.lang.ref.WeakReference;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.After;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.*;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.Scene;
+import javafx.scene.control.ChoiceBox;
+import javafx.scene.control.ChoiceBoxShim;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.ComboBoxShim;
+import javafx.scene.control.Control;
+import javafx.scene.control.FocusModel;
+import javafx.scene.control.ListView;
+import javafx.scene.control.ListViewShim;
+import javafx.scene.control.MultipleSelectionModel;
+import javafx.scene.control.SelectionModel;
+import javafx.scene.control.SingleSelectionModel;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+import javafx.scene.control.TabPaneShim;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TableView.TableViewFocusModel;
+import javafx.scene.control.TableView.TableViewSelectionModel;
+import javafx.scene.control.TableViewShim;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeTableView;
+import javafx.scene.control.TreeTableView.TreeTableViewFocusModel;
+import javafx.scene.control.TreeTableView.TreeTableViewSelectionModel;
+import javafx.scene.control.TreeTableViewShim;
+import javafx.scene.control.TreeView;
+import javafx.scene.control.TreeViewShim;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+/**
+ * Testing for potential memory leaks in xxSelectionModel and xxFocusModel (
+ * https://bugs.openjdk.java.net/browse/JDK-8241455).
+ * Might happen, when the concrete selection/focusModel registers strong listeners on any of the
+ * control's properties.
+ * <p>
+ * Parameterized in not/showing the control before replacing the model (aka:
+ * no/skin that might have a reference to any property of the old model as well).
+ * Note that failing/passing tests with skin reveal the mis/behavior on part on
+ * the skin - added here for convenience (and because it is simple).
+ *
+ */
+@RunWith(Parameterized.class)
+public class SelectionFocusModelMemoryTest {
+    private Scene scene;
+    private Stage stage;
+    private Pane root;
+
+    private boolean showBeforeReplaceSM;
+
+//---------- focusModel
+
+    @Test
+    public void testTreeViewFocusModel() {
+        TreeItem<String> root = new TreeItem<>("root");
+        ObservableList<String> data = FXCollections.observableArrayList("Apple", "Orange", "Banana");
+        data.forEach(text -> root.getChildren().add(new TreeItem<>(text)));
+        TreeView<String> control = new TreeView<>(root);
+        WeakReference<FocusModel<?>> weakRef = new WeakReference<>(control.getFocusModel());
+        FocusModel<TreeItem<String>> replacingSm = TreeViewShim.get_TreeViewFocusModel(control);
+        maybeShowControl(control);
+        control.setFocusModel(replacingSm);
+        attemptGC(weakRef, 10);
+        assertNull("focusModel must be gc'ed", weakRef.get());
+    }
+
+    @Test
+    public void testTreeTableViewFocusModel() {
+        TreeItem<String> root = new TreeItem<>("root");
+        ObservableList<String> data = FXCollections.observableArrayList("Apple", "Orange", "Banana");
+        data.forEach(text -> root.getChildren().add(new TreeItem<>(text)));
+        TreeTableView<String> control = new TreeTableView<>(root);
+        WeakReference<FocusModel<?>> weakRef = new WeakReference<>(control.getFocusModel());
+        TreeTableViewFocusModel<String> replacingSm = new TreeTableViewFocusModel<>(control);
+        maybeShowControl(control);
+        control.setFocusModel(replacingSm);
+        attemptGC(weakRef, 10);
+        assertNull("focusModel must be gc'ed", weakRef.get());
+    }
+
+    @Test
+    public void testTableViewFocusModel() {
+        TableView<String> control = new TableView<>(FXCollections.observableArrayList("Apple", "Orange", "Banana"));
+        WeakReference<FocusModel<?>> weakRef = new WeakReference<>(control.getFocusModel());
+        TableViewFocusModel<String> replacingSm = new TableViewFocusModel<>(control);
+        maybeShowControl(control);
+        control.setFocusModel(replacingSm);
+        attemptGC(weakRef, 10);
+        assertNull("focusModel must be gc'ed", weakRef.get());
+    }
+
+    @Test
+    public void testListViewFocusModel() {
+        ListView<String> control = new ListView<>(FXCollections.observableArrayList("Apple", "Orange", "Banana"));
+        WeakReference<FocusModel<?>> weakRef = new WeakReference<>(control.getFocusModel());
+        FocusModel<String> replacingSm = ListViewShim.getListViewFocusModel(control);
+        maybeShowControl(control);
+        control.setFocusModel(replacingSm);
+        attemptGC(weakRef, 10);
+        assertNull("focusModel must be gc'ed", weakRef.get());
+    }
+
+//------------------------ selectionModel
+
+    @Test
+    public void testTreeViewSelectionModel() {
+        TreeItem<String> root = new TreeItem<>("root");
+        ObservableList<String> data = FXCollections.observableArrayList("Apple", "Orange", "Banana");
+        data.forEach(text -> root.getChildren().add(new TreeItem<>(text)));
+        TreeView<String> control = new TreeView<>(root);
+        WeakReference<SelectionModel<?>> weakRef = new WeakReference<>(control.getSelectionModel());
+        MultipleSelectionModel<TreeItem<String>> replacingSm = TreeViewShim.get_TreeViewBitSetSelectionModel(control);
+        maybeShowControl(control);
+        control.setSelectionModel(replacingSm);
+        attemptGC(weakRef, 10);
+        assertNull("selectionModel must be gc'ed", weakRef.get());
+    }
+
+    @Test
+    public void testTreeTableViewSelectionModel() {
+        TreeItem<String> root = new TreeItem<>("root");
+        ObservableList<String> data = FXCollections.observableArrayList("Apple", "Orange", "Banana");
+        data.forEach(text -> root.getChildren().add(new TreeItem<>(text)));
+        TreeTableView<String> control = new TreeTableView<>(root);
+        WeakReference<SelectionModel<?>> weakRef = new WeakReference<>(control.getSelectionModel());
+        TreeTableViewSelectionModel<String> replacingSm = (TreeTableViewSelectionModel<String>) TreeTableViewShim.get_TreeTableViewArrayListSelectionModel(control);
+        maybeShowControl(control);
+        control.setSelectionModel(replacingSm);
+        attemptGC(weakRef, 10);
+        assertNull("selectionModel must be gc'ed", weakRef.get());
+    }
+
+    @Test
+    public void testTableViewSelectionModel() {
+        TableView<String> control = new TableView<>(FXCollections.observableArrayList("Apple", "Orange", "Banana"));
+        WeakReference<SelectionModel<?>> weakRef = new WeakReference<>(control.getSelectionModel());
+        TableViewSelectionModel<String> replacingSm = TableViewShim.get_TableViewArrayListSelectionModel(control);
+        maybeShowControl(control);
+        control.setSelectionModel(replacingSm);
+        attemptGC(weakRef, 10);
+        assertNull("selectionModel must be gc'ed", weakRef.get());
+    }
+
+    @Test
+    public void testListViewSelectionModel() {
+        ListView<String> control = new ListView<>(FXCollections.observableArrayList("Apple", "Orange", "Banana"));
+        WeakReference<SelectionModel<?>> weakRef = new WeakReference<>(control.getSelectionModel());
+        MultipleSelectionModel<String> replacingSm = ListViewShim.getListViewBitSetSelectionModel(control);
+        maybeShowControl(control);
+        control.setSelectionModel(replacingSm);
+        attemptGC(weakRef, 10);
+        assertNull("selectionModel must be gc'ed", weakRef.get());
+    }
+
+    @Test
+    public void testTabPaneSelectionModel() {
+        // FIXME
+        // can't formally ignore just one parameter, so backing out if showBeforeReplaceSM
+        // has its own issue https://bugs.openjdk.java.net/browse/JDK-8241737
+        if (showBeforeReplaceSM) return;
+        TabPane control = new TabPane();
+        ObservableList<String> data = FXCollections.observableArrayList("Apple", "Orange", "Banana");
+        data.forEach(text -> control.getTabs().add(new Tab("text")));
+        WeakReference<SelectionModel<?>> weakRef = new WeakReference<>(control.getSelectionModel());
+        SingleSelectionModel<Tab> replacingSm = TabPaneShim.getTabPaneSelectionModel(control);
+        maybeShowControl(control);
+        control.setSelectionModel(replacingSm);
+        attemptGC(weakRef, 10);
+        assertNull("selectionModel must be gc'ed", weakRef.get());
+    }
+
+    @Test
+    public void testComboBoxSelectionModel() {
+        ComboBox<String> control = new ComboBox<>(FXCollections.observableArrayList("Apple", "Orange", "Banana"));
+        WeakReference<SelectionModel<?>> weakRef = new WeakReference<>(control.getSelectionModel());
+        SingleSelectionModel<String> replacingSm = ComboBoxShim.get_ComboBoxSelectionModel(control);
+        maybeShowControl(control);
+        control.setSelectionModel(replacingSm);
+        attemptGC(weakRef, 10);
+        assertNull("selectionModel must be gc'ed", weakRef.get());
+    }
+
+    @Test
+    public void testChoiceBoxSelectionModel() {
+        // FIXME
+        // can't formally ignore just one parameter, so backing out if showBeforeReplaceSM
+        // will be fixed as side-effect of skin cleanup in https://bugs.openjdk.java.net/browse/JDK-8087555
+        if (showBeforeReplaceSM) return;
+        ChoiceBox<String> control = new ChoiceBox<>(FXCollections.observableArrayList("Apple", "Orange", "Banana"));
+        WeakReference<SelectionModel<?>> weakRef = new WeakReference<>(control.getSelectionModel());
+        SingleSelectionModel<String> replacingSm = ChoiceBoxShim.get_ChoiceBoxSelectionModel(control);
+        maybeShowControl(control);
+        control.setSelectionModel(replacingSm);
+        attemptGC(weakRef, 10);
+        assertNull("selectionModel must be gc'ed", weakRef.get());
+    }
+
+    private void attemptGC(WeakReference<?> weakRef, int n) {
+        // Attempt gc n times
+        for (int i = 0; i < n; i++) {
+            System.gc();
+            System.runFinalization();
+
+            if (weakRef.get() == null) {
+                break;
+            }
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+               System.err.println("InterruptedException occurred during Thread.sleep()");
+            }
+        }
+    }
+
+    protected void maybeShowControl(Control control) {
+        if (!showBeforeReplaceSM) return;
+        show(control);
+    }
+
+// ------------- parameterized
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        // show the control before replacing the selectionModel
+        Object[][] data = new Object[][] {
+            {false},
+            {true },
+        };
+        return Arrays.asList(data);
+    }
+
+    public SelectionFocusModelMemoryTest(boolean showBeforeReplaceSM) {
+        this.showBeforeReplaceSM = showBeforeReplaceSM;
+    }
+
+//------------------ setup
+
+    private void show(Control node) {
+        if (root == null) {
+            root =  new VBox();
+            scene = new Scene(root);
+            stage = new Stage();
+            stage.setScene(scene);
+        }
+        root.getChildren().add(node);
+        if (!stage.isShowing()) {
+            stage.show();
+        }
+    }
+
+    @After
+    public void cleanup() {
+        if (stage != null) {
+            stage.hide();
+        }
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SelectionFocusModelMemoryTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SelectionFocusModelMemoryTest.java
@@ -196,11 +196,10 @@ public class SelectionFocusModelMemoryTest {
     public void testTabPaneSelectionModel() {
         // FIXME
         // can't formally ignore just one parameter, so backing out if showBeforeReplaceSM
-        // has its own issue https://bugs.openjdk.java.net/browse/JDK-8241737
-        if (showBeforeReplaceSM) return;
+        if (showBeforeReplaceSM) return; //@Ignore("8241737")
         TabPane control = new TabPane();
         ObservableList<String> data = FXCollections.observableArrayList("Apple", "Orange", "Banana");
-        data.forEach(text -> control.getTabs().add(new Tab("text")));
+        data.forEach(text -> control.getTabs().add(new Tab(text)));
         WeakReference<SelectionModel<?>> weakRef = new WeakReference<>(control.getSelectionModel());
         SingleSelectionModel<Tab> replacingSm = TabPaneShim.getTabPaneSelectionModel(control);
         maybeShowControl(control);
@@ -224,8 +223,8 @@ public class SelectionFocusModelMemoryTest {
     public void testChoiceBoxSelectionModel() {
         // FIXME
         // can't formally ignore just one parameter, so backing out if showBeforeReplaceSM
-        // will be fixed as side-effect of skin cleanup in https://bugs.openjdk.java.net/browse/JDK-8087555
-        if (showBeforeReplaceSM) return;
+        // will be fixed as side-effect of skin cleanup
+        if (showBeforeReplaceSM) return; //@Ignore("8087555")
         ChoiceBox<String> control = new ChoiceBox<>(FXCollections.observableArrayList("Apple", "Orange", "Banana"));
         WeakReference<SelectionModel<?>> weakRef = new WeakReference<>(control.getSelectionModel());
         SingleSelectionModel<String> replacingSm = ChoiceBoxShim.get_ChoiceBoxSelectionModel(control);


### PR DESCRIPTION
Several controls with selection/focusModels leave memory leaks on replacing the model.

Added tests for all such, those for the misbehaving models fail before and pass after the fix. 

for convenience, the bug reference https://bugs.openjdk.java.net/browse/JDK-8241455
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241455](https://bugs.openjdk.java.net/browse/JDK-8241455): Memory leak on replacing selection/focusModel


### Reviewers
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/148/head:pull/148`
`$ git checkout pull/148`
