### PR TITLE
8244110: NPE in MenuButtonSkinBase change listener

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuButtonSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuButtonSkinBase.java
@@ -74,7 +74,7 @@ public class MenuButtonSkinBase<C extends MenuButton> extends SkinBase<C> {
      */
     boolean behaveLikeButton = false;
     private ListChangeListener<MenuItem> itemsChangedListener;
-    private ChangeListener<? super Scene> sceneChangeListener;
+    private final ChangeListener<? super Scene> sceneChangeListener;
 
 
     /***************************************************************************

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuButtonSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuButtonSkinBase.java
@@ -31,6 +31,7 @@ import com.sun.javafx.scene.control.ControlAcceleratorSupport;
 import com.sun.javafx.scene.control.LabeledImpl;
 import com.sun.javafx.scene.control.skin.Utils;
 import javafx.application.Platform;
+import javafx.beans.value.ChangeListener;
 import javafx.collections.ListChangeListener;
 import javafx.event.ActionEvent;
 import javafx.scene.Node;
@@ -73,7 +74,7 @@ public class MenuButtonSkinBase<C extends MenuButton> extends SkinBase<C> {
      */
     boolean behaveLikeButton = false;
     private ListChangeListener<MenuItem> itemsChangedListener;
-
+    private ChangeListener<? super Scene> sceneChangeListener;
 
 
     /***************************************************************************
@@ -146,15 +147,18 @@ public class MenuButtonSkinBase<C extends MenuButton> extends SkinBase<C> {
         if (getSkinnable().getScene() != null) {
             ControlAcceleratorSupport.addAcceleratorsIntoScene(getSkinnable().getItems(), getSkinnable());
         }
-        control.sceneProperty().addListener((scene, oldValue, newValue) -> {
+
+        sceneChangeListener = (scene, oldValue, newValue) -> {
             if (oldValue != null) {
                 ControlAcceleratorSupport.removeAcceleratorsFromScene(getSkinnable().getItems(), oldValue);
             }
 
+             // FIXME: null skinnable should not happen
             if (getSkinnable() != null && getSkinnable().getScene() != null) {
                 ControlAcceleratorSupport.addAcceleratorsIntoScene(getSkinnable().getItems(), getSkinnable());
             }
-        });
+        };
+        control.sceneProperty().addListener(sceneChangeListener);
 
         // Register listeners
         registerChangeListener(control.showingProperty(), e -> {
@@ -214,6 +218,16 @@ public class MenuButtonSkinBase<C extends MenuButton> extends SkinBase<C> {
 
     /** {@inheritDoc} */
     @Override public void dispose() {
+        // FIXME : JDK-8244112 - backout if we are already disposed
+        // should check for getSkinnable to be null and return
+
+        // Cleanup accelerators
+        if (getSkinnable().getScene() != null) {
+            ControlAcceleratorSupport.removeAcceleratorsFromScene(getSkinnable().getItems(), getSkinnable().getScene());
+        }
+
+        // Remove listeners
+        getSkinnable().sceneProperty().removeListener(sceneChangeListener);
         getSkinnable().getItems().removeListener(itemsChangedListener);
         super.dispose();
         if (popup != null ) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuBarTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuBarTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -70,9 +71,32 @@ public class MenuBarTest {
     private Stage stage;
 
     @Before public void setup() {
+        setUncaughtExceptionHandler();
+
         tk = (StubToolkit)Toolkit.getToolkit();
         menuBar = new MenuBar();
         menuBar.setUseSystemMenuBar(false);
+    }
+
+    @After public void cleanup() {
+        if (stage != null) {
+            stage.hide();
+        }
+        removeUncaughtExceptionHandler();
+    }
+
+    private void setUncaughtExceptionHandler() {
+        Thread.currentThread().setUncaughtExceptionHandler((thread, throwable) -> {
+            if (throwable instanceof RuntimeException) {
+                throw (RuntimeException)throwable;
+            } else {
+                Thread.currentThread().getThreadGroup().uncaughtException(thread, throwable);
+            }
+        });
+    }
+
+    private void removeUncaughtExceptionHandler() {
+        Thread.currentThread().setUncaughtExceptionHandler(null);
     }
 
     protected void startApp(Parent root) {
@@ -452,7 +476,6 @@ public class MenuBarTest {
     }
 
     @Test public void testKeyNavigationWithAllDisabledMenuItems() {
-
         // Test key navigation with a single disabled menu in menubar
         VBox root = new VBox();
         Menu menu1 = new Menu("Menu1");


### PR DESCRIPTION
Issue : 
https://bugs.openjdk.java.net/browse/JDK-8244110

Root Cause : 
Fix of [JDK-8175358](https://bugs.openjdk.java.net/browse/JDK-8175358) added code to remove accelerators from a scene in Scene property listener of MenuButtonSkinBase. That fix uses getSkinnable() in listener. It turned out that it can be null as found out by failing system test.

Fix : 
As pointed out by @kleopatra on the JBS, getSkinnable() should never be null for a valid skin. Hence, the correct fix is to remove listener cleanly in dispose method. See JBS comments for more info. This also addresses [JDK-8244081](https://bugs.openjdk.java.net/browse/JDK-8244081).

Testing : 
1) Failing system test - passes after the fix
2) 3 unit tests which used to log NPE message silently and pass have been made to fail without this fix - these tests passes after the fix

Special Thanks to @kleopatra for most of the test digging and fix guidance.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244110](https://bugs.openjdk.java.net/browse/JDK-8244110): NPE in MenuButtonSkinBase change listener


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Jeanette Winzenburg ([fastegal](@kleopatra) - Author)

### Contributors
 * Jeanette Winzenburg `<fastegal@openjdk.org>`

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/205/head:pull/205`
`$ git checkout pull/205`
