### PR TITLE
8256686: GitHub actions: build fails due to upgraded MSVC compiler

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -205,7 +205,7 @@ jobs:
       BOOT_JDK_URL: "https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_windows-x64_bin.zip"
       # FIXME: hard-code the location and version of VS 2019 for now
       VS150COMNTOOLS: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build"
-      MSVC_VER: "14.27.29110"
+      MSVC_VER: "14.28.29333"
 
     steps:
       - name: Checkout the source


### PR DESCRIPTION
Simple fix to get GitHub actions working again on Windows. In parallel I will bump the priority of [JDK-8255713](https://bugs.openjdk.java.net/browse/JDK-8255713) so we will detect the version of the compiler and not be sensitive to changes like this on the target machine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Issue
 * [JDK-8256686](https://bugs.openjdk.java.net/browse/JDK-8256686): GitHub actions: build fails due to upgraded MSVC compiler


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/357/head:pull/357`
`$ git checkout pull/357`
