### PR TITLE
8256184: Openjfx build broken (Eclipse)

### DIFF
--- a/modules/javafx.base/.classpath
+++ b/modules/javafx.base/.classpath
@@ -11,6 +11,8 @@
 		<attributes>
 			<attribute name="test" value="true"/>
 			<attribute name="optional" value="true"/>
+			<attribute name="module" value="true"/>
+			<attribute name="add-reads" value="javafx.base=java.management:javafx.base=jdk.management"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4">

--- a/modules/javafx.controls/.classpath
+++ b/modules/javafx.controls/.classpath
@@ -28,7 +28,7 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/base">
 		<attributes>
 			<attribute name="module" value="true"/>
-			<attribute name="add-exports" value="javafx.base/test.com.sun.javafx.binding=javafx.controls"/>
+			<attribute name="add-exports" value="javafx.base/test.com.sun.javafx.binding=javafx.controls:javafx.base/test.util.memory=javafx.controls"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4">

--- a/tests/.classpath
+++ b/tests/.classpath
@@ -36,7 +36,7 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/base">
 		<attributes>
 			<attribute name="module" value="true"/>
-			<attribute name="add-exports" value="javafx.base/com.sun.javafx=ALL-UNNAMED"/>
+			<attribute name="add-exports" value="javafx.base/com.sun.javafx=ALL-UNNAMED:javafx.base/test.util.memory=ALL-UNNAMED"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry combineaccessrules="false" kind="src" path="/controls">


### PR DESCRIPTION
Issue was broken build in Eclipse after fix of [JDK-8244297](https://bugs.openjdk.java.net/browse/JDK-8244297): 

- the new memory test class requires jdk.management/java.management
- users of the test class (in controls) need access to its package

Changed .classpath files in base and controls to fix this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ❌ (1/1 failed) | ❌ (1/1 failed) | ✔️ (1/1 passed) |

**Failed test tasks**
- [Linux x64](https://github.com/kleopatra/jfx/runs/1435434878)
- [Windows x64](https://github.com/kleopatra/jfx/runs/1435434908)

### Issue
 * [JDK-8256184](https://bugs.openjdk.java.net/browse/JDK-8256184): Openjfx build broken (Eclipse)


### Reviewers
 * [Nir Lisker](https://openjdk.java.net/census#nlisker) (@nlisker - **Reviewer**)

### Contributors
 * Nir Lisker `<nlisker@openjdk.org>`

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/352/head:pull/352`
`$ git checkout pull/352`
