### PR TITLE
8254605: repaint on Android broken

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleWindowManager.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleWindowManager.java
@@ -121,7 +121,7 @@ final class MonocleWindowManager {
 
     boolean requestFocus(MonocleWindow window) {
         int index = getWindowIndex(window);
-        if (index != -1 && window.isVisible()) {
+        if (index != -1) {
             focusedWindow = window;
             window.notifyFocus(WindowEvent.FOCUS_GAINED);
             return true;

--- a/tests/system/src/test/java/test/javafx/stage/FocusedWindowMonocleTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/FocusedWindowMonocleTest.java
@@ -28,6 +28,7 @@ package test.javafx.stage;
 import javafx.application.Platform;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 public class FocusedWindowMonocleTest extends FocusedWindowTestBase {
@@ -42,6 +43,7 @@ public class FocusedWindowMonocleTest extends FocusedWindowTestBase {
         initFXBase();
     }
 
+    @Ignore("JDK-8254956")
     @Test
     public void testClosedFocusedStageLeak() throws Exception {
         testClosedFocusedStageLeakBase();


### PR DESCRIPTION
Don't check on windows visiblity when requesting focus.
For a new window, the call to requestFocus is done before the visibility is set to true.
Fix for JDK-8254605

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254605](https://bugs.openjdk.java.net/browse/JDK-8254605): repaint on Android broken


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/322/head:pull/322`
`$ git checkout pull/322`
