### PR TITLE
8251941: ListCell: visual artifact when items contain null values

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -483,7 +483,7 @@ public class ListCell<T> extends IndexedCell<T> {
             // refer to Ensemble8PopUpTree.png - in this case the arrows are being
             // shown as the new cells are instantiated with the arrows in the
             // children list, and are only hidden in updateItem.
-            if ((!isEmpty && oldValue != null) || firstRun) {
+            if (!isEmpty || firstRun) {
                 updateItem(null, true);
                 firstRun = false;
             }


### PR DESCRIPTION
The issue describes the makroscopic effect/s, namely content showing in cells that are off range.

The base reason is missing cleanup of the cell on transition from not-empty to empty when the old item is a null contained in the items. Fixed by changing the logic to cope with that special case. Added tests that fail before and pass after the fix.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251941](https://bugs.openjdk.java.net/browse/JDK-8251941): ListCell: visual artifact when items contain null values


### Reviewers
 * Ajit Ghaisas ([aghaisas](@aghaisas) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/288/head:pull/288`
`$ git checkout pull/288`
