### PR TITLE
8255337: [TestBug] Controls unit tests - ButtonTest and ComboBoxTest - log ClassCastException

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ButtonTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ButtonTest.java
@@ -74,6 +74,8 @@ public class ButtonTest {
     private Scene scene;
     private Stage stage;
     private StackPane root;
+    private MouseEventFirer mouse; //Note : It is created and used by individual tests that need it
+
 
     @Before public void setup() {
         btn = new Button();
@@ -86,6 +88,10 @@ public class ButtonTest {
 
     @After public void after() {
         stage.hide();
+
+        if (mouse != null) {
+            mouse.dispose();
+        }
     }
 
     /*********************************************************************
@@ -415,13 +421,11 @@ public class ButtonTest {
         btn.fireEvent(new ActionEvent());
         btn.fire();
 
-        MouseEventFirer mouse = new MouseEventFirer(btn);
+        mouse = new MouseEventFirer(btn);
 
         mouse.fireMousePressed();
         mouse.fireMouseReleased();
         mouse.fireMouseClicked();
-
-        mouse.dispose();
     }
 
     private int count = 0;
@@ -445,7 +449,7 @@ public class ButtonTest {
 
         assertEquals(0, count);
 
-        MouseEventFirer mouse = new MouseEventFirer(btn);
+        mouse = new MouseEventFirer(btn);
 
         /* Note that right-mouse press events don't force the popup open */
         mouse.fireMousePressed(MouseButton.SECONDARY);
@@ -460,8 +464,6 @@ public class ButtonTest {
         /* Only context menu events force it to appear */
         ContextMenuEventFirer.fireContextMenuEvent(btn);
         assertEquals(1, count);
-
-        mouse.dispose();
     }
 
     static class MyButton extends Button {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ButtonTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ButtonTest.java
@@ -64,8 +64,6 @@ import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-//import com.sun.javafx.test.MouseEventGenerator;
-
 /**
  * action (which can be bound, and can be null),
  * and that action is called when the button is fired.
@@ -76,7 +74,6 @@ public class ButtonTest {
     private Scene scene;
     private Stage stage;
     private StackPane root;
-    private MouseEventFirer mouse;
 
     @Before public void setup() {
         btn = new Button();
@@ -85,12 +82,10 @@ public class ButtonTest {
         scene = new Scene(root);
         stage = new Stage();
         stage.setScene(scene);
-        mouse = new MouseEventFirer(btn);
     }
 
     @After public void after() {
         stage.hide();
-        mouse.dispose();
     }
 
     /*********************************************************************
@@ -420,9 +415,13 @@ public class ButtonTest {
         btn.fireEvent(new ActionEvent());
         btn.fire();
 
+        MouseEventFirer mouse = new MouseEventFirer(btn);
+
         mouse.fireMousePressed();
         mouse.fireMouseReleased();
         mouse.fireMouseClicked();
+
+        mouse.dispose();
     }
 
     private int count = 0;
@@ -446,6 +445,8 @@ public class ButtonTest {
 
         assertEquals(0, count);
 
+        MouseEventFirer mouse = new MouseEventFirer(btn);
+
         /* Note that right-mouse press events don't force the popup open */
         mouse.fireMousePressed(MouseButton.SECONDARY);
         assertEquals(0, count);
@@ -459,6 +460,8 @@ public class ButtonTest {
         /* Only context menu events force it to appear */
         ContextMenuEventFirer.fireContextMenuEvent(btn);
         assertEquals(1, count);
+
+        mouse.dispose();
     }
 
     static class MyButton extends Button {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -653,9 +653,8 @@ public class ComboBoxTest {
     }
 
     @Test public void ensure_getPseudoClassStateReturnsValidValue() {
-        Stage stage = new Stage();
-        Scene scene = new Scene(comboBox);
-        stage.setScene(scene);
+        StageLoader sl = new StageLoader(comboBox);
+
 
         Set<PseudoClass> pseudoClassStates = comboBox.getPseudoClassStates();
         assertFalse(comboBox.isEditable());
@@ -676,6 +675,7 @@ public class ComboBoxTest {
         comboBox.arm();
         assertTrue(pseudoClassStates.contains(PseudoClass.getPseudoClass("armed")));
 
+        sl.dispose();
     }
 
     /*********************************************************************
@@ -726,20 +726,18 @@ public class ComboBoxTest {
     }
 
     @Test public void ensureCanToggleShowing() {
-        Stage stage = new Stage();
-        Scene scene = new Scene(comboBox);
-        stage.setScene(scene);
+        StageLoader sl = new StageLoader(comboBox);
 
         comboBox.show();
         assertTrue(comboBox.isShowing());
         comboBox.hide();
         assertFalse(comboBox.isShowing());
+
+        sl.dispose();
     }
 
     @Test public void ensureCanNotToggleShowingWhenDisabled() {
-        Stage stage = new Stage();
-        Scene scene = new Scene(comboBox);
-        stage.setScene(scene);
+        StageLoader sl = new StageLoader(comboBox);
 
         comboBox.setDisable(true);
         comboBox.show();
@@ -747,6 +745,8 @@ public class ComboBoxTest {
         comboBox.setDisable(false);
         comboBox.show();
         assertTrue(comboBox.isShowing());
+
+        sl.dispose();
     }
 
     @Test public void ensureCanSetPromptText() {
@@ -954,9 +954,8 @@ public class ComboBoxTest {
     @Test public void test_rt20189() {
         comboBox.getItems().addAll("0","1","2","3","4","5","6","7","8","9");
 
-        Stage stage = new Stage();
-        Scene scene = new Scene(comboBox);
-        stage.setScene(scene);
+        StageLoader sl = new StageLoader(comboBox);
+
         comboBox.applyCss();
         comboBox.show();
 
@@ -974,6 +973,8 @@ public class ComboBoxTest {
         item = sm.getSelectedItem();
         assertEquals("2", item);
         assertEquals(2, sm.getSelectedIndex());
+
+        sl.dispose();
     }
 
     @Test public void test_rt27654() {
@@ -981,9 +982,8 @@ public class ComboBoxTest {
 
         SingleSelectionModel sm = comboBox.getSelectionModel();
 
-        Stage stage = new Stage();
-        Scene scene = new Scene(comboBox);
-        stage.setScene(scene);
+        StageLoader sl = new StageLoader(comboBox);
+
         comboBox.applyCss();
         comboBox.show();
         ListCell<String> buttonCell = (ListCell<String>) getDisplayNode();
@@ -1005,14 +1005,15 @@ public class ComboBoxTest {
         assertEquals("2", comboBox.getValue());
         assertEquals("2", buttonCell.getText());
         assertEquals(2, sm.getSelectedIndex());
+
+        sl.dispose();
     }
 
     @Test public void test_rt24412() {
         SingleSelectionModel sm = comboBox.getSelectionModel();
 
-        Stage stage = new Stage();
-        Scene scene = new Scene(comboBox);
-        stage.setScene(scene);
+        StageLoader sl = new StageLoader(comboBox);
+
         comboBox.applyCss();
         comboBox.show();
         ListCell<String> buttonCell = (ListCell<String>) getDisplayNode();
@@ -1036,6 +1037,8 @@ public class ComboBoxTest {
         assertEquals("2", comboBox.getValue());
         assertEquals("2", buttonCell.getText());
         assertEquals(2, sm.getSelectedIndex());
+
+        sl.dispose();
     }
 
     @Test public void test_rt28245() {
@@ -2292,15 +2295,12 @@ public class ComboBoxTest {
 
         Toolkit tk = Toolkit.getToolkit();
 
-        Stage stage = new Stage();
-        stage.setScene(scene);
-        stage.setWidth(500);
-        stage.setHeight(400);
-
-        stage.show();
+        StageLoader sl = new StageLoader(scene);
 
         tk.firePulse();
 
         assertEquals("ComboBox skinProperty changed more than once, which is not expected.", 1, skinChangedCount);
+
+        sl.dispose();
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -93,6 +93,7 @@ import org.junit.Test;
 public class ComboBoxTest {
     private ComboBox<String> comboBox;
     private SingleSelectionModel<String> sm;
+    private StageLoader sl; //Note : It is created and used by individual tests that need it
 
     /*********************************************************************
      *                                                                   *
@@ -131,6 +132,9 @@ public class ComboBoxTest {
     }
 
     @After public void cleanup() {
+        if (sl != null) {
+            sl.dispose();
+        }
         Thread.currentThread().setUncaughtExceptionHandler(null);
     }
 
@@ -653,7 +657,7 @@ public class ComboBoxTest {
     }
 
     @Test public void ensure_getPseudoClassStateReturnsValidValue() {
-        StageLoader sl = new StageLoader(comboBox);
+        sl = new StageLoader(comboBox);
 
 
         Set<PseudoClass> pseudoClassStates = comboBox.getPseudoClassStates();
@@ -674,8 +678,6 @@ public class ComboBoxTest {
 
         comboBox.arm();
         assertTrue(pseudoClassStates.contains(PseudoClass.getPseudoClass("armed")));
-
-        sl.dispose();
     }
 
     /*********************************************************************
@@ -726,18 +728,16 @@ public class ComboBoxTest {
     }
 
     @Test public void ensureCanToggleShowing() {
-        StageLoader sl = new StageLoader(comboBox);
+        sl = new StageLoader(comboBox);
 
         comboBox.show();
         assertTrue(comboBox.isShowing());
         comboBox.hide();
         assertFalse(comboBox.isShowing());
-
-        sl.dispose();
     }
 
     @Test public void ensureCanNotToggleShowingWhenDisabled() {
-        StageLoader sl = new StageLoader(comboBox);
+        sl = new StageLoader(comboBox);
 
         comboBox.setDisable(true);
         comboBox.show();
@@ -745,8 +745,6 @@ public class ComboBoxTest {
         comboBox.setDisable(false);
         comboBox.show();
         assertTrue(comboBox.isShowing());
-
-        sl.dispose();
     }
 
     @Test public void ensureCanSetPromptText() {
@@ -954,7 +952,7 @@ public class ComboBoxTest {
     @Test public void test_rt20189() {
         comboBox.getItems().addAll("0","1","2","3","4","5","6","7","8","9");
 
-        StageLoader sl = new StageLoader(comboBox);
+        sl = new StageLoader(comboBox);
 
         comboBox.applyCss();
         comboBox.show();
@@ -973,8 +971,6 @@ public class ComboBoxTest {
         item = sm.getSelectedItem();
         assertEquals("2", item);
         assertEquals(2, sm.getSelectedIndex());
-
-        sl.dispose();
     }
 
     @Test public void test_rt27654() {
@@ -982,7 +978,7 @@ public class ComboBoxTest {
 
         SingleSelectionModel sm = comboBox.getSelectionModel();
 
-        StageLoader sl = new StageLoader(comboBox);
+        sl = new StageLoader(comboBox);
 
         comboBox.applyCss();
         comboBox.show();
@@ -1005,14 +1001,12 @@ public class ComboBoxTest {
         assertEquals("2", comboBox.getValue());
         assertEquals("2", buttonCell.getText());
         assertEquals(2, sm.getSelectedIndex());
-
-        sl.dispose();
     }
 
     @Test public void test_rt24412() {
         SingleSelectionModel sm = comboBox.getSelectionModel();
 
-        StageLoader sl = new StageLoader(comboBox);
+        sl = new StageLoader(comboBox);
 
         comboBox.applyCss();
         comboBox.show();
@@ -1037,8 +1031,6 @@ public class ComboBoxTest {
         assertEquals("2", comboBox.getValue());
         assertEquals("2", buttonCell.getText());
         assertEquals(2, sm.getSelectedIndex());
-
-        sl.dispose();
     }
 
     @Test public void test_rt28245() {
@@ -1055,7 +1047,7 @@ public class ComboBoxTest {
             }
         });
 
-        StageLoader sl = new StageLoader(comboBox);
+        sl = new StageLoader(comboBox);
 
         assertNull(comboBox.getValue());
         assertTrue(comboBox.getEditor().getText().isEmpty());
@@ -1063,14 +1055,12 @@ public class ComboBoxTest {
         comboBox.requestFocus();
 
         new KeyEventFirer(comboBox).doKeyPress(KeyCode.ENTER);
-
-        sl.dispose();
     }
 
     @Test public void test_rt31479() {
         ComboBox<String> comboBox = new ComboBox<String>();
 
-        StageLoader sl = new StageLoader(comboBox);
+        sl = new StageLoader(comboBox);
 
         final double widthBefore = comboBox.getWidth();
 
@@ -1092,8 +1082,6 @@ public class ComboBoxTest {
 
         // test size
         assertEquals(widthBefore, comboBox.getWidth(), 0.00);
-
-        sl.dispose();
     }
 
     @Test public void test_rt32139() {
@@ -1109,22 +1097,20 @@ public class ComboBoxTest {
             }
         });
 
-        StageLoader sl = new StageLoader(comboBox);
+        sl = new StageLoader(comboBox);
 
         try {
             comboBox.getSelectionModel().select(1);
         } catch (StackOverflowError e) {
             fail("Stack overflow should not happen here");
         }
-
-        sl.dispose();
     }
 
     @Test public void test_rt21186() {
         final ComboBox<String> comboBox = new ComboBox<>();
         comboBox.setEditable(true);
 
-        StageLoader sl = new StageLoader(comboBox);
+        sl = new StageLoader(comboBox);
 
         assertNull(comboBox.getTooltip());
         assertNull(comboBox.getEditor().getTooltip());
@@ -1137,8 +1123,6 @@ public class ComboBoxTest {
         comboBox.setTooltip(null);
         assertNull(comboBox.getTooltip());
         assertNull(comboBox.getEditor().getTooltip());
-
-        sl.dispose();
     }
 
     @Test public void test_rt34573() {
@@ -1152,7 +1136,7 @@ public class ComboBoxTest {
         };
         comboBox.setButtonCell(customCell);
 
-        StageLoader sl = new StageLoader(comboBox);
+        sl = new StageLoader(comboBox);
 
         comboBox.setItems(FXCollections.observableArrayList("A","B","C","D"));
         comboBox.setValue("B");
@@ -1162,8 +1146,6 @@ public class ComboBoxTest {
         comboBox.setItems(FXCollections.observableArrayList("1","2","3","4"));
         assertNull(comboBox.getButtonCell().getText());
         assertEquals(-1, comboBox.getButtonCell().getIndex());
-
-        sl.dispose();
     }
 
     @Test public void test_rt34566() {
@@ -1177,7 +1159,7 @@ public class ComboBoxTest {
         };
         comboBox.setButtonCell(customCell);
 
-        StageLoader sl = new StageLoader(comboBox);
+        sl = new StageLoader(comboBox);
 
         comboBox.setItems(FXCollections.observableArrayList("A","B","C","D"));
 
@@ -1198,8 +1180,6 @@ public class ComboBoxTest {
         assertEquals("A", comboBox.getButtonCell().getText());
         assertEquals(0, comboBox.getButtonCell().getIndex());
         assertFalse(customCell.getPseudoClassStates().contains(empty));
-
-        sl.dispose();
     }
 
     private int test_rt34603_count = 0;
@@ -1221,15 +1201,13 @@ public class ComboBoxTest {
 
         hbox.getChildren().addAll(box, defaultButton);
 
-        StageLoader sl = new StageLoader(hbox);
+        sl = new StageLoader(hbox);
 
         box.getEditor().requestFocus();
         KeyEventFirer keyboard = new KeyEventFirer(box);
         keyboard.doKeyPress(KeyCode.ENTER);
 
         assertEquals(1, test_rt34603_count);
-
-        sl.dispose();
     }
 
     private int test_rt35586_count = 0;
@@ -1243,7 +1221,7 @@ public class ComboBoxTest {
             assertEquals("Test", cb.getEditor().getText());
         });
 
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
 
         cb.requestFocus();
         cb.getEditor().setText("Test");
@@ -1251,8 +1229,6 @@ public class ComboBoxTest {
         keyboard.doKeyPress(KeyCode.ENTER);
 
         assertEquals(1, test_rt35586_count);
-
-        sl.dispose();
     }
 
     @Test public void test_rt35039() {
@@ -1264,7 +1240,7 @@ public class ComboBoxTest {
         combo.setEditable(true);
         combo.setItems(FXCollections.observableArrayList(data));
 
-        StageLoader sl = new StageLoader(combo);
+        sl = new StageLoader(combo);
 
         // everything should be null to start with
         assertNull(combo.getValue());
@@ -1283,14 +1259,12 @@ public class ComboBoxTest {
         assertEquals("bbc", combo.getValue());
         assertEquals("bbc", combo.getEditor().getText());
         assertEquals("bbc", combo.getSelectionModel().getSelectedItem());
-
-        sl.dispose();
     }
 
     @Test public void test_rt35840() {
         final ComboBox<String> cb = new ComboBox<String>();
         cb.setEditable(true);
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
         cb.requestFocus();
 
         KeyEventFirer keyboard = new KeyEventFirer(cb);
@@ -1303,37 +1277,31 @@ public class ComboBoxTest {
         assertNull(cb.getValue());
         keyboard.doKeyPress(KeyCode.ENTER);
         assertEquals("TEST", cb.getValue());
-
-        sl.dispose();
     }
 
     @Test public void test_rt36280_nonEditable_F4ShowsPopup() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
         KeyEventFirer cbKeyboard = new KeyEventFirer(cb);
 
         assertFalse(cb.isShowing());
         cbKeyboard.doKeyPress(KeyCode.F4);  // show the popup
         assertTrue(cb.isShowing());
-
-        sl.dispose();
     }
 
     @Test public void test_rt36280_nonEditable_altUpShowsPopup() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
         KeyEventFirer cbKeyboard = new KeyEventFirer(cb);
 
         assertFalse(cb.isShowing());
         cbKeyboard.doKeyPress(KeyCode.UP, KeyModifier.ALT);  // show the popup
         assertTrue(cb.isShowing());
-
-        sl.dispose();
     }
 
     @Test public void test_rt36280_nonEditable_altDownShowsPopup() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
         KeyEventFirer cbKeyboard = new KeyEventFirer(cb);
 
         new StageLoader(cb);
@@ -1341,14 +1309,12 @@ public class ComboBoxTest {
         assertFalse(cb.isShowing());
         cbKeyboard.doKeyPress(KeyCode.DOWN, KeyModifier.ALT);  // show the popup
         assertTrue(cb.isShowing());
-
-        sl.dispose();
     }
 
     @Test public void testEditorKeyInputsWhenPopupIsShowing() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
         cb.setEditable(true);
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
         KeyEventFirer keyboard = new KeyEventFirer(cb);
 
         // Show the popup
@@ -1459,14 +1425,12 @@ public class ComboBoxTest {
 
         // Sanity
         assertTrue(cb.isShowing());
-
-        sl.dispose();
     }
 
     @Test public void testKeyInputsOnNonEditableComboBox() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
         // cb.setEditable(false); // by default ComboBox is not editable
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
         SingleSelectionModel<String> sm = cb.getSelectionModel();
         sm.select(0);
         KeyEventFirer keyboard = new KeyEventFirer(cb);
@@ -1521,13 +1485,11 @@ public class ComboBoxTest {
 
         // Sanity
         assertTrue(cb.isShowing());
-
-        sl.dispose();
     }
 
     @Test public void testInterceptedKeyMappingsForComboBoxEditor() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
 
         ListView listView = (ListView) ((ComboBoxListViewSkin)cb.getSkin()).getPopupContent();
         ListViewBehavior lvBehavior = (ListViewBehavior)ControlSkinFactory.getBehavior(listView.getSkin());
@@ -1544,8 +1506,6 @@ public class ComboBoxTest {
         cb.setEditable(false);
         testKeyMappingsForNonEditableCB(inputMappings);
         testCommonKeyMappings(inputMappings, verticalInputMappings);
-
-        sl.dispose();
     }
 
     private void testKeyMappingsForEditableCB(ObservableList<?> inputMappings) {
@@ -1589,7 +1549,7 @@ public class ComboBoxTest {
 
     @Test public void test_rt36280_nonEditable_enterHidesShowingPopup() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
         KeyEventFirer cbKeyboard = new KeyEventFirer(cb);
 
         ListView listView = (ListView) ((ComboBoxListViewSkin)cb.getSkin()).getPopupContent();
@@ -1602,13 +1562,11 @@ public class ComboBoxTest {
         assertTrue(cb.isShowing());
         lvKeyboard.doKeyPress(KeyCode.ENTER);  // hide the popup
         assertFalse(cb.isShowing());
-
-        sl.dispose();
     }
 
     @Test public void test_rt36280_nonEditable_spaceHidesShowingPopup() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
         KeyEventFirer cbKeyboard = new KeyEventFirer(cb);
 
         ListView listView = (ListView) ((ComboBoxListViewSkin)cb.getSkin()).getPopupContent();
@@ -1621,13 +1579,11 @@ public class ComboBoxTest {
         assertTrue(cb.isShowing());
         lvKeyboard.doKeyPress(KeyCode.SPACE);  // hide the popup
         assertFalse(cb.isShowing());
-
-        sl.dispose();
     }
 
     @Test public void test_rt36280_nonEditable_escapeHidesShowingPopup() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
         KeyEventFirer cbKeyboard = new KeyEventFirer(cb);
 
         ListView listView = (ListView) ((ComboBoxListViewSkin)cb.getSkin()).getPopupContent();
@@ -1640,13 +1596,11 @@ public class ComboBoxTest {
         assertTrue(cb.isShowing());
         lvKeyboard.doKeyPress(KeyCode.ESCAPE);  // hide the popup
         assertFalse(cb.isShowing());
-
-        sl.dispose();
     }
 
     @Test public void test_rt36280_nonEditable_F4HidesShowingPopup() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
         KeyEventFirer cbKeyboard = new KeyEventFirer(cb);
 
         assertFalse(cb.isShowing());
@@ -1654,13 +1608,11 @@ public class ComboBoxTest {
         assertTrue(cb.isShowing());
         cbKeyboard.doKeyPress(KeyCode.F4);  // hide the popup
         assertFalse(cb.isShowing());
-
-        sl.dispose();
     }
 
     @Test public void test_rt36280_nonEditable_arrowKeysChangeSelection() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
         KeyEventFirer cbKeyboard = new KeyEventFirer(cb);
 
         assertFalse(cb.isShowing());
@@ -1677,40 +1629,34 @@ public class ComboBoxTest {
 
         cbKeyboard.doUpArrowPress();
         assertEquals("a", cb.getSelectionModel().getSelectedItem());
-
-        sl.dispose();
     }
 
     @Test public void test_rt36280_editable_F4ShowsPopup() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
         cb.setEditable(true);
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
         KeyEventFirer cbKeyboard = new KeyEventFirer(cb);
 
         assertFalse(cb.isShowing());
         cbKeyboard.doKeyPress(KeyCode.F4);  // show the popup
         assertTrue(cb.isShowing());
-
-        sl.dispose();
     }
 
     @Test public void test_rt36280_editable_altUpShowsPopup() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
         cb.setEditable(true);
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
         KeyEventFirer cbKeyboard = new KeyEventFirer(cb);
 
         assertFalse(cb.isShowing());
         cbKeyboard.doKeyPress(KeyCode.UP, KeyModifier.ALT);  // show the popup
         assertTrue(cb.isShowing());
-
-        sl.dispose();
     }
 
     @Test public void test_rt36280_editable_altDownShowsPopup_onComboBox() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
         cb.setEditable(true);
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
         KeyEventFirer cbKeyboard = new KeyEventFirer(cb);
 
         assertFalse(cb.isShowing());
@@ -1718,14 +1664,12 @@ public class ComboBoxTest {
         cbKeyboard.doKeyPress(KeyCode.DOWN, KeyModifier.ALT);  // show the popup
         assertTrue(cb.isShowing());
         assertTrue(cb.getEditor().getText().isEmpty());
-
-        sl.dispose();
     }
 
     @Test public void test_rt36280_editable_altDownShowsPopup_onTextField() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
         cb.setEditable(true);
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
 
         KeyEventFirer tfKeyboard = new KeyEventFirer(cb.getEditor());
         assertFalse(cb.isShowing());
@@ -1733,14 +1677,12 @@ public class ComboBoxTest {
         tfKeyboard.doKeyPress(KeyCode.DOWN, KeyModifier.ALT);  // show the popup
         assertTrue(cb.isShowing());
         assertTrue(cb.getEditor().getText().isEmpty());
-
-        sl.dispose();
     }
 
     @Test public void test_rt36280_editable_enterHidesShowingPopup() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
         cb.setEditable(true);
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
         KeyEventFirer cbKeyboard = new KeyEventFirer(cb);
 
         ListView listView = (ListView) ((ComboBoxListViewSkin)cb.getSkin()).getPopupContent();
@@ -1753,14 +1695,12 @@ public class ComboBoxTest {
         assertTrue(cb.isShowing());
         lvKeyboard.doKeyPress(KeyCode.ENTER);  // hide the popup
         assertFalse(cb.isShowing());
-
-        sl.dispose();
     }
 
     @Test public void test_rt36280_editable_spaceHidesShowingPopup() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
         cb.setEditable(true);
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
         KeyEventFirer cbKeyboard = new KeyEventFirer(cb);
 
         ListView listView = (ListView) ((ComboBoxListViewSkin)cb.getSkin()).getPopupContent();
@@ -1773,14 +1713,12 @@ public class ComboBoxTest {
         assertTrue(cb.isShowing());
         lvKeyboard.doKeyPress(KeyCode.SPACE);  // hide the popup
         assertFalse(cb.isShowing());
-
-        sl.dispose();
     }
 
     @Test public void test_rt36280_editable_escapeHidesShowingPopup() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
         cb.setEditable(true);
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
         KeyEventFirer cbKeyboard = new KeyEventFirer(cb);
 
         ListView listView = (ListView) ((ComboBoxListViewSkin)cb.getSkin()).getPopupContent();
@@ -1793,14 +1731,12 @@ public class ComboBoxTest {
         assertTrue(cb.isShowing());
         lvKeyboard.doKeyPress(KeyCode.ESCAPE);  // hide the popup
         assertFalse(cb.isShowing());
-
-        sl.dispose();
     }
 
     @Test public void test_rt36280_editable_F4HidesShowingPopup() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
         cb.setEditable(true);
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
         KeyEventFirer cbKeyboard = new KeyEventFirer(cb);
 
         assertFalse(cb.isShowing());
@@ -1808,14 +1744,12 @@ public class ComboBoxTest {
         assertTrue(cb.isShowing());
         cbKeyboard.doKeyPress(KeyCode.F4);  // hide the popup
         assertFalse(cb.isShowing());
-
-        sl.dispose();
     }
 
     @Test public void test_rt36280_editable_arrowKeysChangeSelection() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
         cb.setEditable(true);
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
         KeyEventFirer cbKeyboard = new KeyEventFirer(cb);
 
         assertFalse(cb.isShowing());
@@ -1832,14 +1766,12 @@ public class ComboBoxTest {
 
         cbKeyboard.doUpArrowPress();
         assertEquals("a", cb.getSelectionModel().getSelectedItem());
-
-        sl.dispose();
     }
 
     @Test public void test_rt36651() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
         cb.setEditable(true);
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
 
         assertNull(cb.getValue());
         assertEquals(-1, cb.getSelectionModel().getSelectedIndex());
@@ -1853,13 +1785,11 @@ public class ComboBoxTest {
         assertNull(cb.getValue());
         assertEquals(-1, cb.getSelectionModel().getSelectedIndex());
         assertNull(cb.getSelectionModel().getSelectedItem());
-
-        sl.dispose();
     }
 
     @Test public void test_rt36717() {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
 
         // the stack overflow only occurs when a ComboBox changes from non-editable to editable
         cb.setEditable(false);
@@ -1867,8 +1797,6 @@ public class ComboBoxTest {
         assertNotNull(cb.getEditor());
         KeyEventFirer tfKeyboard = new KeyEventFirer(cb.getEditor());
         tfKeyboard.doKeyPress(KeyCode.ENTER);   // Stack overflow here
-
-        sl.dispose();
     }
 
     @Test public void test_rt36827() {
@@ -1876,7 +1804,7 @@ public class ComboBoxTest {
         final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b", "c"));
         VBox vbox = new VBox(btn, cb);
 
-        StageLoader sl = new StageLoader(vbox);
+        sl = new StageLoader(vbox);
         sl.getStage().requestFocus();
         btn.requestFocus();
         Toolkit.getToolkit().firePulse();
@@ -1891,8 +1819,6 @@ public class ComboBoxTest {
         assertTrue(cb.isShowing());
         assertTrue(cb.isFocused());
         assertEquals(cb, scene.getFocusOwner());
-
-        sl.dispose();
     }
 
     @Test public void test_rt36902() {
@@ -1906,7 +1832,7 @@ public class ComboBoxTest {
         KeyEventFirer cb1Keyboard = new KeyEventFirer(cb1);
         KeyEventFirer cb2Keyboard = new KeyEventFirer(cb2);
 
-        StageLoader sl = new StageLoader(vbox);
+        sl = new StageLoader(vbox);
         sl.getStage().requestFocus();
         cb1.requestFocus();
         Toolkit.getToolkit().firePulse();
@@ -1945,8 +1871,6 @@ public class ComboBoxTest {
         cb2Keyboard.doKeyPress(KeyCode.TAB, KeyModifier.SHIFT);
         assertTrue(cb1.isFocused());
         assertEquals(cb1, scene.getFocusOwner());
-
-        sl.dispose();
     }
 
     private int rt_38901_counter;
@@ -2018,7 +1942,7 @@ public class ComboBoxTest {
             cb.getItems().setAll("DUMMY " + (rt_22572_counter++));
         });
 
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
 
         assertEquals(-1, cb.getSelectionModel().getSelectedIndex());
         assertNull(cb.getSelectionModel().getSelectedItem());
@@ -2048,8 +1972,6 @@ public class ComboBoxTest {
         assertEquals(-1, cb.getSelectionModel().getSelectedIndex());
         assertNull(cb.getSelectionModel().getSelectedItem());
         assertEquals("DUMMY 0", cb.getValue());
-
-        sl.dispose();
     }
 
     private int rt_22937_counter;
@@ -2065,7 +1987,7 @@ public class ComboBoxTest {
         cb.setEditable(true);
         cb.setValue("Tata");
 
-        StageLoader sl = new StageLoader(cb);
+        sl = new StageLoader(cb);
 
         assertEquals(-1, cb.getSelectionModel().getSelectedIndex());
         assertEquals("Tata", cb.getSelectionModel().getSelectedItem());
@@ -2081,15 +2003,13 @@ public class ComboBoxTest {
         assertEquals(0, cb.getSelectionModel().getSelectedIndex());
         assertEquals("DUMMY 0", cb.getSelectionModel().getSelectedItem());
         assertEquals("DUMMY 0", cb.getValue());
-
-        sl.dispose();
     }
 
     @Test public void test_rt_39809() {
         ComboBox<String> comboBox = new ComboBox<>();
         comboBox.getItems().setAll(null, "1", "2", "3");
 
-        StageLoader sl = new StageLoader(comboBox);
+        sl = new StageLoader(comboBox);
 
         comboBox.getSelectionModel().clearAndSelect(1);
         assertEquals("1", comboBox.getSelectionModel().getSelectedItem());
@@ -2098,15 +2018,13 @@ public class ComboBoxTest {
         comboBox.getSelectionModel().clearAndSelect(0);
         assertEquals(null, comboBox.getSelectionModel().getSelectedItem());
         assertEquals(0, comboBox.getSelectionModel().getSelectedIndex());
-
-        sl.dispose();
     }
 
     @Test public void test_rt_39908() {
         ObservableList<String> model = FXCollections.observableArrayList("0", "1", "2", "3");
         ComboBox<String> comboBox = new ComboBox<>(model);
 
-        StageLoader sl = new StageLoader(comboBox);
+        sl = new StageLoader(comboBox);
 
         comboBox.getSelectionModel().clearAndSelect(1);
         assertEquals("1", comboBox.getSelectionModel().getSelectedItem());
@@ -2115,8 +2033,6 @@ public class ComboBoxTest {
         model.set(0, "a");
         assertEquals("1", comboBox.getSelectionModel().getSelectedItem());
         assertEquals(1, comboBox.getSelectionModel().getSelectedIndex());
-
-        sl.dispose();
     }
 
     /**
@@ -2295,12 +2211,10 @@ public class ComboBoxTest {
 
         Toolkit tk = Toolkit.getToolkit();
 
-        StageLoader sl = new StageLoader(scene);
+        sl = new StageLoader(scene);
 
         tk.firePulse();
 
         assertEquals("ComboBox skinProperty changed more than once, which is not expected.", 1, skinChangedCount);
-
-        sl.dispose();
     }
 }


### PR DESCRIPTION
This is a test fix.

Root cause:
- For ButtonTest - Incorrect use of MouseEventFirer - which puts Button on to the stage and shows it before firing mouse event
- For ComboBoxTest - adding ComboBox to a Stage, not showing the Stage but trying to show the ComboBox


Fix :
- For ButtonTest - Moved MouseEventFirer usage from test class to the 2 tests that need it
- For ComboBoxTest - Started using StageLoader (which adds comboBox to the stage and shows it) instead of separate Scene and Stage creation.


I have attached the logs captured before and after this fix to the JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255337](https://bugs.openjdk.java.net/browse/JDK-8255337): [TestBug] Controls unit tests - ButtonTest and ComboBoxTest - log ClassCastException


### Reviewers
 * [Jeanette Winzenburg](https://openjdk.java.net/census#fastegal) (@kleopatra - Committer)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/337/head:pull/337`
`$ git checkout pull/337`
