### PR TITLE
8245634: [TestBug] Enable and fix tests ignored with message "impl_cssSet API removed"

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -224,10 +224,17 @@ public class CellTest {
         assertTrue(cell.isEditable());
     }
 
-    @Ignore("impl_cssSet API removed")
     @Test public void cannotSpecifyEditableViaCSS() {
-//        cell.impl_cssSet("-fx-editable", false);
+        cell.setStyle("-fx-editable: false;");
+        cell.applyCss();
         assertTrue(cell.isEditable());
+
+        cell.setEditable(false);
+        assertFalse(cell.isEditable());
+
+        cell.setStyle("-fx-editable: true;");
+        cell.applyCss();
+        assertFalse(cell.isEditable());
     }
 
     /*********************************************************************

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/CheckBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/CheckBoxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,6 @@ import org.junit.Test;
 
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.*;
 import static org.junit.Assert.*;
-import org.junit.Ignore;
 
 /**
  */
@@ -185,10 +184,17 @@ public class CheckBoxTest {
         assertPseudoClassDoesNotExist(btn, "indeterminate");
     }
 
-    @Ignore("impl_cssSet API removed")
     @Test public void cannotSpecifyIndeterminateViaCSS() {
-//        btn.impl_cssSet("-fx-indeterminate", true);
+        btn.setStyle("-fx-indeterminate: true;");
+        btn.applyCss();
         assertFalse(btn.isIndeterminate());
+
+        btn.setIndeterminate(true);
+        assertTrue(btn.isIndeterminate());
+
+        btn.setStyle("-fx-indeterminate: false;");
+        btn.applyCss();
+        assertTrue(btn.isIndeterminate());
     }
 
     /*********************************************************************
@@ -254,10 +260,17 @@ public class CheckBoxTest {
         assertPseudoClassDoesNotExist(btn, "selected");
     }
 
-    @Ignore("impl_cssSet API removed")
     @Test public void cannotSpecifySelectedViaCSS() {
-//        btn.impl_cssSet("-fx-selected", true);
+        btn.setStyle("-fx-selected: true;");
+        btn.applyCss();
         assertFalse(btn.isSelected());
+
+        btn.setSelected(true);
+        assertTrue(btn.isSelected());
+
+        btn.setStyle("-fx-selected: false;");
+        btn.applyCss();
+        assertTrue(btn.isSelected());
     }
 
     /*********************************************************************
@@ -299,10 +312,17 @@ public class CheckBoxTest {
         assertEquals("allowIndeterminate", btn.allowIndeterminateProperty().getName());
     }
 
-    @Ignore("impl_cssSet API removed")
     @Test public void cannotSpecifyAllowIndeterminateViaCSS() {
-//        btn.impl_cssSet("-fx-allow-indeterminate", true);
+        btn.setStyle("-fx-allow-indeterminate: true;");
+        btn.applyCss();
         assertFalse(btn.isAllowIndeterminate());
+
+        btn.setAllowIndeterminate(true);
+        assertTrue(btn.isAllowIndeterminate());
+
+        btn.setStyle("-fx-allow-indeterminate: false;");
+        btn.applyCss();
+        assertTrue(btn.isAllowIndeterminate());
     }
 
     /*********************************************************************

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -421,10 +421,17 @@ public class ChoiceBoxTest {
         assertFalse(box.isShowing());
     }
 
-    @Ignore("impl_cssSet API removed")
     @Test public void cannotSpecifyShowingViaCSS() {
-//        box.impl_cssSet("-fx-showing", true);
+        box.setStyle("-fx-showing: true;");
+        box.applyCss();
         assertFalse(box.isShowing());
+
+        box.show();
+        assertTrue(box.isShowing());
+
+        box.setStyle("-fx-showing: false;");
+        box.applyCss();
+        assertTrue(box.isShowing());
     }
 
     @Test public void settingShowingSetsPseudoClass() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/DateCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/DateCellTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -181,10 +181,17 @@ public class DateCellTest {
         assertTrue(cell.isEditable());
     }
 
-    @Ignore("impl_cssSet API removed")
     @Test public void cannotSpecifyEditableViaCSS() {
-//        cell.impl_cssSet("-fx-editable", false);
+        cell.setStyle("-fx-editable: false;");
+        cell.applyCss();
         assertTrue(cell.isEditable());
+
+        cell.setEditable(false);
+        assertFalse(cell.isEditable());
+
+        cell.setStyle("-fx-editable: true;");
+        cell.applyCss();
+        assertFalse(cell.isEditable());
     }
 
     /*********************************************************************


### PR DESCRIPTION
This is a simple test fix.

Issue : https://bugs.openjdk.java.net/browse/JDK-8245634

After fixing [JDK-8245457,](https://bugs.openjdk.java.net/browse/JDK-8245457) I found that there are more ignored tests of similar nature that can be enabled and fixed.
A search for ignored tests with message "impl_cssSet API removed" - revealed a total 6 occurrences in 4 files -
1) CellTest
2) CheckBoxTest
3) ChoiceBoxTest
4) DateCellTest 

This PR enables and fixes these tests.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8245634](https://bugs.openjdk.java.net/browse/JDK-8245634): [TestBug] Enable and fix tests ignored with message "impl_cssSet API removed"


### Reviewers
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/239/head:pull/239`
`$ git checkout pull/239`
