### PR TITLE
8193800: TreeTableView selection changes on sorting

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTablePosition.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTablePosition.java
@@ -77,10 +77,9 @@ public class TreeTablePosition<S,T> extends TablePositionBase<TreeTableColumn<S,
         nonFixedColumnIndex = treeTableView == null || tableColumn == null ? -1 : treeTableView.getVisibleLeafIndex(tableColumn);
     }
 
-    // A call to 'treeTableView.getTreeItem(row)' may result in TreeModificationEvent being triggered.
-    // This causes issue by triggering a new TreeModificationEvent while one TreeModificationEvent
-    // is being handled currently.
-    // This is kind of a copy constructor with different value for row.
+    // Copy-like constructor with a different row.
+    // It is used for updating the selection when the TreeItems are
+    // sorted using TreeTableView.sort() or reordered using setAll().
     TreeTablePosition(@NamedArg("treeTableView") TreeTablePosition<S, T> pos, @NamedArg("row") int row) {
         super(row, pos.getTableColumn());
         this.controlRef = new WeakReference<>(pos.getTreeTableView());

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTablePosition.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTablePosition.java
@@ -77,6 +77,17 @@ public class TreeTablePosition<S,T> extends TablePositionBase<TreeTableColumn<S,
         nonFixedColumnIndex = treeTableView == null || tableColumn == null ? -1 : treeTableView.getVisibleLeafIndex(tableColumn);
     }
 
+    // A call to 'treeTableView.getTreeItem(row)' may result in TreeModificationEvent being triggered.
+    // This causes issue by triggering a new TreeModificationEvent while one TreeModificationEvent
+    // is being handled currently.
+    // This is kind of a copy constructor with different value for row.
+    TreeTablePosition(@NamedArg("treeTableView") TreeTablePosition<S, T> pos, @NamedArg("row") int row) {
+        super(row, pos.getTableColumn());
+        this.controlRef = new WeakReference<>(pos.getTreeTableView());
+        this.treeItemRef = new WeakReference<>(pos.getTreeItem());
+        nonFixedColumnIndex = pos.getColumn();
+    }
+
 
 
     /***************************************************************************

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTablePosition.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTablePosition.java
@@ -77,7 +77,7 @@ public class TreeTablePosition<S,T> extends TablePositionBase<TreeTableColumn<S,
         nonFixedColumnIndex = treeTableView == null || tableColumn == null ? -1 : treeTableView.getVisibleLeafIndex(tableColumn);
     }
 
-    // Copy-like constructor with a different row.
+    // Not public API. A Copy-like constructor with a different row.
     // It is used for updating the selection when the TreeItems are
     // sorted using TreeTableView.sort() or reordered using setAll().
     TreeTablePosition(@NamedArg("treeTableView") TreeTablePosition<S, T> pos, @NamedArg("row") int row) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -1804,6 +1804,11 @@ public class TreeTableView<S> extends Control {
         return visibleLeafColumns.get(column);
     }
 
+    boolean sortingInProgress;
+    protected boolean isSortingInProgress() {
+        return sortingInProgress;
+    }
+
     /**
      * The sort method forces the TreeTableView to re-run its sorting algorithm. More
      * often than not it is not necessary to call this method directly, as it is
@@ -1814,6 +1819,7 @@ public class TreeTableView<S> extends Control {
      * something external changes and a sort is required.
      */
     public void sort() {
+        sortingInProgress = true;
         final ObservableList<TreeTableColumn<S,?>> sortOrder = getSortOrder();
 
         // update the Comparator property
@@ -1832,6 +1838,7 @@ public class TreeTableView<S> extends Control {
             // sortLock = true;
             // TableUtil.handleSortFailure(sortOrder, lastSortEventType, lastSortEventSupportInfo);
             // sortLock = false;
+            sortingInProgress = false;
             return;
         }
 
@@ -1872,7 +1879,6 @@ public class TreeTableView<S> extends Control {
                         removed.add(prevItem);
                     }
                 }
-
                 if (!removed.isEmpty()) {
                     // the sort operation effectively permutates the selectedCells list,
                     // but we cannot fire a permutation event as we are talking about
@@ -1883,7 +1889,10 @@ public class TreeTableView<S> extends Control {
                     sm.fireCustomSelectedCellsListChangeEvent(c);
                 }
             }
+            getSelectionModel().setSelectedIndex(getRow(getSelectionModel().getSelectedItem()));
+            getFocusModel().focus(getSelectionModel().getSelectedIndex());
         }
