### PR TITLE
8255002: Many javafx.controls unit tests have incorrect name containing impl_*

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/AxisTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/AxisTest.java
@@ -319,7 +319,7 @@ public class AxisTest {
     /*********************************************************************
      * CSS related Tests                                                 *
      ********************************************************************/
-    @Test public void whenSideIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenSideIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)axis.sideProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
         ObjectProperty<Side> other = new SimpleObjectProperty<Side>(Side.LEFT);
@@ -327,7 +327,7 @@ public class AxisTest {
         assertFalse(styleable.isSettable(axis));
     }
 
-    @Test public void whenSideIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenSideIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)axis.sideProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
     }
@@ -337,7 +337,7 @@ public class AxisTest {
         assertSame(Side.BOTTOM, axis.getSide());
     }
 
-    @Test public void whenTickMarkVisibleIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenTickMarkVisibleIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)axis.tickMarkVisibleProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
         BooleanProperty other = new SimpleBooleanProperty();
@@ -345,7 +345,7 @@ public class AxisTest {
         assertFalse(styleable.isSettable(axis));
     }
 
-    @Test public void whenTickMarkVisibleIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenTickMarkVisibleIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)axis.tickMarkVisibleProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
     }
@@ -355,7 +355,7 @@ public class AxisTest {
         assertSame(true, axis.isTickMarkVisible());
     }
 
-    @Test public void whenTickLabelsVisibleIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenTickLabelsVisibleIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)axis.tickLabelsVisibleProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
         BooleanProperty other = new SimpleBooleanProperty();
@@ -363,7 +363,7 @@ public class AxisTest {
         assertFalse(styleable.isSettable(axis));
     }
 
-    @Test public void whenTickLabelsVisibleIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenTickLabelsVisibleIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)axis.tickLabelsVisibleProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
     }
@@ -373,7 +373,7 @@ public class AxisTest {
         assertSame(true, axis.isTickMarkVisible());
     }
 
-    @Test public void whenTickLengthIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenTickLengthIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)axis.tickLengthProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
         DoubleProperty other = new SimpleDoubleProperty();
@@ -381,7 +381,7 @@ public class AxisTest {
         assertFalse(styleable.isSettable(axis));
     }
 
-    @Test public void whenTickLengthIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenTickLengthIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)axis.tickLengthProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
     }
@@ -391,7 +391,7 @@ public class AxisTest {
         assertEquals(10.34, axis.tickLengthProperty().get(), 0.000001);
     }
 
-    @Test public void whenTickLabelFontIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenTickLabelFontIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)axis.tickLabelFontProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
         ObjectProperty<Font> other = new SimpleObjectProperty<Font>(Font.getDefault());
@@ -399,7 +399,7 @@ public class AxisTest {
         assertFalse(styleable.isSettable(axis));
     }
 
-    @Test public void whenTickLabelFontIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenTickLabelFontIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)axis.tickLabelFontProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
     }
@@ -409,7 +409,7 @@ public class AxisTest {
         assertSame(Font.getDefault(), axis.getTickLabelFont());
     }
 
-    @Test public void whenTickLabelFillIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenTickLabelFillIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)axis.tickLabelFillProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
         ObjectProperty<Color> other = new SimpleObjectProperty<Color>(Color.BROWN);
@@ -417,7 +417,7 @@ public class AxisTest {
         assertFalse(styleable.isSettable(axis));
     }
 
-    @Test public void whenTickLabelFillIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenTickLabelFillIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)axis.tickLabelFillProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
     }
@@ -427,7 +427,7 @@ public class AxisTest {
         assertSame(Color.BROWN, axis.getTickLabelFill());
     }
 
-    @Test public void whenTickLabelGapIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenTickLabelGapIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)axis.tickLabelGapProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
         DoubleProperty other = new SimpleDoubleProperty();
@@ -435,7 +435,7 @@ public class AxisTest {
         assertFalse(styleable.isSettable(axis));
     }
 
-    @Test public void whenTickLabelGapIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenTickLabelGapIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)axis.tickLabelGapProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/CategoryAxisTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/CategoryAxisTest.java
@@ -159,7 +159,7 @@ public class CategoryAxisTest {
     /*********************************************************************
      * CSS related Tests                                                 *
      ********************************************************************/
-    @Test public void whenStartMarginIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenStartMarginIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)axis.startMarginProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
         DoubleProperty other = new SimpleDoubleProperty();
@@ -167,7 +167,7 @@ public class CategoryAxisTest {
         assertFalse(styleable.isSettable(axis));
     }
 
-    @Test public void whenStartMarginIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenStartMarginIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)axis.startMarginProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
     }
@@ -177,7 +177,7 @@ public class CategoryAxisTest {
         assertEquals(10.34, axis.getStartMargin(), 0.0);
     }
 
-    @Test public void whenEndMarginIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenEndMarginIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)axis.endMarginProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
         DoubleProperty other = new SimpleDoubleProperty();
@@ -185,7 +185,7 @@ public class CategoryAxisTest {
         assertFalse(styleable.isSettable(axis));
     }
 
-    @Test public void whenEndMarginIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenEndMarginIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)axis.endMarginProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
     }
@@ -196,7 +196,7 @@ public class CategoryAxisTest {
     }
 
 
-    @Test public void whenGapStartAndEndIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenGapStartAndEndIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)axis.gapStartAndEndProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
         BooleanProperty other = new SimpleBooleanProperty();
@@ -204,7 +204,7 @@ public class CategoryAxisTest {
         assertFalse(styleable.isSettable(axis));
     }
 
-    @Test public void whenGapStartAndEndIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenGapStartAndEndIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)axis.gapStartAndEndProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/NumberAxisTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/NumberAxisTest.java
@@ -149,7 +149,7 @@ public class NumberAxisTest {
      * CSS related Tests                                                 *
      ********************************************************************/
 
-    @Test public void whenTickUnitIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenTickUnitIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)axis.tickUnitProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
         DoubleProperty other = new SimpleDoubleProperty();
