### PR TITLE
8242077: Add information about HTTP/2 and HttpClient usage in WebEngine

### DIFF
--- a/modules/javafx.web/src/main/java/javafx/scene/web/WebEngine.java
+++ b/modules/javafx.web/src/main/java/javafx/scene/web/WebEngine.java
@@ -325,7 +325,7 @@ window.setMember("app", javaApp);
  * {@link Module#isExported(String) exports} the containing package
  * unconditionally.
  * </p>
- * 
+ *
  * <p>
  * Starting with JavaFX 14, <a href="https://tools.ietf.org/html/rfc7540">HTTP/2</a> support has been added to WebEngine.
  * This is achieved by using {@link java.net.http.HttpClient} instead of {@link URLConnection}. HTTP/2 is activated

--- a/modules/javafx.web/src/main/java/javafx/scene/web/WebEngine.java
+++ b/modules/javafx.web/src/main/java/javafx/scene/web/WebEngine.java
@@ -325,6 +325,12 @@ window.setMember("app", javaApp);
  * {@link Module#isExported(String) exports} the containing package
  * unconditionally.
  * </p>
+ * 
+ * <p>
+ * Starting with JavaFX 14, <a href="https://tools.ietf.org/html/rfc7540">HTTP/2</a> support has been added to WebEngine.
+ * This is achieved by using {@link java.net.http.HttpClient} instead of {@link URLConnection}. HTTP/2 is activated
+ * by default when JavaFX 14 (or later) is used with JDK 12 (or later).
+ * </p>
  *
  * <p><b>Threading</b></p>
  * <p>{@code WebEngine} objects must be created and accessed solely from the


### PR DESCRIPTION
Update WebEngine's Javadoc to add information on how it switches to HttpClient instead of URLConnection in JavaFX 14 when used with JDK 12 or later.

Identification of the correct client is important as both these clients may offer different ways to achieve a task. One such task can be bypassing insecure HTTPS connection.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242077](https://bugs.openjdk.java.net/browse/JDK-8242077): inconsistent behavior for expired certificates (combination JDK/JavaFX version)


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Guru Hb ([ghb](@guruhb) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/189/head:pull/189`
`$ git checkout pull/189`
