### PR TITLE
8211294: ScrollPane content is blurry with 125% scaling

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/CacheFilter.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/CacheFilter.java
@@ -626,8 +626,8 @@ public class CacheFilter {
             }
             renderNodeToScreen(g);
         } else {
-            double mxt = Math.round(xform.getMxt());
-            double myt = Math.round(xform.getMyt());
+            double mxt = xform.getMxt();
+            double myt = xform.getMyt();
             renderCacheToScreen(g, implImage, mxt, myt);
             implImage.unlock();
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/CacheFilter.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/CacheFilter.java
@@ -626,8 +626,8 @@ public class CacheFilter {
             }
             renderNodeToScreen(g);
         } else {
-            double mxt = xform.getMxt();
-            double myt = xform.getMyt();
+            double mxt = Math.round(xform.getMxt());
+            double myt = Math.round(xform.getMyt());
             renderCacheToScreen(g, implImage, mxt, myt);
             implImage.unlock();
         }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
@@ -944,7 +944,7 @@ public class Region extends Parent {
     private double snappedLeftInset = 0;
 
     /**
-     * Cached snapScale values, used for to determine if snapped cached insets values
+     * Cached snapScale values, used to determine if snapped cached insets values
      * should be invalidated because screen scale has changed.
      */
     private double lastUsedSnapScaleY = 0;
@@ -1837,6 +1837,8 @@ public class Region extends Parent {
      * @return Rounded up insets bottom
      */
     public final double snappedBottomInset() {
+        // invalidate the cached values for snapped inset dimensions
+        // if the screen scale changed since they were last computed.
         if (lastUsedSnapScaleY != getSnapScaleY()) {
             updateSnappedInsets();
         }
@@ -1851,6 +1853,8 @@ public class Region extends Parent {
      * @return Rounded up insets left
      */
     public final double snappedLeftInset() {
+        // invalidate the cached values for snapped inset dimensions
+        // if the screen scale changed since they were last computed.
         if (lastUsedSnapScaleX != getSnapScaleX()) {
             updateSnappedInsets();
         }
@@ -1865,6 +1869,8 @@ public class Region extends Parent {
      * @return Rounded up insets right
      */
     public final double snappedRightInset() {
+        // invalidate the cached values for snapped inset dimensions
+        // if the screen scale changed since they were last computed.
         if (lastUsedSnapScaleX != getSnapScaleX()) {
             updateSnappedInsets();
         }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
@@ -943,8 +943,17 @@ public class Region extends Parent {
     private double snappedBottomInset = 0;
     private double snappedLeftInset = 0;
 
+    /**
+     * Cached snapScale values, used for to determine if snapped cached insets values
+     * should be invalidated because screen scale has changed.
+     */
+    private double lastUsedSnapScaleY = 0;
+    private double lastUsedSnapScaleX = 0;
+
     /** Called to update the cached snapped insets */
     private void updateSnappedInsets() {
+        lastUsedSnapScaleX = getSnapScaleX();
+        lastUsedSnapScaleY = getSnapScaleY();
         final Insets insets = getInsets();
         final boolean snap = isSnapToPixel();
         snappedTopInset = snapSpaceY(insets.getTop(), snap);
@@ -1812,6 +1821,11 @@ public class Region extends Parent {
      * @return Rounded up insets top
      */
     public final double snappedTopInset() {
+        // invalidate the cached values for snapped inset dimensions
+        // if the screen scale changed since they were last computed.
+        if (lastUsedSnapScaleY != getSnapScaleY()) {
+            updateSnappedInsets();
+        }
         return snappedTopInset;
     }
 
@@ -1823,6 +1837,9 @@ public class Region extends Parent {
      * @return Rounded up insets bottom
      */
     public final double snappedBottomInset() {
+        if (lastUsedSnapScaleY != getSnapScaleY()) {
+            updateSnappedInsets();
+        }
         return snappedBottomInset;
     }
 
@@ -1834,6 +1851,9 @@ public class Region extends Parent {
      * @return Rounded up insets left
      */
     public final double snappedLeftInset() {
+        if (lastUsedSnapScaleX != getSnapScaleX()) {
+            updateSnappedInsets();
+        }
         return snappedLeftInset;
     }
 
@@ -1845,6 +1865,9 @@ public class Region extends Parent {
      * @return Rounded up insets right
      */
     public final double snappedRightInset() {
+        if (lastUsedSnapScaleX != getSnapScaleX()) {
+            updateSnappedInsets();
+        }
         return snappedRightInset;
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
@@ -946,17 +946,11 @@ public class Region extends Parent {
     /** Called to update the cached snapped insets */
     private void updateSnappedInsets() {
         final Insets insets = getInsets();
-        if (_snapToPixel) {
-            snappedTopInset = Math.ceil(insets.getTop());
-            snappedRightInset = Math.ceil(insets.getRight());
-            snappedBottomInset = Math.ceil(insets.getBottom());
-            snappedLeftInset = Math.ceil(insets.getLeft());
-        } else {
-            snappedTopInset = insets.getTop();
-            snappedRightInset = insets.getRight();
-            snappedBottomInset = insets.getBottom();
-            snappedLeftInset = insets.getLeft();
-        }
+        final boolean snap = isSnapToPixel();
+        snappedTopInset = snapSpaceY(insets.getTop(), snap);
+        snappedRightInset = snapSpaceX(insets.getRight(), snap);
+        snappedBottomInset = snapSpaceY(insets.getBottom(), snap);
+        snappedLeftInset = snapSpaceX(insets.getLeft(), snap);
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/scene/text/TextFlow.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/text/TextFlow.java
@@ -612,10 +612,6 @@ public class TextFlow extends Pane {
     }
 
     /* The methods in this section are copied from Region due to package visibility restriction */
-    private static double snapSpace(double value, boolean snapToPixel) {
-        return snapToPixel ? Math.round(value) : value;
-    }
-
     static double boundedSize(double min, double pref, double max) {
         double a = pref >= min ? pref : min;
         double b = min >= max ? min : max;
@@ -627,11 +623,10 @@ public class TextFlow extends Pane {
     }
 
     double computeChildPrefAreaWidth(Node child, Insets margin, double height) {
-        final boolean snap = isSnapToPixel();
-        double top = margin != null? snapSpace(margin.getTop(), snap) : 0;
-        double bottom = margin != null? snapSpace(margin.getBottom(), snap) : 0;
-        double left = margin != null? snapSpace(margin.getLeft(), snap) : 0;
-        double right = margin != null? snapSpace(margin.getRight(), snap) : 0;
+        double top = margin != null? snapSpaceY(margin.getTop()) : 0;
+        double bottom = margin != null? snapSpaceY(margin.getBottom()) : 0;
+        double left = margin != null? snapSpaceX(margin.getLeft()) : 0;
+        double right = margin != null? snapSpaceX(margin.getRight()) : 0;
         double alt = -1;
         if (child.getContentBias() == Orientation.VERTICAL) { // width depends on height
             alt = snapSizeY(boundedSize(
@@ -646,11 +641,10 @@ public class TextFlow extends Pane {
     }
 
     double computeChildPrefAreaHeight(Node child, Insets margin, double width) {
-        final boolean snap = isSnapToPixel();
-        double top = margin != null? snapSpace(margin.getTop(), snap) : 0;
-        double bottom = margin != null? snapSpace(margin.getBottom(), snap) : 0;
-        double left = margin != null? snapSpace(margin.getLeft(), snap) : 0;
-        double right = margin != null? snapSpace(margin.getRight(), snap) : 0;
+        double top = margin != null? snapSpaceY(margin.getTop()) : 0;
+        double bottom = margin != null? snapSpaceY(margin.getBottom()) : 0;
+        double left = margin != null? snapSpaceX(margin.getLeft()) : 0;
+        double right = margin != null? snapSpaceX(margin.getRight()) : 0;
         double alt = -1;
         if (child.getContentBias() == Orientation.HORIZONTAL) { // height depends on width
             alt = snapSizeX(boundedSize(

--- a/tests/system/src/test/java/test/javafx/scene/UIRenderSnapToPixelTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/UIRenderSnapToPixelTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.javafx.scene;
+
+import com.sun.javafx.PlatformUtil;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
+import junit.framework.Assert;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+public class UIRenderSnapToPixelTest {
+    private static final double scale = 1.25;
+    private static CountDownLatch startupLatch;
+    private static volatile Stage stage;
+
+    @BeforeClass
+    public static void setupOnce() throws Exception {
+        System.setProperty("glass.win.uiScale", String.valueOf(scale));
+        System.setProperty("glass.gtk.uiScale", String.valueOf(scale));
+        startupLatch = new CountDownLatch(1);
+        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
+        assertTrue("Timeout waiting for FX runtime to start", startupLatch.await(15, TimeUnit.SECONDS));
+    }
+
+    @AfterClass
+    public static void teardown() {
+        Platform.runLater(stage::hide);
+        Platform.exit();
+    }
+
+    @Test
+    public void testScrollPaneSnapChildrenToPixels() {
+        assumeTrue(PlatformUtil.isLinux() || PlatformUtil.isWindows());
+
+        Assert.assertEquals("Wrong render scale", scale, stage.getRenderScaleY(), 0.0001);
+
+        for (Node node : stage.getScene().getRoot().getChildrenUnmodifiable()) {
+            if (node instanceof ScrollPane) {
+                var sp = (ScrollPane) node;
+                Assert.assertEquals("Top inset not snapped to pixel", 0, (sp.snappedTopInset() * scale) % 1, 0.0001);
+                Assert.assertEquals("Bottom inset not snapped to pixel", 0, (sp.snappedBottomInset() * scale) % 1, 0.0001);
+                Assert.assertEquals("Left inset not snapped to pixel", 0, (sp.snappedLeftInset() * scale) % 1, 0.0001);
+                Assert.assertEquals("Right inset not snapped to pixel", 0, (sp.snappedLeftInset() * scale) % 1, 0.0001);
+            }
+        }
+    }
+
+    public static class TestApp extends Application {
+        private static void run() {
+            startupLatch.countDown();
+        }
+
+        @Override
+        public void start(Stage primaryStage) throws Exception {
+            final Label label = new Label("This text may appear blurry at some screen scale without the fix for JDK-8211294");
+            final ScrollPane scrollpane = new ScrollPane(label);
+            scrollpane.setSnapToPixel(true);
+            final VBox root = new VBox();
+            root.getChildren().add(new Label("This text should be sharp at all screen scale"));
+            root.getChildren().add(scrollpane);
+            final Scene scene = new Scene(root);
+            primaryStage.setScene(scene);
+            stage = primaryStage;
+            stage.addEventHandler(WindowEvent.WINDOW_SHOWN, e -> Platform.runLater(TestApp::run));
+            stage.show();
+        }
+    }
+
+}

--- a/tests/system/src/test/java/test/javafx/scene/UIRenderSnapToPixelTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/UIRenderSnapToPixelTest.java
@@ -49,6 +49,7 @@ public class UIRenderSnapToPixelTest {
     private static final double scale = 1.25;
     private static CountDownLatch startupLatch;
     private static volatile Stage stage;
+    private static final double epsilon = 0.00001;
 
     @BeforeClass
     public static void setupOnce() throws Exception {
@@ -74,10 +75,10 @@ public class UIRenderSnapToPixelTest {
         for (Node node : stage.getScene().getRoot().getChildrenUnmodifiable()) {
             if (node instanceof ScrollPane) {
                 var sp = (ScrollPane) node;
-                Assert.assertEquals("Top inset not snapped to pixel", 0, (sp.snappedTopInset() * scale) % 1, 0.0001);
-                Assert.assertEquals("Bottom inset not snapped to pixel", 0, (sp.snappedBottomInset() * scale) % 1, 0.0001);
-                Assert.assertEquals("Left inset not snapped to pixel", 0, (sp.snappedLeftInset() * scale) % 1, 0.0001);
-                Assert.assertEquals("Right inset not snapped to pixel", 0, (sp.snappedLeftInset() * scale) % 1, 0.0001);
+                Assert.assertEquals("Top inset not snapped to pixel", 0, ((sp.snappedTopInset() * scale) + epsilon) % 1, 0.0001);
+                Assert.assertEquals("Bottom inset not snapped to pixel", 0, ((sp.snappedBottomInset() * scale) + epsilon) % 1, 0.0001);
+                Assert.assertEquals("Left inset not snapped to pixel", 0, ((sp.snappedLeftInset() * scale) + epsilon) % 1, 0.0001);
+                Assert.assertEquals("Right inset not snapped to pixel", 0, ((sp.snappedRightInset() * scale) + epsilon) % 1, 0.0001);
             }
         }
     }


### PR DESCRIPTION
This PR aims to fix the blurriness to sometimes affects some controls (such as TextArea) in a scene when rendered with a scaling factor that is not an integer (typically when viewed on a HiDPI screen with a 125%, 150% or 175% output scaling).

Please note that regardless of what the JBS issue (and therefore the title of this PR) states, this does not appear to be a Windows only issue as I have observed the same issue on Linux (Ubuntu 20.04).

The following conditions are necessary for the blurriness to appear, but do not guarantee that it will:

- The node, or one of its parents, must have set `Node::cacheProperty` to `true`

- The scaling factor (as detected automatically or explicitly set via glass.win/gtk.uiScale) must be a non integer number (e.g. 1.25, 1.5, 175)

- The effective layout X or Y coordinates for the cached node must be != 0;

Under these conditions, the translate coordinates for the transform used when the cached image for a node is rendered to the screen may be non integer numbers, which is the cause for the blurriness.

Based on these observations, this PR fixes the issue by simply rounding the translate coordinates (using `Math.round`) before the transform is applied in `renderCacheToScreen()` and as far as I can tell, it fixes the blurriness in all the previously affected applications (both trivial test cases or with complex scenegraphs) and does not appear to introduce other noticeable visual artifacts.

Still, there might be a better place somewhere else higher up in the call chain where this should be addressed as it could maybe be the root cause for other rendering glitches, though I'm not yet familiar enough with the code to see if it is really the case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8211294](https://bugs.openjdk.java.net/browse/JDK-8211294): ScrollPane content is blurry with 125% scaling


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/308/head:pull/308`
`$ git checkout pull/308`
