### PR TITLE
8247360: Add missing license file for Microsoft DirectShow Samples

### DIFF
--- a/modules/javafx.media/src/main/legal/directshow.md
+++ b/modules/javafx.media/src/main/legal/directshow.md
@@ -1,0 +1,26 @@
+## Microsoft DirectShow Samples v156905
+
+### MIT License (MIT)
+```
+
+Copyright (c) 1992-2004 Microsoft Corporation. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+```


### PR DESCRIPTION
This adds a missing third-party license file for the Microsoft DirectShow Samples.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247360](https://bugs.openjdk.java.net/browse/JDK-8247360): Add missing license file for Microsoft DirectShow Samples


### Reviewers
 * Alexander Matveev ([almatvee](@sashamatveev) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/252/head:pull/252`
`$ git checkout pull/252`
