### PR TITLE
8250799: NumberStringConverter and its subclasses are missing documentation for all their constructors

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/util/converter/CurrencyStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/CurrencyStringConverter.java
@@ -32,7 +32,7 @@ import java.util.Locale;
 import javafx.util.StringConverter;
 
 /**
- * {@link StringConverter} implementation for {@link Number} values that represent currency.
+ * A {@link StringConverter} implementation for {@link Number} values that represent currency. Instances of this class are immutable.
  *
  * @see PercentageStringConverter
  * @see NumberStringConverter

--- a/modules/javafx.base/src/main/java/javafx/util/converter/CurrencyStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/CurrencyStringConverter.java
@@ -50,6 +50,8 @@ public class CurrencyStringConverter extends NumberStringConverter {
 
     /**
      * Constructs a {@code CurrencyStringConverter} with the given locale and the default format.
+     *
+     * @param locale the locale used in determining the number format used to format the string
      */
     public CurrencyStringConverter(Locale locale) {
         this(locale, null);
@@ -57,6 +59,8 @@ public class CurrencyStringConverter extends NumberStringConverter {
 
     /**
      * Constructs a {@code CurrencyStringConverter} with the default locale and the given decimal format pattern.
+     *
+     * @param pattern the string pattern used in determining the number format used to format the string
      *
      * @see java.text.DecimalFormat
      */
@@ -67,6 +71,9 @@ public class CurrencyStringConverter extends NumberStringConverter {
     /**
      * Constructs a {@code CurrencyStringConverter} with the given locale and decimal format pattern.
      *
+     * @param locale the locale used in determining the number format used to format the string
+     * @param pattern the string pattern used in determining the number format used to format the string
+     *
      * @see java.text.DecimalFormat
      */
     public CurrencyStringConverter(Locale locale, String pattern) {
@@ -75,6 +82,8 @@ public class CurrencyStringConverter extends NumberStringConverter {
 
     /**
      * Constructs a {@code CurrencyStringConverter} with the given number format.
+     *
+     * @param numberFormat the number format used to format the string
      */
     public CurrencyStringConverter(NumberFormat numberFormat) {
         super(null, null, numberFormat);

--- a/modules/javafx.base/src/main/java/javafx/util/converter/CurrencyStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/CurrencyStringConverter.java
@@ -74,7 +74,7 @@ public class CurrencyStringConverter extends NumberStringConverter {
     }
 
     /**
-     * Constructs a {@code CurrencyStringConverter} with the default locale and the given number format.
+     * Constructs a {@code CurrencyStringConverter} with the given number format.
      */
     public CurrencyStringConverter(NumberFormat numberFormat) {
         super(null, null, numberFormat);

--- a/modules/javafx.base/src/main/java/javafx/util/converter/CurrencyStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/CurrencyStringConverter.java
@@ -32,8 +32,7 @@ import java.util.Locale;
 import javafx.util.StringConverter;
 
 /**
- * <p>{@link StringConverter} implementation for {@link Number} values
- * that represent currency.</p>
+ * {@link StringConverter} implementation for {@link Number} values that represent currency.
  *
  * @see PercentageStringConverter
  * @see NumberStringConverter
@@ -42,29 +41,44 @@ import javafx.util.StringConverter;
  */
 public class CurrencyStringConverter extends NumberStringConverter {
 
-    // ------------------------------------------------------------ Constructors
+    /**
+     * Constructs a {@code CurrencyStringConverter} with the default locale and format.
+     */
     public CurrencyStringConverter() {
         this(Locale.getDefault());
     }
 
+    /**
+     * Constructs a {@code CurrencyStringConverter} with the given locale and the default format.
+     */
     public CurrencyStringConverter(Locale locale) {
         this(locale, null);
     }
 
+    /**
+     * Constructs a {@code CurrencyStringConverter} with the default locale and the given decimal format pattern.
+     *
+     * @see java.text.DecimalFormat
+     */
     public CurrencyStringConverter(String pattern) {
         this(Locale.getDefault(), pattern);
     }
 
+    /**
+     * Constructs a {@code CurrencyStringConverter} with the given locale and decimal format pattern.
+     *
+     * @see java.text.DecimalFormat
+     */
     public CurrencyStringConverter(Locale locale, String pattern) {
         super(locale, pattern, null);
     }
 
+    /**
+     * Constructs a {@code CurrencyStringConverter} with the default locale and the given number format.
+     */
     public CurrencyStringConverter(NumberFormat numberFormat) {
         super(null, null, numberFormat);
     }
-
-
-    // ---------------------------------------------------------------0- Methods
 
     /** {@inheritDoc} */
     @Override protected NumberFormat getNumberFormat() {

--- a/modules/javafx.base/src/main/java/javafx/util/converter/NumberStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/NumberStringConverter.java
@@ -52,6 +52,8 @@ public class NumberStringConverter extends StringConverter<Number> {
 
     /**
      * Constructs a {@code NumberStringConverter} with the given locale and the default format.
+     *
+     * @param locale the locale used in determining the number format used to format the string
      */
     public NumberStringConverter(Locale locale) {
         this(locale, null);
@@ -59,6 +61,8 @@ public class NumberStringConverter extends StringConverter<Number> {
 
     /**
      * Constructs a {@code NumberStringConverter} with the default locale and the given decimal format pattern.
+     *
+     * @param pattern the string pattern used in determining the number format used to format the string
      *
      * @see java.text.DecimalFormat
      */
@@ -69,6 +73,9 @@ public class NumberStringConverter extends StringConverter<Number> {
     /**
      * Constructs a {@code NumberStringConverter} with the given locale and decimal format pattern.
      *
+     * @param locale the locale used in determining the number format used to format the string
+     * @param pattern the string pattern used in determining the number format used to format the string
+     *
      * @see java.text.DecimalFormat
      */
     public NumberStringConverter(Locale locale, String pattern) {
@@ -77,6 +84,8 @@ public class NumberStringConverter extends StringConverter<Number> {
 
     /**
      * Constructs a {@code NumberStringConverter} with the given number format.
+     *
+     * @param numberFormat the number format used to format the string
      */
     public NumberStringConverter(NumberFormat numberFormat) {
         this(null, null, numberFormat);

--- a/modules/javafx.base/src/main/java/javafx/util/converter/NumberStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/NumberStringConverter.java
@@ -76,9 +76,7 @@ public class NumberStringConverter extends StringConverter<Number> {
     }
 
     /**
-     * Constructs a {@code NumberStringConverter} with the default locale and the given number format.
-     *
-     * @see java.text.DecimalFormat
+     * Constructs a {@code NumberStringConverter} with the given number format.
      */
     public NumberStringConverter(NumberFormat numberFormat) {
         this(null, null, numberFormat);

--- a/modules/javafx.base/src/main/java/javafx/util/converter/NumberStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/NumberStringConverter.java
@@ -33,34 +33,53 @@ import java.util.Locale;
 import javafx.util.StringConverter;
 
 /**
- * <p>{@link StringConverter} implementation for {@link Number} values.</p>
+ * {@link StringConverter} implementation for {@link Number} values.
+ *
  * @since JavaFX 2.1
  */
 public class NumberStringConverter extends StringConverter<Number> {
-
-    // ------------------------------------------------------ Private properties
 
     final Locale locale;
     final String pattern;
     final NumberFormat numberFormat;
 
-    // ------------------------------------------------------------ Constructors
+    /**
+     * Constructs a {@code NumberStringConverter} with the default locale and format.
+     */
     public NumberStringConverter() {
         this(Locale.getDefault());
     }
 
+    /**
+     * Constructs a {@code NumberStringConverter} with the given locale and the default format.
+     */
     public NumberStringConverter(Locale locale) {
         this(locale, null);
     }
 
+    /**
+     * Constructs a {@code NumberStringConverter} with the default locale and the given decimal format pattern.
+     *
+     * @see java.text.DecimalFormat
+     */
     public NumberStringConverter(String pattern) {
         this(Locale.getDefault(), pattern);
     }
 
+    /**
+     * Constructs a {@code NumberStringConverter} with the given locale and decimal format pattern.
+     *
+     * @see java.text.DecimalFormat
+     */
     public NumberStringConverter(Locale locale, String pattern) {
         this(locale, pattern, null);
     }
 
+    /**
+     * Constructs a {@code NumberStringConverter} with the default locale and the given number format.
+     *
+     * @see java.text.DecimalFormat
+     */
     public NumberStringConverter(NumberFormat numberFormat) {
         this(null, null, numberFormat);
     }
@@ -70,8 +89,6 @@ public class NumberStringConverter extends StringConverter<Number> {
         this.pattern = pattern;
         this.numberFormat = numberFormat;
     }
-
-    // ------------------------------------------------------- Converter Methods
 
     /** {@inheritDoc} */
     @Override public Number fromString(String value) {
@@ -112,11 +129,11 @@ public class NumberStringConverter extends StringConverter<Number> {
     }
 
     /**
-     * <p>Return a <code>NumberFormat</code> instance to use for formatting
-     * and parsing in this {@link StringConverter}.</p>
+     * Returns a {@code NumberFormat} instance to use for formatting
+     * and parsing in this {@code StringConverter}.
      *
      * @return a {@code NumberFormat} instance for formatting and parsing in this
-     * {@link StringConverter}
+     * {@code StringConverter}
      */
     protected NumberFormat getNumberFormat() {
         Locale _locale = locale == null ? Locale.getDefault() : locale;

--- a/modules/javafx.base/src/main/java/javafx/util/converter/NumberStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/NumberStringConverter.java
@@ -33,7 +33,7 @@ import java.util.Locale;
 import javafx.util.StringConverter;
 
 /**
- * {@link StringConverter} implementation for {@link Number} values.
+ * A {@link StringConverter} implementation for {@link Number} values. Instances of this class are immutable.
  *
  * @since JavaFX 2.1
  */

--- a/modules/javafx.base/src/main/java/javafx/util/converter/PercentageStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/PercentageStringConverter.java
@@ -30,8 +30,7 @@ import java.util.Locale;
 import javafx.util.StringConverter;
 
 /**
- * <p>{@link StringConverter} implementation for {@link Number} values
- * that represent percentages.</p>
+ * {@link StringConverter} implementation for {@link Number} values that represent percentages.
  *
  * @see CurrencyStringConverter
  * @see NumberStringConverter
@@ -40,21 +39,26 @@ import javafx.util.StringConverter;
  */
 public class PercentageStringConverter extends NumberStringConverter {
 
-
-    // ------------------------------------------------------------ Constructors
+    /**
+     * Constructs a {@code PercentageStringConverter} with the default locale and format.
+     */
     public PercentageStringConverter() {
         this(Locale.getDefault());
     }
 
+    /**
+     * Constructs a {@code PercentageStringConverter} with the given locale and the default format.
+     */
     public PercentageStringConverter(Locale locale) {
         super(locale, null, null);
     }
 
+    /**
+     * Constructs a {@code PercentageStringConverter} with the default locale and the given number format.
+     */
     public PercentageStringConverter(NumberFormat numberFormat) {
         super(null, null, numberFormat);
     }
-
-    // ----------------------------------------------------------------- Methods
 
     /** {@inheritDoc} */
     @Override public NumberFormat getNumberFormat() {

--- a/modules/javafx.base/src/main/java/javafx/util/converter/PercentageStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/PercentageStringConverter.java
@@ -30,7 +30,8 @@ import java.util.Locale;
 import javafx.util.StringConverter;
 
 /**
- * {@link StringConverter} implementation for {@link Number} values that represent percentages.
+ * A {@link StringConverter} implementation for {@link Number} values that represent percentages. Instances of this class are
+ * immutable.
  *
  * @see CurrencyStringConverter
  * @see NumberStringConverter

--- a/modules/javafx.base/src/main/java/javafx/util/converter/PercentageStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/PercentageStringConverter.java
@@ -49,6 +49,8 @@ public class PercentageStringConverter extends NumberStringConverter {
 
     /**
      * Constructs a {@code PercentageStringConverter} with the given locale and the default format.
+     *
+     * @param locale the locale used in determining the number format used to format the string
      */
     public PercentageStringConverter(Locale locale) {
         super(locale, null, null);
@@ -56,6 +58,8 @@ public class PercentageStringConverter extends NumberStringConverter {
 
     /**
      * Constructs a {@code PercentageStringConverter} with the given number format.
+     *
+     * @param numberFormat the number format used to format the string
      */
     public PercentageStringConverter(NumberFormat numberFormat) {
         super(null, null, numberFormat);

--- a/modules/javafx.base/src/main/java/javafx/util/converter/PercentageStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/PercentageStringConverter.java
@@ -55,7 +55,7 @@ public class PercentageStringConverter extends NumberStringConverter {
     }
 
     /**
-     * Constructs a {@code PercentageStringConverter} with the default locale and the given number format.
+     * Constructs a {@code PercentageStringConverter} with the given number format.
      */
     public PercentageStringConverter(NumberFormat numberFormat) {
         super(null, null, numberFormat);


### PR DESCRIPTION
This was missed the in Javadoc fixes for 15.

Added documentation for all the constructors, did a bit of formatting, and removed redundant comments.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8250799](https://bugs.openjdk.java.net/browse/JDK-8250799): NumberStringConverter and its subclasses are missing documentation for all their constructors


### Reviewers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/277/head:pull/277`
`$ git checkout pull/277`
