### PR TITLE
Remove final from TransformationList (Filtered and Sorted)

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/collections/transformation/FilteredList.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/transformation/FilteredList.java
@@ -47,7 +47,7 @@ import javafx.collections.ObservableList;
  * @see TransformationList
  * @since JavaFX 8.0
  */
-public final class FilteredList<E> extends TransformationList<E, E>{
+public class FilteredList<E> extends TransformationList<E, E>{
 
     private int[] filtered;
     private int size;

--- a/modules/javafx.base/src/main/java/javafx/collections/transformation/SortedList.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/transformation/SortedList.java
@@ -51,7 +51,7 @@ import javafx.collections.ObservableList;
  * @see TransformationList
  * @since JavaFX 8.0
  */
-public final class SortedList<E> extends TransformationList<E, E>{
+public class SortedList<E> extends TransformationList<E, E>{
 
     private Comparator<Element<E>> elementComparator;
     private Element<E>[] sorted;


### PR DESCRIPTION
Right now it is hard to extend the FilteredList and the SortedList as these classes are marked final. This makes it practically impossible to add convenient helper methods, or change the behavior of these classes. I agree that normally you don't need to extend them, but I also don't see any reason why you shouldn't be allowed to do so.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/278/head:pull/278` \
`$ git checkout pull/278`

Update a local copy of the PR: \
`$ git checkout pull/278` \
`$ git pull https://git.openjdk.org/jfx pull/278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 278`

View PR using the GUI difftool: \
`$ git pr show -t 278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/278.diff">https://git.openjdk.org/jfx/pull/278.diff</a>

</details>
