### PR TITLE
8245183: Two fxml unit tests log warnings about deprecated escape sequences

### DIFF
--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/FXMLLoader_ExpressionTest.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/FXMLLoader_ExpressionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -310,6 +310,8 @@ public class FXMLLoader_ExpressionTest {
 
     @Test
     public void testEscapeSequences() throws IOException {
+        System.err.println("Below warning about - deprecated escape sequence - is expected from this test.");
+
         FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource("expression_escapechars.fxml"));
         fxmlLoader.load();
 

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_27529Test.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/RT_27529Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,7 @@ public class RT_27529Test {
 
     @Test
     public void testListAndArrayWithEscapes() throws IOException {
+        System.err.println("Below warnings about - deprecated escape sequence - are expected from this test.");
         FXMLLoader fxmlLoader = new FXMLLoader(getClass().getResource("rt_27529_2.fxml"),
             ResourceBundle.getBundle("test/javafx/fxml/rt_27529"));
         fxmlLoader.load();


### PR DESCRIPTION
Issue : https://bugs.openjdk.java.net/browse/JDK-8245183
Fix : Added a message to the test saying these are expected warnings. Refer JBS comments for more details.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8245183](https://bugs.openjdk.java.net/browse/JDK-8245183): Two fxml unit tests log warnings about deprecated escape sequences


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/225/head:pull/225`
`$ git checkout pull/225`
