### PR TITLE
8245644: Change JavaFX release version in jfx14 branch to 14.0.2

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -41,7 +41,7 @@ jfx.release.suffix=-ea
 # UPDATE THE FOLLOWING VALUES FOR A NEW RELEASE
 jfx.release.major.version=14
 jfx.release.minor.version=0
-jfx.release.security.version=1
+jfx.release.security.version=2
 jfx.release.patch.version=0
 
 # Note: The release version is now calculated in build.gradle as the


### PR DESCRIPTION
Increase security number for the 14.0.2 release
Fix for JDK-8245644
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8245644](https://bugs.openjdk.java.net/browse/JDK-8245644): Change JavaFX release version in jfx14 branch to 14.0.2


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/235/head:pull/235`
`$ git checkout pull/235`
