### PR TITLE
8242508: Upgrade to Visual Studio 2019 version 16.5.3

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -89,7 +89,7 @@ jfx.gradle.version.min=5.3
 
 # Toolchains
 jfx.build.linux.gcc.version=gcc9.2.0-OL6.4+1.0
-jfx.build.windows.msvc.version=VS2017-15.9.16+1.0
+jfx.build.windows.msvc.version=VS2019-16.5.3+1.0
 jfx.build.macosx.xcode.version=Xcode10.1-MacOSX10.14+1.0
 
 # Build tools


### PR DESCRIPTION
This is a toolchain upgrade on Windows from the current Visual Studio 2017 (version 15.9.16) to Visual Studio 2019 (version 16.5.3). This will match a recent upgrade done for JDK 15 -- see [JDK-8244214](https://bugs.openjdk.java.net/browse/JDK-8244214).

I have run a full build and test using this new compiler.

NOTE: although this isn't strictly dependent on [JDK-8244487](https://bugs.openjdk.java.net/browse/JDK-8244487), which is out for review as PR #211 , I plan to wait until that one is approved. I will then integrate PR #211 followed by this PR.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242508](https://bugs.openjdk.java.net/browse/JDK-8242508): Upgrade to Visual Studio 2019 version 16.5.3


### Reviewers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/212/head:pull/212`
`$ git checkout pull/212`
