### PR TITLE
8241737: TabPaneSkin memory leak on replacing selectionModel

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SelectionFocusModelMemoryTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SelectionFocusModelMemoryTest.java
@@ -194,9 +194,6 @@ public class SelectionFocusModelMemoryTest {
 
     @Test
     public void testTabPaneSelectionModel() {
-        // FIXME
-        // can't formally ignore just one parameter, so backing out if showBeforeReplaceSM
-        if (showBeforeReplaceSM) return; //@Ignore("8241737")
         TabPane control = new TabPane();
         ObservableList<String> data = FXCollections.observableArrayList("Apple", "Orange", "Banana");
         data.forEach(text -> control.getTabs().add(new Tab(text)));


### PR DESCRIPTION
`TabPaneSkin` adds a listener to `SelectionModel.selectedItemProperty()` which holds the `SelectionModel` from being GCed. Fix is to add and remove the listener when a `SelectionModel` is changed.

If the fix looks good, We can change all the `getSkinnable().getSelectionModel()` calls to use the new class member `selectionModel`.

The fix seems safe to cause any regression. Enabled an ignored test that was added as part of fix for [JDK-8241455](https://bugs.openjdk.java.net/browse/JDK-8241455).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8241737](https://bugs.openjdk.java.net/browse/JDK-8241737): TabPaneSkin memory leak on replacing selectionModel


### Reviewers
 * Jeanette Winzenburg ([fastegal](@kleopatra) - Author)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/175/head:pull/175`
`$ git checkout pull/175`
