### PR TITLE
8233678: [macos 10.15] System menu bar does not work initially on macOS Catalina

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
@@ -217,28 +217,31 @@ public abstract class Application {
         return userHome + File.separator + "." + name + File.separator;
     }
 
-    private void notifyWillFinishLaunching() {
+    // Subclasses can override the following notify methods.
+    // Overridden methods need to call super.
+
+    protected void notifyWillFinishLaunching() {
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleWillFinishLaunchingAction(this, System.nanoTime());
         }
     }
 
-    private void notifyDidFinishLaunching() {
+    protected void notifyDidFinishLaunching() {
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleDidFinishLaunchingAction(this, System.nanoTime());
         }
     }
 
-    private void notifyWillBecomeActive() {
+    protected void notifyWillBecomeActive() {
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleWillBecomeActiveAction(this, System.nanoTime());
         }
     }
 
-    private void notifyDidBecomeActive() {
+    protected void notifyDidBecomeActive() {
         this.initialActiveEventReceived = true;
         EventHandler handler = getEventHandler();
         if (handler != null) {
@@ -246,14 +249,14 @@ public abstract class Application {
         }
     }
 
-    private void notifyWillResignActive() {
+    protected void notifyWillResignActive() {
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleWillResignActiveAction(this, System.nanoTime());
         }
     }
 
-    private boolean notifyThemeChanged(String themeName) {
+    protected boolean notifyThemeChanged(String themeName) {
         EventHandler handler = getEventHandler();
         if (handler != null) {
             return handler.handleThemeChanged(themeName);
@@ -261,42 +264,42 @@ public abstract class Application {
         return false;
     }
 
-    private void notifyDidResignActive() {
+    protected void notifyDidResignActive() {
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleDidResignActiveAction(this, System.nanoTime());
         }
     }
 
-    private void notifyDidReceiveMemoryWarning() {
+    protected void notifyDidReceiveMemoryWarning() {
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleDidReceiveMemoryWarning(this, System.nanoTime());
         }
     }
 
-    private void notifyWillHide() {
+    protected void notifyWillHide() {
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleWillHideAction(this, System.nanoTime());
         }
     }
 
-    private void notifyDidHide() {
+    protected void notifyDidHide() {
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleDidHideAction(this, System.nanoTime());
         }
     }
 
-    private void notifyWillUnhide() {
+    protected void notifyWillUnhide() {
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleWillUnhideAction(this, System.nanoTime());
         }
     }
 
-    private void notifyDidUnhide() {
+    protected void notifyDidUnhide() {
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleDidUnhideAction(this, System.nanoTime());
@@ -304,7 +307,7 @@ public abstract class Application {
     }
 
     // notificiation when user drag and drops files onto app icon
-    private void notifyOpenFiles(String files[]) {
+    protected void notifyOpenFiles(String files[]) {
         if ((this.initialActiveEventReceived == false) && (this.initialOpenedFiles == null)) {
             // rememeber the initial opened files
             this.initialOpenedFiles = files;
@@ -315,7 +318,7 @@ public abstract class Application {
         }
     }
 
-    private void notifyWillQuit() {
+    protected void notifyWillQuit() {
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleQuitAction(this, System.nanoTime());

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
@@ -221,6 +221,7 @@ public abstract class Application {
     // Overridden methods need to call super.
 
     protected void notifyWillFinishLaunching() {
+        System.err.println("Application::notifyWillFinishLaunching");
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleWillFinishLaunchingAction(this, System.nanoTime());
@@ -228,6 +229,7 @@ public abstract class Application {
     }
 
     protected void notifyDidFinishLaunching() {
+        System.err.println("Application::notifyDidFinishLaunching");
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleDidFinishLaunchingAction(this, System.nanoTime());
@@ -235,6 +237,7 @@ public abstract class Application {
     }
 
     protected void notifyWillBecomeActive() {
+        System.err.println("Application::notifyWillBecomeActive");
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleWillBecomeActiveAction(this, System.nanoTime());
@@ -242,6 +245,7 @@ public abstract class Application {
     }
 
     protected void notifyDidBecomeActive() {
+        System.err.println("Application::notifyDidBecomeActive");
         this.initialActiveEventReceived = true;
         EventHandler handler = getEventHandler();
         if (handler != null) {
@@ -250,6 +254,7 @@ public abstract class Application {
     }
 
     protected void notifyWillResignActive() {
+        System.err.println("Application::notifyWillResignActive");
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleWillResignActiveAction(this, System.nanoTime());
@@ -265,6 +270,7 @@ public abstract class Application {
     }
 
     protected void notifyDidResignActive() {
+        System.err.println("Application::notifyDidResignActive");
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleDidResignActiveAction(this, System.nanoTime());
@@ -591,6 +597,7 @@ public abstract class Application {
     protected abstract Size staticCursor_getBestSize(int width, int height);
 
     public final Menu createMenu(String title) {
+        System.err.println("Application::createMenu title:" + title);
         return new Menu(title);
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
@@ -96,6 +96,7 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
 
     // Spin up a nested even loop waiting for the app reactivation event
     void waitForReactivation() {
+        System.err.println("KCR: waitForReactivation");
         final EventLoop eventLoop = createEventLoop();
         Thread thr = new Thread(() -> {
             try {
@@ -104,13 +105,16 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
                 ex.printStackTrace();
             }
             Application.invokeLater(() -> {
+                System.err.println("KCR: exit nested event loop");
                 eventLoop.leave(null);
             });
         });
         thr.setDaemon(true);
         thr.start();
 
+        System.err.println("KCR: enter nested event loop");
         eventLoop.enter();
+        System.err.println("KCR: nested event loop returns");
     }
 
     native private void _finishTerminating();

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -55,6 +55,8 @@ static BOOL isFullScreenExitingLoop = NO;
 static NSMutableDictionary * keyCodeForCharMap = nil;
 static BOOL isEmbedded = NO;
 static BOOL disableSyncRendering = NO;
+static BOOL firstActivation = YES;
+static BOOL shouldReactivate = NO;
 
 #ifdef STATIC_BUILD
 jint JNICALL JNI_OnLoad_glass(JavaVM *vm, void *reserved)
@@ -271,6 +273,13 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
     }
     [pool drain];
     GLASS_CHECK_EXCEPTION(env);
+
+    if (firstActivation) {
+        LOG("-> deactivate (hide)  app");
+        firstActivation = NO;
+        shouldReactivate = YES;
+        [NSApp hide:NSApp];
+    }
 }
 
 - (void)applicationWillResignActive:(NSNotification *)aNotification
@@ -297,6 +306,12 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
     }
     [pool drain];
     GLASS_CHECK_EXCEPTION(env);
+
+    if (shouldReactivate) {
+        LOG("-> reactivate  app");
+        shouldReactivate = NO;
+        [NSApp activateIgnoringOtherApps:YES];
+    }
 }
 
 - (void)applicationWillHide:(NSNotification *)aNotification

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -40,7 +40,7 @@
 #import "ProcessInfo.h"
 #import <Security/SecRequirement.h>
 
-//#define VERBOSE
+#define VERBOSE
 #ifndef VERBOSE
     #define LOG(MSG, ...)
 #else

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassMenu.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassMenu.m
@@ -324,6 +324,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacMenuBarDelegate__1insert
 
         if ([[glassmenu->item title] compare:@"Apple"] == NSOrderedSame)
         {
+            LOG("calling setAppleMenu");
             [NSApp performSelector:@selector(setAppleMenu:) withObject:glassmenu->item];
         }
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassMenu.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassMenu.m
@@ -33,7 +33,7 @@
 #import "GlassHelper.h"
 #import "GlassKey.h"
 
-//#define VERBOSE
+#define VERBOSE
 #ifndef VERBOSE
     #define LOG(MSG, ...)
 #else

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
@@ -76,7 +76,7 @@
 //    (*env)->DeleteLocalRef(env, theString);
 //}
 
-//#define VERBOSE
+#define VERBOSE
 #ifndef VERBOSE
     #define LOG(MSG, ...)
 #else


### PR DESCRIPTION
This is a proposed fix for the bug where the Apple system menubar is initially non-responsive on macOS 10.15 and later after a JavaFX application has started up. The end user can workaround this by switching to some other application and then back to the JavaFX app, but there is no known workaround that the application developer can use.

JavaFX is using a non-standard approach to creating the system menus, and seems likely that some change in macOS 10.15 means that this no longer works the same as in previous versions of macOS. We have had problems with application startup on macOS in the past that affected the system menubar: see [JDK-8123430](https://bugs.openjdk.java.net/browse/JDK-8123430) and [JDK-8093743](https://bugs.openjdk.java.net/browse/JDK-8093743).

The solution is to deactivate and then reactivate the application after the app has initially been made active, but before any window is initialized and before the system menu is populated.

I pushed this as two commits: one with the fix and one with some temporary verbose debug print statements. I will remove the print statements prior to the formal review, but wanted to leave them in for now in case someone wanted to test them, and ran into an issue (the debug print statements could help isolate any problems).

I have tested this on macOS 10.14, 10.15, and 11 (Big Sur). It will need additional testing.

The only drawback I see with this approach is that there can be a very brief flash when launching the JavaFX app from a  terminal window as the FX application activates, deactivates, and reactivates.

/reviewers 2