### PR TITLE
8214699: Node.getPseudoClassStates must return the same instance on every call

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -654,23 +654,18 @@ public class ComboBoxTest {
         assertTrue(pseudoClassStates.size() >= 0);
 
         comboBox.setEditable(true);
-        pseudoClassStates = comboBox.getPseudoClassStates();
         assertTrue(pseudoClassStates.contains(PseudoClass.getPseudoClass("editable")));
 
         comboBox.setEditable(false);
-        pseudoClassStates = comboBox.getPseudoClassStates();
-        assertTrue(pseudoClassStates.contains(PseudoClass.getPseudoClass("editable")) == false);
+        assertFalse(pseudoClassStates.contains(PseudoClass.getPseudoClass("editable")));
 
         comboBox.show();
-        pseudoClassStates = comboBox.getPseudoClassStates();
         assertTrue(pseudoClassStates.contains(PseudoClass.getPseudoClass("showing")));
 
         comboBox.hide();
-        pseudoClassStates = comboBox.getPseudoClassStates();
-        assertTrue(pseudoClassStates.contains(PseudoClass.getPseudoClass("showing")) == false);
+        assertFalse(pseudoClassStates.contains(PseudoClass.getPseudoClass("showing")));
 
         comboBox.arm();
-        pseudoClassStates = comboBox.getPseudoClassStates();
         assertTrue(pseudoClassStates.contains(PseudoClass.getPseudoClass("armed")));
 
     }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -9367,12 +9367,13 @@ public abstract class Node implements EventTarget, Styleable {
 
     // package so that StyleHelper can get at it
     final ObservableSet<PseudoClass> pseudoClassStates = new PseudoClassState();
-    final ObservableSet<PseudoClass> unmodifiablePseudoClassStates =
+    private final ObservableSet<PseudoClass> unmodifiablePseudoClassStates =
             FXCollections.unmodifiableObservableSet(pseudoClassStates);
     /**
      * @return The active pseudo-class states of this Node, wrapped in an unmodifiable ObservableSet
      * @since JavaFX 8.0
      */
+    @Override
     public final ObservableSet<PseudoClass> getPseudoClassStates() {
         return unmodifiablePseudoClassStates;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -9367,14 +9367,14 @@ public abstract class Node implements EventTarget, Styleable {
 
     // package so that StyleHelper can get at it
     final ObservableSet<PseudoClass> pseudoClassStates = new PseudoClassState();
+    final ObservableSet<PseudoClass> unmodifiablePseudoClassStates =
+            FXCollections.unmodifiableObservableSet(pseudoClassStates);
     /**
      * @return The active pseudo-class states of this Node, wrapped in an unmodifiable ObservableSet
      * @since JavaFX 8.0
      */
     public final ObservableSet<PseudoClass> getPseudoClassStates() {
-
-        return FXCollections.unmodifiableObservableSet(pseudoClassStates);
-
+        return unmodifiablePseudoClassStates;
     }
 
     // Walks up the tree telling each parent that the pseudo class state of

--- a/modules/javafx.graphics/src/shims/java/javafx/scene/NodeShim.java
+++ b/modules/javafx.graphics/src/shims/java/javafx/scene/NodeShim.java
@@ -28,6 +28,8 @@ package javafx.scene;
 import com.sun.javafx.scene.DirtyBits;
 import com.sun.javafx.sg.prism.NGNode;
 
+import javafx.collections.ObservableSet;
+import javafx.css.PseudoClass;
 import javafx.scene.transform.Transform;
 
 public class NodeShim {
@@ -74,5 +76,9 @@ public class NodeShim {
 
     public static <P extends NGNode> P getPeer(Node n) {
         return n.getPeer();
+    }
+
+    public static ObservableSet<PseudoClass> pseudoClassStates(Node n) {
+        return n.pseudoClassStates;
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/NodeTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/NodeTest.java
@@ -44,7 +44,10 @@ import test.com.sun.javafx.test.objects.TestScene;
 import test.com.sun.javafx.test.objects.TestStage;
 import com.sun.javafx.tk.Toolkit;
 import com.sun.javafx.util.Utils;
+import javafx.beans.InvalidationListener;
 import javafx.beans.property.*;
+import javafx.collections.SetChangeListener;
+import javafx.css.PseudoClass;
 import javafx.geometry.BoundingBox;
 import javafx.geometry.Bounds;
 import javafx.geometry.NodeOrientation;
@@ -59,8 +62,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 import java.util.Comparator;
+import java.util.Set;
+
 import javafx.scene.Group;
 import javafx.scene.GroupShim;
 import javafx.scene.Node;
@@ -164,8 +170,53 @@ public class NodeTest {
     @Test
     public void testGetPseudoClassStatesShouldReturnSameSet() {
         Rectangle node = new Rectangle();
+        Set<PseudoClass> set1 = node.getPseudoClassStates();
+        Set<PseudoClass> set2 = node.getPseudoClassStates();
         assertSame("getPseudoClassStates() should always return the same instance",
-                node.getPseudoClassStates(), node.getPseudoClassStates());
+                set1, set2);
+    }
+
+    @Test(expected=UnsupportedOperationException.class)
+    public void testPseudoClassStatesIsUnmodifiable() {
+        Node node = new Rectangle();
+        node.getPseudoClassStates().add(PseudoClass.getPseudoClass("dummy"));
+    }
+
+    @Test
+    public void testUnmodifiablePseudoClassStatesEqualsBackingStates() {
+        Rectangle node = new Rectangle();
+        PseudoClass pseudo = PseudoClass.getPseudoClass("Pseudo");
+        node.pseudoClassStateChanged(pseudo, true);
+        assertEquals(1, node.getPseudoClassStates().size());
+        assertEquals(NodeShim.pseudoClassStates(node).size(), node.getPseudoClassStates().size());
+        assertTrue(NodeShim.pseudoClassStates(node).contains(pseudo));
+        assertTrue(node.getPseudoClassStates().contains(pseudo));
+    }
+
+    private boolean isInvalidationListenerInvoked;
+    private boolean isChangeListenerInvoked;
+    @Test
+    public void testPseudoClassStatesListenersAreInvoked() {
+        Rectangle node = new Rectangle();
+        node.getPseudoClassStates().addListener((InvalidationListener) inv -> {
+            isInvalidationListenerInvoked = true;
+        });
+        node.getPseudoClassStates().addListener((SetChangeListener<PseudoClass>) c -> {
+            isChangeListenerInvoked = true;
+        });
+
+        PseudoClass pseudo = PseudoClass.getPseudoClass("Pseudo");
+        node.pseudoClassStateChanged(pseudo, true);
+        assertTrue(isInvalidationListenerInvoked);
+        assertTrue(isChangeListenerInvoked);
+    }
+
+    @Test
+    public void testPseudoClassStatesNotGCed() {
+        Node node = new Rectangle();
+        WeakReference<Set<?>> weakRef = new WeakReference<>(node.getPseudoClassStates());
+        TestUtils.attemptGC(weakRef);
+        assertNotNull("pseudoClassStates must not be gc'ed", weakRef.get());
     }
 
 // TODO disable this because it depends on TestNode

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/NodeTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/NodeTest.java
@@ -161,6 +161,13 @@ public class NodeTest {
      *                                                                         *
      **************************************************************************/
 
+    @Test
+    public void testGetPseudoClassStatesShouldReturnSameSet() {
+        Rectangle node = new Rectangle();
+        assertSame("getPseudoClassStates() should always return the same instance",
+                node.getPseudoClassStates(), node.getPseudoClassStates());
+    }
+
 // TODO disable this because it depends on TestNode
 //    @Test public void testPeerNotifiedOfVisibilityChanges() {
 //        Rectangle rect = new Rectangle();

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/shape/TestUtils.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/shape/TestUtils.java
@@ -30,6 +30,7 @@ import com.sun.javafx.sg.prism.NGNode;
 import com.sun.prism.paint.Color;
 import javafx.scene.Node;
 
+import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 
 import static org.junit.Assert.*;
@@ -125,5 +126,21 @@ public abstract class TestUtils {
 
     public static Object getObjectValue(Node node, String pgPropertyName) throws Exception {
         return getObjectValue(node, pgPropertyName, false);
+    }
+
+    public static void attemptGC(WeakReference<?> weakRef) {
+        for (int i = 0; i < 10; i++) {
+            System.gc();
+            System.runFinalization();
+
+            if (weakRef.get() == null) {
+                break;
+            }
+            try {
+                Thread.sleep(50);
+            } catch (InterruptedException e) {
+                fail("InterruptedException occurred during Thread.sleep()");
+            }
+        }
     }
 }


### PR DESCRIPTION
Node.getPseudoClassStates() returns a new UnmodifiableObservableSet of PseudoClassState on each call. So in order to listen to any changes in this set, user must call the method Node.getPseudoClassStates() only once and keep a strong reference to the returned UnmodifiableObservableSet.
 
So the fix is that the method Node.getPseudoClassStates() should return the same UnmodifiableObservableSet on every call.
As the returned set is an UnmodifiableObservableSet, it will not have any impact on it's usage.
 
Added a small unit test. and,
Altered(minor) a test which was modified in past(https://github.com/openjdk/jfx/commit/0ac98695a1b11443c342fad4f009d6e03a052522) (https://github.com/openjdk/jfx/commit/62323e0a9c5817b33daa262d6914eba0e8d274ff) along with this method and should be updated in view of this change.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8214699](https://bugs.openjdk.java.net/browse/JDK-8214699): Node.getPseudoClassStates must return the same instance on every call


### Reviewers
 * Jeanette Winzenburg ([fastegal](@kleopatra) - Committer)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/253/head:pull/253`
`$ git checkout pull/253`
