### PR TITLE
8198402: ToggleButton.setToggleGroup causes memory leak when button is removed via ToggleGroup.getToggles()

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ToggleButton.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ToggleButton.java
@@ -193,14 +193,17 @@ import javafx.css.StyleableProperty;
      * being added to the new group.
      */
     private ObjectProperty<ToggleGroup> toggleGroup;
+    @Override
     public final void setToggleGroup(ToggleGroup value) {
         toggleGroupProperty().set(value);
     }
 
+    @Override
     public final ToggleGroup getToggleGroup() {
         return toggleGroup == null ? null : toggleGroup.get();
     }
 
+    @Override
     public final ObjectProperty<ToggleGroup> toggleGroupProperty() {
         if (toggleGroup == null) {
             toggleGroup = new ObjectPropertyBase<ToggleGroup>() {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ToggleButton.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ToggleButton.java
@@ -193,17 +193,14 @@ import javafx.css.StyleableProperty;
      * being added to the new group.
      */
     private ObjectProperty<ToggleGroup> toggleGroup;
-    @Override
     public final void setToggleGroup(ToggleGroup value) {
         toggleGroupProperty().set(value);
     }
 
-    @Override
     public final ToggleGroup getToggleGroup() {
         return toggleGroup == null ? null : toggleGroup.get();
     }
 
-    @Override
     public final ObjectProperty<ToggleGroup> toggleGroupProperty() {
         if (toggleGroup == null) {
             toggleGroup = new ObjectPropertyBase<ToggleGroup>() {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ToggleGroup.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ToggleGroup.java
@@ -71,7 +71,7 @@ public class ToggleGroup {
     private final ObservableList<Toggle> toggles = new VetoableListDecorator<Toggle>(new TrackableObservableList<Toggle>() {
         @Override protected void onChanged(Change<Toggle> c) {
             while (c.next()) {
-                List<Toggle> addedToggles = c.getAddedSubList();
+                final List<Toggle> addedToggles = c.getAddedSubList();
 
                 // Look through the removed toggles.
                 for (Toggle t : c.getRemoved()) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ToggleGroup.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ToggleGroup.java
@@ -71,19 +71,27 @@ public class ToggleGroup {
     private final ObservableList<Toggle> toggles = new VetoableListDecorator<Toggle>(new TrackableObservableList<Toggle>() {
         @Override protected void onChanged(Change<Toggle> c) {
             while (c.next()) {
-                // Look through the removed toggles, and if any of them was the
-                // one and only selected toggle, then we will clear the selected
-                // toggle property.
+                List<Toggle> addedToggles = c.getAddedSubList();
+
+                // Look through the removed toggles.
                 for (Toggle t : c.getRemoved()) {
+                    // If any of them was the one and only selected toggle,
+                    // then we will clear the selected toggle property.
                     if (t.isSelected()) {
                         selectToggle(null);
+                    }
+
+                    // If the toggle is not added again (below) remove
+                    // the group association.
+                    if (!addedToggles.contains(t)) {
+                        t.setToggleGroup(null);
                     }
                 }
 
                 // A Toggle can only be in one group at any one time. If the
                 // group is changed, then the toggle is removed from the old group prior to
                 // being added to the new group.
-                for (Toggle t: c.getAddedSubList()) {
+                for (Toggle t: addedToggles) {
                     if (!ToggleGroup.this.equals(t.getToggleGroup())) {
                         if (t.getToggleGroup() != null) {
                             t.getToggleGroup().getToggles().remove(t);
@@ -95,7 +103,7 @@ public class ToggleGroup {
                 // Look through all the added toggles and the very first selected
                 // toggle we encounter will become the one we make the selected
                 // toggle for this group.
-                for (Toggle t : c.getAddedSubList()) {
+                for (Toggle t : addedToggles) {
                     if (t.isSelected()) {
                         selectToggle(t);
                         break;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ToggleButtonTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ToggleButtonTest.java
@@ -267,7 +267,7 @@ public class ToggleButtonTest {
             try {
                 Thread.sleep(500);
             } catch (InterruptedException e) {
-               System.err.println("InterruptedException occurred during Thread.sleep()");
+                fail("InterruptedException occurred during Thread.sleep()");
             }
         }
     }


### PR DESCRIPTION
Make the two ways of associating a ToggleButton with a ToggleGroup interact correctly.

This fixes https://bugs.openjdk.java.net/browse/JDK-8198402
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8198402](https://bugs.openjdk.java.net/browse/JDK-8198402): ToggleButton.setToggleGroup causes memory leak when button is removed via ToggleGroup.getToggles() 


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/167/head:pull/167`
`$ git checkout pull/167`
