### PR TITLE
8251858: Update to Xcode 11.3.1

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -90,7 +90,7 @@ jfx.gradle.version.min=5.3
 # Toolchains
 jfx.build.linux.gcc.version=gcc9.2.0-OL6.4+1.0
 jfx.build.windows.msvc.version=VS2019-16.5.3+1.0
-jfx.build.macosx.xcode.version=Xcode10.1-MacOSX10.14+1.0
+jfx.build.macosx.xcode.version=Xcode11.3.1-MacOSX10.15+1.0
 
 # Build tools
 jfx.build.cmake.version=3.13.3

--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -45,7 +45,7 @@ MAC.libDest = "lib"
  * In extreme cases you can provide your own properties in your home dir to
  * override these settings or pass them on the command line.
  */
-def prefSdkVersion = "10.11"
+def prefSdkVersion = "10.15"
 def defaultSdkPath = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${prefSdkVersion}.sdk";
 
 // Set the minimum API version that we require (developers do not need to override this)


### PR DESCRIPTION
This updates the compiler used to build JavaFX on macOS to Xcode 11.3.1 + MacOSX10.15 sdk, which matches the compiler used to build JDK 16.

As noted in the bug report, Xcode 11.3.1 needs macOS 10.14.4 (Mojave) or later to build, but the produced artifacts will be able to run on earlier versions of macOS.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251858](https://bugs.openjdk.java.net/browse/JDK-8251858): Update to Xcode 11.3.1


### Reviewers
 * Johan Vos ([jvos](@johanvos) - **Reviewer**)
 * Ambarish Rapte ([arapte](@arapte) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/291/head:pull/291`
`$ git checkout pull/291`
