### PR TITLE
8243110: SVGTest.testSVGRenderingWithPattern fails intermittently

### DIFF
--- a/tests/system/src/test/java/test/javafx/scene/web/SVGTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/SVGTest.java
@@ -37,10 +37,10 @@ import javafx.stage.Stage;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import test.util.Util;
 
+import static javafx.concurrent.Worker.State.SUCCEEDED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -96,7 +96,6 @@ public class SVGTest {
      * @bug 8223298
      * summary Checks if svg pattern is displayed properly
      */
-    @Ignore("JDK-8243110")
     @Test public void testSVGRenderingWithPattern() {
         final CountDownLatch webViewStateLatch = new CountDownLatch(1);
         final String htmlSVGContent = "\n"
@@ -114,9 +113,22 @@ public class SVGTest {
             + "</html>";
 
         Util.runAndWait(() -> {
+            webView.getEngine().getLoadWorker().stateProperty().
+                addListener((observable, oldValue, newValue) -> {
+                if (newValue == SUCCEEDED) {
+                    webView.requestFocus();
+                }
+            });
+
             assertNotNull(webView);
             webView.getEngine().loadContent(htmlSVGContent);
-            webViewStateLatch.countDown();
+
+            webView.focusedProperty().
+                addListener((observable, oldValue, newValue) -> {
+                if (newValue) {
+                    webViewStateLatch.countDown();
+                }
+            });
         });
 
         assertTrue("Timeout when waiting for focus change ", Util.await(webViewStateLatch));

--- a/tests/system/src/test/java/test/javafx/scene/web/SVGTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/SVGTest.java
@@ -113,6 +113,7 @@ public class SVGTest {
             + "</html>";
 
         Util.runAndWait(() -> {
+            assertNotNull(webView);
             webView.getEngine().getLoadWorker().stateProperty().
                 addListener((observable, oldValue, newValue) -> {
                 if (newValue == SUCCEEDED) {
@@ -120,15 +121,14 @@ public class SVGTest {
                 }
             });
 
-            assertNotNull(webView);
-            webView.getEngine().loadContent(htmlSVGContent);
-
             webView.focusedProperty().
                 addListener((observable, oldValue, newValue) -> {
                 if (newValue) {
                     webViewStateLatch.countDown();
                 }
             });
+
+            webView.getEngine().loadContent(htmlSVGContent);
         });
 
         assertTrue("Timeout when waiting for focus change ", Util.await(webViewStateLatch));

--- a/tests/system/src/test/java/test/javafx/scene/web/SVGTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/SVGTest.java
@@ -132,6 +132,7 @@ public class SVGTest {
         });
 
         assertTrue("Timeout when waiting for focus change ", Util.await(webViewStateLatch));
+        Util.sleep(1000);
 
         Util.runAndWait(() -> {
             WritableImage snapshot = svgTestApp.primaryStage.getScene().snapshot(null);


### PR DESCRIPTION
Issue: Snapshot taken before webpage is rendered

Fix: Use stateProperty and sleep to wait for the page to finish rendering
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8243110](https://bugs.openjdk.java.net/browse/JDK-8243110): SVGTest.testSVGRenderingWithPattern fails intermittently


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/240/head:pull/240`
`$ git checkout pull/240`
