### PR TITLE
8249777: build.gradle: project.version should not contain time stamps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -453,6 +453,10 @@ defineProperty("CONF", "Debug")
 ext.IS_DEBUG_JAVA = CONF == "Debug" || CONF == "DebugNative"
 ext.IS_DEBUG_NATIVE = CONF == "DebugNative"
 
+// Specifies whether to enable the Maven publishing tasks
+defineProperty("MAVEN_PUBLISH", "false")
+ext.IS_MAVEN_PUBLISH = Boolean.parseBoolean(MAVEN_PUBLISH)
+
 // Defines the compiler warning levels to use. If empty, then no warnings are generated. If
 // not empty, then the expected syntax is as a space or comma separated list of names, such
 // as defined in the javac documentation.
@@ -553,7 +557,7 @@ if (HUDSON_JOB_NAME == "not_hudson") {
 defineProperty("RELEASE_SUFFIX", relSuffix)
 defineProperty("RELEASE_VERSION_SHORT", "${RELEASE_VERSION}${RELEASE_SUFFIX}")
 defineProperty("RELEASE_VERSION_LONG", "${RELEASE_VERSION_SHORT}+${PROMOTED_BUILD_NUMBER}${relOpt}")
-defineProperty("MAVEN_VERSION", IS_MILESTONE_FCS ? "${RELEASE_VERSION_SHORT}" : "${RELEASE_VERSION_LONG}")
+defineProperty("MAVEN_VERSION", IS_MAVEN_PUBLISH ? (IS_MILESTONE_FCS ? "${RELEASE_VERSION_SHORT}" : "${RELEASE_VERSION_LONG}") : "")
 
 // Check whether the COMPILE_TARGETS property has been specified (if so, it was done by
 // the user and not by this script). If it has not been defined then default
@@ -1337,6 +1341,7 @@ logger.quiet("RELEASE_SUFFIX: $RELEASE_SUFFIX")
 logger.quiet("RELEASE_VERSION_SHORT: $RELEASE_VERSION_SHORT")
 logger.quiet("RELEASE_VERSION_LONG: $RELEASE_VERSION_LONG")
 logger.quiet("RELEASE_VERSION_PADDED: $RELEASE_VERSION_PADDED")
+logger.quiet("MAVEN_PUBLISH: $MAVEN_PUBLISH")
 logger.quiet("MAVEN_VERSION: $MAVEN_VERSION")
 logger.quiet("UPDATE_STUB_CACHE: $UPDATE_STUB_CACHE")
 
@@ -1541,6 +1546,10 @@ void addJSL(Project project, String name, String pkg, List<String> addExports, C
 }
 
 void addMavenPublication(Project project, List<String> projectDependencies) {
+    if (!IS_MAVEN_PUBLISH) {
+        return
+    }
+
     project.apply plugin: 'maven-publish'
 
     project.group = MAVEN_GROUP_ID
@@ -2051,7 +2060,7 @@ project(":graphics") {
     project.ext.includeSources = true
     project.ext.moduleRuntime = true
     project.ext.moduleName = "javafx.graphics"
-    project.ext.mavenPublish = true
+    project.ext.mavenPublish = IS_MAVEN_PUBLISH
 
     getConfigurations().create("antlr");
 

--- a/build.gradle
+++ b/build.gradle
@@ -2060,7 +2060,6 @@ project(":graphics") {
     project.ext.includeSources = true
     project.ext.moduleRuntime = true
     project.ext.moduleName = "javafx.graphics"
-    project.ext.mavenPublish = IS_MAVEN_PUBLISH
 
     getConfigurations().create("antlr");
 


### PR DESCRIPTION
The addMavenPublication method sets the `project.version` to `$MAVEN_VERSION`, where project is base, graphics, controls, etc. When doing an ordinary "developer" build, this property contains the time stamp . This is causing problems with the NetBeans gradle plugin not being able to determine the dependencies between the projects (modules).

We haven't noticed this bug before now, because we suppress the creation of the individual project jar files, but if we were creating them, we would have the problem that each time we ran gradle, it would generate a new `project-$version.jar` file with a different time stamp each time the build was run.

The setting of `project.version=$MAVEN_VERSION` is only used by the maven "publish" tasks, which isn't done for developer builds nor for most productions builds.

The proposed solution is to add a new boolean `MAVEN_PUBLISH` flag, which will default to `false`. This flag will qualify the setting of the `MAVEN_VERSION` property and the configuration of the maven publishing tasks. After this change, it will be necessary to run gradle with `-PMAVEN_PUBLISH=true` in order to run the maven publishing tasks.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8249777](https://bugs.openjdk.java.net/browse/JDK-8249777): build.gradle: project.version should not contain time stamps


### Reviewers
 * Joeri Sykora ([sykora](@tiainen) - Author)
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/270/head:pull/270`
`$ git checkout pull/270`
