### PR TITLE
8241249: NPE in TabPaneSkin.perfromDrag

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
@@ -2048,7 +2048,7 @@ public class TabPaneSkin extends SkinBase<TabPane> {
 
     private void handleHeaderDragged(MouseEvent event) {
         if (event.getButton().equals(MouseButton.PRIMARY)) {
-            perfromDrag(event);
+            performDrag(event);
         }
     }
 
@@ -2071,7 +2071,10 @@ public class TabPaneSkin extends SkinBase<TabPane> {
         return MAX_TO_MIN;
     }
 
-    private void perfromDrag(MouseEvent event) {
+    private void performDrag(MouseEvent event) {
+        if (dragState == DragState.NONE) {
+            return;
+        }
         int dragDirection;
         double dragHeaderNewLayoutX;
         Bounds dragHeaderBounds;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TabPaneTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TabPaneTest.java
@@ -478,6 +478,10 @@ public class TabPaneTest {
         SceneHelper.processMouseEvent(scene,
             MouseEventGenerator.generateMouseEvent(MouseEvent.MOUSE_RELEASED, xval+75, yval+20));
         tk.firePulse();
+
+        SceneHelper.processMouseEvent(scene,
+                MouseEventGenerator.generateMouseEvent(MouseEvent.MOUSE_DRAGGED, xval+75, yval+20));
+        tk.firePulse();
     }
 
     @Test public void setRotateGraphicAndSeeValueIsReflectedInModel() {


### PR DESCRIPTION
This is a simple fix similar to [JDK-8237372](https://bugs.openjdk.java.net/browse/JDK-8237372).
The NPE can occur if a MOUSE_DRAGGED is received by tab header without receiving MOUSE_PRESSED.
The fix also corrects a typo error. `perfromDrag()` to `performDrag()`
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241249](https://bugs.openjdk.java.net/browse/JDK-8241249): NPE in TabPaneSkin.perfromDrag


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/160/head:pull/160`
`$ git checkout pull/160`
