### PR TITLE
8255415: Nested calls to snap methods in Region give different results

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
@@ -213,6 +213,8 @@ public class Region extends Parent {
 
     static Vec2d TEMP_VEC2D = new Vec2d();
 
+    private static final double EPSILON = 1e-14;
+
     /***************************************************************************
      *                                                                         *
      * Static convenience methods for layout                                   *
@@ -299,7 +301,7 @@ public class Region extends Parent {
     }
 
     private static double scaledCeil(double value, double scale) {
-        return Math.ceil(value * scale) / scale;
+        return Math.ceil(value * scale - EPSILON) / scale;
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
@@ -300,6 +300,16 @@ public class Region extends Parent {
         return Math.floor(value * scale) / scale;
     }
 
+    /**
+     * The value is ceiled with a given scale using Math.ceil.
+     * This method guarantees that:
+     *
+     * scaledCeil(scaledCeil(value, scale), scale) == scaledCeil(value, scale)
+     *
+     * @param value The value that needs to be ceiled
+     * @param scale The scale that will be used
+     * @return value ceiled with scale
+     */
     private static double scaledCeil(double value, double scale) {
         return Math.ceil(value * scale - EPSILON) / scale;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
@@ -385,25 +385,46 @@ public class Region extends Parent {
         return snapToPixel ? scaledRound(value, snapScale) : value;
     }
 
+    /**
+     * If snapToPixel is true, then the value is either floored (positive values) or
+     * ceiled (negative values) with a scale. This method guarantees that:
+     *
+     * snapPortionX(snapPortionX(value, snapToPixel), snapToPixel) == snapPortionX(value, snapToPixel)
+     *
+     * @param value The value that needs to be snapped
+     * @param snapToPixel Whether to snap to pixel
+     * @return value either as passed, or floored or ceiled with scale, based on snapToPixel
+     */
     private double snapPortionX(double value, boolean snapToPixel) {
         if (!snapToPixel || value == 0) return value;
         double s = getSnapScaleX();
         value *= s;
         if (value > 0) {
-            value = Math.max(1, Math.floor(value));
+            value = Math.max(1, Math.floor(value + EPSILON));
         } else {
-            value = Math.min(-1, Math.ceil(value));
+            value = Math.min(-1, Math.ceil(value - EPSILON));
         }
         return value / s;
     }
+
+    /**
+     * If snapToPixel is true, then the value is either floored (positive values) or
+     * ceiled (negative values) with a scale. This method guarantees that:
+     *
+     * snapPortionY(snapPortionY(value, snapToPixel), snapToPixel) == snapPortionY(value, snapToPixel)
+     *
+     * @param value The value that needs to be snapped
+     * @param snapToPixel Whether to snap to pixel
+     * @return value either as passed, or floored or ceiled with scale, based on snapToPixel
+     */
     private double snapPortionY(double value, boolean snapToPixel) {
         if (!snapToPixel || value == 0) return value;
         double s = getSnapScaleY();
         value *= s;
         if (value > 0) {
-            value = Math.max(1, Math.floor(value));
+            value = Math.max(1, Math.floor(value + EPSILON));
         } else {
-            value = Math.min(-1, Math.ceil(value));
+            value = Math.min(-1, Math.ceil(value - EPSILON));
         }
         return value / s;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
@@ -296,8 +296,18 @@ public class Region extends Parent {
         return Math.round(value * scale) / scale;
     }
 
+    /**
+     * The value is floored for a given scale using Math.floor.
+     * This method guarantees that:
+     *
+     * scaledFloor(scaledFloor(value, scale), scale) == scaledFloor(value, scale)
+     *
+     * @param value The value that needs to be floored
+     * @param scale The scale that will be used
+     * @return value floored with scale
+     */
     private static double scaledFloor(double value, double scale) {
-        return Math.floor(value * scale) / scale;
+        return Math.floor(value * scale + EPSILON) / scale;
     }
 
     /**

--- a/modules/javafx.graphics/src/shims/java/javafx/scene/layout/RegionShim.java
+++ b/modules/javafx.graphics/src/shims/java/javafx/scene/layout/RegionShim.java
@@ -150,6 +150,14 @@ public class RegionShim extends Region {
         r.addImageListener(image);
     }
 
+    public static double snapPortionX(Region r, double value) {
+        return r.snapPortionX(value);
+    }
+
+    public static double snapPortionY(Region r, double value) {
+        return r.snapPortionY(value);
+    }
+
     //----------------------------------------------------------
 
         @Override public void addImageListener(Image image) {

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionTest.java
@@ -1260,6 +1260,9 @@ public class RegionTest {
         stage.setScene(scene);
 
         double[] scales = new double[] {1.0, 1.25, 1.5, 1.75, 2.0, 1.374562997};
+
+        // test snapSizeX/snapSizeY methods
+
         for (double scale : scales) {
             stage.setRenderScaleX(scale);
             for (int j = 0; j < 1000; j++) {
@@ -1276,6 +1279,28 @@ public class RegionTest {
                 double value = new Random().nextDouble() * 100 - 50;
                 double snappedValue = region.snapSizeY(value);
                 double snapOfSnappedValue = region.snapSizeY(snappedValue);
+                assertEquals(snappedValue, snapOfSnappedValue, 1.0e-14);
+            }
+        }
+
+        // test snapPortionX/snapPortionY methods
+
+        for (double scale : scales) {
+            stage.setRenderScaleX(scale);
+            for (int j = 0; j < 1000; j++) {
+                double value = new Random().nextDouble() * 100 - 50;
+                double snappedValue = RegionShim.snapPortionX(region, value);
+                double snapOfSnappedValue = RegionShim.snapPortionX(region, snappedValue);
+                assertEquals(snappedValue, snapOfSnappedValue, 1.0e-14);
+            }
+        }
+
+        for (double scale : scales) {
+            stage.setRenderScaleY(scale);
+            for (int j = 0; j < 1000; j++) {
+                double value = new Random().nextDouble() * 100 - 50;
+                double snappedValue = RegionShim.snapPortionY(region, value);
+                double snapOfSnappedValue = RegionShim.snapPortionY(region, snappedValue);
                 assertEquals(snappedValue, snapOfSnappedValue, 1.0e-14);
             }
         }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionTest.java
@@ -31,6 +31,7 @@ import javafx.geometry.HPos;
 import javafx.geometry.Insets;
 import javafx.geometry.Orientation;
 import javafx.geometry.VPos;
+import javafx.scene.Scene;
 import javafx.scene.image.Image;
 import test.javafx.scene.image.ImageForTesting;
 import javafx.scene.image.WritableImage;
@@ -39,6 +40,8 @@ import javafx.scene.shape.ClosePath;
 import javafx.scene.shape.LineTo;
 import javafx.scene.shape.MoveTo;
 import javafx.scene.shape.Path;
+import javafx.stage.Stage;
+import java.util.Random;
 import java.util.concurrent.atomic.AtomicBoolean;
 import com.sun.javafx.scene.DirtyBits;
 import com.sun.javafx.scene.NodeHelper;
@@ -1247,5 +1250,34 @@ public class RegionTest {
         NodeHelper.syncPeer(p);
         NodeHelper.syncPeer(r);
         assertFalse(peer.isClean());
+    }
+
+    // Test for JDK-8199592
+    @Test public void snappingASnappedValueGivesTheSameValueTest() {
+        Stage stage = new Stage();
+        Region region = new Region();
+        Scene scene = new Scene(region);
+        stage.setScene(scene);
+
+        double[] scales = new double[] {1.0, 1.25, 1.5, 1.75, 2.0, 1.374562997};
+        for (double scale : scales) {
+            stage.setRenderScaleX(scale);
+            for (int j = 0; j < 1000; j++) {
+                double value = new Random().nextDouble() * 100 - 50;
+                double snappedValue = region.snapSizeX(value);
+                double snapOfSnappedValue = region.snapSizeX(snappedValue);
+                assertEquals(snappedValue, snapOfSnappedValue, 1.0e-14);
+            }
+        }
+
+        for (double scale : scales) {
+            stage.setRenderScaleY(scale);
+            for (int j = 0; j < 1000; j++) {
+                double value = new Random().nextDouble() * 100 - 50;
+                double snappedValue = region.snapSizeY(value);
+                double snapOfSnappedValue = region.snapSizeY(snappedValue);
+                assertEquals(snappedValue, snapOfSnappedValue, 1.0e-14);
+            }
+        }
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/RegionTest.java
@@ -1252,7 +1252,7 @@ public class RegionTest {
         assertFalse(peer.isClean());
     }
 
-    // Test for JDK-8199592
+    // Test for JDK-8255415
     @Test public void snappingASnappedValueGivesTheSameValueTest() {
         Stage stage = new Stage();
         Region region = new Region();


### PR DESCRIPTION
As discussed in the [JBS issue](https://bugs.openjdk.java.net/browse/JDK-8199592), when snapping an already snapped value (either intentionally or by  mistake), the result should be the same, otherwise we'll be jumping unnecessary from a valid pixel to another pixel.

This PR provides a fix to `snapSizeXX` methods used in `Region`, which ultimately use `Math.ceil`, by subtracting an epsilon value to scaled value before ceiling, to ensure snapping a snapped value gives the same value.

A test to verify `snapSizeX` and `snapSizeY` with 1000 random values, and 6 different UI scales is provided.
For the 1.0, 1.25, 1.5 and 2.0 UI scales, the current approach works fine. Only for 1.75 and the random 1.374562997 value fails (the test fails for around 2% of the values with 1.75 and around 10% with 1.374562997).
With the proposed fix, it doesn't fail at all.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255415](https://bugs.openjdk.java.net/browse/JDK-8255415): Nested calls to snap methods in Region give different results


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Jeanette Winzenburg](https://openjdk.java.net/census#fastegal) (@kleopatra - Committer)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/336/head:pull/336`
`$ git checkout pull/336`
