### PR TITLE
8253123: Switch FX build to use JDK 15 as boot JDK

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -73,7 +73,7 @@ javadoc.header=JavaFX&nbsp;16
 ##############################################################################
 
 # JDK
-jfx.build.jdk.version=14
+jfx.build.jdk.version=15
 jfx.build.jdk.buildnum=36
 jfx.build.jdk.version.min=11
 jfx.build.jdk.buildnum.min=28


### PR DESCRIPTION
Updates the boot JDK used to build JavaFX 16 to JDK 15. The minimum remains at JDK 11.

Note to reviewers: the build number for JDK 15 GA is the same as JDK 14 GA, so that property is intentionally unchanged (I didn't forget to update it).
<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253123](https://bugs.openjdk.java.net/browse/JDK-8253123): Switch FX build to use JDK 15 as boot JDK


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Joeri Sykora](https://openjdk.java.net/census#sykora) (@tiainen - Author)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/306/head:pull/306`
`$ git checkout pull/306`
