### PR TITLE
8171898: [WebView] ScrollBarWidget thickness calculation is not correct

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/theme/ScrollBarThemeImpl.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/theme/ScrollBarThemeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,9 +48,6 @@ public final class ScrollBarThemeImpl extends ScrollBarTheme {
 
     private final static PlatformLogger log = PlatformLogger.getLogger(ScrollBarThemeImpl.class.getName());
 
-    private WeakReference<ScrollBar> testSBRef = // used for scrollbar thickness calculation
-            new WeakReference<ScrollBar>(null);
-
     private final Accessor accessor;
 
     private final Pool<ScrollBarWidget> pool;
@@ -81,17 +78,12 @@ public final class ScrollBarThemeImpl extends ScrollBarTheme {
         accessor.addViewListener(new ViewListener(pool, accessor) {
             @Override public void invalidated(Observable ov) {
                 super.invalidated(ov);
-                ScrollBar testSB = new ScrollBarWidget(ScrollBarThemeImpl.this);
+                ScrollBar testSB = new ScrollBarWidget();
                 // testSB should be added to the new WebView (if any)
                 accessor.addChild(testSB);
-                testSBRef = new WeakReference<ScrollBar>(testSB);
             }
         });
 
-    }
-
-    ScrollBar getTestSBRef() {
-        return testSBRef.get();
     }
 
     private static Orientation convertOrientation(int orientation) {
@@ -156,7 +148,7 @@ public final class ScrollBarThemeImpl extends ScrollBarTheme {
     {
         ScrollBarWidget sb = pool.get(id);
         if (sb == null) {
-            sb = new ScrollBarWidget(this);
+            sb = new ScrollBarWidget();
             pool.put(id, sb, accessor.getPage().getUpdateContentCycleID());
             accessor.addChild(sb);
         }

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/theme/ScrollBarWidget.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/theme/ScrollBarWidget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,15 +40,12 @@ public final class ScrollBarWidget extends ScrollBar implements RenderThemeImpl.
         });
     }
 
-    private ScrollBarThemeImpl sbtImpl;
-
     {
         // To initialize the class helper at the begining each constructor of this class
         ScrollBarWidgetHelper.initHelper(this);
     }
 
-    public ScrollBarWidget(ScrollBarThemeImpl sbtImpl) {
-        this.sbtImpl = sbtImpl;
+    public ScrollBarWidget() {
         setOrientation(Orientation.VERTICAL);
         setMin(0);
         setManaged(false);
@@ -72,14 +69,10 @@ public final class ScrollBarWidget extends ScrollBar implements RenderThemeImpl.
         initializeThickness();
     }
 
-    private boolean thicknessInitialized = false;
+    private static boolean thicknessInitialized = false;
     private void initializeThickness() {
         if (!thicknessInitialized) {
-            ScrollBar testSB = sbtImpl.getTestSBRef();
-            if (testSB == null) {
-                return;
-            }
-            int thickness = (int) testSB.prefWidth(-1);
+            int thickness = (int) prefWidth(-1);
             if (thickness != 0 && ScrollBarTheme.getThickness() != thickness) {
                 ScrollBarTheme.setThickness(thickness);
             }


### PR DESCRIPTION
ScrollbarThemeJava delegates scrollbar thickness calculation to ScrollBarWidget::initializeThickness() [ScrollBarWidget.java] method. Since "ScrollbarThemeJava::scrollbarThickness" is not associated with any "ScrollBarWidget" instance, some workaround was made using special "ScrollBarWidget" instance named testRef.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8171898](https://bugs.openjdk.java.net/browse/JDK-8171898): [WebView] ScrollBarWidget thickness calculation is not correct


### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/197/head:pull/197`
`$ git checkout pull/197`
