### PR TITLE
8245456: MacPasteboard throws ClassCastException on static builds

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassPasteboard.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassPasteboard.m
@@ -459,7 +459,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_sun_glass_ui_mac_MacPasteboard__1getUTFs
         NSArray *items = [pasteboard pasteboardItems];
         if ([items count] > 0)
         {
-            jclass jcls = (*env)->FindClass(env, "java/lang/Object");
+            jclass jcls = (*env)->FindClass(env, "[Ljava/lang/String;");
             GLASS_CHECK_EXCEPTION(env);
             utfs = (*env)->NewObjectArray(env, (jsize)[items count], jcls, NULL);
             GLASS_CHECK_EXCEPTION(env);


### PR DESCRIPTION
Trying to paste on a JavaFX app statically built on Mac OS throws:

```
Exception in thread "JavaFX Application Thread" java.lang.ClassCastException 
        at         at com.sun.glass.ui.mac.MacPasteboard._getUTFs(MacPasteboard.java) 
``` 

Checking the native method signature a `String[][]` type is expected. However the native method implementation uses:
```
jobjectArray utfs = (*env)->NewObjectArray(env, size, (*env)->FindClass(env, "java/lang/Object"), NULL);
for (items) {
     jobjectArray array = (*env)->NewObjectArray(env, size, (*env)->FindClass(env, "java/lang/String"), NULL);
}
```

This PR fixes the issue by applying the correct array type signature according to [JNI specs](https://docs.oracle.com/en/java/javase/11/docs/specs/jni/functions.html#findclass).

It has been tested on Mac OS, both with and without static build.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8245456](https://bugs.openjdk.java.net/browse/JDK-8245456): MacPasteboard throws ClassCastException on static builds


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/228/head:pull/228`
`$ git checkout pull/228`
