### PR TITLE
8242001: ChoiceBox: must update value on setting SelectionModel, part2

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ChoiceBox.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ChoiceBox.java
@@ -182,8 +182,7 @@ public class ChoiceBox<T> extends Control {
             oldSM = sm;
             if (sm != null) {
                 sm.selectedItemProperty().addListener(selectedItemListener);
-                // FIXME JDK-8242001 - must sync to model state always
-                if (sm.getSelectedItem() != null && ! valueProperty().isBound()) {
+                if (!valueProperty().isBound()) {
                     ChoiceBox.this.setValue(sm.getSelectedItem());
                 }
             }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxSelectionTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxSelectionTest.java
@@ -33,10 +33,13 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.ChoiceBox;
+import javafx.scene.control.ChoiceBoxShim;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Control;
 import javafx.scene.control.MenuItem;
@@ -314,6 +317,41 @@ public class ChoiceBoxSelectionTest {
         assertEquals(uncontained, box.getValue());
     }
 
+    //------------- tests for JDK-8242001
+
+    /**
+     * Testing JDK-8242001: box value not updated on replacing selection model.
+     *
+     * Happens if replacing.selectedItem == null
+     *
+     */
+    @Test
+    public void testSyncedContainedValueReplaceSMEmpty() {
+        box.setValue(box.getItems().get(1));
+        SingleSelectionModel<String> replaceSM = ChoiceBoxShim.get_ChoiceBoxSelectionModel(box);
+        assertNull(replaceSM.getSelectedItem());
+        box.setSelectionModel(replaceSM);
+        assertEquals(replaceSM.getSelectedItem(), box.getValue());
+    }
+
+    @Test
+    public void testSyncedUncontainedValueReplaceSMEmpty() {
+        box.setValue(uncontained);
+        SingleSelectionModel<String> replaceSM = ChoiceBoxShim.get_ChoiceBoxSelectionModel(box);
+        assertNull(replaceSM.getSelectedItem());
+        box.setSelectionModel(replaceSM);
+        assertEquals(replaceSM.getSelectedItem(), box.getValue());
+    }
+
+    @Test
+    public void testSyncedBoundValueReplaceSMEmpty() {
+        StringProperty valueSource = new SimpleStringProperty("stickyValue");
+        box.valueProperty().bind(valueSource);
+        SingleSelectionModel<String> replaceSM = ChoiceBoxShim.get_ChoiceBoxSelectionModel(box);
+        assertNull(replaceSM.getSelectedItem());
+        box.setSelectionModel(replaceSM);
+        assertEquals(valueSource.get(), box.getValue());
+    }
 
     //----------- setup and sanity test for initial state
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxTest.java
@@ -342,7 +342,8 @@ public class ChoiceBoxTest {
         assertEquals("Orange", box.getValue());
     }
 
-    @Test public void ensureValueIsUpdatedByCorrectSelectionModelWhenSelectionModelIsChanged() {
+    @Test
+    public void ensureValueIsUpdatedByCorrectSelectionModelWhenSelectionModelIsChanged() {
         box.getItems().addAll("Apple", "Orange", "Banana");
         SelectionModel sm1 = box.getSelectionModel();
         sm1.select(1);
@@ -351,7 +352,10 @@ public class ChoiceBoxTest {
         box.setSelectionModel(sm2);
 
         sm1.select(2);  // value should not change as we are using old SM
-        assertEquals("Orange", box.getValue());
+        // was: incorrect test assumption
+        // - setting the new model (with null selected item) changed the value to null
+        // assertEquals("Orange", box.getValue());
+        assertEquals(sm2.getSelectedItem(), box.getValue());
 
         sm2.select(0);  // value should change, as we are using new SM
         assertEquals("Apple", box.getValue());


### PR DESCRIPTION
The issue is that ChoiceBox didn't sync its value to the replaced SelectionModel's selectedItem if the item is null. 

Fixed by removing the constraint from selectionModel property.

Added tests that failed before and passed after the fix. Note that I also changed a test method in ChoiceBoxTest with an incorrect test assumption (which passed for the incorrect implementation).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242001](https://bugs.openjdk.java.net/browse/JDK-8242001): ChoiceBox: must update value on setting SelectionModel, part 2


### Reviewers
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/207/head:pull/207`
`$ git checkout pull/207`
