### PR TITLE
8252191: Update to gcc 10.2 on Linux

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -88,7 +88,7 @@ jfx.gradle.version=6.3
 jfx.gradle.version.min=5.3
 
 # Toolchains
-jfx.build.linux.gcc.version=gcc9.2.0-OL6.4+1.0
+jfx.build.linux.gcc.version=gcc10.2.0-OL6.4+1.0
 jfx.build.windows.msvc.version=VS2019-16.5.3+1.0
 jfx.build.macosx.xcode.version=Xcode11.3.1-MacOSX10.15+1.0
 


### PR DESCRIPTION
This patch updates the compiler to gcc 10.2 on Linux, in order to match JDK 16 -- see [JDK-8253616](https://bugs.openjdk.java.net/browse/JDK-8253616).

I ran a full build and test, including media and WebKit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252191](https://bugs.openjdk.java.net/browse/JDK-8252191): Update to gcc 10.2 on Linux


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/311/head:pull/311`
`$ git checkout pull/311`
