### PR TITLE
8248551: [TestBug] Ignore two failing FXML unit tests which use Nashorn script engine

### DIFF
--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/FXMLLoader_ScriptTest.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/FXMLLoader_ScriptTest.java
@@ -1,6 +1,6 @@
 package test.javafx.fxml;
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,8 +31,11 @@ import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.LoadListener;
+import javax.script.ScriptEngineManager;
+import javax.script.ScriptEngine;
 
 import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
 
 public class FXMLLoader_ScriptTest {
     @Test
@@ -130,6 +133,10 @@ public class FXMLLoader_ScriptTest {
     @Test
     public void testScriptHandler() throws IOException {
 
+        // This test needs Nashorn script engine.
+        // Test will be rewritten under - JDK-8245568
+        assumeTrue(isNashornEngineAvailable());
+
         FXMLLoader loader = new FXMLLoader(getClass().getResource("script_handler.fxml"));
         loader.load();
 
@@ -143,6 +150,10 @@ public class FXMLLoader_ScriptTest {
     @Test
     public void testExternalScriptHandler() throws IOException {
 
+        // This test needs Nashorn script engine.
+        // Test will be rewritten under - JDK-8245568
+        assumeTrue(isNashornEngineAvailable());
+
         FXMLLoader loader = new FXMLLoader(getClass().getResource("script_handler_external.fxml"));
         loader.load();
 
@@ -151,5 +162,12 @@ public class FXMLLoader_ScriptTest {
         loader.getNamespace().put("actionDone", new AtomicBoolean(false));
         w.fire();
         assertTrue(((AtomicBoolean)loader.getNamespace().get("actionDone")).get());
+    }
+
+    private boolean isNashornEngineAvailable() {
+        ScriptEngineManager factory = new ScriptEngineManager();
+        ScriptEngine engine = factory.getEngineByName("nashorn");
+
+        return (engine != null);
     }
 }


### PR DESCRIPTION
Issue : https://bugs.openjdk.java.net/browse/JDK-8248551
Fix : Added a check whether 'Nashorn' script engine is available before running the identified tests, otherwise tests are ignored.

Testing : 
1) With JDK-14, these tests pass- but they log a warning (same as existing behavior without this PR)
2) With JDK-15-ea, these tests get ignored.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248551](https://bugs.openjdk.java.net/browse/JDK-8248551): [TestBug] Ignore two failing FXML unit tests which use Nashorn script engine


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/259/head:pull/259`
`$ git checkout pull/259`
