### PR TITLE
Dummy PR to test error reporting after GitHub Actions are enabled

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -23,12 +23,28 @@
 # questions.
 #
 
+#
+# This GitHub actions YAML file runs a build and test on each of the three primary platforms:
+# Linux, macOS, Windows. The jobs are run using the default (latest) OS platform for each OS.
+# We download a specific version the boot JDK and gradle. We use the default versions
+# of all other build tools (e.g., compilers and ant) that are available on each platform.
+#
+# The build step is run in the default mode without building the native media or webkit libraries.
+# The test is run with web tests excluded. As a follow-up enhancement, we might consider optionally
+# building the media and webkit libraries.
+#
+
 name: JavaFX pre-submit tests
 
 on:
+  # Run GitHub actions on every push to all branches except the main production branches, also
+  # exclude any branch starting with "WIP".
   push:
     branches-ignore:
       - master
+      - main
+      - 'jfx[0-9]+'
+      - 'WIP*'
 
 jobs:
   linux_x64_build:
@@ -37,12 +53,11 @@ jobs:
     if: 'true'
 
     env:
-# FIXME: read this information from a property file
-#      JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).DEFAULT_VERSION_FEATURE }}"
-#      BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
-#      BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_FILENAME }}"
-#      BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_URL }}"
-#      BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
+      # FIXME: read this information from a property file
+      # BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
+      # BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_FILENAME }}"
+      # BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_URL }}"
+      # BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
       BOOT_JDK_VERSION: "15"
       BOOT_JDK_FILENAME: "openjdk-15_linux-x64_bin.tar.gz"
       BOOT_JDK_URL: "https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_linux-x64_bin.tar.gz"
@@ -81,6 +96,7 @@ jobs:
           export JAVA_HOME="${HOME}/bootjdk/jdk-${BOOT_JDK_VERSION}"
           echo "JAVA_HOME=${JAVA_HOME}" >> "${GITHUB_ENV}"
           export PATH="$JAVA_HOME/bin:$PATH"
+          env | sort
           which java
           java -version
           ant -version
@@ -91,7 +107,6 @@ jobs:
         run: |
           set -x
           export PATH="$JAVA_HOME/bin:$PATH"
-          env | sort
           bash gradlew -version
           bash gradlew --info all
 
@@ -100,7 +115,6 @@ jobs:
         run: |
           set -x
           export PATH="$JAVA_HOME/bin:$PATH"
-          env | sort
           bash gradlew --info --continue -PBUILD_SDK_FOR_TEST=false test -x :web:test
 
 
@@ -110,12 +124,11 @@ jobs:
     if: 'true'
 
     env:
-# FIXME: read this information from a property file
-#      JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).DEFAULT_VERSION_FEATURE }}"
-#      BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
-#      BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_FILENAME }}"
-#      BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_URL }}"
-#      BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
+      # FIXME: read this information from a property file
+      # BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
+      # BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_FILENAME }}"
+      # BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_URL }}"
+      # BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
       BOOT_JDK_VERSION: "15"
       BOOT_JDK_FILENAME: "openjdk-15_osx-x64_bin.tar.gz"
       BOOT_JDK_URL: "https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_osx-x64_bin.tar.gz"
@@ -154,6 +167,7 @@ jobs:
           export JAVA_HOME="${HOME}/bootjdk/jdk-${BOOT_JDK_VERSION}.jdk/Contents/Home"
           echo "JAVA_HOME=${JAVA_HOME}" >> "${GITHUB_ENV}"
           export PATH="$JAVA_HOME/bin:$PATH"
+          env | sort
           which java
           java -version
           ant -version
@@ -164,7 +178,6 @@ jobs:
         run: |
           set -x
           export PATH="$JAVA_HOME/bin:$PATH"
-          env | sort
           bash gradlew -version
           bash gradlew --info all
 
