### PR TITLE
8248908: Printer.createPageLayout() returns 0.75" margins instead of hardware margins

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/print/J2DPrinter.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/print/J2DPrinter.java
@@ -698,7 +698,10 @@ public class J2DPrinter implements PrinterImpl {
             for (int i=0; i<media.length; i++) {
                 Media m = media[i];
                 if (m instanceof MediaSizeName) {
-                    pSet.add(addPaper(((MediaSizeName)m)));
+                    Paper p = addPaper(((MediaSizeName)m));
+                    if (p != null) {
+                        pSet.add(p);
+                     }
                 } else if (m instanceof MediaTray) {
                     tSet.add(addPaperSource((MediaTray)m));
                 }
@@ -782,22 +785,34 @@ public class J2DPrinter implements PrinterImpl {
     private final Map<Paper, MediaSizeName> paperToMediaMap
          = new HashMap<Paper, MediaSizeName>();
 
+    private Paper createPaper(MediaSizeName media) {
+        Paper paper = null;
+        MediaSize sz = MediaSize.getMediaSizeForName(media);
+        if (sz != null) {
+            double pw = sz.getX(1) / 1000.0;
+            double ph = sz.getY(1) / 1000.0;
+            paper = PrintHelper.createPaper(media.toString(),
+                                            pw, ph, Units.MM);
+        }
+        return paper;
+   }
+
     private synchronized final Paper addPaper(MediaSizeName media) {
         Paper paper = predefinedPaperMap.get(media);
-        if (paper == null ) {
-            MediaSize sz = MediaSize.getMediaSizeForName(media);
-            if (sz != null) {
-                double pw = sz.getX(1) / 1000.0;
-                double ph = sz.getY(1) / 1000.0;
-                paper = PrintHelper.createPaper(media.toString(),
-                                                pw, ph, Units.MM);
+        if (paper == null) {
+           paper = createPaper(media);
+        }
+        /* If that failed create a Paper from the default MediaSizeName */
+        if (paper == null) {
+            Media m = (Media)service.getDefaultAttributeValue(Media.class);
+            if (m instanceof MediaSizeName) {
+                paper = createPaper((MediaSizeName)m);
             }
         }
-        if (paper == null) {
-            paper = Paper.NA_LETTER;
+        if (paper != null) {
+            paperToMediaMap.put(paper, media);
+            mediaToPaperMap.put(media, paper);
         }
-        paperToMediaMap.put(paper, media);
-        mediaToPaperMap.put(media, paper);
         return paper;
     }
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/print/MarginsTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/print/MarginsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.print;
+
+import javafx.application.Platform;
+
+import javafx.print.PageLayout;
+import javafx.print.PageOrientation;
+import javafx.print.Paper;
+import javafx.print.Printer;
+import static javafx.print.Printer.MarginType.HARDWARE_MINIMUM;
+
+import javax.print.PrintService;
+import javax.print.PrintServiceLookup;
+import javax.print.attribute.HashPrintRequestAttributeSet;
+import javax.print.attribute.PrintRequestAttributeSet;
+import javax.print.attribute.standard.Media;
+import javax.print.attribute.standard.MediaPrintableArea;
+import static javax.print.attribute.standard.MediaPrintableArea.INCH;
+import javax.print.attribute.standard.MediaSizeName;
+
+import org.junit.Test;
+import static org.junit.Assert.fail;
+
+public class MarginsTest {
+
+    @Test public void test() {
+
+        Printer printer = Printer.getDefaultPrinter();
+        if (printer == null) {
+            return;
+        }
+        PageLayout layout =
+             printer.createPageLayout(Paper.NA_LETTER,
+                                      PageOrientation.PORTRAIT,
+                                      HARDWARE_MINIMUM);
+
+        int lm = (int)Math.round(layout.getLeftMargin());
+        int rm = (int)Math.round(layout.getRightMargin());
+        int bm = (int)Math.round(layout.getBottomMargin());
+        int tm = (int)Math.round(layout.getTopMargin());
+
+        System.out.println("FX : lm=" + lm + " rm=" + rm +
+                           " tm=" + tm + " bm=" + bm);
+        /* 0.75ins * 72 = 54 pts  */
+        if (lm != 54 || rm != 54 || tm != 54 || bm != 54) {
+            return; // Got something other than default.
+        }
+
+        /* Could this be what we got from 2D ? Unlikely but check. */
+        PrintService service = PrintServiceLookup.lookupDefaultPrintService();
+        /* If this is null, too much chance of false positive to continue */
+        if (service == null) {
+            return;
+        }
+        PrintRequestAttributeSet pras = new HashPrintRequestAttributeSet();
+        pras.add(MediaSizeName.NA_LETTER);
+        MediaPrintableArea[] mpa = (MediaPrintableArea[])service.
+            getSupportedAttributeValues(MediaPrintableArea.class, null, pras);
+        if (mpa.length == 0) { // never null.
+            return;
+        }
+        int mlm = (int)(Math.round(mpa[0].getX(INCH)*72));
+        int mtm = (int)(Math.round(mpa[0].getX(INCH)*72));
+        System.out.println("2D : lm=" + mlm + " tm= " + mtm);
+        if (mlm == 54 && mtm == 54) {
+            return;
+        }
+        fail("Margins differ.");
+   }
+}

--- a/modules/javafx.graphics/src/test/java/test/javafx/print/MarginsTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/print/MarginsTest.java
@@ -44,15 +44,15 @@ import javax.print.attribute.standard.MediaSizeName;
 
 import org.junit.Test;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeNotNull;
 
 public class MarginsTest {
 
     @Test public void test() {
 
         Printer printer = Printer.getDefaultPrinter();
-        if (printer == null) {
-            return;
-        }
+        assumeNotNull(printer);
+
         PageLayout layout =
              printer.createPageLayout(Paper.NA_LETTER,
                                       PageOrientation.PORTRAIT,


### PR DESCRIPTION
For a Media that had no defined size - eg a "custom" paper - the code was creating a mapping
that over-rode the NA_LETTER size. This might cause multiple problems but definitely meant that
we ended up with default margins.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248908](https://bugs.openjdk.java.net/browse/JDK-8248908): Printer.createPageLayout() returns 0.75" margins instead of hardware margins


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/266/head:pull/266`
`$ git checkout pull/266`
