### PR TITLE
8253935: [testbug] ComboBoxTest.testEditorKeyInputsWhenPopupIsShowing fails on Mac, Linux

### DIFF
--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyModifier.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyModifier.java
@@ -64,6 +64,6 @@ public enum KeyModifier {
     }
 
     public static KeyModifier getWordTraversalKey() {
-        return Utils.isMac() ? ALT : CTRL;
+        return Utils.isMac() ? ALT : getShortcutKey();
     }
 }

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyModifier.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyModifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,5 +61,9 @@ public enum KeyModifier {
             default:
                 return null;
         }
+    }
+
+    public static KeyModifier getWordTraversalKey() {
+        return Utils.isMac() ? ALT : CTRL;
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -1385,39 +1385,24 @@ public class ComboBoxTest {
         assertEquals("", cb.getEditor().getSelectedText());
         assertEquals(0, cb.getEditor().getCaretPosition());
 
-        if (Utils.isMac()) {
-            // Test ALT + RIGHT key
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.ALT);
-        } else {
-            // Test CTRL + RIGHT key
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.getShortcutKey());
-        }
-        assertEquals("", cb.getEditor().getSelectedText());
+        // Test ALT/CTRL + RIGHT key
+        int expectedCaretPosition = 3;
         if (Utils.isWindows()) {
-            assertEquals(4, cb.getEditor().getCaretPosition());
-        } else {
-            assertEquals(3, cb.getEditor().getCaretPosition());
+            expectedCaretPosition = 4;
         }
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.getWordTraversalKey());
+        assertEquals("", cb.getEditor().getSelectedText());
+        assertEquals(expectedCaretPosition, cb.getEditor().getCaretPosition());
 
         // Test CTRL/META + LEFT key
         keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.getShortcutKey());
         assertEquals("", cb.getEditor().getSelectedText());
         assertEquals(0, cb.getEditor().getCaretPosition());
 
-        if (Utils.isMac()) {
-            // Test ALT + SHIFT + RIGHT key
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.ALT, KeyModifier.SHIFT);
-        } else {
-            // Test CTRL + SHIFT + RIGHT key
-            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.getShortcutKey(), KeyModifier.SHIFT);
-        }
-        if (Utils.isWindows()) {
-            assertEquals("ABC ", cb.getEditor().getSelectedText());
-            assertEquals(4, cb.getEditor().getCaretPosition());
-        } else {
-            assertEquals("ABC", cb.getEditor().getSelectedText());
-            assertEquals(3, cb.getEditor().getCaretPosition());
-        }
+        // Test ALT/CTRL + SHIFT + RIGHT key
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.getWordTraversalKey(), KeyModifier.SHIFT);
+        assertEquals(expectedCaretPosition, cb.getEditor().getCaretPosition());
+        assertEquals(cb.getEditor().getText().substring(0, expectedCaretPosition), cb.getEditor().getSelectedText());
 
         // Test CTRL/META + SHIFT + LEFT key
         keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.getShortcutKey(), KeyModifier.SHIFT);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -31,6 +31,7 @@ import com.sun.javafx.scene.control.inputmap.InputMap;
 import com.sun.javafx.scene.control.inputmap.InputMap.KeyMapping;
 import com.sun.javafx.scene.control.inputmap.KeyBinding;
 import com.sun.javafx.tk.Toolkit;
+import com.sun.javafx.util.Utils;
 
 import test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory;
 import test.com.sun.javafx.scene.control.infrastructure.KeyModifier;
@@ -1357,7 +1358,7 @@ public class ComboBoxTest {
         assertTrue(cb.isShowing());
         assertEquals(0, cb.getEditor().getCaretPosition());
 
-        // LEFT, RIGHT keys with CTRL, SHIFT modifiers
+        // LEFT, RIGHT keys with CTRL/META, SHIFT modifiers
         // Test RIGHT key
         keyboard.doRightArrowPress();
         assertEquals(1, cb.getEditor().getCaretPosition());
@@ -1384,27 +1385,46 @@ public class ComboBoxTest {
         assertEquals("", cb.getEditor().getSelectedText());
         assertEquals(0, cb.getEditor().getCaretPosition());
 
-        // Test CTRL + RIGHT key
-        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.CTRL);
+        if (Utils.isMac()) {
+            // Test ALT + RIGHT key
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.ALT);
+        } else {
+            // Test CTRL + RIGHT key
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.getShortcutKey());
+        }
         assertEquals("", cb.getEditor().getSelectedText());
-        assertEquals(4, cb.getEditor().getCaretPosition());
+        if (Utils.isWindows()) {
+            assertEquals(4, cb.getEditor().getCaretPosition());
+        } else {
+            assertEquals(3, cb.getEditor().getCaretPosition());
+        }
 
