### PR TITLE
8244418: MenuBar: IOOB exception on requestFocus on empty bar

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
@@ -472,14 +472,10 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
     }
 
     private void setFocusedMenuIndex(int index) {
-        this.focusedMenuIndex = index;
-        focusedMenu = null;
+        focusedMenuIndex = (index >= -1 && index < getSkinnable().getMenus().size())? index : -1;
+        focusedMenu = (focusedMenuIndex != -1)? getSkinnable().getMenus().get(index) : null;
 
-        if (index != -1 && !(getSkinnable().getMenus().isEmpty())) {
-            focusedMenu = getSkinnable().getMenus().get(index);
-        }
-
-        if (focusedMenu != null && focusedMenuIndex != -1) {
+        if (focusedMenuIndex != -1) {
             openMenuButton = (MenuBarButton)container.getChildren().get(focusedMenuIndex);
             openMenuButton.setHover();
         }
@@ -762,6 +758,10 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
 
     int getFocusedMenuIndex() {
         return focusedMenuIndex;
+    }
+
+    void setFocusedIndex(int index) {
+        this.setFocusedMenuIndex(0);
     }
 
     private boolean menusContainCustomMenuItem() {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
@@ -300,19 +300,15 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
             }
         };
         menuBarFocusedPropertyListener = (ov, t, t1) -> {
-            if (t1) {
+            unSelectMenus();
+            if (t1 && !container.getChildren().isEmpty()) {
                 // RT-23147 when MenuBar's focusTraversable is true the first
                 // menu will visually indicate focus
-                unSelectMenus();
-                if (!container.getChildren().isEmpty()) {
-                    menuModeStart(0);
-                    openMenuButton = ((MenuBarButton)container.getChildren().get(0));
-                    setFocusedMenuIndex(0);
-                    openMenuButton.setHover();
-                }
-            } else {
-                unSelectMenus();
-             }
+                menuModeStart(0);
+                openMenuButton = ((MenuBarButton)container.getChildren().get(0));
+                setFocusedMenuIndex(0);
+                openMenuButton.setHover();
+            }
          };
         weakSceneKeyEventHandler = new WeakEventHandler<KeyEvent>(keyEventHandler);
         Utils.executeOnceWhenPropertyIsNonNull(control.sceneProperty(), (Scene scene) -> {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
@@ -471,9 +471,12 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
         }
     }
 
-    private void setFocusedMenuIndex(int index) {
-        focusedMenuIndex = (index >= -1 && index < getSkinnable().getMenus().size())? index : -1;
-        focusedMenu = (focusedMenuIndex != -1)? getSkinnable().getMenus().get(index) : null;
+    /**
+     * This method is package scoped as it is used in this class as well as for testing
+     */
+    void setFocusedMenuIndex(int index) {
+        focusedMenuIndex = (index >= -1 && index < getSkinnable().getMenus().size()) ? index : -1;
+        focusedMenu = (focusedMenuIndex != -1) ? getSkinnable().getMenus().get(index) : null;
 
         if (focusedMenuIndex != -1) {
             openMenuButton = (MenuBarButton)container.getChildren().get(focusedMenuIndex);
@@ -758,10 +761,6 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
 
     int getFocusedMenuIndex() {
         return focusedMenuIndex;
-    }
-
-    void setFocusedIndex(int index) {
-        this.setFocusedMenuIndex(0);
     }
 
     private boolean menusContainCustomMenuItem() {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
@@ -304,10 +304,12 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
                 // RT-23147 when MenuBar's focusTraversable is true the first
                 // menu will visually indicate focus
                 unSelectMenus();
-                menuModeStart(0);
-                openMenuButton = ((MenuBarButton)container.getChildren().get(0));
-                setFocusedMenuIndex(0);
-                openMenuButton.setHover();
+                if (!container.getChildren().isEmpty()) {
+                    menuModeStart(0);
+                    openMenuButton = ((MenuBarButton)container.getChildren().get(0));
+                    setFocusedMenuIndex(0);
+                    openMenuButton.setHover();
+                }
             } else {
                 unSelectMenus();
              }
@@ -475,7 +477,11 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
 
     private void setFocusedMenuIndex(int index) {
         this.focusedMenuIndex = index;
-        focusedMenu = index == -1 ? null : getSkinnable().getMenus().get(index);
+        focusedMenu = null;
+
+        if (index != -1 && !(getSkinnable().getMenus().isEmpty())) {
+            focusedMenu = getSkinnable().getMenus().get(index);
+        }
 
         if (focusedMenu != null && focusedMenuIndex != -1) {
             openMenuButton = (MenuBarButton)container.getChildren().get(focusedMenuIndex);

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/MenuBarSkinShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/MenuBarSkinShim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,12 +53,12 @@ public class MenuBarSkinShim {
         return cmc;
     }
 
-    public static int getFocusedIndex(MenuBarSkin skin) {
+    public static int getFocusedMenuIndex(MenuBarSkin skin) {
         return skin.getFocusedMenuIndex();
     }
 
-    public static void setFocusedIndex(MenuBarSkin skin, int index) {
-        skin.setFocusedIndex(index);
+    public static void setFocusedMenuIndex(MenuBarSkin skin, int index) {
+        skin.setFocusedMenuIndex(index);
     }
 
 }

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/MenuBarSkinShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/MenuBarSkinShim.java
@@ -56,4 +56,9 @@ public class MenuBarSkinShim {
     public static int getFocusedIndex(MenuBarSkin skin) {
         return skin.getFocusedMenuIndex();
     }
+
+    public static void setFocusedIndex(MenuBarSkin skin, int index) {
+        skin.setFocusedIndex(index);
+    }
+
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuBarTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuBarTest.java
@@ -131,7 +131,23 @@ public class MenuBarTest {
         menuBar.getScene().getWindow().requestFocus();
 
         int focusedIndex = MenuBarSkinShim.getFocusedIndex(skin);
-        assertEquals(focusedIndex, -1);
+        assertEquals(-1, focusedIndex);
+    }
+
+    @Test public void testSimulateTraverseIntoEmptyMenubar() {
+        menuBar.setFocusTraversable(true);
+
+        AnchorPane root = new AnchorPane();
+        root.getChildren().add(menuBar);
+        startApp(root);
+
+        MenuBarSkin skin = (MenuBarSkin)menuBar.getSkin();
+        assertTrue(skin != null);
+
+        // simulate notification from traversalListener
+        MenuBarSkinShim.setFocusedIndex(skin, 0);
+        int focusedIndex = MenuBarSkinShim.getFocusedIndex(skin);
+        assertEquals(-1, focusedIndex);
     }
 
     @Test public void getMenusHasSizeZero() {
@@ -310,7 +326,7 @@ public class MenuBarTest {
 
         // check if focusedMenuIndex is reset to -1 so navigation happens.
         int focusedIndex = MenuBarSkinShim.getFocusedIndex(skin);
-        assertEquals(focusedIndex, -1);
+        assertEquals(-1, focusedIndex);
     }
 
     @Test public void testMenuOnShownEventFiringWithKeyNavigation() {
@@ -695,6 +711,6 @@ public class MenuBarTest {
 
         // check if focusedMenuIndex is 0 (menu1 is still in selected state).
         int focusedIndex = MenuBarSkinShim.getFocusedIndex(skin);
-        assertEquals(focusedIndex, 0);
+        assertEquals(0, focusedIndex);
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuBarTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuBarTest.java
@@ -114,8 +114,24 @@ public class MenuBarTest {
     }
 
     @Test public void defaultConstructorButSetTrueFocusTraversable() {
-            menuBar.setFocusTraversable(true);
+        menuBar.setFocusTraversable(true);
         assertTrue(menuBar.isFocusTraversable());
+    }
+
+    @Test public void testFocusOnEmptyMenubar() {
+        menuBar.setFocusTraversable(true);
+
+        AnchorPane root = new AnchorPane();
+        root.getChildren().add(menuBar);
+        startApp(root);
+
+        MenuBarSkin skin = (MenuBarSkin)menuBar.getSkin();
+        assertTrue(skin != null);
+
+        menuBar.getScene().getWindow().requestFocus();
+
+        int focusedIndex = MenuBarSkinShim.getFocusedIndex(skin);
+        assertEquals(focusedIndex, -1);
     }
 
     @Test public void getMenusHasSizeZero() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuBarTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuBarTest.java
@@ -130,7 +130,7 @@ public class MenuBarTest {
 
         menuBar.getScene().getWindow().requestFocus();
 
-        int focusedIndex = MenuBarSkinShim.getFocusedIndex(skin);
+        int focusedIndex = MenuBarSkinShim.getFocusedMenuIndex(skin);
         assertEquals(-1, focusedIndex);
     }
 
@@ -145,8 +145,8 @@ public class MenuBarTest {
         assertTrue(skin != null);
 
         // simulate notification from traversalListener
-        MenuBarSkinShim.setFocusedIndex(skin, 0);
-        int focusedIndex = MenuBarSkinShim.getFocusedIndex(skin);
+        MenuBarSkinShim.setFocusedMenuIndex(skin, 0);
+        int focusedIndex = MenuBarSkinShim.getFocusedMenuIndex(skin);
         assertEquals(-1, focusedIndex);
     }
 
@@ -325,7 +325,7 @@ public class MenuBarTest {
         tk.firePulse();
 
         // check if focusedMenuIndex is reset to -1 so navigation happens.
-        int focusedIndex = MenuBarSkinShim.getFocusedIndex(skin);
+        int focusedIndex = MenuBarSkinShim.getFocusedMenuIndex(skin);
         assertEquals(-1, focusedIndex);
     }
 
@@ -710,7 +710,7 @@ public class MenuBarTest {
         assertFalse(menu1.isShowing());
 
         // check if focusedMenuIndex is 0 (menu1 is still in selected state).
-        int focusedIndex = MenuBarSkinShim.getFocusedIndex(skin);
+        int focusedIndex = MenuBarSkinShim.getFocusedMenuIndex(skin);
         assertEquals(0, focusedIndex);
     }
 }


### PR DESCRIPTION
Issue : 
https://bugs.openjdk.java.net/browse/JDK-8244418

Root Cause : 
Incorrect assumption about menu list size.

Fix : 
Added check for empty menu list before trying to access it.

Test : 
Added a unit test that fails before fix and passes after it.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244418](https://bugs.openjdk.java.net/browse/JDK-8244418): MenuBar: IOOB exception on requestFocus on empty bar


### Reviewers
 * Jeanette Winzenburg ([fastegal](@kleopatra) - Author)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/216/head:pull/216`
`$ git checkout pull/216`
