### PR TITLE
8213573: MouseLocationOnScreenTest fails intermittently

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
@@ -68,7 +68,7 @@ public class MouseLocationOnScreenTest {
         }
     }
 
-    @Test(timeout = 20000)
+    @Test(timeout = 60000)
     public void testMouseLocation() throws Exception {
 
         Screen screen = Screen.getPrimary();
@@ -82,7 +82,9 @@ public class MouseLocationOnScreenTest {
         Util.runAndWait(() -> {
             edge(robot, x1, y1, x2, y1);         // top
             edge(robot, x1, y1 + 1, x2, y1 + 1); // top
+        });
 
+        Util.runAndWait(() -> {
             edge(robot, x2, y1, x2, y2);         // right
             edge(robot, x2 - 1, y1, x2 - 1, y2); // right
         });
@@ -90,7 +92,9 @@ public class MouseLocationOnScreenTest {
         Util.runAndWait(() -> {
             edge(robot, x1, y1, x1, y2);         // left
             edge(robot, x1 + 1, y1, x1 + 1, y2); // left
+        });
 
+        Util.runAndWait(() -> {
             edge(robot, x1, y2, x2, y2);         // bottom
             edge(robot, x1, y2 - 1, x2, y2 - 1); // bottom
         });
@@ -120,6 +124,7 @@ public class MouseLocationOnScreenTest {
         for (int x = x1; x <= x2; x++) {
             for (int y = y1; y <= y2; y++) {
                 robot.mouseMove(x, y);
+                delay(2);
                 validate(robot, x, y);
             }
         }
@@ -131,13 +136,23 @@ public class MouseLocationOnScreenTest {
         double dy = (y1 - y0) / dmax;
 
         robot.mouseMove(x0, y0);
+        delay(2);
         validate(robot, x0, y0);
 
         for (int i = 1; i <= dmax; i++) {
             int x = (int) (x0 + dx * i);
             int y = (int) (y0 + dy * i);
             robot.mouseMove(x, y);
+            delay(2);
             validate(robot, x, y);
+        }
+    }
+
+    private static void delay(int time) {
+        try {
+            Thread.sleep(time);
+        } catch (InterruptedException e) {
+
         }
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
@@ -43,7 +43,7 @@ import test.util.Util;
 public class MouseLocationOnScreenTest {
     static CountDownLatch startupLatch;
     static Robot robot;
-    private static int delayTime = 1;
+    private static int DELAY_TIME = 1;
 
     public static class TestApp extends Application {
 
@@ -135,7 +135,7 @@ public class MouseLocationOnScreenTest {
         for (int x = x1; x <= x2; x++) {
             for (int y = y1; y <= y2; y++) {
                 robot.mouseMove(x, y);
-                delay(delayTime);
+                Util.sleep(DELAY_TIME);
                 validate(robot, x, y);
             }
         }
@@ -147,23 +147,15 @@ public class MouseLocationOnScreenTest {
         double dy = (y1 - y0) / dmax;
 
         robot.mouseMove(x0, y0);
-        delay(delayTime);
+        Util.sleep(DELAY_TIME);
         validate(robot, x0, y0);
 
         for (int i = 1; i <= dmax; i++) {
             int x = (int) (x0 + dx * i);
             int y = (int) (y0 + dy * i);
             robot.mouseMove(x, y);
-            delay(delayTime);
+            Util.sleep(DELAY_TIME);
             validate(robot, x, y);
-        }
-    }
-
-    private static void delay(int time) {
-        try {
-            Thread.sleep(time);
-        } catch (InterruptedException e) {
-
         }
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
@@ -43,6 +43,7 @@ import test.util.Util;
 public class MouseLocationOnScreenTest {
     static CountDownLatch startupLatch;
     static Robot robot;
+    private static int delayTime = 1;
 
     public static class TestApp extends Application {
 
@@ -68,7 +69,7 @@ public class MouseLocationOnScreenTest {
         }
     }
 
-    @Test(timeout = 60000)
+    @Test(timeout = 120000)
     public void testMouseLocation() throws Exception {
 
         Screen screen = Screen.getPrimary();
@@ -81,27 +82,37 @@ public class MouseLocationOnScreenTest {
         // Check all edge (two pixels in a width)
         Util.runAndWait(() -> {
             edge(robot, x1, y1, x2, y1);         // top
+        });
+        Util.runAndWait(() -> {
             edge(robot, x1, y1 + 1, x2, y1 + 1); // top
         });
 
         Util.runAndWait(() -> {
             edge(robot, x2, y1, x2, y2);         // right
+        });
+        Util.runAndWait(() -> {
             edge(robot, x2 - 1, y1, x2 - 1, y2); // right
         });
 
         Util.runAndWait(() -> {
             edge(robot, x1, y1, x1, y2);         // left
+        });
+        Util.runAndWait(() -> {
             edge(robot, x1 + 1, y1, x1 + 1, y2); // left
         });
 
         Util.runAndWait(() -> {
             edge(robot, x1, y2, x2, y2);         // bottom
+        });
+        Util.runAndWait(() -> {
             edge(robot, x1, y2 - 1, x2, y2 - 1); // bottom
         });
 
         // Check crossing of diagonals
         Util.runAndWait(() -> {
             cross(robot, x1, y1, x2, y2); // cross left-bottom
+        });
+        Util.runAndWait(() -> {
             cross(robot, x1, y2, x2, y1); // cross left-top
         });
     }
@@ -124,7 +135,7 @@ public class MouseLocationOnScreenTest {
         for (int x = x1; x <= x2; x++) {
             for (int y = y1; y <= y2; y++) {
                 robot.mouseMove(x, y);
-                delay(2);
+                delay(delayTime);
                 validate(robot, x, y);
             }
         }
@@ -136,14 +147,14 @@ public class MouseLocationOnScreenTest {
         double dy = (y1 - y0) / dmax;
 
         robot.mouseMove(x0, y0);
-        delay(2);
+        delay(delayTime);
         validate(robot, x0, y0);
 
         for (int i = 1; i <= dmax; i++) {
             int x = (int) (x0 + dx * i);
             int y = (int) (y0 + dy * i);
             robot.mouseMove(x, y);
-            delay(2);
+            delay(delayTime);
             validate(robot, x, y);
         }
     }


### PR DESCRIPTION
The test test.robot.javafx.scene.MouseLocationOnScreenTest fails intermittently on Windows and Mac system though it fails on Windows more often than Mac.

The test uses robot to move the mouse at different positions on screen using mouseMove and then validates the mouse coordinates by robot.getMouseX/Y. If the coordinates returned from Robot.getMouseX/Y are same as mouse coordinates passed to Robot.mouseMove, the test passes, else the test fails.

The issue here is that there is no wait/delay between the calls to mouseMove and getMouseX/Y. When Robot.mouseMove is used to move mouse to a coordinate, robot in turn sends the event to native system. When Robot.getMouseX/Y is called to get the current mouse coordinates, robot again uses native functions to get the mouse location. In current test, it is possible that the Robot.mouseMove is called with particular x,y coordinates and which in turn has send the events to native. As there is no delay/wait after calling Robot.mouseMove, When the Robot.getMouseX/Y is called, it is possible that the earlier event sent to native has not been processed yet. So the mouse has not been moved and Robot.getMouseX/Y may return older mouse coordinates. This results in the test to fail. 

In short, the Robot.mouseMove is an asynchronous call, so it should be used in same way. A follow up bug will be filled to update the specification to reflect this. The test is assuming it to be synchronous and results in intermittent failures.

The fix is to add small delay after calling Robot.mouseMove. Along with this, now as the test will take more time, so the timeout time for test is increased to 120s. Also, I have divided the calls to edge(...) among more Util.runAndWait calls as there is a timeout limit for Util.runAndWait which is set to 10s.

I tested this on Windows 10, Ubuntu 18.04, Ubuntu 20.04, Oracle Linux 8.2, Mac 10.13. For me this test is passing in less than 50 seconds on all platforms. Following command can be used to run the test
gradle --continue --info -PFULL_TEST=true -PUSE_ROBOT=true :systemTest:cleanTest :systemTests:test --tests test.robot.javafx.scene.MouseLocationOnScreenTest

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8213573](https://bugs.openjdk.java.net/browse/JDK-8213573): MouseLocationOnScreenTest fails intermittently


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/333/head:pull/333`
`$ git checkout pull/333`
