### PR TITLE
8242548: Wrapped labeled controls using -fx-line-spacing cut text off

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/skin/Utils.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/skin/Utils.java
@@ -429,7 +429,7 @@ public class Utils {
         // However the calculations include the line spacing as part of a
         // line's height.  In order to not cut off the last line because its
         // line spacing wouldn't fit, the height used for the calculation
-        // is increase here with the line spacing amount.
+        // is increased here with the line spacing amount.
 
         height += lineSpacing;
 

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/skin/Utils.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/skin/Utils.java
@@ -417,17 +417,27 @@ public class Utils {
     }
 
     public static String computeClippedWrappedText(Font font, String text, double width,
-                                            double height, OverrunStyle truncationStyle,
+                                            double height, double lineSpacing, OverrunStyle truncationStyle,
                                             String ellipsisString, TextBoundsType boundsType) {
         if (font == null) {
             throw new IllegalArgumentException("Must specify a font");
         }
 
+        // The height given does not need to include the line spacing after
+        // the last line to be able to render that last line correctly.
+        //
+        // However the calculations include the line spacing as part of a
+        // line's height.  In order to not cut off the last line because its
+        // line spacing wouldn't fit, the height used for the calculation
+        // is increase here with the line spacing amount.
+
+        height += lineSpacing;
+
         String ellipsis = (truncationStyle == CLIP) ? "" : ellipsisString;
         int eLen = ellipsis.length();
         // Do this before using helper, as it's not reentrant.
         double eWidth = computeTextWidth(font, ellipsis, 0);
-        double eHeight = computeTextHeight(font, ellipsis, 0, boundsType);
+        double eHeight = computeTextHeight(font, ellipsis, 0, lineSpacing, boundsType);
 
         if (width < eWidth || height < eHeight) {
             // The ellipsis doesn't fit.
@@ -438,7 +448,7 @@ public class Utils {
         helper.setFont(font);
         helper.setWrappingWidth((int)Math.ceil(width));
         helper.setBoundsType(boundsType);
-        helper.setLineSpacing(0);
+        helper.setLineSpacing(lineSpacing);
 
         boolean leading =  (truncationStyle == LEADING_ELLIPSIS ||
                             truncationStyle == LEADING_WORD_ELLIPSIS);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
@@ -1107,7 +1107,7 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
             String ellipsisString = labeled.getEllipsisString();
 
             if (labeled.isWrapText()) {
-                result = Utils.computeClippedWrappedText(font, s, wrapWidth, wrapHeight, truncationStyle, ellipsisString, text.getBoundsType());
+                result = Utils.computeClippedWrappedText(font, s, wrapWidth, wrapHeight, labeled.getLineSpacing(), truncationStyle, ellipsisString, text.getBoundsType());
             } else if (multiline) {
                 StringBuilder sb = new StringBuilder();
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
@@ -136,6 +136,12 @@ public class LabelSkinTest {
         assertTrue(skin.propertyChanged);
     }
 
+    @Test public void lineSpacingChangesOnLabelShouldInvoke_handleControlPropertyChanged() {
+        skin.addWatchedProperty(label.lineSpacingProperty());
+        label.setLineSpacing(1.0);
+        assertTrue(skin.propertyChanged);
+    }
+
     @Test public void textChangesOnLabelShouldInvoke_handleControlPropertyChanged() {
         skin.addWatchedProperty(label.textProperty());
         label.setText("Bust my buffers!");
@@ -277,6 +283,15 @@ public class LabelSkinTest {
         label.setAlignment(Pos.TOP_CENTER);
         assertTrue(label.isNeedsLayout());
         assertFalse(skin.get_invalidText());
+    }
+
+    @Test public void lineSpacingChangesOnLabelShouldInvalidateLayoutAndDisplayText() {
+        label.layout();
+        skin.updateDisplayedText();
+
+        label.setLineSpacing(1.0);
+        assertTrue(label.isNeedsLayout());
+        assertTrue(skin.get_invalidText());
     }
 
     @Test public void textChangesOnLabelShouldInvalidateLayoutAndDisplayTextAndTextWidth() {
@@ -1143,6 +1158,26 @@ public class LabelSkinTest {
         final double singleLineHeight = Utils.computeTextHeight(label.getFont(), " ", 0, text.getBoundsType());
         final double height = label.prefHeight(-1);
         assertTrue(height >= singleLineHeight * 5);
+    }
+
+    @Test public void whenTextHasNewlinesAndPositiveLineSpacing_computePrefHeight_IncludesTheMultipleLinesAndLineSpacingInThePrefHeight() {
+        label.setLineSpacing(2);
+        label.setText("This\nis a test\nof the emergency\nbroadcast system.\nThis is only a test");
+        label.setPadding(new Insets(0, 0, 0, 0));
+        final double singleLineHeight = Utils.computeTextHeight(label.getFont(), " ", 0, text.getBoundsType());
+        final double expectedHeight = singleLineHeight * 5 + label.getLineSpacing() * 5 - label.getLineSpacing();
+        final double height = label.prefHeight(-1);
+        assertEquals(expectedHeight, height, 0);
+    }
+
+    @Test public void whenTextHasNewlinesAndNegativeLineSpacing_computePrefHeight_IncludesTheMultipleLinesAndLineSpacingInThePrefHeight() {
+        label.setLineSpacing(-2);
+        label.setText("This\nis a test\nof the emergency\nbroadcast system.\nThis is only a test");
+        label.setPadding(new Insets(0, 0, 0, 0));
+        final double singleLineHeight = Utils.computeTextHeight(label.getFont(), " ", 0, text.getBoundsType());
+        final double expectedHeight = singleLineHeight * 5 + label.getLineSpacing() * 5 - label.getLineSpacing();
+        final double height = label.prefHeight(-1);
+        assertEquals(expectedHeight, height, 0);
     }
 
     @Test public void whenTextHasNewlinesAfterPreviousComputationOf_computePrefHeight_IncludesTheMultipleLinesInThePrefHeight() {

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubTextLayout.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubTextLayout.java
@@ -48,6 +48,7 @@ public class StubTextLayout implements TextLayout {
     private Font font;
     private int tabSize = DEFAULT_TAB_SIZE;
     private int nullFontSize = 0;
+    private float spacing;
 
     @Override
     public boolean setContent(String text, Object font) {
@@ -69,6 +70,8 @@ public class StubTextLayout implements TextLayout {
 
     @Override
     public boolean setLineSpacing(float spacing) {
+        this.spacing = spacing;
+
         return true;
     }
 
@@ -92,7 +95,7 @@ public class StubTextLayout implements TextLayout {
         final double fontSize = (font == null ? nullFontSize : ((Font)font).getSize());
         final String[] lines = getText().split("\n");
         double width = 0.0;
-        double height = fontSize * lines.length;
+        double height = fontSize * lines.length + spacing * (lines.length - 1);
         for (String line : lines) {
             final int length;
             if (line.contains("\t")) {


### PR DESCRIPTION
This is a solution for 8242548.  There was zero test coverage, so I added a few tests for this as well.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242548](https://bugs.openjdk.java.net/browse/JDK-8242548): Wrapped labeled controls using -fx-line-spacing cut text off


### Reviewers
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/173/head:pull/173`
`$ git checkout pull/173`
