### PR TITLE
8230809: HTMLEditor formatting lost when selecting all (CTRL-A)

### DIFF
--- a/modules/javafx.web/src/main/java/javafx/scene/web/HTMLEditorSkin.java
+++ b/modules/javafx.web/src/main/java/javafx/scene/web/HTMLEditorSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -353,10 +353,14 @@ public class HTMLEditorSkin extends SkinBase<HTMLEditor> {
                         (event.getCode() == KeyCode.UP || event.getCode() == KeyCode.DOWN ||
                          event.getCode() == KeyCode.LEFT || event.getCode() == KeyCode.RIGHT ||
                          event.getCode() == KeyCode.HOME || event.getCode() == KeyCode.END)) {
+                    enableAtomicityCheck = true;
                     updateToolbarState(true);
+                    enableAtomicityCheck = false;
                 } else if ((event.isControlDown() || event.isMetaDown()) &&
                             event.getCode() == KeyCode.A) {
+                    enableAtomicityCheck = true;
                     updateToolbarState(true);
+                    enableAtomicityCheck = false;
                 }
             });
         });


### PR DESCRIPTION
Bug : https://bugs.openjdk.java.net/browse/JDK-8230809

Root Cause : 
Turned out to be a simpler issue than thought.
Atomicity check was missed while updating toolbar state (which in turn updates styles).

Fix : 
Added the missed atomicity check at two places that handle text selection using keyboard keys.

Testing : 
Added two system test cases. They fail without this fix and pass with it.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8230809](https://bugs.openjdk.java.net/browse/JDK-8230809): HTMLEditor formatting lost when selecting all (CTRL-A)


### Reviewers
 * Arun Joseph ([ajoseph](@arun-Joseph) - Author)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/155/head:pull/155`
`$ git checkout pull/155`
