### PR TITLE
8193286: IntegerSpinnerFactory does not wrap value correctly

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/Spinner.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/Spinner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -783,6 +783,22 @@ public class Spinner<T> extends Control {
             r = r + max - min;
         }
         return r;
+    }
+
+    /*
+     * Convenience method to support wrapping values around their min / max
+     * constraints. Used by the SpinnerValueFactory implementations when
+     * the Spinner wrapAround property is true.
+     */
+    static int wrapValue(int value, int min, int max, boolean wrapUp) {
+        int ret = 0;
+        if (wrapUp) {
+            ret = (min + (value - (max + 1)));
+        } else {
+            ret = (max - ((min-1) - value));
+        }
+
+        return ret;
     }
 
     /*

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SpinnerValueFactory.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SpinnerValueFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -578,7 +578,7 @@ public abstract class SpinnerValueFactory<T> {
             final int min = getMin();
             final int max = getMax();
             final int newIndex = getValue() - steps * getAmountToStepBy();
-            setValue(newIndex >= min ? newIndex : (isWrapAround() ? Spinner.wrapValue(newIndex, min, max) + 1 : min));
+            setValue(newIndex >= min ? newIndex : (isWrapAround() ? Spinner.wrapValue(newIndex, min, max, false) : min));
         }
 
         /** {@inheritDoc} */
@@ -587,11 +587,9 @@ public abstract class SpinnerValueFactory<T> {
             final int max = getMax();
             final int currentValue = getValue();
             final int newIndex = currentValue + steps * getAmountToStepBy();
-            setValue(newIndex <= max ? newIndex : (isWrapAround() ? Spinner.wrapValue(newIndex, min, max) - 1 : max));
+            setValue(newIndex <= max ? newIndex : (isWrapAround() ? Spinner.wrapValue(newIndex, min, max, true) : max));
         }
     }
