### PR TITLE
8245053: Keyboard doesn't show when TextInputControl has focus

### DIFF
--- a/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextAreaSkinAndroid.java
+++ b/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextAreaSkinAndroid.java
@@ -25,29 +25,60 @@
 
 package javafx.scene.control.skin;
 
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.WeakChangeListener;
+import javafx.event.EventHandler;
 import javafx.scene.control.TextArea;
 import javafx.scene.input.MouseEvent;
 
 public class TextAreaSkinAndroid extends TextAreaSkin {
 
+    /**************************************************************************
+     *
+     * Private fields
+     *
+     **************************************************************************/
+
+    private final EventHandler<MouseEvent> mouseEventListener = e -> {
+        if (getSkinnable().isEditable() && getSkinnable().isFocused()) {
+            showSoftwareKeyboard();
+        }
+    };
+
+    private final ChangeListener<Boolean> focusChangeListener = (observable, wasFocused, isFocused) -> {
+        if (getSkinnable().isEditable()) {
+            if (isFocused) {
+                showSoftwareKeyboard();
+            } else {
+                hideSoftwareKeyboard();
+            }
+        }
+    };
+    private final WeakChangeListener<Boolean> weakFocusChangeListener = new WeakChangeListener<>(focusChangeListener);
+
+    /**************************************************************************
+     *
+     * Constructors
+     *
+     **************************************************************************/
+
     public TextAreaSkinAndroid(final TextArea textArea) {
         super(textArea);
+        textArea.addEventHandler(MouseEvent.MOUSE_CLICKED, mouseEventListener);
+        textArea.focusedProperty().addListener(weakFocusChangeListener);
+    }
 
-        textArea.addEventHandler(MouseEvent.MOUSE_CLICKED, e -> {
-            if (textArea.isEditable() && textArea.isFocused()) {
-                showSoftwareKeyboard();
-            }
-        });
+    /***************************************************************************
+     *                                                                         *
+     * Public API                                                              *
+     *                                                                         *
+     **************************************************************************/
 
-        textArea.focusedProperty().addListener((observable, wasFocused, isFocused) -> {
-            if (textArea.isEditable()) {
-                if (isFocused) {
-                    showSoftwareKeyboard();
-                } else {
-                    hideSoftwareKeyboard();
-                }
-            }
-        });
+    /** {@inheritDoc} */
+    @Override public void dispose() {
+        getSkinnable().removeEventHandler(MouseEvent.MOUSE_CLICKED, mouseEventListener);
+        getSkinnable().focusedProperty().removeListener(weakFocusChangeListener);
+        super.dispose();
     }
 
     native void showSoftwareKeyboard();

--- a/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextAreaSkinAndroid.java
+++ b/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextAreaSkinAndroid.java
@@ -46,12 +46,8 @@ public class TextAreaSkinAndroid extends TextAreaSkin {
     };
 
     private final ChangeListener<Boolean> focusChangeListener = (observable, wasFocused, isFocused) -> {
-        if (getSkinnable().isEditable()) {
-            if (isFocused) {
-                showSoftwareKeyboard();
-            } else {
-                hideSoftwareKeyboard();
-            }
+        if (wasFocused && !isFocused) {
+            hideSoftwareKeyboard();
         }
     };
     private final WeakChangeListener<Boolean> weakFocusChangeListener = new WeakChangeListener<>(focusChangeListener);

--- a/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextAreaSkinAndroid.java
+++ b/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextAreaSkinAndroid.java
@@ -25,25 +25,26 @@
 
 package javafx.scene.control.skin;
 
-import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
 import javafx.scene.control.TextArea;
-import javafx.scene.control.skin.TextAreaSkin;
+import javafx.scene.input.MouseEvent;
 
 public class TextAreaSkinAndroid extends TextAreaSkin {
 
     public TextAreaSkinAndroid(final TextArea textArea) {
         super(textArea);
 
-        textArea.focusedProperty().addListener(new ChangeListener<Boolean>() {
-            public void changed(ObservableValue<? extends Boolean> observable,
-                    Boolean wasFocused, Boolean isFocused) {
-                if (textArea.isEditable()) {
-                    if (isFocused) {
-                        showSoftwareKeyboard();
-                    } else {
-                        hideSoftwareKeyboard();
-                    }
+        textArea.addEventHandler(MouseEvent.MOUSE_CLICKED, e -> {
+            if (textArea.isEditable() && textArea.isFocused()) {
+                showSoftwareKeyboard();
+            }
+        });
+
+        textArea.focusedProperty().addListener((observable, wasFocused, isFocused) -> {
+            if (textArea.isEditable()) {
+                if (isFocused) {
+                    showSoftwareKeyboard();
+                } else {
+                    hideSoftwareKeyboard();
                 }
             }
         });

--- a/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextAreaSkinAndroid.java
+++ b/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextAreaSkinAndroid.java
@@ -76,6 +76,7 @@ public class TextAreaSkinAndroid extends TextAreaSkin {
 
     /** {@inheritDoc} */
     @Override public void dispose() {
+        if (getSkinnable() == null) return;
         getSkinnable().removeEventHandler(MouseEvent.MOUSE_CLICKED, mouseEventListener);
         getSkinnable().focusedProperty().removeListener(weakFocusChangeListener);
         super.dispose();

--- a/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextFieldSkinAndroid.java
+++ b/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextFieldSkinAndroid.java
@@ -46,12 +46,8 @@ public class TextFieldSkinAndroid extends TextFieldSkin {
     };
 
     private final ChangeListener<Boolean> focusChangeListener = (observable, wasFocused, isFocused) -> {
-        if (getSkinnable().isEditable()) {
-            if (isFocused) {
-                showSoftwareKeyboard();
-            } else {
-                hideSoftwareKeyboard();
-            }
+        if (wasFocused && !isFocused) {
+            hideSoftwareKeyboard();
         }
     };
     private final WeakChangeListener<Boolean> weakFocusChangeListener = new WeakChangeListener<>(focusChangeListener);

--- a/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextFieldSkinAndroid.java
+++ b/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextFieldSkinAndroid.java
@@ -25,29 +25,61 @@
 
 package javafx.scene.control.skin;
 
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.WeakChangeListener;
+import javafx.event.EventHandler;
 import javafx.scene.control.TextField;
 import javafx.scene.input.MouseEvent;
 
 public class TextFieldSkinAndroid extends TextFieldSkin {
 
+    /**************************************************************************
+     *
+     * Private fields
+     *
+     **************************************************************************/
+
+    private final EventHandler<MouseEvent> mouseEventListener = e -> {
+        if (getSkinnable().isEditable() && getSkinnable().isFocused()) {
+            showSoftwareKeyboard();
+        }
+    };
+
+    private final ChangeListener<Boolean> focusChangeListener = (observable, wasFocused, isFocused) -> {
+        if (getSkinnable().isEditable()) {
+            if (isFocused) {
+                showSoftwareKeyboard();
+            } else {
+                hideSoftwareKeyboard();
+            }
+        }
+    };
+    private final WeakChangeListener<Boolean> weakFocusChangeListener = new WeakChangeListener<>(focusChangeListener);
+
+    /**************************************************************************
+     *
+     * Constructors
+     *
+     **************************************************************************/
+
     public TextFieldSkinAndroid(final TextField textField) {
         super(textField);
 
-        textField.addEventHandler(MouseEvent.MOUSE_CLICKED, e -> {
-            if (textField.isEditable() && textField.isFocused()) {
-                showSoftwareKeyboard();
-            }
-        });
+        textField.addEventHandler(MouseEvent.MOUSE_CLICKED, mouseEventListener);
+        textField.focusedProperty().addListener(weakFocusChangeListener);
+    }
 
-        textField.focusedProperty().addListener((observable, wasFocused, isFocused) -> {
-            if (textField.isEditable()) {
-                if (isFocused) {
-                    showSoftwareKeyboard();
-                } else {
-                    hideSoftwareKeyboard();
-                }
-            }
-        });
+    /***************************************************************************
+     *                                                                         *
+     * Public API                                                              *
+     *                                                                         *
+     **************************************************************************/
+
+    /** {@inheritDoc} */
+    @Override public void dispose() {
+        getSkinnable().addEventHandler(MouseEvent.MOUSE_CLICKED, mouseEventListener);
+        getSkinnable().focusedProperty().removeListener(weakFocusChangeListener);
+        super.dispose();
     }
 
     native void showSoftwareKeyboard();

--- a/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextFieldSkinAndroid.java
+++ b/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextFieldSkinAndroid.java
@@ -78,7 +78,7 @@ public class TextFieldSkinAndroid extends TextFieldSkin {
     /** {@inheritDoc} */
     @Override public void dispose() {
         if (getSkinnable() == null) return;
-        getSkinnable().addEventHandler(MouseEvent.MOUSE_CLICKED, mouseEventListener);
+        getSkinnable().removeEventHandler(MouseEvent.MOUSE_CLICKED, mouseEventListener);
         getSkinnable().focusedProperty().removeListener(weakFocusChangeListener);
         super.dispose();
     }

--- a/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextFieldSkinAndroid.java
+++ b/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextFieldSkinAndroid.java
@@ -77,6 +77,7 @@ public class TextFieldSkinAndroid extends TextFieldSkin {
 
     /** {@inheritDoc} */
     @Override public void dispose() {
+        if (getSkinnable() == null) return;
         getSkinnable().addEventHandler(MouseEvent.MOUSE_CLICKED, mouseEventListener);
         getSkinnable().focusedProperty().removeListener(weakFocusChangeListener);
         super.dispose();

--- a/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextFieldSkinAndroid.java
+++ b/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextFieldSkinAndroid.java
@@ -25,27 +25,26 @@
 
 package javafx.scene.control.skin;
 
-import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
 import javafx.scene.control.TextField;
-
-import com.sun.javafx.scene.control.behavior.TextFieldBehavior;
-import javafx.scene.control.skin.TextFieldSkin;
+import javafx.scene.input.MouseEvent;
 
 public class TextFieldSkinAndroid extends TextFieldSkin {
 
     public TextFieldSkinAndroid(final TextField textField) {
         super(textField);
 
-        textField.focusedProperty().addListener(new ChangeListener<Boolean>() {
-            public void changed(ObservableValue<? extends Boolean> observable,
-                    Boolean wasFocused, Boolean isFocused) {
-                if (textField.isEditable()) {
-                    if (isFocused) {
-                        showSoftwareKeyboard();
-                    } else {
-                        hideSoftwareKeyboard();
-                    }
+        textField.addEventHandler(MouseEvent.MOUSE_CLICKED, e -> {
+            if (textField.isEditable() && textField.isFocused()) {
+                showSoftwareKeyboard();
+            }
+        });
+
+        textField.focusedProperty().addListener((observable, wasFocused, isFocused) -> {
+            if (textField.isEditable()) {
+                if (isFocused) {
+                    showSoftwareKeyboard();
+                } else {
+                    hideSoftwareKeyboard();
                 }
             }
         });


### PR DESCRIPTION
In Android, TextInputControls (TextField and TextArea) are responsible for showing and hiding software keyboard. Currently, a focus listener is attached to these controls and is used to toggle the visibility of keyboard. This condition fails in cases where the control already has focus but the keyboard is not visible.

Ideally, the keyboard should be shown again when the user taps on the TextInputControl. 

This PR adds an event handler for `MouseEvent.MOUSE_CLICKED` event and shows the keyboard  if the TextInput control is both editable and focused.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8245053](https://bugs.openjdk.java.net/browse/JDK-8245053): Keyboard doesn't show when TextInputControl has focus 


### Reviewers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/219/head:pull/219`
`$ git checkout pull/219`
