### PR TITLE
8191758: Match WebKit's font weight rendering with JavaFX

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/FontPlatformDataJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/FontPlatformDataJava.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<FontPlatformData> FontPlatformData::create(
             family,
             fontDescription.computedSize(),
             isItalic(fontDescription.italic()),
-            isFontWeightBold(fontDescription.weight()));
+            fontDescription.weight() >= boldWeightValue());
     return !wcFont ? nullptr : std::make_unique<FontPlatformData>(wcFont, fontDescription.computedSize());
 }
 


### PR DESCRIPTION

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Errors
&nbsp;⚠️ OCA signatory status must be verified
&nbsp;⚠️ The pull request body must not be empty.

### Issue
 * [JDK-8191758](https://bugs.openjdk.java.net/browse/JDK-8191758): Match WebKit's font weight rendering with JavaFX


### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/176/head:pull/176`
`$ git checkout pull/176`
