### PR TITLE
8177945: Single cell selection flickers when adding data to TableView

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ListViewSkin.java
@@ -358,6 +358,8 @@ public class ListViewSkin<T> extends VirtualContainerBase<ListView<T>, ListCell<
         updatePlaceholderRegionVisibility();
         if (newCount == oldCount) {
             needCellsReconfigured = true;
+        } else if (oldCount == 0) {
+            requestRebuildCells();
         }
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ListViewSkin.java
@@ -356,9 +356,7 @@ public class ListViewSkin<T> extends VirtualContainerBase<ListView<T>, ListCell<
         flow.setCellCount(newCount);
 
         updatePlaceholderRegionVisibility();
-        if (newCount != oldCount) {
-            requestRebuildCells();
-        } else {
+        if (newCount == oldCount) {
             needCellsReconfigured = true;
         }
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
@@ -553,14 +553,11 @@ public abstract class TableViewSkinBase<M, S, C extends Control, I extends Index
         // optimised in the future when time permits.
         flow.setCellCount(newCount);
 
-        if (newCount != oldCount) {
-            // FIXME updateItemCount is called _a lot_. Perhaps we can make rebuildCells
-            // smarter. Imagine if items has one million items added - do we really
-            // need to rebuildCells a million times? Maybe this is better now that
-            // we do rebuildCells instead of recreateCells.
-            requestRebuildCells();
-        } else {
+        if (newCount == oldCount) {
             needCellsReconfigured = true;
+        } else if (oldCount == 0) {
+            // see comments above, this is used as an alternative to flow.setDirtyCell(int)
+            requestRebuildCells();
         }
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
@@ -1111,12 +1111,12 @@ public class ListViewTest {
                     items.remove(12);
                     Platform.runLater(() -> {
                         Toolkit.getToolkit().firePulse();
-                        assertEquals(useFixedCellSize ? 39 : 45, rt_35395_counter);
+                        assertEquals(useFixedCellSize ? 5 : 7, rt_35395_counter);
                         rt_35395_counter = 0;
                         items.add(12, "yellow");
                         Platform.runLater(() -> {
                             Toolkit.getToolkit().firePulse();
-                            assertEquals(useFixedCellSize ? 39 : 45, rt_35395_counter);
+                            assertEquals(useFixedCellSize ? 5 : 7, rt_35395_counter);
                             rt_35395_counter = 0;
                             listView.scrollTo(5);
                             Platform.runLater(() -> {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -5478,8 +5478,8 @@ public class TableViewTest {
         sl.dispose();
     }
 
-    @Test
     // see JDK-8177945
+    @Test
     public void test_addingNewItemsDoesNotChangePseudoClassSelectedState() {
         TableColumn firstNameCol = new TableColumn("First Name");
         firstNameCol.setCellValueFactory(new PropertyValueFactory<Person, String>("firstName"));


### PR DESCRIPTION
As discussed in the JBS [issue](https://bugs.openjdk.java.net/browse/JDK-8177945), there are some inconsistencies in the use of `VirtualContainerBase::requestRebuildCells` from `VirtualContainerBase::updateItemCount()`, which is implemented in the different skin classes for virtualised controls `TableViewSkinBase`, `ListViewSkin` or `TreeTableViewSkin`.

The latter already commented out this call (related to JDK-8155798 and JDK-8147483). 

This PR removes now the calls to `VirtualContainerBase::requestRebuildCells` from `TableViewSkinBase`  (except for the case `itemCount = 0` based on JDK-8118897 and JDK-8098235) and `ListViewSkin`.

A test is provided for TableView, that verifies that the `selected` pseudo-class state remains set for the selected cell while adding more items. Without this fix, as the cells are rebuilt, the pseudo-class states are clean and set all over again, thus the flickering.

For ListView, the test rt_35395 (JDK-8091726) is updated, as now there are way less calls to updateItem.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Issue
 * [JDK-8177945](https://bugs.openjdk.java.net/browse/JDK-8177945): Single cell selection flickers when adding data to TableView


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/348/head:pull/348`
`$ git checkout pull/348`
