### PR TITLE
8239589: JavaFX UI will not repaint after reconnecting via Remote Desktop

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PresentingPainter.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PresentingPainter.java
@@ -70,6 +70,7 @@ final class PresentingPainter extends ViewPainter {
             }
             if (factory == null || !factory.isDeviceReady()) {
                 sceneState.getScene().entireSceneNeedsRepaint();
+                factory = null;
                 return;
             }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/UploadingPainter.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/UploadingPainter.java
@@ -90,6 +90,7 @@ final class UploadingPainter extends ViewPainter implements Runnable {
                 factory = GraphicsPipeline.getDefaultResourceFactory();
             }
             if (factory == null || !factory.isDeviceReady()) {
+                factory = null;
                 return;
             }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
@@ -35,6 +35,7 @@ import com.sun.javafx.sg.prism.NGCamera;
 import com.sun.javafx.sg.prism.NGDefaultCamera;
 import com.sun.prism.CompositeMode;
 import com.sun.prism.Graphics;
+import com.sun.prism.GraphicsPipeline;
 import com.sun.prism.MeshView;
 import com.sun.prism.RTTexture;
 import com.sun.prism.RenderTarget;
@@ -45,6 +46,7 @@ import com.sun.prism.ps.Shader;
 
 class D3DContext extends BaseShaderContext {
 
+    public static final int D3DERR_DEVICEREMOVED    = 0x88760870;
     public static final int D3DERR_DEVICENOTRESET   = 0x88760869;
     public static final int D3DERR_DEVICELOST       = 0x88760868;
     public static final int E_FAIL                  = 0x80004005;
@@ -150,6 +152,12 @@ class D3DContext extends BaseShaderContext {
 
         if (hr == D3DERR_DEVICELOST) {
             setLost();
+        }
+        
+        if (hr == D3DERR_DEVICEREMOVED) {
+            setLost();
+            GraphicsPipeline.getPipeline().dispose();
+            GraphicsPipeline.getPipeline().createPipeline();
         }
 
         if (hr == D3DERR_DEVICENOTRESET) {
@@ -457,6 +465,8 @@ class D3DContext extends BaseShaderContext {
                 return "D3DERR_DEVICELOST";
             case (int)D3DERR_OUTOFVIDEOMEMORY:
                 return "D3DERR_OUTOFVIDEOMEMORY";
+            case (int)D3DERR_DEVICEREMOVED:
+                return "D3DERR_DEVICEREMOVED";
             case (int)D3D_OK:
                 return "D3D_OK";
             default:

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
@@ -153,7 +153,7 @@ class D3DContext extends BaseShaderContext {
         if (hr == D3DERR_DEVICELOST) {
             setLost();
         }
-        
+
         if (hr == D3DERR_DEVICEREMOVED) {
             setLost();
             GraphicsPipeline.getPipeline().dispose();

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPipeline.java
@@ -27,6 +27,7 @@ package com.sun.prism.d3d;
 
 import com.sun.glass.ui.Screen;
 import com.sun.glass.utils.NativeLibLoader;
+import com.sun.prism.Graphics;
 import com.sun.prism.GraphicsPipeline;
 import com.sun.prism.ResourceFactory;
 import com.sun.prism.impl.PrismSettings;
@@ -216,7 +217,14 @@ public final class D3DPipeline extends GraphicsPipeline {
     }
 
     private static D3DResourceFactory findDefaultResourceFactory(List<Screen> screens) {
-        for (int adapter = 0, n = nGetAdapterCount(); adapter != n; ++adapter) {
+        int adapterCount = nGetAdapterCount();
+        if(adapterCount == 0){
+            // adapters lost, recreate
+            GraphicsPipeline.getPipeline().dispose();
+            GraphicsPipeline.getPipeline().createPipeline();
+            return null;
+        }
+        for (int adapter = 0, n = adapterCount; adapter != n; ++adapter) {
             D3DResourceFactory rf =
                     getD3DResourceFactory(adapter, getScreenForAdapter(screens, adapter));
 

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPipeline.java
@@ -77,6 +77,14 @@ public final class D3DPipeline extends GraphicsPipeline {
     private static D3DResourceFactory factories[];
 
     public static D3DPipeline getInstance() {
+        if(theInstance == null){
+            if (d3dEnabled) {
+                // device was removed, reinitialize
+                nInit(PrismSettings.class);
+                theInstance = new D3DPipeline();
+                factories = new D3DResourceFactory[nGetAdapterCount()];
+            }
+        }
         return theInstance;
     }
 
@@ -166,6 +174,7 @@ public final class D3DPipeline extends GraphicsPipeline {
         for (int i=0; i!=factories.length; ++i) {
             factories[i] = null;
         }
+        theInstance = null;
         super.dispose();
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/BaseResourcePool.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/BaseResourcePool.java
@@ -460,7 +460,9 @@ public abstract class BaseResourcePool<T> implements ResourcePool<T> {
                 cur = cur.next;
             }
         }
-        throw new IllegalStateException("unmanaged resource freed from pool "+this);
+        if(PrismSettings.verbose) {
+            System.err.println("unmanaged resource freed from pool " + this);
+        }
     }
 
     @Override


### PR DESCRIPTION
When connecting via Remote Desktop to a Windows 10 machine ans starting a JavaFX application, the D3D pipeline is used successfully.
After closing the the Remote Desktop session and reconnecting, the D3D requests fail with an D3DERR_DEVICEREMOVED  HResult, and the application contents are not rendered anymore.
Reinitializing the whole pipeline fixes that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8239589](https://bugs.openjdk.java.net/browse/JDK-8239589): JavaFX UI will not repaint after reconnecting via Remote Desktop


### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/315/head:pull/315`
`$ git checkout pull/315`
