### PR TITLE
8244487: One Windows 10 SDK file missing from FX build

### DIFF
--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -219,6 +219,7 @@ def WinSDKDLLsPath = cygpath("${winSdkDllDir}")
 if (file(WinSDKDLLsPath).exists()) {
     ext.WIN.WinSDKDLLNames = [
         "api-ms-win-core-console-l1-1-0.dll",
+        "api-ms-win-core-console-l1-2-0.dll",
         "api-ms-win-core-datetime-l1-1-0.dll",
         "api-ms-win-core-debug-l1-1-0.dll",
         "api-ms-win-core-errorhandling-l1-1-0.dll",

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -110,6 +110,7 @@ public abstract class Toolkit {
 
     private static final String[] msLibNames = {
         "api-ms-win-core-console-l1-1-0",
+        "api-ms-win-core-console-l1-2-0",
         "api-ms-win-core-datetime-l1-1-0",
         "api-ms-win-core-debug-l1-1-0",
         "api-ms-win-core-errorhandling-l1-1-0",


### PR DESCRIPTION
While auditing the list of redistributed Microsoft files in the JDK versus FX, I discovered one file that the JDK ships that FX does not:

```
api-ms-win-core-console-l1-2-0.dll
```

I checked the Redist directory in the Windows 10 SDK and this is the only one we are missing.

Root cause: the current version of the Windows 10 SDK has 41 redistributable `api-ms-win-*` files. There were 40 when we first upgraded to VS 2017 and Windows 10 SDK three years ago. We didn't reexamine the list when upgrading to a later minor version of VS 2017 and the Windows 10 SDK.

We haven't yet seen any problems as a result, but since we are getting ready to upgrade to VS 2019 see [JDK-8242508](https://bugs.openjdk.java.net/browse/JDK-8242508) -- we should correct this so it doesn't cause problems in the future.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244487](https://bugs.openjdk.java.net/browse/JDK-8244487): One Windows 10 SDK file missing from FX build


### Reviewers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/211/head:pull/211`
`$ git checkout pull/211`
