### PR TITLE
8250238: Media fails to load libav 58 library when using modules from maven central

### DIFF
--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/NativeMediaManager.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/NativeMediaManager.java
@@ -123,6 +123,7 @@ public class NativeMediaManager {
                     dependencies.add("avplugin-57");
                     dependencies.add("avplugin-ffmpeg-56");
                     dependencies.add("avplugin-ffmpeg-57");
+                    dependencies.add("avplugin-ffmpeg-58");
                 }
                 if (HostUtils.isMacOSX()) {
                     dependencies.add("fxplugins");


### PR DESCRIPTION
When running a JavaFX application using the JavaFX modules from maven central, the native libraries are packed into the jar file, and then unpacked as needed by the JavaFX runtime. This fails for libavplugin-ffmpeg-58.so, because the entry for the `avplugin-ffmpeg-58` library is missing from the list of dependent libraries of `jfxmedia` in [NativeMediaManager.java](https://github.com/openjdk/jfx/blob/14-ga/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/NativeMediaManager.java#L118).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8250238](https://bugs.openjdk.java.net/browse/JDK-8250238): Media fails to load libav 58 library when using modules from maven central


### Reviewers
 * Alexander Matveev ([almatvee](@sashamatveev) - **Reviewer**)
 * Joeri Sykora ([sykora](@tiainen) - Author)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/272/head:pull/272`
`$ git checkout pull/272`
