### PR TITLE
8253634: TreeCell/Skin: misbehavior on switching skin

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeCellSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeCellSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,18 +32,16 @@ import java.util.Map;
 import java.util.WeakHashMap;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
-import javafx.beans.InvalidationListener;
-import javafx.beans.Observable;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.value.WritableValue;
 import javafx.geometry.HPos;
 import javafx.geometry.VPos;
 import javafx.scene.Node;
 import javafx.scene.control.Control;
-import javafx.scene.control.ListView;
 import javafx.scene.control.TreeCell;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
+import javafx.scene.layout.Region;
 import javafx.css.StyleableDoubleProperty;
 import javafx.css.StyleableProperty;
 import javafx.css.CssMetaData;
@@ -85,7 +83,6 @@ public class TreeCellSkin<T> extends CellSkinBase<TreeCell<T>> {
     private static final Map<TreeView<?>, Double> maxDisclosureWidthMap = new WeakHashMap<TreeView<?>, Double>();
 
 
-
     /***************************************************************************
      *                                                                         *
      * Private fields                                                          *
@@ -95,10 +92,6 @@ public class TreeCellSkin<T> extends CellSkinBase<TreeCell<T>> {
     private boolean disclosureNodeDirty = true;
     private TreeItem<?> treeItem;
     private final BehaviorBase<TreeCell<T>> behavior;
-
-    private double fixedCellSize;
-    private boolean fixedCellSizeEnabled;
-
 
 
     /***************************************************************************
@@ -129,29 +122,7 @@ public class TreeCellSkin<T> extends CellSkinBase<TreeCell<T>> {
             getSkinnable().requestLayout();
         });
         registerChangeListener(control.textProperty(), e -> getSkinnable().requestLayout());
-
-        setupTreeViewListeners();
     }
-
-    private void setupTreeViewListeners() {
-        TreeView<T> treeView = getSkinnable().getTreeView();
-        if (treeView == null) {
-            getSkinnable().treeViewProperty().addListener(new InvalidationListener() {
-                @Override public void invalidated(Observable observable) {
-                    getSkinnable().treeViewProperty().removeListener(this);
-                    setupTreeViewListeners();
-                }
-            });
-        } else {
-            this.fixedCellSize = treeView.getFixedCellSize();
-            this.fixedCellSizeEnabled = fixedCellSize > 0;
-            registerChangeListener(treeView.fixedCellSizeProperty(), e -> {
-                this.fixedCellSize = getSkinnable().getTreeView().getFixedCellSize();
-                this.fixedCellSizeEnabled = fixedCellSize > 0;
-            });
-        }
-    }
-
 
 
     /***************************************************************************
@@ -277,7 +248,8 @@ public class TreeCellSkin<T> extends CellSkinBase<TreeCell<T>> {
 
     /** {@inheritDoc} */
     @Override protected double computeMinHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset) {
-        if (fixedCellSizeEnabled) {
+        double fixedCellSize = getFixedCellSize();
+        if (fixedCellSize > 0) {
             return fixedCellSize;
         }
 
@@ -288,7 +260,8 @@ public class TreeCellSkin<T> extends CellSkinBase<TreeCell<T>> {
 
     /** {@inheritDoc} */
     @Override protected double computePrefHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset) {
-        if (fixedCellSizeEnabled) {
+        double fixedCellSize = getFixedCellSize();
+        if (fixedCellSize > 0) {
             return fixedCellSize;
         }
 
@@ -305,7 +278,8 @@ public class TreeCellSkin<T> extends CellSkinBase<TreeCell<T>> {
 
     /** {@inheritDoc} */
     @Override protected double computeMaxHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset) {
-        if (fixedCellSizeEnabled) {
+        double fixedCellSize = getFixedCellSize();
+        if (fixedCellSize > 0) {
             return fixedCellSize;
         }
 
@@ -340,6 +314,10 @@ public class TreeCellSkin<T> extends CellSkinBase<TreeCell<T>> {
         return pw;
     }
 
+    private double getFixedCellSize() {
+        TreeView<?> treeView = getSkinnable().getTreeView();
+        return treeView != null ? treeView.getFixedCellSize() : Region.USE_COMPUTED_SIZE;
+    }
 
 
     /***************************************************************************

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import static javafx.scene.control.ControlShim.*;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.*;
 import static org.junit.Assert.*;
 
@@ -730,4 +731,27 @@ public class TreeCellTest {
         TreeCell cell = new TreeCell();
         cell.setSkin(new TreeCellSkin(cell));
     }
+
+    /**
+     * Test that min/max/pref height respect fixedCellSize.
+     * Sanity test when fixing JDK-8253634.
+     */
+    @Test
+    public void testTreeCellHeights() {
+        TreeCell<Object> cell =  new TreeCell<>();
+        TreeView<Object> treeView = new TreeView<>();
+        cell.updateTreeView(treeView);
+        installDefaultSkin(cell);
+        treeView.setFixedCellSize(100);
+        assertEquals("pref height must be fixedCellSize",
+                treeView.getFixedCellSize(),
+                cell.prefHeight(-1), 1);
+        assertEquals("min height must be fixedCellSize",
+                treeView.getFixedCellSize(),
+                cell.minHeight(-1), 1);
+        assertEquals("max height must be fixedCellSize",
+                treeView.getFixedCellSize(),
+                cell.maxHeight(-1), 1);
+    }
+
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinCleanupTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinCleanupTest.java
@@ -42,6 +42,8 @@ import javafx.scene.control.Control;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.ToolBar;
+import javafx.scene.control.TreeCell;
+import javafx.scene.control.TreeView;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
 import javafx.scene.shape.Rectangle;
@@ -55,6 +57,32 @@ public class SkinCleanupTest {
     private Scene scene;
     private Stage stage;
     private Pane root;
+
+// ------------------ TreeCell
+
+    @Test
+    public void testTreeCellReplaceTreeViewWithNull() {
+        TreeCell<Object> cell =  new TreeCell<>();
+        TreeView<Object> treeView = new TreeView<>();
+        cell.updateTreeView(treeView);
+        installDefaultSkin(cell);
+        cell.updateTreeView(null);
+        // 8253634: updating the old treeView must not throw NPE in skin
+        treeView.setFixedCellSize(100);
+    }
+
+    @Test
+    public void testTreeCellPrefHeightOnReplaceTreeView() {
+        TreeCell<Object> cell =  new TreeCell<>();
+        cell.updateTreeView(new TreeView<>());
+        installDefaultSkin(cell);
+        TreeView<Object> treeView = new TreeView<>();
+        treeView.setFixedCellSize(100);
+        cell.updateTreeView(treeView);
+        assertEquals("fixed cell set to value of new treeView",
+                cell.getTreeView().getFixedCellSize(),
+                cell.prefHeight(-1), 1);
+    }
 
 // ------------------ ListCell
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinMemoryLeakTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinMemoryLeakTest.java
@@ -42,13 +42,10 @@ import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactor
 
 import javafx.scene.control.Accordion;
 import javafx.scene.control.ButtonBar;
-import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.ColorPicker;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Control;
 import javafx.scene.control.DatePicker;
-import javafx.scene.control.ListCell;
-import javafx.scene.control.ListView;
 import javafx.scene.control.MenuBar;
 import javafx.scene.control.MenuButton;
 import javafx.scene.control.Pagination;
@@ -63,8 +60,6 @@ import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
-import javafx.scene.control.ToolBar;
-import javafx.scene.control.TreeCell;
 import javafx.scene.control.TreeTableRow;
 import javafx.scene.control.TreeTableView;
 import javafx.scene.control.TreeView;
@@ -128,7 +123,6 @@ public class SkinMemoryLeakTest {
                 TextArea.class,
                 // @Ignore("8240506")
                 TextField.class,
-                TreeCell.class,
                 TreeTableRow.class,
                 TreeTableView.class,
                 TreeView.class


### PR DESCRIPTION
TreeCellSkin installs listeners to the TreeView/fixedCellSize that introduce a memory leak, NPE on replacing the treeView and incorrect update of internal state.

Fixed by removing the listeners (and the internal state had been copied from treeView on change) and access of listView state when needed.

Added tests that failed before and pass after the fix, plus a sanity test to guarantee same (correct) behavior before/after.

Issue and fix is basically the same as for ListCellSkin [JDK-8246745](https://bugs.openjdk.java.net/browse/JDK-8246745)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253634](https://bugs.openjdk.java.net/browse/JDK-8253634): TreeCell/Skin: misbehavior on switching skin


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/309/head:pull/309`
`$ git checkout pull/309`