@@ -157,7 +157,7 @@ public class NumberAxisTest {
         assertFalse(styleable.isSettable(axis));
     }
 
-    @Test public void whenTickUnitIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenTickUnitIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)axis.tickUnitProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/ValueAxisTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/ValueAxisTest.java
@@ -259,7 +259,7 @@ public class ValueAxisTest {
     /*********************************************************************
      * CSS related Tests                                                 *
      ********************************************************************/
-    @Test public void whenMinorTickVisibleIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenMinorTickVisibleIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)axis.minorTickVisibleProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
         BooleanProperty other = new SimpleBooleanProperty();
@@ -267,7 +267,7 @@ public class ValueAxisTest {
         assertFalse(styleable.isSettable(axis));
     }
 
-    @Test public void whenMinorTickVisibleIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenMinorTickVisibleIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)axis.minorTickVisibleProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
     }
@@ -277,7 +277,7 @@ public class ValueAxisTest {
         assertSame(true, axis.isMinorTickVisible());
     }
 
-    @Test public void whenMinorTickLengthIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenMinorTickLengthIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)axis.minorTickLengthProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
         DoubleProperty other = new SimpleDoubleProperty();
@@ -285,7 +285,7 @@ public class ValueAxisTest {
         assertFalse(styleable.isSettable(axis));
     }
 
-    @Test public void whenMinorTickLengthIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenMinorTickLengthIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)axis.minorTickLengthProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
     }
@@ -295,7 +295,7 @@ public class ValueAxisTest {
         assertEquals(10.34, axis.getMinorTickLength(), 0.0);
     }
 
-    @Test public void whenMinorTickCountIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenMinorTickCountIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)axis.minorTickCountProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
         DoubleProperty other = new SimpleDoubleProperty();
@@ -303,7 +303,7 @@ public class ValueAxisTest {
         assertFalse(styleable.isSettable(axis));
     }
 
-    @Test public void whenMinorTickCountIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenMinorTickCountIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)axis.minorTickCountProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(axis));
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -652,7 +652,7 @@ public class ComboBoxTest {
         assertEquals(null, sc.toString(null));
     }
 
