### PR TITLE
8257758: Allow building of JavaFX native libs for Apple Silicon

### DIFF
--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -28,6 +28,11 @@ ext.MAC = [:]
 MAC.canBuild = IS_MAC && IS_64
 if (!MAC.canBuild) return;
 
+def TARGET_ARCH = "x86_64"
+if (hasProperty('targetArch')) {
+    TARGET_ARCH = ext.targetArch
+}
+
 // All desktop related packages should be built
 MAC.compileSwing = true;
 MAC.compileSWT = true;
@@ -119,7 +124,11 @@ def commonParams = [
         "-mmacosx-version-min=$MACOSX_MIN_VERSION",
         "-isysroot", "$MACOSX_SDK_PATH",
         "-iframework$MACOSX_SDK_PATH/System/Library/Frameworks",
-        "-arch", "x86_64"]
+        "-arch", "$TARGET_ARCH"]
+
+if (hasProperty('targetArch')) {
+    commonParams = ["-target", "$TARGET_ARCH-apple-macos-11", commonParams]
+}
 
 def ccBaseFlags = [
         commonParams,

--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -29,8 +29,8 @@ MAC.canBuild = IS_MAC && IS_64
 if (!MAC.canBuild) return;
 
 def TARGET_ARCH = "x86_64"
-if (hasProperty('targetArch')) {
-    TARGET_ARCH = ext.targetArch
+if (hasProperty('TARGET_ARCH')) {
+    TARGET_ARCH = ext.TARGET_ARCH
 }
 
 // All desktop related packages should be built
@@ -126,8 +126,8 @@ def commonParams = [
         "-iframework$MACOSX_SDK_PATH/System/Library/Frameworks",
         "-arch", "$TARGET_ARCH"]
 
-if (hasProperty('targetArch')) {
-    commonParams = ["-target", "$TARGET_ARCH-apple-macos-11", commonParams]
+if (hasProperty('TARGET_ARCH')) {
+    commonParams = ["-target", "${TARGET_ARCH}-apple-macos-11", commonParams]
 }
 
 def ccBaseFlags = [


### PR DESCRIPTION
Fix for JDK-8257758

In case the -PtargetArch=arm64 option is supplied to the gradle build, the
native components that are part of the JavaFX build will target this platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257758](https://bugs.openjdk.java.net/browse/JDK-8257758): Allow building of JavaFX native libs for Apple Silicon


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/363/head:pull/363`
`$ git checkout pull/363`
