### PR TITLE
8256649: Parameterized tests must not use instances as parameters

### DIFF
--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorMemoryLeakTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorMemoryLeakTest.java
@@ -28,7 +28,6 @@ package test.com.sun.javafx.scene.control.behavior;
 import java.lang.ref.WeakReference;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.After;
 import org.junit.Before;
@@ -42,14 +41,12 @@ import static org.junit.Assert.*;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory.*;
 
 import javafx.scene.control.Control;
-import javafx.scene.control.ListView;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TreeTableView;
 import javafx.scene.control.TreeView;
-import test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory;
 
 /**
  * Test for memory leaks in Behavior implementations.
@@ -59,6 +56,7 @@ import test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory;
 @RunWith(Parameterized.class)
 public class BehaviorMemoryLeakTest {
 
+    private Class<Control> controlClass;
     private Control control;
 
     /**
@@ -93,15 +91,11 @@ public class BehaviorMemoryLeakTest {
          );
         // remove the known issues to make the test pass
         controlClasses.removeAll(leakingClasses);
-        // instantiate controls
-        List<Control> controls = controlClasses.stream()
-                .map(ControlSkinFactory::createControl)
-                .collect(Collectors.toList());
-        return asArrays(controls);
+        return asArrays(controlClasses);
     }
 
-    public BehaviorMemoryLeakTest(Control control) {
-        this.control = control;
+    public BehaviorMemoryLeakTest(Class<Control> controlClass) {
+        this.controlClass = controlClass;
     }
 
 //------------------- setup
@@ -120,6 +114,7 @@ public class BehaviorMemoryLeakTest {
                 Thread.currentThread().getThreadGroup().uncaughtException(thread, throwable);
             }
         });
+        control = createControl(controlClass);
         assertNotNull(control);
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinMemoryLeakTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinMemoryLeakTest.java
@@ -28,7 +28,6 @@ package test.javafx.scene.control.skin;
 import java.lang.ref.WeakReference;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.junit.After;
 import org.junit.Before;
@@ -63,7 +62,6 @@ import javafx.scene.control.TextField;
 import javafx.scene.control.TreeTableRow;
 import javafx.scene.control.TreeTableView;
 import javafx.scene.control.TreeView;
-import test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory;
 
 /**
  * Test memory leaks in Skin implementations.
@@ -73,6 +71,7 @@ import test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory;
 @RunWith(Parameterized.class)
 public class SkinMemoryLeakTest {
 
+    private Class<Control> controlClass;
     private Control control;
 
 //--------- tests
@@ -129,15 +128,11 @@ public class SkinMemoryLeakTest {
         );
         // remove the known issues to make the test pass
         controlClasses.removeAll(leakingClasses);
-        // instantiate controls
-        List<Control> controls = controlClasses.stream()
-                .map(ControlSkinFactory::createControl)
-                .collect(Collectors.toList());
-        return asArrays(controls);
+        return asArrays(controlClasses);
     }
 
-    public SkinMemoryLeakTest(Control control) {
-        this.control = control;
+    public SkinMemoryLeakTest(Class<Control> controlClass) {
+        this.controlClass = controlClass;
     }
 
 //------------ setup
@@ -151,6 +146,7 @@ public class SkinMemoryLeakTest {
                 Thread.currentThread().getThreadGroup().uncaughtException(thread, throwable);
             }
         });
+        this.control = createControl(controlClass);
         assertNotNull(control);
     }
 


### PR DESCRIPTION
the issue was an (my ;) overzealous refactoring when introducing support for cross-control testing for memory leaks on switching skins.

Fixed by
- using control class as parameter
- instantiate the control at setup time

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ❌ (1/1 failed) | ✔️ (1/1 passed) |

**Failed test task**
- [Windows x64](https://github.com/kleopatra/jfx/runs/1424948381)

### Issue
 * [JDK-8256649](https://bugs.openjdk.java.net/browse/JDK-8256649): Parameterized tests must not use instances as parameters


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/356/head:pull/356`
`$ git checkout pull/356`