-    @Test public void ensureImpl_getPseudoClassStateReturnsValidValue() {
+    @Test public void ensure_getPseudoClassStateReturnsValidValue() {
         Stage stage = new Stage();
         Scene scene = new Scene(comboBox);
         stage.setScene(scene);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlSkinTest.java
@@ -109,7 +109,7 @@ public class ControlSkinTest {
     /*
      * Binding a skin is honored
      * Be sure to check that "dispose" is called on the old skin
-     * Test that if skin is bound, then impl_cssSettable returns false
+     * Test that if skin is bound, then CssMetaData_isSettable returns false
      */
 //    @Test public void skinCanBeBound() {
 //        ObjectProperty<SkinStub<ControlStub>> skin = new SimpleObjectProperty<SkinStub<ControlStub>>();
@@ -122,7 +122,7 @@ public class ControlSkinTest {
         assertTrue(c.getSkin() instanceof MySkinStub);
     }
 
-    @Test public void impl_cssSetCalledTwiceWithTheSameValueHasNoEffectTheSecondTime() {
+    @Test public void applyStyleCalledTwiceWithTheSameValueHasNoEffectTheSecondTime() {
         StringProperty skinClassName = ControlShim.skinClassNameProperty(c);
         skinClassName.addListener(new InvalidationListener() {
             boolean calledOnce = false;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlTest.java
@@ -70,7 +70,7 @@ import static org.junit.Assert.*;
  *     - Default style-class has what you expect
  *     - (2nd order) CssMetaData_isSettable returns true for thing in their default state
  *     - (2nd order) CssMetaData_isSettable returns false for things manually specified
- *     - (3rd order) impl_cssKeys includes all the public properties
+ *     - (3rd order) getCssMetaData includes all the public properties
  *  - Methods
  *     - For all methods, calling the method mutates the state appropriately
  */

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlTest.java
@@ -68,8 +68,8 @@ import static org.junit.Assert.*;
  *  - CSS
  *     - Change state, watch the pseudo class state change
  *     - Default style-class has what you expect
- *     - (2nd order) impl_cssSettable returns true for thing in their default state
- *     - (2nd order) impl_cssSettable returns false for things manually specified
+ *     - (2nd order) CssMetaData_isSettable returns true for thing in their default state
+ *     - (2nd order) CssMetaData_isSettable returns false for things manually specified
  *     - (3rd order) impl_cssKeys includes all the public properties
  *  - Methods
  *     - For all methods, calling the method mutates the state appropriately

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/HyperlinkTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/HyperlinkTest.java
@@ -139,7 +139,7 @@ public class HyperlinkTest {
      *  - set is honored                                                            *
      *  - can be bound                                                              *
      *  - is false by default                                                       *
-     *  - impl_cssSettable returns false                                            *
+     *  - CssMetaData_isSettable returns false                                            *
      *                                                                              *
      *******************************************************************************/
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/LabelTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/LabelTest.java
@@ -147,7 +147,7 @@ public class LabelTest {
         assertNull(label.getLabelFor());
     }
 
-    @Test public void impl_cssSettable_AlwaysReturnsFalseForLabelFor() {
+    @Test public void CssMetaData_isSettable_AlwaysReturnsFalseForLabelFor() {
         try {
             CssMetaData styleable = ((StyleableProperty)label.labelForProperty()).getCssMetaData();
             assertNull(styleable);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/LabeledTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/LabeledTest.java
@@ -122,8 +122,8 @@ public class LabeledTest {
      *  - can be null                                                               *
      *  - set is honored                                                            *
      *  - can be bound                                                              *
-     *  - if bound, impl_cssSettable returns false                                  *
-     *  - if specified via CSS and not bound, impl_cssSettable returns true         *
+     *  - if bound, CssMetaData_isSettable returns false                                  *
+     *  - if specified via CSS and not bound, CssMetaData_isSettable returns true         *
      *                                                                              *
      *******************************************************************************/
 
@@ -172,8 +172,8 @@ public class LabeledTest {
      *  - set is honored                                                            *
      *  - can be bound                                                              *
      *  - is BLACK by default                                                       *
-     *  - if bound, impl_cssSettable returns false                                  *
-     *  - if specified via CSS and not bound, impl_cssSettable returns true         *
+     *  - if bound, CssMetaData_isSettable returns false                                  *
+     *  - if specified via CSS and not bound, CssMetaData_isSettable returns true         *
      *                                                                              *
      *******************************************************************************/
 
@@ -203,7 +203,7 @@ public class LabeledTest {
         assertSame(Color.RED, labeled.getTextFill());
     }
 
-    @Test public void whenTextFillIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenTextFillIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)labeled.textFillProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
         ObjectProperty<Paint> other = new SimpleObjectProperty<Paint>(Color.RED);
@@ -212,7 +212,7 @@ public class LabeledTest {
 
     }
 
-    @Test public void whenTextFillIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenTextFillIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)labeled.textFillProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
     }
@@ -238,8 +238,8 @@ public class LabeledTest {
      *  - set is honored                                                            *
      *  - can be bound                                                              *
      *  - default is "CENTER_LEFT"                                                  *
-     *  - if bound, impl_cssSettable returns false                                  *
-     *  - if specified via CSS and not bound, impl_cssSettable returns true         *
+     *  - if bound, CssMetaData_isSettable returns false                                  *
+     *  - if specified via CSS and not bound, CssMetaData_isSettable returns true         *
      *                                                                              *
      *******************************************************************************/
 
@@ -268,14 +268,14 @@ public class LabeledTest {
         assertEquals(Pos.BASELINE_RIGHT, labeled.getAlignment());
     }
 
-    @Test public void whenAlignmentIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenAlignmentIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)labeled.alignmentProperty()).getCssMetaData();
         ObjectProperty<Pos> other = new SimpleObjectProperty<Pos>(Pos.BASELINE_RIGHT);
         labeled.alignmentProperty().bind(other);
         assertFalse(styleable.isSettable(labeled));
     }
 
-    @Test public void whenAlignmentIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenAlignmentIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)labeled.alignmentProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
     }
@@ -293,8 +293,8 @@ public class LabeledTest {
      *  - set is honored                                                            *
      *  - can be bound                                                              *
      *  - default is "LEFT"                                                         *
-     *  - if bound, impl_cssSettable returns false                                  *
-     *  - if specified via CSS and not bound, impl_cssSettable returns true         *
+     *  - if bound, CssMetaData_isSettable returns false                                  *
+     *  - if specified via CSS and not bound, CssMetaData_isSettable returns true         *
      *                                                                              *
      *******************************************************************************/
 
@@ -324,7 +324,7 @@ public class LabeledTest {
         assertEquals(TextAlignment.RIGHT, labeled.getTextAlignment());
     }
 
-    @Test public void whenTextAlignmentIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenTextAlignmentIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)labeled.textAlignmentProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
         ObjectProperty<TextAlignment> other = new SimpleObjectProperty<TextAlignment>(TextAlignment.RIGHT);
@@ -332,7 +332,7 @@ public class LabeledTest {
         assertFalse(styleable.isSettable(labeled));
     }
 
-    @Test public void whenTextAlignmentIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenTextAlignmentIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)labeled.textAlignmentProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
     }
@@ -350,8 +350,8 @@ public class LabeledTest {
      *  - set is honored                                                            *
      *  - can be bound                                                              *
      *  - default is "ELLIPSIS"                                                     *
-     *  - if bound, impl_cssSettable returns false                                  *
-     *  - if specified via CSS and not bound, impl_cssSettable returns true         *
+     *  - if bound, CssMetaData_isSettable returns false                                  *
+     *  - if specified via CSS and not bound, CssMetaData_isSettable returns true         *
      *                                                                              *
      *******************************************************************************/
 
@@ -381,7 +381,7 @@ public class LabeledTest {
         assertEquals(OverrunStyle.LEADING_WORD_ELLIPSIS, labeled.getTextOverrun());
     }
 
-    @Test public void whenTextOverrunIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenTextOverrunIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)labeled.textOverrunProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
         ObjectProperty<OverrunStyle> other = new SimpleObjectProperty<OverrunStyle>(OverrunStyle.LEADING_WORD_ELLIPSIS);
@@ -389,7 +389,7 @@ public class LabeledTest {
         assertFalse(styleable.isSettable(labeled));
     }
 
-    @Test public void whenTextOverrunIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenTextOverrunIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)labeled.textOverrunProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
     }
@@ -407,8 +407,8 @@ public class LabeledTest {
      *  - can be bound                                                              *
      *  - default is false                                                          *
      *  - contentBias changes based on wrapText                                     *
-     *  - if bound, impl_cssSettable returns false                                  *
-     *  - if specified via CSS and not bound, impl_cssSettable returns true         *
+     *  - if bound, CssMetaData_isSettable returns false                                  *
+     *  - if specified via CSS and not bound, CssMetaData_isSettable returns true         *
      *                                                                              *
      *******************************************************************************/
 
@@ -433,7 +433,7 @@ public class LabeledTest {
         assertTrue(labeled.isWrapText());
     }
 
-    @Test public void whenWrapTextIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenWrapTextIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)labeled.wrapTextProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
         BooleanProperty other = new SimpleBooleanProperty(true);
@@ -441,7 +441,7 @@ public class LabeledTest {
         assertFalse(styleable.isSettable(labeled));
     }
 
-    @Test public void whenWrapTextIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenWrapTextIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)labeled.wrapTextProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
     }