@@ -173,7 +186,6 @@ jobs:
         run: |
           set -x
           export PATH="$JAVA_HOME/bin:$PATH"
-          env | sort
           bash gradlew --info --continue -PBUILD_SDK_FOR_TEST=false test -x :web:test
 
 
@@ -183,12 +195,11 @@ jobs:
     if: 'true'
 
     env:
-# FIXME: read this information from a property file
-#      JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).DEFAULT_VERSION_FEATURE }}"
-#      BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
-#      BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_FILENAME }}"
-#      BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_URL }}"
-#      BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
+      # FIXME: read this information from a property file
+      # BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
+      # BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_FILENAME }}"
+      # BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_URL }}"
+      # BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
       BOOT_JDK_VERSION: "15"
       BOOT_JDK_FILENAME: "openjdk-15_windows-x64_bin.zip"
       BOOT_JDK_URL: "https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_windows-x64_bin.zip"

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,0 +1,274 @@
+#
+# Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+name: JavaFX pre-submit tests
+
+on:
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  linux_x64_build:
+    name: Linux x64
+    runs-on: "ubuntu-latest"
+    if: 'true'
+
+    env:
+# FIXME: read this information from a property file
+#      JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).DEFAULT_VERSION_FEATURE }}"
+#      BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
+#      BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_FILENAME }}"
+#      BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_URL }}"
+#      BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
+      BOOT_JDK_VERSION: "15"
+      BOOT_JDK_FILENAME: "openjdk-15_linux-x64_bin.tar.gz"
+      BOOT_JDK_URL: "https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_linux-x64_bin.tar.gz"
+
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@v2
+        with:
+          path: jfx
+
+      - name: Install dependencies
+        run: |
+          set -x
+          sudo apt-get install libgl1-mesa-dev libx11-dev libxt-dev pkg-config libgtk2.0-dev libgtk-3-dev libxtst-dev libudev-dev
+
+# FIXME: enable cache for boot JDK
+#      - name: Restore boot JDK from cache
+#        id: bootjdk
+#        uses: actions/cache@v2
+#        with:
+#          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
+#          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
+
+      - name: Download boot JDK
+        run: |
+          set -x
+          mkdir -p "${HOME}/bootjdk"
+          wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
+          # FIXME: sha256sum
+          tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk"
+          # FIXME: enable cache for boot JDK
+
+      - name: Setup environment
+        run: |
+          set -x
+          export JAVA_HOME="${HOME}/bootjdk/jdk-${BOOT_JDK_VERSION}"
+          echo "JAVA_HOME=${JAVA_HOME}" >> "${GITHUB_ENV}"
+          export PATH="$JAVA_HOME/bin:$PATH"
+          which java
+          java -version
+          ant -version
+          gcc -v
+
+      - name: Build JavaFX artifacts
+        working-directory: jfx
+        run: |
+          set -x
+          export PATH="$JAVA_HOME/bin:$PATH"
+          env | sort
+          bash gradlew -version
+          bash gradlew --info all
+
+      - name: Run JavaFX headless tests
+        working-directory: jfx
+        run: |
+          set -x
+          export PATH="$JAVA_HOME/bin:$PATH"
+          env | sort
+          bash gradlew --info --continue -PBUILD_SDK_FOR_TEST=false test -x :web:test
+
+
+  macos_x64_build:
+    name: macOS x64
+    runs-on: "macos-latest"
+    if: 'true'
+
+    env:
+# FIXME: read this information from a property file
+#      JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).DEFAULT_VERSION_FEATURE }}"
+#      BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
+#      BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_FILENAME }}"
+#      BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_URL }}"
+#      BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
+      BOOT_JDK_VERSION: "15"
+      BOOT_JDK_FILENAME: "openjdk-15_osx-x64_bin.tar.gz"
+      BOOT_JDK_URL: "https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_osx-x64_bin.tar.gz"
+
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@v2
+        with:
+          path: jfx
+
+      - name: Install dependencies
+        run: |
+          set -x
+          echo "NOT NEEDED: brew install make"
+
+# FIXME: enable cache for boot JDK
+#      - name: Restore boot JDK from cache
+#        id: bootjdk
+#        uses: actions/cache@v2
+#        with:
+#          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
+#          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
+
+      - name: Download boot JDK
+        run: |
+          set -x
+          mkdir -p "${HOME}/bootjdk"
+          wget -O "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" "${BOOT_JDK_URL}"
+          # FIXME: sha256sum
+          tar -xf "${HOME}/bootjdk/${BOOT_JDK_FILENAME}" -C "${HOME}/bootjdk"
+          # FIXME: enable cache for boot JDK
+
+      - name: Setup environment
+        run: |
+          set -x
+          export JAVA_HOME="${HOME}/bootjdk/jdk-${BOOT_JDK_VERSION}.jdk/Contents/Home"
+          echo "JAVA_HOME=${JAVA_HOME}" >> "${GITHUB_ENV}"
+          export PATH="$JAVA_HOME/bin:$PATH"
+          which java
+          java -version
+          ant -version
+          xcodebuild -version
+
+      - name: Build JavaFX artifacts
+        working-directory: jfx
+        run: |
+          set -x
+          export PATH="$JAVA_HOME/bin:$PATH"
+          env | sort
+          bash gradlew -version
+          bash gradlew --info all
+
+      - name: Run JavaFX headless tests
+        working-directory: jfx
+        run: |
+          set -x
+          export PATH="$JAVA_HOME/bin:$PATH"
+          env | sort
+          bash gradlew --info --continue -PBUILD_SDK_FOR_TEST=false test -x :web:test
+
+
+  windows_x64_build:
+    name: Windows x64
+    runs-on: "windows-latest"
+    if: 'true'
+
+    env:
+# FIXME: read this information from a property file
+#      JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).DEFAULT_VERSION_FEATURE }}"
+#      BOOT_JDK_VERSION: "${{ fromJson(needs.prerequisites.outputs.dependencies).BOOT_JDK_VERSION }}"
+#      BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_FILENAME }}"
+#      BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_URL }}"
+#      BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
+      BOOT_JDK_VERSION: "15"
+      BOOT_JDK_FILENAME: "openjdk-15_windows-x64_bin.zip"
+      BOOT_JDK_URL: "https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_windows-x64_bin.zip"
+      # FIXME: hard-code the location and version of VS 2019 for now
+      VS150COMNTOOLS: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build"
+      MSVC_VER: "14.27.29110"
+
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@v2
+        with:
+          path: jfx
+
+# FIXME: enable cache for boot JDK
+#      - name: Restore boot JDK from cache
+#        id: bootjdk
+#        uses: actions/cache@v2
+#        with:
+#          path: ~/bootjdk/${{ env.BOOT_JDK_VERSION }}
+#          key: bootjdk-${{ runner.os }}-${{ env.BOOT_JDK_VERSION }}-${{ env.BOOT_JDK_SHA256 }}-v1
+
+      - name: Download boot JDK
+        run: |
+          mkdir -p "$HOME\bootjdk"
+          & curl -L "$env:BOOT_JDK_URL" -o "$HOME/bootjdk/$env:BOOT_JDK_FILENAME"
+          # FIXME: sha256sum
+          tar -xf "$HOME/bootjdk/$env:BOOT_JDK_FILENAME" -C "$HOME/bootjdk"
+          # FIXME: enable cache for boot JDK
+
+      - name: Restore cygwin packages from cache
+        id: cygwin
+        uses: actions/cache@v2
+        with:
+          path: ~/cygwin/packages
+          key: cygwin-packages-${{ runner.os }}-v1
+
+      - name: Install cygwin
+        run: |
+          New-Item -Force -ItemType directory -Path "$HOME\cygwin"
+          & curl -L "https://www.cygwin.com/setup-x86_64.exe" -o "$HOME/cygwin/setup-x86_64.exe"
+          Start-Process -FilePath "$HOME\cygwin\setup-x86_64.exe" -ArgumentList "--quiet-mode --packages make,zip,unzip --root $HOME\cygwin\cygwin64 --local-package-dir $HOME\cygwin\packages --site http://mirrors.kernel.org/sourceware/cygwin --no-desktop --no-shortcuts --no-startmenu --no-admin" -Wait -NoNewWindow
+
+      - name: Setup environment
+        run: |
+          echo "VS150COMNTOOLS=$env:VS150COMNTOOLS"
+          echo "MSVC_VER=$env:MSVC_VER"
+          # echo "dir ...\VC\Tools\MSVC"
+          # dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC"
+          # echo "dir VS150COMNTOOLS"
+          # dir "$env:VS150COMNTOOLS"
+
+          $env:Path = "$HOME\cygwin\cygwin64\bin;$HOME\cygwin\cygwin64\bin;$env:Path" ;
+          $env:JAVA_HOME = "$HOME\bootjdk\jdk-$env:BOOT_JDK_VERSION" ;
+          echo "JAVA_HOME=$env:JAVA_HOME"
+          $env:Path = "$env:JAVA_HOME\bin;$env:Path" ;
+          echo "Path=$env:Path"
+          which java
+          java -version
+          which ant
+          ant -version
+
+          # Save JAVA_HOME and Path (renamed to THE_PATH) in env variables
+          echo "JAVA_HOME=$env:JAVA_HOME" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "THE_PATH=$env:Path" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Build JavaFX artifacts
+        working-directory: jfx
+        run: |
+          echo "JAVA_HOME=$env:JAVA_HOME"
+          $env:Path = "$env:THE_PATH" ;
+          echo "Path=$env:Path"
+          which java
+          java -version
+          .\gradlew.bat -version
+          .\gradlew.bat --info all
+
+      - name: Run JavaFX headless tests
+        working-directory: jfx
+        run: |
+          echo "JAVA_HOME=$env:JAVA_HOME"
+          $env:Path = "$env:THE_PATH" ;
+          echo "Path=$env:Path"
+          .\gradlew.bat --info --continue -PBUILD_SDK_FOR_TEST=false test -x :web:test

