### PR TITLE
8252546: Move ObservableValue's equality check and lazy evaluation descriptions to @implSpec

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/beans/value/ObservableValue.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/value/ObservableValue.java
@@ -39,14 +39,11 @@ import javafx.beans.Observable;
  * <p>
  * An implementation of {@code ObservableValue} may support lazy evaluation,
  * which means that the value is not immediately recomputed after changes, but
- * lazily the next time the value is requested. All bindings and properties in
- * this library support lazy evaluation.
+ * lazily the next time the value is requested (see note 1 in {@code implSpec}).
  * <p>
  * An {@code ObservableValue} generates two types of events: change events and
- * invalidation events. A change event indicates that the value has changed.
- * Current implementing classes in JavaFX check for a change using reference
- * equality (and not object equality, {@code Object#equals(Object)}) of the value. An
- * invalidation event is generated if the current value is not valid anymore.
+ * invalidation events. A change event indicates that the value has changed
+ * (see note 2 in {@code implSpec}). An invalidation event is generated if the current value is not valid anymore.
  * This distinction becomes important if the {@code ObservableValue} supports
  * lazy evaluation, because for a lazily evaluated value one does not know if an
  * invalid value really has changed until it is recomputed. For this reason,
@@ -69,6 +66,12 @@ import javafx.beans.Observable;
  *
  * @param <T>
  *            The type of the wrapped value.
+ *
+ * @implSpec <ol>
+ * <li> All bindings and properties in this library support lazy evaluation.
+ * <li> Current implementing classes in JavaFX check for a change using reference
+ * equality (and not object equality, {@code Object#equals(Object)}) of the value.
+ * </ol>
  *
  * @see ObservableBooleanValue
  * @see ObservableDoubleValue

--- a/modules/javafx.base/src/main/java/javafx/beans/value/ObservableValue.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/value/ObservableValue.java
@@ -39,11 +39,12 @@ import javafx.beans.Observable;
  * <p>
  * An implementation of {@code ObservableValue} may support lazy evaluation,
  * which means that the value is not immediately recomputed after changes, but
- * lazily the next time the value is requested (see note 1 in the "Implementation Requirements").
+ * lazily the next time the value is requested (see note 1 in "Implementation Requirements").
  * <p>
  * An {@code ObservableValue} generates two types of events: change events and
  * invalidation events. A change event indicates that the value has changed
- * (see note 2 in "Implementation Requirements"). An invalidation event is generated if the current value is not valid anymore.
+ * (see note 2 in "Implementation Requirements"). An
+ * invalidation event is generated if the current value is not valid anymore.
  * This distinction becomes important if the {@code ObservableValue} supports
  * lazy evaluation, because for a lazily evaluated value one does not know if an
  * invalid value really has changed until it is recomputed. For this reason,
@@ -68,9 +69,9 @@ import javafx.beans.Observable;
  *            The type of the wrapped value.
  *
  * @implSpec <ol>
- * <li> All bindings and properties in the JavaFX library support lazy evaluation.
+ * <li> All bindings and properties in the JavaFX library support lazy evaluation.</li>
  * <li> All implementing classes in the JavaFX library check for a change using reference
- * equality (and not object equality, {@code Object#equals(Object)}) of the value.
+ * equality (and not object equality, {@code Object#equals(Object)}) of the value.</li>
  * </ol>
  *
  * @see ObservableBooleanValue

--- a/modules/javafx.base/src/main/java/javafx/beans/value/ObservableValue.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/value/ObservableValue.java
@@ -39,11 +39,11 @@ import javafx.beans.Observable;
  * <p>
  * An implementation of {@code ObservableValue} may support lazy evaluation,
  * which means that the value is not immediately recomputed after changes, but
- * lazily the next time the value is requested (see note 1 in {@code implSpec}).
+ * lazily the next time the value is requested (see note 1 in the "Implementation Requirements").
  * <p>
  * An {@code ObservableValue} generates two types of events: change events and
  * invalidation events. A change event indicates that the value has changed
- * (see note 2 in {@code implSpec}). An invalidation event is generated if the current value is not valid anymore.
+ * (see note 2 in "Implementation Requirements"). An invalidation event is generated if the current value is not valid anymore.
  * This distinction becomes important if the {@code ObservableValue} supports
  * lazy evaluation, because for a lazily evaluated value one does not know if an
  * invalid value really has changed until it is recomputed. For this reason,
@@ -68,8 +68,8 @@ import javafx.beans.Observable;
  *            The type of the wrapped value.
  *
  * @implSpec <ol>
- * <li> All bindings and properties in this library support lazy evaluation.
- * <li> Current implementing classes in JavaFX check for a change using reference
+ * <li> All bindings and properties in the JavaFX library support lazy evaluation.
+ * <li> All implementing classes in the JavaFX library check for a change using reference
  * equality (and not object equality, {@code Object#equals(Object)}) of the value.
  * </ol>
  *


### PR DESCRIPTION
Moving implementation details about lazy evaluation and equality checking to `@implSpec`.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252546](https://bugs.openjdk.java.net/browse/JDK-8252546): Move ObservableValue's equality check and lazy evaluation descriptions to @implSpec


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/292/head:pull/292`
`$ git checkout pull/292`
