### PR TITLE
8253597: TreeTableView: must select leaf row on click into indentation region

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TreeTableCellBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TreeTableCellBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,7 +120,8 @@ public class TreeTableCellBehavior<S,T> extends TableCellBehaviorBase<TreeItem<S
 
         if (column == treeColumn) {
             final Node disclosureNode = getNode().getTreeTableRow().getDisclosureNode();
-            if (disclosureNode != null) {
+          // fix JDK-8253597: check disclosure node for visibility along with existence
+          if (disclosureNode != null && disclosureNode.isVisible()) {
                 double startX = 0;
                 for (TreeTableColumn<S,?> tc : treeTableView.getVisibleLeafColumns()) {
                     if (tc == treeColumn) break;

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/MouseEventFirer.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/MouseEventFirer.java
@@ -256,7 +256,7 @@ public final class MouseEventFirer {
     /**
      * Fires a mouseEvent with the given configuration options onto the target.
      * Hot-fix for JDK-8253769.
-     * The mouseEvent is created such that coordiate transformation constraints seem to be respected.
+     * The mouseEvent is created such that coordinate transformation constraints seem to be respected.
      */
     private void fireMouseEventAlternative(EventType<MouseEvent> evtType, MouseButton button, int clickCount, double deltaX, double deltaY, KeyModifier... modifiers) {
 

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/MouseEventFirer.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/MouseEventFirer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,15 @@
 
 package test.com.sun.javafx.scene.control.infrastructure;
 
+import java.util.Arrays;
+import java.util.List;
+
 import javafx.event.Event;
 import javafx.event.EventTarget;
 import javafx.event.EventType;
 import javafx.geometry.BoundingBox;
 import javafx.geometry.Bounds;
+import javafx.geometry.Point2D;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.input.MouseButton;
@@ -37,15 +41,21 @@ import javafx.scene.input.MouseEvent;
 import javafx.scene.input.PickResult;
 import javafx.stage.Window;
 
-import java.util.Arrays;
-import java.util.List;
-
+/**
+ * Helper to fire MouseEvents onto a EventTarget which is either Node or Scene.
+ * There are methods to configure the event by eventType, clickCount, location (delta from default),
+ * mouseButton and keyModifiers.
+ * <p>
+ * The default local coordinates are the center of the target.
+ */
 public final class MouseEventFirer {
     private final EventTarget target;
 
     private final Scene scene;
     private final Bounds targetBounds;
     private StageLoader sl;
+
+    private boolean alternative;
 
     public MouseEventFirer(EventTarget target) {
         this.target = target;
@@ -71,6 +81,19 @@ public final class MouseEventFirer {
         } else {
             throw new RuntimeException("EventTarget of invalid type (" + target + ")");
         }
+    }
+
+    /**
+     * Instantiates a MouseEventFirer on the given node.
+     * <p>
+     * Note: this was added as hot-fix for JDK-8253769.
+     *
+     * @param target the node to fire on
+     * @param alternative uses alternative creation path for mouseEvent if true.
+     */
+    public MouseEventFirer(Node target, boolean alternative) {
+        this(target);
+        this.alternative = alternative;
     }
 
     public void dispose() {
@@ -158,6 +181,15 @@ public final class MouseEventFirer {
     }
 
     private void fireMouseEvent(EventType<MouseEvent> evtType, MouseButton button, int clickCount, double deltaX, double deltaY, KeyModifier... modifiers) {
+        if (alternative) {
+            fireMouseEventAlternative(evtType, button, clickCount, deltaX, deltaY, modifiers);
+            return;
+        }
+        // TBD: JDK-8253769
+        // the mouseEvent created here seems to be valid (in regard to coordinate transformations
+        // of local/scene/screen) only if the target is glued to the upper leading edge of the scene
+        // and zero deltaX/Y!
+
         // calculate bounds
         final Window window = scene.getWindow();
 
@@ -217,6 +249,55 @@ public final class MouseEventFirer {
 //        Stage stage = new Stage();
 //        stage.setScene(new Scene(new Pane(canvas), image.getWidth(), image.getHeight()));
 //        stage.show();
+
+        Event.fireEvent(target, evt);
+    }
+
+    /**
+     * Fires a mouseEvent with the given configuration options onto the target.
+     * Hot-fix for JDK-8253769.
+     * The mouseEvent is created such that coordiate transformation constraints seem to be respected.
+     */
+    private void fireMouseEventAlternative(EventType<MouseEvent> evtType, MouseButton button, int clickCount, double deltaX, double deltaY, KeyModifier... modifiers) {
+
+        // width / height of target node
+        final double w = targetBounds.getWidth();
+        final double h = targetBounds.getHeight();
+
+        // x / y click position is centered
+        final double x = w / 2.0 + deltaX;
+        final double y = h / 2.0 + deltaY;
+
+        Node node = (Node) target;
+
+        Point2D localP = new Point2D(x, y);
+        Point2D sceneP = node.localToScene(localP);
+        Point2D screenP = node.localToScreen(localP);
+
+        final List<KeyModifier> ml = Arrays.asList(modifiers);
+
+        MouseEvent evt = new MouseEvent(
+                target, // target of this firer
+                null,   // default source (don't care, event dispatch will take over)
+                evtType,
+                sceneP.getX(), sceneP.getY(), // can use scene coordinates because source is null
+                screenP.getX(), screenP.getY(),
+                button,
+                clickCount,
+                ml.contains(KeyModifier.SHIFT),    // shiftDown
+                ml.contains(KeyModifier.CTRL),     // ctrlDown
+                ml.contains(KeyModifier.ALT),      // altDown
+                ml.contains(KeyModifier.META),     // metaData
+                button == MouseButton.PRIMARY,     // primary button
+                button == MouseButton.MIDDLE,      // middle button
+                button == MouseButton.SECONDARY,   // secondary button
+                button == MouseButton.BACK,        // back button
+                button == MouseButton.FORWARD,     // forward button
+                false,                             // synthesized
+                button == MouseButton.SECONDARY,   // is popup trigger
+                true,                              // still since pick
+                null    // default pick (don't care, event constructor will take over)
+                );
 
         Event.fireEvent(target, evt);
     }

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/MouseEventFirerTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/MouseEventFirerTest.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.javafx.scene.control.infrastructure;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import com.sun.javafx.tk.Toolkit;
+
+import static javafx.scene.layout.AnchorPane.*;
+import static org.junit.Assert.*;
+
+import javafx.geometry.Bounds;
+import javafx.geometry.Point2D;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Labeled;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.AnchorPane;
+import javafx.stage.Stage;
+
+/**
+ * Test for MouseEventFirer.
+ * <p>
+ * The test is parameterized on not/using (old/new) the alternative mouseEvent creation
+ * path.
+ */
+@RunWith(Parameterized.class)
+public class MouseEventFirerTest {
+
+    //------------ fields
+
+    private Scene scene;
+    private Stage stage;
+    private AnchorPane content;
+
+    private static final double EPS = 1;
+    // margins for center node
+    private final double VERTICAL_DISTANCE = 100.;
+    private final double HORIZONTAL_DISTANCE = 20.;
+
+    private Node topLeft, center, bottomRight;
+
+//------- standalone node
+
+    @Test
+    public void testLocalStandaloneDeltaNegative() {
+        Button button = new Button("standalone button, a bit longish");
+        assertLocal(button, - 10, - 5);
+    }
+
+    @Test
+    public void testLocalStandaloneDelta() {
+        Button button = new Button("standalone button, a bit longish");
+        assertLocal(button, 10, 5);
+    }
+
+    @Test
+    public void testLocalStandalone() {
+        Button button = new Button("standalone button, a bit longish");
+        assertLocal(button, 0, 0);
+    }
+
+    @Test
+    public void testMouseCoordinatesStandaloneDeltaNegative() {
+        Button button = new Button("standalone button, a bit longish");
+        assertMouseCoordinatesDelta(button, - 10, - 5);
+    }
+
+    @Test
+    public void testMouseCoordinatesStandaloneDelta() {
+        Button button = new Button("standalone button, a bit longish");
+        assertMouseCoordinatesDelta(button, 10, 5);
+    }
+
+    @Test
+    public void testMouseCoordinatesStandalone() {
+        Button button = new Button("standalone button, a bit longish");
+        assertMouseCoordinatesDelta(button, 0, 0);
+    }
+
+// --------- test local coordinates
+
+    @Test
+    public void testLocalDeltaNegative() {
+        content.getChildren().forEach(child -> assertLocal(child, - 10, - 5));
+    }
+
+    @Test
+    public void testLocalDelta() {
+        content.getChildren().forEach(child -> assertLocal(child, 10, 5));
+    }
+
+    @Test
+    public void testLocal() {
+        content.getChildren().forEach(child -> assertLocal(child, 0, 0));
+    }
+
+    /**
+     * Fires a mousePressed with the given x/y location on the given target
+     * and asserts the local mouse coordinates.
+     *
+     */
+    protected void assertLocal(Node target, double deltaX, double deltaY) {
+        MouseEventFirer firer = new MouseEventFirer(target, useAlternative);
+        String text = target instanceof Labeled ? ((Labeled) target).getText() : target.getId();
+        target.setOnMousePressed(e -> {
+            double width = target.getLayoutBounds().getWidth();
+            double height = target.getLayoutBounds().getHeight();
+            assertEquals("local x of " + text, width /2 + deltaX, e.getX(), EPS);
+            assertEquals("local y of " + text, height / 2 + deltaY, e.getY(), EPS);
+        });
+        firer.fireMousePressed(deltaX, deltaY);
+    }
+
+//------------ test scene/screen coordinates
+
+    @Test
+    public void testMouseCoordinatesDeltaNegative() {
+        content.getChildren().forEach(child -> assertMouseCoordinatesDelta(child, - 10, - 5));
+    }
+
+    @Test
+    public void testMouseCoordinatesDelta() {
+        content.getChildren().forEach(child -> assertMouseCoordinatesDelta(child, 10, 5));
+    }
+
+    @Test
+    public void testMouseCoordinates() {
+        content.getChildren().forEach(child -> assertMouseCoordinatesDelta(child, 0, 0));
+    }
+
+    /**
+     * Fires a mousePressed with the given x/y location on the given target
+     *  and asserts basic mouseEvent constraints.
+     */
+    protected void assertMouseCoordinatesDelta(Node target, double deltaX, double deltaY) {
+        MouseEventFirer firer = new MouseEventFirer(target, useAlternative);
+        target.setOnMousePressed(this::assertMouseEventCoordinates);
+        firer.fireMousePressed(deltaX, deltaY);
+    }
+
+    /**
+     * Asserts scene/screen coordinates of event are same as localToScene/Screen.
+     */
+    protected void assertMouseEventCoordinates(MouseEvent mouse) {
+        assertSame(mouse.getTarget(), mouse.getSource());
+        Node receiver = (Node) mouse.getTarget();
+        String text = receiver instanceof Labeled ? ((Labeled) receiver).getText() : receiver.getId();
+
+        Point2D sceneP = receiver.localToScene(mouse.getX(), mouse.getY());
+        assertEquals("sceneX of " + text, sceneP.getX(), mouse.getSceneX(), EPS);
+        assertEquals("sceneY of " + text, sceneP.getY(), mouse.getSceneY(), EPS);
+        Point2D screenP = receiver.localToScreen(mouse.getX(), mouse.getY());
+        assertEquals("screenX of " + text, screenP.getX(), mouse.getScreenX(), EPS);
+        assertEquals("screenY of " + text, screenP.getY(), mouse.getScreenY(), EPS);
+    }
+
+ // ------------- parameterized in not/alternative mouseEvent creation
+
+    private boolean useAlternative;
+
+    @Parameterized.Parameters
+    public static Collection<Object[]> data() {
+        // current / alternative mouseEvent creation
+        Object[][] data = new Object[][] {
+            // @Ignore("8253769")
+            // {false},
+            {true},
+        };
+        return Arrays.asList(data);
+    }
+
+    public MouseEventFirerTest(boolean useAlternative) {
+        this.useAlternative = useAlternative;
+    }
+
+ // ------------ setup/cleanup/intial
+
+    @Test
+    public void testFirer() {
+        new MouseEventFirer(topLeft, true);
+        assertSame("sanity: firer must not change hierarchy", scene, topLeft.getScene());
+        assertSame("sanity: firer must not change hierarchy", stage, topLeft.getScene().getWindow());
+    }
+
+    @Test
+    public void testAnchorRight() {
+        setLeftAnchor(topLeft, null);
+        setRightAnchor(topLeft, 0.);
+        Toolkit.getToolkit().firePulse();
+        assertEquals(content.getWidth() - topLeft.prefWidth(-1), topLeft.getBoundsInParent().getMinX(), EPS);
+    }
+
+    @Test
+    public void testLayoutBounds() {
+        Bounds initial = topLeft.getLayoutBounds();
+        setLeftAnchor(topLeft, null);
+        setRightAnchor(topLeft, 0.);
+        Toolkit.getToolkit().firePulse();
+        assertEquals("sanity: layout bounds unchanged", initial, topLeft.getLayoutBounds());
+    }
+
+    @Test
+    public void testContentLayout() {
+        assertTrue(stage.isShowing());
+        // content sizing controlled by big middle node
+        assertEquals(2* VERTICAL_DISTANCE + center.prefHeight(-1), content.getHeight(), EPS);
+        assertEquals(2* HORIZONTAL_DISTANCE + center.prefWidth(-1), content.getWidth(), EPS);
+        // middle
+        assertEquals(HORIZONTAL_DISTANCE, center.getBoundsInParent().getMinX(), EPS);
+        assertEquals(VERTICAL_DISTANCE, center.getBoundsInParent().getMinY(),EPS);
+        // top
+        assertEquals(0, topLeft.getBoundsInParent().getMinX(), EPS);
+        assertEquals(0, topLeft.getBoundsInParent().getMinY(), EPS);
+        // bottom
+        assertEquals(0, bottomRight.getBoundsInParent().getMinX(), EPS);
+        assertEquals(content.getHeight() - bottomRight.prefHeight(-1), bottomRight.getBoundsInParent().getMinY(), EPS);
+    }
+
+    @Before
+    public void setup() {
+        Thread.currentThread().setUncaughtExceptionHandler((thread, throwable) -> {
+            if (throwable instanceof RuntimeException) {
+                throw (RuntimeException)throwable;
+            } else {
+                Thread.currentThread().getThreadGroup().uncaughtException(thread, throwable);
+            }
+        });
+        topLeft = new Button("topLeft");
+        // glue to topLeft
+        setTopAnchor(topLeft, 0.);
+        setLeftAnchor(topLeft, 0.);
+
+        center = new Button("center: a longish text nearly filling horizontally");
+        // glue into center
+        setTopAnchor(center, VERTICAL_DISTANCE);
+        setBottomAnchor(center, VERTICAL_DISTANCE);
+        setLeftAnchor(center, HORIZONTAL_DISTANCE);
+        setRightAnchor(center, HORIZONTAL_DISTANCE);
+
+        bottomRight = new Button("botRight");
+        // glue to bottom-right
+        setBottomAnchor(bottomRight, 0.);
+        setLeftAnchor(bottomRight, 0.);
+
+        content = new AnchorPane(topLeft, center, bottomRight);
+        scene = new Scene(content);
+        stage = new Stage();
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    @After
+    public void tearDown() {
+        if (stage != null) stage.hide();
+        Thread.currentThread().setUncaughtExceptionHandler(null);
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableViewDisclosureNodeTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableViewDisclosureNodeTest.java
@@ -1,0 +1,324 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.control.skin;
+
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.sun.javafx.tk.Toolkit;
+
+import static org.junit.Assert.*;
+import static test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils.*;
+
+import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.Control;
+import javafx.scene.control.IndexedCell;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeTableCell;
+import javafx.scene.control.TreeTableColumn;
+import javafx.scene.control.TreeTableRow;
+import javafx.scene.control.TreeTableView;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import test.com.sun.javafx.scene.control.infrastructure.MouseEventFirer;
+
+/**
+ * Tests around disclosure node.
+ */
+public class TreeTableViewDisclosureNodeTest {
+
+//------------ fields
+
+    private Scene scene;
+    private Stage stage;
+    private Pane content;
+
+    private TreeTableView<String> treeTable;
+    private TreeItem<String> root;
+    private TreeTableView.TreeTableViewSelectionModel<?> sm;
+
+    // indices of root children
+    private int rootLeafChildIndex;
+    private int rootExpandedChildIndex;
+    private int rootCollapsedChildIndex;
+
+//------------
+
+    /**
+     * Test fix for JDK-8253597.
+     */
+    @Test
+    public void testSelectChildLeafAfterExpand() {
+        showTreeTable();
+        TreeItem<String> child = root.getChildren().get(rootCollapsedChildIndex);
+        // expand child that was initially collapsed
+        child.setExpanded(true);
+        Toolkit.getToolkit().firePulse();
+
+        TreeItem<String> grandChild = child.getChildren().get(0);
+        int grandChildRowIndex = treeTable.getRow(grandChild);
+        assertTrue("sanity: grandChild is leaf", grandChild.isLeaf());
+        assertFalse("sanity: grandChild not selected", sm.isSelected(grandChildRowIndex));
+        fireMouseIntoIndentationRegion(grandChildRowIndex);
+        assertTrue("grandChild must be selected " + grandChildRowIndex, sm.isSelected(grandChildRowIndex));
+    }
+
+    /**
+     * This is the deeper reason for JDK-8253597: on re-use of a treeTableRow
+     * in leaf rows, the disclosureNode is not removed
+     */
+    @Test @Ignore("real-cleanup")
+    public void testRowReuse() {
+        showTreeTable();
+        TreeItem<String> expandedChild = root.getChildren().get(rootExpandedChildIndex);
+        TreeItem<String> grandChild = expandedChild.getChildren().get(0);
+        int grandChildRowIndex = treeTable.getRow(grandChild);
+        assertNull("leaf must not have disclosureNode", getDisclosureNode(grandChildRowIndex));
+        // collapse/expand cycle
+        expandedChild.setExpanded(false);
+        Toolkit.getToolkit().firePulse();
+        expandedChild.setExpanded(true);
+        Toolkit.getToolkit().firePulse();
+        assertNull("leaf must not have disclosureNode", getDisclosureNode(grandChildRowIndex));
+    }
+
+    /**
+     * Sanity: firing into disclosure node region of initially visible child leaf selects.
+     */
+    @Test
+    public void testSelectChildLeaf() {
+        showTreeTable();
+        TreeItem<String> expandedChild = root.getChildren().get(rootExpandedChildIndex);
+        TreeItem<String> grandChild = expandedChild.getChildren().get(0);
+        int grandChildRowIndex = treeTable.getRow(grandChild);
+        fireMouseIntoIndentationRegion(grandChildRowIndex);
+        assertTrue("row must be selected" + grandChildRowIndex, sm.isSelected(grandChildRowIndex));
+    }
+
+    /**
+     * Sanity: firing into disclosure node region top-level leaf child selects.
+     */
+    @Test
+    public void testSelectRootLeaf() {
+        showTreeTable();
+        TreeItem<String> leafChild = root.getChildren().get(rootLeafChildIndex);
+        int leafChildRowIndex = treeTable.getRow(leafChild);
+        fireMouseIntoIndentationRegion(leafChildRowIndex);
+        assertTrue("row must be selected" + leafChildRowIndex, sm.isSelected(leafChildRowIndex));
+   }
+
+    /**
+     * Sanity test: firing into disclosure node region of collapsed child must expand it.
+     */
+    @Test
+    public void testExpandCollapsedChild() {
+        showTreeTable();
+        TreeItem<String> child = root.getChildren().get(rootCollapsedChildIndex);
+        boolean expanded = child.isExpanded();
+        fireMouseIntoIndentationRegion(treeTable.getRow(child));
+        assertEquals("expansion state changed" + child.getValue(), !expanded,  child.isExpanded());
+    }
+
+    /**
+     * Test inital state of disclosureNode.
+     * Note that a leaf row that was visible initially, does not have
+     * a disclosureNode.
+     */
+    @Test
+    public void testInitialRowState() {
+        showTreeTable();
+        // root
+        assertHasVisibleDisclosureNode(0);
+        // leaf child of root
+        assertNull(getDisclosureNode(rootLeafChildIndex + 1));
+        // expanded child of root
+        assertHasVisibleDisclosureNode(rootExpandedChildIndex + 1);
+        assertNull(getDisclosureNode(rootExpandedChildIndex + 2));
+    }
+
+    /**
+     * Fires a mouse pressed/released into the indentation region of the
+     * first (single) tableCell of the given row.
+     */
+    protected void fireMouseIntoIndentationRegion(int rowIndex) {
+        TreeTableRow<?> grandChildTableRow = getTableRow(rowIndex);
+        // single column == single child cell
+        TreeTableCell<?, ?> cell = (TreeTableCell<?, ?>) grandChildTableRow.lookup(".tree-table-cell");
+        MouseEventFirer mouse = new MouseEventFirer(cell, true);
+        // target to hit disclosure
+        double targetX = - cell.getWidth() / 2; // compensate default center offset to zero
+        mouse.fireMousePressAndRelease(1, targetX, 0);
+        Toolkit.getToolkit().firePulse();
+    }
+
+    /**
+     * Asserts that the tableRow at the given row has a disclosureNode with the
+     * given visibility.
+     *
+     */
+    protected void assertHasVisibleDisclosureNode(int rowIndex) {
+        Node disclosure = getDisclosureNode(rowIndex);
+        assertNotNull("disclosureNode must added", disclosure);
+        assertTrue("disclosureNode must be visible", disclosure.isVisible());
+    }
+
+// ------ accessor helpers
+
+    /**
+     * Returns the disclosureNode for the given rowIndex.
+     */
+    protected Node getDisclosureNode(int rowIndex) {
+        TreeTableRow<?> tableRow = getTableRow(rowIndex);
+        Node disclosure = tableRow.lookup(".tree-disclosure-node");
+        return disclosure;
+    }
+
+    /**
+     * Returns the TreeTableRow for the given treeItem. The item must be
+     * accessible as specified by treeTable.getRow(treeItem).
+     */
+    protected TreeTableRow<?> getTableRow(TreeItem<String> treeItem) {
+        return getTableRow(treeTable.getRow(treeItem));
+    }
+
+    /**
+     * Returns the TreeTableRow for the given rowIndex. The index must
+     * be in the range 0 <= rowIndex < treeTable.getExpandedItemCount()
+     */
+    protected TreeTableRow<?> getTableRow(int rowIndex) {
+        IndexedCell<?> tableRow = getCell(treeTable, rowIndex);
+        assertTrue("sanity: expect TreeTableRow but was: " + tableRow, tableRow instanceof TreeTableRow);
+        assertEquals("sanity: row index", rowIndex, tableRow.getIndex());
+        return (TreeTableRow<?>) tableRow;
+    }
+
+  //---------------- setup and initial
+
+    @Test
+    public void testInitialTreeTableState() {
+        assertTrue(treeTable.isShowRoot());
+        assertSame(root, treeTable.getRoot());
+        assertTrue(root.getChildren().get(rootLeafChildIndex).isLeaf());
+        assertTrue(root.getChildren().get(rootExpandedChildIndex).isExpanded());
+        assertFalse(root.getChildren().get(rootCollapsedChildIndex).isExpanded());
+        int rowCount = root.getChildren().size() + 1 // root and direct children
+                + root.getChildren().get(rootExpandedChildIndex).getChildren().size(); // expanded child,
+        assertEquals(rowCount, treeTable.getExpandedItemCount());
+        showTreeTable();
+        List<Node> children = List.of(treeTable);
+        assertEquals(children, content.getChildren());
+        assertTrue(sm.isEmpty());
+    }
+
+    protected void showTreeTable() {
+        showControl(treeTable);
+    }
+
+    /**
+     * Ensures the control is shown and focused in an active scenegraph.
+     */
+    protected void showControl(Control control) {
+        if (content == null) {
+            content = new VBox();
+            scene = new Scene(content);
+            stage = new Stage();
+            stage.setScene(scene);
+        }
+        if (!content.getChildren().contains(control)) {
+            content.getChildren().add(control);
+        }
+        stage.show();
+        stage.requestFocus();
+        control.requestFocus();
+        assertTrue(control.isFocused());
+        assertSame(control, scene.getFocusOwner());
+    }
+
+    /**
+     Tree structure:
+
+         -v expanded root
+               leaf             // rootLeafChildIndex
+            -v expanded child   // rootExpandedChildIndex
+                 child leaf
+                 child leaf
+                 child leaf
+            -> collapsed child  // rootCollapsedChildIndex
+            -> collapsed child
+           ...
+     */
+    protected void fillTree(TreeItem<String> rootItem) {
+        rootItem.setExpanded(true);
+        rootItem.getChildren().add(0, new TreeItem<>("leafChild"));
+        for (int i = 0; i < 10; i++) {
+            TreeItem<String> newChild = new TreeItem<>("child " + i);
+            if (i == 0) newChild.setExpanded(true);
+            rootItem.getChildren().add(newChild);
+            for (int j = 0; j < 3; j++) {
+                TreeItem<String> newChild2 = new TreeItem<>(i + " grandChild " + j);
+                newChild.getChildren().add(newChild2);
+            }
+        }
+    }
+
+    @Before
+    public void setup() {
+        Thread.currentThread().setUncaughtExceptionHandler((thread, throwable) -> {
+            if (throwable instanceof RuntimeException) {
+                throw (RuntimeException)throwable;
+            } else {
+                Thread.currentThread().getThreadGroup().uncaughtException(thread, throwable);
+            }
+        });
+        rootLeafChildIndex = 0;
+        rootExpandedChildIndex = 1;
+        rootCollapsedChildIndex = 2;
+        root = new TreeItem<>("Root");
+        treeTable = new TreeTableView<String>(root);
+        fillTree(root);
+
+        sm = treeTable.getSelectionModel();
+
+        TreeTableColumn<String, String> treeColumn = new TreeTableColumn<>("Col1");
+        treeColumn.setPrefWidth(200);
+        treeColumn.setCellValueFactory(call -> new ReadOnlyStringWrapper(call.getValue().getValue()));
+        treeTable.getColumns().add(treeColumn);
+    }
+
+    @After
+    public void tearDown() {
+        if (stage != null) stage.hide();
+        Thread.currentThread().setUncaughtExceptionHandler(null);
+    }
+
+}


### PR DESCRIPTION
.. but doesn't reliably (see report for details). Fixed in TreeTableCellBehavior to check for visibility of the disclosureNode. 

Added test that failed before and passes after, along with a couple of sanity tests. 

Also added an alternative mouseEvent creation path into MouseEventFirer (and test) to work-around [JDK-8253769](https://bugs.openjdk.java.net/browse/JDK-8253769)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253597](https://bugs.openjdk.java.net/browse/JDK-8253597): TreeTableView: must select leaf row on click into indentation region


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/313/head:pull/313`
`$ git checkout pull/313`
