### PR TITLE
Animation redesign

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/ClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/ClipEnvelope.java
@@ -73,7 +73,7 @@ public abstract class ClipEnvelope {
     protected ClipEnvelope(Animation animation) {
         this.animation = animation;
         if (animation != null) {
-            cycleTicks = TickCalculation.fromDuration(animation.getCycleDuration());
+            updateCycleTicks(animation.getCycleDuration());
             rate = animation.getRate();
         }
     }
@@ -92,6 +92,7 @@ public abstract class ClipEnvelope {
     public abstract ClipEnvelope setCycleDuration(Duration cycleDuration);
     public abstract ClipEnvelope setCycleCount(int cycleCount);
     public abstract void setRate(double rate);
+    public abstract int getCycleNum();
 
     /**
      * Calculates the {@link Animation#currentRateProperty() currentRate} for a running animation.

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/ClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/ClipEnvelope.java
@@ -194,7 +194,6 @@ public abstract class ClipEnvelope {
         }
 
         if (ticksChange == 0) {
-            new Throwable().printStackTrace();
             if (!animation.getCuePoints().isEmpty())
                 System.out.println("delta = 0");
             return;

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/ClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/ClipEnvelope.java
@@ -69,6 +69,7 @@ public abstract class ClipEnvelope {
      * The current position of the play head. 0 <= ticks <= totalTicks for finite cycles, any value for infinite cycles.
      */
     protected long ticks = 0;
+
     protected boolean inTimePulse = false;
     protected boolean aborted = false;
 
@@ -233,18 +234,18 @@ public abstract class ClipEnvelope {
         if (!animation.getCuePoints().isEmpty())
             System.out.println("jump newDest = " + newDest);
         final long oldTicks = ticks;
-        ticks = newDest;// calculateNewTicks(newDest);
-        if (!animation.getCuePoints().isEmpty())
-            System.out.println("jump new ticks = " + ticks);
-
+        ticks = newDest;
         final long ticksChange = ticks - oldTicks;
+        if (!animation.getCuePoints().isEmpty())
+            System.out.println("ticks: " + oldTicks + " -> " + ticks + " = " + ticksChange);
         if (ticksChange == 0) {
             if (!animation.getCuePoints().isEmpty()) {
                 System.out.println("jump ticksChange = 0");
             }
-            return;
+//            return;
         }
-
+        if (!animation.getCuePoints().isEmpty())
+            System.out.println("jump old deltaTicks = " + deltaTicks);
         deltaTicks += ticksChange;
         if (!animation.getCuePoints().isEmpty())
             System.out.println("jump new deltaTicks = " + deltaTicks);

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/FiniteClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/FiniteClipEnvelope.java
@@ -28,7 +28,6 @@ package com.sun.scenario.animation.shared;
 import com.sun.javafx.util.Utils;
 
 import javafx.animation.Animation;
-import javafx.animation.Animation.Status;
 import javafx.util.Duration;
 
 /**
@@ -86,38 +85,7 @@ public class FiniteClipEnvelope extends MultiLoopClipEnvelope {
     }
 
     @Override
-    protected long calculatePulseTicks(long newDest) {
+    protected long calculateNewTicks(long newDest) {
         return Utils.clamp(0, deltaTicks + newDest, totalTicks);
-    }
-
-    @Override
-    public void jumpTo(long newTicks) {
-        if (cycleTicks == 0L) {
-            return;
-        }
-
-        final long oldTicks = ticks;
-        ticks = Utils.clamp(0, newTicks, totalTicks);
-        final long delta = ticks - oldTicks;
-//        System.out.println("delta = " + delta);
-        if (delta == 0) {
-//            System.out.println();
-//            return;
-        }
-        deltaTicks += delta;
-        cyclePos = ticks % cycleTicks;
-        if (autoReverse && animation.getStatus() == Status.RUNNING) {
-             setAnimationCurrentRate(calculateCurrentRunningRate()); // needed? a pulse calculates the rate anyway, but needed if cached
-        } 
-        if ((cyclePos == 0) && (ticks != 0)) { // TODO: check when pos = 0 and when pos = cycleticks
-            cyclePos = cycleTicks;
-        }
-
-//        System.out.println("pos = " + TickCalculation.toMillis(pos));
-//        System.out.println("rate = " + rate);
-        AnimationAccessor.getDefault().jumpTo(animation, cyclePos, cycleTicks, false);
-        abortCurrentPulse();
-
-//        System.out.println();
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/FiniteClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/FiniteClipEnvelope.java
@@ -86,7 +86,7 @@ public class FiniteClipEnvelope extends MultiLoopClipEnvelope {
     }
 
     @Override
-    protected long calculateNewTicks(long newDest) {
+    protected long calculatePulseTicks(long newDest) {
         return Utils.clamp(0, deltaTicks + newDest, totalTicks);
     }
 
@@ -107,7 +107,7 @@ public class FiniteClipEnvelope extends MultiLoopClipEnvelope {
         deltaTicks += delta;
         cyclePos = ticks % cycleTicks;
         if (autoReverse && animation.getStatus() == Status.RUNNING) {
-             setCurrentRate(calculateCurrentRunningRate()); // needed? a pulse calculates the rate anyway, but needed if cached
+             setAnimationCurrentRate(calculateCurrentRunningRate()); // needed? a pulse calculates the rate anyway, but needed if cached
         } 
         if ((cyclePos == 0) && (ticks != 0)) { // TODO: check when pos = 0 and when pos = cycleticks
             cyclePos = cycleTicks;

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/FiniteClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/FiniteClipEnvelope.java
@@ -76,17 +76,17 @@ public class FiniteClipEnvelope extends MultiLoopClipEnvelope {
 
     @Override
     public void setRate(double newRate) {
-//        final boolean toggled = isDirectionChanged(newRate);
-//        final long newTicks = toggled ? totalTicks - ticks : ticks;
-        if (animation.getStatus() != Status.STOPPED) {
+//      boolean switchedDirection = newRate * rate < 0;
+//      final long newTicks = switchedDirection ? totalTicks - ticks : ticks;
+      if (animation.getStatus() != Status.STOPPED) {
 //          deltaTicks = newTicks - (switchedDirection ? -1 : 1) * ticksRateChange(newRate); d + T - 2t
-            deltaTicks = ticks - ticksRateChange(newRate);
-            abortCurrentPulse();
-        }
-//        ticks = newTicks;
-        System.out.println("Finite setRate ticks = " + ticks);
-        rate = newRate;
-    }
+          deltaTicks = ticks - ticksRateChange(newRate);
+          abortCurrentPulse();
+      }
+//      ticks = newTicks;
+      System.out.println("Finite setRate ticks = " + ticks);
+      rate = newRate;
+  }
 
     // Fails on auto-reverse even cycle count when switching
    @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/FiniteClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/FiniteClipEnvelope.java
@@ -41,6 +41,8 @@ public class FiniteClipEnvelope extends MultiLoopClipEnvelope {
 
     protected FiniteClipEnvelope(Animation animation) {
         super(animation);
+        if (!animation.getCuePoints().isEmpty())
+            System.out.println("FiniteClipEnvelope");
         if (animation != null) {
             autoReverse = animation.isAutoReverse();
             cycleCount = animation.getCycleCount();
@@ -68,86 +70,145 @@ public class FiniteClipEnvelope extends MultiLoopClipEnvelope {
         return this;
     }
 
-    @Override
-    public void setRate(double newRate) {
-        final boolean toggled = isDirectionChanged(newRate);
-        final long newTicks = toggled ? totalTicks - ticks : ticks;
-        final Status status = animation.getStatus();
-        if (status != Status.STOPPED) {
-            setInternalCurrentRate((Math.abs(currentRate - rate) < EPSILON) ? newRate : -newRate);
-            deltaTicks = newTicks - ticksRateChange(newRate);
-            abortCurrentPulse();
-        }
-        ticks = newTicks;
-        rate = newRate;
-    }
-
-    @Override
-    protected double calculateCurrentRate() {
-        return !autoReverse ? rate
-                : isDuringEvenCycle() == (rate > 0) ? rate : -rate;
-    }
-
     private void updateTotalTicks() {
         totalTicks = cycleCount * cycleTicks;
     }
 
     @Override
-    public void timePulse(long currentTick) {
-        if (cycleTicks == 0L) {
-            return;
+    public void setRate(double newRate) {
+//        final boolean toggled = isDirectionChanged(newRate);
+//        final long newTicks = toggled ? totalTicks - ticks : ticks;
+        if (animation.getStatus() != Status.STOPPED) {
+//          deltaTicks = newTicks - (switchedDirection ? -1 : 1) * ticksRateChange(newRate); d + T - 2t
+            deltaTicks = ticks - ticksRateChange(newRate);
+            abortCurrentPulse();
         }
-        aborted = false;
-        inTimePulse = true;
-
-        try {
-            final long oldTicks = ticks;
-            long ticksChange = Math.round(currentTick * Math.abs(rate));
-            ticks = Utils.clamp(0, deltaTicks + ticksChange, totalTicks);
-
-            final boolean reachedEnd = ticks >= totalTicks;
-
-            long overallDelta = ticks - oldTicks; // overall delta between current position and new position
-            if (overallDelta == 0) {
-                return;
-            }
-
-            long cycleDelta = (currentRate > 0) ? cycleTicks - cyclePos : cyclePos; // delta to reach end of cycle
-
-            while (overallDelta >= cycleDelta) {
-                if (cycleDelta > 0) {
-                    cyclePos = (currentRate > 0)? cycleTicks : 0;
-                    overallDelta -= cycleDelta;
-                    AnimationAccessor.getDefault().playTo(animation, cyclePos, cycleTicks);
-                    if (aborted) {
-                        return;
-                    }
-                }
-
-                if (!reachedEnd || (overallDelta > 0)) {
-                    if (autoReverse) {
-                        setCurrentRate(-currentRate);
-                    } else {
-                        cyclePos = (currentRate > 0)? 0 : cycleTicks;
-                        AnimationAccessor.getDefault().jumpTo(animation, cyclePos, cycleTicks, false);
-                    }
-                }
-                cycleDelta = cycleTicks;
-            }
-
-            if (overallDelta > 0 && !reachedEnd) {
-                cyclePos += (currentRate > 0) ? overallDelta : -overallDelta;
-                AnimationAccessor.getDefault().playTo(animation, cyclePos, cycleTicks);
-            }
-
-            if(reachedEnd && !aborted) {
-                AnimationAccessor.getDefault().finished(animation);
-            }
-
-        } finally {
-            inTimePulse = false;
-        }
+//        ticks = newTicks;
+        System.out.println("Finite setRate ticks = " + ticks);
+        rate = newRate;
     }
+
+    // Fails on auto-reverse even cycle count when switching
+   @Override
+   protected boolean isDuringEvenCycle() {
+       System.out.println("startPositive = " + startedPositive);
+       System.out.println("rate > 0 = " + (rate > 0));
+       System.out.println("cycleCount % 2 = " + (cycleCount % 2 == 0));
+       if (rate > 0) {
+           if (!startedPositive && cycleCount % 2 == 0) {
+               return isDuringNegEvenCycle();
+           }
+           return isDuringPosEvenCycle();
+//           System.out.println("isDuringEvenCycle rate > 0 = " + b);
+//           return b;
+       } else {
+           if (startedPositive && cycleCount % 2 == 0) {
+               return isDuringPosEvenCycle();
+           }
+           return isDuringNegEvenCycle();
+           
+//           System.out.println("isDuringEvenCycle rate < 0 = " + b);
+//           return b;
+       }
+   }
+
+   protected boolean isDuringPosEvenCycle() {
+       return ticks % (2 * cycleTicks) < cycleTicks;
+   }
+
+   protected boolean isDuringNegEvenCycle() {
+       return (totalTicks - ticks) % (2 * cycleTicks) < cycleTicks;
+   }
+
+   @Override
+   public void timePulse(long destinationTick) {
+       if (cycleTicks == 0L) {
+           return;
+       }
+       aborted = false;
+       inTimePulse = true;
+
+       System.out.println("dest = " + destinationTick);
+
+       try {
+           double currentRate = calculateCurrentRunningRate();
+           System.out.println("rate, curRate = " + rate + ", " + currentRate);
+           final long oldTicks = ticks;
+           System.out.println("oldTicks = " + oldTicks);
+           System.out.println("deltaTicks = " + deltaTicks);
+           destinationTick = Math.round(destinationTick * currentRate);
+           if (autoReverse && !isDuringEvenCycle()) {
+               destinationTick = -destinationTick;
+           }
+           System.out.println("new dest = " + destinationTick);
+//           long ticksChange = Math.round(destinationTick * Math.abs(rate));
+           ticks = Utils.clamp(0, deltaTicks + destinationTick, totalTicks);
+           System.out.println("ticks = " + ticks);
+
+           // overall delta between current position and new position. always >= 0
+           long overallDelta = Math.abs(ticks - oldTicks);
+           System.out.println("overallDelta = " + overallDelta);
+           if (overallDelta == 0) {
+               System.out.println("delta = 0");
+//               return;
+           }
+
+           System.out.println("cyclePos = " + cyclePos);
+//           currentRate = calculateCurrentRunningRate();
+//           System.out.println("Finite pulse rate = " + currentRate);
+
+           final boolean reachedEnd = (rate > 0) ? (ticks == totalTicks) : (ticks == 0);
+           System.out.println("reachedEnd = " + reachedEnd);
+
+           // delta to reach end of cycle, always >= 0. 0 if at the start/end of a cycle
+           long cycleDelta = currentRate > 0 ? cycleTicks - cyclePos : cyclePos;
+           System.out.println("cycleDelta = " + cycleDelta);
+
+           // check if the end of the cycle is inside the range of [currentTick, destinationTick]
+           // If yes, advance to the end of the cycle and pass the rest of the ticks to the next cycle.
+           // If the next cycle is completed, continue to the next etc.
+//           long leftoverTicks = Math.abs(overallDelta) - cycleDelta;
+           while (overallDelta >= cycleDelta) {
+               cyclePos = (currentRate > 0) ? cycleTicks : 0;
+               System.out.println("finishing cycle cyclePos = " + cyclePos + " ------------------------");
+               AnimationAccessor.getDefault().playTo(animation, cyclePos, cycleTicks);
+               if (aborted) {
+                   return;
+               }
+               overallDelta -= cycleDelta;
+               System.out.println("leftover delta = " + overallDelta);
+
+               if (overallDelta > 0 || !reachedEnd) {
+                   if (autoReverse) { // change direction
+                       setCurrentRate(-currentRate);
+                       currentRate = -currentRate;
+                       System.out.println("switching direction to " + currentRate + " ------------------------");
+                   } else { // jump back to the the cycle
+                       cyclePos = (currentRate > 0) ? 0 : cycleTicks;
+                       System.out.println("restaring cycle cyclePos = " + cyclePos + " ------------------------");
+                       AnimationAccessor.getDefault().jumpTo(animation, cyclePos, cycleTicks, false);
+                   }
+               }
+               cycleDelta = cycleTicks;
+           }
+
+           if (overallDelta > 0/* && !reachedEnd */) {
+//               cyclePos += Math.signum(currentRate) * overallDelta;
+               cyclePos += (currentRate > 0) ? overallDelta : -overallDelta;
+               System.out.println("new cyclePos = " + cyclePos);
+               AnimationAccessor.getDefault().playTo(animation, cyclePos, cycleTicks);
+           }
+
+           if (reachedEnd && !aborted) {
+               System.out.println("finished");
+               AnimationAccessor.getDefault().finished(animation);
+           }
+           System.out.println();
+
+       } finally {
+           inTimePulse = false;
+       }
+   }
 
     @Override
     public void jumpTo(long newTicks) {
@@ -156,38 +217,51 @@ public class FiniteClipEnvelope extends MultiLoopClipEnvelope {
         }
 
         final long oldTicks = ticks;
-        if (rate < 0) {
-            newTicks = totalTicks - newTicks;
-        }
+//        if (rate < 0) {
+//            newTicks = totalTicks - newTicks;
+//        }
         ticks = Utils.clamp(0, newTicks, totalTicks);
         final long delta = ticks - oldTicks;
-        if (delta != 0) {
-            deltaTicks += delta;
-            if (autoReverse) {
-                final boolean forward = ticks % (2 * cycleTicks) < cycleTicks;
-                if (forward == (rate > 0)) {
-                    cyclePos = ticks % cycleTicks;
-                    if (animation.getStatus() == Status.RUNNING) {
-                        setCurrentRate(Math.abs(rate));
-                    }
-                } else {
-                    cyclePos = cycleTicks - (ticks % cycleTicks);
-                    if (animation.getStatus() == Status.RUNNING) {
-                        setCurrentRate(-Math.abs(rate));
-                    }
-                }
-            } else {
-                cyclePos = ticks % cycleTicks;
-                if (rate < 0) {
-                    cyclePos = cycleTicks - cyclePos;
-                }
-                if ((cyclePos == 0) && (ticks > 0)) {
-                    cyclePos = cycleTicks;
-                }
-            }
-
-            AnimationAccessor.getDefault().jumpTo(animation, cyclePos, cycleTicks, false);
-            abortCurrentPulse();
+//        System.out.println("delta = " + delta);
+        if (delta == 0) {
+//            System.out.println();
+//            return;
         }
+        deltaTicks += delta;
+        cyclePos = ticks % cycleTicks;
+        if (autoReverse) {
+//            pos = ticks % cycleTicks;
+            if (animation.getStatus() == Status.RUNNING) {
+                setCurrentRate(calculateCurrentRunningRate()); // needed? a pulse calculates the rate anyway
+            }
+//            if (isDuringForwardCycle() == (rate > 0)) { // TODO: should use calculateCurrentRate
+////                pos = ticks % cycleTicks;
+//                if (animation.getStatus() == Status.RUNNING) {
+//                    // this rate is never 0, even though the anim one is, so setting the current
+//                    // rate can be wrong because it is based on an older rate
+//                    setCurrentRate(Math.abs(rate));
+//                }
+//            } else {
+// //               pos = cycleTicks - (ticks % cycleTicks);
+//                if (animation.getStatus() == Status.RUNNING) {
+//                    setCurrentRate(-Math.abs(rate));
+//                }
+//            }
+        } //else {
+//            pos = ticks % cycleTicks;
+//            if (rate < 0) {
+//                pos = cycleTicks - pos;
+//            }
+            if ((cyclePos == 0) && (ticks != 0)) { // TODO: check when pos = 0 and when pos = cycleticks
+                cyclePos = cycleTicks;
+            }
+ //       }
+
+//        System.out.println("pos = " + TickCalculation.toMillis(pos));
+//        System.out.println("rate = " + rate);
+        AnimationAccessor.getDefault().jumpTo(animation, cyclePos, cycleTicks, false);
+        abortCurrentPulse();
+
+//        System.out.println();
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/FiniteClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/FiniteClipEnvelope.java
@@ -88,7 +88,6 @@ public class FiniteClipEnvelope extends MultiLoopClipEnvelope {
       rate = newRate;
   }
 
-    // Fails on auto-reverse even cycle count when switching
    @Override
    protected boolean isDuringEvenCycle() {
        System.out.println("startPositive = " + startedPositive);

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/InfiniteClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/InfiniteClipEnvelope.java
@@ -26,7 +26,6 @@
 package com.sun.scenario.animation.shared;
 
 import javafx.animation.Animation;
-import javafx.animation.Animation.Status;
 import javafx.util.Duration;
 
 /**
@@ -77,55 +76,12 @@ public class InfiniteClipEnvelope extends MultiLoopClipEnvelope {
     }
 
     @Override
-    protected long calculatePulseTicks(long newDest) {
+    protected long calculateNewTicks(long newDest) {
         return deltaTicks + newDest;
-    }
-
-    /**
-     * {@link Animation#jumpTo(Duration)} already deals with jumping to the end of an infinite animation by jumping to
-     * the end of a cycle. 
-     */
-    @Override
-    public void jumpTo(long newTicks) {
-        if (cycleTicks == 0L) {
-            return;
-        }
-        final long oldTicks = ticks;
-        ticks = Math.max(0, newTicks) % (2 * cycleTicks);
-        
-        if (!animation.getCuePoints().isEmpty())
-            System.out.println("jump new ticks = " + ticks);
-            
-        final long delta = Math.abs(ticks - oldTicks);
-        if (delta == 0) {
-            if (!animation.getCuePoints().isEmpty()) {
-                System.out.println("jump new delta = 0");
-                new Throwable().printStackTrace();
-            }
-                
-            return;
-        }
-
-        deltaTicks += delta;
-        if (!animation.getCuePoints().isEmpty())
-            System.out.println("jump new deltaTicks = " + deltaTicks);
-            
-        cyclePos = ticks % cycleTicks;
-        if (!animation.getCuePoints().isEmpty())
-            System.out.println("jump new cyclePos = " + cyclePos);
-        
-        if (autoReverse && animation.getStatus() == Status.RUNNING) {
-//            double currentRate = calculateCurrentRunningRate();
-//            setCurrentRate(currentRate); // needed? a pulse calculates the rate anyway, but needed if cached
-//            System.out.println("jump new cur rate = " + currentRate);
-        }
-        if ((cyclePos == 0) && (ticks != 0)) { // TODO: check when pos = 0 and when pos = cycleticks
-            cyclePos = cycleTicks;
-        }
-        AnimationAccessor.getDefault().jumpTo(animation, cyclePos, cycleTicks, false);
-        abortCurrentPulse();
-        
-        if (!animation.getCuePoints().isEmpty())
-            System.out.println();
+        // ticks = Math.max(0, newTicks) % (2 * cycleTicks); for jump?
+        /**
+         * {@link Animation#jumpTo(Duration)} already deals with jumping to the end of an infinite animation by jumping to
+         * the end of a cycle. 
+         */
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/InfiniteClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/InfiniteClipEnvelope.java
@@ -94,7 +94,7 @@ public class InfiniteClipEnvelope extends MultiLoopClipEnvelope {
     }
 
     @Override
-    public void timePulse(long currentTick) {
+    public void timePulse(long destinationTick) {
         if (cycleTicks == 0L) {
             return;
         }
@@ -106,7 +106,7 @@ public class InfiniteClipEnvelope extends MultiLoopClipEnvelope {
             System.out.println("curRate = " + currentRate);
 
             final long oldTicks = ticks;
-            long ticksChange = Math.round(currentTick * Math.abs(rate));
+            long ticksChange = Math.round(destinationTick * rate);
             ticks = Math.max(0, deltaTicks + ticksChange);
 
             long overallDelta = ticks - oldTicks; // overall delta between current position and new position

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/InfiniteClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/InfiniteClipEnvelope.java
@@ -60,7 +60,7 @@ public class InfiniteClipEnvelope extends MultiLoopClipEnvelope {
     @Override
     public void setRate(double rate) {
         if (animation.getStatus() != Status.STOPPED) {
-            boolean switchedDirection = isDirectionChanged(rate);
+            boolean switchedDirection = false;// isDirectionChanged(rate);
             deltaTicks = ticks + (switchedDirection ? ticksRateChange(rate) : -ticksRateChange(rate));
             if (switchedDirection) {
                 final long delta = 2 * cycleTicks - cyclePos;
@@ -75,14 +75,22 @@ public class InfiniteClipEnvelope extends MultiLoopClipEnvelope {
 
     protected boolean isDuringEvenCycle() {
         if (rate > 0) {
-            boolean b = ticks % (2 * cycleTicks) < cycleTicks;
+            boolean b = isDuringPosEvenCycle();
             System.out.println("isDuringEvenCycle = " + b);
             return b;
         } else {
-            boolean b = (2 * cycleTicks - ticks) % (2 * cycleTicks) < cycleTicks;
+            boolean b = isDuringNegEvenCycle();
             System.out.println("isDuringEvenCycle = " + b);
             return b;
         }
+    }
+
+    protected boolean isDuringPosEvenCycle() {
+        return ticks % (2 * cycleTicks) < cycleTicks;
+    }
+
+    protected boolean isDuringNegEvenCycle() {
+        return (2 * cycleTicks - ticks) % (2 * cycleTicks) < cycleTicks;
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/InfiniteClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/InfiniteClipEnvelope.java
@@ -59,17 +59,16 @@ public class InfiniteClipEnvelope extends MultiLoopClipEnvelope {
 
     @Override
     public int getCycleNum() {
+        long cycleNum;
         if (startedPositive) {
-            long cycleNum = ticks / cycleTicks;
-            long i = ticks >= 0 ? cycleNum : cycleNum - 1;
-            System.out.println("getCycleNum effectiveNum = " + i);
-            return (int) i;
+            cycleNum = ticks / cycleTicks;
+            cycleNum = ticks >= 0 ? cycleNum : cycleNum - 1;
         } else {
-            long cycleNum = -(ticks - cycleTicks) / cycleTicks;
-            long i = ticks <= cycleTicks ? cycleNum : cycleNum - 1;
-            System.out.println("getCycleNum effectiveNum = " + i);
-            return (int) i;
+            cycleNum = -(ticks - cycleTicks) / cycleTicks;
+            cycleNum = ticks <= cycleTicks ? cycleNum : cycleNum - 1;
         }
+        System.out.println("getCycleNum cycleNum = " + cycleNum);
+        return (int) cycleNum;
     }
 
     @Override
@@ -78,7 +77,7 @@ public class InfiniteClipEnvelope extends MultiLoopClipEnvelope {
     }
 
     @Override
-    protected long calculateNewTicks(long newDest) {
+    protected long calculatePulseTicks(long newDest) {
         return deltaTicks + newDest;
     }
 
@@ -94,13 +93,27 @@ public class InfiniteClipEnvelope extends MultiLoopClipEnvelope {
         final long oldTicks = ticks;
         ticks = Math.max(0, newTicks) % (2 * cycleTicks);
         
-        System.out.println("jump new ticks = " + ticks);
-        final long delta = ticks - oldTicks;
+        if (!animation.getCuePoints().isEmpty())
+            System.out.println("jump new ticks = " + ticks);
+            
+        final long delta = Math.abs(ticks - oldTicks);
         if (delta == 0) {
+            if (!animation.getCuePoints().isEmpty()) {
+                System.out.println("jump new delta = 0");
+                new Throwable().printStackTrace();
+            }
+                
             return;
         }
+
         deltaTicks += delta;
+        if (!animation.getCuePoints().isEmpty())
+            System.out.println("jump new deltaTicks = " + deltaTicks);
+            
         cyclePos = ticks % cycleTicks;
+        if (!animation.getCuePoints().isEmpty())
+            System.out.println("jump new cyclePos = " + cyclePos);
+        
         if (autoReverse && animation.getStatus() == Status.RUNNING) {
 //            double currentRate = calculateCurrentRunningRate();
 //            setCurrentRate(currentRate); // needed? a pulse calculates the rate anyway, but needed if cached
@@ -111,6 +124,8 @@ public class InfiniteClipEnvelope extends MultiLoopClipEnvelope {
         }
         AnimationAccessor.getDefault().jumpTo(animation, cyclePos, cycleTicks, false);
         abortCurrentPulse();
-        System.out.println();
+        
+        if (!animation.getCuePoints().isEmpty())
+            System.out.println();
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/MultiLoopClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/MultiLoopClipEnvelope.java
@@ -68,30 +68,20 @@ abstract class MultiLoopClipEnvelope extends ClipEnvelope {
     }
 
     public double calculateCurrentRunningRate() {
-        double curRate = (!isAutoReverse() || isDuringEvenCycle()) ? rate : -rate;
-//        if (autoReverse && !isDuringEvenCycle()) {
-//            curRate = -curRate;
-//        }
+        boolean b = shouldNegateRate();
+        System.out.println("shouldNegateRate = " + b);
+        double curRate = b ? -rate : rate;
         return curRate;
     }
 
-    protected boolean isDuringEvenCycle() {
-//      if (rate > 0) {
-        // 0 - 11999 T
-        // 12k - 23999 F
-        // 24k - 25999 T
-        // 36k F
-        boolean b = ticks % (2 * cycleTicks) < cycleTicks;
-        System.out.println("isDuringEvenCycle = " + b);
-        return b;
-//      } else {
-        // 0 F
-        // 1 - 12k T
-        // 12001 - 24k F
-        // 24001 - 36k T
-//          boolean b = ticks % (2 * cycleTicks) < cycleTicks;
-//          return b;
-//      }
+    private boolean shouldNegateRate() {
+        return isAutoReverse() && !isDuringEffectiveEvenCycle();
+    }
+
+    private boolean isDuringEffectiveEvenCycle() {
+        boolean effectiveEven = getCycleNum() % 2 == 0;
+        System.out.println("isDuringEffectiveEvenCycle = " + effectiveEven);
+        return effectiveEven;
     }
 
     protected boolean isDirectionChanged(double newRate) {

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/MultiLoopClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/MultiLoopClipEnvelope.java
@@ -98,13 +98,9 @@ abstract class MultiLoopClipEnvelope extends ClipEnvelope {
         return newRate * rate < 0;
     }
 
-    protected long ticksRateChange(double newRate) {
-        return Math.round((ticks - deltaTicks) * Math.abs(newRate / rate));
-     }
-
     @Override
     public void start() {
         super.start();
-        startedPositive = !(rate <= 0); // TODO: rate == 0 should be handled. it's in Animation
+        startedPositive = rate >= 0; // TODO: rate == 0 should be handled. it's in Animation
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/MultiLoopClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/MultiLoopClipEnvelope.java
@@ -117,6 +117,8 @@ abstract class MultiLoopClipEnvelope extends ClipEnvelope {
 
     @Override
     protected void calculateCyclePosition() {
+        if (!animation.getCuePoints().isEmpty())
+            System.out.println("jump old cyclePos = " + cyclePos);
         cyclePos = ticks % cycleTicks;
         if (!animation.getCuePoints().isEmpty())
             System.out.println("jump new cyclePos = " + cyclePos);
@@ -128,6 +130,7 @@ abstract class MultiLoopClipEnvelope extends ClipEnvelope {
         }
         if ((cyclePos == 0) && (ticks != 0)) { // TODO: check when pos = 0 and when pos = cycleticks
             cyclePos = cycleTicks;
+            System.out.println("(cyclePos == 0) && (ticks != 0) --> new cyclePos = " + cyclePos);
         }
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/SingleLoopClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/SingleLoopClipEnvelope.java
@@ -78,6 +78,11 @@ public class SingleLoopClipEnvelope extends ClipEnvelope {
     }
 
     @Override
+    public int getCycleNum() {
+        return 0;
+    }
+
+    @Override
     public double calculateCurrentRunningRate() {
         return rate;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/SingleLoopClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/SingleLoopClipEnvelope.java
@@ -88,31 +88,22 @@ public class SingleLoopClipEnvelope extends ClipEnvelope {
     }
 
     @Override
-    protected long calculatePulseTicks(long newDest) {
+    protected long calculateNewTicks(long newDest) {
         return Utils.clamp(0, deltaTicks + newDest, cycleTicks);
     }
 
     @Override
-    protected void doPlayTo(double currentRate, long ticksChange, boolean reachedEnd) {
+    protected void playTo(double currentRate, long ticksChange, boolean reachedEnd) {
         AnimationAccessor.getDefault().playTo(animation, ticks, cycleTicks);
     }
 
     @Override
-    public void jumpTo(long newTicks) {
-        if (cycleTicks == 0L) {
-            return;
-        }
+    protected void calculateCyclePosition() {
+        // no cycle position
+    }
 
-        final long oldTicks = ticks;
-        ticks = Utils.clamp(0, newTicks, cycleTicks);
-        final long delta = ticks - oldTicks;
-        if (delta == 0) {
-            return;
-        }
-        deltaTicks += delta;
-
+    @Override
+    protected void jump() {
         AnimationAccessor.getDefault().jumpTo(animation, ticks, cycleTicks, false);
-
-        abortCurrentPulse();
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/SingleLoopClipEnvelope.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/SingleLoopClipEnvelope.java
@@ -88,12 +88,12 @@ public class SingleLoopClipEnvelope extends ClipEnvelope {
     }
 
     @Override
-    protected long calculateNewTicks(long newDest) {
+    protected long calculatePulseTicks(long newDest) {
         return Utils.clamp(0, deltaTicks + newDest, cycleTicks);
     }
 
     @Override
-    protected void doPlayTo(double currentRate, long overallDelta, boolean reachedEnd) {
+    protected void doPlayTo(double currentRate, long ticksChange, boolean reachedEnd) {
         AnimationAccessor.getDefault().playTo(animation, ticks, cycleTicks);
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
@@ -818,7 +818,7 @@ public abstract class Animation {
 
         lastPlayedFinished = false;
 
-        double millis = time.isIndefinite() ? getCycleDuration().toMillis() :
+        double millis = time.isIndefinite() ? getCycleDuration().toMillis() * 2 :
             Utils.clamp(0, time.toMillis(), getTotalDuration().toMillis());
         long ticks = TickCalculation.fromMillis(millis);
 

--- a/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
@@ -990,7 +990,8 @@ public abstract class Animation {
             case STOPPED: // TODO: what if started with rate = 0 ?
                 if (startable(true)) {
                     final double rate = getRate();
-                    if (lastPlayedFinished) {
+                    if (lastPlayedFinished ) {
+                    
                         jumpTo(rate < 0 ? getTotalDuration() : Duration.ZERO);
                     }
                     doStart(true);
@@ -1056,7 +1057,6 @@ public abstract class Animation {
         if (!paused) {
             timer.removePulseReceiver(pulseReceiver);
         }
-        clipEnvelope.stop();
         doSetCurrentRate(0.0);
         setStatus(Status.STOPPED);
     }

--- a/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
@@ -1008,11 +1008,6 @@ public abstract class Animation {
         }
     }
 
-    /////////////////
-    // CHECK WHAT THE do METHODS HAD AND WHAT TTHE PARTS THAT CALLED THEM HAD. PARENT TRANSITIONS USE THESE
-    // SO MAKE SURE THE CONTENTS REMAIN
-    //////////////////
-
     void doStart(boolean forceSync) {
         sync(forceSync);
         clipEnvelope.start();

--- a/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
@@ -818,7 +818,7 @@ public abstract class Animation {
 
         lastPlayedFinished = false;
 
-        double millis = time.isIndefinite() ? getCycleDuration().toMillis() * 2 :
+        double millis = time.isIndefinite() ? getCycleDuration().toMillis() :
             Utils.clamp(0, time.toMillis(), getTotalDuration().toMillis());
         long ticks = TickCalculation.fromMillis(millis);
 
@@ -1007,7 +1007,7 @@ public abstract class Animation {
             case PAUSED:
                 doResume();
                 if (!isNearZero(getRate())) {
-                    doSetCurrentRate(clipEnvelope.calculateCurrentRunningRate());
+//                    doSetCurrentRate(clipEnvelope.calculateCurrentRunningRate());
                     resumeReceiver();
                 }
                 break;
@@ -1018,7 +1018,7 @@ public abstract class Animation {
     void doStart(boolean forceSync) {
         sync(forceSync);
 //      if (getRate() != 0) {
-            doSetCurrentRate(clipEnvelope.calculateCurrentRunningRate());
+//          doSetCurrentRate(clipEnvelope.calculateCurrentRunningRate());
 //      }
         clipEnvelope.start();
         lastPulse = 0;

--- a/modules/javafx.graphics/src/main/java/javafx/animation/ParallelTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/ParallelTransition.java
@@ -547,7 +547,7 @@ public final class ParallelTransition extends Transition {
 
                     offsetTicks[i] = (getCurrentRate() > 0)? newTicks - delays[i] : add(durations[i], delays[i]) - newTicks;
                 } else if (status == Status.PAUSED) {
-                    offsetTicks[i] += (newTicks - oldTicks) * Math.signum(this.clipEnvelope.getCurrentRate());
+                    offsetTicks[i] += (newTicks - oldTicks) * Math.signum(this.clipEnvelope.calculateCurrentRunningRate());
                 } else {
                     offsetTicks[i] += (getCurrentRate() > 0) ? newTicks - oldTicks : oldTicks - newTicks;
                 }

--- a/modules/javafx.graphics/src/main/java/javafx/animation/SequentialTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/SequentialTransition.java
@@ -695,13 +695,13 @@ public final class SequentialTransition extends Transition {
         }
         if (oldIndex == curIndex) {
             if (currentRate == 0) {
-                offsetTicks += (newTicks - oldTicks) * Math.signum(this.clipEnvelope.getCurrentRate());
+                offsetTicks += (newTicks - oldTicks) * Math.signum(this.clipEnvelope.calculateCurrentRunningRate());
             } else {
                 offsetTicks += currentRate > 0 ? newTicks - oldTicks : oldTicks - newTicks;
             }
         } else {
             if (currentRate == 0) {
-                if (this.clipEnvelope.getCurrentRate() > 0) {
+                if (this.clipEnvelope.calculateCurrentRunningRate() > 0) {
                     offsetTicks = Math.max(0, newTicks - currentDelay);
                 } else {
                     offsetTicks = startTimes[curIndex] + durations[curIndex] - newTicks;

--- a/modules/javafx.graphics/src/main/java/javafx/animation/Timeline.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/Timeline.java
@@ -202,7 +202,7 @@ public final class Timeline extends Animation {
         if (parent != null) {
             throw new IllegalStateException("Cannot stop when embedded in another animation");
         }
-        if (getStatus() == Status.RUNNING) {
+        if (isRunning()) {
             clipCore.abort();
         }
         super.stop();

--- a/modules/javafx.graphics/src/main/java/javafx/animation/Transition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/Transition.java
@@ -217,7 +217,7 @@ public abstract class Transition extends Animation {
     @Override
     void doJumpTo(long currentTicks, long cycleTicks, boolean forceJump) {
         setCurrentTicks(currentTicks);
-        if (getStatus() != Status.STOPPED || forceJump) {
+        if (!isStopped() || forceJump) {
             sync(false);
             interpolate(calculateFraction(currentTicks, cycleTicks));
         }

--- a/modules/javafx.graphics/src/test/java/test/com/sun/scenario/animation/shared/ClipEnvelopeMock.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/scenario/animation/shared/ClipEnvelopeMock.java
@@ -39,6 +39,7 @@ public class ClipEnvelopeMock extends ClipEnvelope {
     public double getRate() {
         return rate;
     }
+
     private boolean autoReverse;
 
     public boolean getAutoReverse() {
@@ -116,7 +117,29 @@ public class ClipEnvelopeMock extends ClipEnvelope {
     }
 
     @Override
-    protected double calculateCurrentRate() {
+    public double calculateCurrentRunningRate() {
         return rate;
+    }
+
+    @Override
+    public int getCycleNum() {
+        return 0;
+    }
+
+    @Override
+    protected long calculatePulseTicks(long newDest) {
+        return ticks + newDest;
+    }
+
+    @Override
+    protected boolean hasReachedEnd() {
+        // TODO Auto-generated method stub
+        return false;
+    }
+
+    @Override
+    protected void doPlayTo(double currentRate, long overallDelta, boolean reachedEnd) {
+        // TODO Auto-generated method stub
+        
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/com/sun/scenario/animation/shared/ClipEnvelopeMock.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/scenario/animation/shared/ClipEnvelopeMock.java
@@ -127,7 +127,7 @@ public class ClipEnvelopeMock extends ClipEnvelope {
     }
 
     @Override
-    protected long calculatePulseTicks(long newDest) {
+    protected long calculateNewTicks(long newDest) {
         return ticks + newDest;
     }
 
@@ -138,7 +138,19 @@ public class ClipEnvelopeMock extends ClipEnvelope {
     }
 
     @Override
-    protected void doPlayTo(double currentRate, long overallDelta, boolean reachedEnd) {
+    protected void playTo(double currentRate, long overallDelta, boolean reachedEnd) {
+        // TODO Auto-generated method stub
+        
+    }
+
+    @Override
+    protected void calculateCyclePosition() {
+        // TODO Auto-generated method stub
+        
+    }
+
+    @Override
+    protected void jump() {
         // TODO Auto-generated method stub
         
     }

--- a/modules/javafx.graphics/src/test/java/test/com/sun/scenario/animation/shared/SingleLoopClipEnvelopeTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/scenario/animation/shared/SingleLoopClipEnvelopeTest.java
@@ -91,8 +91,10 @@ public class SingleLoopClipEnvelopeTest {
 
     @Test
     public void testJump() {
+        // Jumping to the same location is ignored in the implementation, so AnimationMock#doJumpTo
+        // is not called and the Command is not set to JUMP
         clip.jumpTo(0);
-        animation.check(Command.JUMP, 0, CYCLE_TICKS);
+        animation.check(Command.NONE, 0, CYCLE_TICKS);
 
         clip.jumpTo(6 * 300);
         animation.check(Command.JUMP, 6 * 300, CYCLE_TICKS);


### PR DESCRIPTION
This PR is not meant to be integrated, but serve as a discussion for a few behavior questions about animations.

The following issues are solved with these changes:
* [JDK-8236858](https://bugs.openjdk.java.net/browse/JDK-8236858)
* [JDK-8237748](https://bugs.openjdk.java.net/browse/JDK-8237748)
* [JDK-8237757](https://bugs.openjdk.java.net/browse/JDK-8237757)

### Summary of changes

* `currentRate`'s behavior has been redefined for `Animation` and `ClipEnvelope`. The internal `currentRate` has been removed from the `ClipEnvelope`. Now `Animation` only sets the current rate when the `ClipEnvelope` isn't running (the receiver is paused), which are the cases when the animation is paused, stopped or `rate=0`. Otherwise, `ClipEnvelope` provides a way to calculate this value based on its internal data and it updates the animation when the current rate changes due to alternating cycles. This also means that `ClipEnvelope` will never deal with `rate=0`.
* The calculation of ticks in `ClipEnvelope` has been unified and a lot of functionality has been pulled up the hierarchy.
* The `lastPlayedForward` value that `Animation` held has been replaced by `startedPositive` in `MultiLoopClipEnvelope` since it's an internal detail (though see below).
* Added an internal cycle number property to `ClipEnvelope`. Currently it is only used to determine if a cycle is even or odd for the purpose of calculating the current rate,
* Internal documentation has been added 
* Parent animations haven't been dealt with thoroughly.

### Discussion

1. The starting direction of the animation is crucial to its behavior. As explained in the field's doc, it resolves an ambiguity.
2. Should jumpTo jump according to the starting direction? If no, what should jumping to 500 with 2 cycles and autoReverse do?
3. How cyce number should work for infinite animations?