### PR TITLE
8244421: Wrong scrollbar position on touch enabled devices

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -2348,8 +2348,13 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
         final double breadthBarLength = isVertical ? snapSizeY(hbar.prefHeight(-1)) : snapSizeX(vbar.prefWidth(-1));
         final double lengthBarBreadth = isVertical ? snapSizeX(vbar.prefWidth(-1)) : snapSizeY(hbar.prefHeight(-1));
 
-        setViewportBreadth((isVertical ? getWidth() : getHeight()) - (needLengthBar ? lengthBarBreadth : 0));
-        setViewportLength((isVertical ? getHeight() : getWidth()) - (needBreadthBar ? breadthBarLength : 0));
+        if (!Properties.IS_TOUCH_SUPPORTED) {
+            setViewportBreadth((isVertical ? getWidth() : getHeight()) - (needLengthBar ? lengthBarBreadth : 0));
+            setViewportLength((isVertical ? getHeight() : getWidth()) - (needBreadthBar ? breadthBarLength : 0));
+        } else {
+            setViewportBreadth((isVertical ? getWidth() : getHeight()));
+            setViewportLength((isVertical ? getHeight() : getWidth()));
+        }
     }
 
     private void initViewport() {


### PR DESCRIPTION
`VirtualFlow` makes use of `VirtualScrollBar` controls, that are laid out next to the clipped container region, by default. 

However, when touch is supported, these scrollBars are floating controls laid out over the container. Therefore, in this case, when the viewport dimensions are updated, the presence of the scrollBars shouldn't be taken into account.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244421](https://bugs.openjdk.java.net/browse/JDK-8244421): Wrong scrollbar position on touch enabled devices


### Reviewers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/208/head:pull/208`
`$ git checkout pull/208`
