### PR TITLE
8255042: Change JavaFX release version in jfx15 branch to 15.0.1

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -41,7 +41,7 @@ jfx.release.suffix=-ea
 # UPDATE THE FOLLOWING VALUES FOR A NEW RELEASE
 jfx.release.major.version=15
 jfx.release.minor.version=0
-jfx.release.security.version=0
+jfx.release.security.version=1
 jfx.release.patch.version=0
 
 # Note: The release version is now calculated in build.gradle as the


### PR DESCRIPTION
Increase release version to 15.0.1
Fix for JDK-8255042

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255042](https://bugs.openjdk.java.net/browse/JDK-8255042): Change JavaFX release version in jfx15 branch to 15.0.1


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/325/head:pull/325`
`$ git checkout pull/325`
