### PR TITLE
8231372: JFXPanel fails to render if setScene called on Swing thread

### DIFF
--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
@@ -299,12 +299,11 @@ public class JFXPanel extends JComponent {
                     (PrivilegedAction<EventQueue>) java.awt.Toolkit
                             .getDefaultToolkit()::getSystemEventQueue);
             SecondaryLoop secondaryLoop = eventQueue.createSecondaryLoop();
-            if (secondaryLoop.enter()) {
-                Platform.runLater(() -> {
-                    setSceneImpl(newScene);
-                });
+            Platform.runLater(() -> {
+                setSceneImpl(newScene);
                 secondaryLoop.exit();
-            }
+            });
+            secondaryLoop.enter();
         }
     }
 

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
@@ -300,8 +300,11 @@ public class JFXPanel extends JComponent {
                             .getDefaultToolkit()::getSystemEventQueue);
             SecondaryLoop secondaryLoop = eventQueue.createSecondaryLoop();
             Platform.runLater(() -> {
-                setSceneImpl(newScene);
-                secondaryLoop.exit();
+                try {
+                    setSceneImpl(newScene);
+                } finally {
+                    secondaryLoop.exit();
+                }
             });
             secondaryLoop.enter();
         }

--- a/tests/system/src/test/java/test/javafx/embed/swing/JFXPanelTest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/JFXPanelTest.java
@@ -155,5 +155,58 @@ public class JFXPanelTest {
 
         Assert.assertTrue(firstPressedEventLatch.await(5000, TimeUnit.MILLISECONDS));
     }
-}
 
+    @Test
+    public void setSceneOnFXThread() throws Exception {
+
+        CountDownLatch completionLatch = new CountDownLatch(1);
+
+        SwingUtilities.invokeLater(() -> {
+            JFXPanel fxPanel = new JFXPanel();
+            fxPanel.setPreferredSize(new Dimension(100, 100));
+            JFrame jframe = new JFrame();
+            JPanel jpanel = new JPanel();
+            jpanel.add(fxPanel);
+            jframe.add(jpanel);
+            jframe.pack();
+            jframe.setVisible(true);
+
+            Platform.runLater(() -> {
+                Scene scene = new Scene(new Group());
+                fxPanel.setScene(scene);
+                completionLatch.countDown();
+            });
+        });
+
+        Assert.assertTrue("Timeout waiting for setScene to complete",
+                completionLatch.await(5000, TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    public void setSceneOnSwingThread() throws Exception {
+
+        CountDownLatch completionLatch = new CountDownLatch(1);
+
+        SwingUtilities.invokeLater(() -> {
+            JFXPanel fxPanel = new JFXPanel();
+            fxPanel.setPreferredSize(new Dimension(100, 100));
+            JFrame jframe = new JFrame();
+            JPanel jpanel = new JPanel();
+            jpanel.add(fxPanel);
+            jframe.add(jpanel);
+            jframe.pack();
+            jframe.setVisible(true);
+
+            Platform.runLater(() -> {
+                Scene scene = new Scene(new Group());
+                SwingUtilities.invokeLater(() -> {
+                    fxPanel.setScene(scene);
+                    completionLatch.countDown();
+                });
+            });
+        });
+
+        Assert.assertTrue("Timeout waiting for setScene to complete",
+                completionLatch.await(5000, TimeUnit.MILLISECONDS));
+    }
+}

--- a/tests/system/src/test/java/test/javafx/embed/swing/JFXPanelTest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/JFXPanelTest.java
@@ -28,6 +28,7 @@ import com.sun.javafx.PlatformUtil;
 import org.junit.Assume;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
 import junit.framework.AssertionFailedError;
@@ -53,6 +54,8 @@ import java.util.concurrent.TimeUnit;
 public class JFXPanelTest {
     // Used to launch the application before running any test
     private static final CountDownLatch launchLatch = new CountDownLatch(1);
+
+    JFrame jframe;
 
     // Application class. An instance is created and initialized before running
     // the first test, and it lives through the execution of all tests.
@@ -84,6 +87,13 @@ public class JFXPanelTest {
         Platform.exit();
     }
 
+    @After
+    public void doCleanup() {
+        if (jframe != null) {
+            SwingUtilities.invokeLater(() -> jframe.dispose());
+        }
+    }
+
     static class TestFXPanel extends JFXPanel {
         protected void processMouseEventPublic(MouseEvent e) {
             processMouseEvent(e);
@@ -103,7 +113,7 @@ public class JFXPanelTest {
             dummyFXPanel.setPreferredSize(new Dimension(100, 100));
             TestFXPanel fxPnl = new TestFXPanel();
             fxPnl.setPreferredSize(new Dimension(100, 100));
-            JFrame jframe = new JFrame();
+            jframe = new JFrame();
             JPanel jpanel = new JPanel();
             jpanel.add(dummyFXPanel);
             jpanel.add(fxPnl);
@@ -164,7 +174,7 @@ public class JFXPanelTest {
         SwingUtilities.invokeLater(() -> {
             JFXPanel fxPanel = new JFXPanel();
             fxPanel.setPreferredSize(new Dimension(100, 100));
-            JFrame jframe = new JFrame();
+            jframe = new JFrame();
             JPanel jpanel = new JPanel();
             jpanel.add(fxPanel);
             jframe.add(jpanel);
@@ -190,7 +200,7 @@ public class JFXPanelTest {
         SwingUtilities.invokeLater(() -> {
             JFXPanel fxPanel = new JFXPanel();
             fxPanel.setPreferredSize(new Dimension(100, 100));
-            JFrame jframe = new JFrame();
+            jframe = new JFrame();
             JPanel jpanel = new JPanel();
             jpanel.add(fxPanel);
             jframe.add(jpanel);


### PR DESCRIPTION
This fix was originally proposed by @mruzicka in PR #16 which was closed several months ago without being integrated. At the time we didn't have a test case that was failing.

While evaluating a bug that I filed, [JDK-8235843](https://bugs.openjdk.java.net/browse/JDK-8235843), I discovered that that bug was a duplicate of this one. The original proposed fix is correct, although I modified it slightly to add a try / finally so that the secondary event loop will be terminated even if the setScene throws an exception. I also added a unit test. Since the bulk of the fix is from PR #16, I will add the contributor of that PR.

NOTE to reviewers: I pushed two commits to my branch. The first is exactly the commit created for PR #16 and the second is the unit test along with the fix to the code to add try / finally. As always, they will be squashed into a single commit by Skara.

 /summary Correctly terminate secondary event loop in JFXPanel::setScene 

/contributor add Michal Růžička <michal.ruza@gmail.com>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8231372](https://bugs.openjdk.java.net/browse/JDK-8231372): JFXPanel fails to render if setScene called on Swing thread


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Contributors
 * Michal Růžička `<michal.ruza@gmail.com>`

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/362/head:pull/362`
`$ git checkout pull/362`
