### PR TITLE
8248365: Debug build crashes on Windows when playing media file

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/projects/win/glib-lite/Makefile.ffi
+++ b/modules/javafx.media/src/main/native/gstreamer/projects/win/glib-lite/Makefile.ffi
@@ -29,10 +29,11 @@ CFLAGS = -DFFI_BUILDING \
 
 LIBFLAGS = -out:$(shell cygpath -ma $(TARGET)) -nologo
 
+# Do not use -RTC1(-RTCs) in debug build. See JDK-8248365.
 ifeq ($(BUILD_TYPE), Release)
     CFLAGS += -O1 -Oy -MD -Gy -GF
 else # debug
-    CFLAGS += -Od -Oy- -RTC1 -MDd -Zi -Fd$(PDB)
+    CFLAGS += -Od -Oy- -RTCu -MDd -Zi -Fd$(PDB)
 endif
 
 ifeq ($(ARCH), x32)


### PR DESCRIPTION
According to information found for similar bugs filed against libffi, this is known issue with libffi. libffi modifies stack frames and it triggers stack frame run-time error checking. Fixed by disabling stack frame error checking in debug build. It was already off in release build.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248365](https://bugs.openjdk.java.net/browse/JDK-8248365): Debug build crashes on Windows when playing media file


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/265/head:pull/265`
`$ git checkout pull/265`