@@ -468,8 +468,8 @@ public class LabeledTest {
      *  - set is honored                                                            *
      *  - can be bound                                                              *
      *  - default is Font.getDefault()                                              *
-     *  - if bound, impl_cssSettable returns false                                  *
-     *  - if specified via CSS and not bound, impl_cssSettable returns true         *
+     *  - if bound, CssMetaData_isSettable returns false                                  *
+     *  - if specified via CSS and not bound, CssMetaData_isSettable returns true         *
      *                                                                              *
      *******************************************************************************/
 
@@ -503,7 +503,7 @@ public class LabeledTest {
         assertEquals(f, labeled.getFont());
     }
 
-    @Test public void whenFontIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenFontIsBound_CssMetaData_isSettable_ReturnsFalse() {
         final Font f = Font.font("Arial", 25);
         CssMetaData styleable = ((StyleableProperty)labeled.fontProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
@@ -512,7 +512,7 @@ public class LabeledTest {
         assertFalse(styleable.isSettable(labeled));
     }
 
-    @Test public void whenFontIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenFontIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         final Font f = Font.font("Arial", 25);
         CssMetaData styleable = ((StyleableProperty)labeled.fontProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
@@ -532,8 +532,8 @@ public class LabeledTest {
      *  - set is honored                                                            *
      *  - can be bound                                                              *
      *  - default is null                                                           *
-     *  - if bound, impl_cssSettable returns false                                  *
-     *  - if specified via CSS and not bound, impl_cssSettable returns true         *
+     *  - if bound, CssMetaData_isSettable returns false                                  *
+     *  - if specified via CSS and not bound, CssMetaData_isSettable returns true         *
      *                                                                              *
      *******************************************************************************/
 
@@ -568,7 +568,7 @@ public class LabeledTest {
     }
 
     @Ignore ("CSS Graphic must be a URL, and then it will try to load the image. Not sure how to test.")
-    @Test public void whenGraphicIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenGraphicIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)labeled.graphicProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
         Rectangle r = new Rectangle();
@@ -578,7 +578,7 @@ public class LabeledTest {
     }
 
     @Ignore ("CSS Graphic must be a URL, and then it will try to load the image. Not sure how to test.")
-    @Test public void whenGraphicIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenGraphicIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)labeled.graphicProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
     }
@@ -596,8 +596,8 @@ public class LabeledTest {
      *  - set is honored                                                            *
      *  - can be bound                                                              *
      *  - default is false                                                          *
-     *  - if bound, impl_cssSettable returns false                                  *
-     *  - if specified via CSS and not bound, impl_cssSettable returns true         *
+     *  - if bound, CssMetaData_isSettable returns false                                  *
+     *  - if specified via CSS and not bound, CssMetaData_isSettable returns true         *
      *                                                                              *
      *******************************************************************************/
 
@@ -622,7 +622,7 @@ public class LabeledTest {
         assertTrue(labeled.isUnderline());
     }
 
-    @Test public void whenUnderlineIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenUnderlineIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)labeled.underlineProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
         BooleanProperty other = new SimpleBooleanProperty(true);
@@ -630,7 +630,7 @@ public class LabeledTest {
         assertFalse(styleable.isSettable(labeled));
     }
 
-    @Test public void whenUnderlineIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenUnderlineIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)labeled.underlineProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
     }
@@ -648,8 +648,8 @@ public class LabeledTest {
      *  - set is honored                                                            *
      *  - can be bound                                                              *
      *  - default is "LEFT"                                                         *
-     *  - if bound, impl_cssSettable returns false                                  *
-     *  - if specified via CSS and not bound, impl_cssSettable returns true         *
+     *  - if bound, CssMetaData_isSettable returns false                                  *
+     *  - if specified via CSS and not bound, CssMetaData_isSettable returns true         *
      *                                                                              *
      *******************************************************************************/
 
@@ -679,7 +679,7 @@ public class LabeledTest {
         assertEquals(ContentDisplay.RIGHT, labeled.getContentDisplay());
     }
 
-    @Test public void whenContentDisplayIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenContentDisplayIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)labeled.contentDisplayProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
         ObjectProperty<ContentDisplay> other = new SimpleObjectProperty<ContentDisplay>(ContentDisplay.RIGHT);
@@ -687,7 +687,7 @@ public class LabeledTest {
         assertFalse(styleable.isSettable(labeled));
     }
 
-    @Test public void whenContentDisplayIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenContentDisplayIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)labeled.contentDisplayProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
     }
@@ -704,8 +704,8 @@ public class LabeledTest {
      *  - set is honored                                                            *
      *  - can be bound                                                              *
      *  - default is 4                                                              *
-     *  - if bound, impl_cssSettable returns false                                  *
-     *  - if specified via CSS and not bound, impl_cssSettable returns true         *
+     *  - if bound, CssMetaData_isSettable returns false                                  *
+     *  - if specified via CSS and not bound, CssMetaData_isSettable returns true         *
      *                                                                              *
      *******************************************************************************/
 
@@ -735,7 +735,7 @@ public class LabeledTest {
         assertEquals(25, labeled.getGraphicTextGap(), 0);
     }
 
-    @Test public void whenGraphicTextGapIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenGraphicTextGapIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)labeled.graphicTextGapProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
         DoubleProperty other = new SimpleDoubleProperty(25);
@@ -743,7 +743,7 @@ public class LabeledTest {
         assertFalse(styleable.isSettable(labeled));
     }
 
