### PR TITLE
8255272: Create release notes for JavaFX 15.0.1

### DIFF
--- a/doc-files/release-notes-15.0.1.md
+++ b/doc-files/release-notes-15.0.1.md
@@ -15,3 +15,7 @@ Issue key|Summary|Subcomponent
 [JDK-8255063](https://bugs.openjdk.java.net/browse/JDK-8255063) | Cherry pick GTK WebKit 2.28.3 changes | web          
 [JDK-8255062](https://bugs.openjdk.java.net/browse/JDK-8255062) | Update to 610.1 version of WebKit     | web      
 
+## List of Security fixes
+Issue key|Summary|Subcomponent
+---------|-------|------------
+[JDK-8248177](not public) | Improve XML support | web          

--- a/doc-files/release-notes-15.0.1.md
+++ b/doc-files/release-notes-15.0.1.md
@@ -1,0 +1,17 @@
+# Release Notes for JavaFX 15.0.1
+
+## Introduction
+
+The following notes describe important changes and information about this release. In some cases, the descriptions provide links to additional detailed information about an issue or a change.
+
+As of JDK 11 the JavaFX modules are delivered separately from the JDK. These release notes cover the standalone JavaFX 15.0.1 release. As such, they complement the [JavaFX 15 Release Notes](https://github.com/openjdk/jfx/blob/jfx15/doc-files/release-notes-15.md).
+
+JavaFX 15.0.1 requires JDK 11 or later.
+
+## List of Fixed Bugs
+Issue key|Summary|Subcomponent
+---------|-------|------------
+[JDK-8255064](https://bugs.openjdk.java.net/browse/JDK-8255064) | Cherry pick GTK WebKit 2.28.4 changes | web          
+[JDK-8255063](https://bugs.openjdk.java.net/browse/JDK-8255063) | Cherry pick GTK WebKit 2.28.3 changes | web          
+[JDK-8255062](https://bugs.openjdk.java.net/browse/JDK-8255062) | Update to 610.1 version of WebKit     | web      
+

--- a/doc-files/release-notes-15.0.1.md
+++ b/doc-files/release-notes-15.0.1.md
@@ -11,9 +11,10 @@ JavaFX 15.0.1 requires JDK 11 or later.
 ## List of Fixed Bugs
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8255064](https://bugs.openjdk.java.net/browse/JDK-8255064) | Cherry pick GTK WebKit 2.28.4 changes | web          
-[JDK-8255063](https://bugs.openjdk.java.net/browse/JDK-8255063) | Cherry pick GTK WebKit 2.28.3 changes | web          
-[JDK-8255062](https://bugs.openjdk.java.net/browse/JDK-8255062) | Update to 610.1 version of WebKit     | web      
+| [JDK-8252381](https://bugs.openjdk.java.net/browse/JDK-8252381) | Cherry pick GTK WebKit 2.28.4 changes | web          |
+| [JDK-8249839](https://bugs.openjdk.java.net/browse/JDK-8249839) | Cherry pick GTK WebKit 2.28.3 changes | web          |
+| [JDK-8245284](https://bugs.openjdk.java.net/browse/JDK-8245284) | Update to 610.1 version of WebKit     | web          |
+
 
 ## List of Security fixes
 Issue key|Summary|Subcomponent


### PR DESCRIPTION
releasenotes for JavaFX 15.0.1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255272](https://bugs.openjdk.java.net/browse/JDK-8255272): Create release notes for JavaFX 15.0.1


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/335/head:pull/335`
`$ git checkout pull/335`
