### PR TITLE
8254040: [testbug] Need additional regressions tests for ObservableList removeAll / retainAll

### DIFF
--- a/modules/javafx.base/src/test/java/test/javafx/collections/FilteredListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/FilteredListTest.java
@@ -56,6 +56,24 @@ public class FilteredListTest {
         filteredList.addListener(mlo);
     }
 
+    @Test
+    public void test_rt35857_removeFiltered() {
+        ObservableList<String> copyList = FXCollections.observableArrayList(list);
+        // no relation, but use a different method to remove just to be on the super safe side
+        filteredList.forEach(e -> copyList.remove(e));
+        // list has duplicates!
+        list.removeAll(filteredList);
+        assertEquals(copyList, list);
+    }
+
+    @Test
+    public void test_rt35857_retainFiltered() {
+        ObservableList<String> copyFiltered = FXCollections.observableArrayList(filteredList);
+        list.retainAll(filteredList);
+        assertEquals("sanity: filteredList unchanged", copyFiltered, filteredList);
+        assertEquals(filteredList, list);
+    }
+
     private <E> void compareIndices(FilteredList<E> filtered) {
         ObservableList<? extends E> source = filtered.getSource();
         for (int i = 0; i < filtered.size(); i++) {

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListTest.java
@@ -28,6 +28,7 @@ package test.javafx.collections;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -238,6 +239,16 @@ public class ObservableListTest  {
         assertEquals(2, mlo.calls.size());
         mlo.checkAddRemove(0, list, Arrays.asList("one"), 0, 0);
         mlo.checkAddRemove(1, list, Arrays.asList("three", "four"), 1, 1);
+    }
+
+    @Test
+    public void testRetainAllEmptySource() {
+        // grab default data
+        List<String> data = new ArrayList<>(list);
+        // retain none == remove all
+        list.retainAll();
+        assertTrue(list.isEmpty());
+        mlo.check1AddRemove(list, data, 0, 0);
     }
 
     @Test

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -3486,6 +3486,68 @@ public class TreeTableViewTest {
 
         assertTrue(treeView.getSortOrder().isEmpty());
     }
+    //--------- regression testing of JDK-8093144 (was: RT-35857)
+
+    /**
+     * Note: 8093144 is not an issue for the current implementation of TreeTableView/SelectionModel
+     * because selectedItems.getModelItem delegates to TreeTableView.getRow which is implemented
+     * to look into its cached items.
+     * <p>
+     * These regression tests guard agains potential future changes in implementation.
+     */
+    @Test
+    public void test_rt35857_selectLast_retainAllSelected() {
+        TreeTableView<String> treeView = new TreeTableView<String>(createTreeItem());
+        treeView.getSelectionModel().select(treeView.getRoot().getChildren().size());
+
+        assert_rt35857(treeView.getRoot().getChildren(), treeView.getSelectionModel(), true);
+    }
+
+    @Test
+    public void test_rt35857_selectLast_removeAllSelected() {
+        TreeTableView<String> treeView = new TreeTableView<String>(createTreeItem());
+        treeView.getSelectionModel().select(treeView.getRoot().getChildren().size());
+
+        assert_rt35857(treeView.getRoot().getChildren(), treeView.getSelectionModel(), false);
+    }
+
+    @Test
+    public void test_rt35857_selectFirst_retainAllSelected() {
+        TreeTableView<String> treeView = new TreeTableView<String>(createTreeItem());
+        treeView.getSelectionModel().select(1);
+
+        assert_rt35857(treeView.getRoot().getChildren(), treeView.getSelectionModel(), true);
+    }
+
+    /**
+     * Creates and returns an expanded TreeItem with 3 children.
+     */
+    protected TreeItem<String> createTreeItem() {
+        TreeItem<String> root = new TreeItem<>("Root");
+        root.setExpanded(true);
+        root.getChildren().setAll(new TreeItem("A"), new TreeItem("B"), new TreeItem("C"));
+        return root;
+    }
+
+    /**
+     * Modifies the items by retain/removeAll (depending on the given flag) selectedItems
+     * of the selectionModels and asserts the state of the items.
+     */
+    protected <T> void assert_rt35857(ObservableList<T> items, MultipleSelectionModel<T> sm, boolean retain) {
+        T selectedItem = sm.getSelectedItem();
+        ObservableList<T> expected;
+        if (retain) {
+            expected = FXCollections.observableArrayList(selectedItem);
+            items.retainAll(sm.getSelectedItems());
+        } else {
+            expected = FXCollections.observableArrayList(items);
+            expected.remove(selectedItem);
+            items.removeAll(sm.getSelectedItems());
+        }
+        String modified = (retain ? " retainAll " : " removeAll ") + " selectedItems ";
+        assertEquals("expected list after" + modified, expected, items);
+    }
+
 
     @Test public void test_rt35857() {
         TreeItem<String> root = new TreeItem<>("Root");
@@ -3508,6 +3570,7 @@ public class TreeTableViewTest {
         assertEquals("B", root.getChildren().get(0).getValue());
         assertEquals("C", root.getChildren().get(1).getValue());
     }
+    //--------- end regression testing of JDK-8093144 (was: RT-35857)
 
     private int rt36452_instanceCount = 0;
     @Test public void test_rt36452() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
@@ -1649,6 +1649,68 @@ public class TreeViewTest {
         sl.dispose();
     }
 
+    //--------- regression testing of JDK-8093144 (was: RT-35857)
+
+    /**
+     * Note: 8093144 is not an issue for the current implementation of TreeView/SelectionModel
+     * because selectedItems.getModelItem delegates to TreeView.getRow which is implemented
+     * to look into its cached items.
+     * <p>
+     * These regression tests guard agains potential future changes in implementation.
+     */
+    @Test
+    public void test_rt35857_selectLast_retainAllSelected() {
+        TreeView<String> treeView = new TreeView<String>(createTreeItem());
+        treeView.getSelectionModel().select(treeView.getRoot().getChildren().size());
+
+        assert_rt35857(treeView.getRoot().getChildren(), treeView.getSelectionModel(), true);
+    }
+
+    @Test
+    public void test_rt35857_selectLast_removeAllSelected() {
+        TreeView<String> treeView = new TreeView<String>(createTreeItem());
+        treeView.getSelectionModel().select(treeView.getRoot().getChildren().size());
+
+        assert_rt35857(treeView.getRoot().getChildren(), treeView.getSelectionModel(), false);
+    }
+
+    @Test
+    public void test_rt35857_selectFirst_retainAllSelected() {
+        TreeView<String> treeView = new TreeView<String>(createTreeItem());
+        treeView.getSelectionModel().select(1);
+
+        assert_rt35857(treeView.getRoot().getChildren(), treeView.getSelectionModel(), true);
+    }
+
+    /**
+     * Creates and returns an expanded TreeItem with 3 children.
+     */
+    protected TreeItem<String> createTreeItem() {
+        TreeItem<String> root = new TreeItem<>("Root");
+        root.setExpanded(true);
+        root.getChildren().setAll(new TreeItem("A"), new TreeItem("B"), new TreeItem("C"));
+        return root;
+    }
+
+    /**
+     * Modifies the items by retain/removeAll (depending on the given flag) selectedItems
+     * of the selectionModels and asserts the state of the items.
+     */
+    protected <T> void assert_rt35857(ObservableList<T> items, MultipleSelectionModel<T> sm, boolean retain) {
+        T selectedItem = sm.getSelectedItem();
+        ObservableList<T> expected;
+        if (retain) {
+            expected = FXCollections.observableArrayList(selectedItem);
+            items.retainAll(sm.getSelectedItems());
+        } else {
+            expected = FXCollections.observableArrayList(items);
+            expected.remove(selectedItem);
+            items.removeAll(sm.getSelectedItems());
+        }
+        String modified = (retain ? " retainAll " : " removeAll ") + " selectedItems ";
+        assertEquals("expected list after" + modified, expected, items);
+    }
+
     @Test public void test_rt35857() {
         TreeItem<String> root = new TreeItem<>("Root");
         root.setExpanded(true);
@@ -1670,6 +1732,7 @@ public class TreeViewTest {
         assertEquals("B", root.getChildren().get(0).getValue());
         assertEquals("C", root.getChildren().get(1).getValue());
     }
+  //--------- end regression testing of JDK-8093144 (was: RT-35857)
 
     private int rt_35889_cancel_count = 0;
     @Test public void test_rt35889() {


### PR DESCRIPTION
issue is about missing regressions tests for [JDK-8093144](https://bugs.openjdk.java.net/browse/JDK-8093144)

added tests for implementations of ObservableList that might be effected (FilteredList, selectedItems in ListView and friends) - see bug report for details. Happily, the tests are passing with the current code base :) To see them failing requires to replace the methods with invalid implementations (the bug report has a snippet that can be c&p'ed to replace the correct version)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254040](https://bugs.openjdk.java.net/browse/JDK-8254040): [testbug] Need additional regressions tests for ObservableList removeAll / retainAll


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/319/head:pull/319`
`$ git checkout pull/319`
