### PR TITLE
8169501: GIF animation is too fast

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCImageDecoderImpl.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCImageDecoderImpl.java
@@ -294,7 +294,7 @@ final class WCImageDecoderImpl extends WCImageDecoder {
         int dur = (meta == null || meta.delayTime == null) ? 0 : meta.delayTime;
         // Many annoying ads try to animate too fast.
         // See RT-13535 or <http://webkit.org/b/36082>.
-        if (dur < 11) dur = 100;
+        if (dur < 51) dur = 100;
         return dur;
     }
 


### PR DESCRIPTION
issue is caused by the threshold value for frame duration used by javaFx before it gets normalized. JavaFx is using threshold value 10 while other browser (Safari, Firefox) is using 50 due to which, value between 10 and 50 don't get normalized and animation runs at faster speed. To fix the issue change frame duration normalization value to <= 50.
Safari : https://bugs.webkit.org/show_bug.cgi?id=14413
Firefox : https://bugzilla.mozilla.org/show_bug.cgi?id=386269

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8169501](https://bugs.openjdk.java.net/browse/JDK-8169501): GIF animation is too fast


### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/221/head:pull/221`
`$ git checkout pull/221`
