### PR TITLE
8244417: support static build for Windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1424,7 +1424,7 @@ void addNative(Project project, String name) {
                 cleanTask.delete "$libRootDir/${t.name}"
             }
             nativeTask.dependsOn(linkTask)
-            if (IS_WINDOWS && t.name == "win") {
+            if (IS_WINDOWS && t.name == "win" && (!IS_STATIC_BUILD || name == "glass")) {
                 def rcTask = project.task("rc$capitalName$capitalVariant", type: CompileResourceTask, group: "Build") {
                     description = "Compiles native sources for $name"
                     matches = ".*\\.rc"

--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -34,7 +34,7 @@ WIN.compileSWT = true;
 WIN.includeNull3d = true
 
 // Lambda for naming the generated libs
-WIN.library = { name -> return "${name}.dll" as String }
+WIN.library = { name -> return (IS_STATIC_BUILD ? "${name}.lib" : "${name}.dll") as String }
 
 WIN.libDest = "bin"
 WIN.modLibDest = "lib"
@@ -116,8 +116,12 @@ def ccFlags = ["/nologo", "/W3", "/EHsc", "/c",
         "/DUNICODE", "/D_UNICODE", "/DWIN32", "/DIAL", "/D_LITTLE_ENDIAN", "/DWIN32_LEAN_AND_MEAN",
         "/I$JDK_HOME/include", "/I$JDK_HOME/include/win32",
         ccDebugFlags].flatten();
+if (IS_STATIC_BUILD) ccFlags.add("/DSTATIC_BUILD")
 
-def linkFlags = ["/nologo", "/dll", "/manifest", "/opt:REF", "/incremental:no", "/dynamicbase", "/nxcompat"];
+def linkFlags = ["/nologo"]
+if (!IS_STATIC_BUILD) {
+    linkFlags += ["/dll", "/manifest", "/opt:REF", "/incremental:no", "/dynamicbase", "/nxcompat"]
+}
 if (!IS_64) linkFlags.add("/safeseh");
 if (IS_DEBUG_NATIVE) linkFlags.add("/debug");
 
@@ -150,7 +154,7 @@ if (hasProperty('toolchainDir')) {
                       : "$WINDOWS_VS_VSINSTALLDIR/VC/BIN")
 }
 def compiler = IS_COMPILE_PARFAIT ? "cl.exe" : cygpath("$msvcBinDir/cl.exe")
-def linker = IS_COMPILE_PARFAIT ? "link.exe" : cygpath("$msvcBinDir/link.exe")
+def linker = IS_STATIC_BUILD ? (IS_COMPILE_PARFAIT ? "lib.exe" : cygpath("$msvcBinDir/lib.exe")) : (IS_COMPILE_PARFAIT ? "link.exe" : cygpath("$msvcBinDir/link.exe"))
 def winSdkBinDir = "$WINDOWS_SDK_DIR/Bin"
 if (WINDOWS_VS_VER != "100") {
     winSdkBinDir += "/$CPU_BITS"
@@ -290,7 +294,7 @@ def rcFlags = [
     "/d", "\"JFX_BUILD_ID=${rcVerBuild}\"",
     "/d", "\"JFX_COPYRIGHT=Copyright \u00A9 ${rcVerCopyrYear}\"",
     "/d", "\"JFX_FVER=${rcVerFile}\"",
-    "/d", "\"JFX_FTYPE=0x2L\"",
+    "/d", "\"JFX_FTYPE=${IS_STATIC_BUILD ? "0x7L" : "0x2L" }\"",
     "/nologo"
 ];
 
@@ -313,10 +317,10 @@ WIN.glass.rcFlags = [
 WIN.glass.ccFlags = [ccFlags, "/WX"].flatten()
 if (WINDOWS_VS_VER != "100") WIN.glass.ccFlags -= ["/WX"]
 WIN.glass.linker = linker
-WIN.glass.linkFlags = [linkFlags, "delayimp.lib", "gdi32.lib", "urlmon.lib", "Comdlg32.lib",
+WIN.glass.linkFlags = (IS_STATIC_BUILD ? [linkFlags] : [linkFlags, "delayimp.lib", "gdi32.lib", "urlmon.lib", "Comdlg32.lib",
         "winmm.lib", "imm32.lib", "shell32.lib", "Uiautomationcore.lib", "dwmapi.lib",
         "/DELAYLOAD:user32.dll", "/DELAYLOAD:urlmon.dll", "/DELAYLOAD:winmm.dll", "/DELAYLOAD:shell32.dll",
-        "/DELAYLOAD:Uiautomationcore.dll", "/DELAYLOAD:dwmapi.dll"].flatten()
+        "/DELAYLOAD:Uiautomationcore.dll", "/DELAYLOAD:dwmapi.dll"]).flatten()
 WIN.glass.lib = "glass"
 
 WIN.decora = [:]
@@ -361,7 +365,7 @@ WIN.prismD3D.nativeSource = [
 WIN.prismD3D.compiler = compiler
 WIN.prismD3D.ccFlags = [ccFlags, "/Ibuild/headers/PrismD3D"].flatten()
 WIN.prismD3D.linker = linker
-WIN.prismD3D.linkFlags = [linkFlags, "user32.lib"].flatten()
+WIN.prismD3D.linkFlags = (IS_STATIC_BUILD ? [linkFlags] : [linkFlags, "user32.lib"]).flatten()
 WIN.prismD3D.lib = "prism_d3d"
 WIN.prismD3D.rcCompiler = rcCompiler;
 WIN.prismD3D.rcSource = defaultRcSource
@@ -391,7 +395,7 @@ WIN.prismES2.nativeSource = [
 WIN.prismES2.compiler = compiler
 WIN.prismES2.ccFlags = ["/Ob1", "/GF", "/Gy", "/GS", "/DWIN32", ccFlags].flatten()
 WIN.prismES2.linker = linker
-WIN.prismES2.linkFlags = [linkFlags, "/SUBSYSTEM:WINDOWS", "opengl32.lib", "gdi32.lib", "user32.lib", "kernel32.lib"].flatten()
+WIN.prismES2.linkFlags = (IS_STATIC_BUILD ? [linkFlags] : [linkFlags, "/SUBSYSTEM:WINDOWS", "opengl32.lib", "gdi32.lib", "user32.lib", "kernel32.lib"]).flatten()
 WIN.prismES2.lib = "prism_es2"
 WIN.prismES2.rcCompiler = rcCompiler;
 WIN.prismES2.rcSource = defaultRcSource
@@ -407,7 +411,7 @@ WIN.font.compiler = compiler
 WIN.font.ccFlags = ["/DJFXFONT_PLUS", "/D_WIN32_WINNT=0x0601", ccFlags].flatten()
 WIN.font.ccFlags -= ["/DUNICODE", "/D_UNICODE"]
 WIN.font.linker = linker
-WIN.font.linkFlags = [linkFlags, "advapi32.lib", "gdi32.lib", "user32.lib", "dwrite.lib", "d2d1.lib", "windowscodecs.lib", "ole32.lib"].flatten()
+WIN.font.linkFlags = (IS_STATIC_BUILD ? [linkFlags] : [linkFlags, "advapi32.lib", "gdi32.lib", "user32.lib", "dwrite.lib", "d2d1.lib", "windowscodecs.lib", "ole32.lib"]).flatten()
 WIN.font.lib = "javafx_font"
 WIN.font.rcCompiler = rcCompiler;
 WIN.font.rcSource = defaultRcSource

--- a/modules/javafx.graphics/src/main/native-font/directwrite.cpp
+++ b/modules/javafx.graphics/src/main/native-font/directwrite.cpp
@@ -51,7 +51,7 @@ typedef HRESULT (WINAPI*D2D1CreateFactoryProc)(
   void **factory
 );
 
-jboolean checkAndClearException(JNIEnv* env)
+static jboolean checkAndClearException(JNIEnv* env)
 {
     jthrowable t = env->ExceptionOccurred();
     if (!t) {

--- a/modules/javafx.graphics/src/main/native-font/fontpath.c
+++ b/modules/javafx.graphics/src/main/native-font/fontpath.c
@@ -50,6 +50,20 @@
         } \
     } while (0)
 
+#ifdef STATIC_BUILD
+JNIEXPORT jint JNICALL JNI_OnLoad_javafx_font(JavaVM *vm, void *reserved) {
+#ifdef JNI_VERSION_1_8
+    JNIEnv *env;
+    if ((*vm)->GetEnv(vm, (void **)&env, JNI_VERSION_1_8) != JNI_OK) {
+        return JNI_VERSION_1_4;
+    }
+    return JNI_VERSION_1_8;
+#else
+    return JNI_VERSION_1_4;
+#endif // JNI_VERSION_1_8
+}
+#endif // STATIC_BUILD
+
 JNIEXPORT jbyteArray JNICALL
 Java_com_sun_javafx_font_PrismFontFactory_getFontPath(JNIEnv *env, jobject thiz)
 {

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassApplication.cpp
@@ -355,6 +355,7 @@ ULONG GlassApplication::GetAccessibilityCount()
 
 extern "C" {
 
+#ifndef STATIC_BUILD
 BOOL WINAPI DllMain(HANDLE hinstDLL, DWORD dwReason, LPVOID lpvReserved)
 {
     if (dwReason == DLL_PROCESS_ATTACH) {
@@ -362,6 +363,7 @@ BOOL WINAPI DllMain(HANDLE hinstDLL, DWORD dwReason, LPVOID lpvReserved)
     }
     return TRUE;
 }
+#endif
 
 /*
  * Class:     com_sun_glass_ui_win_WinApplication
@@ -371,6 +373,11 @@ BOOL WINAPI DllMain(HANDLE hinstDLL, DWORD dwReason, LPVOID lpvReserved)
 JNIEXPORT void JNICALL Java_com_sun_glass_ui_win_WinApplication_initIDs
   (JNIEnv *env, jclass cls, jfloat overrideUIScale)
 {
+#ifdef STATIC_BUILD
+    HINSTANCE hInstExe = ::GetModuleHandle(NULL);
+    GlassApplication::SetHInstance((HINSTANCE)hInstExe);
+#endif
+
     GlassApplication::overrideUIScale = overrideUIScale;
 
     javaIDs.Application.reportExceptionMID =

--- a/modules/javafx.graphics/src/main/native-glass/win/Utils.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/Utils.cpp
@@ -109,7 +109,11 @@ jint GetModifiers()
 
 extern "C" {
 
+#ifdef STATIC_BUILD
+JNIEXPORT jint JNICALL JNI_OnLoad_glass(JavaVM *vm, void *reserved)
+#else
 JNIEXPORT jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
+#endif
 {
     memset(&javaIDs, 0, sizeof(javaIDs));
     jvm = vm;

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DPipeline.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DPipeline.cc
@@ -36,9 +36,7 @@ typedef HRESULT WINAPI FnDirect3DCreate9Ex(UINT SDKVersion, IDirect3D9Ex**);
 FnDirect3DCreate9 * pD3D9FactoryFunction = 0;
 FnDirect3DCreate9Ex * pD3D9FactoryExFunction = 0;
 
-extern jboolean checkAndClearException(JNIEnv *env);
-
-jboolean checkAndClearException(JNIEnv *env) {
+static jboolean checkAndClearException(JNIEnv *env) {
     if (!env->ExceptionCheck()) {
         return JNI_FALSE;
     }
@@ -77,6 +75,7 @@ IDirect3D9Ex * Direct3DCreate9Ex() {
     return SUCCEEDED(hr) ? pD3D : 0;
 }
 
+#ifndef STATIC_BUILD
 BOOL APIENTRY DllMain( HANDLE hModule,
                        DWORD  ul_reason_for_call,
                        LPVOID lpReserved)
@@ -91,6 +90,7 @@ BOOL APIENTRY DllMain( HANDLE hModule,
     }
     return TRUE;
 }
+#endif // STATIC_BUILD
 
 struct ConfigJavaStaticClass : IConfig {
     JNIEnv *_env; jclass _psClass;
@@ -127,6 +127,10 @@ JNIEXPORT jboolean JNICALL Java_com_sun_prism_d3d_D3DPipeline_nInit
         return false;
     }
 
+#ifdef STATIC_BUILD
+    loadD3DLibrary();
+#endif // STATIC_BUILD
+
     TraceLn(NWT_TRACE_INFO, "D3DPipeline_nInit");
     D3DPipelineManager *pMgr = D3DPipelineManager::CreateInstance(ConfigJavaStaticClass(env, psClass));
 
@@ -154,6 +158,10 @@ JNIEXPORT void JNICALL Java_com_sun_prism_d3d_D3DPipeline_nDispose(JNIEnv *pEnv,
     if (D3DPipelineManager::GetInstance()) {
         D3DPipelineManager::DeleteInstance();
     }
+
+#ifdef STATIC_BUILD
+    freeD3DLibrary();
+#endif // STATIC_BUILD
 }
 
 

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DShader.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DShader.cc
@@ -196,4 +196,19 @@ JNIEXPORT jint JNICALL Java_com_sun_prism_d3d_D3DShader_nGetRegister
     return -1;
 }
 
+#ifdef STATIC_BUILD
+JNIEXPORT jint JNICALL JNI_OnLoad_prism_d3d(JavaVM *vm, void *reserved) {
+#ifdef JNI_VERSION_1_8
+    //min. returned JNI_VERSION required by JDK8 for builtin libraries
+    JNIEnv *env;
+    if (vm->GetEnv((void **)&env, JNI_VERSION_1_8) != JNI_OK) {
+        return JNI_VERSION_1_4;
+    }
+    return JNI_VERSION_1_8;
+#else
+    return JNI_VERSION_1_4;
+#endif // JNI_VERSION_1_8
+}
+#endif // STATIC_BUILD
+
 }

--- a/modules/javafx.graphics/src/main/native-prism-es2/windows/WinGLFactory.c
+++ b/modules/javafx.graphics/src/main/native-prism-es2/windows/WinGLFactory.c
@@ -33,6 +33,21 @@
 #include "../PrismES2Defs.h"
 #include "com_sun_prism_es2_WinGLFactory.h"
 
+#ifdef STATIC_BUILD
+JNIEXPORT jint JNICALL JNI_OnLoad_prism_es2(JavaVM *vm, void * reserved) {
+#ifdef JNI_VERSION_1_8
+    //min. returned JNI_VERSION required by JDK8 for builtin libraries
+    JNIEnv *env;
+    if ((*vm)->GetEnv(vm, (void **)&env, JNI_VERSION_1_8) != JNI_OK) {
+        return JNI_VERSION_1_4;
+    }
+    return JNI_VERSION_1_8;
+#else
+    return JNI_VERSION_1_4;
+#endif // JNI_VERSION_1_8
+}
+#endif // STATIC_BUILD
+
 PIXELFORMATDESCRIPTOR getPFD(jint* attrArr) {
 
     static PIXELFORMATDESCRIPTOR pfd = {


### PR DESCRIPTION
Adds support for building static libraries of the OpenJFX modules for the Windows platform. Building static libraries is done by providing the gradle property `-PSTATIC_BUILD=true`.

Changes include:

- add static flags for the compiler and linker
- use `lib` for linking instead of `link`
- only build and include version.rc once (from GlassResources.rc)
- include library specific `JNI_OnLoad_xxx` methods
- functionality loaded via `DllMain` has been implemented at a different location
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244417](https://bugs.openjdk.java.net/browse/JDK-8244417): support static build for Windows


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/214/head:pull/214`
`$ git checkout pull/214`
