### PR TITLE
8251241: macOS: iconify property doesn't change after minimize when resizable is false

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
@@ -94,10 +94,14 @@ extern NSSize maxScreenDimensions;
     if (self->suppressWindowResizeEvent == NO)
     {
         GET_MAIN_JENV;
-        (*env)->CallVoidMethod(env, jWindow, jWindowNotifyResize,
-            [self->nsWindow isZoomed]
-                ? com_sun_glass_events_WindowEvent_MAXIMIZE
-                : type,
+
+        if([self->nsWindow isMiniaturized]) {
+            type = com_sun_glass_events_WindowEvent_MINIMIZE;
+        } else if([self->nsWindow isZoomed]) {
+            type = com_sun_glass_events_WindowEvent_MAXIMIZE;
+        }
+
+        (*env)->CallVoidMethod(env, jWindow, jWindowNotifyResize, type,
              (int)frame.size.width, (int)frame.size.height);
         [self _sendJavaWindowMoveToAnotherScreenEventIfNeeded];
     }

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
@@ -95,9 +95,9 @@ extern NSSize maxScreenDimensions;
     {
         GET_MAIN_JENV;
 
-        if([self->nsWindow isMiniaturized]) {
+        if ([self->nsWindow isMiniaturized]) {
             type = com_sun_glass_events_WindowEvent_MINIMIZE;
-        } else if([self->nsWindow isZoomed]) {
+        } else if ([self->nsWindow isZoomed]) {
             type = com_sun_glass_events_WindowEvent_MAXIMIZE;
         }
 

--- a/tests/system/src/test/java/test/robot/javafx/stage/IconifyTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/IconifyTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import test.robot.testharness.VisualTestBase;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static test.util.Util.TIMEOUT;
 
 /**
@@ -55,7 +56,7 @@ public class IconifyTest extends VisualTestBase {
     private Stage bottomStage;
     private Stage topStage;
 
-    public void canIconifyStage(StageStyle stageStyle) throws Exception {
+    public void canIconifyStage(StageStyle stageStyle, boolean resizable) throws Exception {
         final CountDownLatch shownLatch = new CountDownLatch(2);
 
         runAndWait(() -> {
@@ -72,6 +73,7 @@ public class IconifyTest extends VisualTestBase {
             // Top stage, will be inconified
             topStage = getStage(true);
             topStage.initStyle(stageStyle);
+            topStage.setResizable(resizable);
             Scene topScene = new Scene(new Pane(), WIDTH, HEIGHT);
             topScene.setFill(TOP_COLOR);
             topStage.setScene(topScene);
@@ -90,6 +92,7 @@ public class IconifyTest extends VisualTestBase {
 
         sleep(500);
         runAndWait(() -> {
+            assertFalse(topStage.isIconified());
             Color color = getColor(100, 100);
             assertColorEquals(TOP_COLOR, color, TOLERANCE);
         });
@@ -100,19 +103,41 @@ public class IconifyTest extends VisualTestBase {
 
         sleep(500);
         runAndWait(() -> {
+            assertTrue(topStage.isIconified());
             Color color = getColor(100, 100);
             assertColorEquals(BOTTOM_COLOR, color, TOLERANCE);
+        });
+
+        runAndWait(() -> {
+            topStage.setIconified(false);
+        });
+
+        sleep(500);
+        runAndWait(() -> {
+            assertFalse(topStage.isIconified());
+            Color color = getColor(100, 100);
+            assertColorEquals(TOP_COLOR, color, TOLERANCE);
         });
     }
 
     @Test(timeout = 15000)
+    public void canIconifyDecoratedStage() throws Exception {
+        canIconifyStage(StageStyle.DECORATED, true);
+    }
+
+    @Test(timeout = 15000)
     public void canIconifyUndecoratedStage() throws Exception {
-        canIconifyStage(StageStyle.UNDECORATED);
+        canIconifyStage(StageStyle.UNDECORATED, true);
     }
 
     @Test(timeout = 15000)
     public void canIconifyTransparentStage() throws Exception {
-        canIconifyStage(StageStyle.TRANSPARENT);
+        canIconifyStage(StageStyle.TRANSPARENT, true);
+    }
+
+    @Test(timeout = 15000)
+    public void canIconifyNonResizableStage() throws Exception {
+        canIconifyStage(StageStyle.DECORATED, false);
     }
 
 }


### PR DESCRIPTION
ticket: https://bugs.openjdk.java.net/browse/JDK-8251241

This small change fixing the minimize for mac.
Changes are property registered.
Calling setIconize(true) no longer resets to false.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251241](https://bugs.openjdk.java.net/browse/JDK-8251241): macOS: iconify property doesn't change after minimize when resizable is false


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/280/head:pull/280`
`$ git checkout pull/280`