-    @Test public void whenGraphicTextGapIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenGraphicTextGapIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)labeled.graphicTextGapProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuButtonTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuButtonTest.java
@@ -213,7 +213,7 @@ public class MenuButtonTest {
     }
 
     //TODO: test show()/isShowing() for disabled=true
-    //TODO: test MenuButton.impl_getPsuedoClassState
+    //TODO: test MenuButton.getPsuedoClassState
 
     @Test
     public void test_RT_21894() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/MiscellaneousTests.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/MiscellaneousTests.java
@@ -62,7 +62,7 @@ public class MiscellaneousTests {
         Scene scene = new Scene(new Group(container, new Button("button")));
 
         //
-        // Gotta put this in a window for the pulse listener to get hooked up (see Scene#impl_initPeer().
+        // Gotta put this in a window for the pulse listener to get hooked up (see Scene#initPeer().
         // Need the pulse listener since we want to enter root via Scene#doCSSPass()
         //
         Stage stage = new Stage();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/PaginationTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/PaginationTest.java
@@ -133,7 +133,7 @@ public class PaginationTest {
     /*********************************************************************
      * CSS related Tests                                                 *
      ********************************************************************/
-    @Test public void whenMaxPageIndicatorCountIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenMaxPageIndicatorCountIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)pagination.maxPageIndicatorCountProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(pagination));
         IntegerProperty intPr = new SimpleIntegerProperty(10);
@@ -141,7 +141,7 @@ public class PaginationTest {
         assertFalse(styleable.isSettable(pagination));
     }
 
-    @Test public void whenMaxPageIndicatorCountIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenMaxPageIndicatorCountIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)pagination.maxPageIndicatorCountProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(pagination));
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ScrollBarTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ScrollBarTest.java
@@ -263,7 +263,7 @@ public class ScrollBarTest {
     /*********************************************************************
      * CSS related Tests                                                 *
      ********************************************************************/
-    @Test public void whenOrientationIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenOrientationIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)scrollBar.orientationProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(scrollBar));
         ObjectProperty<Orientation> other = new SimpleObjectProperty<Orientation>(Orientation.VERTICAL);
@@ -271,7 +271,7 @@ public class ScrollBarTest {
         assertFalse(styleable.isSettable(scrollBar));
     }
 
-    @Test public void whenOrientationIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenOrientationIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)scrollBar.orientationProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(scrollBar));
     }
@@ -281,7 +281,7 @@ public class ScrollBarTest {
         assertSame(Orientation.VERTICAL, scrollBar.getOrientation());
     }
 
-    @Test public void whenUnitIncIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenUnitIncIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)scrollBar.unitIncrementProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(scrollBar));
         DoubleProperty other = new SimpleDoubleProperty(2.0);
@@ -289,7 +289,7 @@ public class ScrollBarTest {
         assertFalse(styleable.isSettable(scrollBar));
     }
 
-    @Test public void whenUnitIncIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenUnitIncIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)scrollBar.unitIncrementProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(scrollBar));
     }
@@ -299,7 +299,7 @@ public class ScrollBarTest {
         assertEquals(6.0, scrollBar.getUnitIncrement(), 0.0);
     }
 
-    @Test public void whenBlockIncIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenBlockIncIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)scrollBar.blockIncrementProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(scrollBar));
         DoubleProperty other = new SimpleDoubleProperty(2.0);
@@ -307,7 +307,7 @@ public class ScrollBarTest {
         assertFalse(styleable.isSettable(scrollBar));
     }
 
-    @Test public void whenBlockIncIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenBlockIncIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)scrollBar.blockIncrementProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(scrollBar));
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ScrollPaneTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ScrollPaneTest.java
@@ -402,7 +402,7 @@ public class ScrollPaneTest {
     /*********************************************************************
      * CSS related Tests                                                 *
      ********************************************************************/
-    @Test public void whenHbarPolicyIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenHbarPolicyIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)scrollPane.hbarPolicyProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(scrollPane));
         ObjectProperty<ScrollPane.ScrollBarPolicy> other = new SimpleObjectProperty<ScrollPane.ScrollBarPolicy>(ScrollPane.ScrollBarPolicy.AS_NEEDED);
@@ -410,7 +410,7 @@ public class ScrollPaneTest {
         assertFalse(styleable.isSettable(scrollPane));
     }
 
-    @Test public void whenHbarPolicyIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenHbarPolicyIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)scrollPane.hbarPolicyProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(scrollPane));
     }
@@ -420,7 +420,7 @@ public class ScrollPaneTest {
         assertSame(ScrollPane.ScrollBarPolicy.NEVER, scrollPane.hbarPolicyProperty().get());
     }
 
-    @Test public void whenVbarPolicyIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenVbarPolicyIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)scrollPane.vbarPolicyProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(scrollPane));
         ObjectProperty<ScrollPane.ScrollBarPolicy> other = new SimpleObjectProperty<ScrollPane.ScrollBarPolicy>(ScrollPane.ScrollBarPolicy.AS_NEEDED);
@@ -428,7 +428,7 @@ public class ScrollPaneTest {
         assertFalse(styleable.isSettable(scrollPane));
     }
 
-    @Test public void whenVbarPolicyIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenVbarPolicyIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)scrollPane.vbarPolicyProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(scrollPane));
     }
@@ -438,7 +438,7 @@ public class ScrollPaneTest {
         assertSame(ScrollPane.ScrollBarPolicy.NEVER, scrollPane.getVbarPolicy());
     }
 
-    @Test public void whenFitToWidthIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenFitToWidthIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)scrollPane.fitToWidthProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(scrollPane));
         BooleanProperty other = new SimpleBooleanProperty();
@@ -446,7 +446,7 @@ public class ScrollPaneTest {
         assertFalse(styleable.isSettable(scrollPane));
     }
 
-    @Test public void whenFitToWidthIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenFitToWidthIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)scrollPane.fitToWidthProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(scrollPane));
     }
