### PR TITLE
8246745: ListCell/Skin: misbehavior on switching skin

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ListCellSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ListCellSkin.java
@@ -26,17 +26,13 @@
 package javafx.scene.control.skin;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
-import javafx.beans.InvalidationListener;
-import javafx.beans.Observable;
+import com.sun.javafx.scene.control.behavior.ListCellBehavior;
+
 import javafx.geometry.Orientation;
-import javafx.scene.Node;
-import javafx.scene.control.Accordion;
-import javafx.scene.control.Button;
 import javafx.scene.control.Control;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
-
-import com.sun.javafx.scene.control.behavior.ListCellBehavior;
+import javafx.scene.layout.Region;
 
 /**
  * Default skin implementation for the {@link ListCell} control.
@@ -52,11 +48,7 @@ public class ListCellSkin<T> extends CellSkinBase<ListCell<T>> {
      *                                                                         *
      **************************************************************************/
 
-    private double fixedCellSize;
-    private boolean fixedCellSizeEnabled;
     private final BehaviorBase<ListCell<T>> behavior;
-
-
 
     /***************************************************************************
      *                                                                         *
@@ -77,30 +69,7 @@ public class ListCellSkin<T> extends CellSkinBase<ListCell<T>> {
         // install default input map for the ListCell control
         behavior = new ListCellBehavior<>(control);
 //        control.setInputMap(behavior.getInputMap());
-
-        setupListeners();
     }
-
-    private void setupListeners() {
-        ListView listView = getSkinnable().getListView();
-        if (listView == null) {
-            getSkinnable().listViewProperty().addListener(new InvalidationListener() {
-                @Override public void invalidated(Observable observable) {
-                    getSkinnable().listViewProperty().removeListener(this);
-                    setupListeners();
-                }
-            });
-        } else {
-            this.fixedCellSize = listView.getFixedCellSize();
-            this.fixedCellSizeEnabled = fixedCellSize > 0;
-            registerChangeListener(listView.fixedCellSizeProperty(), e -> {
-                this.fixedCellSize = getSkinnable().getListView().getFixedCellSize();
-                this.fixedCellSizeEnabled = fixedCellSize > 0;
-            });
-        }
-    }
-
-
 
     /***************************************************************************
      *                                                                         *
@@ -127,7 +96,8 @@ public class ListCellSkin<T> extends CellSkinBase<ListCell<T>> {
 
     /** {@inheritDoc} */
     @Override protected double computePrefHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset) {
-        if (fixedCellSizeEnabled) {
+        double fixedCellSize = getFixedCellSize();
+        if (fixedCellSize > 0) {
             return fixedCellSize;
         }
 
@@ -140,7 +110,8 @@ public class ListCellSkin<T> extends CellSkinBase<ListCell<T>> {
 
     /** {@inheritDoc} */
     @Override protected double computeMinHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset) {
-        if (fixedCellSizeEnabled) {
+        double fixedCellSize = getFixedCellSize();
+        if (fixedCellSize > 0) {
             return fixedCellSize;
         }
 
@@ -149,10 +120,15 @@ public class ListCellSkin<T> extends CellSkinBase<ListCell<T>> {
 
     /** {@inheritDoc} */
     @Override protected double computeMaxHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset) {
-        if (fixedCellSizeEnabled) {
+        double fixedCellSize = getFixedCellSize();
+        if (fixedCellSize > 0) {
             return fixedCellSize;
         }
-
         return super.computeMaxHeight(width, topInset, rightInset, bottomInset, leftInset);
+    }
+
+    private double getFixedCellSize() {
+        ListView<?> listView = getSkinnable().getListView();
+        return listView != null ? listView.getFixedCellSize() : Region.USE_COMPUTED_SIZE;
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -42,6 +42,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static javafx.scene.control.ControlShim.*;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.*;
 import static org.junit.Assert.*;
 
@@ -723,4 +724,28 @@ public class ListCellTest {
         ListCell cell = new ListCell();
         cell.setSkin(new ListCellSkin(cell));
     }
+
+    /**
+     * Test that min/max/pref height respect fixedCellSize.
+     * Sanity test when fixing JDK-8246745.
+     */
+    @Test
+    public void testListCellHeights() {
+        ListCell<Object> cell =  new ListCell<>();
+        ListView<Object> listView = new ListView<>();
+        cell.updateListView(listView);
+        installDefaultSkin(cell);
+        listView.setFixedCellSize(100);
+        assertEquals("pref height must be fixedCellSize",
+                listView.getFixedCellSize(),
+                cell.prefHeight(-1), 1);
+        assertEquals("min height must be fixedCellSize",
+                listView.getFixedCellSize(),
+                cell.minHeight(-1), 1);
+        assertEquals("max height must be fixedCellSize",
+                listView.getFixedCellSize(),
+                cell.maxHeight(-1), 1);
+    }
+
+
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinCleanupTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinCleanupTest.java
@@ -65,6 +65,7 @@ public class SkinCleanupTest {
         cell.updateListView(listView);
         installDefaultSkin(cell);
         cell.updateListView(null);
+        // 8246745: updating the old listView must not throw NPE in skin
         listView.setFixedCellSize(100);
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinCleanupTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinCleanupTest.java
@@ -39,6 +39,7 @@ import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.Control;
+import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.ToolBar;
 import javafx.scene.layout.Pane;
@@ -54,6 +55,31 @@ public class SkinCleanupTest {
     private Scene scene;
     private Stage stage;
     private Pane root;
+
+// ------------------ ListCell
+
+    @Test
+    public void testListCellReplaceListViewWithNull() {
+        ListCell<Object> cell =  new ListCell<>();
+        ListView<Object> listView = new ListView<>();
+        cell.updateListView(listView);
+        installDefaultSkin(cell);
+        cell.updateListView(null);
+        listView.setFixedCellSize(100);
+    }
+
+   @Test
+   public void testListCellPrefHeightOnReplaceListView() {
+       ListCell<Object> cell =  new ListCell<>();
+       cell.updateListView(new ListView<>());
+       installDefaultSkin(cell);
+       ListView<Object> listView = new ListView<>();
+       listView.setFixedCellSize(100);
+       cell.updateListView(listView);
+       assertEquals("fixed cell set to value of new listView",
+               cell.getListView().getFixedCellSize(),
+               cell.prefHeight(-1), 1);
+   }
 
   //-------------- listView
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinMemoryLeakTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinMemoryLeakTest.java
@@ -110,7 +110,6 @@ public class SkinMemoryLeakTest {
                 ColorPicker.class,
                 ComboBox.class,
                 DatePicker.class,
-                ListCell.class,
                 MenuBar.class,
                 MenuButton.class,
                 Pagination.class,


### PR DESCRIPTION
ListCellSkin installs listeners to the ListView/fixedCellSize that introduce a memory leak, NPE on replacing the listView and incorrect update of internal state (see bug report for details)

Fixed by removing the listeners (and the internal state had been copied from listView on change) and access of listView state when needed.

Added tests that failed before and pass after the fix, plus a sanity test to guarantee same (correct) behavior before/after.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8246745](https://bugs.openjdk.java.net/browse/JDK-8246745): ListCell/Skin: misbehavior on switching skin


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/251/head:pull/251`
`$ git checkout pull/251`
