### PR TITLE
8199592: Control labels truncated at certain DPI scaling levels

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/stage/Window.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/Window.java
@@ -1080,12 +1080,6 @@ public class Window implements EventTarget {
                     // Register pulse listener
                     tk.addStageTkPulseListener(peerBoundsConfigurator);
 
-                    if (getScene() != null) {
-                        SceneHelper.initPeer(getScene());
-                        peer.setScene(SceneHelper.getPeer(getScene()));
-                        SceneHelper.preferredSize(getScene());
-                    }
-
                     updateOutputScales(peer.getOutputScaleX(), peer.getOutputScaleY());
                     // updateOutputScales may cause an update to the render
                     // scales in many cases, but if the scale has not changed
@@ -1097,6 +1091,12 @@ public class Window implements EventTarget {
                     // forced setSize and setLocation down below.
                     peerBoundsConfigurator.setRenderScaleX(getRenderScaleX());
                     peerBoundsConfigurator.setRenderScaleY(getRenderScaleY());
+
+                    if (getScene() != null) {
+                        SceneHelper.initPeer(getScene());
+                        peer.setScene(SceneHelper.getPeer(getScene()));
+                        SceneHelper.preferredSize(getScene());
+                    }
 
                     // Set peer bounds
                     if ((getScene() != null) && (!widthExplicit || !heightExplicit)) {

--- a/tests/system/src/test/java/test/javafx/scene/UIRenderSceneTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/UIRenderSceneTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.javafx.scene;
+
+import com.sun.javafx.PlatformUtil;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.CheckBox;
+import javafx.scene.layout.HBox;
+import javafx.scene.text.Text;
+import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
+import junit.framework.Assert;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+public class UIRenderSceneTest {
+    private static CountDownLatch startupLatch;
+    private static volatile Stage stage;
+    private static final double scale = 1.75;
+
+    public static class TestApp extends Application {
+
+        @Override
+        public void start(Stage primaryStage) throws Exception {
+            final HBox box = new HBox();
+            box.setAlignment(Pos.CENTER);
+            box.setPadding(new Insets(8));
+            box.setSpacing(8);
+
+            for (int i = 0; i < 4; i++) {
+                box.getChildren().add(new CheckBox("Check"));
+            }
+            Scene scene = new Scene(box);
+            primaryStage.setScene(scene);
+            stage = primaryStage;
+            stage.addEventHandler(WindowEvent.WINDOW_SHOWN,
+                    e -> Platform.runLater(startupLatch::countDown));
+            stage.show();
+        }
+    }
+
+    @BeforeClass
+    public static void setupOnce() {
+        System.setProperty("glass.win.uiScale", String.valueOf(scale));
+        System.setProperty("glass.gtk.uiScale", String.valueOf(scale));
+        startupLatch = new CountDownLatch(1);
+        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
+        try {
+            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
+                fail("Timeout waiting for FX runtime to start");
+            }
+        } catch (InterruptedException ex) {
+            fail("Unexpected exception: " + ex);
+        }
+    }
+
+    @Test
+    public void testCheckBoxTextDoesNotHaveEllipsis() {
+        assumeTrue(PlatformUtil.isLinux() || PlatformUtil.isWindows());
+
+        Assert.assertEquals("Wrong render scale", scale,
+                stage.getRenderScaleY(), 0.0001);
+
+        for (Node node : stage.getScene().getRoot().getChildrenUnmodifiable()) {
+            CheckBox box = (CheckBox) node;
+            Assert.assertEquals("Wrong text", "Check", ((Text) box.lookup(".text")).getText());
+        }
+    }
+
+    @AfterClass
+    public static void teardown() {
+        Platform.runLater(stage::hide);
+        Platform.exit();
+    }
+}

--- a/tests/system/src/test/java/test/javafx/scene/UIRenderSceneTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/UIRenderSceneTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 public class UIRenderSceneTest {
@@ -74,18 +75,13 @@ public class UIRenderSceneTest {
     }
 
     @BeforeClass
-    public static void setupOnce() {
+    public static void setupOnce() throws Exception {
         System.setProperty("glass.win.uiScale", String.valueOf(scale));
         System.setProperty("glass.gtk.uiScale", String.valueOf(scale));
         startupLatch = new CountDownLatch(1);
         new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        try {
-            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
-                fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            fail("Unexpected exception: " + ex);
-        }
+        assertTrue("Timeout waiting for FX runtime to start",
+                startupLatch.await(15, TimeUnit.SECONDS));
     }
 
     @Test


### PR DESCRIPTION
As commented in the [JBS issue](https://bugs.openjdk.java.net/browse/JDK-8199592), the default UI scale 1.0 is used to perform initial calculations of preferred sizes of the scene, even if the scale has already a different value (i.e 175%). As a workaround, calling `Stage::sizeToScene` fix it, as it forces to do new calculations but now with the correct UI scale.

This PR moves the call to `Window::updateOutputScales` before the scene initialization takes place, so the UI scale is correctly set for the initial preferred size of the scene, and no workaround is required.

It also provides a system test that can be tested on Linux and Windows. Before applying the fix, the `Check` text of the checkboxes is rendered as `Che...`. With the fix, the test verifies, for a given UI scale, that the rendered text is `Check`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ❌ (1/1 failed) | ✔️ (1/1 passed) |

**Failed test task**
- [Windows x64](https://github.com/jperedadnr/jfx/runs/1430462292)

### Issue
 * [JDK-8199592](https://bugs.openjdk.java.net/browse/JDK-8199592): Control labels truncated at certain DPI scaling levels


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/351/head:pull/351`
`$ git checkout pull/351`