@@ -456,7 +456,7 @@ public class ScrollPaneTest {
         assertSame(true, scrollPane.isFitToWidth());
     }
 
-    @Test public void whenFitToHeightIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenFitToHeightIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)scrollPane.fitToHeightProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(scrollPane));
         BooleanProperty other = new SimpleBooleanProperty();
@@ -464,7 +464,7 @@ public class ScrollPaneTest {
         assertFalse(styleable.isSettable(scrollPane));
     }
 
-    @Test public void whenFitToHeightIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenFitToHeightIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)scrollPane.fitToHeightProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(scrollPane));
     }
@@ -474,7 +474,7 @@ public class ScrollPaneTest {
         assertSame(true, scrollPane.isFitToHeight());
     }
 
-    @Test public void whenPannableIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenPannableIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)scrollPane.pannableProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(scrollPane));
         BooleanProperty other = new SimpleBooleanProperty();
@@ -482,7 +482,7 @@ public class ScrollPaneTest {
         assertFalse(styleable.isSettable(scrollPane));
     }
 
-    @Test public void whenPannableIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenPannableIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)scrollPane.pannableProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(scrollPane));
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SeparatorTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SeparatorTest.java
@@ -106,8 +106,8 @@ public class SeparatorTest {
      *  - set is honored                                                            *
      *  - can be bound                                                              *
      *  - is HORIZONTAL by default                                                  *
-     *  - if bound, impl_cssSettable returns false                                  *
-     *  - if specified via CSS and not bound, impl_cssSettable returns true         *
+     *  - if bound, CssMetaData_isSettable returns false                                  *
+     *  - if specified via CSS and not bound, CssMetaData_isSettable returns true         *
      *                                                                              *
      *******************************************************************************/
 
@@ -137,7 +137,7 @@ public class SeparatorTest {
         assertSame(Orientation.VERTICAL, separator.getOrientation());
     }
 
-    @Test public void whenOrientationIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenOrientationIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)separator.orientationProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(separator));
         ObjectProperty<Orientation> other = new SimpleObjectProperty<Orientation>(Orientation.VERTICAL);
@@ -145,7 +145,7 @@ public class SeparatorTest {
         assertFalse(styleable.isSettable(separator));
     }
 
-    @Test public void whenOrientationIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenOrientationIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)separator.orientationProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(separator));
     }
@@ -158,7 +158,7 @@ public class SeparatorTest {
     @Ignore("This is an unreliable test because it uses the string version " +
             "of the function instead of the other, and no check is made " +
             "for bits set")
-    @Test public void whenSettingOrientationToItsExistingValue_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenSettingOrientationToItsExistingValue_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)separator.orientationProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(separator));
         separator.setOrientation(Orientation.HORIZONTAL);
@@ -183,8 +183,8 @@ public class SeparatorTest {
      *  - set is honored                                                            *
      *  - can be bound                                                              *
      *  - is CENTER by default                                                      *
-     *  - if bound, impl_cssSettable returns false                                  *
-     *  - if specified via CSS and not bound, impl_cssSettable returns true         *
+     *  - if bound, CssMetaData_isSettable returns false                                  *
+     *  - if specified via CSS and not bound, CssMetaData_isSettable returns true         *
      *                                                                              *
      *******************************************************************************/
 
@@ -214,7 +214,7 @@ public class SeparatorTest {
         assertSame(HPos.RIGHT, separator.getHalignment());
     }
 
-    @Test public void whenHalignmentIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenHalignmentIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)separator.halignmentProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(separator));
         ObjectProperty<HPos> other = new SimpleObjectProperty<HPos>(HPos.RIGHT);
@@ -222,7 +222,7 @@ public class SeparatorTest {
         assertFalse(styleable.isSettable(separator));
     }
 
-    @Test public void whenHalignmentIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenHalignmentIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)separator.halignmentProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(separator));
     }
@@ -240,8 +240,8 @@ public class SeparatorTest {
      *  - set is honored                                                            *
      *  - can be bound                                                              *
      *  - is CENTER by default                                                      *
-     *  - if bound, impl_cssSettable returns false                                  *
-     *  - if specified via CSS and not bound, impl_cssSettable returns true         *
+     *  - if bound, CssMetaData_isSettable returns false                                  *
+     *  - if specified via CSS and not bound, CssMetaData_isSettable returns true         *
      *                                                                              *
      *******************************************************************************/
 
@@ -271,7 +271,7 @@ public class SeparatorTest {
         assertSame(VPos.BASELINE, separator.getValignment());
     }
 
-    @Test public void whenValignmentIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenValignmentIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)separator.valignmentProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(separator));
         ObjectProperty<VPos> other = new SimpleObjectProperty<VPos>(VPos.BASELINE);
@@ -279,7 +279,7 @@ public class SeparatorTest {
         assertFalse(styleable.isSettable(separator));
     }
 
-    @Test public void whenValignmentIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenValignmentIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)separator.valignmentProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(separator));
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SplitPaneTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SplitPaneTest.java
@@ -212,7 +212,7 @@ public class SplitPaneTest {
     /*********************************************************************
      * CSS related Tests                                                 *
      ********************************************************************/
-    @Test public void whenOrientationIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenOrientationIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)splitPane.orientationProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(splitPane));
         ObjectProperty<Orientation> other = new SimpleObjectProperty<Orientation>(Orientation.VERTICAL);
@@ -220,7 +220,7 @@ public class SplitPaneTest {
         assertFalse(styleable.isSettable(splitPane));
     }
 
-    @Test public void whenOrientationIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenOrientationIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)splitPane.orientationProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(splitPane));
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TabPaneTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TabPaneTest.java
@@ -342,7 +342,7 @@ public class TabPaneTest {
      * CSS related Tests                                                 *
      ********************************************************************/
 
-    @Test public void whenTabMinWidthIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenTabMinWidthIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)tabPane.tabMinWidthProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(tabPane));
         DoubleProperty other = new SimpleDoubleProperty(30.0);
