### PR TITLE
8242490: Upgrade to gcc 9.2 on Linux

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -88,7 +88,7 @@ jfx.gradle.version=6.3
 jfx.gradle.version.min=5.3
 
 # Toolchains
-jfx.build.linux.gcc.version=gcc8.3.0-OL6.4+1.0
+jfx.build.linux.gcc.version=gcc9.2.0-OL6.4+1.0
 jfx.build.windows.msvc.version=VS2017-15.9.16+1.0
 jfx.build.macosx.xcode.version=Xcode10.1-MacOSX10.14+1.0
 


### PR DESCRIPTION
This is a compiler upgrade on Linux from the current gcc 8.3 compiler to gcc 9.2. This will match a recent upgrade done for JDK 15 -- see [JDK-8241721](https://bugs.openjdk.java.net/browse/JDK-8241721).

On a related note, using the gcc 9 compiler produces many (harmless) warnings that will be addressed by [JDK-8241476](https://bugs.openjdk.java.net/browse/JDK-8241476) -- see PR #150.

I have run a full build and test using this new compiler.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242490](https://bugs.openjdk.java.net/browse/JDK-8242490): Upgrade to gcc 9.2 on Linux


### Reviewers
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/178/head:pull/178`
`$ git checkout pull/178`
