### PR TITLE
8244297: Provide utility for testing for memory leaks

### DIFF
--- a/modules/javafx.base/src/test/java/de/sandec/jmemorybuddy/JMemoryBuddy.java
+++ b/modules/javafx.base/src/test/java/de/sandec/jmemorybuddy/JMemoryBuddy.java
@@ -1,0 +1,214 @@
+package de.sandec.jmemorybuddy;
+
+import com.sun.management.HotSpotDiagnosticMXBean;
+import javax.management.MBeanServer;
+import java.io.File;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.ref.WeakReference;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class JMemoryBuddy {
+
+    static int steps = 10;
+    static int overallTime = 1000;
+    static int sleepTime = overallTime / steps;
+    private static String MX_BEAN_PROXY_TYPE = "com.sun.management:type=HotSpotDiagnostic";
+
+    static String outputFolderString = ".";
+
+    static {
+        outputFolderString = System.getProperty("jmemorybuddy.output",".");
+        overallTime = Integer.parseInt(System.getProperty("jmemorybuddy.checktime","1000"));
+        steps = Integer.parseInt(System.getProperty("jmemorybuddy.steps", "10"));
+    }
+
+    public static void createGarbage() {
+        LinkedList list = new LinkedList<Integer>();
+        int counter = 0;
+        while(counter < 999999) {
+            counter += 1;
+            list.add(1);
+        }
+    }
+
+    public static void assertCollectable(WeakReference weakReference) {
+        if(!checkCollectable(weakReference)) {
+            AssertCollectable assertCollectable = new AssertCollectable(weakReference);
+            createHeapDump();
+            throw new AssertionError("Content of WeakReference was not collected. content: " + weakReference.get());
+        }
+    }
+
+    public static boolean checkCollectable(WeakReference weakReference) {
+        return checkCollectable(steps, weakReference) > 0;
+    }
+
+    private static int checkCollectable(int stepsLeft, WeakReference weakReference) {
+        int counter = stepsLeft;
+
+        if(weakReference.get() != null) {
+            createGarbage();
+            System.gc();
+            System.runFinalization();
+        }
+
+        while(counter > 0 && weakReference.get() != null) {
+            try {
+                Thread.sleep(sleepTime);
+            } catch (InterruptedException e) {}
+            counter = counter - 1;
+            createGarbage();
+            System.gc();
+            System.runFinalization();
+        }
+
+        if(weakReference.get() == null && counter < steps / 3) {
+            int percentageUsed = (int) ((steps - counter) / steps * 100);
+            System.out.println("Warning test seems to be unstable. time used: " + percentageUsed + "%");
+        }
+
+        return counter;
+    }
+
+    public static void assertNotCollectable(WeakReference weakReference) {
+        if(!checkNotCollectable(weakReference)) {
+            throw new AssertionError("Content of WeakReference was collected!");
+        }
+    }
+    public static boolean checkNotCollectable(WeakReference weakReference) {
+        System.gc();
+        return weakReference.get() != null;
+    }
+
+    public static void memoryTest(Consumer<MemoryTestAPI> f) {
+        LinkedList<WeakReference> toBeCollected = new LinkedList<WeakReference>();
+        LinkedList<WeakReference> toBeNotCollected = new LinkedList<WeakReference>();
+        LinkedList<SetAsReferenced> toBeReferenced = new LinkedList<SetAsReferenced>();
+
+        f.accept(new MemoryTestAPI() {
+            public void assertCollectable(Object ref) {
+                if(ref == null) throw new NullPointerException();
+                toBeCollected.add(new WeakReference<Object>(ref));
+            }
+            public void assertNotCollectable(Object ref) {
+                if(ref == null) throw new NullPointerException();
+                toBeNotCollected.add(new WeakReference<Object>(ref));
+            }
+            public void setAsReferenced(Object ref) {
+                if(ref == null) throw new NullPointerException();
+                toBeReferenced.add(new SetAsReferenced(ref));
+            }
+        });
+
+        int stepsLeft = steps;
+        boolean failed = false;
+
+        for(WeakReference wRef: toBeCollected) {
+            stepsLeft = checkCollectable(stepsLeft, wRef);
+        }
+        if(stepsLeft == 0) {
+            failed = true;
+        }
+        for(WeakReference wRef: toBeNotCollected) {
+            if(!checkNotCollectable(wRef)) {
+                failed = true;
+            };
+        }
+
+        if(failed) {
+            LinkedList<AssertCollectable> toBeCollectedMarked = new LinkedList<AssertCollectable>();
+            LinkedList<AssertNotCollectable> toBeNotCollectedMarked = new LinkedList<AssertNotCollectable>();
+
+            for(WeakReference wRef: toBeCollected) {
+                toBeCollectedMarked.add(new AssertCollectable(wRef));
+            }
+            for(WeakReference wRef: toBeNotCollected) {
+                toBeNotCollectedMarked.add(new AssertNotCollectable(wRef));
+            }
+            createHeapDump();
+            if(toBeNotCollectedMarked.isEmpty()) {
+                throw new AssertionError("The following references should be collected: " + toBeCollectedMarked);
+            } else {
+                throw new AssertionError("The following references should be collected: " + toBeCollectedMarked + " and " + toBeNotCollectedMarked.size() + " should not be collected: ");
+            }
+        }
+
+
+    }
+
+
+    public static void createHeapDump() {
+        try {
+            String dateString = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date());
+            String fileName = "heapdump_jmemb_" + dateString + ".hprof";
+            File outputFolder = new File(outputFolderString);
+            String heapdumpFile = new java.io.File(outputFolder,fileName).getAbsolutePath();
+            System.out.println("Creating Heapdump at: " + heapdumpFile);
+            getHotspotMBean().dumpHeap(heapdumpFile, true);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static void setMxBeanProxyName(String mxBeanName) {
+        MX_BEAN_PROXY_TYPE = mxBeanName;
+    }
+
+    private static HotSpotDiagnosticMXBean getHotspotMBean() throws IOException {
+        MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+        HotSpotDiagnosticMXBean bean =
+                ManagementFactory.newPlatformMXBeanProxy(server,
+                        MX_BEAN_PROXY_TYPE, HotSpotDiagnosticMXBean.class);
+        return bean;
+    }
+
+    public static interface MemoryTestAPI {
+        public void assertCollectable(Object ref);
+        public void assertNotCollectable(Object ref);
+        public void setAsReferenced(Object ref);
+    }
+
+    static class AssertCollectable {
+        WeakReference<Object> assertCollectable;
+
+        AssertCollectable(WeakReference<Object> ref) {
+            this.assertCollectable = ref;
+        }
+
+        WeakReference<Object> getWeakReference() {
+            return assertCollectable;
+        }
+
+        @Override
+        public String toString() {
+            Object el = assertCollectable.get();
+            return el != null ? el.toString() : "null";
+        }
+    }
+
+    static class AssertNotCollectable {
+        WeakReference<Object> assertNotCollectable;
+
+        AssertNotCollectable(WeakReference<Object> ref) {
+            this.assertNotCollectable = ref;
+        }
+
+        WeakReference<Object> getWeakReference() {
+            return assertNotCollectable;
+        }
+    }
+
+    static class SetAsReferenced {
+        Object setAsReferenced;
+
+        SetAsReferenced(Object ref) {
+            this.setAsReferenced = ref;
+        }
+    }
+
+}

--- a/modules/javafx.base/src/test/java/test/util/memory/JMemoryBuddy.java
+++ b/modules/javafx.base/src/test/java/test/util/memory/JMemoryBuddy.java
@@ -39,14 +39,13 @@ import java.util.function.Function;
 
 public class JMemoryBuddy {
 
-    static int steps = 10;
-    static int overallTime = 1000;
-    static int sleepTime = overallTime / steps;
-    static boolean createHeapdump = false;
-    static int garbageAmount = 999999;
+    private static int steps = 10;
+    private static int overallTime = 1000;
+    private static int sleepTime = overallTime / steps;
+    private static boolean createHeapdump = false;
+    private static int garbageAmount = 999999;
     private static String MX_BEAN_PROXY_TYPE = "com.sun.management:type=HotSpotDiagnostic";
-
-    static String outputFolderString = ".";
+    private static String outputFolderString = ".";
 
     static {
         outputFolderString = System.getProperty("jmemorybuddy.output",".");
@@ -56,7 +55,7 @@ public class JMemoryBuddy {
         garbageAmount = Integer.parseInt(System.getProperty("jmemorybuddy.garbageAmount", "10"));
     }
 
-    public static void createGarbage() {
+    private static void createGarbage() {
         LinkedList list = new LinkedList<Integer>();
         int counter = 0;
         while(counter < garbageAmount) {
@@ -65,6 +64,11 @@ public class JMemoryBuddy {
         }
     }
 
+    /**
+     * Checks whethr the content of the WeakReference can be collected.
+     * @param weakReference
+     * @return It throws an excpetion when the weakReference was not collectable.
+     */
     public static void assertCollectable(WeakReference weakReference) {
         if(!checkCollectable(weakReference)) {
             AssertCollectable assertCollectable = new AssertCollectable(weakReference);
@@ -73,6 +77,11 @@ public class JMemoryBuddy {
         }
     }
 
+    /**
+     * Checks whethr the content of the WeakReference can be collected.
+     * @param weakReference
+     * @return Returns true, when the provided WeakReference can be collected.
+     */
     public static boolean checkCollectable(WeakReference weakReference) {
         return checkCollectable(steps, weakReference) > 0;
     }
@@ -104,17 +113,33 @@ public class JMemoryBuddy {
         return counter;
     }
 
+    /**
+     * Checks whethr the content of the WeakReference can not be collected.
+     * @param weakReference
+     * @return It throws an excpetion when the weakReference was collectable.
+     */
     public static void assertNotCollectable(WeakReference weakReference) {
         if(!checkNotCollectable(weakReference)) {
             throw new AssertionError("Content of WeakReference was collected!");
         }
     }
+
+    /**
+     * Checks whethr the content of the WeakReference can not be collected.
+     * @param weakReference
+     * @return Returns true, when the provided WeakReference can be collected.
+     */
     public static boolean checkNotCollectable(WeakReference weakReference) {
         createGarbage();
         System.gc();
         return weakReference.get() != null;
     }
 
+    /**
+     * A standard method to define a test which checks code for specific memory semantic.
+     * The parameter of the lambda provides an API to define the required memory semantic.
+     * @param f
+     */
     public static void memoryTest(Consumer<MemoryTestAPI> f) {
         LinkedList<WeakReference> toBeCollected = new LinkedList<WeakReference>();
         LinkedList<AssertNotCollectable> toBeNotCollected = new LinkedList<AssertNotCollectable>();
@@ -176,7 +201,7 @@ public class JMemoryBuddy {
     }
 
 
-    public static void createHeapDump() {
+    private static void createHeapDump() {
         if(createHeapdump) {
             try {
                 String dateString = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date());
@@ -206,8 +231,21 @@ public class JMemoryBuddy {
     }
 
     public static interface MemoryTestAPI {
+        /**
+         * After executing the lambda, the provided ref must be collectable. Otherwise an Exception is thrown.
+         * @param ref
+         */
         public void assertCollectable(Object ref);
+        /**
+         * After executing the lambda, the provided ref must be not collectable. Otherwise an Exception is thrown.
+         * @param ref
+         */
         public void assertNotCollectable(Object ref);
+
+        /**
+         * The provided reference won't be collected, until memoryTest finishes all it's tests.
+         * @param ref
+         */
         public void setAsReferenced(Object ref);
     }
 
@@ -229,7 +267,7 @@ public class JMemoryBuddy {
         }
     }
 
-    static class AssertNotCollectable {
+    private static class AssertNotCollectable {
         WeakReference<Object> assertNotCollectable;
         String originalResultOfToString;
 
@@ -248,7 +286,7 @@ public class JMemoryBuddy {
         }
     }
 
-    static class SetAsReferenced {
+    private static class SetAsReferenced {
         Object setAsReferenced;
 
         SetAsReferenced(Object ref) {

--- a/modules/javafx.base/src/test/java/test/util/memory/JMemoryBuddy.java
+++ b/modules/javafx.base/src/test/java/test/util/memory/JMemoryBuddy.java
@@ -131,7 +131,7 @@ public class JMemoryBuddy {
     }
 
     /**
-     * Checks whether the content of the WeakReference can not be collected.
+     * Checks whether the content of the WeakReference cannot be collected.
      * @param weakReference The WeakReference to check.
      */
     public static void assertNotCollectable(WeakReference weakReference) {
@@ -141,11 +141,14 @@ public class JMemoryBuddy {
     }
 
     /**
-     * Checks whether the content of the WeakReference can not be collected.
+     * Checks whether the content of the WeakReference cannot be collected.
      * @param weakReference The WeakReference to check.
-     * @return Returns true, when the provided WeakReference can not be collected.
+     * @return Returns true, when the provided WeakReference cannot be collected.
      */
     public static boolean checkNotCollectable(WeakReference weakReference) {
+        createGarbage();
+        System.gc();
+        System.runFinalization();
         createGarbage();
         System.gc();
         return weakReference.get() != null;
@@ -212,10 +215,7 @@ public class JMemoryBuddy {
                 throw new AssertionError("The following references should be collected: " + toBeCollectedMarked + " and " + toBeNotCollected.size() + " should not be collected: " + toBeNotCollectedMarked);
             }
         }
-
-
     }
-
 
     static void createHeapDump() {
         if (createHeapdump) {

--- a/modules/javafx.base/src/test/java/test/util/memory/JMemoryBuddy.java
+++ b/modules/javafx.base/src/test/java/test/util/memory/JMemoryBuddy.java
@@ -37,6 +37,10 @@ import java.util.LinkedList;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+
+/**
+ * Checkout <a href="https://github.com/Sandec/JMemoryBuddy">https://github.com/Sandec/JMemoryBuddy</a> for more documentation.
+ */
 public class JMemoryBuddy {
 
     private static int steps = 10;
@@ -55,7 +59,7 @@ public class JMemoryBuddy {
         garbageAmount = Integer.parseInt(System.getProperty("jmemorybuddy.garbageAmount", "10"));
     }
 
-    private static void createGarbage() {
+    static void createGarbage() {
         LinkedList list = new LinkedList<Integer>();
         int counter = 0;
         while(counter < garbageAmount) {
@@ -65,9 +69,8 @@ public class JMemoryBuddy {
     }
 
     /**
-     * Checks whethr the content of the WeakReference can be collected.
-     * @param weakReference
-     * @return It throws an excpetion when the weakReference was not collectable.
+     * Checks whether the content of the WeakReference can be collected.
+     * @param weakReference The WeakReference to check.
      */
     public static void assertCollectable(WeakReference weakReference) {
         if(!checkCollectable(weakReference)) {
@@ -78,8 +81,8 @@ public class JMemoryBuddy {
     }
 
     /**
-     * Checks whethr the content of the WeakReference can be collected.
-     * @param weakReference
+     * Checks whether the content of the WeakReference can be collected.
+     * @param weakReference The WeakReference to check.
      * @return Returns true, when the provided WeakReference can be collected.
      */
     public static boolean checkCollectable(WeakReference weakReference) {
@@ -114,9 +117,8 @@ public class JMemoryBuddy {
     }
 
     /**
-     * Checks whethr the content of the WeakReference can not be collected.
-     * @param weakReference
-     * @return It throws an excpetion when the weakReference was collectable.
+     * Checks whether the content of the WeakReference can not be collected.
+     * @param weakReference The WeakReference to check.
      */
     public static void assertNotCollectable(WeakReference weakReference) {
         if(!checkNotCollectable(weakReference)) {
@@ -125,8 +127,8 @@ public class JMemoryBuddy {
     }
 
     /**
-     * Checks whethr the content of the WeakReference can not be collected.
-     * @param weakReference
+     * Checks whether the content of the WeakReference can not be collected.
+     * @param weakReference The WeakReference to check.
      * @return Returns true, when the provided WeakReference can be collected.
      */
     public static boolean checkNotCollectable(WeakReference weakReference) {
@@ -138,7 +140,7 @@ public class JMemoryBuddy {
     /**
      * A standard method to define a test which checks code for specific memory semantic.
      * The parameter of the lambda provides an API to define the required memory semantic.
-     * @param f
+     * @param f A function which get's executed with the API to define the required memory semantic.
      */
     public static void memoryTest(Consumer<MemoryTestAPI> f) {
         LinkedList<WeakReference> toBeCollected = new LinkedList<WeakReference>();
@@ -201,7 +203,7 @@ public class JMemoryBuddy {
     }
 
 
-    private static void createHeapDump() {
+    static void createHeapDump() {
         if(createHeapdump) {
             try {
                 String dateString = new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss").format(new Date());
@@ -233,18 +235,18 @@ public class JMemoryBuddy {
     public static interface MemoryTestAPI {
         /**
          * After executing the lambda, the provided ref must be collectable. Otherwise an Exception is thrown.
-         * @param ref
+         * @param ref The reference which should be collectable.
          */
         public void assertCollectable(Object ref);
         /**
          * After executing the lambda, the provided ref must be not collectable. Otherwise an Exception is thrown.
-         * @param ref
+         * @param ref The reference which should not be collectable.
          */
         public void assertNotCollectable(Object ref);
 
         /**
-         * The provided reference won't be collected, until memoryTest finishes all it's tests.
-         * @param ref
+         * The provided reference will be reference hard, so it won't be collected, until memoryTest finishes.
+         * @param ref The reference which should get a hard reference for this test.
          */
         public void setAsReferenced(Object ref);
     }

--- a/modules/javafx.base/src/test/java/test/util/memory/JMemoryBuddy.java
+++ b/modules/javafx.base/src/test/java/test/util/memory/JMemoryBuddy.java
@@ -66,15 +66,15 @@ public class JMemoryBuddy {
         File folder1 = new File("target");
         File folder2 = new File("build");
 
-        if(folder1.exists()) return folder1.getAbsolutePath();
-        if(folder2.exists()) return folder2.getAbsolutePath();
+        if (folder1.exists()) return folder1.getAbsolutePath();
+        if (folder2.exists()) return folder2.getAbsolutePath();
         return ".";
     }
 
     static void createGarbage() {
         LinkedList list = new LinkedList<Integer>();
         int counter = 0;
-        while(counter < garbageAmount) {
+        while (counter < garbageAmount) {
             counter += 1;
             list.add(1);
         }
@@ -110,7 +110,7 @@ public class JMemoryBuddy {
             System.runFinalization();
         }
 
-        while(counter > 0 && weakReference.get() != null) {
+        while (counter > 0 && weakReference.get() != null) {
             try {
                 Thread.sleep(sleepDuration);
             } catch (InterruptedException e) {
@@ -179,13 +179,13 @@ public class JMemoryBuddy {
         int stepsLeft = steps;
         boolean failed = false;
 
-        for(WeakReference wRef: toBeCollected) {
+        for (WeakReference wRef: toBeCollected) {
             stepsLeft = checkCollectable(stepsLeft, wRef);
         }
         if (stepsLeft == 0) {
             failed = true;
         }
-        for(AssertNotCollectable wRef: toBeNotCollected) {
+        for (AssertNotCollectable wRef: toBeNotCollected) {
             if (!checkNotCollectable(wRef.getWeakReference())) {
                 failed = true;
             };
@@ -195,12 +195,12 @@ public class JMemoryBuddy {
             LinkedList<AssertCollectable> toBeCollectedMarked = new LinkedList<AssertCollectable>();
             LinkedList<AssertNotCollectable> toBeNotCollectedMarked = new LinkedList<AssertNotCollectable>();
 
-            for(WeakReference wRef: toBeCollected) {
+            for (WeakReference wRef: toBeCollected) {
                 if (wRef.get() != null) {
                     toBeCollectedMarked.add(new AssertCollectable(wRef));
                 }
             }
-            for(AssertNotCollectable wRef: toBeNotCollected) {
+            for (AssertNotCollectable wRef: toBeNotCollected) {
                 if (wRef.getWeakReference().get() == null) {
                     toBeNotCollectedMarked.add(wRef);
                 }

--- a/modules/javafx.base/src/test/java/test/util/memory/JMemoryBuddy.java
+++ b/modules/javafx.base/src/test/java/test/util/memory/JMemoryBuddy.java
@@ -47,8 +47,8 @@ import java.util.function.Function;
 public class JMemoryBuddy {
 
     private static int steps = 10;
-    private static int overallTime = 1000;
-    private static int sleepTime = overallTime / steps;
+    private static int testDuration = 1000;
+    private static int sleepDuration = testDuration / steps;
     private static boolean createHeapdump = false;
     private static int garbageAmount = 999999;
     private static String MX_BEAN_PROXY_TYPE = "com.sun.management:type=HotSpotDiagnostic";
@@ -56,7 +56,7 @@ public class JMemoryBuddy {
 
     static {
         outputFolderString = System.getProperty("jmemorybuddy.output", getDefaultOutputFolder());
-        overallTime = Integer.parseInt(System.getProperty("jmemorybuddy.checktime","1000"));
+        testDuration = Integer.parseInt(System.getProperty("jmemorybuddy.testDuration","1000"));
         steps = Integer.parseInt(System.getProperty("jmemorybuddy.steps", "10"));
         createHeapdump = Boolean.parseBoolean(System.getProperty("jmemorybuddy.createHeapdump", "false"));
         garbageAmount = Integer.parseInt(System.getProperty("jmemorybuddy.garbageAmount", "10"));
@@ -112,7 +112,7 @@ public class JMemoryBuddy {
 
         while(counter > 0 && weakReference.get() != null) {
             try {
-                Thread.sleep(sleepTime);
+                Thread.sleep(sleepDuration);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }

--- a/modules/javafx.base/src/test/java/test/util/memory/JMemoryBuddy.java
+++ b/modules/javafx.base/src/test/java/test/util/memory/JMemoryBuddy.java
@@ -51,7 +51,7 @@ public class JMemoryBuddy {
     private static int sleepDuration = testDuration / steps;
     private static boolean createHeapdump = false;
     private static int garbageAmount = 999999;
-    private static String MX_BEAN_PROXY_TYPE = "com.sun.management:type=HotSpotDiagnostic";
+    private static String mxBeanProxyName = "com.sun.management:type=HotSpotDiagnostic";
     private static String outputFolderString = ".";
 
     static {
@@ -235,14 +235,14 @@ public class JMemoryBuddy {
     }
 
     private static void setMxBeanProxyName(String mxBeanName) {
-        MX_BEAN_PROXY_TYPE = mxBeanName;
+        mxBeanProxyName = mxBeanName;
     }
 
     private static HotSpotDiagnosticMXBean getHotspotMBean() throws IOException {
         MBeanServer server = ManagementFactory.getPlatformMBeanServer();
         HotSpotDiagnosticMXBean bean =
                 ManagementFactory.newPlatformMXBeanProxy(server,
-                        MX_BEAN_PROXY_TYPE, HotSpotDiagnosticMXBean.class);
+                        mxBeanProxyName, HotSpotDiagnosticMXBean.class);
         return bean;
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ToggleButtonTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ToggleButtonTest.java
@@ -30,7 +30,6 @@ import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.
 import test.com.sun.javafx.pgstub.StubToolkit;
 import com.sun.javafx.logging.PlatformLogger;
 import com.sun.javafx.tk.Toolkit;
-import java.lang.ref.WeakReference;
 import javafx.event.ActionEvent;
 import javafx.event.EventType;
 import javafx.geometry.Pos;
@@ -42,7 +41,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Before;
 import org.junit.Test;
-import de.sandec.jmemorybuddy.JMemoryBuddy;
+import test.util.memory.JMemoryBuddy;
 
 /**
  *

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ToggleButtonTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ToggleButtonTest.java
@@ -42,6 +42,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Before;
 import org.junit.Test;
+import de.sandec.jmemorybuddy.JMemoryBuddy;
 
 /**
  *
@@ -157,65 +158,55 @@ public class ToggleButtonTest {
     }
 
     @Test public void toggleGroupViaGroupAddAndRemoveClearsReference() {
-        WeakReference<ToggleButton> ref = new WeakReference<>(toggle);
+        JMemoryBuddy.memoryTest(checker -> {
+            toggleGroup.getToggles().add(toggle);
+            toggleGroup.getToggles().clear();
 
-        toggleGroup.getToggles().add(toggle);
-        toggleGroup.getToggles().clear();
-
-        toggle = null;
-        attemptGC(ref, 5);
-
-        assertNull(ref.get());
+            checker.assertCollectable(toggle);
+            toggle = null;
+        });
     }
 
     @Test public void toggleGroupViaToggleSetClearsReference() {
-        WeakReference<ToggleButton> ref = new WeakReference<>(toggle);
+        JMemoryBuddy.memoryTest(checker -> {
+            toggle.setToggleGroup(toggleGroup);
+            toggle.setToggleGroup(null);
 
-        toggle.setToggleGroup(toggleGroup);
-        toggle.setToggleGroup(null);
-
-        toggle = null;
-        attemptGC(ref, 5);
-
-        assertNull(ref.get());
+            checker.assertCollectable(toggle);
+            toggle = null;
+        });
     }
 
     @Test public void toggleGroupViaToggleThenGroupClearsReference() {
-        WeakReference<ToggleButton> ref = new WeakReference<>(toggle);
+        JMemoryBuddy.memoryTest(checker -> {
+            toggle.setToggleGroup(toggleGroup);
+            toggleGroup.getToggles().clear();
 
-        toggle.setToggleGroup(toggleGroup);
-        toggleGroup.getToggles().clear();
-
-        toggle = null;
-        attemptGC(ref, 5);
-
-        assertNull(ref.get());
+            checker.assertCollectable(toggle);
+            toggle = null;
+        });
     }
 
     @Test public void toggleGroupViaGroupThenToggleClearsReference() {
-        WeakReference<ToggleButton> ref = new WeakReference<>(toggle);
+        JMemoryBuddy.memoryTest(checker -> {
+            toggleGroup.getToggles().add(toggle);
+            toggle.setToggleGroup(null);
 
-        toggleGroup.getToggles().add(toggle);
-        toggle.setToggleGroup(null);
-
-        toggle = null;
-        attemptGC(ref, 5);
-
-        assertNull(ref.get());
+            checker.assertCollectable(toggle);
+            toggle = null;
+        });
     }
 
     @Test public void toggleGroupSwitchingClearsReference() {
-        WeakReference<ToggleButton> ref = new WeakReference<>(toggle);
+        JMemoryBuddy.memoryTest(checker -> {
+            ToggleGroup anotherToggleGroup = new ToggleGroup();
+            toggle.setToggleGroup(toggleGroup);
+            toggle.setToggleGroup(anotherToggleGroup);
+            toggle.setToggleGroup(null);
 
-        ToggleGroup anotherToggleGroup = new ToggleGroup();
-        toggle.setToggleGroup(toggleGroup);
-        toggle.setToggleGroup(anotherToggleGroup);
-        toggle.setToggleGroup(null);
-
-        toggle = null;
-        attemptGC(ref, 5);
-
-        assertNull(ref.get());
+            checker.assertCollectable(toggle);
+            toggle = null;
+        });
     }
 
     /*********************************************************************
@@ -253,22 +244,5 @@ public class ToggleButtonTest {
             PlatformLogger.getLogger(ToggleButtonTest.class.getName()).severe(null, ex);
         }
         assertTrue("fire() doesnt emit ActionEvent!", flag[0]);
-    }
-
-    private void attemptGC(WeakReference<? extends Object> weakRef, int n) {
-        // Attempt gc n times
-        for (int i = 0; i < n; i++) {
-            System.gc();
-            System.runFinalization();
-
-            if (weakRef.get() == null) {
-                break;
-            }
-            try {
-                Thread.sleep(500);
-            } catch (InterruptedException e) {
-                fail("InterruptedException occurred during Thread.sleep()");
-            }
-        }
     }
 }

--- a/tests/system/src/test/java/test/javafx/accessibility/virtualflow/VirtualFlowMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/accessibility/virtualflow/VirtualFlowMemoryLeakTest.java
@@ -56,7 +56,7 @@ import javafx.scene.control.TableView;
 import javafx.scene.control.TableView.TableViewSelectionModel;
 import javafx.stage.Stage;
 import test.util.Util;
-import de.sandec.jmemorybuddy.JMemoryBuddy;
+import test.util.memory.JMemoryBuddy;
 
 public class VirtualFlowMemoryLeakTest {
 

--- a/tests/system/src/test/java/test/javafx/accessibility/virtualflow/VirtualFlowMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/accessibility/virtualflow/VirtualFlowMemoryLeakTest.java
@@ -56,6 +56,7 @@ import javafx.scene.control.TableView;
 import javafx.scene.control.TableView.TableViewSelectionModel;
 import javafx.stage.Stage;
 import test.util.Util;
+import de.sandec.jmemorybuddy.JMemoryBuddy;
 
 public class VirtualFlowMemoryLeakTest {
 
@@ -175,15 +176,7 @@ public class VirtualFlowMemoryLeakTest {
         }
         runAndWait(() -> items.clear());
 
-        for (int j = 0; j < 5; ++j) {
-            System.gc();
-            System.runFinalization();
-            if (firstRowRef.get() == null) {
-                break;
-            }
-            MILLISECONDS.sleep(100);
-        }
-        assertEquals(null, firstRowRef.get());
+        JMemoryBuddy.assertCollectable(firstRowRef);
     }
 
     private void runAndWait(final Runnable runnable) {

--- a/tests/system/src/test/java/test/javafx/scene/InitialNodesMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/InitialNodesMemoryLeakTest.java
@@ -85,17 +85,7 @@ public class InitialNodesMemoryLeakTest {
 
     @Test
     public void testRootNodeMemoryLeak() throws Exception {
-        for (int j = 0; j < 10; j++) {
-            System.gc();
-            System.runFinalization();
-
-            if (groupWRef.get() == null) {
-                break;
-            }
-
-            Util.sleep(500);
-        }
-        Assert.assertNull("Couldn't collect Node", groupWRef.get());
+        JMemoryBuddy.assertCollectable("groupWRef");
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/InitialNodesMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/InitialNodesMemoryLeakTest.java
@@ -38,6 +38,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import test.util.Util;
 import static org.junit.Assert.fail;
+import test.util.memory.JMemoryBuddy;
 
 import java.lang.ref.WeakReference;
 import java.util.concurrent.CountDownLatch;
@@ -85,7 +86,7 @@ public class InitialNodesMemoryLeakTest {
 
     @Test
     public void testRootNodeMemoryLeak() throws Exception {
-        JMemoryBuddy.assertCollectable("groupWRef");
+        JMemoryBuddy.assertCollectable(groupWRef);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/control/ProgressIndicatorLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/ProgressIndicatorLeakTest.java
@@ -43,7 +43,7 @@ import junit.framework.Assert;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import de.sandec.jmemorybuddy.JMemoryBuddy;
+import test.util.memory.JMemoryBuddy;
 
 public class ProgressIndicatorLeakTest {
 

--- a/tests/system/src/test/java/test/javafx/scene/control/ProgressIndicatorLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/ProgressIndicatorLeakTest.java
@@ -43,6 +43,7 @@ import junit.framework.Assert;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import de.sandec.jmemorybuddy.JMemoryBuddy;
 
 public class ProgressIndicatorLeakTest {
 
@@ -81,23 +82,7 @@ public class ProgressIndicatorLeakTest {
 
     @Test
     public void memoryTest() throws Exception {
-        assertCollectable(detIndicator);
-    }
-
-    public static void assertCollectable(WeakReference weakReference) throws Exception {
-        int counter = 0;
-
-        System.gc();
-        System.runFinalization();
-
-        while (counter < 10 && weakReference.get() != null) {
-            Thread.sleep(100);
-            counter = counter + 1;
-            System.gc();
-            System.runFinalization();
-        }
-
-        Assert.assertNull(weakReference.get());
+        JMemoryBuddy.assertCollectable(detIndicator);
     }
 
     @AfterClass


### PR DESCRIPTION
It's based on the discussion of my previous PR: https://github.com/openjdk/jfx/pull/71

I Added test utility class copied from JMemoryBuddy and used it to simplify 4 of the existing unit tests.

It's a direct copy of my project [JMemoryBuddy](https://github.com/Sandec/JMemoryBuddy) without any changes.
I'm also using it in most of the projects I'm involved with and in my experience, the tests with this Library are very stable. I can't remember wrong test results. Sometimes the memory behaviour of some libraries itself is not stable but the tests with JMemoryBuddy are basically always correct.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244297](https://bugs.openjdk.java.net/browse/JDK-8244297): Provide utility for testing for memory leaks


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/204/head:pull/204`
`$ git checkout pull/204`
