### PR TITLE
8244579: Windows "User Objects" leakage with WebView 

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/java/MainThreadJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/java/MainThreadJava.cpp
@@ -28,6 +28,7 @@
 #include <wtf/java/JavaEnv.h>
 #include <wtf/java/JavaRef.h>
 #include <wtf/MainThread.h>
+#include <wtf/RunLoop.h>
 
 namespace WTF {
 void scheduleDispatchFunctionsOnMainThread()
@@ -49,6 +50,9 @@ void scheduleDispatchFunctionsOnMainThread()
 
 void initializeMainThreadPlatform()
 {
+#if OS(WINDOWS)
+    RunLoop::registerRunLoopMessageWindowClass();
+#endif
 }
 
 bool isMainThreadIfInitialized()


### PR DESCRIPTION
Cause: The Window Class `RunLoopMessageWindow` is never registered (this happens because registerRunLoopMessageWindowClass() is moved to MainThreadWin.cpp while openjfx uses MainThreadJava.cpp) and this causes every SetTimer() call in [RunLoopWin.cpp](https://github.com/openjdk/jfx/blob/master/modules/javafx.web/src/main/native/Source/WTF/wtf/win/RunLoopWin.cpp) to create a new user object instead of reusing the same object over again.

Fix: Call registerRunLoopMessageWindowClass() from MainThreadJava.cpp

Test: To verify open any webpage using WebView on WIndows, with and without the fix and compare the number of user objects created using Windows Task Manager.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244579](https://bugs.openjdk.java.net/browse/JDK-8244579): Windows "User Objects" leakage with WebView


### Reviewers
 * Guru Hb ([ghb](@guruhb) - **Reviewer**)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/229/head:pull/229`
`$ git checkout pull/229`
