### PR TITLE
8242489: ChoiceBox: initially toggle not sync'ed to selection

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ChoiceBox.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ChoiceBox.java
@@ -182,7 +182,7 @@ public class ChoiceBox<T> extends Control {
             oldSM = sm;
             if (sm != null) {
                 sm.selectedItemProperty().addListener(selectedItemListener);
-                // unfixed part of JDK-8090015 - why exclude null?
+                // FIXME JDK-8242001 - must sync to model state always
                 if (sm.getSelectedItem() != null && ! valueProperty().isBound()) {
                     ChoiceBox.this.setValue(sm.getSelectedItem());
                 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ChoiceBox.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ChoiceBox.java
@@ -182,6 +182,7 @@ public class ChoiceBox<T> extends Control {
             oldSM = sm;
             if (sm != null) {
                 sm.selectedItemProperty().addListener(selectedItemListener);
+                // unfixed part of JDK-8090015 - why exclude null?
                 if (sm.getSelectedItem() != null && ! valueProperty().isBound()) {
                     ChoiceBox.this.setValue(sm.getSelectedItem());
                 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ChoiceBoxSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ChoiceBoxSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,9 +28,6 @@ package javafx.scene.control.skin;
 import com.sun.javafx.scene.control.ContextMenuContent;
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
 import javafx.beans.WeakInvalidationListener;
-import javafx.scene.Node;
-import javafx.scene.control.Accordion;
-import javafx.scene.control.Button;
 import javafx.scene.control.Control;
 import javafx.scene.control.SkinBase;
 import javafx.util.StringConverter;
@@ -156,20 +153,11 @@ public class ChoiceBoxSkin<T> extends SkinBase<ChoiceBox<T>> {
         registerChangeListener(control.selectionModelProperty(), e -> updateSelectionModel());
         registerChangeListener(control.showingProperty(), e -> {
             if (getSkinnable().isShowing()) {
-                MenuItem item = null;
 
-                SelectionModel sm = getSkinnable().getSelectionModel();
+                SelectionModel<T> sm = getSkinnable().getSelectionModel();
                 if (sm == null) return;
 
                 long currentSelectedIndex = sm.getSelectedIndex();
-                int itemInControlCount = choiceBoxItems.size();
-                boolean hasSelection = currentSelectedIndex >= 0 && currentSelectedIndex < itemInControlCount;
-                if (hasSelection) {
-                    item = popup.getItems().get((int) currentSelectedIndex);
-                    if (item != null && item instanceof RadioMenuItem) ((RadioMenuItem)item).setSelected(true);
-                } else {
-                    if (itemInControlCount > 0) item = popup.getItems().get(0);
-                }
 
                 // This is a fix for RT-9071. Ideally this won't be necessary in
                 // the long-run, but for now at least this resolves the
@@ -199,15 +187,6 @@ public class ChoiceBoxSkin<T> extends SkinBase<ChoiceBox<T>> {
             updateSelection();
             if(selectionModel != null && selectionModel.getSelectedIndex() == -1) {
                 label.setText(""); // clear label text when selectedIndex is -1
-            }
-        });
-        registerChangeListener(control.getSelectionModel().selectedItemProperty(), e -> {
-            if (getSkinnable().getSelectionModel() != null) {
-                int index = getSkinnable().getSelectionModel().getSelectedIndex();
-                if (index != -1) {
-                    MenuItem item = popup.getItems().get(index);
-                    if (item instanceof RadioMenuItem) ((RadioMenuItem)item).setSelected(true);
-                }
             }
         });
         registerChangeListener(control.converterProperty(), e -> {
@@ -364,6 +343,11 @@ public class ChoiceBoxSkin<T> extends SkinBase<ChoiceBox<T>> {
         return label.getText();
     }
 
+    // Test only purpose
+    ContextMenu getChoiceBoxPopup() {
+        return popup;
+    }
+
     private void addPopupItem(final T o, int i) {
         MenuItem popupItem = null;
         if (o instanceof Separator) {
@@ -428,6 +412,7 @@ public class ChoiceBoxSkin<T> extends SkinBase<ChoiceBox<T>> {
                 MenuItem selectedItem = popup.getItems().get(selectedIndex);
                 if (selectedItem instanceof RadioMenuItem) {
                     ((RadioMenuItem) selectedItem).setSelected(true);
+                } else {
                     toggleGroup.selectToggle(null);
                 }
                 // update the label

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ChoiceBoxSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ChoiceBoxSkin.java
@@ -413,6 +413,8 @@ public class ChoiceBoxSkin<T> extends SkinBase<ChoiceBox<T>> {
                 if (selectedItem instanceof RadioMenuItem) {
                     ((RadioMenuItem) selectedItem).setSelected(true);
                 } else {
+                    // need to unselect toggles if selectionModel allows a Separator/MenuItem
+                    // to be selected
                     toggleGroup.selectToggle(null);
                 }
                 // update the label

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/ChoiceBoxSkinNodesShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/ChoiceBoxSkinNodesShim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,17 @@
 
 package javafx.scene.control.skin;
 
+import javafx.scene.control.ContextMenu;
+
 public class ChoiceBoxSkinNodesShim {
 
     // can only access the getChoiceBoxSelectedText method in ChoiceBoxSkin
     // from this package.
     public static String getChoiceBoxSelectedText(ChoiceBoxSkin skin) {
         return skin.getChoiceBoxSelectedText();
+    }
+
+    public static ContextMenu getChoiceBoxPopup(ChoiceBoxSkin skin) {
+        return skin.getChoiceBoxPopup();
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxSelectionTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxSelectionTest.java
@@ -1,0 +1,334 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.control;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+import javafx.collections.FXCollections;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.ChoiceBox;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.Control;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.RadioMenuItem;
+import javafx.scene.control.Separator;
+import javafx.scene.control.SingleSelectionModel;
+import javafx.scene.control.skin.ChoiceBoxSkin;
+import javafx.scene.control.skin.ChoiceBoxSkinNodesShim;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+/**
+ * Temporary collection of tests around state of toggle in popup.
+ * <p>
+ *
+ * Note that the selection should be correct even if the
+ * popup has not yet been shown! That's hampered by JDK-8242489 (see
+ * analysis in bug).
+ *
+ * <p>
+ * Need to test (testBaseToggle):
+ * a) initial sync of selection state: selected toggle must be that of selectedIndex or none
+ * b) change selection state after skin: selected toggle must follow
+ *
+ */
+public class ChoiceBoxSelectionTest {
+    private Scene scene;
+    private Stage stage;
+    private Pane root;
+
+    private ChoiceBox<String> box;
+
+    private String uncontained;
+
+    /**
+     * selected index taken by toggle when popup open
+     */
+    @Test
+    public void testBaseToggleInitialSelectOpenPopup() {
+        SingleSelectionModel<String> sm = box.getSelectionModel();
+        int selectedIndex = box.getItems().size() - 1;
+        sm.select(selectedIndex);
+        showChoiceBox();
+        box.show();
+        assertToggleSelected(selectedIndex);
+    }
+
+    /**
+     * selected index taken by toggle
+     */
+    @Test
+    public void testBaseToggleInitialSelect() {
+        SingleSelectionModel<String> sm = box.getSelectionModel();
+        int selectedIndex = box.getItems().size() - 1;
+        sm.select(selectedIndex);
+        showChoiceBox();
+        assertToggleSelected(selectedIndex);
+    }
+
+    /**
+     * toggle must be unselected if separator is selected
+     */
+    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @Test
+    public void testBaseToggleSeparator() {
+        ChoiceBox box = new ChoiceBox(FXCollections.observableArrayList(
+                "Apple", "Banana", new Separator(), "Orange"));
+        int separatorIndex = 2;
+        showControl(box);
+        SingleSelectionModel<?> sm = box.getSelectionModel();
+        int selectedIndex = 1;
+        sm.select(selectedIndex);
+        sm.select(separatorIndex);
+        assertToggleSelected(box, -1);
+    }
+
+    /**
+     * Not quite https://bugs.openjdk.java.net/browse/JDK-8089398
+     * (the issue there is setting value while selectionModel == null)
+     *
+     * This here throws NPE if selectionModel is null when the skin is attached.
+     * Base reason is JDK-8242489.
+     *
+     * @see ChoiceBoxTest#selectionModelCanBeNull()
+     */
+    @Test
+    public void testNullSelectionModel() {
+        box.setSelectionModel(null);
+        showChoiceBox();
+    }
+
+
+//------------ toggle follows selection change: select -> show -> empty
+
+    /**
+     * select -> show -> clear
+     */
+    @Test
+    public void testBaseToggleClearSelection() {
+        SingleSelectionModel<String> sm = box.getSelectionModel();
+        sm.select(2);
+        showChoiceBox();
+        sm.clearSelection();
+        assertToggleSelected(-1);
+    }
+
+    /**
+     * select -> show -> select(-1)
+     */
+    @Test
+    public void testBaseToggleMinusIndex() {
+        SingleSelectionModel<String> sm = box.getSelectionModel();
+        sm.select(2);
+        showChoiceBox();
+        sm.select(-1);
+        assertToggleSelected(-1);
+    }
+
+    /**
+     * select -> show -> select(null)
+     */
+    @Test
+    public void testBaseToggleNullItem() {
+        SingleSelectionModel<String> sm = box.getSelectionModel();
+        sm.select(2);
+        showChoiceBox();
+        sm.select(null);
+        assertToggleSelected(-1);
+    }
+
+    /**
+     * select -> show -> null value
+     */
+    @Test
+    public void testBaseToggleNullValue() {
+        SingleSelectionModel<String> sm = box.getSelectionModel();
+        sm.select(2);
+        showChoiceBox();
+        box.setValue(null);
+        assertToggleSelected(-1);
+    }
+
+    //------------ toggle follows selection change: select -> show -> other selection
+
+    @Test
+    public void testBaseToggleChangeIndex() {
+        SingleSelectionModel<String> sm = box.getSelectionModel();
+        sm.select(2);
+        showChoiceBox();
+        int other = 1;
+        sm.select(other);
+        assertToggleSelected(other);
+    }
+
+    @Test
+    public void testBaseToggleChangeItem() {
+        SingleSelectionModel<String> sm = box.getSelectionModel();
+        sm.select(2);
+        showChoiceBox();
+        int other = 1;
+        String otherItem = box.getItems().get(other);
+        sm.select(otherItem);
+        assertToggleSelected(other);
+    }
+
+    @Test
+    public void testBaseToggleChangeValue() {
+        SingleSelectionModel<String> sm = box.getSelectionModel();
+        sm.select(2);
+        showChoiceBox();
+        int other = 1;
+        String otherItem = box.getItems().get(other);
+        box.setValue(otherItem);
+        assertToggleSelected(other);
+    }
+
+//------------ toggle follows selection change: empty -> selected
+
+    @Test
+    public void testBaseToggleSetValue() {
+        showChoiceBox();
+        int selectedIndex = box.getItems().size() - 1;
+        box.setValue(box.getItems().get(selectedIndex));
+        assertToggleSelected(selectedIndex);
+    }
+
+    @Test
+    public void testBaseToggleSelectItem() {
+        showChoiceBox();
+        SingleSelectionModel<String> sm = box.getSelectionModel();
+        int selectedIndex = box.getItems().size() - 1;
+        sm.select(box.getItems().get(selectedIndex));
+        assertToggleSelected(selectedIndex);
+    }
+
+    @Test
+    public void testBaseToggleSelectIndex() {
+        showChoiceBox();
+        SingleSelectionModel<String> sm = box.getSelectionModel();
+        int selectedIndex = box.getItems().size() - 1;
+        sm.select(selectedIndex);
+        assertToggleSelected(selectedIndex);
+    }
+
+    //------------- assertion helper
+
+    protected void assertToggleSelected(ChoiceBox<?> box, int selectedIndex) {
+        boolean isSelected = selectedIndex >= 0;
+        ContextMenu popup = ChoiceBoxSkinNodesShim.getChoiceBoxPopup((ChoiceBoxSkin<?>) box.getSkin());
+        for (int i = 0; i < popup.getItems().size(); i++) {
+            boolean shouldBeSelected = isSelected ? selectedIndex == i : false;
+            MenuItem item = popup.getItems().get(i);
+            if (item instanceof RadioMenuItem) {
+                RadioMenuItem selectedToggle = (RadioMenuItem) popup.getItems().get(i);
+                assertEquals("toggle " + selectedToggle.getText() + " at index: " + i + " must be selected: " + shouldBeSelected,
+                        shouldBeSelected,
+                        selectedToggle.isSelected());
+            }
+        }
+    }
+
+    protected void assertToggleSelected(int selectedIndex) {
+        assertToggleSelected(box, selectedIndex);
+    }
+
+    //------------- ignored tests, other issues
+
+    /**
+     * Issue "8241999": toggle not unselected on setting uncontained value.
+     */
+    @Test
+    @Ignore("8241999")
+    public void testSyncedToggleUncontainedValue() {
+        SingleSelectionModel<String> sm = box.getSelectionModel();
+        sm.select(2);
+        showChoiceBox();
+        box.setValue(uncontained);
+        assertToggleSelected(-1);
+    }
+
+    /**
+     * Base reason for "8241999": selected index not sync'ed.
+     */
+    @Test
+    @Ignore("8241999")
+    public void testSyncedSelectedIndexUncontained() {
+        box.setValue(box.getItems().get(1));
+        box.setValue(uncontained);
+        assertEquals(-1, box.getSelectionModel().getSelectedIndex());
+    }
+
+    //----------- setup and sanity test for initial state
+
+    @Test
+    public void testSetupState() {
+        assertNotNull(box);
+        showChoiceBox();
+        List<Node> expected = List.of(box);
+        assertEquals(expected, root.getChildren());
+    }
+
+    protected void showChoiceBox() {
+        showControl(box);
+    }
+
+    protected void showControl(Control box) {
+        if (!root.getChildren().contains(box)) {
+            root.getChildren().add(box);
+        }
+        stage.show();
+        stage.requestFocus();
+        box.requestFocus();
+        assertTrue(box.isFocused());
+        assertSame(box, scene.getFocusOwner());
+    }
+
+    @After
+    public void cleanup() {
+        stage.hide();
+    }
+
+    @Before
+    public void setup() {
+        uncontained = "uncontained";
+        root = new VBox();
+        scene = new Scene(root);
+        stage = new Stage();
+        stage.setScene(scene);
+        box = new ChoiceBox<>(FXCollections.observableArrayList("Apple", "Banana", "Orange"));
+        root.getChildren().addAll(box);
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxSelectionTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxSelectionTest.java
@@ -99,7 +99,7 @@ public class ChoiceBoxSelectionTest {
     }
 
     /**
-     * toggle must be unselected if separator is selected
+     * Toggle must be unselected if separator is selected
      */
     @SuppressWarnings({ "rawtypes", "unchecked" })
     @Test
@@ -112,6 +112,8 @@ public class ChoiceBoxSelectionTest {
         int selectedIndex = 1;
         sm.select(selectedIndex);
         sm.select(separatorIndex);
+        // implementation detail of current sm (openjfx14): it allows a Separator
+        // to be selected - skin must unselect its toggles
         assertToggleSelected(box, -1);
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SelectionFocusModelMemoryTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SelectionFocusModelMemoryTest.java
@@ -221,10 +221,6 @@ public class SelectionFocusModelMemoryTest {
 
     @Test
     public void testChoiceBoxSelectionModel() {
-        // FIXME
-        // can't formally ignore just one parameter, so backing out if showBeforeReplaceSM
-        // will be fixed as side-effect of skin cleanup
-        if (showBeforeReplaceSM) return; //@Ignore("8087555")
         ChoiceBox<String> control = new ChoiceBox<>(FXCollections.observableArrayList("Apple", "Orange", "Banana"));
         WeakReference<SelectionModel<?>> weakRef = new WeakReference<>(control.getSelectionModel());
         SingleSelectionModel<String> replacingSm = ChoiceBoxShim.get_ChoiceBoxSelectionModel(control);


### PR DESCRIPTION
Macroscopic issue is that initially, the toggle is not sync'ed to the selection state. Root reason is an missing else block when updating toggle selection state (see report for details).

Fixed by introducing the else block and removing all follow-up errors that tried to amend the consequences of the incorrect selection state

- removed listener to selected item
- removed toggle selection update in showing listener

The former also fixed the memory leak when replacing the selectionModel plus an unreported NPE when the selectionModel is null initially. 

Added tests that failed before the fix and passed after. As there had been no tests around toggle state, so added some to verify that the change doesn't break. Enhanced shim/skin to allow access to popup for testing. Removed the informally ignored test part for memory leak.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242489](https://bugs.openjdk.java.net/browse/JDK-8242489): ChoiceBox: initially toggle not sync'ed to selection 


### Reviewers
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/177/head:pull/177`
`$ git checkout pull/177`
