### PR TITLE
8254100: FX: Update copyright year in docs, readme files to 2021

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -54,7 +54,7 @@ jfx.release.patch.version=0
 #
 ##############################################################################
 
-javadoc.bottom=<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2020, Oracle and/or its affiliates. All rights reserved.</small>
+javadoc.bottom=<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2021, Oracle and/or its affiliates. All rights reserved.</small>
 
 javadoc.title=JavaFX 16
 javadoc.header=JavaFX&nbsp;16

--- a/modules/javafx.fxml/src/main/docs/javafx/fxml/doc-files/introduction_to_fxml.html
+++ b/modules/javafx.fxml/src/main/docs/javafx/fxml/doc-files/introduction_to_fxml.html
@@ -1107,7 +1107,7 @@ module. A type is reflectively accessible if the module
 </p>
 <hr>
 <p>
-<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2020, Oracle and/or its affiliates. All rights reserved.</small>
+<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2021, Oracle and/or its affiliates. All rights reserved.</small>
 </p>
 </body>
 </html>

--- a/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
+++ b/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
@@ -6046,7 +6046,7 @@
     <p>[5] Uniform Resource Identifier (URI): Generic Syntax <a href="http://www.ietf.org/rfc/rfc3986">RFC-3986</a></p>
     <hr>
     <p>
-<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2020, Oracle and/or its affiliates. All rights reserved.</small>
+<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2021, Oracle and/or its affiliates. All rights reserved.</small>
     </p>
     <br>
   </body>


### PR DESCRIPTION
Copyright year in these 3 docs needs to be updated to 2021.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254100](https://bugs.openjdk.java.net/browse/JDK-8254100): FX: Update copyright year in docs, readme files to 2021


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/330/head:pull/330`
`$ git checkout pull/330`