@@ -350,7 +350,7 @@ public class TabPaneTest {
         assertFalse(styleable.isSettable(tabPane));
     }
 
-    @Test public void whenTabMinWidthIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenTabMinWidthIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)tabPane.tabMinWidthProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(tabPane));
     }
@@ -360,7 +360,7 @@ public class TabPaneTest {
         assertEquals(34.0, tabPane.getTabMinWidth(), 0.0);
     }
 
-    @Test public void whenTabMaxWidthIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenTabMaxWidthIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)tabPane.tabMaxWidthProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(tabPane));
         DoubleProperty other = new SimpleDoubleProperty(30.0);
@@ -368,7 +368,7 @@ public class TabPaneTest {
         assertFalse(styleable.isSettable(tabPane));
     }
 
-    @Test public void whenTabMaxWidthIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenTabMaxWidthIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)tabPane.tabMaxWidthProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(tabPane));
     }
@@ -378,7 +378,7 @@ public class TabPaneTest {
         assertEquals(34.0, tabPane.getTabMaxWidth(), 0.0);
     }
 
-    @Test public void whenTabMinHeightIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenTabMinHeightIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)tabPane.tabMinHeightProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(tabPane));
         DoubleProperty other = new SimpleDoubleProperty(30.0);
@@ -386,7 +386,7 @@ public class TabPaneTest {
         assertFalse(styleable.isSettable(tabPane));
     }
 
-    @Test public void whenTabMinHeightIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenTabMinHeightIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)tabPane.tabMinHeightProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(tabPane));
     }
@@ -396,7 +396,7 @@ public class TabPaneTest {
         assertEquals(34.0, tabPane.getTabMinHeight(), 0.0);
     }
 
-    @Test public void whenTabMaxHeightIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenTabMaxHeightIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)tabPane.tabMaxHeightProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(tabPane));
         DoubleProperty other = new SimpleDoubleProperty(30.0);
@@ -404,7 +404,7 @@ public class TabPaneTest {
         assertFalse(styleable.isSettable(tabPane));
     }
 
-    @Test public void whenTabMaxHeightIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenTabMaxHeightIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)tabPane.tabMaxHeightProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(tabPane));
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TitledPaneTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TitledPaneTest.java
@@ -211,7 +211,7 @@ public class TitledPaneTest {
     /*********************************************************************
      * CSS related Tests                                                 *
      ********************************************************************/
-    @Test public void whenAnimatedIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenAnimatedIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)titledPane.animatedProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(titledPane));
         BooleanProperty other = new SimpleBooleanProperty();
@@ -219,12 +219,12 @@ public class TitledPaneTest {
         assertFalse(styleable.isSettable(titledPane));
     }
 
-    @Test public void whenAnimatedIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenAnimatedIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)titledPane.animatedProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(titledPane));
     }
 
-    @Test public void whenCollapsibleIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenCollapsibleIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)titledPane.collapsibleProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(titledPane));
         BooleanProperty other = new SimpleBooleanProperty();
@@ -232,7 +232,7 @@ public class TitledPaneTest {
         assertFalse(styleable.isSettable(titledPane));
     }
 
-    @Test public void whenCollapsibleIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenCollapsibleIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)titledPane.collapsibleProperty()).getCssMetaData();
         ((StyleableProperty)titledPane.collapsibleProperty()).applyStyle(null, Boolean.FALSE);
         assertTrue(styleable.isSettable(titledPane));

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ToolbarTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ToolbarTest.java
@@ -126,7 +126,7 @@ public class ToolbarTest {
     /*********************************************************************
      * CSS related Tests                                                 *
      ********************************************************************/
-    @Test public void whenOrientationIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenOrientationIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)toolBar.orientationProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(toolBar));
         ObjectProperty<Orientation> other = new SimpleObjectProperty<Orientation>(Orientation.VERTICAL);
@@ -134,7 +134,7 @@ public class ToolbarTest {
         assertFalse(styleable.isSettable(toolBar));
     }
 
-    @Test public void whenOrientationIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenOrientationIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)toolBar.orientationProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(toolBar));
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TooltipTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TooltipTest.java
@@ -270,7 +270,7 @@ public class TooltipTest {
     /*********************************************************************
      * CSS related Tests                                                 *
      ********************************************************************/
-    @Test public void whenTextAlignmentIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenTextAlignmentIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)toolTip.textAlignmentProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(toolTip.get_bridge()));
         ObjectProperty<TextAlignment> other = new SimpleObjectProperty<TextAlignment>(TextAlignment.JUSTIFY);
@@ -278,7 +278,7 @@ public class TooltipTest {
         assertFalse(styleable.isSettable(toolTip.get_bridge()));
     }
 
-    @Test public void whenTextAlignmentIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenTextAlignmentIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)toolTip.textAlignmentProperty()).getCssMetaData();
         ((StyleableProperty)toolTip.textAlignmentProperty()).applyStyle(null, TextAlignment.RIGHT);
         assertTrue(styleable.isSettable(toolTip.get_bridge()));
@@ -289,7 +289,7 @@ public class TooltipTest {
         assertSame(TextAlignment.CENTER, toolTip.getTextAlignment());
     }
 
-    @Test public void whenTextOverrunIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenTextOverrunIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)toolTip.textOverrunProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(toolTip.get_bridge()));
         ObjectProperty<OverrunStyle> other = new SimpleObjectProperty<OverrunStyle>(OverrunStyle.LEADING_ELLIPSIS);
@@ -297,7 +297,7 @@ public class TooltipTest {
         assertFalse(styleable.isSettable(toolTip.get_bridge()));
     }
 