+        sortingInProgress = false;
     }
 
     /**
@@ -2540,68 +2549,41 @@ public class TreeTableView<S> extends Control {
                         shift += -count + 1;
                         startRow++;
                     } else if (e.wasPermutated()) {
-                        // General approach:
-                        //   -- detected a sort has happened
-                        //   -- Create a permutation lookup map (1)
-                        //   -- dump all the selected indices into a list (2)
-                        //   -- create a list containing the new indices (3)
-                        //   -- for each previously-selected index (4)
-                        //     -- if index is in the permutation lookup map
-                        //       -- add the new index to the new indices list
-                        //   -- Perform batch selection (5)
+                        // Approach:
+                        // Get the current selection.
+                        // Create a new selection with updated index(row).
+                        // Update the current selection with new selection.
+                        // If sorting is in progress then Selection change events will be sent from
+                        // sort() method, and should not be sent from here.
+                        // else, in case otherwise, the selection change events would be generated.
+                        // Do not call shiftSelection() in case of permutation change(when shift == 0).
 
-                        startAtomic();
+                        List<TreeTablePosition<S, ?>> currentSelection = new ArrayList<>(selectedCellsMap.getSelectedCells());
+                        List<TreeTablePosition<S, ?>> updatedSelection = new ArrayList<>();
 
-                        final int offset = startRow + 1;
-
-                        // (1)
-                        int length = e.getTo() - e.getFrom();
-                        HashMap<Integer, Integer> pMap = new HashMap<> (length);
-                        for (int i = e.getFrom(); i < e.getTo(); i++) {
-                            pMap.put(i, e.getChange().getPermutation(i));
-                        }
-
-                        // (2)
-                        List<TreeTablePosition<S,?>> selectedIndices = new ArrayList<>(getSelectedCells());
-
-                        // (3)
-                        List<TreeTablePosition<S,?>> newIndices = new ArrayList<>(selectedIndices.size());
-
-                        // (4)
                         boolean selectionIndicesChanged = false;
-                        for (int i = 0; i < selectedIndices.size(); i++) {
-                            final TreeTablePosition<S,?> oldIndex = selectedIndices.get(i);
-                            final int oldRow = oldIndex.getRow() - offset;
-
-                            if (pMap.containsKey(oldRow)) {
-                                int newIndex = pMap.get(oldRow) + offset;
-
-                                selectionIndicesChanged = selectionIndicesChanged || newIndex != oldRow;
-
-                                newIndices.add(new TreeTablePosition<>(oldIndex.getTreeTableView(), newIndex, oldIndex.getTableColumn()));
+                        for (TreeTablePosition<S, ?> selectedCell : currentSelection) {
+                            int newRow = treeTableView.getRow(selectedCell.getTreeItem());
+                            if (selectedCell.getRow() != newRow) {
+                                selectionIndicesChanged = true;
                             }
-
-                            // check if the root element of this event was selected, so that we can retain it
-                            if (oldIndex.getRow() == startRow) {
-                                newIndices.add(new TreeTablePosition<>(oldIndex.getTreeTableView(), oldIndex.getRow(), oldIndex.getTableColumn()));
-                            }
+                            updatedSelection.add(new TreeTablePosition<>(selectedCell, newRow));
                         }
-
                         if (selectionIndicesChanged) {
-                            // (5)
-                            quietClearSelection();
-                            stopAtomic();
-
-                            selectedCellsMap.setAll(newIndices);
-
-                            final int offsetOldIndex = oldSelectedIndex - offset;
-                            if (offsetOldIndex >= 0 && offsetOldIndex < getItemCount()) {
-                                int newIndex = e.getChange().getPermutation(offsetOldIndex);
-                                setSelectedIndex(newIndex + offset);
-                                focus(newIndex + offset);
+                            if (treeTableView.isSortingInProgress()) {
+                                startAtomic();
+                                quietClearSelection();
+                                selectedCellsMap.setAll(updatedSelection);
+                                stopAtomic();
+                            } else {
+                                startAtomic();
+                                quietClearSelection();
+                                stopAtomic();
+                                selectedCellsMap.setAll(updatedSelection);
+                                int selectedIndex = treeTableView.getRow(getSelectedItem());
+                                setSelectedIndex(selectedIndex);
+                                focus(selectedIndex);
                             }
-                        } else {
-                            stopAtomic();
                         }
                     } else if (e.wasAdded()) {
                         // shuffle selection by the number of added items
@@ -2663,42 +2645,44 @@ public class TreeTableView<S> extends Control {
                     }
                 } while (e.getChange() != null && e.getChange().next());
 
-                shiftSelection(startRow, shift, new Callback<ShiftParams, Void>() {
-                    @Override public Void call(ShiftParams param) {
+                if (shift != 0) {
+                    shiftSelection(startRow, shift, new Callback<ShiftParams, Void>() {
+                        @Override public Void call(ShiftParams param) {
 
-                        // we make the shifts atomic, as otherwise listeners to
-                        // the items / indices lists get a lot of intermediate
-                        // noise. They eventually get the summary event fired
-                        // from within shiftSelection, so this is ok.
-                        startAtomic();
+                            // we make the shifts atomic, as otherwise listeners to
+                            // the items / indices lists get a lot of intermediate
+                            // noise. They eventually get the summary event fired
+                            // from within shiftSelection, so this is ok.
+                            startAtomic();
 
-                        final int clearIndex = param.getClearIndex();
-                        final int setIndex = param.getSetIndex();
-                        TreeTablePosition<S,?> oldTP = null;
-                        if (clearIndex > -1) {
-                            for (int i = 0; i < selectedCellsMap.size(); i++) {
-                                TreeTablePosition<S,?> tp = selectedCellsMap.get(i);
-                                if (tp.getRow() == clearIndex) {
-                                    oldTP = tp;
-                                    selectedCellsMap.remove(tp);
-                                } else if (tp.getRow() == setIndex && !param.isSelected()) {
-                                    selectedCellsMap.remove(tp);
+                            final int clearIndex = param.getClearIndex();
+                            final int setIndex = param.getSetIndex();
+                            TreeTablePosition<S,?> oldTP = null;
+                            if (clearIndex > -1) {
+                                for (int i = 0; i < selectedCellsMap.size(); i++) {
+                                    TreeTablePosition<S,?> tp = selectedCellsMap.get(i);
+                                    if (tp.getRow() == clearIndex) {
+                                        oldTP = tp;
+                                        selectedCellsMap.remove(tp);
+                                    } else if (tp.getRow() == setIndex && !param.isSelected()) {
+                                        selectedCellsMap.remove(tp);
+                                    }
                                 }
                             }
+
+                            if (oldTP != null && param.isSelected()) {
+                                TreeTablePosition<S,?> newTP = new TreeTablePosition<>(
+                                        treeTableView, param.getSetIndex(), oldTP.getTableColumn());
+
+                                selectedCellsMap.add(newTP);
+                            }
+
+                            stopAtomic();
+
+                            return null;
                         }
-
-                        if (oldTP != null && param.isSelected()) {
-                            TreeTablePosition<S,?> newTP = new TreeTablePosition<>(
-                                    treeTableView, param.getSetIndex(), oldTP.getTableColumn());
-
-                            selectedCellsMap.add(newTP);
-                        }
-
-                        stopAtomic();
-
-                        return null;
-                    }
-                });
+                    });
+                }
             }
         };
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -1853,16 +1853,24 @@ public class TreeTableView<S> extends Control {
 
         // get the sort policy and run it
         Callback<TreeTableView<S>, Boolean> sortPolicy = getSortPolicy();
-        if (sortPolicy == null) return;
+        if (sortPolicy == null) {
+            sortingInProgress = false;
+            return;
+        }
         Boolean success = sortPolicy.call(this);
 
         if (getSortMode() == TreeSortMode.ALL_DESCENDANTS) {
             Set<TreeItem<S>> sortedParents = new HashSet<>();
             for (TreeTablePosition<S,?> selectedPosition : prevState) {
-                TreeItem<S> parent = selectedPosition.getTreeItem().getParent();
-                while (parent != null && sortedParents.add(parent)) {
-                    parent.getChildren();
-                    parent = parent.getParent();
+                // This null check is not required ideally.
+                // The selectedPosition.getTreeItem() should always return a valid TreeItem.
+                // But, it is possible to be null due to JDK-8248217.
+                if (selectedPosition.getTreeItem() != null) {
+                    TreeItem<S> parent = selectedPosition.getTreeItem().getParent();
+                    while (parent != null && sortedParents.add(parent)) {
+                        parent.getChildren();
+                        parent = parent.getParent();
+                    }
                 }
             }
         }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -1810,11 +1810,6 @@ public class TreeTableView<S> extends Control {
         return sortingInProgress;
     }
 
-    private boolean sortTreeOfSelectedItems = true;
-    boolean isSortTreeOfSelectedItems() {
-        return sortTreeOfSelectedItems;
-    }
-
     /**
      * The sort method forces the TreeTableView to re-run its sorting algorithm. More
      * often than not it is not necessary to call this method directly, as it is
@@ -1861,7 +1856,7 @@ public class TreeTableView<S> extends Control {
         if (sortPolicy == null) return;
         Boolean success = sortPolicy.call(this);
 
-        if (getSortMode() == TreeSortMode.ALL_DESCENDANTS && isSortTreeOfSelectedItems()) {
+        if (getSortMode() == TreeSortMode.ALL_DESCENDANTS) {
             Set<TreeItem<S>> sortedParents = new HashSet<>();
             for (TreeTablePosition<S,?> selectedPosition : prevState) {
                 TreeItem<S> parent = selectedPosition.getTreeItem().getParent();

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -1804,7 +1804,7 @@ public class TreeTableView<S> extends Control {
         return visibleLeafColumns.get(column);
     }
 
-    boolean sortingInProgress;
+    private boolean sortingInProgress;
     boolean isSortingInProgress() {
         return sortingInProgress;
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -1805,7 +1805,7 @@ public class TreeTableView<S> extends Control {
     }
 
     boolean sortingInProgress;
-    protected boolean isSortingInProgress() {
+    boolean isSortingInProgress() {
         return sortingInProgress;
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -397,7 +397,7 @@ public class TreeTableViewTest {
         verifySelectionAfterPermutation();
     }
 
-    @Ignore("JDK-8248217")
+    @Ignore("JDK-8193442")
     @Test public void testSelectionUpdatesCorrectlyAfterRemovingSelectedItem() {
         setupForPermutationTest();
         TreeItem<String> parentOfSelectedTreeItem = ((TreeItem<String>)sm.getSelectedItem()).getParent();
@@ -408,7 +408,7 @@ public class TreeTableViewTest {
         verifySelectionAfterPermutation();
     }
 
-    @Ignore("JDK-8248217")
+    @Ignore("JDK-8248389")
     @Test public void testSelectionUpdatesCorrectlyAfterAddingAnItemBeforeSelectedItem() {
         setupForPermutationTest();
         TreeItem<String> parentOfSelectedTreeItem = ((TreeItem<String>)sm.getSelectedItem()).getParent();
@@ -428,7 +428,7 @@ public class TreeTableViewTest {
         verifySelectionAfterPermutation();
     }
 
-    @Ignore("JDK-8248217")
+    @Ignore("JDK-8193442")
     @Test public void testSelectionUpdatesCorrectlyAfterChildReverseRemoveOneAndSetAll() {
         setupForPermutationTest();
         TreeItem<String> parentTreeItem = ((TreeItem<String>)sm.getSelectedItem()).getParent();
@@ -438,9 +438,8 @@ public class TreeTableViewTest {
         verifySelectionAfterPermutation();
     }
 
-    @Ignore("JDK-8248217")
+    @Ignore("JDK-8193442")
     @Test public void testSelectionUpdatesCorrectlyAfterChildRemoveOneAndSetAll() {
-        TreeTableColumn<String, String> col = setupForPermutationTest();
         TreeItem<String> parentTreeItem = ((TreeItem<String>)sm.getSelectedItem()).getParent();
         List<TreeItem<String>> children = new ArrayList<>(parentTreeItem.getChildren());
         children.remove(0);
@@ -448,7 +447,7 @@ public class TreeTableViewTest {
         verifySelectionAfterPermutation();
     }
 
-    @Ignore("JDK-8248217")
+    @Ignore("JDK-8193442")
     @Test public void testSelectionUpdatesCorrectlyAfterChildRemoveOneAndSetAllAndSort() {
         TreeTableColumn<String, String> col = setupForPermutationTest();
         TreeItem<String> parentTreeItem = ((TreeItem<String>)sm.getSelectedItem()).getParent();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -370,6 +370,102 @@ public class TreeTableViewTest {
         return col;
     }
 
+    private int countSelectedIndexChangeEvent;
+    private int countSelectedItemChangeEvent;
+    private int countSelectedIndicesChangeEvent;
+    private int countSelectedItemsChangeEvent;
+    private TreeItem<String> selectedItem;
+    private List<TreeTablePosition<String,?>> selectedCellsBeforePermutation;
+
+    @Test public void testSelectionUpdatesCorrectlyAfterSort() {
+        TreeTableColumn<String, String> col = initSortTestStructure();
+        setupForPermutationTest();
+        VirtualFlowTestUtils.assertListContainsItemsInOrder(treeTableView.getRoot().getChildren(), apple, orange, banana);
+        treeTableView.getSortOrder().add(col);
+        VirtualFlowTestUtils.assertListContainsItemsInOrder(treeTableView.getRoot().getChildren(), apple, banana, orange);
+        verifySelectionAfterPermutation();
+    }
+
+    @Test public void testSelectionUpdatesCorrectlyAfterRootSetAll() {
+        initSortTestStructure();
+        setupForPermutationTest();
+        treeTableView.getRoot().getChildren().setAll(banana, apple, orange);
+        verifySelectionAfterPermutation();
+    }
+
+    @Test public void testSelectionUpdatesCorrectlyAfterChildSetAll() {
+        initSortTestStructure();
+        setupForPermutationTest();
+        banana.getChildren().setAll(banana.getChildren().get(2), banana.getChildren().get(0), banana.getChildren().get(1));
+        verifySelectionAfterPermutation();
+    }
+
+    private void setupForPermutationTest() {
+        countSelectedIndexChangeEvent = 0;
+        countSelectedItemChangeEvent = 0;
+        countSelectedIndicesChangeEvent = 0;
+        countSelectedItemsChangeEvent = 0;
+
+        apple.getChildren().addAll(new TreeItem("Apple3"), new TreeItem("Apple2"), new TreeItem("Apple1"));
+        apple.setExpanded(true);
+        orange.getChildren().addAll(new TreeItem("Orange3"), new TreeItem("Orange2"), new TreeItem("Orange1"));
+        orange.setExpanded(true);
+        banana.getChildren().addAll(new TreeItem("Banana3"), new TreeItem("Banana2"), new TreeItem("Banana1"));
+        banana.setExpanded(true);
+
+        sm.setSelectionMode(SelectionMode.MULTIPLE);
+        sm.selectIndices(2, 5, 8, 10);
+
+        // Sanity checks
+        assertEquals(4, sm.getSelectedIndices().size());
+        assertEquals(10, sm.getSelectedIndex());
+        assertEquals(treeTableView.getTreeItem(10), sm.getSelectedItem());
+
+        selectedItem = (TreeItem<String>) sm.getSelectedItem();
+        selectedCellsBeforePermutation = new ArrayList<>(sm.getSelectedCells());
+
+        sm.selectedIndexProperty().addListener(ov -> {
+            countSelectedIndexChangeEvent++;
+        });
+        sm.selectedItemProperty().addListener(l -> {
+            countSelectedItemChangeEvent++;
+        });
+        sm.getSelectedIndices().addListener((ListChangeListener) c -> {
+            countSelectedIndicesChangeEvent++;
+        });
+        sm.getSelectedItems().addListener((ListChangeListener) c -> {
+            countSelectedItemsChangeEvent++;
+        });
+    }
+
+    private void verifySelectionAfterPermutation() {
+        assertEquals("Selected index should be updated", treeTableView.getRow(selectedItem), sm.getSelectedIndex());
+        assertEquals("Selected Item should remain same", selectedItem, sm.getSelectedItem());
+
+        final List<TreeTablePosition<String,?>> selectedCellsAfterPermutation =
+                new ArrayList<>(sm.getSelectedCells());
+        assertEquals("The number of selected items before and after permutation, should remain same",
+                selectedCellsBeforePermutation.size(), selectedCellsAfterPermutation.size());
+        // Verify that the cells that were selected before permutation,
+        // remain selected after permutation.
+        for (TreeTablePosition beforePos : selectedCellsBeforePermutation) {
+            boolean isCellStillSelected = false;
+            for (TreeTablePosition afterPos : selectedCellsAfterPermutation) {
+                if ((beforePos.getTreeItem() == afterPos.getTreeItem()) &&
+                        (beforePos.getTableColumn() == afterPos.getTableColumn()) &&
+                        (beforePos.getColumn() == afterPos.getColumn())) {
+                    isCellStillSelected = true;
+                }
+            }
+            assertTrue("The item (" + beforePos.getRow() + ", " + beforePos.getColumn() +
+                    ") lost selection during permutation", isCellStillSelected);
+        }
+        assertEquals(1, countSelectedIndexChangeEvent);
+        assertEquals(0, countSelectedItemChangeEvent);
+        assertEquals(1, countSelectedIndicesChangeEvent);
+        assertEquals(1, countSelectedItemsChangeEvent);
+    }
+
     @Ignore("This test is only valid if sort event consumption should revert changes")
     @Test public void testSortEventCanBeConsumedToStopSortOccurring_changeSortOrderList() {
         TreeTableColumn<String, String> col = initSortTestStructure();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -374,83 +374,133 @@ public class TreeTableViewTest {
     private int countSelectedItemChangeEvent;
     private int countSelectedIndicesChangeEvent;
     private int countSelectedItemsChangeEvent;
-    private TreeItem<String> selectedItem;
-    private List<TreeTablePosition<String,?>> selectedCellsBeforePermutation;
+    private TreeItem<String> selectedItemBefore;
+    private List<TreeItem<String>> selectedItemsBefore;
+    private List<Integer> selectedIndicesBefore;
+    private List<TreeTablePosition<String,?>> selectedCellsBefore;
 
     @Test public void testSelectionUpdatesCorrectlyAfterSort() {
-        TreeTableColumn<String, String> col = initSortTestStructure();
-        setupForPermutationTest();
-        VirtualFlowTestUtils.assertListContainsItemsInOrder(treeTableView.getRoot().getChildren(), apple, orange, banana);
+        TreeTableColumn<String, String> col = setupForPermutationTest();
         treeTableView.getSortOrder().add(col);
-        VirtualFlowTestUtils.assertListContainsItemsInOrder(treeTableView.getRoot().getChildren(), apple, banana, orange);
         verifySelectionAfterPermutation();
     }
 
     @Test public void testSelectionUpdatesCorrectlyAfterRootSetAll() {
-        initSortTestStructure();
         setupForPermutationTest();
-        treeTableView.getRoot().getChildren().setAll(banana, apple, orange);
+        reverseChildrenOrder(treeTableView.getRoot());
         verifySelectionAfterPermutation();
     }
 
     @Test public void testSelectionUpdatesCorrectlyAfterChildSetAll() {
-        initSortTestStructure();
         setupForPermutationTest();
-        banana.getChildren().setAll(banana.getChildren().get(2), banana.getChildren().get(0), banana.getChildren().get(1));
+        reverseChildrenOrder(((TreeItem<String>)sm.getSelectedItem()).getParent());
         verifySelectionAfterPermutation();
     }
 
-    private void setupForPermutationTest() {
+    private void reverseChildrenOrder(TreeItem<String> treeItem) {
+        List<TreeItem<String>> childrenReversed = new ArrayList<>();
+        int childrenSize = treeItem.getChildren().size();
+        for (int i = 0; i < childrenSize; i++) {
+            childrenReversed.add(treeItem.getChildren().get(childrenSize - 1 - i));
+        }
+        treeItem.getChildren().setAll(childrenReversed);
+    }
+
+    private TreeTableColumn<String, String> setupForPermutationTest() {
         countSelectedIndexChangeEvent = 0;
         countSelectedItemChangeEvent = 0;
         countSelectedIndicesChangeEvent = 0;
         countSelectedItemsChangeEvent = 0;
 
-        apple.getChildren().addAll(new TreeItem("Apple3"), new TreeItem("Apple2"), new TreeItem("Apple1"));
-        apple.setExpanded(true);
-        orange.getChildren().addAll(new TreeItem("Orange3"), new TreeItem("Orange2"), new TreeItem("Orange1"));
-        orange.setExpanded(true);
-        banana.getChildren().addAll(new TreeItem("Banana3"), new TreeItem("Banana2"), new TreeItem("Banana1"));
-        banana.setExpanded(true);
+        TreeTableColumn<String, String> col = new TreeTableColumn<String, String>("column");
+        col.setSortType(DESCENDING);
+        col.setCellValueFactory(param -> new ReadOnlyObjectWrapper<String>(param.getValue().getValue()));
+        treeTableView.getColumns().add(col);
+
+        TreeItem<String> treeRoot = new TreeItem<String>("root");
+        treeRoot.setExpanded(true);
+        treeTableView.setRoot(treeRoot);
+
+        final int FIRST_LEVEL_COUNT = 8;
+        for (int i = 0; i < FIRST_LEVEL_COUNT; i++) {
+            TreeItem<String> ti = new TreeItem<>( "" + i);
+            ti.setExpanded(true);
+            treeRoot.getChildren().add(ti);
+
+            for (int j = 0; j < FIRST_LEVEL_COUNT - 1; j++) {
+                TreeItem<String> tj = new TreeItem<>("" + i + j);
+                tj.setExpanded(true);
+                ti.getChildren().add(tj);
+
+                for (int k = 0; k < FIRST_LEVEL_COUNT - 2; k++) {
+                    TreeItem<String> tk = new TreeItem<>("" + i + j + k);
+                    tk.setExpanded(true);
+                    tj.getChildren().add(tk);
+
+                    for (int l = 0; l < FIRST_LEVEL_COUNT - 3; l++) {
+                        TreeItem<String> tl = new TreeItem<>("" + i + j + k + l);
+                        tl.setExpanded(true);
+                        tk.getChildren().add(tl);
+
+                        for (int m = 0; m < FIRST_LEVEL_COUNT - 4; m++) {
+                            TreeItem<String> tm = new TreeItem<>("" + i + j + k + l + m);
+                            tl.getChildren().add(tm);
+                        }
+                    }
+                }
+            }
+        }
 
         sm.setSelectionMode(SelectionMode.MULTIPLE);
-        sm.selectIndices(2, 5, 8, 10);
+        int indices[] = new int[] {1, 400, 800, 1200, 1600, 2000, 2400, 2800, 3200, 3600, 4000, 4400, 4800, 5200, 5600, 6000, 6400};
+        sm.selectIndices(1, 400, 800, 1200, 1600, 2000, 2400, 2800, 3200, 3600, 4000, 4400, 4800, 5200, 5600, 6000, 6400);
 
         // Sanity checks
-        assertEquals(4, sm.getSelectedIndices().size());
-        assertEquals(10, sm.getSelectedIndex());
-        assertEquals(treeTableView.getTreeItem(10), sm.getSelectedItem());
+        assertEquals(indices.length, sm.getSelectedIndices().size());
+        assertEquals(indices.length, sm.getSelectedItems().size());
+        assertEquals(indices.length, sm.getSelectedCells().size());
+        assertEquals(indices[indices.length - 1], sm.getSelectedIndex());
+        assertEquals(treeTableView.getTreeItem(indices[indices.length - 1]), sm.getSelectedItem());
 
-        selectedItem = (TreeItem<String>) sm.getSelectedItem();
-        selectedCellsBeforePermutation = new ArrayList<>(sm.getSelectedCells());
+        selectedItemBefore = (TreeItem<String>) sm.getSelectedItem();
+        selectedItemsBefore = new ArrayList<>(sm.getSelectedItems());
+        selectedIndicesBefore = new ArrayList<>(sm.getSelectedIndices());
+        selectedCellsBefore = new ArrayList<>(sm.getSelectedCells());
 
         sm.selectedIndexProperty().addListener(ov -> {
             countSelectedIndexChangeEvent++;
+            assertEquals(selectedItemBefore, treeTableView.getTreeItem(sm.getSelectedIndex()));
         });
         sm.selectedItemProperty().addListener(l -> {
             countSelectedItemChangeEvent++;
         });
         sm.getSelectedIndices().addListener((ListChangeListener) c -> {
             countSelectedIndicesChangeEvent++;
+            c.next();
+            if (c.wasRemoved()) {
+                assertTrue(selectedIndicesBefore.equals(c.getRemoved()));
+            }
+            verifySelectedIndices(c.getAddedSubList());
+            verifySelectedIndices(c.getList());
         });
         sm.getSelectedItems().addListener((ListChangeListener) c -> {
             countSelectedItemsChangeEvent++;
+            c.next();
+            if (c.wasRemoved()) {
+                verifySelectedItems(c.getRemoved());
+            }
+            verifySelectedItems(c.getAddedSubList());
+            verifySelectedItems(c.getList());
         });
+
+        return col;
     }
 
-    private void verifySelectionAfterPermutation() {
-        assertEquals("Selected index should be updated", treeTableView.getRow(selectedItem), sm.getSelectedIndex());
-        assertEquals("Selected Item should remain same", selectedItem, sm.getSelectedItem());
-
-        final List<TreeTablePosition<String,?>> selectedCellsAfterPermutation =
-                new ArrayList<>(sm.getSelectedCells());
-        assertEquals("The number of selected items before and after permutation, should remain same",
-                selectedCellsBeforePermutation.size(), selectedCellsAfterPermutation.size());
-        // Verify that the cells that were selected before permutation,
-        // remain selected after permutation.
-        for (TreeTablePosition beforePos : selectedCellsBeforePermutation) {
+    private void verifySelectedCells(List<TreeTablePosition<String, ?>> selectedCells) {
+        assertEquals(selectedCellsBefore.size(), selectedCells.size());
+        for (TreeTablePosition beforePos : selectedCellsBefore) {
             boolean isCellStillSelected = false;
-            for (TreeTablePosition afterPos : selectedCellsAfterPermutation) {
+            for (TreeTablePosition afterPos : selectedCells) {
                 if ((beforePos.getTreeItem() == afterPos.getTreeItem()) &&
                         (beforePos.getTableColumn() == afterPos.getTableColumn()) &&
                         (beforePos.getColumn() == afterPos.getColumn())) {
@@ -460,10 +510,35 @@ public class TreeTableViewTest {
             assertTrue("The item (" + beforePos.getRow() + ", " + beforePos.getColumn() +
                     ") lost selection during permutation", isCellStillSelected);
         }
+    }
+
+    private void verifySelectedItems(List<TreeItem<String>> selectedItems) {
+        assertEquals(selectedItemsBefore.size(), selectedItems.size());
+        for (TreeItem<String> item : selectedItemsBefore) {
+            assertTrue("The item (" + item + ") lost selection during permutation",
+                    selectedItems.contains(item));
+        }
+    }
+
+    private void verifySelectedIndices(List<Integer> currentIndices) {
+        assertEquals(selectedIndicesBefore.size(), currentIndices.size());
+        for (Integer row : currentIndices) {
+            assertTrue(selectedItemsBefore.contains(treeTableView.getTreeItem(row)));
+        }
+    }
+
+    private void verifySelectionAfterPermutation() {
         assertEquals(1, countSelectedIndexChangeEvent);
         assertEquals(0, countSelectedItemChangeEvent);
         assertEquals(1, countSelectedIndicesChangeEvent);
         assertEquals(1, countSelectedItemsChangeEvent);
+
+        assertEquals("Selected Item should remain same", selectedItemBefore, sm.getSelectedItem());
+        assertEquals("Selected index should be updated", treeTableView.getRow(selectedItemBefore), sm.getSelectedIndex());
+
+        verifySelectedCells(sm.getSelectedCells());
+        verifySelectedItems(sm.getSelectedItems());
+        verifySelectedIndices(sm.getSelectedIndices());
     }
 
     @Ignore("This test is only valid if sort event consumption should revert changes")


### PR DESCRIPTION
Issue:
In TreeTableView, in case of Multiple selection mode, if nested items are selected, then TreeTableView does not retain/update the selection correctly when the tree items are permuted(either by `sort()` or by reordering using `setAll()`).

Cause:

1. For permutation, the current implementation uses `TreeModificationEvent` to update the selection.
2. The indices from these TreeModificationEvents are not reliable.
3. It uses the non public `TreeTablePosition` constructor to create intermediate `TreeItem` positions, this constructor results in another unexpected TreeModificationEvent while one for sorting is already being processed.
4. In case of sorting, there can be multiple intermediate TreeModificationEvents generated, and for each TreeModificationEvent, the selection gets updated and results in selection change events being generated.
5. Each time a TreeItem is expanded or collapsed, the selection must be shifted, but shifting is not necessary in case of permutation.
All these issues combine in wrong update of the selection.

Fix:

1. On each TreeModificationEvent for permutation, for updating the selection, use index of TreeItem from the TreeTableView but not from the TreeModificationEvent.
2. Added a new non public TreeTablePosition constructor, which is almost a copy constructor but accepts a different row.
3. In case of sorting, send out the set of selection change events only once after the sorting is over.
4. In case of setAll, send out the set of selection change events same as before.(setAll results in only one TreeModificationEvent, which effectively results in only one set of selection change events).
`shiftSelection()` should not be called in case of permutation i.e. call `if (shift != 0)`

Verification:
The change is very limited to updating of selection of TreeTableView items when the TreeItems are permuted, so the change should not cause any other failures.
Added unit tests which fail before and pass after the fix.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8193800](https://bugs.openjdk.java.net/browse/JDK-8193800): TreeTableView selection changes on sorting


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/244/head:pull/244`
`$ git checkout pull/244`
