### PR TITLE
8245635: GlassPasteboard::getUTFs fails on iOS

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassPasteboard.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassPasteboard.m
@@ -310,7 +310,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_sun_glass_ui_ios_IosPasteboard__1getUTFs
         NSArray *items = [pasteboard items];
         if ([items count] > 0)
         {
-            utfs = (*env)->NewObjectArray(env, [items count], (*env)->FindClass(env, "java/lang/Object"), NULL);
+            utfs = (*env)->NewObjectArray(env, [items count], (*env)->FindClass(env, "[Ljava/lang/String;"), NULL);
             for (int i=0; i<[items count]; i++)
             {
                 NSDictionary *item = [items objectAtIndex:i];

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassPasteboard.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassPasteboard.m
@@ -310,17 +310,21 @@ JNIEXPORT jobjectArray JNICALL Java_com_sun_glass_ui_ios_IosPasteboard__1getUTFs
         NSArray *items = [pasteboard items];
         if ([items count] > 0)
         {
-            utfs = (*env)->NewObjectArray(env, [items count], (*env)->FindClass(env, "[Ljava/lang/String;"), NULL);
+            utfs = (*env)->NewObjectArray(env, (jsize)[items count], (*env)->FindClass(env, "[Ljava/lang/String;"), NULL);
             for (int i=0; i<[items count]; i++)
             {
                 NSDictionary *item = [items objectAtIndex:i];
 
-                NSEnumerator *e = [item keyEnumerator];
-                NSString *type;
-                while ((type = [e nextObject])) {
-                    jobjectArray array = (*env)->NewObjectArray(env, 1, (*env)->FindClass(env, "java/lang/String"), NULL);
-                    (*env)->SetObjectArrayElement(env, array, 0, (*env)->NewStringUTF(env, [type UTF8String]));
-                    (*env)->SetObjectArrayElement(env, utfs, i, array);
+                NSArray *keys = [item allKeys];
+                if ([keys count] > 0)
+                {
+                    jobjectArray array = (*env)->NewObjectArray(env, (jsize)[keys count], (*env)->FindClass(env, "java/lang/String"), NULL);
+                    for (int j=0; j<[keys count]; j++)
+                    {
+                        NSString *type = [keys objectAtIndex:j];
+                        (*env)->SetObjectArrayElement(env, array, j, (*env)->NewStringUTF(env, [type UTF8String]));
+                    }
+                    (*env)->SetObjectArrayElement(env, utfs, (jsize)i, array);
                 }
             }
         }


### PR DESCRIPTION
As a follow-up of JDK-8245456, IosPasteboard throws a ClassCastException when trying to paste clipboard content on iOS devices. Same fix apply, using the correct signature.

When retrieving the UTF formats, the native method fails to create the correct String array, as the total number of keys is not taken into account. Using a for loop fixes the issue.

Relates to JDK-8245499 and JDK-8245575
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8245635](https://bugs.openjdk.java.net/browse/JDK-8245635): GlassPasteboard::getUTFs fails on iOS


### Reviewers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/233/head:pull/233`
`$ git checkout pull/233`
