### PR TITLE
8252060: gstreamer fails to build with gcc 10

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gstreamer/gst/gstconfig.h
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gstreamer/gst/gstconfig.h
@@ -162,7 +162,11 @@
 #ifdef GSTREAMER_LITE
   // We using def file to limit export, so not need to export all APIs
   #ifndef GST_API
-    #define GST_API
+    #if defined(__GNUC__)
+      #define GST_API GST_EXPORT
+    #else
+      #define GST_API
+    #endif
   #endif
 #else // GSTREAMER_LITE
   #ifndef GST_API


### PR DESCRIPTION
Fixed by defining GST_API as GST_EXPORT for gcc compiler as per Kevin proposed solution. On Windows we do not need to define GST_API, since we using .def file to export symbols.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252060](https://bugs.openjdk.java.net/browse/JDK-8252060): gstreamer fails to build with gcc 10


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/287/head:pull/287`
`$ git checkout pull/287`
