### PR TITLE
8202296: Monocle MouseInput doesn't send keyboard modifiers in events.

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MouseInput.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MouseInput.java
@@ -105,7 +105,9 @@ class MouseInput {
                 MonocleView oldView = (MonocleView) oldWindow.getView();
                 if (oldView != null) {
                     // send exit event
-                    int modifiers = state.getModifiers(); // TODO: include key modifiers
+                    KeyState keyState = new KeyState();
+                    KeyInput.getInstance().getState(keyState);
+                    int modifiers = state.getModifiers() | keyState.getModifiers();
                     int button = state.getButton();
                     boolean isPopupTrigger = false; // TODO
                     int oldX = state.getX();
@@ -145,7 +147,9 @@ class MouseInput {
         int relY = y - window.getY();
         // send enter event
         if (oldWindow != window && view != null) {
-            int modifiers = state.getModifiers(); // TODO: include key modifiers
+            KeyState keyState = new KeyState();
+            KeyInput.getInstance().getState(keyState);
+            int modifiers = state.getModifiers() | keyState.getModifiers();
             int button = state.getButton();
             boolean isPopupTrigger = false; // TODO
             postMouseEvent(view, MouseEvent.ENTER, button,
@@ -156,7 +160,9 @@ class MouseInput {
         if (oldWindow != window | newAbsoluteLocation) {
             boolean isDrag = !state.getButtonsPressed().isEmpty();
             int eventType = isDrag ? MouseEvent.DRAG : MouseEvent.MOVE;
-            int modifiers = state.getModifiers(); // TODO: include key modifiers
+            KeyState keyState = new KeyState();
+            KeyInput.getInstance().getState(keyState);
+            int modifiers = state.getModifiers() | keyState.getModifiers();
             int button = state.getButton();
             boolean isPopupTrigger = false; // TODO
             postMouseEvent(view, eventType, button,
@@ -172,11 +178,14 @@ class MouseInput {
             for (int i = 0; i < buttons.size(); i++) {
                 int button = buttons.get(i);
                 pressState.pressButton(button);
+                KeyState keyState = new KeyState();
+                KeyInput.getInstance().getState(keyState);
+                int modifiers = pressState.getModifiers() | keyState.getModifiers();
                 // send press event
                 boolean isPopupTrigger = false; // TODO
                 postMouseEvent(view, MouseEvent.DOWN, button,
                                relX, relY, x, y,
-                               pressState.getModifiers(), isPopupTrigger,
+                               modifiers, isPopupTrigger,
                                synthesized);
             }
         }
@@ -190,11 +199,14 @@ class MouseInput {
             for (int i = 0; i < buttons.size(); i++) {
                 int button = buttons.get(i);
                 releaseState.releaseButton(button);
+                KeyState keyState = new KeyState();
+                KeyInput.getInstance().getState(keyState);
+                int modifiers = releaseState.getModifiers() | keyState.getModifiers();
                 // send release event
                 boolean isPopupTrigger = false; // TODO
                 postMouseEvent(view, MouseEvent.UP, button,
                                relX, relY, x, y,
-                               releaseState.getModifiers(), isPopupTrigger,
+                               modifiers, isPopupTrigger,
                                synthesized);
             }
         }
@@ -208,7 +220,9 @@ class MouseInput {
                 default: dY = 0.0; break;
             }
             if (dY != 0.0) {
-                int modifiers = newState.getModifiers();
+                KeyState keyState = new KeyState();
+                KeyInput.getInstance().getState(keyState);
+                int modifiers = newState.getModifiers() | keyState.getModifiers();
                 RunnableProcessor.runLater(() -> {
                     view.notifyScroll(relX, relY, x, y, 0.0, dY,
                                       modifiers, 1, 0, 0, 0, 1.0, 1.0);

--- a/tests/system/src/test/java/test/robot/com/sun/glass/ui/monocle/RobotTest.java
+++ b/tests/system/src/test/java/test/robot/com/sun/glass/ui/monocle/RobotTest.java
@@ -61,10 +61,10 @@ public class RobotTest {
         TestLogShim.log(name.getMethodName());
         TestApplication.showFullScreenScene();
     }
-    
+
     @Test
     public void clickKeyModifierTest() throws Exception {
-    	runWithKeyPress(KeyCode.CONTROL, MouseButton.PRIMARY, "Clicked at 300, 400 with modifier 'CTRL'", evt -> {
+        runWithKeyPress(KeyCode.CONTROL, MouseButton.PRIMARY, "Clicked at 300, 400 with modifier 'CTRL'", evt -> {
             assertTrue("Ctrl should be down",evt.isControlDown());
         });
         runWithKeyPress(KeyCode.SHIFT, MouseButton.PRIMARY, "Clicked at 300, 400 with modifier 'SHIFT'", evt -> {
@@ -74,16 +74,16 @@ public class RobotTest {
             assertTrue("Alt should be down",evt.isAltDown());
         });
     }
-    
+
     private void runWithKeyPress(KeyCode code, MouseButton button, String message, Consumer<MouseEvent> test) throws Exception {
         TestApplication.getStage().getScene().setOnMouseClicked(
                 (e) -> {
-                	test.accept(e);
-                	TestLogShim.format("Clicked at %.0f, %.0f with modifier '%s'", e.getScreenX(), e.getScreenY(), modifierString(e));
+                    test.accept(e);
+                    TestLogShim.format("Clicked at %.0f, %.0f with modifier '%s'", e.getScreenX(), e.getScreenY(), modifierString(e));
                 }
         );
-    	
-    	Platform.runLater(() -> {
+
+        Platform.runLater(() -> {
             Robot robot = new Robot();
             robot.mouseMove(300, 400);
             robot.keyPress(code);
@@ -93,7 +93,7 @@ public class RobotTest {
         });
     	TestLogShim.waitForLog(message);
     }
-    
+
     private static String modifierString(MouseEvent evt) {
     	List<String> modifiers = new ArrayList<>();
     	if(evt.isAltDown()) {

--- a/tests/system/src/test/java/test/robot/com/sun/glass/ui/monocle/RobotTest.java
+++ b/tests/system/src/test/java/test/robot/com/sun/glass/ui/monocle/RobotTest.java
@@ -30,6 +30,7 @@ import javafx.application.Platform;
 import javafx.geometry.Point2D;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.robot.Robot;
 
 import org.junit.Before;
@@ -38,6 +39,13 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 /**
  * This is a generic test for Glass robot. It is in the monocle.input package
@@ -52,6 +60,52 @@ public class RobotTest {
         TestLogShim.reset();
         TestLogShim.log(name.getMethodName());
         TestApplication.showFullScreenScene();
+    }
+    
+    @Test
+    public void clickKeyModifierTest() throws Exception {
+    	runWithKeyPress(KeyCode.CONTROL, MouseButton.PRIMARY, "Clicked at 300, 400 with modifier 'CTRL'", evt -> {
+            assertTrue("Ctrl should be down",evt.isControlDown());
+        });
+        runWithKeyPress(KeyCode.SHIFT, MouseButton.PRIMARY, "Clicked at 300, 400 with modifier 'SHIFT'", evt -> {
+            assertTrue("Shift should be down",evt.isShiftDown());
+        });
+        runWithKeyPress(KeyCode.ALT, MouseButton.PRIMARY, "Clicked at 300, 400 with modifier 'ALT'", evt -> {
+            assertTrue("Alt should be down",evt.isAltDown());
+        });
+    }
+    
+    private void runWithKeyPress(KeyCode code, MouseButton button, String message, Consumer<MouseEvent> test) throws Exception {
+        TestApplication.getStage().getScene().setOnMouseClicked(
+                (e) -> {
+                	test.accept(e);
+                	TestLogShim.format("Clicked at %.0f, %.0f with modifier '%s'", e.getScreenX(), e.getScreenY(), modifierString(e));
+                }
+        );
+    	
+    	Platform.runLater(() -> {
+            Robot robot = new Robot();
+            robot.mouseMove(300, 400);
+            robot.keyPress(code);
+            robot.mousePress(button);
+            robot.mouseRelease(button);
+            robot.keyRelease(code);
+        });
+    	TestLogShim.waitForLog(message);
+    }
+    
+    private static String modifierString(MouseEvent evt) {
+    	List<String> modifiers = new ArrayList<>();
+    	if(evt.isAltDown()) {
+    		modifiers.add("ALT");
+    	}
+    	if(evt.isControlDown()) {
+    		modifiers.add("CTRL");
+    	}
+    	if(evt.isShiftDown()) {
+    		modifiers.add("SHIFT");
+    	}
+    	return modifiers.stream().collect(Collectors.joining(", "));
     }
 
     @Test

--- a/tests/system/src/test/java/test/robot/com/sun/glass/ui/monocle/RobotTest.java
+++ b/tests/system/src/test/java/test/robot/com/sun/glass/ui/monocle/RobotTest.java
@@ -95,17 +95,17 @@ public class RobotTest {
     }
 
     private static String modifierString(MouseEvent evt) {
-    	List<String> modifiers = new ArrayList<>();
-    	if(evt.isAltDown()) {
-    		modifiers.add("ALT");
-    	}
-    	if(evt.isControlDown()) {
-    		modifiers.add("CTRL");
-    	}
-    	if(evt.isShiftDown()) {
-    		modifiers.add("SHIFT");
-    	}
-    	return modifiers.stream().collect(Collectors.joining(", "));
+        List<String> modifiers = new ArrayList<>();
+        if(evt.isAltDown()) {
+            modifiers.add("ALT");
+        }
+        if(evt.isControlDown()) {
+            modifiers.add("CTRL");
+        }
+        if(evt.isShiftDown()) {
+            modifiers.add("SHIFT");
+        }
+        return modifiers.stream().collect(Collectors.joining(", "));
     }
 
     @Test

--- a/tests/system/src/test/java/test/robot/com/sun/glass/ui/monocle/RobotTest.java
+++ b/tests/system/src/test/java/test/robot/com/sun/glass/ui/monocle/RobotTest.java
@@ -91,7 +91,7 @@ public class RobotTest {
             robot.mouseRelease(button);
             robot.keyRelease(code);
         });
-    	TestLogShim.waitForLog(message);
+        TestLogShim.waitForLog(message);
     }
 
     private static String modifierString(MouseEvent evt) {


### PR DESCRIPTION
Extract keystate and add to the existing modifier mask, to support eg
multi-select

https://bugs.openjdk.java.net/browse/JDK-8202296
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8202296](https://bugs.openjdk.java.net/browse/JDK-8202296): Monocle MouseInput doesn't send keyboard modifiers in events.


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/170/head:pull/170`
`$ git checkout pull/170`
