### PR TITLE
8242507: Add support for Visual Studio 2019

### DIFF
--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -190,22 +190,18 @@ if (hasProperty('toolchainDir')) {
 def winSdkDllDir = "$WINDOWS_VS_WINSDKDLLINSTALLDIR/$CPU_BITS"
 
 def WINDOWS_DLL_VER = WINDOWS_VS_VER
-ext.MSVCR = null
-ext.MSVCP = null
 
 def windowsCRTVer = System.getenv("WINDOWS_CRT_VER") ?: WINDOWS_CRT_VER
 if (WINDOWS_VS_VER == "150") {
     WINDOWS_DLL_VER = "140"
-    ext.MSVCR = cygpath("${msvcRedstDir}/Microsoft.VC${windowsCRTVer}.CRT/vcruntime${WINDOWS_DLL_VER}.dll")
-    ext.MSVCP = cygpath("${msvcRedstDir}/Microsoft.VC${windowsCRTVer}.CRT/msvcp${WINDOWS_DLL_VER}.dll")
 }
 
 def vs2017DllPath = cygpath("${msvcRedstDir}/Microsoft.VC${windowsCRTVer}.CRT")
 if (file(vs2017DllPath).exists()) {
     ext.WIN.VS2017DLLNames = [
-        "concrt140.dll",
         "msvcp140.dll",
-        "vcruntime140.dll"
+        "vcruntime140.dll",
+        "vcruntime140_1.dll"
     ];
     ext.WIN.VS2017DLLs = []
     ext.WIN.VS2017DLLNames.each { vsdll->

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
@@ -96,7 +96,7 @@ final class WinApplication extends Application implements InvokeLaterDispatcher.
                 } else {
                     overrideUIScale = 1.0f;
                 }
-                // This loading of msvcp140.dll and vcruntime140.dll (VS2017) is required on Windows platforms
+                // Load required Microsoft runtime DLLs on Windows platforms
                 Toolkit.loadMSWindowsLibraries();
                 Application.loadNativeLibrary();
                 return null;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -153,8 +153,8 @@ public abstract class Toolkit {
 
         // Finally load VS 2017 DLLs in the following order
         "vcruntime140",
-        "msvcp140",
-        "concrt140"
+        "vcruntime140_1",
+        "msvcp140"
 };
 
     private static String lookupToolkitClass(String name) {
@@ -207,7 +207,7 @@ public abstract class Toolkit {
             return null;
         });
 
-        // This loading of msvcp140.dll and vcruntime140.dll (VS2017) is required on Windows platforms
+        // Load required Microsoft runtime DLLs on Windows platforms
         if (PlatformUtil.isWindows()) {
             loadMSWindowsLibraries();
         }


### PR DESCRIPTION
This PR adds support for Microsoft Visual Studio 2019 (VS 2019), but does not change the default compiler, which remains at VS 2017 15.9.16. Changing the build compiler to VS 2019 will be proposed in a future PR using a new bug ID, and isn't planned until after the JDK updates their compiler.

In order to allow developer builds to use Microsoft Visual Studio 2019, we need the following changes at build time and runtime.

At build time:

1. Copy `vsruntime140_1.dll` (if present) to output `sdk/bin` dir
2. Don't copy the unused  `concrt140.dll` (it is not used in VS 2017 either)

At runtime:

1. Load `vsruntime140_1.dll` if present
2. Don't load the unused `concrt140.dll`

Additionally, I removed two unused build variables, `ext.MSVCR` and `ext.MSVCP`, which would otherwise have needed to be updated.

I have done a full build and test run using both VS 2017 (which is still the default), and VS 2019.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242507](https://bugs.openjdk.java.net/browse/JDK-8242507): Add support for Visual Studio 2019


### Reviewers
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/195/head:pull/195`
`$ git checkout pull/195`
