### PR TITLE
8256821: TreeViewSkin/Behavior: misbehavior on switching skin

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TreeViewBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TreeViewBehavior.java
@@ -154,14 +154,6 @@ public class TreeViewBehavior<T> extends BehaviorBase<TreeView<T>> {
     public TreeViewBehavior(TreeView<T> control) {
         super(control);
 
-//        // Fix for RT-16565
-//        getNode().selectionModelProperty().addListener(weakSelectionModelListener);
-//        if (control.getSelectionModel() != null) {
-//            control.getSelectionModel().getSelectedIndices().addListener(weakSelectedIndicesListener);
-//        }
-
-
-
         // create a map for treeView-specific mappings
         treeViewInputMap = createInputMap();
 
@@ -255,6 +247,12 @@ public class TreeViewBehavior<T> extends BehaviorBase<TreeView<T>> {
     }
 
     @Override public void dispose() {
+        getNode().selectionModelProperty().removeListener(weakSelectionModelListener);
+        MultipleSelectionModel<TreeItem<T>> sm = getNode().getSelectionModel();
+        if (sm != null) {
+            sm.getSelectedIndices().removeListener(weakSelectedIndicesListener);
+        }
+        getNode().removeEventFilter(KeyEvent.ANY, keyEventListener);
         TreeCellBehavior.removeAnchor(getNode());
         super.dispose();
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeViewSkin.java
@@ -136,6 +136,10 @@ public class TreeViewSkin<T> extends VirtualContainerBase<TreeView<T>, TreeCell<
 
 
 
+    private EventHandler<MouseEvent> ml;
+
+
+
     /***************************************************************************
      *                                                                         *
      * Constructors                                                            *
@@ -165,7 +169,7 @@ public class TreeViewSkin<T> extends VirtualContainerBase<TreeView<T>, TreeCell<
 
         setRoot(getSkinnable().getRoot());
 
-        EventHandler<MouseEvent> ml = event -> {
+        ml = event -> {
             // RT-15127: cancel editing on scroll. This is a bit extreme
             // (we are cancelling editing on touching the scrollbars).
             // This can be improved at a later date.
@@ -226,6 +230,17 @@ public class TreeViewSkin<T> extends VirtualContainerBase<TreeView<T>, TreeCell<
 
     /** {@inheritDoc} */
     @Override public void dispose() {
+        if (getSkinnable() == null) return;
+
+        getSkinnable().getProperties().removeListener(propertiesMapListener);
+        setRoot(null);
+        // leaking without nulling factory
+        flow.setCellFactory(null);
+        // for completeness - but no effect with/out? Same as in ListViewSkin
+        // don't without seeing any effect - it's not on the skinnable, but on a child, so shouldn't
+        flow.getVbar().removeEventFilter(MouseEvent.MOUSE_PRESSED, ml);
+        flow.getHbar().removeEventFilter(MouseEvent.MOUSE_PRESSED, ml);
+
         super.dispose();
 
         if (behavior != null) {

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorCleanupTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorCleanupTest.java
@@ -39,6 +39,8 @@ import static org.junit.Assert.*;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory.*;
 
 import javafx.scene.control.ListView;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeView;
 
 /**
  * Test for misbehavior of individual implementations that turned
@@ -46,6 +48,51 @@ import javafx.scene.control.ListView;
  *
  */
 public class BehaviorCleanupTest {
+
+//----------- TreeView
+
+    /**
+     * Test cleanup of selection listeners in TreeViewBehavior.
+     */
+    @Test
+    public void testTreeViewBehaviorDisposeSelect() {
+        TreeView<String> treeView = new TreeView<>(createRoot());
+        WeakReference<BehaviorBase<?>> weakRef = new WeakReference<>(createBehavior(treeView));
+        treeView.getSelectionModel().select(1);
+        weakRef.get().dispose();
+        treeView.getSelectionModel().select(0);
+        assertNull("anchor must remain cleared on selecting when disposed",
+                treeView.getProperties().get("anchor"));
+    }
+
+    @Test
+    public void testTreeViewBehaviorSelect() {
+        TreeView<String> treeView = new TreeView<>(createRoot());
+        createBehavior(treeView);
+        int last = 1;
+        treeView.getSelectionModel().select(last);
+        assertEquals("anchor must be set", last, treeView.getProperties().get("anchor"));
+    }
+
+    @Test
+    public void testTreeViewBehaviorDispose() {
+        TreeView<String> treeView = new TreeView<>(createRoot());
+        WeakReference<BehaviorBase<?>> weakRef = new WeakReference<>(createBehavior(treeView));
+        treeView.getSelectionModel().select(1);
+        weakRef.get().dispose();
+        assertNull("anchor must be cleared after dispose", treeView.getProperties().get("anchor"));
+    }
+
+    /**
+     * Creates and returns an expanded treeItem with two children.
+     */
+    private TreeItem<String> createRoot() {
+        TreeItem<String> root = new TreeItem<>("root");
+        root.setExpanded(true);
+        root.getChildren().addAll(new TreeItem<>("child one"), new TreeItem<>("child two"));
+        return root;
+    }
+
 
 // ---------- ListView
 

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorMemoryLeakTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorMemoryLeakTest.java
@@ -46,7 +46,6 @@ import javafx.scene.control.TableView;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TreeTableView;
-import javafx.scene.control.TreeView;
 
 /**
  * Test for memory leaks in Behavior implementations.
@@ -86,8 +85,7 @@ public class BehaviorMemoryLeakTest {
                 TableView.class,
                 TextArea.class,
                 TextField.class,
-                TreeTableView.class,
-                TreeView.class
+                TreeTableView.class
          );
         // remove the known issues to make the test pass
         controlClasses.removeAll(leakingClasses);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinCleanupTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinCleanupTest.java
@@ -112,9 +112,9 @@ public class SkinCleanupTest {
      */
     @Test
     public void testMemoryLeakAlternativeSkinWithRoot() {
-        TreeView<String> control = new TreeView<>(createRoot());
-        installDefaultSkin(control);
-        WeakReference<?> weakRef = new WeakReference<>(replaceSkin(control));
+        TreeView<String> treeView = new TreeView<>(createRoot());
+        installDefaultSkin(treeView);
+        WeakReference<?> weakRef = new WeakReference<>(replaceSkin(treeView));
         assertNotNull(weakRef.get());
         attemptGC(weakRef);
         assertEquals("Skin must be gc'ed", null, weakRef.get());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinCleanupTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinCleanupTest.java
@@ -68,10 +68,10 @@ public class SkinCleanupTest {
      */
     @Test
     public void testTreeViewSetRoot() {
-        TreeView<String> listView = new TreeView<>(createRoot());
-        installDefaultSkin(listView);
-        replaceSkin(listView);
-        listView.setRoot(createRoot());
+        TreeView<String> treeView = new TreeView<>(createRoot());
+        installDefaultSkin(treeView);
+        replaceSkin(treeView);
+        treeView.setRoot(createRoot());
     }
 
     /**
@@ -79,10 +79,10 @@ public class SkinCleanupTest {
      */
     @Test
     public void testTreeViewAddRootChild() {
-        TreeView<String> listView = new TreeView<>(createRoot());
-        installDefaultSkin(listView);
-        replaceSkin(listView);
-        listView.getRoot().getChildren().add(createRoot());
+        TreeView<String> treeView = new TreeView<>(createRoot());
+        installDefaultSkin(treeView);
+        replaceSkin(treeView);
+        treeView.getRoot().getChildren().add(createRoot());
     }
 
     /**
@@ -90,10 +90,10 @@ public class SkinCleanupTest {
      */
     @Test
     public void testTreeViewReplaceRootChildren() {
-        TreeView<String> listView = new TreeView<>(createRoot());
-        installDefaultSkin(listView);
-        replaceSkin(listView);
-        listView.getRoot().getChildren().setAll(createRoot().getChildren());
+        TreeView<String> treeView = new TreeView<>(createRoot());
+        installDefaultSkin(treeView);
+        replaceSkin(treeView);
+        treeView.getRoot().getChildren().setAll(createRoot().getChildren());
     }
 
     /**
@@ -101,10 +101,10 @@ public class SkinCleanupTest {
      */
     @Test
     public void testTreeViewRefresh() {
-        TreeView<String> listView = new TreeView<>();
-        installDefaultSkin(listView);
-        replaceSkin(listView);
-        listView.refresh();
+        TreeView<String> treeView = new TreeView<>();
+        installDefaultSkin(treeView);
+        replaceSkin(treeView);
+        treeView.refresh();
     }
 
     /**

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinMemoryLeakTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinMemoryLeakTest.java
@@ -61,7 +61,6 @@ import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TreeTableRow;
 import javafx.scene.control.TreeTableView;
-import javafx.scene.control.TreeView;
 
 /**
  * Test memory leaks in Skin implementations.
@@ -123,8 +122,7 @@ public class SkinMemoryLeakTest {
                 // @Ignore("8240506")
                 TextField.class,
                 TreeTableRow.class,
-                TreeTableView.class,
-                TreeView.class
+                TreeTableView.class
         );
         // remove the known issues to make the test pass
         controlClasses.removeAll(leakingClasses);


### PR DESCRIPTION
issues with behavior:
- memory leak due to an key eventHandler that's not removed
- after dispose, still modifying treeView (anchor) state due to listeners selection that are not removed

issues with skin:
- memory leak due to behavior leaking
- memory leak due to cellFactory in flow not removed
- throws NPE after switching (on modifying root children, refresh) due to listeners not removed

Fixed by cleaning up as needed. Added tests that are failing before and passing after the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256821](https://bugs.openjdk.java.net/browse/JDK-8256821): TreeViewSkin/Behavior: misbehavior on switching skin


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/358/head:pull/358`
`$ git checkout pull/358`
