### PR TITLE
8251946: ObservableList.setAll does not conform to specification

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/VetoableListDecorator.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/VetoableListDecorator.java
@@ -113,8 +113,7 @@ public abstract class VetoableListDecorator<E> implements ObservableList<E> {
         onProposedChange(Collections.unmodifiableList(new ArrayList(col)), 0, size());
         try {
             modCount++;
-            list.setAll(col);
-            return true;
+            return list.setAll(col);
         } catch(Exception e) {
             modCount--;
             throw e;

--- a/modules/javafx.base/src/main/java/javafx/collections/ModifiableObservableListBase.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/ModifiableObservableListBase.java
@@ -29,6 +29,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Objects;
 
 /**
  * Abstract class that serves as a base class for {@link ObservableList} implementations that are modifiable.
@@ -90,12 +91,28 @@ public abstract class ModifiableObservableListBase<E> extends ObservableListBase
     public boolean setAll(Collection<? extends E> col) {
         beginChange();
         try {
-            clear();
-            addAll(col);
+            Iterator<? extends E> itr = col.iterator();
+            boolean changed = false;
+            int i;
+
+            for (i = 0; i < size() && itr.hasNext(); i++) {
+                E e = itr.next();
+                E old = set(i, e);
+                changed |= !Objects.equals(e, old);
+            }
+
+            if (i < size()) {
+                remove(i, size());
+                return true;
+            } else if (itr.hasNext()) {
+                itr.forEachRemaining(this::add);
+                return true;
+            } else {
+                return changed;
+            }
         } finally {
             endChange();
         }
-        return true;
     }
 
     @Override

--- a/modules/javafx.base/src/main/java/javafx/collections/ModifiableObservableListBase.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/ModifiableObservableListBase.java
@@ -92,8 +92,8 @@ public abstract class ModifiableObservableListBase<E> extends ObservableListBase
         beginChange();
         try {
             clear();
-            boolean res = super.addAll(col);
-            return res;
+            addAll(col);
+            return true;
         } finally {
             endChange();
         }

--- a/modules/javafx.base/src/main/java/javafx/collections/ModifiableObservableListBase.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/ModifiableObservableListBase.java
@@ -29,7 +29,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.Objects;
 
 /**
  * Abstract class that serves as a base class for {@link ObservableList} implementations that are modifiable.
@@ -93,8 +92,8 @@ public abstract class ModifiableObservableListBase<E> extends ObservableListBase
         beginChange();
         try {
             clear();
-            addAll(col);
-            return true;
+            boolean res = super.addAll(col);
+            return res;
         } finally {
             endChange();
         }

--- a/modules/javafx.base/src/main/java/javafx/collections/ModifiableObservableListBase.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/ModifiableObservableListBase.java
@@ -89,27 +89,12 @@ public abstract class ModifiableObservableListBase<E> extends ObservableListBase
 
     @Override
     public boolean setAll(Collection<? extends E> col) {
+        if (isEmpty() && col.isEmpty()) return false;
         beginChange();
         try {
-            Iterator<? extends E> itr = col.iterator();
-            boolean changed = false;
-            int i;
-
-            for (i = 0; i < size() && itr.hasNext(); i++) {
-                E e = itr.next();
-                E old = set(i, e);
-                changed |= !Objects.equals(e, old);
-            }
-
-            if (i < size()) {
-                remove(i, size());
-                return true;
-            } else if (itr.hasNext()) {
-                itr.forEachRemaining(this::add);
-                return true;
-            } else {
-                return changed;
-            }
+            clear();
+            addAll(col);
+            return true;
         } finally {
             endChange();
         }

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListTest.java
@@ -256,6 +256,23 @@ public class ObservableListTest  {
     }
 
     @Test
+    public void testSetAll() {
+        useListData("one", "two", "three");
+        boolean r = list.setAll("one");
+        assertTrue(r);
+
+        r = list.setAll("one", "four", "five");
+        assertTrue(r);
+    }
+
+    @Test
+    public void testSetAllNoUpdate() {
+        useListData("one", "two", "three");
+        boolean r = list.setAll("one", "two", "three");
+        assertFalse(r);
+    }
+
+    @Test
     public void testObserverCanRemoveObservers() {
         final ListChangeListener<String> listObserver = change -> {
             change.getList().removeListener(mlo);

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListTest.java
@@ -266,6 +266,9 @@ public class ObservableListTest  {
 
         r = list.setAll();
         assertTrue(r);
+
+        r = list.setAll("one");
+        assertTrue(r);
     }
 
     @Test

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListTest.java
@@ -267,8 +267,8 @@ public class ObservableListTest  {
 
     @Test
     public void testSetAllNoUpdate() {
-        useListData("one", "two", "three");
-        boolean r = list.setAll("one", "two", "three");
+        useListData();
+        boolean r = list.setAll();
         assertFalse(r);
     }
 

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListTest.java
@@ -263,6 +263,9 @@ public class ObservableListTest  {
 
         r = list.setAll("one", "four", "five");
         assertTrue(r);
+
+        r = list.setAll();
+        assertTrue(r);
     }
 
     @Test


### PR DESCRIPTION
Hi, this PR fixes [JDK-8251946](https://bugs.openjdk.java.net/browse/JDK-8251946) computing whether the list was actually modified instead of just returning `true`. The list was modified if
1. it was not empty (modified by calling `#clear()`), or if
2. it was modified as result of the `#addAll()` call.

If you want any test coverage for this please let me know.

I reported the issue a couple of days ago via web formula and waited for the confirmation to open this PR but now I see that @kevinrushforth (sorry for pinging) is already assigned to the JBS issue. I'm not too familiar with how you handle JBS issues or more specifically whether assigning is used to indicate that the issue is in the assignee's "domain", or that the assignee is already working on it. In the latter case, please feel free to close this PR. (My OCA submission is still pending anyway.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251946](https://bugs.openjdk.java.net/browse/JDK-8251946): ObservableList.setAll does not conform to specification


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/284/head:pull/284`
`$ git checkout pull/284`
