### PR TITLE
8244735: Error on iOS passing keys with unicode values greater than 255

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosView.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosView.java
@@ -82,5 +82,10 @@ final class IosView extends View {
     @Override protected void _uploadPixels(long ptr, Pixels pixels) {
         throw new RuntimeException("IosView._uploadPixels() UNIMPLEMENTED.");
     }
+
+    private void notifyUnicode(int type, int keyCode, int unicode, int modifiers) {
+        notifyKey(type, keyCode, new char[] {(char) unicode}, modifiers);
+    }
+
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassApplication.m
@@ -664,12 +664,12 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_ios_IosApplication__1initIDs
 
     // view specific
     mat_jViewClass = (*env)->NewGlobalRef(env, (*env)->FindClass(env, "com/sun/glass/ui/ios/IosView"));
+    mat_jViewNotifyKey = (*env)->GetMethodID(env, mat_jViewClass, "notifyUnicode", "(IIII)V");
     jclass mat_jViewBaseClass = (*env)->FindClass(env, "com/sun/glass/ui/View");
     GLASS_CHECK_EXCEPTION(env);
 
     mat_jViewNotifyResize = (*env)->GetMethodID(env, mat_jViewBaseClass, "notifyResize", "(II)V");
     mat_jViewNotifyRepaint = (*env)->GetMethodID(env, mat_jViewBaseClass, "notifyRepaint", "(IIII)V");
-    mat_jViewNotifyKey = (*env)->GetMethodID(env, mat_jViewBaseClass, "notifyKey", "(II[CI)V");
     mat_jViewNotifyMouse = (*env)->GetMethodID(env, mat_jViewBaseClass, "notifyMouse", "(IIIIIIIZZ)V");
     mat_jViewNotifyInputMethod = (*env)->GetMethodID(env, mat_jViewBaseClass, "notifyInputMethod", "(Ljava/lang/String;[I[I[BIII)V");
     mat_jViewNotifyView = (*env)->GetMethodID(env, mat_jViewBaseClass, "notifyView", "(I)V");

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassViewDelegate.h
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassViewDelegate.h
@@ -74,7 +74,7 @@ typedef __attribute__((NSObject)) CFMutableDictionaryRef GlassMutableDictionaryR
 - (void)sendJavaMouseEvent:(CGPoint)viewPoint type:(int)type button:(int)button;
 
 // Java events callbacks
-- (void)sendJavaKeyEventWithType:(int)type keyCode:(int)code chars:(char)chr modifiers:(int)modif;
+- (void)sendJavaKeyEventWithType:(int)type keyCode:(int)code unicode:(int)unicode modifiers:(int)modif;
 
 - (void)sendJavaTouchEvent:(UIEvent *)theEvent;
 

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassViewDelegate.m
@@ -554,17 +554,11 @@ static jint getTouchStateFromPhase(int phase)
 }
 
 
-- (void)sendJavaKeyEventWithType:(int)type keyCode:(int)code chars:(char)chr modifiers:(int)modif;
+- (void)sendJavaKeyEventWithType:(int)type keyCode:(int)code unicode:(int)unicode modifiers:(int)modif
 {
     GET_MAIN_JENV;
 
-    jchar jc[1] = {(jchar) chr};
-    jcharArray jChars = (*env)->NewCharArray(env, 1);
-    (*env)->SetCharArrayRegion(env, jChars, 0, 1, jc);
-
-    (*env)->CallVoidMethod(env, self.jView, mat_jViewNotifyKey, type, code, jChars, modif);
-
-    (*env)->DeleteLocalRef(env, jChars);
+    (*env)->CallVoidMethod(env, self.jView, mat_jViewNotifyKey, type, code, unicode, modif);
 
     GLASS_CHECK_EXCEPTION(env);
 }
