### PR TITLE
8255497: [TestBug] Controls unit tests - clean up unnecessary prints on STANDARD_OUT

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYChartTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYChartTest.java
@@ -74,7 +74,7 @@ public class XYChartTest extends ChartTestBase {
         startApp();
         pulse();
         yaxis.getTickMarks().toString();
-        System.out.println(" --- "+yaxis.getTickMarks().toString());
+        //System.out.println(" --- "+yaxis.getTickMarks().toString());
     }
 
     // RT-22166

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -939,13 +939,10 @@ public class ComboBoxTest {
 
         assertEquals("2", listView.getSelectionModel().getSelectedItem());
 
-        System.out.println(listView.getSkin());
-
         VirtualFlow flow = (VirtualFlow)listView.lookup("#virtual-flow");
         assertNotNull(flow);
 
         IndexedCell cell = flow.getVisibleCell(2);
-        System.out.println("cell: " + cell);
         assertEquals("TO_STRING", cell.getText());
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
@@ -935,7 +935,7 @@ public class ListViewTest {
         textFieldListView.setCellFactory(TextFieldListCell.forListView());
         textFieldListView.setOnEditCancel(t -> {
             rt_35889_cancel_count++;
-            System.out.println("On Edit Cancel: " + t);
+            //System.out.println("On Edit Cancel: " + t);
         });
 
         ListCell cell0 = (ListCell) VirtualFlowTestUtils.getCell(textFieldListView, 0);
@@ -1474,7 +1474,8 @@ public class ListViewTest {
         MultipleSelectionModel<String> sm = stringListView.getSelectionModel();
         sm.setSelectionMode(SelectionMode.MULTIPLE);
 
-        sm.getSelectedItems().addListener((ListChangeListener<String>) change -> {
+        // Enable below prints for debug if needed
+        /*sm.getSelectedItems().addListener((ListChangeListener<String>) change -> {
             while (change.next()) {
                 System.out.println("sm.getSelectedItems(): " + change.getList());
             }
@@ -1484,7 +1485,7 @@ public class ListViewTest {
             while (change.next()) {
                 System.out.println("rt_39482_list: " + change.getList());
             }
-        });
+        });*/
 
         Bindings.bindContent(rt_39482_list, sm.getSelectedItems());
 
@@ -1500,7 +1501,6 @@ public class ListViewTest {
     private void test_rt_39482_selectRow(String expectedString,
                                          MultipleSelectionModel<String> sm,
                                          int rowToSelect) {
-        System.out.println("\nSelect row " + rowToSelect);
         sm.selectAll();
         assertEquals(4, sm.getSelectedIndices().size());
         assertEquals(4, sm.getSelectedItems().size());
@@ -1908,7 +1908,7 @@ public class ListViewTest {
             // number of items selected
             c.reset();
             c.next();
-            System.out.println("Added items: " + c.getAddedSubList());
+            //System.out.println("Added items: " + c.getAddedSubList());
             assertEquals(indices.length, c.getAddedSize());
             assertArrayEquals(indices, c.getAddedSubList().stream().mapToInt(i -> i).toArray());
         };

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -4650,17 +4650,14 @@ public class TableViewTest {
         assertEquals(0, listOne.size());
         assertEquals(0, listTwo.size());
 
-        System.out.println("Test One:");
         listTwo.setAll("a", "b", "c", "d");
         assertEquals(4, listOne.size());
         assertEquals(4, listTwo.size());
 
-        System.out.println("\nTest Two:");
         listTwo.setAll("e", "f", "g", "h");
         assertEquals(4, listOne.size());
         assertEquals(4, listTwo.size());
 
-        System.out.println("\nTest Three:");
         listTwo.setAll("i", "j", "k", "l");
         assertEquals(4, listOne.size());
         assertEquals(4, listTwo.size());
@@ -4678,7 +4675,8 @@ public class TableViewTest {
         TableView.TableViewSelectionModel<String> sm = stringTableView.getSelectionModel();
         sm.setSelectionMode(SelectionMode.MULTIPLE);
 
-        sm.getSelectedItems().addListener((ListChangeListener<String>) change -> {
+        // Enable below prints for debug if needed
+        /*sm.getSelectedItems().addListener((ListChangeListener<String>) change -> {
             while (change.next()) {
                 System.out.println("sm.getSelectedItems(): " + change.getList());
             }
@@ -4688,7 +4686,7 @@ public class TableViewTest {
             while (change.next()) {
                 System.out.println("rt_39482_list: " + change.getList());
             }
-        });
+        });*/
 
         Bindings.bindContent(rt_39482_list, sm.getSelectedItems());
 
@@ -4705,7 +4703,6 @@ public class TableViewTest {
                                          TableView.TableViewSelectionModel<String> sm,
                                          int rowToSelect,
                                          TableColumn<String,String> columnToSelect) {
-        System.out.println("\nSelect row " + rowToSelect);
         sm.selectAll();
         assertEquals(4, sm.getSelectedCells().size());
         assertEquals(4, sm.getSelectedIndices().size());
@@ -5207,7 +5204,7 @@ public class TableViewTest {
             // number of items selected
             c.reset();
             c.next();
-            System.out.println("Added items: " + c.getAddedSubList());
+            //System.out.println("Added items: " + c.getAddedSubList());
             assertEquals(indices.length, c.getAddedSize());
             assertArrayEquals(indices, c.getAddedSubList().stream().mapToInt(i -> i).toArray());
         };

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TooltipTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TooltipTest.java
@@ -115,7 +115,7 @@ public class TooltipTest {
     }
 
     @Test public void defaultFontIsnotNull() {
-        System.out.println("toolTip.getFont() " + toolTip.getFont());
+        //System.out.println("toolTip.getFont() " + toolTip.getFont());
         assertNotNull(toolTip.getFont());
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -5191,7 +5191,6 @@ public class TreeTableViewTest {
                                          TreeTableView.TreeTableViewSelectionModel<String> sm,
                                          int rowToSelect,
                                          TreeTableColumn<String,String> columnToSelect) {
-        System.out.println("\nSelect row " + rowToSelect);
         sm.selectAll();
         assertEquals(4, sm.getSelectedCells().size());
         assertEquals(4, sm.getSelectedIndices().size());
@@ -6058,7 +6057,7 @@ public class TreeTableViewTest {
             // number of items selected
             c.reset();
             c.next();
-            System.out.println("Added items: " + c.getAddedSubList());
+            //System.out.println("Added items: " + c.getAddedSubList());
             assertEquals(indices.length, c.getAddedSize());
             assertArrayEquals(indices, c.getAddedSubList().stream().mapToInt(i -> i).toArray());
         };
@@ -6375,7 +6374,6 @@ public class TreeTableViewTest {
         assertEquals(1, itemsEventCount.get());
 
         step.set(1);
-        System.out.println("about to collapse now");
         childNode1.setExpanded(false); // collapse Child Node 1 and expect both children to be deselected
         assertTrue(sm.isSelected(1));
         assertFalse(sm.isSelected(2));
@@ -6413,8 +6411,8 @@ public class TreeTableViewTest {
 
         view.expandedItemCountProperty().addListener((observable, oldCount, newCount) -> {
             if (childNode1.isExpanded()) return;
-            System.out.println(sm.getSelectedIndices());
-            System.out.println(sm.getSelectedItems());
+            //System.out.println(sm.getSelectedIndices());
+            //System.out.println(sm.getSelectedItems());
             assertTrue(sm.isSelected(1));
             assertFalse(sm.isSelected(2));
             assertFalse(sm.isSelected(3));

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewKeyInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewKeyInputTest.java
@@ -1537,7 +1537,7 @@ public class TreeViewKeyInputTest {
 
         treeView.editingItemProperty().addListener(observable -> {
             assertNotNull(treeView.getEditingItem());
-            System.out.println("editing item: " + treeView.getEditingItem());
+            //System.out.println("editing item: " + treeView.getEditingItem());
             rt32783_count++;
         });
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
@@ -1205,7 +1205,6 @@ public class TreeViewTest {
 
         treeView.getSelectionModel().getSelectedItems().addListener((ListChangeListener) c -> {
             while (c.next()) {
-                System.out.println(c);
                 rt_33559_count++;
             }
         });
@@ -1747,7 +1746,6 @@ public class TreeViewTest {
         textFieldTreeView.setCellFactory(TextFieldTreeCell.forTreeView());
         textFieldTreeView.setOnEditCancel(t -> {
             rt_35889_cancel_count++;
-            System.out.println("On Edit Cancel: " + t);
         });
 
         TreeCell cell0 = (TreeCell) VirtualFlowTestUtils.getCell(textFieldTreeView, 0);
@@ -1851,9 +1849,9 @@ public class TreeViewTest {
 
         final TreeView<String> treeView = new TreeView<String>(root);
 
-        treeView.getFocusModel().focusedIndexProperty().addListener((observable, oldValue, newValue) -> {
-            System.out.println("focusedIndex: " + oldValue + " to " + newValue);
-        });
+        //treeView.getFocusModel().focusedIndexProperty().addListener((observable, oldValue, newValue) -> {
+        //    System.out.println("focusedIndex: " + oldValue + " to " + newValue);
+        //});
 
         MultipleSelectionModel<TreeItem<String>> sm = treeView.getSelectionModel();
         FocusModel<TreeItem<String>> fm = treeView.getFocusModel();
@@ -2723,7 +2721,6 @@ public class TreeViewTest {
     private void test_rt_39482_selectRow(String expectedString,
                                          MultipleSelectionModel<TreeItem<String>> sm,
                                          int rowToSelect) {
-        System.out.println("\nSelect row " + rowToSelect);
         sm.selectAll();
         assertEquals(4, sm.getSelectedIndices().size());
         assertEquals(4, sm.getSelectedItems().size());
@@ -3480,7 +3477,6 @@ public class TreeViewTest {
             // number of items selected
             c.reset();
             c.next();
-            System.out.println("Added items: " + c.getAddedSubList());
             assertEquals(indices.length, c.getAddedSize());
             assertArrayEquals(indices, c.getAddedSubList().stream().mapToInt(i -> i).toArray());
         };
@@ -3625,7 +3621,6 @@ public class TreeViewTest {
         assertEquals(1, itemsEventCount.get());
 
         step.set(1);
-        System.out.println("about to collapse now");
         childNode1.setExpanded(false); // collapse Child Node 1 and expect both children to be deselected
         assertTrue(sm.isSelected(1));
         assertFalse(sm.isSelected(2));
@@ -3663,8 +3658,8 @@ public class TreeViewTest {
 
         view.expandedItemCountProperty().addListener((observable, oldCount, newCount) -> {
             if (childNode1.isExpanded()) return;
-            System.out.println(sm.getSelectedIndices());
-            System.out.println(sm.getSelectedItems());
+            //System.out.println(sm.getSelectedIndices());
+            //System.out.println(sm.getSelectedItems());
             assertTrue(sm.isSelected(1));
             assertFalse(sm.isSelected(2));
             assertFalse(sm.isSelected(3));


### PR DESCRIPTION
This is a test cleanup task. More details in the JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255497](https://bugs.openjdk.java.net/browse/JDK-8255497): [TestBug] Controls unit tests - clean up unnecessary prints on STANDARD_OUT


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/341/head:pull/341`
`$ git checkout pull/341`
