### PR TITLE
8252811: The list of cells in a VirtualFlow is cleared every time the number of items changes

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -836,12 +836,6 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             if (countChanged) {
                 layoutChildren();
 
-                // Fix for RT-13965: Without this line of code, the number of items in
-                // the sheet would constantly grow, leaking memory for the life of the
-                // application. This was especially apparent when the total number of
-                // cells changes - regardless of whether it became bigger or smaller.
-                sheetChildren.clear();
-
                 Parent parent = getParent();
                 if (parent != null) parent.requestLayout();
             }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -1168,6 +1168,38 @@ public class VirtualFlowTest {
     public void testScrollOneCellHorizontal() {
         assertLastCellInsideViewport(false);
     }
+
+    @Test
+    // see JDK-8252811
+    public void testSheetChildrenRemainsConstant() {
+        flow.setVertical(true);
+        flow.setCellCount(20);
+        flow.resize(300, 300);
+        pulse();
+
+        int sheetChildrenSize = flow.sheetChildren.size();
+        assertEquals("Wrong number of sheet children", 12, sheetChildrenSize);
+
+        for (int i = 1; i < 50; i++) {
+            flow.setCellCount(20 + i);
+            pulse();
+            sheetChildrenSize = flow.sheetChildren.size();
+            assertEquals("Wrong number of sheet children after inserting " + i + " items", 12, sheetChildrenSize);
+        }
+
+        for (int i = 1; i < 50; i++) {
+            flow.setCellCount(70 - i);
+            pulse();
+            sheetChildrenSize = flow.sheetChildren.size();
+            assertEquals("Wrong number of sheet children after removing " + i + " items", 12, sheetChildrenSize);
+        }
+
+        flow.setCellCount(0);
+        pulse();
+        sheetChildrenSize = flow.sheetChildren.size();
+        assertEquals("Wrong number of sheet children after removing all items", 12, sheetChildrenSize);
+    }
+
 }
 
 class CellStub extends IndexedCellShim {


### PR DESCRIPTION
This PR removes an old fix (RT-13965/JDK-8113318), which was applied in 2011 to avoid a memory leak in `VirtualFlow::sheetChildren`, after new items were constantly added.

With the current VirtualFlow implementation, there are in place the necessary methods that take care of cleaning or adding new cells to the sheetChildren list, and such memory leak doesn't exist, the size remains constant when new items are added or removed (see included unity test). 

The call to `sheetchildren.clear()`, on the contrary, has a big impact in performance and CPU usage, when new items are constantly added, as has been reported in JDK-8185886/#108.
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252811](https://bugs.openjdk.java.net/browse/JDK-8252811): The list of cells in a VirtualFlow is cleared every time the number of items changes


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/298/head:pull/298`
`$ git checkout pull/298`
