### PR TITLE
8237602: TabPane doesn't respect order of TabPane.getTabs() list

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
@@ -579,7 +579,6 @@ public class TabPaneSkin extends SkinBase<TabPane> {
         getSkinnable().getTabs().addListener((ListChangeListener<Tab>) c -> {
             List<Tab> tabsToRemove = new ArrayList<>();
             List<Tab> tabsToAdd = new ArrayList<>();
-            int insertPos = -1;
 
             while (c.next()) {
                 if (c.wasPermutated()) {
@@ -619,7 +618,6 @@ public class TabPaneSkin extends SkinBase<TabPane> {
                 }
                 if (c.wasAdded()) {
                     tabsToAdd.addAll(c.getAddedSubList());
-                    insertPos = c.getFrom();
                 }
             }
 
@@ -647,7 +645,9 @@ public class TabPaneSkin extends SkinBase<TabPane> {
                     }
                 }
 
-                addTabs(tabsToAdd, insertPos == -1 ? tabContentRegions.size() : insertPos);
+                if (!tabsToAdd.isEmpty()) {
+                    addTabs(tabsToAdd, getSkinnable().getTabs().indexOf(tabsToAdd.get(0)));
+                }
                 for (Pair<Integer, TabHeaderSkin> move : headersToMove) {
                     tabHeaderArea.moveTab(move.getKey(), move.getValue());
                 }
@@ -991,8 +991,10 @@ public class TabPaneSkin extends SkinBase<TabPane> {
         }
 
         private void moveTab(int moveToIndex, TabHeaderSkin tabHeaderSkin) {
-            headersRegion.getChildren().remove(tabHeaderSkin);
-            headersRegion.getChildren().add(moveToIndex, tabHeaderSkin);
+            if (moveToIndex != headersRegion.getChildren().indexOf(tabHeaderSkin)) {
+                headersRegion.getChildren().remove(tabHeaderSkin);
+                headersRegion.getChildren().add(moveToIndex, tabHeaderSkin);
+            }
         }
 
         private TabHeaderSkin getTabHeaderSkin(Tab tab) {

--- a/tests/system/src/test/java/test/robot/javafx/scene/TabPanePermuteGetTabsTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TabPanePermuteGetTabsTest.java
@@ -191,7 +191,7 @@ public class TabPanePermuteGetTabsTest {
 
     // Test for JDK-8237602
     @Test
-    public void testPermutGetTabsWithMoreTabs1() {
+    public void testAddingNewTabsWithExistingTabsAtSameIndex() {
         // Step #1
         Util.runAndWait(() -> {
             tabPane.getTabs().setAll(tab[0], tab[1]);


### PR DESCRIPTION
Issue:
When tabs are permuted as mentioned in the issue description as, 
1. TabPane.getTabs().setAll(tab0, tab1)
2. TabPane.getTabs().setAll(tab0, tab1, tab2, tab3);
the tab headers do not get permuted in same order as `TabPane.getTabs()`.

=> tab headers should be shown in order as  tab0, tab1, tab2, tab3.
=> but are show in order as  tab2, tab3, tab0, tab1

Cause:
Newly added tabs(tab2, tab3) are not inserted at correct index. The index `Change.getFrom()` (0) used from Change does not remain valid after the tabs to be moved(tab0, tab1) are removed from `tabsToAdd` list.

Fix:
Use the index of first newly added tab, from `TabPane.getTabs()`, which would be always reliable.

Verification:
No existing tests fail due to this change.
Added a system test which fails without and pass with fix.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8237602](https://bugs.openjdk.java.net/browse/JDK-8237602): TabPane doesn't respect order of TabPane.getTabs() list


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Jeanette Winzenburg ([fastegal](@kleopatra) - Author)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/201/head:pull/201`
`$ git checkout pull/201`
