### PR TITLE
8255487: Mark SandboxAppTest unstable on Windows

### DIFF
--- a/tests/system/src/test/java/test/sandbox/SandboxAppTest.java
+++ b/tests/system/src/test/java/test/sandbox/SandboxAppTest.java
@@ -28,6 +28,7 @@ package test.sandbox;
 import com.sun.javafx.PlatformUtil;
 import java.util.ArrayList;
 import junit.framework.AssertionFailedError;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.Ignore;
 
@@ -95,6 +96,13 @@ public class SandboxAppTest {
            default:
                 throw new AssertionFailedError(testAppName
                         + ": Unexpected error exit: " + retVal);
+        }
+    }
+
+    @Before
+    public void setupEach() {
+        if (PlatformUtil.isWindows()) {
+            assumeTrue(Boolean.getBoolean("unstable.test")); // JDK-8255486
         }
     }
 


### PR DESCRIPTION
This test is somewhat unstable on Windows. Even after the test timeout was increased to 25 seconds, it still times out on some Windows machines.

The proposed fix is to mark this test unstable on Windows so our nightly build will not execute it and get frequent failures. It can still be run by passing `-PUNSTABLE_TEST=true` to gradle. For example:

```
gradle --info -PUNSTABLE_TEST=true -PFULL_TEST=true cleanTest :systemTests:test --tests SandboxAppTest
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255487](https://bugs.openjdk.java.net/browse/JDK-8255487): Mark SandboxAppTest unstable on Windows


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/340/head:pull/340`
`$ git checkout pull/340`
