### PR TITLE
8191758: Match WebKit's font weight rendering with JavaFX

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/FontPlatformDataJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/FontPlatformDataJava.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<FontPlatformData> FontPlatformData::create(
             family,
             fontDescription.computedSize(),
             isItalic(fontDescription.italic()),
-            isFontWeightBold(fontDescription.weight()));
+            fontDescription.weight() >= boldWeightValue());
     return !wcFont ? nullptr : std::make_unique<FontPlatformData>(wcFont, fontDescription.computedSize());
 }
 

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/WebViewTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/WebViewTest.java
@@ -26,6 +26,7 @@
 package test.javafx.scene.web;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.io.File;
 import java.util.concurrent.FutureTask;
@@ -87,6 +88,30 @@ public class WebViewTest extends TestBase {
     private void setZoom(final WebView view, final float zoom) throws Exception {
         submit(() -> {
             view.setZoom(zoom);
+        });
+    }
+
+    /**
+     * @test
+     * @bug 8191758
+     * To make sure extra-heavy weights of the system font can be achieved
+     */
+    @Test public void testFontWeights() {
+        loadContent(
+            "<!DOCTYPE html><html><head></head>" +
+            "<body>" +
+            "   <div style=\"font: 19px system-ui\">" +
+            "       <div style=\"font-style: italic;\">" +
+            "           <span id=\"six\" style=\"font-weight: 600;\">Hello, World</span>" +
+            "           <span id=\"nine\" style=\"font-weight: 900;\">Hello, World</span>" +
+            "       </div>" +
+            "   </div>" +
+            "</body> </html>"
+            );
+        submit(()->{
+            assertFalse("Font weight test failed ",
+                (Boolean) getEngine().executeScript(
+                "document.getElementById('six').offsetWidth == document.getElementById('nine').offsetWidth"));
         });
     }
 }

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/WebViewTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/WebViewTest.java
@@ -108,7 +108,7 @@ public class WebViewTest extends TestBase {
             "   </div>" +
             "</body> </html>"
             );
-        submit(()->{
+        submit(() -> {
             assertFalse("Font weight test failed ",
                 (Boolean) getEngine().executeScript(
                 "document.getElementById('six').offsetWidth == document.getElementById('nine').offsetWidth"));


### PR DESCRIPTION
As per JavaFx 700 font weight is considered to be bold but webkit is using 600 font weight for text to become bold. to fix issue, use boldWeightValue() function which uses 700 font weight rather than isFontWeightBold() which compare against 600 font weight.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8191758](https://bugs.openjdk.java.net/browse/JDK-8191758): Match WebKit's font weight rendering with JavaFX


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Arun Joseph ([ajoseph](@arun-Joseph) - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/180/head:pull/180`
`$ git checkout pull/180`
