### PR TITLE
8254013: gradle test should run all test classes even if they don't end with "Test"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1936,8 +1936,8 @@ allprojects {
         executable = JAVA;
         enableAssertions = true;
         testLogging.exceptionFormat = "full";
-        scanForTestClasses = false;
-        include("**/*Test.*");
+        scanForTestClasses = true;
+        include("**/*.*");
         if (BUILD_CLOSED && DO_JCOV) {
             addJCov(project, test)
         }
@@ -2447,8 +2447,8 @@ project(":graphics") {
             "-DCSS_META_DATA_TEST_DIR=$cssDir"
         enableAssertions = true
         testLogging.exceptionFormat = "full"
-        scanForTestClasses = false
-        include "**/*Test.*"
+        scanForTestClasses = true
+        include "**/*.*"
         if (BUILD_CLOSED && DO_JCOV) {
             addJCov(project, test)
         }


### PR DESCRIPTION
The test targets in `build.gradle` are set up to run only classes whose name ends with exactly `Test`. A test class named `RunMyTest.java` will be run, but a test called `CheckSomething.java` will not be. This was done because gradle's built-in scanner for test classes was buggy in earlier versions of gradle. It seems to have been fixed in the gradle 3.x time frame from what I can tell.

The current approach leads to two problems. The first is that gradle will try to execute  all classes named `XxxxxTest.java` whether or not it should. Attempting to execute utility classes without test methods (meaning without at least one method annotated with `@Test`) or `abstract` classes (whether or not there are any test methods) will fail.

The second is that a test class that isn't named `XxxxxTest.java` will not be run, even if it contains `@Test` methods. This can (and has) lead to tests being skipped when they should be run.

The solution is to enable gradle's built-in scanning for test classes which works exactly like you would expect it to: it runs any concrete class that has at least one `@Test` method or whose parent class has such a method. This means that a class with no test methods that subclasses an abstract class with `@Test` methods will be run correctly.

I ran a full test on all three platforms. The following test classes which were formerly not run are now run:

modules/javafx.base: test.javafx.collections.ObservableListWithExtractor : 52 tests
modules/javafx.base: test.javafx.event.EventSerializationEventExists 0 tests (*)
modules/javafx.controls:. test.javafx.scene.control.MiscellaneousTests : 3 tests
tests/system: test.com.sun.javafx.application.SwingNoExit : 1 test

They pass on all three platforms.

(*) - There is only one test in this class and it is currently `@Ignore`d

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254013](https://bugs.openjdk.java.net/browse/JDK-8254013): gradle test should run all test classes even if they don't end with "Test"


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - Author)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/329/head:pull/329`
`$ git checkout pull/329`
