### PR TITLE
8253086: Optimization of removeAll and retainAll of ObservableListWrapper

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/ObservableListWrapper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/ObservableListWrapper.java
@@ -169,7 +169,8 @@ public class ObservableListWrapper<E> extends ModifiableObservableListBase<E> im
 
     @Override
     public boolean removeAll(Collection<?> c) {
-        if (this.isEmpty() || c.isEmpty()) {
+        // Throw NullPointerException if c is null
+        if (c.isEmpty() || this.isEmpty()) {
             return false;
         }
         beginChange();
@@ -186,11 +187,19 @@ public class ObservableListWrapper<E> extends ModifiableObservableListBase<E> im
 
     @Override
     public boolean retainAll(Collection<?> c) {
-        if (this.isEmpty() || c.isEmpty()) {
+        // Throw NullPointerException if c is null
+        if (c.isEmpty()) {
+            boolean retained = !this.isEmpty();
+            if (retained) {
+                clear();
+            }
+            return retained;
+        }
+        if (this.isEmpty()) {
             return false;
         }
-        beginChange();
         boolean retained = false;
+        beginChange();
         for (int i = size()-1; i>=0; i--) {
             if (!c.contains(get(i))) {
                 remove(i);

--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/ObservableListWrapper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/ObservableListWrapper.java
@@ -169,40 +169,36 @@ public class ObservableListWrapper<E> extends ModifiableObservableListBase<E> im
 
     @Override
     public boolean removeAll(Collection<?> c) {
-        beginChange();
-        BitSet bs = new BitSet(c.size());
-        for (int i = 0; i < size(); ++i) {
-            if (c.contains(get(i))) {
-                bs.set(i);
-            }
+        if (this.isEmpty() || c.isEmpty()) {
+            return false;
         }
-        if (!bs.isEmpty()) {
-            int cur = size();
-            while ((cur = bs.previousSetBit(cur - 1)) >= 0) {
-                remove(cur);
+        beginChange();
+        boolean removed = false;
+        for (int i = size()-1; i>=0; i--) {
+            if (c.contains(get(i))) {
+                remove(i);
+                removed = true;
             }
         }
         endChange();
-        return !bs.isEmpty();
+        return removed;
     }
 
     @Override
     public boolean retainAll(Collection<?> c) {
-        beginChange();
-        BitSet bs = new BitSet(c.size());
-        for (int i = 0; i < size(); ++i) {
-            if (!c.contains(get(i))) {
-                bs.set(i);
-            }
+        if (this.isEmpty() || c.isEmpty()) {
+            return false;
         }
-        if (!bs.isEmpty()) {
-            int cur = size();
-            while ((cur = bs.previousSetBit(cur - 1)) >= 0) {
-                remove(cur);
+        beginChange();
+        boolean retained = false;
+        for (int i = size()-1; i>=0; i--) {
+            if (!c.contains(get(i))) {
+                remove(i);
+                retained = true;
             }
         }
         endChange();
-        return !bs.isEmpty();
+        return retained;
     }
 
     private SortHelper helper;

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/collections/ObservableListWrapperTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/collections/ObservableListWrapperTest.java
@@ -71,41 +71,90 @@ public class ObservableListWrapperTest {
 
     @Test
     public void testRemoveAll_Args() {
-        ObservableList<Integer> list = new ObservableListWrapper<>(new ArrayList<>(Arrays.asList(1, 2, 3)));
-        assertFalse(list.removeAll(0));
-        assertEquals(3, list.size());
-        assertTrue(list.removeAll(1));
-        assertEquals(2, list.size());
-        assertFalse(list.removeAll(1));
-        assertEquals(2, list.size());
-        assertTrue(list.removeAll(1, 2));
-        assertEquals(1, list.size());
-        assertTrue(list.removeAll(3));
-        assertEquals(0, list.size());
-        assertFalse(list.removeAll(Collections.EMPTY_SET));
-        assertFalse(list.removeAll(1));
-        assertFalse(list.removeAll(1, 2));
+        {
+            ObservableList<Integer> list = new ObservableListWrapper<>(
+                new ArrayList<>(Arrays.asList(1, 2, 3)));
+            assertFalse(list.removeAll(0));
+            assertEquals(Arrays.asList(1, 2, 3), list);
+            assertTrue(list.removeAll(1));
+            assertEquals(Arrays.asList(2, 3), list);
+            assertFalse(list.removeAll(1));
+            assertEquals(Arrays.asList(2, 3), list);
+            assertTrue(list.removeAll(1, 2));
+            assertEquals(Arrays.asList(3), list);
+            assertTrue(list.removeAll(3));
+            assertEquals(0, list.size());
+            assertFalse(list.removeAll(Collections.EMPTY_SET));
+            assertFalse(list.removeAll(1));
+            assertFalse(list.removeAll(1, 2));
+        }
+        {
+            ObservableList<Integer> list = new ObservableListWrapper<>(
+                new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5)));
+            assertTrue(list.removeAll(2, 4));
+            assertEquals(Arrays.asList(1, 3, 5), list);
+            assertTrue(list.removeAll(1, 5));
+            assertEquals(Arrays.asList(3), list);
+        }
+        {
+            ObservableList<Integer> list = new ObservableListWrapper<>(
+                new ArrayList<>(Arrays.asList(11, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+            assertTrue(list.removeAll(11));
+            assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), list);
+            assertTrue(list.removeAll(1, 2, 9, 10));
+            assertEquals(Arrays.asList(3, 4, 5, 6, 7, 8), list);
+            assertTrue(list.removeAll(5, 6));
+            assertEquals(Arrays.asList(3, 4, 7, 8), list);
+            assertTrue(list.removeAll(8, 7, 4, 3));
+            assertEquals(0, list.size());
+        }
     }
 
     @Test
     public void testRetainAll_Args() {
-        ObservableList<Integer> list = new ObservableListWrapper<>(new ArrayList<>(Arrays.asList(1, 2, 3)));
-        assertFalse(list.retainAll(0, 1, 2, 3));
-        assertEquals(3, list.size());
-        assertFalse(list.retainAll(1, 2, 3));
-        assertEquals(3, list.size());
-        assertTrue(list.retainAll(2, 3));
-        assertEquals(2, list.size());
-        assertTrue(list.retainAll(3));
-        assertEquals(1, list.size());
-        assertTrue(list.retainAll(1,2));
-        assertEquals(0, list.size());
-        assertFalse(list.retainAll(Collections.EMPTY_SET));
-        assertFalse(list.retainAll(2,3));
-        assertFalse(list.retainAll(3));
+        {
+            ObservableList<Integer> list = new ObservableListWrapper<>(
+                new ArrayList<>(Arrays.asList(1, 2, 3)));
+            assertFalse(list.retainAll(0, 1, 2, 3));
+            assertEquals(Arrays.asList(1, 2, 3), list);
+            assertFalse(list.retainAll(1, 2, 3));
+            assertEquals(Arrays.asList(1, 2, 3), list);
+            assertTrue(list.retainAll(2, 3));
+            assertEquals(Arrays.asList(2, 3), list);
+            assertTrue(list.retainAll(3));
+            assertEquals(Arrays.asList(3), list);
+            assertTrue(list.retainAll(1,2));
+            assertEquals(0, list.size());
+            assertFalse(list.retainAll(Collections.EMPTY_SET));
+            assertFalse(list.retainAll(2,3));
+            assertFalse(list.retainAll(3));
 
-        list = new ObservableListWrapper<>(new ArrayList<>(Arrays.asList(1, 2, 3)));
-        assertTrue(list.retainAll(Collections.EMPTY_SET));
-        assertEquals(0, list.size());
+            list = new ObservableListWrapper<>(
+                new ArrayList<>(Arrays.asList(1, 2, 3)));
+            assertTrue(list.retainAll(Collections.EMPTY_SET));
+            assertEquals(0, list.size());
+        }
+        {
+            ObservableList<Integer> list = new ObservableListWrapper<>(
+                new ArrayList<>(Arrays.asList(1, 2, 3, 4, 5)));
+            assertTrue(list.retainAll(1, 3, 5));
+            assertEquals(Arrays.asList(1, 3, 5), list);
+            assertTrue(list.retainAll(3));
+            assertEquals(Arrays.asList(3), list);
+        }
+        {
+            ObservableList<Integer> list = new ObservableListWrapper<>(
+                new ArrayList<>(Arrays.asList(11, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11)));
+            assertTrue(list.retainAll(1, 2, 3, 4, 5, 6, 7, 8, 9, 10));
+            assertEquals(Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10), list);
+            assertTrue(list.retainAll(3, 4, 5, 6, 7, 8));
+            assertEquals(Arrays.asList(3, 4, 5, 6, 7, 8), list);
+            assertTrue(list.retainAll(3, 4, 7, 8));
+            assertEquals(Arrays.asList(3, 4, 7, 8), list);
+            assertFalse(list.retainAll(3, 4, 7, 8));
+            assertEquals(Arrays.asList(3, 4, 7, 8), list);
+            assertTrue(list.retainAll(0));
+            assertEquals(0, list.size());
+        }
     }
 }

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/collections/ObservableListWrapperTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/collections/ObservableListWrapperTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.javafx.collections;
+
+import javafx.collections.ObservableList;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.sun.javafx.collections.ObservableListWrapper;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class ObservableListWrapperTest {
+
+    @Test(expected = NullPointerException.class)
+    public void testRemoveAll_Null() {
+        ObservableList<Integer> list = new ObservableListWrapper<>(new ArrayList<>());
+        list.removeAll((Collection)null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testRetainAll_Null() {
+        ObservableList<Integer> list = new ObservableListWrapper<>(new ArrayList<>());
+        list.retainAll((Collection)null);
+    }
+
+    @Test
+    public void testRemoveAll_Empty() {
+        ObservableList<Integer> list = new ObservableListWrapper<>(new ArrayList<>());
+        assertFalse(list.removeAll(Collections.EMPTY_LIST));
+        assertFalse(list.removeAll(Collections.EMPTY_SET));
+    }
+
+    @Test
+    public void testRetainAll_Empty() {
+        ObservableList<Integer> list = new ObservableListWrapper<>(new ArrayList<>());
+        assertFalse(list.retainAll(Collections.EMPTY_LIST));
+        assertFalse(list.retainAll(Collections.EMPTY_SET));
+    }
+
+    @Test
+    public void testRemoveAll_Args() {
+        ObservableList<Integer> list = new ObservableListWrapper<>(new ArrayList<>(Arrays.asList(1, 2, 3)));
+        assertFalse(list.removeAll(0));
+        assertEquals(3, list.size());
+        assertTrue(list.removeAll(1));
+        assertEquals(2, list.size());
+        assertFalse(list.removeAll(1));
+        assertEquals(2, list.size());
+        assertTrue(list.removeAll(1, 2));
+        assertEquals(1, list.size());
+        assertTrue(list.removeAll(3));
+        assertEquals(0, list.size());
+        assertFalse(list.removeAll(Collections.EMPTY_SET));
+        assertFalse(list.removeAll(1));
+        assertFalse(list.removeAll(1, 2));
+    }
+
+    @Test
+    public void testRetainAll_Args() {
+        ObservableList<Integer> list = new ObservableListWrapper<>(new ArrayList<>(Arrays.asList(1, 2, 3)));
+        assertFalse(list.retainAll(0, 1, 2, 3));
+        assertEquals(3, list.size());
+        assertFalse(list.retainAll(1, 2, 3));
+        assertEquals(3, list.size());
+        assertTrue(list.retainAll(2, 3));
+        assertEquals(2, list.size());
+        assertTrue(list.retainAll(3));
+        assertEquals(1, list.size());
+        assertTrue(list.retainAll(1,2));
+        assertEquals(0, list.size());
+        assertFalse(list.retainAll(Collections.EMPTY_SET));
+        assertFalse(list.retainAll(2,3));
+        assertFalse(list.retainAll(3));
+
+        list = new ObservableListWrapper<>(new ArrayList<>(Arrays.asList(1, 2, 3)));
+        assertTrue(list.retainAll(Collections.EMPTY_SET));
+        assertEquals(0, list.size());
+    }
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
@@ -837,6 +837,22 @@ public class ListViewTest {
         assertEquals("C", fxList.get(1));
     }
 
+    @Test public void test_rt35857Back() {
+        ObservableList<String> fxList = FXCollections.observableArrayList("A", "B", "C");
+        final ListView<String> listView = new ListView<String>(fxList);
+
+        listView.getSelectionModel().select(2);
+
+        ObservableList<String> selectedItems = listView.getSelectionModel().getSelectedItems();
+        assertEquals(1, selectedItems.size());
+        assertEquals("C", selectedItems.get(0));
+
+        listView.getItems().removeAll(selectedItems);
+        assertEquals(2, fxList.size());
+        assertEquals("A", fxList.get(0));
+        assertEquals("B", fxList.get(1));
+    }
+
     private int rt_35889_cancel_count = 0;
     @Test public void test_rt35889() {
         final ListView<String> textFieldListView = new ListView<String>();


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8253086

ObservableListWrapper.java
 * public boolean removeAll(Collection<?> c)
* public boolean retainAll(Collection<?> c)

These two methods use BitSet, but it doesn't make sense.
By rewriting to the equivalent behavior that does not use BitSet, it is possible to reduce the CPU load in a wide range of use cases.

The test is done with the following command.

* gradle base: test
* gradle controls: test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8253086](https://bugs.openjdk.org/browse/JDK-8253086): Optimization of removeAll and retainAll of ObservableListWrapper


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/305/head:pull/305` \
`$ git checkout pull/305`

Update a local copy of the PR: \
`$ git checkout pull/305` \
`$ git pull https://git.openjdk.org/jfx.git pull/305/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 305`

View PR using the GUI difftool: \
`$ git pr show -t 305`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/305.diff">https://git.openjdk.org/jfx/pull/305.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/305#issuecomment-691953964)