### PR TITLE
8236971: [macos] Gestures handled incorrectly due to missing events

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassTouches.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassTouches.m
@@ -181,6 +181,7 @@ static CGEventRef listenTouchEvents(CGEventTapProxy proxy, CGEventType type,
     if (@available(macOS 10.15, *)) {
         useEventTap = NO;
     }
+    fprintf(stderr, "useEventTap = %s\n", (useEventTap ? "YES" : "NO"));
 
     self = [super init];
     if (self != nil)

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassTouches.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassTouches.m
@@ -181,7 +181,6 @@ static CGEventRef listenTouchEvents(CGEventTapProxy proxy, CGEventType type,
     if (@available(macOS 10.15, *)) {
         useEventTap = NO;
     }
-    fprintf(stderr, "useEventTap = %s\n", (useEventTap ? "YES" : "NO"));
 
     self = [super init];
     if (self != nil)

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView2D.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView2D.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -215,32 +215,22 @@
 
 - (void)rotateWithEvent:(NSEvent *)theEvent
 {
-    [self->delegate sendJavaGestureEvent:theEvent type:com_sun_glass_ui_mac_MacGestureSupport_GESTURE_ROTATE];
+    [self->delegate doRotateWithEvent:theEvent];
 }
 
 - (void)swipeWithEvent:(NSEvent *)theEvent
 {
-    [self->delegate sendJavaGestureEvent:theEvent type:com_sun_glass_ui_mac_MacGestureSupport_GESTURE_SWIPE];
+    [self->delegate doSwipeWithEvent:theEvent];
 }
 
 - (void)magnifyWithEvent:(NSEvent *)theEvent
 {
-    [self->delegate sendJavaGestureEvent:theEvent type:com_sun_glass_ui_mac_MacGestureSupport_GESTURE_MAGNIFY];
-}
-
-- (void)endGestureWithEvent:(NSEvent *)theEvent
-{
-    [self->delegate sendJavaGestureEndEvent:theEvent];
-}
-
-- (void)beginGestureWithEvent:(NSEvent *)theEvent
-{
-    [self->delegate sendJavaGestureBeginEvent:theEvent];
+    [self->delegate doMagnifyWithEvent:theEvent];
 }
 
 - (void)scrollWheel:(NSEvent *)theEvent
 {
-    [self->delegate sendJavaMouseEvent:theEvent];
+    [self->delegate doScrollWheel:theEvent];
 }
 
 - (BOOL)performKeyEquivalent:(NSEvent *)theEvent

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView2D.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView2D.m
@@ -228,6 +228,16 @@
     [self->delegate doMagnifyWithEvent:theEvent];
 }
 
+- (void)endGestureWithEvent:(NSEvent *)theEvent
+{
+    fprintf(stderr, "GlassView2D: endGestureWithEvent -- ignored\n");
+}
+
+- (void)beginGestureWithEvent:(NSEvent *)theEvent
+{
+    fprintf(stderr, "GlassView2D: beginGestureWithEvent -- ignored\n");
+}
+
 - (void)scrollWheel:(NSEvent *)theEvent
 {
     [self->delegate doScrollWheel:theEvent];

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView2D.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView2D.m
@@ -228,16 +228,6 @@
     [self->delegate doMagnifyWithEvent:theEvent];
 }
 
-- (void)endGestureWithEvent:(NSEvent *)theEvent
-{
-    fprintf(stderr, "GlassView2D: endGestureWithEvent -- ignored\n");
-}
-
-- (void)beginGestureWithEvent:(NSEvent *)theEvent
-{
-    fprintf(stderr, "GlassView2D: beginGestureWithEvent -- ignored\n");
-}
-
 - (void)scrollWheel:(NSEvent *)theEvent
 {
     [self->delegate doScrollWheel:theEvent];

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -441,33 +441,23 @@
 
 - (void)rotateWithEvent:(NSEvent *)theEvent
 {
-    [self->_delegate sendJavaGestureEvent:theEvent type:com_sun_glass_ui_mac_MacGestureSupport_GESTURE_ROTATE];
+    [self->_delegate doRotateWithEvent:theEvent];
 }
 
 - (void)swipeWithEvent:(NSEvent *)theEvent
 {
-    [self->_delegate sendJavaGestureEvent:theEvent type:com_sun_glass_ui_mac_MacGestureSupport_GESTURE_SWIPE];
+    [self->_delegate doSwipeWithEvent:theEvent];
 }
 
 - (void)magnifyWithEvent:(NSEvent *)theEvent
 {
-    [self->_delegate sendJavaGestureEvent:theEvent type:com_sun_glass_ui_mac_MacGestureSupport_GESTURE_MAGNIFY];
-}
-
-- (void)endGestureWithEvent:(NSEvent *)theEvent
-{
-    [self->_delegate sendJavaGestureEndEvent:theEvent];
-}
-
-- (void)beginGestureWithEvent:(NSEvent *)theEvent
-{
-    [self->_delegate sendJavaGestureBeginEvent:theEvent];
+    [self->_delegate doMagnifyWithEvent:theEvent];
 }
 
 - (void)scrollWheel:(NSEvent *)theEvent
 {
     MOUSELOG("scrollWheel");
-    [self->_delegate sendJavaMouseEvent:theEvent];
+    [self->_delegate doScrollWheel:theEvent];
 }
 
 - (BOOL)performKeyEquivalent:(NSEvent *)theEvent

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
@@ -454,16 +454,6 @@
     [self->_delegate doMagnifyWithEvent:theEvent];
 }
 
-- (void)endGestureWithEvent:(NSEvent *)theEvent
-{
-    fprintf(stderr, "GlassView3D: endGestureWithEvent -- ignored\n");
-}
-
-- (void)beginGestureWithEvent:(NSEvent *)theEvent
-{
-    fprintf(stderr, "GlassView3D: beginGestureWithEvent -- ignored\n");
-}
-
 - (void)scrollWheel:(NSEvent *)theEvent
 {
     MOUSELOG("scrollWheel");

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
@@ -454,6 +454,16 @@
     [self->_delegate doMagnifyWithEvent:theEvent];
 }
 
+- (void)endGestureWithEvent:(NSEvent *)theEvent
+{
+    fprintf(stderr, "GlassView3D: endGestureWithEvent -- ignored\n");
+}
+
+- (void)beginGestureWithEvent:(NSEvent *)theEvent
+{
+    fprintf(stderr, "GlassView3D: beginGestureWithEvent -- ignored\n");
+}
+
 - (void)scrollWheel:(NSEvent *)theEvent
 {
     MOUSELOG("scrollWheel");

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,14 @@
 #import "GlassDragSource.h"
 #import "GlassAccessible.h"
 
+// Bit mask for tracking gesture begin / end
+typedef enum GestureMaskType {
+    GESTURE_MASK_SCROLL  = 1 << 0,
+    GESTURE_MASK_SWIPE   = 1 << 1,
+    GESTURE_MASK_ROTATE  = 1 << 2,
+    GESTURE_MASK_MAGNIFY = 1 << 3,
+} GestureMaskType;
+
 // helper class that implements the custom GlassView functionality
 @interface GlassViewDelegate : NSObject <GlassDragSourceDelegate>
 {
@@ -51,6 +59,7 @@
     int                     mouseDownMask; // bit 0 - left, 1 - right, 2 - other button
 
     BOOL                    gestureInProgress;
+    GestureMaskType         gesturesBeganMask;
 
     NSEvent                 *lastEvent;
 
@@ -84,6 +93,10 @@
 - (void)sendJavaGestureEvent:(NSEvent *)theEvent type:(int)type;
 - (void)sendJavaGestureBeginEvent:(NSEvent *)theEvent;
 - (void)sendJavaGestureEndEvent:(NSEvent *)theEvent;
+- (void)doRotateWithEvent:(NSEvent *)theEvent;
+- (void)doSwipeWithEvent:(NSEvent *)theEvent;
+- (void)doMagnifyWithEvent:(NSEvent *)theEvent;
+- (void)doScrollWheel:(NSEvent *)theEvent;
 
 - (NSDragOperation)sendJavaDndEvent:(id <NSDraggingInfo>)info type:(jint)type;
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,6 +68,11 @@
 
 // Tracks pressed modifier keys
 static NSUInteger s_modifierFlags = 0;
+
+@interface GlassViewDelegate (hidden)
+- (void)maybeBeginGestureWithEvent:(NSEvent *)theEvent withMask:(GestureMaskType)theMask;
+- (void)maybeEndGestureWithEvent:(NSEvent *)theEvent withMask:(GestureMaskType)theMask;
+@end
 
 // Extracted from class-dump utility output for NSEvent class
 @interface NSEvent (hidden)
@@ -150,6 +155,7 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
         self->mouseDownMask = 0;
 
         self->gestureInProgress = NO;
+        self->gesturesBeganMask = 0;
 
         self->nativeFullScreenModeWindow = nil;
 
@@ -843,6 +849,72 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
 
     }
     GLASS_CHECK_EXCEPTION(env);
+}
+
+/*
+ * This method is a replacement for the deprecated beginGestureWithEvent
+ * method, which is no longer delivered to a View by macOS. This
+ * is called for each gesture event to track the beginning of a
+ * gesture using the phase of the event. We call sendJavaGestureBeginEvent
+ * if there are no other gestures active.
+ */
+- (void)maybeBeginGestureWithEvent:(NSEvent *)theEvent withMask:(GestureMaskType)theMask
+{
+    NSEventPhase phase = [theEvent phase];
+    if (phase == NSEventPhaseBegan) {
+        if (gesturesBeganMask == 0) {
+            [self sendJavaGestureBeginEvent:theEvent];
+        }
+        gesturesBeganMask |= theMask;
+    }
+}
+
+/*
+ * This method is a replacement for the deprecated endGestureWithEvent
+ * method, which is no longer delivered to a View by macOS. This
+ * is called for each gesture event to track the end of a
+ * gesture using the phase of the event. We call sendJavaGestureEndEvent
+ * if there are no other gestures active.
+ */
+- (void)maybeEndGestureWithEvent:(NSEvent *)theEvent withMask:(GestureMaskType)theMask
+{
+    NSEventPhase phase = [theEvent phase];
+    if (phase == NSEventPhaseEnded || phase == NSEventPhaseCancelled) {
+        if ((gesturesBeganMask & theMask) != 0) {
+            gesturesBeganMask &= ~theMask;
+            if (gesturesBeganMask == 0) {
+                [self sendJavaGestureEndEvent:theEvent];
+            }
+        }
+    }
+}
+
+- (void)doRotateWithEvent:(NSEvent *)theEvent
+{
+    [self maybeBeginGestureWithEvent:theEvent withMask:GESTURE_MASK_ROTATE];
+    [self sendJavaGestureEvent:theEvent type:com_sun_glass_ui_mac_MacGestureSupport_GESTURE_ROTATE];
+    [self maybeEndGestureWithEvent:theEvent withMask:GESTURE_MASK_ROTATE];
+}
+
+- (void)doSwipeWithEvent:(NSEvent *)theEvent
+{
+    [self maybeBeginGestureWithEvent:theEvent withMask:GESTURE_MASK_SWIPE];
+    [self sendJavaGestureEvent:theEvent type:com_sun_glass_ui_mac_MacGestureSupport_GESTURE_SWIPE];
+    [self maybeEndGestureWithEvent:theEvent withMask:GESTURE_MASK_SWIPE];
+}
+
+- (void)doMagnifyWithEvent:(NSEvent *)theEvent
+{
+    [self maybeBeginGestureWithEvent:theEvent withMask:GESTURE_MASK_MAGNIFY];
+    [self sendJavaGestureEvent:theEvent type:com_sun_glass_ui_mac_MacGestureSupport_GESTURE_MAGNIFY];
+    [self maybeEndGestureWithEvent:theEvent withMask:GESTURE_MASK_MAGNIFY];
+}
+
+- (void)doScrollWheel:(NSEvent *)theEvent
+{
+    [self maybeBeginGestureWithEvent:theEvent withMask:GESTURE_MASK_SCROLL];
+    [self sendJavaMouseEvent:theEvent];
+    [self maybeEndGestureWithEvent:theEvent withMask:GESTURE_MASK_SCROLL];
 }
 
 - (NSDragOperation)sendJavaDndEvent:(id <NSDraggingInfo>)info type:(jint)type

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
@@ -617,7 +617,6 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
                 sender = com_sun_glass_ui_mac_MacGestureSupport_SCROLL_SRC_GESTURE;
             }
 
