### PR TITLE
8251352: Many javafx.base classes have implicit no-arg constructors

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/beans/property/DoubleProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/DoubleProperty.java
@@ -61,6 +61,12 @@ public abstract class DoubleProperty extends ReadOnlyDoubleProperty implements
         Property<Number>, WritableDoubleValue {
 
     /**
+     * Creates a default {@code DoubleProperty}.
+     */
+    public DoubleProperty() {
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/modules/javafx.base/src/main/java/javafx/beans/property/FloatProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/FloatProperty.java
@@ -60,6 +60,12 @@ public abstract class FloatProperty extends ReadOnlyFloatProperty implements
         Property<Number>, WritableFloatValue {
 
     /**
+     * Creates a default {@code FloatProperty}.
+     */
+    public FloatProperty() {
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/modules/javafx.base/src/main/java/javafx/beans/property/IntegerProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/IntegerProperty.java
@@ -60,6 +60,12 @@ public abstract class IntegerProperty extends ReadOnlyIntegerProperty implements
         Property<Number>, WritableIntegerValue {
 
     /**
+     * Creates a default {@code IntegerProperty}.
+     */
+    public IntegerProperty() {
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ListProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ListProperty.java
@@ -55,6 +55,13 @@ import javafx.collections.ObservableList;
  */
 public abstract class ListProperty<E> extends ReadOnlyListProperty<E> implements
         Property<ObservableList<E>>, WritableListValue<E> {
+
+    /**
+     * Creates a default {@code ListProperty}.
+     */
+    public ListProperty() {
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/modules/javafx.base/src/main/java/javafx/beans/property/LongProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/LongProperty.java
@@ -59,6 +59,12 @@ public abstract class LongProperty extends ReadOnlyLongProperty implements
         Property<Number>, WritableLongValue {
 
     /**
+     * Creates a default {@code LongProperty}.
+     */
+    public LongProperty() {
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/modules/javafx.base/src/main/java/javafx/beans/property/MapProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/MapProperty.java
@@ -56,6 +56,13 @@ import javafx.collections.ObservableMap;
  */
 public abstract class MapProperty<K, V> extends ReadOnlyMapProperty<K, V> implements
         Property<ObservableMap<K, V>>, WritableMapValue<K, V> {
+
+    /**
+     * Creates a default {@code MapProperty}.
+     */
+    public MapProperty() {
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ObjectProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ObjectProperty.java
@@ -65,6 +65,12 @@ public abstract class ObjectProperty<T> extends ReadOnlyObjectProperty<T>
         implements Property<T>, WritableObjectValue<T> {
 
     /**
+     * Creates a default {@code ObjectProperty}.
+     */
+    public ObjectProperty() {
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyBooleanPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyBooleanPropertyBase.java
@@ -41,6 +41,12 @@ public abstract class ReadOnlyBooleanPropertyBase extends ReadOnlyBooleanPropert
 
     ExpressionHelper<Boolean> helper;
 
+    /**
+     * Creates a default {@code ReadOnlyBooleanPropertyBase}.
+     */
+    public ReadOnlyBooleanPropertyBase() {
+    }
+
     @Override
     public void addListener(InvalidationListener listener) {
         helper = ExpressionHelper.addListener(helper, this, listener);

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyDoublePropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyDoublePropertyBase.java
@@ -41,6 +41,12 @@ public abstract class ReadOnlyDoublePropertyBase extends ReadOnlyDoubleProperty 
 
     ExpressionHelper<Number> helper;
 
+    /**
+     * Creates a default {@code ReadOnlyDoublePropertyBase}.
+     */
+    public ReadOnlyDoublePropertyBase() {
+    }
+
     @Override
     public void addListener(InvalidationListener listener) {
         helper = ExpressionHelper.addListener(helper, this, listener);

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyFloatPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyFloatPropertyBase.java
@@ -41,6 +41,12 @@ public abstract class ReadOnlyFloatPropertyBase extends ReadOnlyFloatProperty {
 
     ExpressionHelper<Number> helper;
 
+    /**
+     * Creates a default {@code ReadOnlyFloatPropertyBase}.
+     */
+    public ReadOnlyFloatPropertyBase() {
+    }
+
     @Override
     public void addListener(InvalidationListener listener) {
         helper = ExpressionHelper.addListener(helper, this, listener);

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyIntegerPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyIntegerPropertyBase.java
@@ -41,6 +41,12 @@ public abstract class ReadOnlyIntegerPropertyBase extends ReadOnlyIntegerPropert
 
     ExpressionHelper<Number> helper;
 
+    /**
+     * Creates a default {@code ReadOnlyIntegerPropertyBase}.
+     */
+    public ReadOnlyIntegerPropertyBase() {
+    }
+
     @Override
     public void addListener(InvalidationListener listener) {
         helper = ExpressionHelper.addListener(helper, this, listener);

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyListPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyListPropertyBase.java
@@ -43,6 +43,12 @@ public abstract class ReadOnlyListPropertyBase<E> extends ReadOnlyListProperty<E
 
     private ListExpressionHelper<E> helper;
 
+    /**
+     * Creates a default {@code ReadOnlyListPropertyBase}.
+     */
+    public ReadOnlyListPropertyBase() {
+    }
+
     @Override
     public void addListener(InvalidationListener listener) {
         helper = ListExpressionHelper.addListener(helper, this, listener);

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyLongPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyLongPropertyBase.java
@@ -41,6 +41,12 @@ public abstract class ReadOnlyLongPropertyBase extends ReadOnlyLongProperty {
 
     ExpressionHelper<Number> helper;
 
+    /**
+     * Creates a default {@code ReadOnlyLongPropertyBase}.
+     */
+    public ReadOnlyLongPropertyBase() {
+    }
+
     @Override
     public void addListener(InvalidationListener listener) {
         helper = ExpressionHelper.addListener(helper, this, listener);

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyMapPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyMapPropertyBase.java
@@ -42,6 +42,12 @@ public abstract class ReadOnlyMapPropertyBase<K, V> extends ReadOnlyMapProperty<
 
     private MapExpressionHelper<K, V> helper;
 
+    /**
+     * Creates a default {@code ReadOnlyMapPropertyBase}.
+     */
+    public ReadOnlyMapPropertyBase() {
+    }
+
     @Override
     public void addListener(InvalidationListener listener) {
         helper = MapExpressionHelper.addListener(helper, this, listener);

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyObjectPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyObjectPropertyBase.java
@@ -43,6 +43,12 @@ public abstract class ReadOnlyObjectPropertyBase<T> extends ReadOnlyObjectProper
 
     ExpressionHelper<T> helper;
 
+    /**
+     * Creates a default {@code ReadOnlyObjectPropertyBase}.
+     */
+    public ReadOnlyObjectPropertyBase() {
+    }
+
     @Override
     public void addListener(InvalidationListener listener) {
         helper = ExpressionHelper.addListener(helper, this, listener);

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlySetPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlySetPropertyBase.java
@@ -44,6 +44,12 @@ public abstract class ReadOnlySetPropertyBase<E> extends ReadOnlySetProperty<E> 
 
     private SetExpressionHelper<E> helper;
 
+    /**
+     * Creates a default {@code ReadOnlySetPropertyBase}.
+     */
+    public ReadOnlySetPropertyBase() {
+    }
+
     @Override
     public void addListener(InvalidationListener listener) {
         helper = SetExpressionHelper.addListener(helper, this, listener);

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyStringPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyStringPropertyBase.java
@@ -41,6 +41,12 @@ public abstract class ReadOnlyStringPropertyBase extends ReadOnlyStringProperty 
 
     ExpressionHelper<String> helper;
 
+    /**
+     * Creates a default {@code ReadOnlyStringPropertyBase}.
+     */
+    public ReadOnlyStringPropertyBase() {
+    }
+
     @Override
     public void addListener(InvalidationListener listener) {
         helper = ExpressionHelper.addListener(helper, this, listener);

--- a/modules/javafx.base/src/main/java/javafx/beans/property/SetProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/SetProperty.java
@@ -57,6 +57,13 @@ import javafx.collections.ObservableSet;
  */
 public abstract class SetProperty<E> extends ReadOnlySetProperty<E> implements
         Property<ObservableSet<E>>, WritableSetValue<E> {
+
+    /**
+     * Creates a default {@code SetProperty}.
+     */
+    public SetProperty() {
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/modules/javafx.base/src/main/java/javafx/beans/property/StringProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/StringProperty.java
@@ -58,6 +58,12 @@ public abstract class StringProperty extends ReadOnlyStringProperty implements
         Property<String>, WritableStringValue {
 
     /**
+     * Creates a default {@code StringProperty}.
+     */
+    public StringProperty() {
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/modules/javafx.base/src/main/java/javafx/beans/value/ObservableValueBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/value/ObservableValueBase.java
@@ -48,6 +48,12 @@ public abstract class ObservableValueBase<T> implements ObservableValue<T> {
     private ExpressionHelper<T> helper;
 
     /**
+     * Creates a default {@code ObservableValueBase}.
+     */
+    public ObservableValueBase() {
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/modules/javafx.base/src/main/java/javafx/collections/ModifiableObservableListBase.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/ModifiableObservableListBase.java
@@ -80,6 +80,12 @@ import java.util.ListIterator;
  */
 public abstract class ModifiableObservableListBase<E> extends ObservableListBase<E> {
 
+    /**
+     * Creates a default {@code ModifiableObservableListBase}.
+     */
+    public ModifiableObservableListBase() {
+    }
+
     @Override
     public boolean setAll(Collection<? extends E> col) {
         beginChange();

--- a/modules/javafx.base/src/main/java/javafx/collections/ObservableArrayBase.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/ObservableArrayBase.java
@@ -42,6 +42,12 @@ public abstract class ObservableArrayBase<T extends ObservableArray<T>> implemen
 
     private ArrayListenerHelper<T> listenerHelper;
 
+    /**
+     * Creates a default {@code ObservableArrayBase}.
+     */
+    public ObservableArrayBase() {
+    }
+
     @Override public final void addListener(InvalidationListener listener) {
         listenerHelper = ArrayListenerHelper.<T>addListener(listenerHelper, (T) this, listener);
     }

--- a/modules/javafx.base/src/main/java/javafx/collections/ObservableListBase.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/ObservableListBase.java
@@ -94,6 +94,12 @@ public abstract class ObservableListBase<E> extends AbstractList<E>  implements 
     private final ListChangeBuilder<E> changeBuilder = new ListChangeBuilder<E>(this);
 
     /**
+     * Creates a default {@code ObservableListBase}.
+     */
+    public ObservableListBase() {
+    }
+
+    /**
      * Adds a new update operation to the change.
      * <p><strong>Note</strong>: needs to be called inside {@code beginChange()} / {@code endChange()} block.
      * <p><strong>Note</strong>: needs to reflect the <em>current</em> state of the list.

--- a/modules/javafx.base/src/main/java/javafx/util/StringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/StringConverter.java
@@ -32,6 +32,13 @@ package javafx.util;
  * @since JavaFX 2.0
  */
 public abstract class StringConverter<T> {
+
+    /**
+     * Creates a default {@code StringConverter}.
+     */
+    public StringConverter() {
+    }
+
     /**
     * Converts the object provided into its string form.
     * Format of the returned string is defined by the specific converter.

--- a/modules/javafx.base/src/main/java/javafx/util/converter/BigDecimalStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/BigDecimalStringConverter.java
@@ -34,6 +34,12 @@ import javafx.util.StringConverter;
  */
 public class BigDecimalStringConverter extends StringConverter<BigDecimal> {
 
+    /**
+     * Creates a default {@code BigDecimalStringConverter}.
+     */
+    public BigDecimalStringConverter() {
+    }
+
     /** {@inheritDoc} */
     @Override public BigDecimal fromString(String value) {
         // If the specified value is null or zero-length, return null

--- a/modules/javafx.base/src/main/java/javafx/util/converter/BigIntegerStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/BigIntegerStringConverter.java
@@ -33,6 +33,13 @@ import javafx.util.StringConverter;
  * @since JavaFX 2.1
  */
 public class BigIntegerStringConverter extends StringConverter<BigInteger> {
+
+    /**
+     * Creates a default {@code BigIntegerStringConverter}.
+     */
+    public BigIntegerStringConverter() {
+    }
+
     /** {@inheritDoc} */
     @Override public BigInteger fromString(String value) {
         // If the specified value is null or zero-length, return null

--- a/modules/javafx.base/src/main/java/javafx/util/converter/BooleanStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/BooleanStringConverter.java
@@ -33,6 +33,13 @@ import javafx.util.StringConverter;
  * @since JavaFX 2.1
  */
 public class BooleanStringConverter extends StringConverter<Boolean> {
+
+    /**
+     * Creates a default {@code BooleanStringConverter}.
+     */
+    public BooleanStringConverter() {
+    }
+
     /** {@inheritDoc} */
     @Override public Boolean fromString(String value) {
         // If the specified value is null or zero-length, return null

--- a/modules/javafx.base/src/main/java/javafx/util/converter/ByteStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/ByteStringConverter.java
@@ -33,6 +33,13 @@ import javafx.util.StringConverter;
  * @since JavaFX 2.1
  */
 public class ByteStringConverter extends StringConverter<Byte> {
+
+    /**
+     * Creates a default {@code ByteStringConverter}.
+     */
+    public ByteStringConverter() {
+    }
+
     /** {@inheritDoc} */
     @Override public Byte fromString(String value) {
         // If the specified value is null or zero-length, return null

--- a/modules/javafx.base/src/main/java/javafx/util/converter/CharacterStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/CharacterStringConverter.java
@@ -33,6 +33,13 @@ import javafx.util.StringConverter;
  * @since JavaFX 2.1
  */
 public class CharacterStringConverter extends StringConverter<Character> {
+
+    /**
+     * Creates a default {@code CharacterStringConverter}.
+     */
+    public CharacterStringConverter() {
+    }
+
     /** {@inheritDoc} */
     @Override public Character fromString(String value) {
         // If the specified value is null or zero-length, return null

--- a/modules/javafx.base/src/main/java/javafx/util/converter/DefaultStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/DefaultStringConverter.java
@@ -32,6 +32,13 @@ import javafx.util.StringConverter;
  * @since JavaFX 2.1
  */
 public class DefaultStringConverter extends StringConverter<String> {
+
+    /**
+     * Creates a default {@code DefaultStringConverter}.
+     */
+    public DefaultStringConverter() {
+    }
+
     /** {@inheritDoc} */
     @Override public String toString(String value) {
         return (value != null) ? value : "";

--- a/modules/javafx.base/src/main/java/javafx/util/converter/DoubleStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/DoubleStringConverter.java
@@ -33,6 +33,13 @@ import javafx.util.StringConverter;
  * @since JavaFX 2.1
  */
 public class DoubleStringConverter extends StringConverter<Double> {
+
+    /**
+     * Creates a default {@code DoubleStringConverter}.
+     */
+    public DoubleStringConverter() {
+    }
+
     /** {@inheritDoc} */
     @Override public Double fromString(String value) {
         // If the specified value is null or zero-length, return null

--- a/modules/javafx.base/src/main/java/javafx/util/converter/FloatStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/FloatStringConverter.java
@@ -33,6 +33,13 @@ import javafx.util.StringConverter;
  * @since JavaFX 2.1
  */
 public class FloatStringConverter extends StringConverter<Float> {
+
+    /**
+     * Creates a default {@code FloatStringConverter}.
+     */
+    public FloatStringConverter() {
+    }
+
     /** {@inheritDoc} */
     @Override public Float fromString(String value) {
         // If the specified value is null or zero-length, return null

--- a/modules/javafx.base/src/main/java/javafx/util/converter/IntegerStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/IntegerStringConverter.java
@@ -33,6 +33,13 @@ import javafx.util.StringConverter;
  * @since JavaFX 2.1
  */
 public class IntegerStringConverter extends StringConverter<Integer> {
+
+    /**
+     * Creates a default {@code IntegerStringConverter}.
+     */
+    public IntegerStringConverter() {
+    }
+
     /** {@inheritDoc} */
     @Override public Integer fromString(String value) {
         // If the specified value is null or zero-length, return null

--- a/modules/javafx.base/src/main/java/javafx/util/converter/LongStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/LongStringConverter.java
@@ -33,6 +33,13 @@ import javafx.util.StringConverter;
  * @since JavaFX 2.1
  */
 public class LongStringConverter extends StringConverter<Long> {
+
+    /**
+     * Creates a default {@code LongStringConverter}.
+     */
+    public LongStringConverter() {
+    }
+
     /** {@inheritDoc} */
     @Override public Long fromString(String value) {
         // If the specified value is null or zero-length, return null

--- a/modules/javafx.base/src/main/java/javafx/util/converter/ShortStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/ShortStringConverter.java
@@ -32,6 +32,13 @@ import javafx.util.StringConverter;
  * @since JavaFX 2.1
  */
 public class ShortStringConverter extends StringConverter<Short> {
+
+    /**
+     * Creates a default {@code ShortStringConverter}.
+     */
+    public ShortStringConverter() {
+    }
+
     /** {@inheritDoc} */
     @Override public Short fromString(String text) {
         // If the specified value is null or zero-length, return null


### PR DESCRIPTION
Added missing explicit no-arg constructors to classes in package javafx.beans.property, javafx.collections, javafx.util and javafx.util.converter in module javafx.base.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251352](https://bugs.openjdk.java.net/browse/JDK-8251352): Many javafx.base classes have implicit no-arg constructors


### Reviewers
 * Nir Lisker ([nlisker](@nlisker) - **Reviewer**)
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/282/head:pull/282`
`$ git checkout pull/282`
