### PR TITLE
8256978: GitHub actions: build fails on Linux due to missing package

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Install dependencies
         run: |
           set -x
-          sudo apt-get install libgl1-mesa-dev libx11-dev libxt-dev pkg-config libgtk2.0-dev libgtk-3-dev libxtst-dev libudev-dev
+          sudo apt-get install libgl1-mesa-dev libx11-dev libxt-dev pkg-config libgtk2.0-dev libgtk-3-dev libxtst-dev
 
 # FIXME: enable cache for boot JDK
 #      - name: Restore boot JDK from cache


### PR DESCRIPTION
This is a simple fix to remove and unused package from the list of packages we specify to install on Linux when running GitHub actions.

As a follow-on fix, I am going to do what the JDK did and specify the version of each OS to use to partially insulate us from such changes in the GitHub actions defaults.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Testing

|     | Linux x64 | Windows x64 | macOS x64 |
| --- | ----- | ----- | ----- |
| Build / test | ✔️ (1/1 passed) | ✔️ (1/1 passed) | ✔️ (1/1 passed) |

### Issue
 * [JDK-8256978](https://bugs.openjdk.java.net/browse/JDK-8256978): GitHub actions: build fails on Linux due to missing package


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/359/head:pull/359`
`$ git checkout pull/359`
