### PR TITLE
8253696: WebEngine refuses to load local "file:///" CSS stylesheets when using JDK 15

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/URLLoader.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/URLLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/URLLoader.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/URLLoader.java
@@ -867,13 +867,15 @@ final class URLLoader extends URLLoaderBase implements Runnable {
      */
     private static String extractHeaders(URLConnection c) {
         StringBuilder sb = new StringBuilder();
-        Map<String, List<String>> headers = c.getHeaderFields();
-        for (Map.Entry<String, List<String>> entry: headers.entrySet()) {
-            String key = entry.getKey();
-            List<String> values = entry.getValue();
-            for (String value : values) {
-                sb.append(key != null ? key : "");
-                sb.append(':').append(value).append('\n');
+        if (c instanceof HttpURLConnection) {
+            Map<String, List<String>> headers = c.getHeaderFields();
+            for (Map.Entry<String, List<String>> entry: headers.entrySet()) {
+                String key = entry.getKey();
+                List<String> values = entry.getValue();
+                for (String value : values) {
+                    sb.append(key != null ? key : "");
+                    sb.append(':').append(value).append('\n');
+                }
             }
         }
         return sb.toString();

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/LoadTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/LoadTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/LoadTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/LoadTest.java
@@ -192,6 +192,16 @@ public class LoadTest extends TestBase {
         assertNotNull("Document is null", webEngine.getDocument());
     }
 
+    @Test public void testLoadLocalCSS() {
+        load(new File("src/test/resources/test/html/dom.html"));
+        submit(() -> {
+            assertEquals("Font weight should be bold", "bold", (String) getEngine().executeScript(
+                "window.getComputedStyle(document.getElementById('p3')).getPropertyValue('font-weight')"));
+            assertEquals("font style should be italic", "italic", (String) getEngine().executeScript(
+                "window.getComputedStyle(document.getElementById('p3')).getPropertyValue('font-style')"));
+        });
+    }
+
     /**
      * @test
      * @bug 8140501

--- a/modules/javafx.web/src/test/resources/test/html/dom.html
+++ b/modules/javafx.web/src/test/resources/test/html/dom.html
@@ -31,6 +31,9 @@
 <p id="p1">Things <b>do</b> change</p>
 <p id="p2">Again <i>and</i> again</p>
 
+<!-- used by testLoadLocalCSS -->
+<p id="p3" class="head2">Sample Text</p>
+
 <!-- used by testNodeTypes -->
 <p id="showcase-paragraph">
 text<!--comment--><span class="spanclass">spantext</span></p>


### PR DESCRIPTION
Issue: In JDK15, [URLConnection](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/sun/net/www/URLConnection.java) class overrode the getHeaderFields() methods to return properties, which previously returned an empty map from its super class.

Fix: Extract headers only when it's a HttpURLConnection, otherwise return an empty String.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253696](https://bugs.openjdk.java.net/browse/JDK-8253696): WebEngine refuses to load local "file:///" CSS stylesheets when using JDK 15


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/314/head:pull/314`
`$ git checkout pull/314`
