### PR TITLE
8249799: Create release notes for JavaFX 14.0.2.1

### DIFF
--- a/doc-files/release-notes-14.0.2.1.md
+++ b/doc-files/release-notes-14.0.2.1.md
@@ -1,0 +1,29 @@
+# Release Notes for JavaFX 14.0.2.1
+
+## Introduction
+
+The following notes describe important changes and information about this release. In some cases, the descriptions provide links to additional detailed information about an issue or a change.
+
+These notes document the JavaFX 14.0.2.1 update release. As such, they complement
+the [JavaFX 14 Release Notes](https://github.com/openjdk/jfx/blob/jfx14/doc-files/release-notes-14.md) and the
+the [JavaFX 14.0.1 Release Notes](https://github.com/openjdk/jfx/blob/jfx14/doc-files/release-notes-14.0.1.md).
+
+## List of Fixed Bugs
+
+Issue key|Summary|Subcomponent
+---------|-------|------------
+[JDK-8249657](https://bugs.openjdk.java.net/browse/JDK-8249657) | Windows "User Objects" leakage with WebView | web
+[JDK-8249706](https://bugs.openjdk.java.net/browse/JDK-8249706) | Update libxml2 to version 2.9.10 | web
+[JDK-8249707](https://bugs.openjdk.java.net/browse/JDK-8249707) | Update libjpeg to version 9d | graphics
+[JDK-8249708](https://bugs.openjdk.java.net/browse/JDK-8249708) | [macos 10.15] JavaFX Application hangs on video play on Catalina | media
+[JDK-8249709](https://bugs.openjdk.java.net/browse/JDK-8249709) | [macos 10.15] JavaFX Media hangs on some video files on Catalina | media
+[JDK-8249710](https://bugs.openjdk.java.net/browse/JDK-8249710) | [macos10.15] Long startup delay playing media over https on Catalina | media
+
+
+## List of Security fixes
+
+Issue key|Summary|Subcomponent
+---------|-------|------------
+[JDK-8241108] (not public) | Glib improvements | media
+[JDK-8245422] (not public) | Better Pisces rasterizing | graphics
+

--- a/doc-files/release-notes-14.0.2.1.md
+++ b/doc-files/release-notes-14.0.2.1.md
@@ -12,12 +12,12 @@ the [JavaFX 14.0.1 Release Notes](https://github.com/openjdk/jfx/blob/jfx14/doc-
 
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8244579](https://bugs.openjdk.java.net/browse/JDK-8249657) | Windows "User Objects" leakage with WebView | web
-[JDK-8237889](https://bugs.openjdk.java.net/browse/JDK-8249706) | Update libxml2 to version 2.9.10 | web
-[JDK-8239107](https://bugs.openjdk.java.net/browse/JDK-8249707) | Update libjpeg to version 9d | graphics
-[JDK-8236832](https://bugs.openjdk.java.net/browse/JDK-8249708) | [macos 10.15] JavaFX Application hangs on video play on Catalina | media
-[JDK-8240694](https://bugs.openjdk.java.net/browse/JDK-8249709) | [macos 10.15] JavaFX Media hangs on some video files on Catalina | media
-[JDK-8241629](https://bugs.openjdk.java.net/browse/JDK-8249710) | [macos10.15] Long startup delay playing media over https on Catalina | media
+[JDK-8244579](https://bugs.openjdk.java.net/browse/JDK-8244579) | Windows "User Objects" leakage with WebView | web
+[JDK-8237889](https://bugs.openjdk.java.net/browse/JDK-8237889) | Update libxml2 to version 2.9.10 | web
+[JDK-8239107](https://bugs.openjdk.java.net/browse/JDK-8239107) | Update libjpeg to version 9d | graphics
+[JDK-8236832](https://bugs.openjdk.java.net/browse/JDK-8236832) | [macos 10.15] JavaFX Application hangs on video play on Catalina | media
+[JDK-8240694](https://bugs.openjdk.java.net/browse/JDK-8240694) | [macos 10.15] JavaFX Media hangs on some video files on Catalina | media
+[JDK-8241629](https://bugs.openjdk.java.net/browse/JDK-8241629) | [macos10.15] Long startup delay playing media over https on Catalina | media
 
 
 ## List of Security fixes

--- a/doc-files/release-notes-14.0.2.1.md
+++ b/doc-files/release-notes-14.0.2.1.md
@@ -12,12 +12,12 @@ the [JavaFX 14.0.1 Release Notes](https://github.com/openjdk/jfx/blob/jfx14/doc-
 
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8249657](https://bugs.openjdk.java.net/browse/JDK-8249657) | Windows "User Objects" leakage with WebView | web
-[JDK-8249706](https://bugs.openjdk.java.net/browse/JDK-8249706) | Update libxml2 to version 2.9.10 | web
-[JDK-8249707](https://bugs.openjdk.java.net/browse/JDK-8249707) | Update libjpeg to version 9d | graphics
-[JDK-8249708](https://bugs.openjdk.java.net/browse/JDK-8249708) | [macos 10.15] JavaFX Application hangs on video play on Catalina | media
-[JDK-8249709](https://bugs.openjdk.java.net/browse/JDK-8249709) | [macos 10.15] JavaFX Media hangs on some video files on Catalina | media
-[JDK-8249710](https://bugs.openjdk.java.net/browse/JDK-8249710) | [macos10.15] Long startup delay playing media over https on Catalina | media
+[JDK-8244579](https://bugs.openjdk.java.net/browse/JDK-8249657) | Windows "User Objects" leakage with WebView | web
+[JDK-8237889](https://bugs.openjdk.java.net/browse/JDK-8249706) | Update libxml2 to version 2.9.10 | web
+[JDK-8239107](https://bugs.openjdk.java.net/browse/JDK-8249707) | Update libjpeg to version 9d | graphics
+[JDK-8236832](https://bugs.openjdk.java.net/browse/JDK-8249708) | [macos 10.15] JavaFX Application hangs on video play on Catalina | media
+[JDK-8240694](https://bugs.openjdk.java.net/browse/JDK-8249709) | [macos 10.15] JavaFX Media hangs on some video files on Catalina | media
+[JDK-8241629](https://bugs.openjdk.java.net/browse/JDK-8249710) | [macos10.15] Long startup delay playing media over https on Catalina | media
 
 
 ## List of Security fixes


### PR DESCRIPTION
Add release notes for 14.0.2.1
Fix for JDK-8249799
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8249799](https://bugs.openjdk.java.net/browse/JDK-8249799): Create release notes for JavaFX 14.0.2.1


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/269/head:pull/269`
`$ git checkout pull/269`
