### PR TITLE
8252192: Update to Visual Studio 2019 version 16.7.2

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -89,7 +89,7 @@ jfx.gradle.version.min=5.3
 
 # Toolchains
 jfx.build.linux.gcc.version=gcc9.2.0-OL6.4+1.0
-jfx.build.windows.msvc.version=VS2019-16.5.3+1.0
+jfx.build.windows.msvc.version=VS2019-16.7.2+1.0
 jfx.build.macosx.xcode.version=Xcode11.3.1-MacOSX10.15+1.0
 
 # Build tools


### PR DESCRIPTION
This patch updates the compiler to Visual Studio 2019 version 16.7.2 on Windows, in order to match JDK 16 -- see [JDK-8253615](https://bugs.openjdk.java.net/browse/JDK-8253615).

I ran a full build and test, including media and WebKit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252192](https://bugs.openjdk.java.net/browse/JDK-8252192): Update to Visual Studio 2019 version 16.7.2


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Joeri Sykora](https://openjdk.java.net/census#sykora) (@tiainen - Author)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/312/head:pull/312`
`$ git checkout pull/312`
