### PR TITLE
8242892: SpinnerValueFactory has an implicit no-arg constructor

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SpinnerValueFactory.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SpinnerValueFactory.java
@@ -89,6 +89,11 @@ import java.util.List;
  */
 public abstract class SpinnerValueFactory<T> {
 
+    /**
+     * Creates a default SpinnerValueFactory.
+     */
+    public SpinnerValueFactory() {}
+
     /***************************************************************************
      *                                                                         *
      * Private fields                                                          *


### PR DESCRIPTION
Issue : https://bugs.openjdk.java.net/browse/JDK-8242892

Fix : Added a constructor to SpinnerValueFactory class with minimal description.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242892](https://bugs.openjdk.java.net/browse/JDK-8242892): SpinnerValueFactory has an implicit no-arg constructor


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/250/head:pull/250`
`$ git checkout pull/250`
