### PR TITLE
8246099: Intermittent test failures in SandboxAppTest

### DIFF
--- a/tests/system/src/test/java/test/sandbox/Constants.java
+++ b/tests/system/src/test/java/test/sandbox/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ package test.sandbox;
 public class Constants {
 
     // Test timeout in milliseconds
-    public static final int TIMEOUT = 10000;
+    public static final int TIMEOUT = 30000;
 
     // Time in milliseconds to show the stage
     public static final int SHOWTIME = 2500;

--- a/tests/system/src/test/java/test/sandbox/SandboxAppTest.java
+++ b/tests/system/src/test/java/test/sandbox/SandboxAppTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,24 +100,24 @@ public class SandboxAppTest {
 
     // TEST CASES
 
-    @Test (timeout = 15000)
+    @Test (timeout = 25000)
     public void testFXApp() throws Exception {
         runSandboxedApp("FXApp");
     }
 
-    @Test (timeout = 15000)
+    @Test (timeout = 25000)
     public void testFXNonApp() throws Exception {
         runSandboxedApp("FXNonApp");
     }
 
     @Ignore("JDK-8202451")
-    @Test (timeout = 15000)
+    @Test (timeout = 25000)
     public void testJFXPanelApp() throws Exception {
         runSandboxedApp("JFXPanelApp");
     }
 
     @Ignore("JDK-8202451")
-    @Test (timeout = 15000)
+    @Test (timeout = 25000)
     public void testJFXPanelImplicitExitApp() throws Exception {
         runSandboxedApp("JFXPanelImplicitExitApp", 0);
     }


### PR DESCRIPTION
This is a fix for an intermittent test failure, due to a timeout, in `SandboxAppTest` that we are starting to see on some of our test machines.

The failure is happening because of a 10 second timeout in the launched application. This doesn't seem to be enough to run the test to completion in all cases. I note that the similar launched apps, such as those launched by `MainLauncherTest`, `ModuleLauncherTest`, and `JarLauncherTest` don't have a timeout (they just rely on the timeout value of the launching test itself).

The app timeout was just added to prevent the test suite from hanging if the application were to get stuck, so there is no need for it to be such a small value (nor to have it be less than the test timeout).

The proposed solution is to increase the app timeout to 30 seconds (up from 10) and the test timeout to 25 (up from 15).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8246099](https://bugs.openjdk.java.net/browse/JDK-8246099): Intermittent test failures in SandboxAppTest


### Reviewers
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/241/head:pull/241`
`$ git checkout pull/241`
