### PR TITLE
8246202: ChoiceBoxSkin: misbehavior on switching skin, part 2

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ChoiceBoxSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ChoiceBoxSkin.java
@@ -147,7 +147,7 @@ public class ChoiceBoxSkin<T> extends SkinBase<ChoiceBox<T>> {
         initialize();
 
         itemsObserver = observable -> updateChoiceBoxItems();
-        control.itemsProperty().addListener(new WeakInvalidationListener(itemsObserver));
+        control.itemsProperty().addListener(itemsObserver);
 
         control.requestLayout();
         registerChangeListener(control.selectionModelProperty(), e -> updateSelectionModel());
@@ -206,6 +206,9 @@ public class ChoiceBoxSkin<T> extends SkinBase<ChoiceBox<T>> {
 
     /** {@inheritDoc} */
     @Override public void dispose() {
+        if (getSkinnable() == null) return;
+        // removing itemsObserver fixes NP on setting items
+        getSkinnable().itemsProperty().removeListener(itemsObserver);
          // removing the content listener fixes NPE from listener
         if (choiceBoxItems != null) {
             choiceBoxItems.removeListener(weakChoiceBoxItemsListener);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinCleanupTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinCleanupTest.java
@@ -114,7 +114,7 @@ public class SkinCleanupTest {
      * FIXME: Left-over from ChoiceBox fix.
      * NPE on sequence setItems -> modify items after skin is replaced.
      */
-    @Test @Ignore("8246202")
+    @Test
     public void testChoiceBoxSetItems() {
         ChoiceBox<String> box = new ChoiceBox<>();
         installDefaultSkin(box);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinCleanupTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinCleanupTest.java
@@ -111,7 +111,6 @@ public class SkinCleanupTest {
 //-------- choiceBox, toolBar
 
     /**
-     * FIXME: Left-over from ChoiceBox fix.
      * NPE on sequence setItems -> modify items after skin is replaced.
      */
     @Test


### PR DESCRIPTION
issue is a listener in ChoiceBoxSkin that wasn't removed (forgotten in my first cleanup ;)

Removed, un-ignored test that failed/passed before/after the fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8246202](https://bugs.openjdk.java.net/browse/JDK-8246202): ChoiceBoxSkin: misbehavior on switching skin, part 2


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/320/head:pull/320`
`$ git checkout pull/320`
