### PR TITLE
8252596: [TESTBUG] WebPageShim::paint is not thread-safe

### DIFF
--- a/modules/javafx.web/src/shims/java/com/sun/webkit/WebPageShim.java
+++ b/modules/javafx.web/src/shims/java/com/sun/webkit/WebPageShim.java
@@ -26,6 +26,7 @@
 package com.sun.webkit;
 
 import com.sun.javafx.webkit.prism.WCBufferedContextShim;
+import com.sun.javafx.webkit.prism.PrismInvokerShim;
 import com.sun.webkit.WebPage;
 import com.sun.webkit.event.WCMouseEvent;
 import com.sun.webkit.graphics.WCGraphicsContext;
@@ -50,7 +51,9 @@ public class WebPageShim {
 
     public static BufferedImage paint(WebPage page, int x, int y, int w, int h) {
         final WCGraphicsContext gc = setupPageWithGraphics(page, x, y, w, h);
-        page.paint(gc, x, y, w, h);
+        PrismInvokerShim.runOnRenderThread(() -> {
+            page.paint(gc, x, y, w, h);
+        });
         return gc.getImage().toBufferedImage();
     }
 


### PR DESCRIPTION
Issue: Tests using `WebPageShim::paint` fails around 1/10 times.

Fix: Execute `WebPageShim::paint` in the render thread using `PrismInvoker`. Ran tests over 100 times, no failures.

Used the initial unit test in the PR for [JDK-8202990](https://bugs.openjdk.java.net/browse/JDK-8202990).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252596](https://bugs.openjdk.java.net/browse/JDK-8252596): [TESTBUG] WebPageShim::paint is not thread-safe


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/327/head:pull/327`
`$ git checkout pull/327`
