### PR TITLE
8234876: Unit test classes should not extend Application

### DIFF
--- a/tests/system/src/test/java/test/com/sun/javafx/image/impl/ImageRaceTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/image/impl/ImageRaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,13 +38,10 @@ import com.sun.javafx.image.impl.IntArgb;
 import com.sun.javafx.image.impl.IntArgbPre;
 import java.util.ArrayList;
 import java.util.List;
-import javafx.application.Application;
-import javafx.application.Platform;
-import javafx.stage.Stage;
 import org.junit.Test;
 import static test.util.Util.TIMEOUT;
 
-public class ImageRaceTest extends Application {
+public class ImageRaceTest {
     static boolean verbose;
     static List<Initializer> initalizers = new ArrayList<>();
     static volatile boolean ready = false;
@@ -72,13 +69,6 @@ public class ImageRaceTest extends Application {
             init.get();
             if (verbose) System.err.println(getName()+" done");
         }
-    }
-
-    @Override
-    public void start(Stage stage) {
-        forkAndJoinInitializers();
-
-        Platform.exit();
     }
 
     void forkAndJoinInitializers() {
@@ -111,11 +101,6 @@ public class ImageRaceTest extends Application {
                 }
             }
         } catch (InterruptedException ex) {}
-    }
-
-    public static void main(String[] args) {
-        init(args);
-        Application.launch(args);
     }
 
     static void init(String[] args) {

--- a/tests/system/src/test/java/test/javafx/scene/control/AccordionTitlePaneLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/AccordionTitlePaneLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ import javafx.scene.control.Accordion;
 import javafx.scene.control.TitledPane;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
-import javafx.stage.WindowEvent;
 
 import test.util.Util;
 
@@ -45,37 +44,40 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-public class AccordionTitlePaneLeakTest extends Application {
+public class AccordionTitlePaneLeakTest {
 
     static private CountDownLatch startupLatch;
     static private Accordion accordion;
     static private StackPane root;
     static private Stage stage;
 
-    @Override
-    public void start(Stage primaryStage) throws Exception {
-        stage = primaryStage;
-        accordion = new Accordion();
-        root = new StackPane(accordion);
-        stage.setScene(new Scene(root));
-        stage.addEventHandler(WindowEvent.WINDOW_SHOWN, e -> {
-            Platform.runLater(() -> startupLatch.countDown());
-        });
-        stage.show();
+    public static class TestApp extends Application {
+        @Override
+        public void start(Stage primaryStage) throws Exception {
+            stage = primaryStage;
+            accordion = new Accordion();
+            root = new StackPane(accordion);
+            stage.setScene(new Scene(root));
+            stage.setOnShown(l -> {
+                Platform.runLater(() -> startupLatch.countDown());
+            });
+            stage.show();
+        }
     }
 
     @BeforeClass
-    public static void initFX() {
+    public static void initFX() throws Exception {
         startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(AccordionTitlePaneLeakTest.class, (String[]) null)).start();
+        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
+        Assert.assertTrue("Timeout waiting for FX runtime to start", startupLatch.await(15, TimeUnit.SECONDS));
+    }
 
-        try {
-            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
-                Assert.fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            Assert.fail("Unexpected exception: " + ex);
-        }
+    @AfterClass
+    public static void teardownOnce() {
+        Platform.runLater(() -> {
+            stage.hide();
+            Platform.exit();
+        });
     }
 
     @Test
@@ -95,13 +97,5 @@ public class AccordionTitlePaneLeakTest extends Application {
         }
         // Ensure accordion's skin no longer hold a ref to titled pane.
         Assert.assertNull("Couldn't collect TitledPane", weakRefToPane.get());
-    }
-
-    @AfterClass
-    public static void teardownOnce() {
-        Platform.runLater(() -> {
-            stage.hide();
-            Platform.exit();
-        });
     }
 }


### PR DESCRIPTION
Copied from JBS:
As a best practice, unit test classes that are run by Junit should not extend javafx.application.Application. 
JUnit constructs an instance of a test class for each test method that it runs. This will be different from the instance of the object that is constructed when Application.launch method is called, and this can lead to unexpected behavior.
Most of our tests use helper classes or nested (static) sub classes of Application, but the following two test classes do not:

tests/system/src/test/java/test/com/sun/javafx/image/impl/ImageRaceTest.java
tests/system/src/test/java/test/javafx/scene/control/AccordionTitlePaneLeakTest.java 

----
Changes in the tests are:
ImageRaceTest.java->  Does not require a sub class of Application.
AccordionTitlePaneLeakTest.java->  Required minor changes to create a static sub class.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8234876](https://bugs.openjdk.java.net/browse/JDK-8234876): Unit test classes should not extend Application


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/237/head:pull/237`
`$ git checkout pull/237`