-    @Test public void whenTextOverrunIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenTextOverrunIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)toolTip.textOverrunProperty()).getCssMetaData();
         ((StyleableProperty)toolTip.textOverrunProperty()).applyStyle(null, OverrunStyle.CENTER_ELLIPSIS);
         assertTrue(styleable.isSettable(toolTip.get_bridge()));
@@ -308,7 +308,7 @@ public class TooltipTest {
         assertSame(OverrunStyle.CLIP, toolTip.getTextOverrun());
     }
 
-    @Test public void whenWrapTextIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenWrapTextIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)toolTip.wrapTextProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(toolTip.get_bridge()));
         BooleanProperty other = new SimpleBooleanProperty();
@@ -316,7 +316,7 @@ public class TooltipTest {
         assertFalse(styleable.isSettable(toolTip.get_bridge()));
     }
 
-    @Test public void whenWrapTextIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenWrapTextIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)toolTip.wrapTextProperty()).getCssMetaData();
           assertTrue(styleable.isSettable(toolTip.get_bridge()));
     }
@@ -326,7 +326,7 @@ public class TooltipTest {
         assertSame(true, toolTip.isWrapText());
     }
 
-    @Test public void whenFontIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenFontIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)toolTip.fontProperty()).getCssMetaData();
           assertTrue(styleable.isSettable(toolTip.get_bridge()));
         ObjectProperty<Font> other = new SimpleObjectProperty<Font>();
@@ -334,7 +334,7 @@ public class TooltipTest {
           assertFalse(styleable.isSettable(toolTip.get_bridge()));
     }
 
-    @Test public void whenFontIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenFontIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)toolTip.fontProperty()).getCssMetaData();
           assertTrue(styleable.isSettable(toolTip.get_bridge()));
     }
@@ -344,7 +344,7 @@ public class TooltipTest {
         assertSame(Font.getDefault(), toolTip.getFont());
     }
 
-    @Test public void whenGraphicIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenGraphicIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)toolTip.graphicProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(toolTip.get_bridge()));
         ObjectProperty<Node> other = new SimpleObjectProperty<Node>();
@@ -352,7 +352,7 @@ public class TooltipTest {
           assertFalse(styleable.isSettable(toolTip.get_bridge()));
     }
 
-    @Test public void whenGraphicIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenGraphicIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)toolTip.graphicProperty()).getCssMetaData();
           assertTrue(styleable.isSettable(toolTip.get_bridge()));
     }
@@ -364,14 +364,14 @@ public class TooltipTest {
         assertNotNull(toolTip.getGraphic());
     }
 
-    @Test public void whenContentDisplayIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenContentDisplayIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)toolTip.contentDisplayProperty()).getCssMetaData();
           assertTrue(styleable.isSettable(toolTip.get_bridge()));
         ObjectProperty<ContentDisplay> other = new SimpleObjectProperty<ContentDisplay>();
         toolTip.contentDisplayProperty().bind(other);
           assertFalse(styleable.isSettable(toolTip.get_bridge()));
     }
-     @Test public void whenContentDisplayIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+     @Test public void whenContentDisplayIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)toolTip.contentDisplayProperty()).getCssMetaData();
           assertTrue(styleable.isSettable(toolTip.get_bridge()));
     }
@@ -381,7 +381,7 @@ public class TooltipTest {
         assertSame(toolTip.getContentDisplay(), ContentDisplay.BOTTOM);
     }
 
-    @Test public void whenGraphicTextGapIsBound_impl_cssSettable_ReturnsFalse() {
+    @Test public void whenGraphicTextGapIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)toolTip.graphicTextGapProperty()).getCssMetaData();
           assertTrue(styleable.isSettable(toolTip.get_bridge()));
         DoubleProperty other = new SimpleDoubleProperty();
@@ -389,7 +389,7 @@ public class TooltipTest {
           assertFalse(styleable.isSettable(toolTip.get_bridge()));
     }
 
-    @Test public void whenGraphicTextGapIsSpecifiedViaCSSAndIsNotBound_impl_cssSettable_ReturnsTrue() {
+    @Test public void whenGraphicTextGapIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)toolTip.graphicTextGapProperty()).getCssMetaData();
           assertTrue(styleable.isSettable(toolTip.get_bridge()));
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -837,21 +837,6 @@ public class VirtualFlowTest {
         assertTrue("The cells didn't get created", VirtualFlowShim.cells_size(flow.cells) > 0);
     }
 
-//    /**
-//     * During layout the order and contents of cells will change. We need
-//     * to make sure that CSS for cells is applied at this time. To test this,
-//     * I just set the position and perform a new pulse. Since layout happens
-//     * after the CSS updates are applied, if the test fails, then there will
-//     * be cells left in a state where they need their CSS applied.
-//     */
-//    @Test public void testCellLifeCycle_CSSUpdatesHappenDuringLayout() {
-//        flow.setPosition(.35);
-//        pulse();
-//        for (int i = 0; i < VirtualFlowShim.cells_size(flow.cells); i++) {
-//            IndexedCell cell = VirtualFlowShim.<T>cells_get(flow.cells, i);
-//            assertEquals(CssFlags.CLEAN, cell.impl_getCSSFlags());
-//        }
-//    }
 
     ////////////////////////////////////////////////////////////////////////////
     //


### PR DESCRIPTION
It is a test cleanup work.

Issue :
Many unit tests in javafx.controls module have incorrect naming that use text "impl_" in names and comments.
The test code correctly avoids using impl_* methods (as they were removed in JDK 9), but test names still have "impl_" in them.

Fix :
These tests are renamed by replacing impl_* with appropriate css method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255002](https://bugs.openjdk.java.net/browse/JDK-8255002): Many javafx.controls unit tests have incorrect name containing impl_*


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/326/head:pull/326`
`$ git checkout pull/326`
