### PR TITLE
8255241: [TestBug] Re-enable few ignored tests in javafx.controls module that pass with latest code

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableColumnBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableColumnBase.java
@@ -117,7 +117,8 @@ public abstract class TableColumnBase<S,T> implements EventTarget, Styleable {
      *                                                                         *
      **************************************************************************/
 
-    // NOTE: If these numbers change, update the copy of this value in TableColumnHeader
+    // NOTE: If these numbers change, update the copy of this value in 
+    // TableColumnHeader and in TableColumnShim
     static final double DEFAULT_WIDTH = 80.0F;
     static final double DEFAULT_MIN_WIDTH = 10.0F;
     static final double DEFAULT_MAX_WIDTH = 5000.0F;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableColumnBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableColumnBase.java
@@ -117,7 +117,7 @@ public abstract class TableColumnBase<S,T> implements EventTarget, Styleable {
      *                                                                         *
      **************************************************************************/
 
-    // NOTE: If these numbers change, update the copy of this value in 
+    // NOTE: If these numbers change, update the copy of this value in
     // TableColumnHeader and in TableColumnShim
     static final double DEFAULT_WIDTH = 80.0F;
     static final double DEFAULT_MIN_WIDTH = 10.0F;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableColumnBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableColumnBase.java
@@ -117,8 +117,7 @@ public abstract class TableColumnBase<S,T> implements EventTarget, Styleable {
      *                                                                         *
      **************************************************************************/
 
-    // NOTE: If these numbers change, update the copy of this value in
-    // TableColumnHeader and in TableColumnShim
+    // NOTE: If these numbers change, update the copy of this value in TableColumnHeader
     static final double DEFAULT_WIDTH = 80.0F;
     static final double DEFAULT_MIN_WIDTH = 10.0F;
     static final double DEFAULT_MAX_WIDTH = 5000.0F;

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/TableColumnShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/TableColumnShim.java
@@ -30,5 +30,9 @@ public class TableColumnShim {
         tc.setTableView(tv);
     }
 
+    // NOTE: These constants are direct copy of TableColumnBase
+    public static final double DEFAULT_WIDTH = 80.0F;
+    public static final double DEFAULT_MIN_WIDTH = 10.0F;
+    public static final double DEFAULT_MAX_WIDTH = 5000.0F;
 
 }

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/TableColumnShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/TableColumnShim.java
@@ -30,9 +30,7 @@ public class TableColumnShim {
         tc.setTableView(tv);
     }
 
-    // NOTE: These constants are direct copy of TableColumnBase
-    public static final double DEFAULT_WIDTH = 80.0F;
-    public static final double DEFAULT_MIN_WIDTH = 10.0F;
-    public static final double DEFAULT_MAX_WIDTH = 5000.0F;
-
+    public static final double DEFAULT_WIDTH = TableColumnBase.DEFAULT_WIDTH;
+    public static final double DEFAULT_MIN_WIDTH = TableColumnBase.DEFAULT_MIN_WIDTH;
+    public static final double DEFAULT_MAX_WIDTH = TableColumnBase.DEFAULT_MAX_WIDTH;
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYChartDataTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYChartDataTest.java
@@ -32,7 +32,6 @@ import javafx.scene.chart.LineChart;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart;
 import javafx.scene.chart.XYChartShim;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -49,7 +48,6 @@ public class XYChartDataTest {
         assertEquals(20, XYChartShim.Data_getCurrentY(data).longValue());
     }
 
-    @Ignore("Waiting on fix for RT-13478")
     @Test public void updatingValuesBeforeAddingToASeriesShouldUpdateValuesAndCurrentValues() {
         XYChart.Data<Number,Number> data = new XYChart.Data<Number,Number>(10, 20);
         data.setXValue(100);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/LabeledTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/LabeledTest.java
@@ -567,7 +567,6 @@ public class LabeledTest {
         assertEquals(r, labeled.getGraphic());
     }
 
-    @Ignore ("CSS Graphic must be a URL, and then it will try to load the image. Not sure how to test.")
     @Test public void whenGraphicIsBound_CssMetaData_isSettable_ReturnsFalse() {
         CssMetaData styleable = ((StyleableProperty)labeled.graphicProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));
@@ -577,7 +576,6 @@ public class LabeledTest {
         assertFalse(styleable.isSettable(labeled));
     }
 
-    @Ignore ("CSS Graphic must be a URL, and then it will try to load the image. Not sure how to test.")
     @Test public void whenGraphicIsSpecifiedViaCSSAndIsNotBound_CssMetaData_isSettable_ReturnsTrue() {
         CssMetaData styleable = ((StyleableProperty)labeled.graphicProperty()).getCssMetaData();
         assertTrue(styleable.isSettable(labeled));

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -39,7 +39,6 @@ import javafx.scene.control.MultipleSelectionModel;
 import javafx.scene.control.MultipleSelectionModelBaseShim;
 import javafx.scene.control.SelectionMode;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static javafx.scene.control.ControlShim.*;
@@ -490,7 +489,7 @@ public class ListCellTest {
         assertFalse(other.isSelected());
     }
 
-    @Ignore @Test public void replacingTheSelectionModelRemovesTheListenerFromTheOldModel() {
+    @Test public void replacingTheSelectionModelRemovesTheListenerFromTheOldModel() {
         cell.updateIndex(0);
         cell.updateListView(list);
         MultipleSelectionModel<String> sm = list.getSelectionModel();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TabPaneTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TabPaneTest.java
@@ -733,7 +733,6 @@ public class TabPaneTest {
         assertEquals(tab1, tabPane.getSelectionModel().getSelectedItem());
     }
 
-    @Ignore
     @Test public void mousePressSelectsATab_RT20476() {
         tabPane.getTabs().add(tab1);
         tabPane.getTabs().add(tab2);
@@ -765,7 +764,6 @@ public class TabPaneTest {
     }
 
     private int counter = 0;
-    @Ignore
     @Test public void setOnSelectionChangedFiresTwice_RT21089() {
         tabPane.getTabs().add(tab1);
         tabPane.getTabs().add(tab2);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TabTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TabTest.java
@@ -53,7 +53,6 @@ import static org.junit.Assert.*;
 
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -442,11 +441,6 @@ public class TabTest {
         Tooltip tt = new Tooltip();
         tab.setTooltip(tt);
         assertSame(tab.getTooltip(), tt);
-    }
-    @Ignore("The following test is incomplete with no proper sense.")
-    @Test public void checkEventDispatcherChain() {
-        EventDispatchChain chain = new EventDispatchChainImpl();
-        tab.buildEventDispatchChain(chain);
     }
 
     @Test public void setDisableAndSeeValue() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableColumnTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableColumnTest.java
@@ -60,7 +60,6 @@ import javafx.scene.control.TableView;
 
 import test.com.sun.javafx.scene.control.test.Person;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -462,10 +461,9 @@ public class TableColumnTest {
      * minWidth Tests                                                           *
      ***************************************************************************/
 
-    @Ignore ("Fails with hardcoded value of 10")
-    @Test public void minWidthIs_USE_COMPUTED_SIZE_ByDefault() {
-        assertEquals(Control.USE_COMPUTED_SIZE, column.getMinWidth(), 0);
-        assertEquals(Control.USE_COMPUTED_SIZE, column.minWidthProperty().get(), 0);
+    @Test public void minWidthIs_DEFAULT_MIN_WIDTH_ByDefault() {
+        assertEquals(TableColumnShim.DEFAULT_MIN_WIDTH, column.getMinWidth(), 0);
+        assertEquals(TableColumnShim.DEFAULT_MIN_WIDTH, column.minWidthProperty().get(), 0);
     }
 
     @Test public void minWidthCanBeSet() {
@@ -494,10 +492,9 @@ public class TableColumnTest {
      * maxWidth Tests                                                           *
      ***************************************************************************/
 
-    @Ignore ("Fails with hardcoded value of 5000")
-    @Test public void maxWidthIs_USE_COMPUTED_SIZE_ByDefault() {
-        assertEquals(Control.USE_COMPUTED_SIZE, column.getMaxWidth(), 0);
-        assertEquals(Control.USE_COMPUTED_SIZE, column.maxWidthProperty().get(), 0);
+    @Test public void maxWidthIs_DEFAULT_MAX_WIDTH_ByDefault() {
+        assertEquals(TableColumnShim.DEFAULT_MAX_WIDTH, column.getMaxWidth(), 0);
+        assertEquals(TableColumnShim.DEFAULT_MAX_WIDTH, column.maxWidthProperty().get(), 0);
     }
 
     @Test public void maxWidthCanBeSet() {
@@ -526,10 +523,9 @@ public class TableColumnTest {
      * prefWidth Tests                                                          *
      ***************************************************************************/
 
-    @Ignore ("Fails with hardcoded value of 80")
-    @Test public void prefWidthIs_USE_COMPUTED_SIZE_ByDefault() {
-        assertEquals(Control.USE_COMPUTED_SIZE, column.getPrefWidth(), 0);
-        assertEquals(Control.USE_COMPUTED_SIZE, column.prefWidthProperty().get(), 0);
+    @Test public void prefWidthIs_DEFAULT_WIDTH_ByDefault() {
+        assertEquals(TableColumnShim.DEFAULT_WIDTH, column.getPrefWidth(), 0);
+        assertEquals(TableColumnShim.DEFAULT_WIDTH, column.prefWidthProperty().get(), 0);
     }
 
     @Test public void prefWidthCanBeSet() {
@@ -1123,7 +1119,6 @@ public class TableColumnTest {
         assertSame(wilma, items.get(2));
     }
 
-    @Ignore("This started failing when I upgraded to Java 7")
     @Test public void sortingMixOfComparableAndNonComparable() {
         Person fred = new Person("Fred", 36);
         Person wilma = new Person("Wilma", 34);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextAreaTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextAreaTest.java
@@ -36,7 +36,6 @@ import javafx.scene.control.TextArea;
 import javafx.scene.control.TextInputControlShim;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.*;
@@ -193,7 +192,6 @@ public class TextAreaTest {
         assertTrue("PromptText cannot be bound", txtArea.getPromptText().equals("newvalue"));
     }
 
-    @Ignore("TODO: Please remove ignore annotation after RT-15799 is fixed.")
     @Test public void checkTextPropertyBind() {
         StringProperty strPr = new SimpleStringProperty("value");
         txtArea.textProperty().bind(strPr);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
@@ -221,7 +221,6 @@ public class TextFieldTest {
         assertTrue("PromptText cannot be bound", txtField.getPromptText().equals("newvalue"));
     }
 
-    @Ignore("TODO: Please remove ignore annotation after RT-15799 is fixed.")
     @Test public void checkTextPropertyBind() {
         StringProperty strPr = new SimpleStringProperty("value");
         txtField.textProperty().bind(strPr);


### PR DESCRIPTION
Some of the ignored unit tests in javafx.controls module pass with latest code.
This bug is to address -
- removal of ignored tag
- fixing the test if fix is minor

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255241](https://bugs.openjdk.java.net/browse/JDK-8255241): [TestBug] Re-enable few ignored tests in javafx.controls module that pass with latest code


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/331/head:pull/331`
`$ git checkout pull/331`
