### PR TITLE
8244112: Skin implementations: must not violate contract of dispose

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ButtonSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ButtonSkin.java
@@ -175,6 +175,7 @@ public class ButtonSkin extends LabeledSkinBase<Button> {
 
     /** {@inheritDoc} */
     @Override public void dispose() {
+        if (getSkinnable() == null) return;
         if (getSkinnable().isDefaultButton()) {
             setDefaultButton(false);
         }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuButtonSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuButtonSkinBase.java
@@ -218,8 +218,6 @@ public class MenuButtonSkinBase<C extends MenuButton> extends SkinBase<C> {
 
     /** {@inheritDoc} */
     @Override public void dispose() {
-        // FIXME : JDK-8244112 - backout if we are already disposed
-        // should check for getSkinnable to be null and return
         if (getSkinnable() == null) return;
 
         // Cleanup accelerators

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuButtonSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuButtonSkinBase.java
@@ -220,6 +220,7 @@ public class MenuButtonSkinBase<C extends MenuButton> extends SkinBase<C> {
     @Override public void dispose() {
         // FIXME : JDK-8244112 - backout if we are already disposed
         // should check for getSkinnable to be null and return
+        if (getSkinnable() == null) return;
 
         // Cleanup accelerators
         if (getSkinnable().getScene() != null) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableCellSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableCellSkinBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableCellSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableCellSkinBase.java
@@ -133,6 +133,7 @@ public abstract class TableCellSkinBase<S, T, C extends IndexedCell<T>> extends 
 
     /** {@inheritDoc} */
     @Override public void dispose() {
+        if (getSkinnable() == null) return;
         TableColumnBase<?,T> tableColumn = getTableColumn();
         if (tableColumn != null) {
             tableColumn.widthProperty().removeListener(weakColumnWidthListener);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
@@ -357,6 +357,7 @@ public abstract class TableViewSkinBase<M, S, C extends Control, I extends Index
 
     /** {@inheritDoc} */
     @Override public void dispose() {
+        if (getSkinnable() == null) return;
         final ObjectProperty<ObservableList<S>> itemsProperty = TableSkinUtils.itemsProperty(this);
 
         getVisibleLeafColumns().removeListener(weakVisibleLeafColumnsListener);

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/ControlShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/ControlShim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/ControlShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/ControlShim.java
@@ -31,11 +31,11 @@ public class ControlShim extends Control {
     /**
      * Installs the default skin for the given control.
      *
-     * Note that this has no noticeable effect if the the control's
+     * Note that this has no noticeable effect if the control's
      * skin already is set to the default skin (see skinProperty for
      * implementations details).
      *
-     * @param control the control the set the default skin on
+     * @param control the control to set the default skin on
      */
     public static void installDefaultSkin(Control control) {
         control.setSkin(control.createDefaultSkin());

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/ControlShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/ControlShim.java
@@ -28,6 +28,19 @@ import javafx.beans.property.StringProperty;
 
 public class ControlShim extends Control {
 
+    /**
+     * Installs the default skin for the given control.
+     *
+     * Note that this has no noticeable effect if the the control's
+     * skin already is set to the default skin (see skinProperty for
+     * implementations details).
+     *
+     * @param control the control the set the default skin on
+     */
+    public static void installDefaultSkin(Control control) {
+        control.setSkin(control.createDefaultSkin());
+    }
+
     public static StringProperty skinClassNameProperty(Control c) {
         return c.skinClassNameProperty();
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextAreaTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextAreaTest.java
@@ -34,6 +34,8 @@ import javafx.beans.property.StringProperty;
 import javafx.scene.Scene;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextInputControlShim;
+import javafx.scene.control.skin.TextAreaSkin;
+
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -482,4 +484,25 @@ public class TextAreaTest {
         dummyTxtArea.deleteText(0,6);
         assertEquals(dummyTxtArea.getParagraphs().get(0).toString(), "another");
     }
+
+    @Test @Ignore("8244418")
+    public void testDisposeSkin() {
+        txtArea.setSkin(new TextAreaSkin(txtArea));
+        txtArea.getSkin().dispose();
+    }
+
+    @Test @Ignore("8244418")
+    public void testReplaceSkin() {
+        txtArea.setSkin(new TextAreaSkin(txtArea));
+        txtArea.setSkin(new TextAreaSkin1(txtArea));
+    }
+
+    public static class TextAreaSkin1 extends TextAreaSkin {
+
+        public TextAreaSkin1(TextArea control) {
+            super(control);
+        }
+
+    }
+
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextAreaTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextAreaTest.java
@@ -34,8 +34,6 @@ import javafx.beans.property.StringProperty;
 import javafx.scene.Scene;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextInputControlShim;
-import javafx.scene.control.skin.TextAreaSkin;
-
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -484,25 +482,4 @@ public class TextAreaTest {
         dummyTxtArea.deleteText(0,6);
         assertEquals(dummyTxtArea.getParagraphs().get(0).toString(), "another");
     }
-
-    @Test @Ignore("8244418")
-    public void testDisposeSkin() {
-        txtArea.setSkin(new TextAreaSkin(txtArea));
-        txtArea.getSkin().dispose();
-    }
-
-    @Test @Ignore("8244418")
-    public void testReplaceSkin() {
-        txtArea.setSkin(new TextAreaSkin(txtArea));
-        txtArea.setSkin(new TextAreaSkin1(txtArea));
-    }
-
-    public static class TextAreaSkin1 extends TextAreaSkin {
-
-        public TextAreaSkin1(TextArea control) {
-            super(control);
-        }
-
-    }
-
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinDisposeContractTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinDisposeContractTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.control.skin;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static javafx.scene.control.ControlShim.*;
+
+import javafx.scene.control.Accordion;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.ChoiceBox;
+import javafx.scene.control.ColorPicker;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Control;
+import javafx.scene.control.DateCell;
+import javafx.scene.control.DatePicker;
+import javafx.scene.control.Hyperlink;
+import javafx.scene.control.Label;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.control.MenuBar;
+import javafx.scene.control.MenuButton;
+import javafx.scene.control.Pagination;
+import javafx.scene.control.PasswordField;
+import javafx.scene.control.ProgressBar;
+import javafx.scene.control.ProgressIndicator;
+import javafx.scene.control.RadioButton;
+import javafx.scene.control.ScrollBar;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.Separator;
+import javafx.scene.control.Slider;
+import javafx.scene.control.Spinner;
+import javafx.scene.control.SplitMenuButton;
+import javafx.scene.control.SplitPane;
+import javafx.scene.control.TabPane;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableRow;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TextField;
+import javafx.scene.control.TitledPane;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.control.ToolBar;
+import javafx.scene.control.TreeCell;
+import javafx.scene.control.TreeTableCell;
+import javafx.scene.control.TreeTableRow;
+import javafx.scene.control.TreeTableView;
+import javafx.scene.control.TreeView;
+
+/**
+ * Test for https://bugs.openjdk.java.net/browse/JDK-8244112:
+ * skin must not blow if dispose is called more than once.
+ * <p>
+ * This test is parameterized in the type of control.
+ */
+@RunWith(Parameterized.class)
+public class SkinDisposeContractTest {
+
+    private Control control;
+    private Class<Control> controlClass;
+
+    /**
+     * Skin must support multiple calls to dispose.
+     * <p>
+     * default -> dispose -> dispose
+     * <p>
+     * Errors on second dispose are JDK-8243940.
+     * Failures/errors on first dispose (or before) are other errors - controls
+     * are commented with issue reference
+     *
+     */
+    @Test
+    public void testDefaultDispose() {
+        installDefaultSkin(control);
+        control.getSkin().dispose();
+        control.getSkin().dispose();
+    }
+
+  //---------------- parameterized
+
+    // Note: name property not supported before junit 4.11
+    @Parameterized.Parameters //(name = "{index}: {0} ")
+    public static Collection<Object[]> data() {
+        // class of control to test
+        // commented controls have different issues as described in the referenced issues
+        Object[][] data = new Object[][] {
+            {Accordion.class, },
+            {Button.class, },
+            {ButtonBar.class, },
+            {CheckBox.class, },
+            {ChoiceBox.class, },
+            {ColorPicker.class, },
+            {ComboBox.class, },
+            {DateCell.class, },
+            {DatePicker.class, },
+            {Hyperlink.class, },
+            {Label.class, },
+            {ListCell.class, },
+            {ListView.class, },
+            {MenuBar.class, },
+            {MenuButton.class, },
+            {Pagination.class, },
+            {PasswordField.class, },
+            {ProgressBar.class, },
+            {ProgressIndicator.class, },
+            {RadioButton.class, },
+            {ScrollBar.class, },
+            {ScrollPane.class, },
+            {Separator.class, },
+            {Slider.class, },
+            {Spinner.class, },
+            {SplitMenuButton.class, },
+            {SplitPane.class, },
+            {TableCell.class, },
+            {TableRow.class, },
+            {TableView.class, },
+            {TabPane.class, },
+            // @Ignore("8244418")
+            // {TextArea.class, },
+            {TextField.class, },
+            {TitledPane.class, },
+            {ToggleButton.class, },
+            {ToolBar.class, },
+            {TreeCell.class, },
+            {TreeTableCell.class, },
+            {TreeTableRow.class, },
+            {TreeTableView.class, },
+            {TreeView.class, },
+        };
+        return Arrays.asList(data);
+    }
+
+    public SkinDisposeContractTest(Class<Control> controlClass) {
+        this.controlClass = controlClass;
+    }
+
+//----------------------
+
+    @After
+    public void cleanup() {
+        Thread.currentThread().setUncaughtExceptionHandler(null);
+    }
+
+    @Before
+    public void setup() {
+        Thread.currentThread().setUncaughtExceptionHandler((thread, throwable) -> {
+            if (throwable instanceof RuntimeException) {
+                throw (RuntimeException)throwable;
+            } else {
+                Thread.currentThread().getThreadGroup().uncaughtException(thread, throwable);
+            }
+        });
+        control = createControl(controlClass);
+    }
+
+    /**
+     * Creates and returns an instance of the given control class.
+     * @param <T> the type of the control
+     * @param controlClass
+     * @return an instance of the class
+     */
+    public static <T extends Control> T createControl(Class<T> controlClass) {
+        try {
+            return controlClass.getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinDisposeContractTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinDisposeContractTest.java
@@ -146,7 +146,7 @@ public class SkinDisposeContractTest {
             {TableRow.class, },
             {TableView.class, },
             {TabPane.class, },
-            // @Ignore("8244418")
+            // @Ignore("8244419")
             // {TextArea.class, },
             {TextField.class, },
             {TitledPane.class, },

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinPopupContractTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinPopupContractTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.control.skin;
+
+import org.junit.Test;
+
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.Tooltip;
+import javafx.scene.control.skin.ContextMenuSkin;
+import javafx.scene.control.skin.TooltipSkin;
+
+/**
+ * Tests for Skinnables that are not Controls.
+ */
+public class SkinPopupContractTest {
+
+    @Test
+    public void testTooltipSkinDispose() {
+        Tooltip tooltip = new Tooltip();
+        tooltip.setSkin(new TooltipSkin(tooltip));
+        tooltip.getSkin().dispose();
+        tooltip.getSkin().dispose();
+    }
+
+    @Test
+    public void testContextMenuSkinDispose() {
+        ContextMenu tooltip = new ContextMenu();
+        tooltip.setSkin(new ContextMenuSkin(tooltip));
+        tooltip.getSkin().dispose();
+        tooltip.getSkin().dispose();
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinPopupContractTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinPopupContractTest.java
@@ -47,10 +47,10 @@ public class SkinPopupContractTest {
 
     @Test
     public void testContextMenuSkinDispose() {
-        ContextMenu tooltip = new ContextMenu();
-        tooltip.setSkin(new ContextMenuSkin(tooltip));
-        tooltip.getSkin().dispose();
-        tooltip.getSkin().dispose();
+        ContextMenu contextMenu = new ContextMenu();
+        contextMenu.setSkin(new ContextMenuSkin(contextMenu));
+        contextMenu.getSkin().dispose();
+        contextMenu.getSkin().dispose();
     }
 
 }


### PR DESCRIPTION
some skins have not been guarding themselves against multiple calls to dispose (see issue for details)

Fixed by backing out off dispose if skinnable is null. Added test (parameterized in control class) for all controls in the controls package. Those that failed for the misbehaving skins before are passing after the fix.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244112](https://bugs.openjdk.java.net/browse/JDK-8244112): Skin implementations: must not violate contract of dispose 


### Reviewers
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/209/head:pull/209`
`$ git checkout pull/209`
