### PR TITLE
8242530: [macos] Some audio files miss spectrum data when another audio file plays first

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/gst/spectrum/gstspectrum.c
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/gst/spectrum/gstspectrum.c
@@ -270,6 +270,7 @@ gst_spectrum_init (GstSpectrum * spectrum)
   spectrum->bps_user = 0;
   spectrum->bpf_user = 0;
   spectrum->user_data = NULL;
+  spectrum->post_message_callback = NULL;
 #endif // GSTREAMER_LITE and OSX
 
   g_mutex_init (&spectrum->lock);
@@ -1060,7 +1061,15 @@ gst_spectrum_transform_ip (GstBaseTransform * trans, GstBuffer * buffer)
         m = gst_spectrum_message_new (spectrum, spectrum->message_ts,
             spectrum->interval);
 
+#if defined (GSTREAMER_LITE) && defined (OSX)
+        if (spectrum->post_message_callback != NULL) {
+          spectrum->post_message_callback(GST_ELEMENT (spectrum), m);
+        } else {
+          gst_element_post_message (GST_ELEMENT (spectrum), m);
+        }
+#else // GSTREAMER_LITE && OSX
         gst_element_post_message (GST_ELEMENT (spectrum), m);
+#endif // GSTREAMER_LITE && OSX
 #ifndef GSTREAMER_LITE
       }
 #endif // GSTREAMER_LITE

--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/gst/spectrum/gstspectrum.h
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/gst/spectrum/gstspectrum.h
@@ -40,6 +40,15 @@ typedef struct _GstSpectrumChannel GstSpectrumChannel;
 typedef void (*GstSpectrumInputData)(const guint8 * in, gfloat * out,
     guint len, guint channels, gfloat max_value, guint op, guint nfft);
 
+#if defined (GSTREAMER_LITE) && defined (OSX)
+// Used to overwrite post_message callback to get spectrum messages in OSXPlatform.
+// We cannot use GST_ELEMENT_GET_CLASS(spectrum)->post_message, since it will
+// change callback for all instances of spectrum elements and it will conflict
+// with GStreamer platform.
+typedef gboolean (*PostMessageCallbackProc)(GstElement * element,
+                                            GstMessage * message);
+#endif // GSTREAMER_LITE and OSX
+
 struct _GstSpectrumChannel
 {
   gfloat *input;
@@ -86,6 +95,7 @@ struct _GstSpectrum
   guint bps_user; // User provided values to avoid more complex spectrum initialization
   guint bpf_user;
   void *user_data;
+  PostMessageCallbackProc post_message_callback;
 #endif // GSTREAMER_LITE and OSX
 };
 

--- a/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFAudioSpectrumUnit.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFAudioSpectrumUnit.cpp
@@ -272,10 +272,10 @@ void AVFAudioSpectrumUnit::SetupSpectralProcessor() {
     mSpectrum = GST_SPECTRUM(mSpectrumElement);
     mSpectrum->user_data = (void*)this;
 
-    // Set our own callback for post message
-    GstElementClass *klass;
-    klass = GST_ELEMENT_GET_CLASS(mSpectrumElement);
-    klass->post_message = PostMessageCallback;
+    // Set our own callback for post message, do not use
+    // GST_ELEMENT_GET_CLASS(mSpectrumElement)->post_message, since it will change
+    // callback for all instances of spectrum element.
+    mSpectrum->post_message_callback = PostMessageCallback;
 
     // Configure spectrum element
     // Do send magnitude and phase information, off by default


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8242530

- GstElementClass which is base class for all elements has same instance between all spectrum elements (not sure if it is same for all elements) and thus post_message was sending events to AVFoundation callback from GStreamer platform. This issue is reproducible if we load OSXPlatfrom first and then play media files using GStreamer. Fixed by introducing separate callback to send messages to AVFoundation.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242530](https://bugs.openjdk.java.net/browse/JDK-8242530): [macos] Some audio files miss spectrum data when another audio file plays first


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/184/head:pull/184`
`$ git checkout pull/184`
