### PR TITLE
8247163: JFXPanel throws exception on click when no Scene is set

### DIFF
--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
@@ -449,8 +449,10 @@ public class JFXPanel extends JComponent {
                 // The extra simulated mouse pressed event is removed by making the JavaFX scene focused.
                 // It is safe, because in JavaFX only the method "setFocused(true)" is called,
                 // which doesn't have any side-effects when called multiple times.
-                int focusCause = AbstractEvents.FOCUSEVENT_ACTIVATED;
-                stagePeer.setFocused(true, focusCause);
+                if(stagePeer != null) {
+                    int focusCause = AbstractEvents.FOCUSEVENT_ACTIVATED;
+                    stagePeer.setFocused(true, focusCause);
+                }
             }
         }
 

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
@@ -449,7 +449,7 @@ public class JFXPanel extends JComponent {
                 // The extra simulated mouse pressed event is removed by making the JavaFX scene focused.
                 // It is safe, because in JavaFX only the method "setFocused(true)" is called,
                 // which doesn't have any side-effects when called multiple times.
-                if(stagePeer != null) {
+                if (stagePeer != null) {
                     int focusCause = AbstractEvents.FOCUSEVENT_ACTIVATED;
                     stagePeer.setFocused(true, focusCause);
                 }

--- a/tests/system/src/test/java/test/javafx/embed/swing/JFXPanelTest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/JFXPanelTest.java
@@ -137,5 +137,23 @@ public class JFXPanelTest {
 
         Assert.assertEquals(1, pressedEventCounter[0]);
     }
+
+    @Test
+    public void testClickOnEmptyJFXPanel() throws Exception {
+        CountDownLatch firstPressedEventLatch = new CountDownLatch(1);
+
+        SwingUtilities.invokeLater(() -> {
+            TestFXPanel fxPnl = new TestFXPanel();
+
+            MouseEvent e = new MouseEvent(fxPnl, MouseEvent.MOUSE_PRESSED, 0, MouseEvent.BUTTON1_DOWN_MASK,
+                    5, 5, 1, false, MouseEvent.BUTTON1);
+
+            fxPnl.processMouseEventPublic(e);
+
+            firstPressedEventLatch.countDown();
+        });
+
+        Assert.assertTrue(firstPressedEventLatch.await(5000, TimeUnit.MILLISECONDS));
+    }
 }
 


### PR DESCRIPTION
Fixing exception when clicking on JFXPanel when no Scene is set.

quick test: `./gradlew -PFULL_TEST=true -PUSE_ROBOT=true :systemTests: test --tests *javafx.embed.swing.JFXPan* --info`

It's a regression from my previous PR: https://github.com/openjdk/jfx/pull/25
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247163](https://bugs.openjdk.java.net/browse/JDK-8247163): JFXPanel throws exception on click when no Scene is set


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/248/head:pull/248`
`$ git checkout pull/248`