--- a/modules/javafx.base/src/test/java/test/javafx/util/DurationTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/DurationTest.java
@@ -41,6 +41,9 @@ public class DurationTest {
 
     @Test public void millis_withZeroResultsIn_ZERO() {
         assertSame(Duration.ZERO, Duration.millis(0));
+        final boolean isMac
+                = System.getProperty("os.name").startsWith("Mac");
+        assertFalse("KCR: inject test failure", isMac);
     }
 
     @Test public void millis_withOneResultsIn_ONE() {

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
@@ -57,6 +57,8 @@ static jmethodID midNotifyResize;
 static jmethodID midNotifyScaleChanged;
 static jmethodID midNotifyMoveToAnotherScreen;
 
+int failure = KCR__inject_build_failure;
+
 unsigned int GlassWindow::sm_instanceCounter = 0;
 HHOOK GlassWindow::sm_hCBTFilter = NULL;
 HWND GlassWindow::sm_grabWindow = NULL;


### PR DESCRIPTION
This PR is intended only for testing purposes to show what will happen after the GitHub Actions build / test runs are enabled in PR #33 

In this example I have injected a build failure on Windows and a test failure on Mac. Linux should pass. I'm only interested in how these failures are reported by Skara in this dummy PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ❌ (1/1 failed) | ❌ (1/1 failed) |

**Failed test tasks**
- [Windows x64](https://github.com/kevinrushforth/jfx/runs/1316694644)
- [macOS x64](https://github.com/kevinrushforth/jfx/runs/1316694612)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/339/head:pull/339`
`$ git checkout pull/339`
