### PR TITLE
8245575: Show the ContextMenu of input controls with long press gesture on iOS

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassApplication.m
@@ -62,6 +62,7 @@ jmethodID mat_jViewNotifyResize = 0;
 jmethodID mat_jViewNotifyRepaint = 0;
 jmethodID mat_jViewNotifyKey = 0;
 jmethodID mat_jViewNotifyMouse = 0;
+jmethodID mat_jViewNotifyMenu = 0;
 jmethodID mat_jViewNotifyInputMethod = 0;
 jmethodID mat_jViewNotifyView = 0;
 
@@ -671,6 +672,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_ios_IosApplication__1initIDs
     mat_jViewNotifyResize = (*env)->GetMethodID(env, mat_jViewBaseClass, "notifyResize", "(II)V");
     mat_jViewNotifyRepaint = (*env)->GetMethodID(env, mat_jViewBaseClass, "notifyRepaint", "(IIII)V");
     mat_jViewNotifyMouse = (*env)->GetMethodID(env, mat_jViewBaseClass, "notifyMouse", "(IIIIIIIZZ)V");
+    mat_jViewNotifyMenu = (*env)->GetMethodID(env, mat_jViewBaseClass, "notifyMenu", "(IIIIZ)V");
     mat_jViewNotifyInputMethod = (*env)->GetMethodID(env, mat_jViewBaseClass, "notifyInputMethod", "(Ljava/lang/String;[I[I[BIII)V");
     mat_jViewNotifyView = (*env)->GetMethodID(env, mat_jViewBaseClass, "notifyView", "(I)V");
     GLASS_CHECK_EXCEPTION(env);

--- a/modules/javafx.graphics/src/main/native-glass/ios/common.h
+++ b/modules/javafx.graphics/src/main/native-glass/ios/common.h
@@ -53,6 +53,7 @@ extern jmethodID mat_jViewNotifyResize;
 extern jmethodID mat_jViewNotifyRepaint;
 extern jmethodID mat_jViewNotifyKey;
 extern jmethodID mat_jViewNotifyMouse;
+extern jmethodID mat_jViewNotifyMenu;
 extern jmethodID mat_jViewNotifyInputMethod;
 extern jmethodID mat_jViewNotifyView;
 


### PR DESCRIPTION
This PR uses iOS long press gesture to generate a menu event that will trigger a `ContextMenuEvent`. 

Based on this event, input controls will show the ContextMenu (once JDK-8245499 is fixed), and if required, a developer could add an event handler based on `ContextMenuEvent.CONTEXT_MENU_REQUESTED` for custom processing of such event.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8245575](https://bugs.openjdk.java.net/browse/JDK-8245575): Show the ContextMenu of input controls with long press gesture on iOS


### Reviewers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/232/head:pull/232`
`$ git checkout pull/232`
