### PR TITLE
8247494: Test failure in ImageRaceTest on some systems

### DIFF
--- a/tests/system/src/test/java/test/com/sun/javafx/image/impl/ImageRaceTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/image/impl/ImageRaceTest.java
@@ -65,7 +65,11 @@ public class ImageRaceTest {
         public void run() {
             if (verbose) System.err.println(getName()+" started");
             running = true;
-            while (!ready) { yield(); }
+            while (!ready) {
+                try {
+                    sleep(1);
+                } catch (InterruptedException ex) {}
+            }
             init.get();
             if (verbose) System.err.println(getName()+" done");
         }
@@ -76,7 +80,9 @@ public class ImageRaceTest {
         for (Initializer i : initalizers) {
             i.start();
             while (!i.isRunning() && System.currentTimeMillis() < limit) {
-                Thread.yield();
+                try {
+                    Thread.sleep(1);
+                } catch (InterruptedException ex) {}
             }
             if (!i.isRunning()) {
                 throw new RuntimeException("Initializer "+i+" never started");


### PR DESCRIPTION
The test test.com.sun.javafx.image.impl.ImageRaceTest is fails intermittently in linux

This is caused by use of Thread.yield. Thread.yield is used to pause the current thread for some time. It gives a hint to thread scheduler that the current thread should pause and other threads with same or higher priority should execute. But it is a hint only and can be ignored. so the current thread may very well continue to operate. This causes the test to fail on some slow machines.

Better approach in this scenario would be to use Thread.sleep to make the thread wait for some time for some event.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8247494](https://bugs.openjdk.java.net/browse/JDK-8247494): Test failure in ImageRaceTest on some systems


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/332/head:pull/332`
`$ git checkout pull/332`
