### PR TITLE
8248490: [macOS] Undecorated stage does not minimize

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1405,6 +1405,16 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_mac_MacWindow__1minimize
     {
         GlassWindow *window = getGlassWindow(env, jPtr);
 
+        NSUInteger styleMask = [window->nsWindow styleMask];
+        BOOL isMiniaturizable = (styleMask & NSMiniaturizableWindowMask) != 0;
+
+        // if the window does not have NSMiniaturizableWindowMask set
+        // we need to temporarily set it to allow the window to
+        // be programmatically minimized or restored.
+        if (!isMiniaturizable) {
+            [window->nsWindow setStyleMask: styleMask | NSMiniaturizableWindowMask];
+        }
+
         if (jMiniaturize == JNI_TRUE)
         {
             [window->nsWindow miniaturize:nil];
@@ -1413,6 +1423,12 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_mac_MacWindow__1minimize
         {
             [window->nsWindow deminiaturize:nil];
         }
+
+        // Restore the state of NSMiniaturizableWindowMask
+        if (!isMiniaturizable) {
+            [window->nsWindow setStyleMask: styleMask];
+        }
+
     }
     GLASS_POOL_EXIT;
     GLASS_CHECK_EXCEPTION(env);

--- a/tests/system/src/test/java/test/robot/javafx/stage/IconifyTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/IconifyTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.robot.javafx.stage;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.layout.Pane;
+import javafx.scene.paint.Color;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+import org.junit.Test;
+import test.robot.testharness.VisualTestBase;
+
+import static org.junit.Assert.assertTrue;
+import static test.util.Util.TIMEOUT;
+
+/**
+ * Test ability to programmatically iconify UNDECORATED and TRANSPARENT stages
+ */
+public class IconifyTest extends VisualTestBase {
+
+    private static final int WIDTH = 300;
+    private static final int HEIGHT = 300;
+
+    private static final Color BOTTOM_COLOR = Color.LIME;
+    private static final Color TOP_COLOR = Color.RED;
+
+    private static final double TOLERANCE = 0.07;
+
+    private Stage bottomStage;
+    private Stage topStage;
+
+    public void canIconifyStage(StageStyle stageStyle) throws Exception {
+        final CountDownLatch shownLatch = new CountDownLatch(2);
+
+        runAndWait(() -> {
+            // Bottom stage, should be visible after top stage is iconified
+            bottomStage = getStage(true);
+            Scene bottomScene = new Scene(new Pane(), WIDTH, HEIGHT);
+            bottomScene.setFill(BOTTOM_COLOR);
+            bottomStage.setScene(bottomScene);
+            bottomStage.setX(0);
+            bottomStage.setY(0);
+            bottomStage.setOnShown(e -> Platform.runLater(shownLatch::countDown));
+            bottomStage.show();
+
+            // Top stage, will be inconified
+            topStage = getStage(true);
+            topStage.initStyle(stageStyle);
+            Scene topScene = new Scene(new Pane(), WIDTH, HEIGHT);
+            topScene.setFill(TOP_COLOR);
+            topStage.setScene(topScene);
+            topStage.setX(0);
+            topStage.setY(0);
+            topStage.setOnShown(e -> Platform.runLater(shownLatch::countDown));
+            topStage.show();
+        });
+
+        assertTrue("Timeout waiting for stages to be shown",
+            shownLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
+
+        runAndWait(() -> {
+            topStage.toFront();
+        });
+
+        sleep(500);
+        runAndWait(() -> {
+            Color color = getColor(100, 100);
+            assertColorEquals(TOP_COLOR, color, TOLERANCE);
+        });
+
+        runAndWait(() -> {
+            topStage.setIconified(true);
+        });
+
+        sleep(500);
+        runAndWait(() -> {
+            Color color = getColor(100, 100);
+            assertColorEquals(BOTTOM_COLOR, color, TOLERANCE);
+        });
+    }
+
+    @Test(timeout = 15000)
+    public void canIconifyUndecoratedStage() throws Exception {
+        canIconifyStage(StageStyle.UNDECORATED);
+    }
+
+    @Test(timeout = 15000)
+    public void canIconifyTransparentStage() throws Exception {
+        canIconifyStage(StageStyle.TRANSPARENT);
+    }
+
+}


### PR DESCRIPTION
When running a JavaFX application on macOS using a JDK compiled with the MacOSX 10.13 SDK or later, an undecorated or transparent stage cannot be programmatically minimized (iconified). The reason for this failure is that JavaFX only sets the `NSMiniaturizableWindowMask` bit in the `styleMask` of the `NSWindow` for decorated windows. Previous versions of the MacOSX SDK would minimize and restore a windows regardless of the setting of this flag. When the application is compiled against a newer SDK, Apple honors that flag and prevents the window from being minimized.

Note that it is the version of the SDK used to compile the JDK and not the version that is used to compile JavaFX that exposes this bug.

The fix is to temporarily set the `NSMiniaturizableWindowMask` prior to calling `miniaturize` or `deminiaturize`, and restore it afterwards. This seems safer than setting the bit unconditionally when the NSWindow is created, which would have been another approach.

A similar fix was done for AWT. See [JDK-8214046](https://bugs.openjdk.java.net/browse/JDK-8214046).

I propose to fix this in JavaFX 15, so it it targeted to the `jfx15` branch.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248490](https://bugs.openjdk.java.net/browse/JDK-8248490): [macOS] Undecorated stage does not minimize


### Reviewers
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/264/head:pull/264`
`$ git checkout pull/264`
