### PR TITLE
8242505: Some WebKit tests might fail because Microsoft libraries are not loaded

### DIFF
--- a/modules/javafx.web/src/test/java/test/com/sun/webkit/SharedBufferTest.java
+++ b/modules/javafx.web/src/test/java/test/com/sun/webkit/SharedBufferTest.java
@@ -25,6 +25,8 @@
 
 package test.com.sun.webkit;
 
+import com.sun.javafx.PlatformUtil;
+import com.sun.javafx.tk.Toolkit;
 import com.sun.webkit.SharedBuffer;
 import com.sun.webkit.SharedBufferShim;
 import com.sun.webkit.WebPage;
@@ -50,6 +52,10 @@ public class SharedBufferTest {
 
     @BeforeClass
     public static void beforeClass() throws ClassNotFoundException {
+        if (PlatformUtil.isWindows()) {
+            // Must load Microsoft libs before loading jfxwebkit.dll
+            Toolkit.loadMSWindowsLibraries();
+        }
         Class.forName(WebPage.class.getName());
     }
 

--- a/modules/javafx.web/src/test/java/test/com/sun/webkit/SimpleSharedBufferInputStreamTest.java
+++ b/modules/javafx.web/src/test/java/test/com/sun/webkit/SimpleSharedBufferInputStreamTest.java
@@ -25,6 +25,8 @@
 
 package test.com.sun.webkit;
 
+import com.sun.javafx.PlatformUtil;
+import com.sun.javafx.tk.Toolkit;
 import com.sun.webkit.SharedBuffer;
 import com.sun.webkit.SharedBufferShim;
 import com.sun.webkit.SimpleSharedBufferInputStream;
@@ -52,6 +54,10 @@ public class SimpleSharedBufferInputStreamTest {
 
     @BeforeClass
     public static void beforeClass() throws ClassNotFoundException {
+        if (PlatformUtil.isWindows()) {
+            // Must load Microsoft libs before loading jfxwebkit.dll
+            Toolkit.loadMSWindowsLibraries();
+        }
         Class.forName(WebPage.class.getName());
     }
 


### PR DESCRIPTION
This PR will allow javafx.web unit tests to run to completion and pass on Windows with Visual Studio 2019.

Two of the WebKit tests load the native WebKit library without initializing the JavaFX runtime. This will lead to test failures and will hang the test run if those tests are run before the other tests, and if the system doesn't have all the needed runtime libraries. 

The simple fix is to call the Toolkit method to load those libraries. This is only needed for unit tests that don't already initialize the JavaFX runtime (e.g., by calling `Platform::startup` or `Application::launch`) and call internal methods that execute native code as part of the test.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242505](https://bugs.openjdk.java.net/browse/JDK-8242505): Some WebKit tests might fail because Microsoft libraries are not loaded


### Reviewers
 * Guru Hb ([ghb](@guruhb) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/194/head:pull/194`
`$ git checkout pull/194`
