### PR TITLE
8246348: Crash in libpango on Ubuntu 20.04 with some unicode chars

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/OSPango.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/OSPango.java
@@ -83,6 +83,7 @@ class OSPango {
     /* Miscellaneous (glib, fontconfig) */
     static final native long g_utf8_offset_to_pointer(long str, long offset);
     static final native long g_utf8_pointer_to_offset(long str, long pos);
+    static final native long g_utf8_strlen(long str, long max);
     static final native long g_utf16_to_utf8(char[] str);
     static final native void g_free(long ptr);
     static final native int g_list_length(long list);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/PangoGlyphLayout.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/PangoGlyphLayout.java
@@ -86,9 +86,6 @@ class PangoGlyphLayout extends GlyphLayout {
 
     private Map<TextRun, Long> runUtf8 = new HashMap<>();
     public void layout(TextRun run, PGFont font, FontStrike strike, char[] text) {
-        for (char c: text) {
-            if (c == 0) c = '\f';
-        }
         /* Create the pango font and attribute list */
         FontResource fr = font.getFontResource();
         boolean composite = fr instanceof CompositeFontResource;
@@ -143,10 +140,9 @@ class PangoGlyphLayout extends GlyphLayout {
         }
 
         /* Itemize */
-        long start = OSPango.g_utf8_offset_to_pointer(str, run.getStart());
         long utflen = OSPango.g_utf8_strlen(str,-1);
         long end = OSPango.g_utf8_offset_to_pointer(str, utflen);
-        long runs = OSPango.pango_itemize(context, str, (int)(start - str), (int)(end - start), attrList, 0);
+        long runs = OSPango.pango_itemize(context, str, 0, (int)(end - str), attrList, 0);
 
         if (runs != 0) {
             /* Shape all PangoItem into PangoGlyphString */

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/PangoGlyphLayout.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/PangoGlyphLayout.java
@@ -86,6 +86,9 @@ class PangoGlyphLayout extends GlyphLayout {
 
     private Map<TextRun, Long> runUtf8 = new HashMap<>();
     public void layout(TextRun run, PGFont font, FontStrike strike, char[] text) {
+        for (char c: text) {
+            if (c == 0) c = '\f';
+        }
         /* Create the pango font and attribute list */
         FontResource fr = font.getFontResource();
         boolean composite = fr instanceof CompositeFontResource;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/PangoGlyphLayout.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/PangoGlyphLayout.java
@@ -35,7 +35,7 @@ import com.sun.javafx.text.GlyphLayout;
 import com.sun.javafx.text.TextRun;
 
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 class PangoGlyphLayout extends GlyphLayout {
@@ -84,7 +84,7 @@ class PangoGlyphLayout extends GlyphLayout {
         return true;
     }
 
-    private Map<TextRun, Long> runUtf8 = new HashMap<>();
+    private Map<TextRun, Long> runUtf8 = new LinkedHashMap<>();
     public void layout(TextRun run, PGFont font, FontStrike strike, char[] text) {
         /* Create the pango font and attribute list */
         FontResource fr = font.getFontResource();
@@ -133,10 +133,10 @@ class PangoGlyphLayout extends GlyphLayout {
         if (str == null) {
             char[] rtext = Arrays.copyOfRange(text, run.getStart(), run.getEnd());
             str = OSPango.g_utf16_to_utf8(rtext);
-            runUtf8.put(run, str);
             if (check(str, "Failed allocating UTF-8 buffer.", context, desc, attrList)) {
                 return;
             }
+            runUtf8.put(run, str);
         }
 
         /* Itemize */

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/PangoGlyphLayout.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/PangoGlyphLayout.java
@@ -135,7 +135,8 @@ class PangoGlyphLayout extends GlyphLayout {
 
         /* Itemize */
         long start = OSPango.g_utf8_offset_to_pointer(str, run.getStart());
-        long end = OSPango.g_utf8_offset_to_pointer(str, run.getEnd());
+        long utflen = OSPango.g_utf8_strlen(str,-1);
+        long end = OSPango.g_utf8_offset_to_pointer(str, utflen);
         long runs = OSPango.pango_itemize(context, str, (int)(start - str), (int)(end - start), attrList, 0);
 
         if (runs != 0) {

--- a/modules/javafx.graphics/src/main/native-font/pango.c
+++ b/modules/javafx.graphics/src/main/native-font/pango.c
@@ -398,6 +398,13 @@ JNIEXPORT jlong JNICALL OS_NATIVE(g_1utf8_1pointer_1to_1offset)
     return (jlong)g_utf8_pointer_to_offset((const gchar *)str, (const gchar *)pos);
 }
 
+JNIEXPORT jlong JNICALL OS_NATIVE(g_1utf8_1strlen)
+    (JNIEnv *env, jclass that, jlong str, jlong pos)
+{
+    if (!str) return 0;
+    return (jlong)g_utf8_strlen((const gchar *)str, (const gchar *)pos);
+}
+
 JNIEXPORT jlong JNICALL OS_NATIVE(g_1utf16_1to_1utf8)
     (JNIEnv *env, jclass that, jcharArray str)
 {

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/text/TextLayoutTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/text/TextLayoutTest.java
@@ -35,6 +35,7 @@ import com.sun.javafx.scene.text.TextLine;
 import com.sun.javafx.scene.text.FontHelper;
 import com.sun.javafx.font.CharToGlyphMapper;
 import com.sun.javafx.text.PrismTextLayout;
+import com.sun.javafx.text.GlyphLayout;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -93,6 +94,11 @@ public class TextLayoutTest {
         for (int i = 0; i < runs.length; i++) {
             assertEquals("run " +i, complex[i], runs[i].isComplex());
         }
+    }
+
+    @Test public void utf16chars() {
+         GlyphLayout layout = GlyphLayout.getInstance();
+         assertNotNull(layout);
     }
 
     @SuppressWarnings("deprecation")

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/text/TextLayoutTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/text/TextLayoutTest.java
@@ -26,7 +26,6 @@
 package test.com.sun.javafx.text;
 
 import javafx.scene.text.Font;
-import com.sun.javafx.text.TextRun;
 
 import com.sun.javafx.font.PGFont;
 import com.sun.javafx.geom.RectBounds;
@@ -36,8 +35,6 @@ import com.sun.javafx.scene.text.TextLine;
 import com.sun.javafx.scene.text.FontHelper;
 import com.sun.javafx.font.CharToGlyphMapper;
 import com.sun.javafx.text.PrismTextLayout;
-import com.sun.javafx.text.GlyphLayout;
-import com.sun.javafx.text.TextRun;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -96,21 +93,6 @@ public class TextLayoutTest {
         for (int i = 0; i < runs.length; i++) {
             assertEquals("run " +i, complex[i], runs[i].isComplex());
         }
-    }
-
-    @Ignore() // ignored since StubFontLoader used in tests return fonts with null resources
-    @Test public void utf16chars() {
-        GlyphLayout layout = GlyphLayout.getInstance();
-        assertNotNull(layout);
-        char[] text = new char[5];
-        text[0] = 0xD83D;
-        text[1] = 0xDC68;
-        text[2] = 0xD83C;
-        text[3] = 0xDFFE;
-        text[4] = 0x17FF;
-        TextRun run = new TextRun(0, 5, (byte)0, true, 0, null, 0, false);
-        PGFont font = (PGFont) FontHelper.getNativeFont(Font.getDefault());
-        layout.layout(run, font, null, text);
     }
 
     @SuppressWarnings("deprecation")

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/text/TextLayoutTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/text/TextLayoutTest.java
@@ -26,6 +26,7 @@
 package test.com.sun.javafx.text;
 
 import javafx.scene.text.Font;
+import com.sun.javafx.text.TextRun;
 
 import com.sun.javafx.font.PGFont;
 import com.sun.javafx.geom.RectBounds;
@@ -36,6 +37,7 @@ import com.sun.javafx.scene.text.FontHelper;
 import com.sun.javafx.font.CharToGlyphMapper;
 import com.sun.javafx.text.PrismTextLayout;
 import com.sun.javafx.text.GlyphLayout;
+import com.sun.javafx.text.TextRun;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -96,9 +98,19 @@ public class TextLayoutTest {
         }
     }
 
+    @Ignore() // ignored since StubFontLoader used in tests return fonts with null resources
     @Test public void utf16chars() {
-         GlyphLayout layout = GlyphLayout.getInstance();
-         assertNotNull(layout);
+        GlyphLayout layout = GlyphLayout.getInstance();
+        assertNotNull(layout);
+        char[] text = new char[5];
+        text[0] = 0xD83D;
+        text[1] = 0xDC68;
+        text[2] = 0xD83C;
+        text[3] = 0xDFFE;
+        text[4] = 0x17FF;
+        TextRun run = new TextRun(0, 5, (byte)0, true, 0, null, 0, false);
+        PGFont font = (PGFont) FontHelper.getNativeFont(Font.getDefault());
+        layout.layout(run, font, null, text);
     }
 
     @SuppressWarnings("deprecation")

--- a/tests/system/src/test/java/test/com/sun/javafx/font/freetype/PangoTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/font/freetype/PangoTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.javafx.font.freetype;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
+import javafx.scene.text.Text;
+import javafx.stage.Stage;
+
+import org.junit.Test;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import junit.framework.AssertionFailedError;
+import static test.util.Util.TIMEOUT;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test program for UTF16 to UTF8 conversion and Pango
+ */
+public class PangoTest {
+
+    static CountDownLatch launchLatch = new CountDownLatch(1);
+
+    static MyApp myApp;
+    static Pane pane;
+
+    public static class MyApp extends Application {
+
+        Stage stage = null;
+
+        public MyApp() {
+            super();
+        }
+
+        @Override
+        public void init() {
+            myApp = this;
+        }
+
+        @Override
+        public void start(Stage primaryStage) throws Exception {
+            this.stage = primaryStage;
+            pane = new VBox(10);
+            Scene scene = new Scene(pane, 400, 200);
+            stage.setScene(scene);
+            stage.show();
+            launchLatch.countDown();
+        }
+    }
+
+    @BeforeClass
+    public static void setupOnce() {
+        // Start the Application
+        new Thread(() -> Application.launch(MyApp.class, (String[]) null)).start();
+
+        try {
+            if (!launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS)) {
+                throw new AssertionFailedError("Timeout waiting for Application to launch");
+            }
+        } catch (InterruptedException ex) {
+            AssertionFailedError err = new AssertionFailedError("Unexpected exception");
+            err.initCause(ex);
+            throw err;
+        }
+
+        assertEquals(0, launchLatch.getCount());
+    }
+
+
+
+    @AfterClass
+    public static void teardownOnce() {
+        Platform.exit();
+    }
+
+    private void addTextToPane(Text text) {
+        final CountDownLatch rDone = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            text.layoutYProperty().addListener(inv -> {
+                rDone.countDown();
+            });
+            pane.getChildren().add(text);
+        });
+
+        try {
+            if (!rDone.await(TIMEOUT, TimeUnit.MILLISECONDS)) {
+                throw new AssertionFailedError("Timeout waiting for runLater");
+            }
+        } catch (InterruptedException ex) {
+            throw new AssertionFailedError("Unexpected exception waiting for runLater");
+        }
+    }
+
+    @Test
+    public void testZeroChar() {
+        String FULL_UNICODE_SET;
+        StringBuilder builder = new StringBuilder();
+        for (int character = 0; character < 10000; character++) {
+             char[] chars = Character.toChars(character);
+             builder.append(chars);
+        }
+        FULL_UNICODE_SET = builder.toString();
+        Text text = new Text(FULL_UNICODE_SET);
+        addTextToPane(text);
+    }
+
+    @Test
+    public void testSurrogatePair() {
+        StringBuilder builder = new StringBuilder();
+        builder.append(Character.toChars(55358));
+        builder.append(Character.toChars(56605));
+        builder.append(Character.toChars(8205));
+
+        Text text = new Text(builder.toString());
+        addTextToPane(text);
+    }
+}

--- a/tests/system/src/test/java/test/com/sun/javafx/font/freetype/PangoTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/font/freetype/PangoTest.java
@@ -83,7 +83,7 @@ public class PangoTest {
     public static void setupOnce() throws Exception {
         // Start the Application
         new Thread(() -> Application.launch(MyApp.class, (String[]) null)).start();
-        assertTrue("Timeout waiting for Application to launch", 
+        assertTrue("Timeout waiting for Application to launch",
                 launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
         assertEquals(0, launchLatch.getCount());
     }


### PR DESCRIPTION
This addresses https://bugs.openjdk.java.net/browse/JDK-8246348
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8246348](https://bugs.openjdk.java.net/browse/JDK-8246348): Crash in libpango on Ubuntu 20.04 with some unicode chars


### Reviewers
 * Phil Race ([prr](@prrace) - **Reviewer**)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/249/head:pull/249`
`$ git checkout pull/249`
