### PR TITLE
8240264: iOS: Unnecessary logging on every pulse when GL context changes

### DIFF
--- a/modules/javafx.graphics/src/main/native-prism-es2/ios/IOSGLContext.c
+++ b/modules/javafx.graphics/src/main/native-prism-es2/ios/IOSGLContext.c
@@ -289,5 +289,5 @@ JNIEXPORT void JNICALL Java_com_sun_prism_es2_IOSGLContext_nMakeCurrent
     interval = (vSyncNeeded) ? 1 : 0;
     ctxInfo->state.vSyncEnabled = vSyncNeeded;
     setSwapInterval(ctxInfo->context, interval);
-    fprintf(stderr, "setSwapInterval(%d)\n", interval);
+    // fprintf(stderr, "setSwapInterval(%d)\n", interval);
 }

--- a/modules/javafx.graphics/src/main/native-prism-es2/ios/IOSGLContext.c
+++ b/modules/javafx.graphics/src/main/native-prism-es2/ios/IOSGLContext.c
@@ -34,6 +34,26 @@
 #include "com_sun_prism_es2_IOSGLContext.h"
 
 extern void printAndReleaseResources(jlong pf, jlong ctx, const char *message);
+jboolean pulseLoggingRequested;
+
+jboolean isPulseLoggingRequested(JNIEnv *env) {
+    jclass loggerCls = (*env)->FindClass(env, "com/sun/javafx/logging/PulseLogger");
+    if ((*env)->ExceptionCheck(env) || loggerCls == NULL) {
+        (*env)->ExceptionClear(env);
+        return JNI_FALSE;
+    }
+    jmethodID loggerMID = (*env)->GetStaticMethodID(env, loggerCls, "isPulseLoggingRequested", "()Z");
+    if ((*env)->ExceptionCheck(env) || loggerMID == NULL) {
+        (*env)->ExceptionClear(env);
+        return JNI_FALSE;
+    }
+    jboolean result = (*env)->CallStaticBooleanMethod(env, loggerCls, loggerMID);
+    if ((*env)->ExceptionCheck(env)) {
+        (*env)->ExceptionClear(env);
+        return JNI_FALSE;
+    }
+    return result;
+}
 
 /*
  * Class:     com_sun_prism_es2_IOSGLContext
@@ -51,6 +71,7 @@ JNIEXPORT jlong JNICALL Java_com_sun_prism_es2_IOSGLContext_nInitialize
     int  versionNumbers[2];
     const char *glExtensions;
 
+    pulseLoggingRequested = isPulseLoggingRequested(env);
     jlong pixelFormat = 0;
     jlong win = 0;
     jlong context = 0;
@@ -289,5 +310,7 @@ JNIEXPORT void JNICALL Java_com_sun_prism_es2_IOSGLContext_nMakeCurrent
     interval = (vSyncNeeded) ? 1 : 0;
     ctxInfo->state.vSyncEnabled = vSyncNeeded;
     setSwapInterval(ctxInfo->context, interval);
-    // fprintf(stderr, "setSwapInterval(%d)\n", interval);
+    if (pulseLoggingRequested) {
+        fprintf(stderr, "setSwapInterval(%d)\n", interval);
+    }
 }

--- a/modules/javafx.graphics/src/main/native-prism-es2/ios/IOSWindowSystemInterface.m
+++ b/modules/javafx.graphics/src/main/native-prism-es2/ios/IOSWindowSystemInterface.m
@@ -82,7 +82,7 @@ jboolean clearCurrentContext(void *context) {
 }
 
 jboolean deleteContext(void *context) {
-    fprintf(stderr, "IOSWindowSystemInterface : deleteContext unimp\n");
+    // fprintf(stderr, "IOSWindowSystemInterface : deleteContext unimp\n");
     return JNI_FALSE;
 }
 
@@ -92,7 +92,7 @@ jboolean flushBuffer(void *context) {
 }
 
 void setSwapInterval(void *context, int interval) {
-    fprintf(stderr, "IOSWindowSystemInterface : setSwapInterval unimp\n");
+    // fprintf(stderr, "IOSWindowSystemInterface : setSwapInterval unimp\n");
 }
 
 

--- a/modules/javafx.graphics/src/main/native-prism-es2/ios/IOSWindowSystemInterface.m
+++ b/modules/javafx.graphics/src/main/native-prism-es2/ios/IOSWindowSystemInterface.m
@@ -82,9 +82,7 @@ jboolean clearCurrentContext(void *context) {
 }
 
 jboolean deleteContext(void *context) {
-    if (pulseLoggingRequested) {
-        fprintf(stderr, "IOSWindowSystemInterface : deleteContext unimp\n");
-    }
+    fprintf(stderr, "IOSWindowSystemInterface : deleteContext unimp\n");
     return JNI_FALSE;
 }
 

--- a/modules/javafx.graphics/src/main/native-prism-es2/ios/IOSWindowSystemInterface.m
+++ b/modules/javafx.graphics/src/main/native-prism-es2/ios/IOSWindowSystemInterface.m
@@ -82,7 +82,9 @@ jboolean clearCurrentContext(void *context) {
 }
 
 jboolean deleteContext(void *context) {
-    // fprintf(stderr, "IOSWindowSystemInterface : deleteContext unimp\n");
+    if (pulseLoggingRequested) {
+        fprintf(stderr, "IOSWindowSystemInterface : deleteContext unimp\n");
+    }
     return JNI_FALSE;
 }
 
@@ -92,7 +94,9 @@ jboolean flushBuffer(void *context) {
 }
 
 void setSwapInterval(void *context, int interval) {
-    // fprintf(stderr, "IOSWindowSystemInterface : setSwapInterval unimp\n");
+    if (pulseLoggingRequested) {
+        fprintf(stderr, "IOSWindowSystemInterface : setSwapInterval unimp\n");
+    }
 }
 
 

--- a/modules/javafx.graphics/src/main/native-prism-es2/ios/ios-window-system.h
+++ b/modules/javafx.graphics/src/main/native-prism-es2/ios/ios-window-system.h
@@ -50,3 +50,4 @@ void* getProcAddress(const char *procName);
 
 void setSwapInterval(void* nsContext, int interval);
 
+extern jboolean pulseLoggingRequested;


### PR DESCRIPTION
This PR comments out too verbose console logging, as it has been done with some other fprintf calls.
As a follow up of this PR, a custom directive that enables this output if needed can be considered.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240264](https://bugs.openjdk.java.net/browse/JDK-8240264): iOS: Unnecessary logging on every pulse when GL context changes


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/165/head:pull/165`
`$ git checkout pull/165`
