### PR TITLE
8234540: javafx.web LeakTest.testGarbageCollectability fails intermittently

### DIFF
--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/LeakTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/LeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/LeakTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/LeakTest.java
@@ -87,7 +87,6 @@ public class LeakTest extends TestBase {
             willGC[0] = new WeakReference<WebView>(webView);
             willGC[1] = new WeakReference<WebEngine>(webView.getEngine());
             willGC[2] = new WeakReference<WebPage>(WebEngineShim.getPage(webView.getEngine()));
-            webView = null;
         });
 
         Thread.sleep(SLEEP_TIME);

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/LeakTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/LeakTest.java
@@ -32,9 +32,7 @@ import com.sun.webkit.WebPage;
 import java.io.File;
 import java.lang.ref.Reference;
 import java.lang.ref.WeakReference;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.LinkedBlockingQueue;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
 import javafx.concurrent.Worker.State;
@@ -50,7 +48,6 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
 
 public class LeakTest extends TestBase {
 
@@ -82,37 +79,33 @@ public class LeakTest extends TestBase {
     }
 
     @Test public void testGarbageCollectability() throws InterruptedException {
-        assumeTrue(Boolean.getBoolean("unstable.test")); // JDK-8234540
+        final int count = 3;
+        Reference<?>[] willGC = new Reference[count];
 
-        final BlockingQueue<WeakReference<WebPage>> webPageRefQueue =
-                new LinkedBlockingQueue<WeakReference<WebPage>>();
         submit(() -> {
             WebView webView = new WebView();
-            WeakReference<WebView> webViewRef =
-                    new WeakReference<WebView>(webView);
-            WeakReference<WebEngine> webEngineRef =
-                    new WeakReference<WebEngine>(webView.getEngine());
-            webPageRefQueue.add(
-                    new WeakReference<WebPage>(
-                            WebEngineShim.getPage(webView.getEngine())));
+            willGC[0] = new WeakReference<WebView>(webView);
+            willGC[1] = new WeakReference<WebEngine>(webView.getEngine());
+            willGC[2] = new WeakReference<WebPage>(WebEngineShim.getPage(webView.getEngine()));
             webView = null;
-            System.gc();
-            assertNull("WebView has not been GCed", webViewRef.get());
-            assertNull("WebEngine has not been GCed", webEngineRef.get());
         });
 
-        WeakReference<WebPage> webPageRef = webPageRefQueue.take();
-        long endTime = System.currentTimeMillis() + 5000;
-        while (true) {
+        Thread.sleep(SLEEP_TIME);
+
+        for (int i = 0; i < 5; i++) {
             System.gc();
-            if (webPageRef.get() == null) {
+            System.runFinalization();
+
+            if (isAllElementsNull(willGC)) {
                 break;
             }
-            if (System.currentTimeMillis() > endTime) {
-                fail("WebPage has not been GCed");
-            }
-            Thread.sleep(100);
+
+            Thread.sleep(SLEEP_TIME);
         }
+
+        assertNull("WebView has not been GCed", willGC[0].get());
+        assertNull("WebEngine has not been GCed", willGC[1].get());
+        assertNull("WebPage has not been GCed", willGC[2].get());
     }
 
     private static boolean isAllElementsNull(Reference<?>[] array) {


### PR DESCRIPTION
Cause: The test assumes that WebView/WebPage will be GCed right after `System.gc()`

Fix: Use `runFinalization()` and `sleep()` to wait for objects to get GCed
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8234540](https://bugs.openjdk.java.net/browse/JDK-8234540): javafx.web LeakTest.testGarbageCollectability fails intermittently


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/236/head:pull/236`
`$ git checkout pull/236`
