### PR TITLE
8129123: ComboBox popup list view does not scrollTo when ComboBox value/selection is set

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -417,8 +417,10 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
                     T itemsObj = comboBoxItems.get(index);
                     if ((itemsObj != null && itemsObj.equals(newValue)) || (itemsObj == null && newValue == null)) {
                         listViewSM.select(index);
+                        listView.scrollTo(index);
                     } else {
                         listViewSM.select(newValue);
+                        listView.scrollTo(newValue);
                     }
                 } else {
                     // just select the first instance of newValue in the list
@@ -429,6 +431,7 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
                         updateDisplayNode();
                     } else {
                         listViewSM.select(listViewIndex);
+                        listView.scrollTo(listViewIndex);
                     }
                 }
             }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,8 @@ import javafx.css.PseudoClass;
 
 import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
+import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
+
 import javafx.scene.control.skin.ComboBoxListViewSkin;
 
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.assertStyleClassContains;
@@ -2057,5 +2059,49 @@ public class ComboBoxTest {
         tk.firePulse();
 
         assertEquals("ComboBox skinProperty changed more than once, which is not expected.", 1, skinChangedCount);
+    }
+
+    @Test public void test_JDK_8129123() {
+        final int LIST_SIZE = 50;
+
+        ComboBox<String> comboBox = new ComboBox<>();
+
+        BorderPane p = new BorderPane();
+        p.setCenter(comboBox);
+
+        Scene scene = new Scene(p);
+
+        Stage stage = new Stage();
+        stage.setScene(scene);
+        stage.setWidth(500);
+        stage.setHeight(400);
+        stage.show();
+
+        Toolkit.getToolkit().firePulse();
+
+        for (int i = 0; i < LIST_SIZE; i++) {
+            comboBox.getItems().add(String.valueOf(i));
+        }
+        comboBox.show();
+
+        VirtualFlow<IndexedCell<?>> virtualFlow = (VirtualFlow<IndexedCell<?>>) VirtualFlowTestUtils.getVirtualFlow(comboBox);
+
+        int index = 0;
+        comboBox.getSelectionModel().select(index);
+        Toolkit.getToolkit().firePulse();
+
+        int first = virtualFlow.getFirstVisibleCell().getIndex();
+        int last = virtualFlow.getLastVisibleCell().getIndex();
+        assertTrue(" visible range [" + first + ", " + last + "] must include " + index,
+                first <= index  && index <= last);
+
+        index = LIST_SIZE - 1;
+        comboBox.getSelectionModel().select(index);
+        Toolkit.getToolkit().firePulse();
+
+        first = virtualFlow.getFirstVisibleCell().getIndex();
+        last = virtualFlow.getLastVisibleCell().getIndex();
+        assertTrue(" visible range [" + first + ", " + last + "] must include " + index,
+                first <= index  && index <= last);
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -2095,6 +2095,15 @@ public class ComboBoxTest {
         assertTrue(" visible range [" + first + ", " + last + "] must include " + index,
                 first <= index  && index <= last);
 
+        index = LIST_SIZE / 2;
+        comboBox.getSelectionModel().select(index);
+        Toolkit.getToolkit().firePulse();
+
+        first = virtualFlow.getFirstVisibleCell().getIndex();
+        last = virtualFlow.getLastVisibleCell().getIndex();
+        assertTrue(" visible range [" + first + ", " + last + "] must include " + index,
+                first <= index  && index <= last);
+
         index = LIST_SIZE - 1;
         comboBox.getSelectionModel().select(index);
         Toolkit.getToolkit().firePulse();


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8129123

This pull request fixes JDK-8129123. This bug also effects Windows and Linux platforms.
Also, I believe JDK-8196037 is a duplicate of this issue.

I've tested this against OpenJDK 11.0.6 on Ubuntu 18.04, Arch Linux and Windows 10.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8129123](https://bugs.openjdk.java.net/browse/JDK-8129123): ComboBox popup list view does not scrollTo when ComboBox value/selection is set


### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/166/head:pull/166`
`$ git checkout pull/166`
