### PR TITLE
8252062: WebKit build fails with recent VS 2019 compiler 

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/style/StyleResolver.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/style/StyleResolver.cpp
@@ -107,7 +107,7 @@ Resolver::Resolver(Document& document)
     if (view)
         m_mediaQueryEvaluator = MediaQueryEvaluator { view->mediaType() };
     else
-        m_mediaQueryEvaluator = MediaQueryEvaluator { "all" };
+        m_mediaQueryEvaluator = MediaQueryEvaluator { };
 
     if (root) {
         m_rootDefaultStyle = styleForElement(*root, m_document.renderStyle(), nullptr, RuleMatchingBehavior::MatchOnlyUserAgentRules).renderStyle;


### PR DESCRIPTION
The WebKit build fails with recent VS 2019 compiler.

Bug: This MediaQueryEvaluator constructor takes a String parameter, but the conversion of char* to String is failing.

Fix: Use the default constructor of MediaQueryEvaluator, which also returns true for "all".

Test: Build webkit with the recent VS 2019 compiler with and without this fix. It should fail without the fix and build with the fix.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252062](https://bugs.openjdk.java.net/browse/JDK-8252062): WebKit build fails with recent VS 2019 compiler


### Reviewers
 * Kevin Rushforth ([kcr](@kevinrushforth) - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/294/head:pull/294`
`$ git checkout pull/294`
