### PR TITLE
8255714: Switch FX build to use JDK 15.0.1 as boot JDK

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -58,9 +58,9 @@ jobs:
       # BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_FILENAME }}"
       # BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_URL }}"
       # BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
-      BOOT_JDK_VERSION: "15"
-      BOOT_JDK_FILENAME: "openjdk-15_linux-x64_bin.tar.gz"
-      BOOT_JDK_URL: "https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_linux-x64_bin.tar.gz"
+      BOOT_JDK_VERSION: "15.0.1"
+      BOOT_JDK_FILENAME: "openjdk-15.0.1_linux-x64_bin.tar.gz"
+      BOOT_JDK_URL: "https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz"
 
     steps:
       - name: Checkout the source
@@ -129,9 +129,9 @@ jobs:
       # BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_FILENAME }}"
       # BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_URL }}"
       # BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
-      BOOT_JDK_VERSION: "15"
-      BOOT_JDK_FILENAME: "openjdk-15_osx-x64_bin.tar.gz"
-      BOOT_JDK_URL: "https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_osx-x64_bin.tar.gz"
+      BOOT_JDK_VERSION: "15.0.1"
+      BOOT_JDK_FILENAME: "openjdk-15.0.1_osx-x64_bin.tar.gz"
+      BOOT_JDK_URL: "https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_osx-x64_bin.tar.gz"
 
     steps:
       - name: Checkout the source
@@ -200,9 +200,9 @@ jobs:
       # BOOT_JDK_FILENAME: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_FILENAME }}"
       # BOOT_JDK_URL: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_URL }}"
       # BOOT_JDK_SHA256: "${{ fromJson(needs.prerequisites.outputs.dependencies).LINUX_X64_BOOT_JDK_SHA256 }}"
-      BOOT_JDK_VERSION: "15"
-      BOOT_JDK_FILENAME: "openjdk-15_windows-x64_bin.zip"
-      BOOT_JDK_URL: "https://download.java.net/java/GA/jdk15/779bf45e88a44cbd9ea6621d33e33db1/36/GPL/openjdk-15_windows-x64_bin.zip"
+      BOOT_JDK_VERSION: "15.0.1"
+      BOOT_JDK_FILENAME: "openjdk-15.0.1_windows-x64_bin.zip"
+      BOOT_JDK_URL: "https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_windows-x64_bin.zip"
       # FIXME: hard-code the location and version of VS 2019 for now
       VS150COMNTOOLS: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build"
       MSVC_VER: "14.27.29110"

--- a/build.properties
+++ b/build.properties
@@ -73,8 +73,8 @@ javadoc.header=JavaFX&nbsp;16
 ##############################################################################
 
 # JDK
-jfx.build.jdk.version=15
-jfx.build.jdk.buildnum=36
+jfx.build.jdk.version=15.0.1
+jfx.build.jdk.buildnum=9
 jfx.build.jdk.version.min=11
 jfx.build.jdk.buildnum.min=28
 


### PR DESCRIPTION
Bump the boot JDK used to build JavaFX to 15.0.1. This does not change the minimum boot JDK which remains at JDK 11.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Issue
 * [JDK-8255714](https://bugs.openjdk.java.net/browse/JDK-8255714): Switch FX build to use JDK 15.0.1 as boot JDK


### Reviewers
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/347/head:pull/347`
`$ git checkout pull/347`
