### PR TITLE
8244212: Optionally download media and webkit libraries from latest openjfx EA build

### DIFF
--- a/WEBKIT-MEDIA-STUBS.md
+++ b/WEBKIT-MEDIA-STUBS.md
@@ -17,25 +17,23 @@ If you are not actively working on these sources, you may want to cache the outp
 
 ## Cached libraries
 
-You can place WebKit and Media shared libraries in these folders:
+You can manually place WebKit and Media shared libraries in these folders:
 
-* Unix libraries (*.so or *.dynlib files)
+* Unix libraries (*.so or *.dylib files)
 ````
     $projectDir/../caches/sdk/lib
-    $projectDir/../caches/modular-sdk/modules_libs/$module
-    $JDK_HOME/lib
 ````
 
 * Windows libraries (*.dll files)
 ````
     $projectDir/../caches/sdk/bin
-    $projectDir/../caches/modular-sdk/modules_libs/$module
-    $JDK_HOME/bin
 ````
 
 ## Officially released libraries
 
-You can use officially released libraries by specifying this Gradle property:
+Gradle has a task to automate downloading officially released libraries from MavenCentral.
+
+You can enable the task by specifying this Gradle property:
 
     -PSTUB_RUNTIME_OPENJFX="15-ea+4"
 
@@ -50,4 +48,4 @@ Specify these options to Gradle
 
     -x :web:test
 
