### PR TITLE
8201570: Get two bytes for the Linux input event type, not four

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxEventBuffer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxEventBuffer.java
@@ -90,7 +90,7 @@ class LinuxEventBuffer {
      */
     synchronized boolean put(ByteBuffer event) throws
             InterruptedException {
-        boolean isSync = event.getInt(eventStruct.getTypeIndex()) == 0
+        boolean isSync = event.getShort(eventStruct.getTypeIndex()) == 0
                 && event.getInt(eventStruct.getValueIndex()) == 0;
         while (bb.limit() - bb.position() < event.limit()) {
             // Block if bb is full. This should be the


### PR DESCRIPTION
Fixes [JDK-8201570](https://bugs.openjdk.java.net/browse/JDK-8201570).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8201570](https://bugs.openjdk.java.net/browse/JDK-8201570): Get two bytes for the Linux input event type, not four


### Reviewers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/257/head:pull/257`
`$ git checkout pull/257`