-        // Test CTRL + LEFT key
-        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.CTRL);
+        // Test CTRL/META + LEFT key
+        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.getShortcutKey());
         assertEquals("", cb.getEditor().getSelectedText());
         assertEquals(0, cb.getEditor().getCaretPosition());
 
-        // Test CTRL + SHIFT + RIGHT key
-        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.CTRL, KeyModifier.SHIFT);
-        assertEquals("ABC ", cb.getEditor().getSelectedText());
-        assertEquals(4, cb.getEditor().getCaretPosition());
+        if (Utils.isMac()) {
+            // Test ALT + SHIFT + RIGHT key
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.ALT, KeyModifier.SHIFT);
+        } else {
+            // Test CTRL + SHIFT + RIGHT key
+            keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.getShortcutKey(), KeyModifier.SHIFT);
+        }
+        if (Utils.isWindows()) {
+            assertEquals("ABC ", cb.getEditor().getSelectedText());
+            assertEquals(4, cb.getEditor().getCaretPosition());
+        } else {
+            assertEquals("ABC", cb.getEditor().getSelectedText());
+            assertEquals(3, cb.getEditor().getCaretPosition());
+        }
 
-        // Test CTRL + SHIFT + LEFT key
-        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.CTRL, KeyModifier.SHIFT);
+        // Test CTRL/META + SHIFT + LEFT key
+        keyboard.doKeyPress(KeyCode.LEFT, KeyModifier.getShortcutKey(), KeyModifier.SHIFT);
         assertEquals("", cb.getEditor().getSelectedText());
         assertEquals(0, cb.getEditor().getCaretPosition());
 
-        // HOME, END keys with CTRL, SHIFT modifiers
+        // HOME, END keys with CTRL/META, SHIFT modifiers
         // Test END key
         keyboard.doKeyPress(KeyCode.END);
         assertEquals(7, cb.getEditor().getCaretPosition());
@@ -1423,27 +1443,27 @@ public class ComboBoxTest {
         assertEquals("", cb.getEditor().getSelectedText());
         assertEquals(0, cb.getEditor().getCaretPosition());
 
-        // Test CTRL + END key
-        keyboard.doKeyPress(KeyCode.END, KeyModifier.CTRL);
+        // Test CTRL/META + END key
+        keyboard.doKeyPress(KeyCode.END, KeyModifier.getShortcutKey());
         assertEquals("", cb.getEditor().getSelectedText());
         assertEquals(7, cb.getEditor().getCaretPosition());
 
-        // Test CTRL + HOME key
-        keyboard.doKeyPress(KeyCode.HOME, KeyModifier.CTRL);
+        // Test CTRL/META + HOME key
+        keyboard.doKeyPress(KeyCode.HOME, KeyModifier.getShortcutKey());
         assertEquals("", cb.getEditor().getSelectedText());
         assertEquals(0, cb.getEditor().getCaretPosition());
 
-        // Test CTRL + SHIFT + END key
-        keyboard.doKeyPress(KeyCode.END, KeyModifier.CTRL, KeyModifier.SHIFT);
+        // Test CTRL/META + SHIFT + END key
+        keyboard.doKeyPress(KeyCode.END, KeyModifier.getShortcutKey(), KeyModifier.SHIFT);
         assertEquals(cb.getEditor().getText(), cb.getEditor().getSelectedText());
         assertEquals(7, cb.getEditor().getCaretPosition());
 
-        // Test CTRL + SHIFT + HOME key
-        keyboard.doKeyPress(KeyCode.HOME, KeyModifier.CTRL, KeyModifier.SHIFT);
+        // Test CTRL/META + SHIFT + HOME key
+        keyboard.doKeyPress(KeyCode.HOME, KeyModifier.getShortcutKey(), KeyModifier.SHIFT);
         assertEquals("", cb.getEditor().getSelectedText());
         assertEquals(0, cb.getEditor().getCaretPosition());
 
-        // Test CTRL + A key
+        // Test CTRL/META + A key
         keyboard.doLeftArrowPress();
         assertEquals("", cb.getEditor().getSelectedText());
         keyboard.doKeyPress(KeyCode.A, KeyModifier.getShortcutKey());


### PR DESCRIPTION
The test fails on Mac and Linux.
Cause of failure:
- Linux: Unlike Windows, on Linux CTRL + Arrow keys move the caret to end/beginning of current word and not to beginning/end of next word.
- Mac: On Mac correct keys to traverse through words is ALT + Arrow and not CTRL + Arrow. And like on Linux, ALT + Arrow keys move the caret to end/beginning of current word and not to beginning/end of next word.

Fix is to use correct keys and asserts according to platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253935](https://bugs.openjdk.java.net/browse/JDK-8253935): [testbug] ComboBoxTest.testEditorKeyInputsWhenPopupIsShowing fails on Mac, Linux


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/317/head:pull/317`
`$ git checkout pull/317`
