### PR TITLE
8254569: Remove hard dependency on Dispman in Monocle fb rendering

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/AcceleratedScreen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/AcceleratedScreen.java
@@ -33,10 +33,10 @@ public class AcceleratedScreen {
     private static long glesLibraryHandle;
     private static long eglLibraryHandle;
     private static boolean initialized = false;
-    private long eglSurface;
-    private long eglContext;
-    private long eglDisplay;
-    private long nativeWindow;
+    long eglSurface;
+    long eglContext;
+    long eglDisplay;
+    long nativeWindow;
     protected static final LinuxSystem ls = LinuxSystem.getLinuxSystem();
     private EGL egl;
     long eglConfigs[] = {0};
@@ -53,6 +53,14 @@ public class AcceleratedScreen {
      */
     protected long platformGetNativeWindow() {
         return 0L;
+    }
+
+    /**
+     * Create and initialize an AcceleratedScreen. Subclasses should override
+     * this constructor in case the {@link #AcceleratedScreen(int[]) AcceleratedScreen(int[])}
+     * constructor is not sufficient.
+     */
+    AcceleratedScreen() {
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLAcceleratedScreen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLAcceleratedScreen.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.glass.ui.monocle;
+
+/**
+ * The <code>EGLAcceleratedScreen</code> manages the link to the hardware-accelerated
+ * component, using EGL. This class is not directly using EGL commands,
+ * as the order and meaning of parameters might vary between implementations.
+ * Also, implementation-specific logic may be applied before, in between, or
+ * after the EGL commands.
+ */
+public class EGLAcceleratedScreen extends AcceleratedScreen {
+
+    private long eglWindowHandle = -1;
+
+    /**
+     * Create a new <code>EGLAcceleratedScreen</code> with a set of attributes.
+     * This will create an <code>EGL Context</code> that can be used by the
+     * Prism component.
+     * @param attributes an array of attributes that will be used by the underlying
+     *        implementation to get the best matching configuration.
+     */
+    EGLAcceleratedScreen(int[] attributes) throws GLException {
+        eglWindowHandle = platformGetNativeWindow();
+        eglDisplay = nGetEglDisplayHandle();
+        nEglInitialize(eglDisplay);
+        nEglBindApi(EGL.EGL_OPENGL_ES_API);
+        long eglConfig = nEglChooseConfig(eglDisplay, attributes);
+        eglSurface = nEglCreateWindowSurface(eglDisplay, eglConfig, eglWindowHandle);
+        eglContext = nEglCreateContext(eglDisplay, eglConfig);
+    }
+
+    @Override
+    protected long platformGetNativeWindow() {
+        String displayID = System.getProperty("egl.displayid", "/dev/dri/card1" );
+        return nPlatformGetNativeWindow(displayID);
+    }
+
+    public void enableRendering(boolean flag) {
+        if (flag) {
+            nEglMakeCurrent(eglDisplay, eglSurface, eglSurface,
+                                       eglContext);
+        } else {
+            nEglMakeCurrent(eglDisplay, 0, 0, eglContext);
+        }
+    }
+
+    public boolean swapBuffers() {
+        boolean result = false;
+        synchronized(NativeScreen.framebufferSwapLock) {
+            result = nEglSwapBuffers(eglDisplay, eglSurface);
+        }
+        return result;
+    }
+
+    private native long nPlatformGetNativeWindow(String displayID);
+    private native long nGetEglDisplayHandle();
+    private native boolean nEglInitialize(long handle);
+    private native boolean nEglBindApi(int v);
+    private native long nEglChooseConfig(long eglDisplay, int[] attribs);
+    private native boolean nEglMakeCurrent(long eglDisplay, long eglDrawSurface, long eglReadSurface, long eglContext);
+    private native long nEglCreateWindowSurface(long eglDisplay, long eglConfig, long nativeWindow);
+    private native long nEglCreateContext(long eglDisplay, long eglConfig);
+    private native boolean nEglSwapBuffers(long eglDisplay, long eglSurface);
+}

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLAcceleratedScreen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLAcceleratedScreen.java
@@ -48,6 +48,9 @@ public class EGLAcceleratedScreen extends AcceleratedScreen {
         nEglInitialize(eglDisplay);
         nEglBindApi(EGL.EGL_OPENGL_ES_API);
         long eglConfig = nEglChooseConfig(eglDisplay, attributes);
+        if (eglConfig == -1) {
+            throw new IllegalArgumentException("Could not create an EGLChooseConfig");
+        }
         eglSurface = nEglCreateWindowSurface(eglDisplay, eglConfig, eglWindowHandle);
         eglContext = nEglCreateContext(eglDisplay, eglConfig);
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLAcceleratedScreen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLAcceleratedScreen.java
@@ -61,6 +61,7 @@ public class EGLAcceleratedScreen extends AcceleratedScreen {
         return nPlatformGetNativeWindow(displayID);
     }
 
+    @Override
     public void enableRendering(boolean flag) {
         if (flag) {
             nEglMakeCurrent(eglDisplay, eglSurface, eglSurface,
@@ -72,7 +73,7 @@ public class EGLAcceleratedScreen extends AcceleratedScreen {
 
     public boolean swapBuffers() {
         boolean result = false;
-        synchronized(NativeScreen.framebufferSwapLock) {
+        synchronized (NativeScreen.framebufferSwapLock) {
             result = nEglSwapBuffers(eglDisplay, eglSurface);
         }
         return result;

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLAcceleratedScreen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLAcceleratedScreen.java
@@ -71,6 +71,7 @@ public class EGLAcceleratedScreen extends AcceleratedScreen {
         }
     }
 
+    @Override
     public boolean swapBuffers() {
         boolean result = false;
         synchronized (NativeScreen.framebufferSwapLock) {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLPlatform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLPlatform.java
@@ -34,13 +34,20 @@ public class EGLPlatform extends LinuxPlatform {
     public EGLPlatform() {
         String lib = System.getProperty("monocle.egl.lib");
         if (lib != null) {
-            LinuxSystem.getLinuxSystem().dlopen(lib, LinuxSystem.RTLD_LAZY | LinuxSystem.RTLD_GLOBAL);
+            long handle = LinuxSystem.getLinuxSystem().dlopen(lib, LinuxSystem.RTLD_LAZY | LinuxSystem.RTLD_GLOBAL);
+            if (handle == 0) {
+                throw new UnsatisfiedLinkError("EGLPlatform failed to load the requested library " + lib);
+            }
         }
     }
 
     @Override
     public synchronized AcceleratedScreen getAcceleratedScreen(int[] attributes) throws GLException {
-        return new EGLAcceleratedScreen(attributes);
+        if (accScreen == null) {
+            accScreen = new EGLAcceleratedScreen(attributes);
+        }
+        return accScreen;
+
     }
 
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLPlatform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLPlatform.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.glass.ui.monocle;
+
+public class EGLPlatform extends LinuxPlatform {
+
+    /**
+     * Create an <code>EGLPlatform</code>. If a library with specific native code is needed for this platform,
+     * it will be downloaded now. The system property <code>monocle.egl.lib</code> can be used to define the
+     * name of the library that should be loaded.
+     */
+    public EGLPlatform() {
+        String lib = System.getProperty("monocle.egl.lib");
+        if (lib != null) {
+            LinuxSystem.getLinuxSystem().dlopen(lib, LinuxSystem.RTLD_LAZY | LinuxSystem.RTLD_GLOBAL);
+        }
+    }
+
+    @Override
+    public synchronized AcceleratedScreen getAcceleratedScreen(int[] attributes) throws GLException {
+        return new EGLAcceleratedScreen(attributes);
+    }
+
+}

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLPlatformFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLPlatformFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.glass.ui.monocle;
+
+public class EGLPlatformFactory extends NativePlatformFactory {
+
+    @Override
+    protected boolean matches() {
+        return true;
+    }
+
+    @Override
+    protected int getMajorVersion() {
+        return 1;
+    }
+
+    @Override
+    protected int getMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    protected NativePlatform createNativePlatform() {
+        return new EGLPlatform();
+    }
+
+
+}

--- a/modules/javafx.graphics/src/main/native-glass/monocle/egl/eglBridge.c
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/egl/eglBridge.c
@@ -1,0 +1,86 @@
+/* Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+#include "com_sun_glass_ui_monocle_EGLAcceleratedScreen.h"
+#include "Monocle.h"
+#include "egl_ext.h"
+
+JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_monocle_EGLAcceleratedScreen_nPlatformGetNativeWindow
+    (JNIEnv *env, jobject obj, jstring cardId) {
+    const char *ccid = (*env)->GetStringUTFChars(env, cardId, NULL);
+    long answer = getNativeWindowHandle(ccid);
+    (*env)->ReleaseStringUTFChars(env, cardId, ccid);
+    return (jlong)answer;
+}
+
+JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_monocle_EGLAcceleratedScreen_nGetEglDisplayHandle
+    (JNIEnv *env, jobject obj) {
+    long answer = getEGLDisplayHandle();
+    return (jlong)answer;
+}
+
+JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_monocle_EGLAcceleratedScreen_nEglInitialize
+    (JNIEnv *env, jclass clazz, jlong eglDisplay) {
+    jboolean answer = doEglInitialize(asPtr(eglDisplay));
+    return answer;
+}
+
+JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_monocle_EGLAcceleratedScreen_nEglBindApi
+    (JNIEnv *env, jclass clazz, jint api) {
+    jboolean answer = doEglBindApi((int)api);
+    return answer;
+}
+
+JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_monocle_EGLAcceleratedScreen_nEglChooseConfig
+    (JNIEnv *env, jclass clazz, jlong eglDisplay, jintArray attribs) {
+    jint *attrArray = (*env)->GetIntArrayElements(env, attribs, JNI_FALSE);
+    jlong answer = doEglChooseConfig(eglDisplay, attrArray);
+    (*env)->ReleaseIntArrayElements(env, attribs, attrArray, JNI_ABORT);
+    return answer;
+}
+
+JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_monocle_EGLAcceleratedScreen_nEglCreateWindowSurface
+    (JNIEnv *env, jclass clazz, jlong eglDisplay, jlong config, jlong nativeWindow) {
+    jlong answer = doEglCreateWindowSurface(eglDisplay, config, nativeWindow);
+    return answer;
+}
+
+JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_monocle_EGLAcceleratedScreen_nEglCreateContext
+ (JNIEnv *UNUSED(env), jclass UNUSED(clazz), jlong eglDisplay, jlong config) {
+    jlong answer = doEglCreateContext(eglDisplay, config);
+    return answer;
+}
+
+JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_monocle_EGLAcceleratedScreen_nEglMakeCurrent
+   (JNIEnv *UNUSED(env), jclass UNUSED(clazz), jlong eglDisplay, jlong drawSurface,
+    jlong readSurface, jlong eglContext) {
+    jlong answer = doEglMakeCurrent(eglDisplay, drawSurface, readSurface, eglContext);
+    return answer;
+}
+
+JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_monocle_EGLAcceleratedScreen_nEglSwapBuffers
+    (JNIEnv *UNUSED(env), jclass UNUSED(clazz), jlong eglDisplay, jlong eglSurface)  {
+    jlong answer = doEglSwapBuffers(eglDisplay, eglSurface);
+    return answer;
+}
+

--- a/modules/javafx.graphics/src/main/native-glass/monocle/egl/eglBridge.c
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/egl/eglBridge.c
@@ -35,7 +35,7 @@ JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_monocle_EGLAcceleratedScreen_nPlat
 
 JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_monocle_EGLAcceleratedScreen_nGetEglDisplayHandle
     (JNIEnv *env, jobject obj) {
-    long answer = getEGLDisplayHandle();
+    long answer = getEglDisplayHandle();
     return (jlong)answer;
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/monocle/egl/eglBridge.c
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/egl/eglBridge.c
@@ -54,6 +54,10 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_monocle_EGLAcceleratedScreen_nE
 JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_monocle_EGLAcceleratedScreen_nEglChooseConfig
     (JNIEnv *env, jclass clazz, jlong eglDisplay, jintArray attribs) {
     jint *attrArray = (*env)->GetIntArrayElements(env, attribs, JNI_FALSE);
+    if (attrArray == 0) {
+        fprintf(stderr, "Fatal error getting int* from int[]\n");
+        return -1;
+    }
     jlong answer = doEglChooseConfig(eglDisplay, attrArray);
     (*env)->ReleaseIntArrayElements(env, attribs, attrArray, JNI_ABORT);
     return answer;

--- a/modules/javafx.graphics/src/main/native-glass/monocle/egl/egl_ext.h
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/egl/egl_ext.h
@@ -10,7 +10,7 @@ extern jlong doEglCreateWindowSurface (jlong eglDisplay, jlong config,
 
 extern jlong doEglCreateContext (jlong eglDisplay, jlong config);
 
-extern jboolean doEglMakeCurrent (jlong eglDisplay, jlong drawSurface, 
+extern jboolean doEglMakeCurrent (jlong eglDisplay, jlong drawSurface,
      jlong readSurface, jlong eglContext);
 
 extern jboolean doEglSwapBuffers(jlong eglDisplay, jlong eglSurface);

--- a/modules/javafx.graphics/src/main/native-glass/monocle/egl/egl_ext.h
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/egl/egl_ext.h
@@ -1,3 +1,29 @@
+/*
+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+#ifndef __EGL_EXT__
+#define __EGL_EXT__
 #include <jni.h>
 extern long getNativeWindowHandle(const char *v);
 extern long getEGLDisplayHandle();
@@ -14,3 +40,4 @@ extern jboolean doEglMakeCurrent (jlong eglDisplay, jlong drawSurface,
      jlong readSurface, jlong eglContext);
 
 extern jboolean doEglSwapBuffers(jlong eglDisplay, jlong eglSurface);
+#endif // EGL_EXT

--- a/modules/javafx.graphics/src/main/native-glass/monocle/egl/egl_ext.h
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/egl/egl_ext.h
@@ -25,18 +25,18 @@
 #ifndef __EGL_EXT__
 #define __EGL_EXT__
 #include <jni.h>
-extern long getNativeWindowHandle(const char *v);
-extern long getEGLDisplayHandle();
+extern jlong getNativeWindowHandle(const char *v);
+extern jlong getEglDisplayHandle();
 extern jboolean doEglInitialize(void* handle);
 extern jboolean doEglBindApi(int api);
-extern jlong doEglChooseConfig (long eglDisplay, int* attribs);
+extern jlong doEglChooseConfig (jlong eglDisplay, int* attribs);
 
-extern jlong doEglCreateWindowSurface (jlong eglDisplay, jlong config,
+extern jlong doEglCreateWindowSurface(jlong eglDisplay, jlong config,
      jlong nativeWindow);
 
-extern jlong doEglCreateContext (jlong eglDisplay, jlong config);
+extern jlong doEglCreateContext(jlong eglDisplay, jlong config);
 
-extern jboolean doEglMakeCurrent (jlong eglDisplay, jlong drawSurface,
+extern jboolean doEglMakeCurrent(jlong eglDisplay, jlong drawSurface,
      jlong readSurface, jlong eglContext);
 
 extern jboolean doEglSwapBuffers(jlong eglDisplay, jlong eglSurface);

--- a/modules/javafx.graphics/src/main/native-glass/monocle/egl/egl_ext.h
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/egl/egl_ext.h
@@ -1,0 +1,16 @@
+#include <jni.h>
+extern long getNativeWindowHandle(const char *v);
+extern long getEGLDisplayHandle();
+extern jboolean doEglInitialize(void* handle);
+extern jboolean doEglBindApi(int api);
+extern jlong doEglChooseConfig (long eglDisplay, int* attribs);
+
+extern jlong doEglCreateWindowSurface (jlong eglDisplay, jlong config,
+     jlong nativeWindow);
+
+extern jlong doEglCreateContext (jlong eglDisplay, jlong config);
+
+extern jboolean doEglMakeCurrent (jlong eglDisplay, jlong drawSurface, 
+     jlong readSurface, jlong eglContext);
+
+extern jboolean doEglSwapBuffers(jlong eglDisplay, jlong eglSurface);

--- a/modules/javafx.graphics/src/main/native-prism-es2/monocle/MonocleGLFactory.c
+++ b/modules/javafx.graphics/src/main/native-prism-es2/monocle/MonocleGLFactory.c
@@ -108,6 +108,9 @@ JNIEXPORT jlong JNICALL Java_com_sun_prism_es2_MonocleGLFactory_nPopulateNativeC
 
     // from the eglWrapper.c
     void *handle = asPtr(libraryHandle);
+    if (libraryHandle == 0) {
+         handle = RTLD_DEFAULT;
+    }
 
     /* set function pointers */
     ctxInfo->glActiveTexture = (PFNGLACTIVETEXTUREPROC)

--- a/modules/javafx.graphics/src/main/native-prism-es2/monocle/MonocleGLFactory.c
+++ b/modules/javafx.graphics/src/main/native-prism-es2/monocle/MonocleGLFactory.c
@@ -35,6 +35,10 @@
 #include "../PrismES2Defs.h"
 
 #include "com_sun_prism_es2_MonocleGLContext.h"
+#ifndef ANDROID
+#define __USE_GNU
+#include <dlfcn.h>
+#endif
 
 extern void *get_dlsym(void *handle, const char *symbol, int warn);
 


### PR DESCRIPTION
Allow the EGL functionality in monocle to leverage EGL-based systems. The low-level specific details about how the EGL calls should be constructed are left out, and a native interface (egl_ext.h) is created that can be mapped to any low-level system.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254569](https://bugs.openjdk.java.net/browse/JDK-8254569): Remove hard dependency on Dispman in Monocle fb rendering


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Jose Pereda](https://openjdk.java.net/census#jpereda) (@jperedadnr - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/343/head:pull/343`
`$ git checkout pull/343`
