### PR TITLE
8242577: Cell selection fails on iOS most of the times

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassViewDelegate.h
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassViewDelegate.h
@@ -57,6 +57,7 @@ typedef __attribute__((NSObject)) CFMutableDictionaryRef GlassMutableDictionaryR
 // touches
 @property (nonatomic, strong) GlassMutableDictionaryRef touches;
 @property (nonatomic) jlong lastTouchId;
+@property (nonatomic) CGPoint beginTouchEventPoint; // coordinates at the beginning of a 'touch' event
 // gestures
 @property (nonatomic, retain) GlassGestureDelegate *delegate;
 


### PR DESCRIPTION
There are cases when iOS sends one or more NSTouchPhaseMoved for a given touch event, in between NSTouchPhaseBegan and NSTouchPhaseEnded , even if the initial event location didn't change.

By default, all these events are emulated as mouse enter/down, drag and up/exit events.

However, when the user taps quickly or even holds steady on a cell, if these touch moved events are generated and sent as mouse drag events, the cell selection fails, as the flag `latePress` used in [CellBehaviorBase](https://github.com/openjdk/jfx/blob/master/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/CellBehaviorBase.java#L191) is set to false, preventing the cell selection that should happen upon touch release event.

This PR prevents emulating mouse drag events when the touch event doesn't change its location.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242577](https://bugs.openjdk.java.net/browse/JDK-8242577): Cell selection fails on iOS most of the times


### Reviewers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/181/head:pull/181`
`$ git checkout pull/181`