-Note that this is fine for local work. But a full test *is* required before submitting a PR, see CONTRIBUTING.md.
+Note that this is fine for local work. But a full test *is* required before submitting a PR, see [CONTRIBUTING.md](https://github.com/openjdk/jfx/blob/master/CONTRIBUTING.md).

--- a/WEBKIT-MEDIA-STUBS.md
+++ b/WEBKIT-MEDIA-STUBS.md
@@ -10,7 +10,7 @@ Specify these Gradle properties to enable building of WebKit and Media libraries
 
     -PCOMPILE_WEBKIT=true -PCOMPILE_MEDIA=true
 
-Note that these take some time to build.
+Note that these require additional build tooling and take some time to build.
 
 If you are not actively working on these sources, you may want to cache the output by copying it to one of the folders mentioned below.
 

--- a/WEBKIT-MEDIA-STUBS.md
+++ b/WEBKIT-MEDIA-STUBS.md
@@ -1,0 +1,53 @@
+# Web Testing
+
+The web project needs WebKit and Media shared libraries to run tests.
+
+These can be supplied in a number of ways. See sections below.
+
+## Compiled from source
+
+Specify these Gradle properties to enable building of WebKit and Media libraries from source:
+
+    -PCOMPILE_WEBKIT=true -PCOMPILE_MEDIA=true
+
+Note that these take some time to build.
+
+If you are not actively working on these sources, you may want to cache the output by copying it to one of the folders mentioned below.
+
+
+## Cached libraries
+
+You can place WebKit and Media shared libraries in these folders:
+
+* Unix libraries (*.so or *.dynlib files)
+````
+    $projectDir/../caches/sdk/lib
+    $projectDir/../caches/modular-sdk/modules_libs/$module
+    $JDK_HOME/lib
+````
+
+* Windows libraries (*.dll files)
+````
+    $projectDir/../caches/sdk/bin
+    $projectDir/../caches/modular-sdk/modules_libs/$module
+    $JDK_HOME/bin
+````
+
+## Officially released libraries
+
+You can use officially released libraries by specifying this Gradle property:
+
+    -PSTUB_RUNTIME_OPENJFX="15-ea+4"
+
+Note that these libraries may not be compatible with the source tree you are working with. Always use the [latest version](https://search.maven.org/search?q=g:org.openjfx%20AND%20a:javafx); this may improve your chances of compatibility.
+
+
+## Skip Web tests
+
+You can also skip the web module tests.
+
+Specify these options to Gradle
+
+    -x :web:test
+
+Note that this is fine for local work. But a full test *is* required before submitting a PR, see CONTRIBUTING.md.

--- a/build.gradle
+++ b/build.gradle
@@ -1249,7 +1249,8 @@ if (gradle.gradleVersion != jfxGradleVersion) {
 
 // Look for stub runtime in bundled sdk, standalone sdk, or boot JDK
 
-// Allows automatic provisioning of webkit+media shared libraries from an official OpenJFX build
+// Allows automatic provisioning of webkit+media shared libraries
+// from official OpenJFX releases, downloaded from MavenCentral
 defineProperty("STUB_RUNTIME_OPENJFX", "")
 ext.IS_STUB_RUNTIME_OPENJFX = !STUB_RUNTIME_OPENJFX.isBlank()
 

--- a/build.gradle
+++ b/build.gradle
@@ -1249,14 +1249,14 @@ if (gradle.gradleVersion != jfxGradleVersion) {
 
 // Look for stub runtime in bundled sdk, standalone sdk, or boot JDK
 
-// Allows automatic provisioning of webkit+media shared libraries from an official OpenJfx build
+// Allows automatic provisioning of webkit+media shared libraries from an official OpenJFX build
 defineProperty("STUB_RUNTIME_OPENJFX", "")
 ext.IS_STUB_RUNTIME_OPENJFX = !STUB_RUNTIME_OPENJFX.isBlank()
 
 def String cachedBundledRuntime = cygpath("$projectDir") + "/../caches/modular-sdk"
 def String cachedStandaloneRuntime = cygpath("$projectDir") + "/../caches/sdk"
 def String jdkStubRuntime = cygpath("$JDK_HOME")
-def String openjfxStubRuntime = cygpath("$projectDir") + "/build/openjfxStub"
+def String openjfxStubRuntime = cygpath("$projectDir") + "/buildSrc/build/openjfxStub"
 
 def defaultStubRuntime = ""
 if (file(cachedBundledRuntime).exists()) {
@@ -4335,7 +4335,7 @@ compileTargets { t ->
 
 /******************************************************************************
  *                                                                            *
- *                             OpenJfx Stubs                                  *
+ *                             OpenJFX Stubs                                  *
  *                                                                            *
  *****************************************************************************/
 
@@ -4351,7 +4351,7 @@ if (IS_STUB_RUNTIME_OPENJFX) {
     }
 }
 
-// Extract binary libraries from OpenJfx artifacts for use as stubs
+// Extract binary libraries from OpenJFX artifacts for use as stubs
 task prepOpenJfxStubs(type: Copy) {
     enabled = IS_STUB_RUNTIME_OPENJFX
 

--- a/build.gradle
+++ b/build.gradle
@@ -1249,9 +1249,14 @@ if (gradle.gradleVersion != jfxGradleVersion) {
 
 // Look for stub runtime in bundled sdk, standalone sdk, or boot JDK
 
+// Allows automatic provisioning of webkit+media shared libraries from an official OpenJfx build
+defineProperty("STUB_RUNTIME_OPENJFX", "")
+ext.IS_STUB_RUNTIME_OPENJFX = !STUB_RUNTIME_OPENJFX.isBlank()
+
 def String cachedBundledRuntime = cygpath("$projectDir") + "/../caches/modular-sdk"
 def String cachedStandaloneRuntime = cygpath("$projectDir") + "/../caches/sdk"
 def String jdkStubRuntime = cygpath("$JDK_HOME")
+def String openjfxStubRuntime = cygpath("$projectDir") + "/build/openjfxStub"
 
 def defaultStubRuntime = ""
 if (file(cachedBundledRuntime).exists()) {
@@ -1260,6 +1265,8 @@ if (file(cachedBundledRuntime).exists()) {
     defaultStubRuntime = cachedStandaloneRuntime
 } else if (BUILD_CLOSED) {
     defaultStubRuntime = cachedBundledRuntime
+} else if (IS_STUB_RUNTIME_OPENJFX) {
+    defaultStubRuntime = openjfxStubRuntime
 } else {
     defaultStubRuntime = jdkStubRuntime
 }
@@ -3381,16 +3388,21 @@ project(":web") {
 
     test {
         doFirst {
-            if (!IS_COMPILE_WEBKIT) {
-                println "*****************************************************"
+            if (IS_STUB_RUNTIME_OPENJFX) {
+                println "********************************************************"
+                println "WARNING: running web tests with officially built webkit."
+                println "The webkit native library may not be compatible with the"
+                println "source tree you are using."
+                println "If tests fail, try compiling webkit instead."
+                println "See WEBKIT-MEDIA-STUBS.md"
+                println "********************************************************"
+            } else if (!IS_COMPILE_WEBKIT) {
+                println "******************************************************"
                 println "WARNING: running web tests without building webkit."
                 println "The webkit native library will be copied from the JDK,"
                 println "which might lead to failures in some web tests."
-                println "To avoid these failures, you should either build"
-                println "webkit locally, copy the native webkit library from a"
-                println "recent build, or skip execution of web test cases with"
-                println "'-x :web:test'"
-                println "*****************************************************"
+                println "See WEBKIT-MEDIA-STUBS.md"
+                println "******************************************************"
             }
         }
         // Run web tests in headless mode
@@ -4323,6 +4335,36 @@ compileTargets { t ->
 
 /******************************************************************************
  *                                                                            *
+ *                             OpenJfx Stubs                                  *
+ *                                                                            *
+ *****************************************************************************/
+
+configurations {
+    openjfxStubs
+}
+
+if (IS_STUB_RUNTIME_OPENJFX) {
+    def String platform = IS_MAC ? "mac" : IS_WINDOWS ? "win" : IS_LINUX ? "linux" : ""
+    dependencies {
+        openjfxStubs "org.openjfx:javafx-media:$STUB_RUNTIME_OPENJFX:$platform@jar"
+        openjfxStubs "org.openjfx:javafx-web:$STUB_RUNTIME_OPENJFX:$platform@jar"
+    }
+}
+
+// Extract binary libraries from OpenJfx artifacts for use as stubs
+task prepOpenJfxStubs(type: Copy) {
+    enabled = IS_STUB_RUNTIME_OPENJFX
+
+    from configurations.openjfxStubs.files.collect { zipTree(it) }
+    include("*.dll")
+    include("*.dylib")
+    include("*.so")
+    into IS_WINDOWS ? file("$openjfxStubRuntime/bin") : file("$openjfxStubRuntime/lib")
+}
+
+
+/******************************************************************************
+ *                                                                            *
  *                               Modules                                      *
  *                                                                            *
  *****************************************************************************/
@@ -4915,7 +4957,7 @@ compileTargets { t ->
             }
         }
 
-        def buildModuleMediaTask = task("buildModuleMedia$t.capital", type: Copy, dependsOn: mediaProject.assemble) {
+        def buildModuleMediaTask = task("buildModuleMedia$t.capital", type: Copy, dependsOn: [mediaProject.assemble, prepOpenJfxStubs]) {
             group = "Basic"
             description = "copies javafx.media native libraries"
 
@@ -4952,7 +4994,7 @@ compileTargets { t ->
             }
         }
 
-        def buildModuleWeb = task("buildModuleWeb$t.capital", type: Copy, dependsOn: webProject.assemble) {
+        def buildModuleWeb = task("buildModuleWeb$t.capital", type: Copy, dependsOn: [webProject.assemble, prepOpenJfxStubs]) {
             group = "Basic"
             description = "copies javafx.web native libraries"
 


### PR DESCRIPTION
I have tested on Linux (Fedora 31) only. 
It works as intended (with one test failure due to 15-ea+4 being too old now).

UPDATE_STUB_CACHE suggests there is some magic available to help manage the stub cache.
But as I could not find anything about it, that section in the documentation may need some love.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244212](https://bugs.openjdk.java.net/browse/JDK-8244212): Optionally download media and webkit libraries from latest openjfx EA build


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/202/head:pull/202`
`$ git checkout pull/202`
