### PR TITLE
8244647: Wrong first layout pass of Scrollbar controls on touch supported devices

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -2445,11 +2445,13 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             }
             else {
                 if (isVertical) {
-                    hbar.resizeRelocate(0, (viewportLength-hbar.getHeight()),
-                            viewportBreadth, hbar.prefHeight(viewportBreadth));
+                    double prefHeight = hbar.prefHeight(viewportBreadth);
+                    hbar.resizeRelocate(0, viewportLength-prefHeight,
+                            viewportBreadth, prefHeight);
                 } else {
-                    vbar.resizeRelocate((viewportLength-vbar.getWidth()), 0,
-                            vbar.prefWidth(viewportBreadth), viewportBreadth);
+                    double prefWidth = vbar.prefWidth(viewportBreadth);
+                    vbar.resizeRelocate(viewportLength-prefWidth, 0,
+                            prefWidth, viewportBreadth);
                 }
             }
 
@@ -2522,9 +2524,11 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             }
             else {
                 if (isVertical) {
-                    vbar.resizeRelocate((viewportBreadth-vbar.getWidth()), 0, vbar.prefWidth(viewportLength), viewportLength);
+                    double prefWidth = vbar.prefWidth(viewportLength);
+                    vbar.resizeRelocate(viewportBreadth-prefWidth, 0, prefWidth, viewportLength);
                 } else {
-                    hbar.resizeRelocate(0, (viewportBreadth-hbar.getHeight()), viewportLength, hbar.prefHeight(-1));
+                    double prefHeight = hbar.prefHeight(-1);
+                    hbar.resizeRelocate(0, viewportBreadth-prefHeight, viewportLength, prefHeight);
                 }
             }
         }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -2446,11 +2446,11 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             else {
                 if (isVertical) {
                     double prefHeight = hbar.prefHeight(viewportBreadth);
-                    hbar.resizeRelocate(0, viewportLength-prefHeight,
+                    hbar.resizeRelocate(0, viewportLength - prefHeight,
                             viewportBreadth, prefHeight);
                 } else {
                     double prefWidth = vbar.prefWidth(viewportBreadth);
-                    vbar.resizeRelocate(viewportLength-prefWidth, 0,
+                    vbar.resizeRelocate(viewportLength - prefWidth, 0,
                             prefWidth, viewportBreadth);
                 }
             }
@@ -2525,10 +2525,10 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             else {
                 if (isVertical) {
                     double prefWidth = vbar.prefWidth(viewportLength);
-                    vbar.resizeRelocate(viewportBreadth-prefWidth, 0, prefWidth, viewportLength);
+                    vbar.resizeRelocate(viewportBreadth - prefWidth, 0, prefWidth, viewportLength);
                 } else {
                     double prefHeight = hbar.prefHeight(-1);
-                    hbar.resizeRelocate(0, viewportBreadth-prefHeight, viewportLength, prefHeight);
+                    hbar.resizeRelocate(0, viewportBreadth - prefHeight, viewportLength, prefHeight);
                 }
             }
         }


### PR DESCRIPTION
There is a visual glitch when the scrollbar controls are laid out on touch enabled devices. 

The first time they are laid out in the wrong location (20 px from right or bottom), while the next passes are correct (8 px from right or bottom). 

The reason for this glitch is the use of `getWidth()` or `getHeight()` in the `resizeRelocate` calls to relocate the bars before the controls have been properly resized yet: The initial w/h values are set to the default (20 px / 100 px), while the pref values are correctly set to 8 px.

This PR fixes that, by using the same prefWidth/prefHeight for both resizing and relocating. 

It has been tested on Mac OS and Linux (with `-Dcom.sun.javafx.touch=true`), and on Android and iOS.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244647](https://bugs.openjdk.java.net/browse/JDK-8244647): Wrong first layout pass of Scrollbar controls on touch supported devices


### Reviewers
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/215/head:pull/215`
`$ git checkout pull/215`
