### PR TITLE
8242209: Increase web native thread stack size for x86 mode

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/win/ThreadingWin.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/win/ThreadingWin.cpp
@@ -155,8 +155,15 @@ static unsigned __stdcall wtfThreadEntryPoint(void* data)
 
 bool Thread::establishHandle(NewThreadContext* data)
 {
+    size_t stackSize = 0;
+#if PLATFORM(JAVA) && USE(JSVALUE32_64)
+    stackSize = 1024 * 1024;
+#endif
+
     unsigned threadIdentifier = 0;
-    HANDLE threadHandle = reinterpret_cast<HANDLE>(_beginthreadex(0, 0, wtfThreadEntryPoint, data, 0, &threadIdentifier));
+    unsigned initFlag = stackSize ? STACK_SIZE_PARAM_IS_A_RESERVATION : 0;
+
+    HANDLE threadHandle = reinterpret_cast<HANDLE>(_beginthreadex(0, stackSize, wtfThreadEntryPoint, data, initFlag, &threadIdentifier));
     if (!threadHandle) {
         LOG_ERROR("Failed to create thread at entry point %p with data %p: %ld", wtfThreadEntryPoint, data, errno);
         return false;


### PR DESCRIPTION
CLoop interpreter used in 32-bit Windows uses 87 KB of stack space each time CLoop::execute() is called. For web native threads which has a default stack size of 320 KB, a Stack Overflow Error is raised just after two calls to execute() function. While 64-bit windows has a default stack size of 1 MB.

Fix: Increase the thread stack size of web native threads for x86 to 1 MB.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242209](https://bugs.openjdk.java.net/browse/JDK-8242209): Increase web native thread stack size for x86 mode


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Guru Hb ([ghb](@guruhb) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/159/head:pull/159`
`$ git checkout pull/159`
