### PR TITLE
8243255: Font size is large in JavaFX app with enabled Monocle on Raspberry Pi

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/PlatformUtil.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/PlatformUtil.java
@@ -238,8 +238,7 @@ public class PlatformUtil {
             // Strip everything after the last "/" or "\" to get rid of the jar filename
             int lastIndexOfSlash = Math.max(
                     s.lastIndexOf('/'), s.lastIndexOf('\\'));
-            return new File(new URL(s.substring(0, lastIndexOfSlash + 1)).getPath())
-                    .getParentFile();
+            return new File(new URL(s.substring(0, lastIndexOfSlash + 1)).getPath());
         } catch (MalformedURLException e) {
             return null;
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleApplication.java
@@ -225,7 +225,7 @@ public final class MonocleApplication extends Application {
                                    0, 0, ns.getWidth(), ns.getHeight(),
                                    0, 0, ns.getWidth(), ns.getHeight(),
                                    0, 0, ns.getWidth(), ns.getHeight(),
-                                   ns.getWidth(), ns.getHeight(),
+                                   ns.getDPI(), ns.getDPI(),
                                    1.f, 1.f, ns.getScale(), ns.getScale());
         // Move the cursor to the middle of the screen
         MouseState mouseState = new MouseState();


### PR DESCRIPTION
See the detailed issue description on: http://mail.openjdk.java.net/pipermail/openjfx-dev/2020-April/025975.html

The fix 8236448 https://github.com/openjdk/jfx/pull/75 changes [MonocleApplication.staticScreen_getScreens()](https://github.com/openjdk/jfx/pull/75/files#diff-b66ff7fe72c6c5cd26003572ca901bfdL228) method code from  
> ns.getDPI(), ns.getDPI(), ns.getScale(), ns.getScale(), ns.getScale(), ns.getScale()

 to
 > ns.getWidth(), ns.getHeight(), 1.f, 1.f, ns.getScale(), ns.getScale()"

so the font size is not properly calculated based on the given DPI value.

I left the platformScaleX and platformScaleY as 1.f because I do not know how it affects Android/Dalvik platform. On Raspberry Pi where I run JavaFX code with Monocle the DispmanScreen is used which have fixed scale 1.0 value so the app works in the same way.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8243255](https://bugs.openjdk.java.net/browse/JDK-8243255): Font size is large in JavaFX app with enabled Monocle on Raspberry Pi


### Reviewers
 * jgneff (no known github.com user name / role)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/193/head:pull/193`
`$ git checkout pull/193`
