### PR TITLE
8242167: ios keyboard handling

### DIFF
--- a/modules/javafx.controls/src/ios/java/javafx/scene/control/skin/TextAreaSkinIos.java
+++ b/modules/javafx.controls/src/ios/java/javafx/scene/control/skin/TextAreaSkinIos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,36 +23,33 @@
  * questions.
  */
 
-#import <UIKit/UIKit.h>
-#import <QuartzCore/QuartzCore.h>
-#import <OpenGLES/ES2/gl.h>
-#import <OpenGLES/ES2/glext.h>
+package javafx.scene.control.skin;
 
-#import "GlassStatics.h"
-#import "GlassView.h"
-#import "common.h"
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.scene.control.TextArea;
+import javafx.scene.control.skin.TextAreaSkin;
 
+public class TextAreaSkinIos extends TextAreaSkin {
 
-@interface GLView : UIScrollView
-{
-    @public GLuint renderBuffer;
-    @public GLuint frameBuffer;
-    BOOL                isHiDPIAware;
+    public TextAreaSkinIos(final TextArea textArea) {
+        super(textArea);
+
+        textArea.focusedProperty().addListener(new ChangeListener<Boolean>() {
+            public void changed(ObservableValue<? extends Boolean> observable,
+                    Boolean wasFocused, Boolean isFocused) {
+                if (textArea.isEditable()) {
+                    if (isFocused) {
+                        showSoftwareKeyboard();
+                    } else {
+                        hideSoftwareKeyboard();
+                    }
+                }
+            }
+        });
+    }
+
+    native void showSoftwareKeyboard();
+    native void hideSoftwareKeyboard();
+
 }
-
-@end
-
-
-@interface GlassViewGL : GLView <GlassView>
-{
-    @public GlassViewDelegate    *delegate;
-
-    CGRect              _bounds; // used to temporarily hold frame being set on main thread
-    //User input help views
-    UIView              *inputAccessoryView;
-    UIView              *nativeView; // view used for user input
-}
--(void) doInsertText:(NSString*)myText;
--(void) doDeleteBackward;
-
-@end

--- a/modules/javafx.controls/src/ios/java/javafx/scene/control/skin/TextFieldSkinIos.java
+++ b/modules/javafx.controls/src/ios/java/javafx/scene/control/skin/TextFieldSkinIos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,36 +23,35 @@
  * questions.
  */
 
-#import <UIKit/UIKit.h>
-#import <QuartzCore/QuartzCore.h>
-#import <OpenGLES/ES2/gl.h>
-#import <OpenGLES/ES2/glext.h>
+package javafx.scene.control.skin;
 
-#import "GlassStatics.h"
-#import "GlassView.h"
-#import "common.h"
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.scene.control.TextField;
 
+import com.sun.javafx.scene.control.behavior.TextFieldBehavior;
+import javafx.scene.control.skin.TextFieldSkin;
 
-@interface GLView : UIScrollView
-{
-    @public GLuint renderBuffer;
-    @public GLuint frameBuffer;
-    BOOL                isHiDPIAware;
+public class TextFieldSkinIos extends TextFieldSkin {
+
+    public TextFieldSkinIos(final TextField textField) {
+        super(textField);
+
+        textField.focusedProperty().addListener(new ChangeListener<Boolean>() {
+            public void changed(ObservableValue<? extends Boolean> observable,
+                    Boolean wasFocused, Boolean isFocused) {
+                if (textField.isEditable()) {
+                    if (isFocused) {
+                        showSoftwareKeyboard();
+                    } else {
+                        hideSoftwareKeyboard();
+                    }
+                }
+            }
+        });
+    }
+
+    native void showSoftwareKeyboard();
+    native void hideSoftwareKeyboard();
+
 }
-
-@end
-
-
-@interface GlassViewGL : GLView <GlassView>
-{
-    @public GlassViewDelegate    *delegate;
-
-    CGRect              _bounds; // used to temporarily hold frame being set on main thread
-    //User input help views
-    UIView              *inputAccessoryView;
-    UIView              *nativeView; // view used for user input
-}
--(void) doInsertText:(NSString*)myText;
--(void) doDeleteBackward;
-
-@end

--- a/modules/javafx.controls/src/ios/resources/com/sun/javafx/scene/control/skin/caspian/ios.css
+++ b/modules/javafx.controls/src/ios/resources/com/sun/javafx/scene/control/skin/caspian/ios.css
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*******************************************************************************
+ *                                                                             *
+ * Ios specific css                                                        *
+ *                                                                             *
+ ******************************************************************************/
+
+
+/*******************************************************************************
+ *                                                                             *
+ * TextField                                                                   *
+ *                                                                             *
+ ******************************************************************************/
+
+.text-field {
+    -fx-skin: "javafx.scene.control.skin.TextFieldSkinIos";
+}
+
+
+/*******************************************************************************
+ *                                                                             *
+ * TextArea                                                                    *
+ *                                                                             *
+ ******************************************************************************/
+
+.text-area {
+    -fx-skin: "javafx.scene.control.skin.TextAreaSkinIos";
+}
+

--- a/modules/javafx.controls/src/ios/resources/com/sun/javafx/scene/control/skin/modena/ios.css
+++ b/modules/javafx.controls/src/ios/resources/com/sun/javafx/scene/control/skin/modena/ios.css
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*******************************************************************************
+ *                                                                             *
+ * Ios specific css                                                        *
+ *                                                                             *
+ ******************************************************************************/
+
+
+/*******************************************************************************
+ *                                                                             *
+ * TextField                                                                   *
+ *                                                                             *
+ ******************************************************************************/
+
+.text-field {
+    -fx-skin: "javafx.scene.control.skin.TextFieldSkinIos";
+}
+
+
+/*******************************************************************************
+ *                                                                             *
+ * TextArea                                                                    *
+ *                                                                             *
+ ******************************************************************************/
+
+.text-area {
+    -fx-skin: "javafx.scene.control.skin.TextAreaSkinIos";
+}
+

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextAreaBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextAreaBehavior.java
@@ -149,33 +149,11 @@ public class TextAreaBehavior extends TextInputControlBehavior<TextArea> {
                 // TextArea doesn't lose selection on focus lost, whereas the TextField does.
                 final TextArea textArea = getNode();
                 if (textArea.isFocused()) {
-                    if (PlatformUtil.isIOS()) {
-                        // Special handling of focus on iOS is required to allow to
-                        // control native keyboard, because native keyboard is popped-up only when native
-                        // text component gets focus. When we have JFX keyboard we can remove this code
-                        final Bounds bounds = textArea.getBoundsInParent();
-                        double w = bounds.getWidth();
-                        double h = bounds.getHeight();
-                        Affine3D trans = TextFieldBehavior.calculateNodeToSceneTransform(textArea);
-                        String text = textArea.textProperty().getValueSafe();
-
-                        // we need to display native text input component on the place where JFX component is drawn
-                        // all parameters needed to do that are passed to native impl. here
-                        WindowHelper.getPeer(textArea.getScene().getWindow()).requestInput(
-                                text, TextFieldBehavior.TextInputTypes.TEXT_AREA.ordinal(), w, h,
-                                trans.getMxx(), trans.getMxy(), trans.getMxz(), trans.getMxt(),
-                                trans.getMyx(), trans.getMyy(), trans.getMyz(), trans.getMyt(),
-                                trans.getMzx(), trans.getMzy(), trans.getMzz(), trans.getMzt());
-                    }
                     if (!focusGainedByMouseClick) {
                         setCaretAnimating(true);
                     }
                 } else {
 //                    skin.hideCaret();
-                    if (PlatformUtil.isIOS() && textArea.getScene() != null) {
-                        // releasing the focus => we need to hide the native component and also native keyboard
-                        WindowHelper.getPeer(textArea.getScene().getWindow()).releaseInput();
-                    }
                     focusGainedByMouseClick = false;
                     setCaretAnimating(false);
                 }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextFieldBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextFieldBehavior.java
@@ -120,41 +120,10 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
         TextField textField = getNode();
 
         if (textField.isFocused()) {
-            if (PlatformUtil.isIOS()) {
-                // special handling of focus on iOS is required to allow to
-                // control native keyboard, because nat. keyboard is poped-up only when native
-                // text component gets focus. When we have JFX keyboard we can remove this code
-                TextInputTypes type = TextInputTypes.TEXT_FIELD;
-                if (textField.getClass().equals(javafx.scene.control.PasswordField.class)) {
-                    type = TextInputTypes.PASSWORD_FIELD;
-                } else if (textField.getParent().getClass().equals(javafx.scene.control.ComboBox.class)) {
-                    type = TextInputTypes.EDITABLE_COMBO;
-                }
-                final Bounds bounds = textField.getBoundsInParent();
-                double w = bounds.getWidth();
-                double h = bounds.getHeight();
-                Affine3D trans = calculateNodeToSceneTransform(textField);
-//                Insets insets = skin.getInsets();
-//                w -= insets.getLeft() + insets.getRight();
-//                h -= insets.getTop() + insets.getBottom();
-                String text = textField.getText();
-
-                // we need to display native text input component on the place where JFX component is drawn
-                // all parameters needed to do that are passed to native impl. here
-                WindowHelper.getPeer(textField.getScene().getWindow()).requestInput(
-                        text, type.ordinal(), w, h,
-                        trans.getMxx(), trans.getMxy(), trans.getMxz(), trans.getMxt(),// + insets.getLeft(),
-                        trans.getMyx(), trans.getMyy(), trans.getMyz(), trans.getMyt(),// + insets.getTop(),
-                        trans.getMzx(), trans.getMzy(), trans.getMzz(), trans.getMzt());
-            }
             if (!focusGainedByMouseClick) {
                 setCaretAnimating(true);
             }
         } else {
-            if (PlatformUtil.isIOS() && textField.getScene() != null) {
-                // releasing the focus => we need to hide the native component and also native keyboard
-                WindowHelper.getPeer(textField.getScene().getWindow()).releaseInput();
-            }
             focusGainedByMouseClick = false;
             setCaretAnimating(false);
         }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextInputControlSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextInputControlSkin.java
@@ -687,12 +687,6 @@ public abstract class TextInputControlSkin<T extends TextInputControl> extends S
         final TextInputControl textInput = getSkinnable();
         if (textInput.isEditable() && !textInput.textProperty().isBound() && !textInput.isDisabled()) {
 
-            // just replace the text on iOS
-            if (PlatformUtil.isIOS()) {
-               textInput.setText(event.getCommitted());
-               return;
-            }
-
             // remove previous input method text (if any) or selected text
             if (imlength != 0) {
                 removeHighlight(imattrs);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
@@ -787,6 +787,9 @@ public class PlatformImpl {
                 if (PlatformUtil.isAndroid()) {
                     uaStylesheets.add("com/sun/javafx/scene/control/skin/caspian/android.css");
                 }
+                if (PlatformUtil.isIOS()) {
+                    uaStylesheets.add("com/sun/javafx/scene/control/skin/caspian/ios.css");
+                }
             }
 
             if (isSupported(ConditionalFeature.TWO_LEVEL_FOCUS)) {
@@ -815,6 +818,9 @@ public class PlatformImpl {
             }
             if (PlatformUtil.isAndroid()) {
                 uaStylesheets.add("com/sun/javafx/scene/control/skin/modena/android.css");
+            }
+            if (PlatformUtil.isIOS()) {
+                uaStylesheets.add("com/sun/javafx/scene/control/skin/modena/ios.css");
             }
 
             if (isSupported(ConditionalFeature.TWO_LEVEL_FOCUS)) {

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassViewGL.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassViewGL.m
@@ -124,6 +124,19 @@ static EAGLContext * ctx = nil;
 
 @implementation GlassViewGL : GLView
 
+-(void) doInsertText:(NSString*)myText {
+    int asciiCode = [myText characterAtIndex:0];
+    [self->delegate sendJavaKeyEventWithType:111 keyCode:asciiCode chars:(char)asciiCode modifiers:0];
+    [self->delegate sendJavaKeyEventWithType:113 keyCode:asciiCode chars:(char)asciiCode modifiers:0];
+    [self->delegate sendJavaKeyEventWithType:112 keyCode:asciiCode chars:(char)asciiCode modifiers:0];
+}
+
+-(void) doDeleteBackward {
+    int asciiCode = 8;
+    [self->delegate sendJavaKeyEventWithType:111 keyCode:asciiCode chars:(char)asciiCode modifiers:0];
+    [self->delegate sendJavaKeyEventWithType:113 keyCode:asciiCode chars:(char)asciiCode modifiers:0];
+    [self->delegate sendJavaKeyEventWithType:112 keyCode:asciiCode chars:(char)asciiCode modifiers:0];
+}
 
 -(BOOL) touchesShouldBegin:(NSSet *)touches withEvent:(UIEvent *)event inContentView:(UIView *)view
 {

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassWindow.h
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassWindow.h
@@ -40,7 +40,7 @@
 
 @end
 
-@interface GlassWindow : UIView
+@interface GlassWindow : UIView<UIKeyInput>
 {
     jobject             jWindow; // Glass java Window object
 

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassWindow.m
@@ -213,6 +213,55 @@ static inline void setWindowFrame(GlassWindow *window, CGFloat x, CGFloat y, CGF
 +(GlassMainView *) getMasterWindowHost {
     return masterWindowHost;
 }
+
+- (BOOL) canBecomeFirstResponder {return YES;}
+
+- (BOOL)hasText {
+        return YES;
+}
+
+- (void)insertText:(NSString *)theText {
+    const char * inputString = [theText UTF8String];
+    for(GlassViewGL * subView in [self->hostView subviews]) {
+        if(subView != nil && [subView isKindOfClass:[GlassViewGL class]] == YES) {
+            [subView doInsertText:theText];
+        }
+    }
+}
+
+- (void)deleteBackward {
+    for(GlassViewGL * subView in [self->hostView subviews]) {
+        if(subView != nil && [subView isKindOfClass:[GlassViewGL class]] == YES) {
+            [subView doDeleteBackward];
+        }
+    }
+}
+
+JNIEXPORT void JNICALL Java_javafx_scene_control_skin_TextFieldSkinIos_showSoftwareKeyboard
+(JNIEnv *env, jobject jTextFieldSkin)
+{
+    [focusOwner becomeFirstResponder];
+}
+
+JNIEXPORT void JNICALL Java_javafx_scene_control_skin_TextFieldSkinIos_hideSoftwareKeyboard
+(JNIEnv *env, jobject jTextFieldSkin)
+{
+    [focusOwner resignFirstResponder];
+}
+
+JNIEXPORT void JNICALL Java_javafx_scene_control_skin_TextAreaSkinIos_showSoftwareKeyboard
+(JNIEnv *env, jobject jTextAreaSkin)
+{
+    [focusOwner becomeFirstResponder];
+}
+
+JNIEXPORT void JNICALL Java_javafx_scene_control_skin_TextAreaSkinIos_hideSoftwareKeyboard
+(JNIEnv *env, jobject jTextAreaSkin)
+{
+    [focusOwner resignFirstResponder];
+}
+
+
 // request subviews to repaint
 - (void) displaySubviews
 {
@@ -1631,25 +1680,8 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_ios_IosWindow__1requestInput
     jdouble myx, jdouble myy, jdouble myz, jdouble myt,
     jdouble mzx, jdouble mzy, jdouble mzz, jdouble mzt)
 {
-    GLASS_ASSERT_MAIN_JAVA_THREAD(env);
-    GLASS_POOL_ENTER;
-
-    GlassWindow *window = getGlassWindow(env, ptr);
-
-    const char *str;
-    str = (*env)->GetStringUTFChars(env, text, NULL);
-    if (str == nil) {
-        return;
-    }
-    NSString *nsstr = [NSString stringWithUTF8String:str];
-    (*env)->ReleaseStringUTFChars(env, text, str);
-
-    [window requestInput:nsstr type:(int)type width:(double)width height:(double)height
-                     mxx:(double)mxx mxy:(double)mxy mxz:(double)mxz mxt:(double)mxt
-                     myx:(double)myx myy:(double)myy myz:(double)myz myt:(double)myt
-                     mzx:(double)mzx mzy:(double)mzy mzz:(double)mzz mzt:(double)mzt];
-    GLASS_POOL_EXIT;
-    GLASS_CHECK_EXCEPTION(env);
+    fprintf(stderr, "We should never be here!\n");
+    return;
 }
 
 


### PR DESCRIPTION
Use JavaFX controls for TextField and TextArea instead of the native iOS ones
This fixes JDK-8242167
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242167](https://bugs.openjdk.java.net/browse/JDK-8242167): ios keyboard handling


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/158/head:pull/158`
`$ git checkout pull/158`
