### PR TITLE
8251555: Remove unused focusedWindow field in glass Window to avoid leak

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Window.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Window.java
@@ -738,16 +738,6 @@ public abstract class Window {
         return (this.styleMask & Window.TRANSPARENT) != 0;
     }
 
-    private static volatile Window focusedWindow = null;
-    public static Window getFocusedWindow() {
-        Application.checkEventThread();
-        return Window.focusedWindow;
-    }
-
-    private static void setFocusedWindow(final Window window) {
-        Window.focusedWindow = window;
-    }
-
     public boolean isFocused() {
         Application.checkEventThread();
         return this.isFocused;
@@ -1322,11 +1312,6 @@ public abstract class Window {
 
         if (this.isFocused != focused) {
             this.isFocused = focused;
-            if (this.isFocused) {
-                setFocusedWindow(this);
-            } else {
-                setFocusedWindow(null);
-            }
             handleWindowEvent(System.nanoTime(), event);
         }
     }


### PR DESCRIPTION
This is a follow-up to [JDK-8241840](https://bugs.openjdk.java.net/browse/JDK-8241840) that removes an unused static `focusedWindow` field and its associated getter and setter from the platform-independent glass Window class. This is entirely unused by any of the glass platforms. The Monocle platform keeps track of the `focusedWindow` attribute itself.

The existing `test.javafx.stage.FocusedWindowNativeTest` automated test, which was added as part of [JDK-8241840](https://bugs.openjdk.java.net/browse/JDK-8241840), was failing fairly consistently on one of our test machines before this fix, and now passes.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251555](https://bugs.openjdk.java.net/browse/JDK-8251555): Remove unused focusedWindow field in glass Window to avoid leak


### Reviewers
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/286/head:pull/286`
`$ git checkout pull/286`