@@ -715,7 +709,7 @@ static BOOL isTouchEnded(int phase)
 -(BOOL)textFieldShouldReturn:(UITextField *)textField{
     [self sendJavaKeyEventWithType:com_sun_glass_events_KeyEvent_PRESS
                                           keyCode:com_sun_glass_events_KeyEvent_VK_ENTER
-                                            chars:(char)13
+                                          unicode:(char)13
                                         modifiers:0];
 
     [[GlassWindow getMasterWindow] resignFocusOwner];

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassViewGL.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassViewGL.m
@@ -125,17 +125,27 @@ static EAGLContext * ctx = nil;
 @implementation GlassViewGL : GLView
 
 -(void) doInsertText:(NSString*)myText {
-    int asciiCode = [myText characterAtIndex:0];
-    [self->delegate sendJavaKeyEventWithType:111 keyCode:asciiCode chars:(char)asciiCode modifiers:0];
-    [self->delegate sendJavaKeyEventWithType:113 keyCode:asciiCode chars:(char)asciiCode modifiers:0];
-    [self->delegate sendJavaKeyEventWithType:112 keyCode:asciiCode chars:(char)asciiCode modifiers:0];
+    int unicode = [myText characterAtIndex:0];
+    int code = com_sun_glass_events_KeyEvent_VK_UNDEFINED;
+    if (unicode == com_sun_glass_events_KeyEvent_VK_ENTER) {
+         code = unicode;
+    }
+    [self->delegate sendJavaKeyEventWithType:com_sun_glass_events_KeyEvent_PRESS
+        keyCode:code unicode:unicode modifiers:0];
+    [self->delegate sendJavaKeyEventWithType:com_sun_glass_events_KeyEvent_TYPED
+        keyCode:code unicode:unicode modifiers:0];
+    [self->delegate sendJavaKeyEventWithType:com_sun_glass_events_KeyEvent_RELEASE
+        keyCode:code unicode:unicode modifiers:0];
 }
 
 -(void) doDeleteBackward {
-    int asciiCode = 8;
-    [self->delegate sendJavaKeyEventWithType:111 keyCode:asciiCode chars:(char)asciiCode modifiers:0];
-    [self->delegate sendJavaKeyEventWithType:113 keyCode:asciiCode chars:(char)asciiCode modifiers:0];
-    [self->delegate sendJavaKeyEventWithType:112 keyCode:asciiCode chars:(char)asciiCode modifiers:0];
+    int unicode = com_sun_glass_events_KeyEvent_VK_BACKSPACE;
+    [self->delegate sendJavaKeyEventWithType:com_sun_glass_events_KeyEvent_PRESS
+        keyCode:unicode unicode:unicode modifiers:0];
+    [self->delegate sendJavaKeyEventWithType:com_sun_glass_events_KeyEvent_TYPED
+        keyCode:unicode unicode:unicode modifiers:0];
+    [self->delegate sendJavaKeyEventWithType:com_sun_glass_events_KeyEvent_RELEASE
+        keyCode:unicode unicode:unicode modifiers:0];
 }
 
 -(BOOL) touchesShouldBegin:(NSSet *)touches withEvent:(UIEvent *)event inContentView:(UIView *)view

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassWindow.m
@@ -327,6 +327,10 @@ JNIEXPORT void JNICALL Java_javafx_scene_control_skin_TextAreaSkinIos_hideSoftwa
     return self;
 }
 
+- (UIKeyboardType) keyboardType
+{
+    return UIKeyboardTypeASCIICapable;
+}
 
 #pragma mark ---
 


### PR DESCRIPTION
With this PR, we pass directly the 16-bit unsigned short for a character (unicode value) to the Java layer, avoiding the cast with the C++ 8-bit char, that fails for non-ascii characters like euro (€) or quote ("). 

We also avoid the mapping between iOS keys and JavaFX `KeyCode`, except for `ENTER` and `BACK_SPACE`, as the mapping for some keys was wrong, like for "%", with ascii value 0x25, that was mapped to KeyCode.LEFT. 

Finally, the iOS keyboard is set to `UIKeyboardTypeASCIICapable`, to prevent the display of the emoji keyboard, that can't be currently processed.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244735](https://bugs.openjdk.java.net/browse/JDK-8244735): Error on iOS passing keys with unicode values greater than 255


### Reviewers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/217/head:pull/217`
`$ git checkout pull/217`