-            fprintf(stderr, "MOUSE_WHEEL event: type = %d\n", type);
             const jclass jGestureSupportClass = [GlassHelper ClassForName:"com.sun.glass.ui.mac.MacGestureSupport"
                                                                   withEnv:env];
             if (jGestureSupportClass)
@@ -790,7 +789,6 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
     GET_MAIN_JENV;
     const jclass jGestureSupportClass = [GlassHelper ClassForName:"com.sun.glass.ui.mac.MacGestureSupport"
                                                           withEnv:env];
-    fprintf(stderr, "sendJavaGestureEvent: type = %d\n", type);
     if (jGestureSupportClass)
     {
         switch (type)
@@ -826,13 +824,11 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
 
 - (void)sendJavaGestureBeginEvent:(NSEvent *)theEvent
 {
-    fprintf(stderr, "sendJavaGestureBeginEvent\n");
     self->gestureInProgress = YES;
 }
 
 - (void)sendJavaGestureEndEvent:(NSEvent *)theEvent
 {
-    fprintf(stderr, "sendJavaGestureEndEvent\n");
     self->gestureInProgress = NO;
 
     NSPoint viewPoint = [nsView convertPoint:[theEvent locationInWindow] fromView:nil]; // convert from window coordinates to view coordinates
@@ -865,7 +861,6 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
 - (void)maybeBeginGestureWithEvent:(NSEvent *)theEvent withMask:(GestureMaskType)theMask
 {
     NSEventPhase phase = [theEvent phase];
-    fprintf(stderr, "maybeBeginGestureWithEvent: phase = 0x%lx\n", (unsigned long)phase);
     if (phase == NSEventPhaseBegan) {
         if (gesturesBeganMask == 0) {
             [self sendJavaGestureBeginEvent:theEvent];
@@ -884,7 +879,6 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
 - (void)maybeEndGestureWithEvent:(NSEvent *)theEvent withMask:(GestureMaskType)theMask
 {
     NSEventPhase phase = [theEvent phase];
-    fprintf(stderr, "maybeEndGestureWithEvent: phase = 0x%lx\n", (unsigned long)phase);
     if (phase == NSEventPhaseEnded || phase == NSEventPhaseCancelled) {
         if ((gesturesBeganMask & theMask) != 0) {
             gesturesBeganMask &= ~theMask;
@@ -897,7 +891,6 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
 
 - (void)doRotateWithEvent:(NSEvent *)theEvent
 {
-    fprintf(stderr, "GlassViewDelegate: rotateWithEvent\n");
     [self maybeBeginGestureWithEvent:theEvent withMask:GESTURE_MASK_ROTATE];
     [self sendJavaGestureEvent:theEvent type:com_sun_glass_ui_mac_MacGestureSupport_GESTURE_ROTATE];
     [self maybeEndGestureWithEvent:theEvent withMask:GESTURE_MASK_ROTATE];
@@ -905,7 +898,6 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
 
 - (void)doSwipeWithEvent:(NSEvent *)theEvent
 {
-    fprintf(stderr, "GlassViewDelegate: swipeWithEvent\n");
     [self maybeBeginGestureWithEvent:theEvent withMask:GESTURE_MASK_SWIPE];
     [self sendJavaGestureEvent:theEvent type:com_sun_glass_ui_mac_MacGestureSupport_GESTURE_SWIPE];
     [self maybeEndGestureWithEvent:theEvent withMask:GESTURE_MASK_SWIPE];
@@ -913,7 +905,6 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
 
 - (void)doMagnifyWithEvent:(NSEvent *)theEvent
 {
-    fprintf(stderr, "GlassViewDelegate: magnifyWithEvent\n");
     [self maybeBeginGestureWithEvent:theEvent withMask:GESTURE_MASK_MAGNIFY];
     [self sendJavaGestureEvent:theEvent type:com_sun_glass_ui_mac_MacGestureSupport_GESTURE_MAGNIFY];
     [self maybeEndGestureWithEvent:theEvent withMask:GESTURE_MASK_MAGNIFY];
@@ -921,7 +912,6 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
 
 - (void)doScrollWheel:(NSEvent *)theEvent
 {
-    fprintf(stderr, "GlassViewDelegate: scrollWheel\n");
     [self maybeBeginGestureWithEvent:theEvent withMask:GESTURE_MASK_SCROLL];
     [self sendJavaMouseEvent:theEvent];
     [self maybeEndGestureWithEvent:theEvent withMask:GESTURE_MASK_SCROLL];

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
@@ -617,6 +617,7 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
                 sender = com_sun_glass_ui_mac_MacGestureSupport_SCROLL_SRC_GESTURE;
             }
 
+            fprintf(stderr, "MOUSE_WHEEL event: type = %d\n", type);
             const jclass jGestureSupportClass = [GlassHelper ClassForName:"com.sun.glass.ui.mac.MacGestureSupport"
                                                                   withEnv:env];
             if (jGestureSupportClass)
@@ -789,6 +790,7 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
     GET_MAIN_JENV;
     const jclass jGestureSupportClass = [GlassHelper ClassForName:"com.sun.glass.ui.mac.MacGestureSupport"
                                                           withEnv:env];
+    fprintf(stderr, "sendJavaGestureEvent: type = %d\n", type);
     if (jGestureSupportClass)
     {
         switch (type)
@@ -824,11 +826,13 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
 
 - (void)sendJavaGestureBeginEvent:(NSEvent *)theEvent
 {
+    fprintf(stderr, "sendJavaGestureBeginEvent\n");
     self->gestureInProgress = YES;
 }
 
 - (void)sendJavaGestureEndEvent:(NSEvent *)theEvent
 {
+    fprintf(stderr, "sendJavaGestureEndEvent\n");
     self->gestureInProgress = NO;
 
     NSPoint viewPoint = [nsView convertPoint:[theEvent locationInWindow] fromView:nil]; // convert from window coordinates to view coordinates
@@ -861,6 +865,7 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
 - (void)maybeBeginGestureWithEvent:(NSEvent *)theEvent withMask:(GestureMaskType)theMask
 {
     NSEventPhase phase = [theEvent phase];
+    fprintf(stderr, "maybeBeginGestureWithEvent: phase = 0x%lx\n", (unsigned long)phase);
     if (phase == NSEventPhaseBegan) {
         if (gesturesBeganMask == 0) {
             [self sendJavaGestureBeginEvent:theEvent];
@@ -879,6 +884,7 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
 - (void)maybeEndGestureWithEvent:(NSEvent *)theEvent withMask:(GestureMaskType)theMask
 {
     NSEventPhase phase = [theEvent phase];
+    fprintf(stderr, "maybeEndGestureWithEvent: phase = 0x%lx\n", (unsigned long)phase);
     if (phase == NSEventPhaseEnded || phase == NSEventPhaseCancelled) {
         if ((gesturesBeganMask & theMask) != 0) {
             gesturesBeganMask &= ~theMask;
@@ -891,6 +897,7 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
 
 - (void)doRotateWithEvent:(NSEvent *)theEvent
 {
+    fprintf(stderr, "GlassViewDelegate: rotateWithEvent\n");
     [self maybeBeginGestureWithEvent:theEvent withMask:GESTURE_MASK_ROTATE];
     [self sendJavaGestureEvent:theEvent type:com_sun_glass_ui_mac_MacGestureSupport_GESTURE_ROTATE];
     [self maybeEndGestureWithEvent:theEvent withMask:GESTURE_MASK_ROTATE];
@@ -898,6 +905,7 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
 
 - (void)doSwipeWithEvent:(NSEvent *)theEvent
 {
+    fprintf(stderr, "GlassViewDelegate: swipeWithEvent\n");
     [self maybeBeginGestureWithEvent:theEvent withMask:GESTURE_MASK_SWIPE];
     [self sendJavaGestureEvent:theEvent type:com_sun_glass_ui_mac_MacGestureSupport_GESTURE_SWIPE];
     [self maybeEndGestureWithEvent:theEvent withMask:GESTURE_MASK_SWIPE];
@@ -905,6 +913,7 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
 
 - (void)doMagnifyWithEvent:(NSEvent *)theEvent
 {
+    fprintf(stderr, "GlassViewDelegate: magnifyWithEvent\n");
     [self maybeBeginGestureWithEvent:theEvent withMask:GESTURE_MASK_MAGNIFY];
     [self sendJavaGestureEvent:theEvent type:com_sun_glass_ui_mac_MacGestureSupport_GESTURE_MAGNIFY];
     [self maybeEndGestureWithEvent:theEvent withMask:GESTURE_MASK_MAGNIFY];
@@ -912,6 +921,7 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
 
 - (void)doScrollWheel:(NSEvent *)theEvent
 {
+    fprintf(stderr, "GlassViewDelegate: scrollWheel\n");
     [self maybeBeginGestureWithEvent:theEvent withMask:GESTURE_MASK_SCROLL];
     [self sendJavaMouseEvent:theEvent];
     [self maybeEndGestureWithEvent:theEvent withMask:GESTURE_MASK_SCROLL];


### PR DESCRIPTION
As noted in the JBS issue, this bug is a result of a deliberate change by Apple that affects applications (in this case the JDK) linked against MacOSX 10.11 SDK or later -- they no longer call two methods that we are relying on, `beginGestureWithEvent` and `endGestureWithEvent`. There is no deprecation warning or any other indication at compile time or runtime that these methods are ineffective. They just stopped calling them. It is documented in their developer guide:

[developer.apple.com/documentation/appkit/nsresponder/1526368-begingesturewithevent](https://developer.apple.com/documentation/appkit/nsresponder/1526368-begingesturewithevent?language=objc)

Note that it's the version of the MacOSX SDK that the JDK is linked with that matters. JavaFX gesture notification works when run on a JDK that was linked against the 10.10 SDK or earlier (regardless of what MacOSX SDK was used to link the JavaFX libraries). JavaFX gesture notification fails when run on a JDK that was linked against the 10.11 SDK or later. 

The solution, as indicated in the Apple documentation referred to above, is to use the phase information from gesture events to track when to call begin / end gesture.

The fix does the following things:
1. Removes the `beginGestureWithEvent` and `endGestureWithEvent` responder methods in `GlassView2D` and `GlassView3D`
2. Calls new local methods from each gesture to track when to call the associated `GlassViewDelegate` notification methods, `sendJavaGestureBeginEvent` and `sendJavaGestureEndEvent`

I've tested this on macOS 10.13.6 and 10.15.3 (Catalina) and the attached program now runs correctly. I also tested the GestureEvent sample in Ensemble8 and it reproduces the problem before the fix and works correctly after the fix.

I instrumented the code with print statements (which I have since reverted) and verified that the stream of events is as expected, and matches JDK 8u241 with bundled FX.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8236971](https://bugs.openjdk.java.net/browse/JDK-8236971): [macos] Gestures handled incorrectly due to missing events


### Reviewers
 * Michael Paus ([mpaus](@mipastgt) - Author)
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/156/head:pull/156`
`$ git checkout pull/156`