-
-
 
     /**
      * A {@link javafx.scene.control.SpinnerValueFactory} implementation designed to iterate through

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,6 +89,7 @@ public class SpinnerTest {
 
         intSpinner = new Spinner<>(0, 10, 5, 1);
         intValueFactory = (IntegerSpinnerValueFactory) intSpinner.getValueFactory();
+        intValueFactory.setWrapAround(false);
 
         dblSpinner = new Spinner<>(0.0, 1.0, 0.5, 0.05);
         dblValueFactory = (DoubleSpinnerValueFactory) dblSpinner.getValueFactory();
@@ -388,6 +389,184 @@ public class SpinnerTest {
         intValueFactory.increment(1); // 0
         intValueFactory.increment(1); // 1
         assertEquals(1, (int) intValueFactory.getValue());
+    }
+
+    // TODO : This should wrap around and select a value between min and max
+    @Test public void intSpinner_testWrapAround_increment_LargeStep() {
+        intValueFactory.setWrapAround(true);
+        intValueFactory.increment(1000);
+        intValueFactory.increment(1000);
+        assertEquals(10, (int) intValueFactory.getValue());
+    }
+
+    @Test public void intSpinner_testWrapAround_increment_general() {
+        IntegerSpinnerValueFactory factory = new IntegerSpinnerValueFactory(4, 10, 4, 1);
+        factory.setWrapAround(true);
+        factory.increment(1); // 5
+        factory.increment(1); // 6
+        factory.increment(1); // 7
+        factory.increment(1); // 8
+        factory.increment(1); // 9
+        factory.increment(1); // 10
+        factory.increment(1); // 4 -- wrapped around
+        factory.increment(1); // 5
+        assertEquals(5, (int) factory.getValue());
+
+        factory.setValue(4);
+        factory.setAmountToStepBy(2);
+        factory.increment(1); // 6
+        factory.increment(1); // 8
+        factory.increment(1); // 10
+        factory.increment(1); // 5
+        factory.increment(1); // 7
+        factory.increment(1); // 9
+        factory.increment(1); // 4 -- wrapped around
+        factory.increment(1); // 6
+        assertEquals(6, (int) factory.getValue());
+
+        factory.setValue(4);
+        factory.setAmountToStepBy(3);
+        factory.increment(1); // 7
+        factory.increment(1); // 10
+        factory.increment(1); // 6 -- wrapped around
+        factory.increment(1); // 9
+        factory.increment(1); // 5 -- wrapped around
+        factory.increment(1); // 8
+        factory.increment(1); // 4 -- wrapped around
+        factory.increment(1); // 7
+        assertEquals(7, (int) factory.getValue());
+
+        factory.setValue(4);
+        factory.setAmountToStepBy(4);
+        factory.increment(1); // 8
+        factory.increment(1); // 5 -- wrapped around
+        factory.increment(1); // 9
+        factory.increment(1); // 6 -- wrapped around
+        factory.increment(1); // 10
+        factory.increment(1); // 7 -- wrapped around
+        factory.increment(1); // 4 -- wrapped around
+        factory.increment(1); // 8
+        assertEquals(8, (int) factory.getValue());
+
+        factory.setValue(4);
+        factory.setAmountToStepBy(5);
+        factory.increment(1); // 9
+        factory.increment(1); // 7 -- wrapped around
+        factory.increment(1); // 5 -- wrapped around
+        factory.increment(1); // 10
+        factory.increment(1); // 8 -- wrapped around
+        factory.increment(1); // 6 -- wrapped around
+        factory.increment(1); // 4 -- wrapped around
+        factory.increment(1); // 9
+        assertEquals(9, (int) factory.getValue());
+
+        factory.setValue(4);
+        factory.setAmountToStepBy(6);
+        factory.increment(1); // 10
+        factory.increment(1); // 9 -- wrapped around
+        factory.increment(1); // 8 -- wrapped around
+        factory.increment(1); // 7 -- wrapped around
+        factory.increment(1); // 6 -- wrapped around
+        factory.increment(1); // 5 -- wrapped around
+        factory.increment(1); // 4 -- wrapped around
+        factory.increment(1); // 10
+        assertEquals(10, (int) factory.getValue());
+
+
+        // TODO: Set amount to step-by greater than the total numbers between max and min
+        // Wrap around should wrap and select a value.
+        factory.setValue(7);
+        factory.setAmountToStepBy(10);
+        factory.increment(1);
+        factory.increment(1);
+        factory.increment(1);
+        factory.increment(1);
+        assertEquals(10, (int) factory.getValue());
+    }
+
+    @Test public void intSpinner_testWrapAround_decrement_general() {
+        IntegerSpinnerValueFactory factory = new IntegerSpinnerValueFactory(4, 10, 8, 1);
+        factory.setWrapAround(true);
+        factory.decrement(1); // 7
+        factory.decrement(1); // 6
+        factory.decrement(1); // 5
+        factory.decrement(1); // 4
+        factory.decrement(1); // 10 -- wrapped around
+        factory.decrement(1); // 9
+        factory.decrement(1); // 8
+        factory.decrement(1); // 7
+        assertEquals(7, (int) factory.getValue());
+
+        factory.setValue(8);
+        factory.setAmountToStepBy(2);
+        factory.decrement(1); // 6
+        factory.decrement(1); // 4
+        factory.decrement(1); // 9  -- wrapped around
+        factory.decrement(1); // 7
+        factory.decrement(1); // 5
+        factory.decrement(1); // 10  -- wrapped around
+        factory.decrement(1); // 8
+        factory.decrement(1); // 6
+        factory.setValue(6);
+        factory.setAmountToStepBy(3);
+        factory.decrement(1); // 10  -- wrapped around
+        factory.decrement(1); // 7
+        assertEquals(7, (int) factory.getValue());
+
+        factory.decrement(1); // 4
+        factory.decrement(1); // 8  -- wrapped around
+        factory.decrement(1); // 5
+        factory.decrement(1); // 9  -- wrapped around
+        factory.decrement(1); // 6
+        factory.decrement(1); // 10 -- wrapped around
+        assertEquals(10, (int) factory.getValue());
+
+        factory.setValue(4);
+        factory.setAmountToStepBy(4);
+        factory.decrement(1); // 7
+        factory.decrement(1); // 10 -- wrapped around
+        factory.decrement(1); // 6
+        factory.decrement(1); // 9 -- wrapped around
+        factory.decrement(1); // 5
+        factory.decrement(1); // 8 -- wrapped around
+        factory.decrement(1); // 4
+        factory.decrement(1); // 7 -- wrapped around
+        assertEquals(7, (int) factory.getValue());
+
+        factory.setValue(10);
+        factory.setAmountToStepBy(5);
+        factory.decrement(1); // 5
+        factory.decrement(1); // 7 -- wrapped around
+        factory.decrement(1); // 9 -- wrapped around
+        factory.decrement(1); // 4
+        factory.decrement(1); // 6 -- wrapped around
+        factory.decrement(1); // 8 -- wrapped around
+        factory.decrement(1); // 10 -- wrapped around
+        factory.decrement(1); // 5
+        assertEquals(5, (int) factory.getValue());
+
+        factory.setValue(10);
+        factory.setAmountToStepBy(6);
+        factory.decrement(1); // 4
+        factory.decrement(1); // 5 -- wrapped around
+        factory.decrement(1); // 6 -- wrapped around
+        factory.decrement(1); // 7 -- wrapped around
+        factory.decrement(1); // 8 -- wrapped around
+        factory.decrement(1); // 9 -- wrapped around
+        factory.decrement(1); // 10 -- wrapped around
+        factory.decrement(1); // 4
+        assertEquals(4, (int) factory.getValue());
+
+
+        // TODO: Set amount to step-by greater than the total numbers between max and min
+        // Wrap around should wrap and select a value.
+        factory.setValue(7);
+        factory.setAmountToStepBy(10);
+        factory.decrement(1);
+        factory.decrement(1);
+        factory.decrement(1);
+        factory.decrement(1);
+        assertEquals(4, (int) factory.getValue());
     }
 
     @Test public void intSpinner_testWrapAround_increment_twoSteps() {


### PR DESCRIPTION
Issue : https://bugs.openjdk.java.net/browse/JDK-8193286

Root Cause : 
Incorrect implementation.
Current implementation of int wrapValue(int,int,int) in Spinner.java works well if min is 0.
Hence this implementation works with ListSpinnerValueFactory, but fails with IntegerSpinnerValueFactory.

Fix : 
Added a method for IntegerSpinnerValueFactory with separate implementation.

Testing : 
Added unit tests to test increment/decrement in multiple steps and with different amountToStepBy values.

Also, identified a related behavioral issue https://bugs.openjdk.java.net/browse/JDK-8242553, which will be addressed separately.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8193286](https://bugs.openjdk.java.net/browse/JDK-8193286): IntegerSpinnerFactory does not wrap value correctly


### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/174/head:pull/174`
`$ git checkout pull/174`
