### PR TITLE
8256362: JavaFX must warn when the javafx.* modules are loaded from the classpath

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
@@ -31,8 +31,10 @@ import com.sun.javafx.css.StyleManager;
 import com.sun.javafx.tk.TKListener;
 import com.sun.javafx.tk.TKStage;
 import com.sun.javafx.tk.Toolkit;
+import com.sun.javafx.util.Logging;
 import com.sun.javafx.util.ModuleHelper;
 
+import java.lang.module.ModuleDescriptor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.AccessControlContext;
@@ -185,6 +187,23 @@ public class PlatformImpl {
             // If we've already initialized, just put the runnable on the queue.
             runLater(r);
             return;
+        }
+
+        final Module module = PlatformImpl.class.getModule();
+        final ModuleDescriptor moduleDesc = module.getDescriptor();
+        if (!module.isNamed()
+                || !"javafx.graphics".equals(module.getName())
+                || moduleDesc == null
+                || moduleDesc.isAutomatic()
+                || moduleDesc.isOpen()) {
+
+            String warningStr = "Unsupported JavaFX configuration: "
+                + "classes were loaded from '" + module + "'";
+            if (moduleDesc != null) {
+                warningStr += ", isAutomatic: " + moduleDesc.isAutomatic();
+                warningStr += ", isOpen: " + moduleDesc.isOpen();
+            }
+            Logging.getJavaFXLogger().warning(warningStr);
         }
 
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {

--- a/modules/javafx.graphics/src/main/java/javafx/application/Application.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Application.java
@@ -80,6 +80,12 @@ import com.sun.javafx.css.StyleManager;
  * {@link #stop} method returns or {@link System#exit} is called.
  * </p>
  *
+ * <p><b>Note:</b> The JavaFX classes must be loaded from a set of
+ * named {@code javafx.*} modules on the <em>module path</em>.
+ * Loading the JavaFX classes from the classpath is not supported.
+ * See {@link Platform#startup(Runnable) Platform.startup}
+ * for more information.
+ *
  * <p><b>Deploying an Application as a Module</b></p>
  * <p>
  * If the {@code Application} subclass is in a named module then that class

--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -90,6 +90,14 @@ public final class Platform {
      * that the JavaFX runtime be started once.
      * </p>
      *
+     * <p><b>Note:</b> The JavaFX classes must be loaded from a set of
+     * named {@code javafx.*} modules on the <em>module path</em>.
+     * Loading the JavaFX classes from the classpath is not supported.
+     * A warning is logged when the JavaFX runtime is started if the JavaFX
+     * classes are not loaded from the expected named module.
+     * This warning is logged regardless of whether the JavaFX runtime was
+     * started by calling this method or automatically as described above.
+     *
      * @throws IllegalStateException if the JavaFX runtime is already running
      *
      * @param runnable the Runnable whose run method will be executed on the

--- a/modules/javafx.graphics/src/main/java/module-info.java
+++ b/modules/javafx.graphics/src/main/java/module-info.java
@@ -30,6 +30,12 @@
  * as well as APIs for animation, css, concurrency, geometry, printing, and
  * windowing.
  *
+ * <p><b>Note:</b> The JavaFX classes must be loaded from a set of
+ * named {@code javafx.*} modules on the <em>module path</em>.
+ * Loading the JavaFX classes from the classpath is not supported.
+ * See {@link javafx.application.Platform#startup(Runnable) Platform.startup}
+ * for more information.
+ *
  * @moduleGraph
  * @since 9
  */


### PR DESCRIPTION
This fix adds documentation and a warning to clarify that loading the JavaFX modules from the classpath is not a supported configuration. This will not affect deployments that put the JavaFX modular jars on the classpath, but will simply warn that it is an unsupported mode.

JavaFX is built and distributed as a set of named modules, each in its own modular jar file. This supports running both modular and non-modular applications.

The JavaFX runtime expects its classes to be loaded from a set of named `javafx.*` modules, and does not support loading those modules from the classpath. The Java launcher will fail to load applications that extend `javafx.application.Application` unless the `javafx.graphics` module is on the module path.

Applications that do not extend `javafx.application.Application` can be loaded even if the `javafx.*` classes are loaded from the classpath, but this is an unsupported configuration.

This creates the perception that there is a problem with the standard case of loading a subclass of `javafx.application.Application`, since it fails to load in the case where the JavaFX classes are loaded from the classpath. Further, allowing applications to run in an unsupported mode that likely has bugs creates a maintenance burden. Another problem is that when the JavaFX classes are loaded from the classpath, it breaks encapsulation, since we mo longer get the benefit of the java module system.

The primary reason given for application deployments loading the javafx modules on the classpath usually boils down to one of tooling support, although both gradle and maven now support modules as do all of the popular IDEs.

/csr needed
/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256362](https://bugs.openjdk.java.net/browse/JDK-8256362): JavaFX must warn when the javafx.* modules are loaded from the classpath


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - Committer)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/354/head:pull/354`
`$ git checkout pull/354`
