### PR TITLE
8241710: NullPointerException while entering empty submenu with "arrow right"

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ContextMenuContent.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ContextMenuContent.java
@@ -650,15 +650,19 @@ public class ContextMenuContent extends Region {
 
     private void showMenu(Menu menu) {
         menu.show();
-        // request focus on the first item of the submenu after it is shown
-        ContextMenuContent cmContent = (ContextMenuContent)submenu.getSkin().getNode();
-        if (cmContent != null) {
-           if (cmContent.itemsContainer.getChildren().size() > 0) {
-               cmContent.itemsContainer.getChildren().get(0).requestFocus();
-               cmContent.currentFocusedIndex = 0;
-           } else {
-               cmContent.requestFocus();
-           }
+
+        // if there is a submenu
+        if (submenu != null) {
+            // request focus on the first item of the submenu after it is shown
+            ContextMenuContent cmContent = (ContextMenuContent)submenu.getSkin().getNode();
+            if (cmContent != null) {
+               if (cmContent.itemsContainer.getChildren().size() > 0) {
+                   cmContent.itemsContainer.getChildren().get(0).requestFocus();
+                   cmContent.currentFocusedIndex = 0;
+               } else {
+                   cmContent.requestFocus();
+               }
+            }
         }
     }
 

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ContextMenuContent.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ContextMenuContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -651,18 +651,19 @@ public class ContextMenuContent extends Region {
     private void showMenu(Menu menu) {
         menu.show();
 
-        // if there is a submenu
-        if (submenu != null) {
-            // request focus on the first item of the submenu after it is shown
-            ContextMenuContent cmContent = (ContextMenuContent)submenu.getSkin().getNode();
-            if (cmContent != null) {
-               if (cmContent.itemsContainer.getChildren().size() > 0) {
-                   cmContent.itemsContainer.getChildren().get(0).requestFocus();
-                   cmContent.currentFocusedIndex = 0;
-               } else {
-                   cmContent.requestFocus();
-               }
-            }
+        if (submenu == null) {
+            return;
+        }
+
+        // request focus on the first item of the submenu after it is shown
+        ContextMenuContent cmContent = (ContextMenuContent)submenu.getSkin().getNode();
+        if (cmContent != null) {
+           if (cmContent.itemsContainer.getChildren().size() > 0) {
+               cmContent.itemsContainer.getChildren().get(0).requestFocus();
+               cmContent.currentFocusedIndex = 0;
+           } else {
+               cmContent.requestFocus();
+           }
         }
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ContextMenuTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ContextMenuTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ContextMenuTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ContextMenuTest.java
@@ -452,6 +452,22 @@ public class ContextMenuTest {
                 subMenuItem1, focusedItem);
     }
 
+    @Test public void test_emptySubMenu_rightKeyDoesNothing() {
+        Menu testMenu = new Menu("Menu1");
+        ContextMenu testCM = new ContextMenu();
+
+        testCM.getItems().addAll(testMenu);
+        testCM.show(anchorBtn, Side.RIGHT, 0, 0);
+        assertNotNull(getShowingMenuContent(testCM));
+
+        // Go to testMenu
+        pressDownKey(testCM);
+
+        // testMenu does not have any subMenu - try to open it
+        // this used to casue NPE - fixed in JDK-8241710
+        pressRightKey(testCM);
+    }
+
     @Test public void test_navigateSubMenu_leftKeyClosesSubMenu() {
         ContextMenu cm = createContextMenuAndShowSubMenu();
 


### PR DESCRIPTION
Bug : https://bugs.openjdk.java.net/browse/JDK-8241710

Root Cause : A menu can have empty submenu. This was not checked while processing RIGHT arrow key.

Fix : Added the null check for submenu. Added a unit test case which fails without fix and passes with it.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241710](https://bugs.openjdk.java.net/browse/JDK-8241710): NullPointerException while entering empty submenu with "arrow right"


### Reviewers
 * Jeanette Winzenburg ([fastegal](@kleopatra) - Author)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/161/head:pull/161`
`$ git checkout pull/161`
