### PR TITLE
8246204: No 3D support for newer Intel graphics drivers on Linux

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/X11GLFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/X11GLFactory.java
@@ -42,7 +42,6 @@ class X11GLFactory extends GLFactory {
     private GLGPUInfo preQualificationFilter[] = {
         new GLGPUInfo("advanced micro devices", null),
         new GLGPUInfo("ati", null),
-        new GLGPUInfo("intel open source technology center", null),
         new GLGPUInfo("intel", null),
         new GLGPUInfo("nvidia", null),
         new GLGPUInfo("nouveau", null),

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/X11GLFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/X11GLFactory.java
@@ -43,6 +43,7 @@ class X11GLFactory extends GLFactory {
         new GLGPUInfo("advanced micro devices", null),
         new GLGPUInfo("ati", null),
         new GLGPUInfo("intel open source technology center", null),
+        new GLGPUInfo("intel", null),
         new GLGPUInfo("nvidia", null),
         new GLGPUInfo("nouveau", null),
         new GLGPUInfo("x.org", null)


### PR DESCRIPTION
It seems to be sufficient to add "intel" as an additional vendor to the list in the X11GLFactory class. Tests pass and my own application also works with the new build.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8246204](https://bugs.openjdk.java.net/browse/JDK-8246204): No 3D support for newer Intel graphics drivers on Linux


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/243/head:pull/243`
`$ git checkout pull/243`
