### PR TITLE
8257897: Fix webkit build for XCode 12 

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/PointerPreparations.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/PointerPreparations.h
@@ -34,16 +34,16 @@ namespace WTF {
 #if COMPILER_HAS_CLANG_BUILTIN(__builtin_get_vtable_pointer)
 
 template<typename T>
-ALWAYS_INLINE void* getVTablePointer(T* o) { return __builtin_get_vtable_pointer(o); }
+ALWAYS_INLINE const void* getVTablePointer(T* o) { return __builtin_get_vtable_pointer(o); }
 
 #else // not COMPILER_HAS_CLANG_BUILTIN(__builtin_get_vtable_pointer)
 
 #if CPU(ARM64E)
 template<typename T>
-ALWAYS_INLINE void* getVTablePointer(T* o) { return __builtin_ptrauth_auth(*(reinterpret_cast<void**>(o)), ptrauth_key_cxx_vtable_pointer, 0); }
+ALWAYS_INLINE const void* getVTablePointer(T* o) { return __builtin_ptrauth_auth(*(reinterpret_cast<void**>(o)), ptrauth_key_cxx_vtable_pointer, 0); }
 #else // not CPU(ARM64E)
 template<typename T>
-ALWAYS_INLINE void* getVTablePointer(T* o) { return (*(reinterpret_cast<void**>(o))); }
+ALWAYS_INLINE const void* getVTablePointer(T* o) { return (*(reinterpret_cast<void**>(o))); }
 #endif // not CPU(ARM64E)
 
 #endif // not COMPILER_HAS_CLANG_BUILTIN(__builtin_get_vtable_pointer)

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -4882,7 +4882,7 @@ END
         push(@implContent, <<END) if $vtableNameGnu;
 
 #if ENABLE(BINDING_INTEGRITY)
-    void* actualVTablePointer = getVTablePointer(impl.ptr());
+    const void* actualVTablePointer = getVTablePointer(impl.ptr());
 #if PLATFORM(WIN)
     void* expectedVTablePointer = ${vtableRefWin};
 #else

--- a/modules/javafx.web/src/main/native/Source/WebCore/bridge/jni/JNIUtility.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bridge/jni/JNIUtility.h
@@ -30,11 +30,7 @@
 #include <wtf/java/JavaRef.h>
 #include "JavaType.h"
 
-#if OS(MAC_OS_X)
-#include <JavaVM/jni.h>
-#else
 #include <jni.h>
-#endif
 
 namespace JSC {
 


### PR DESCRIPTION
The WebKit build fails with recent Xcode 12.

Bug: `getVTablePointer()` should return a const void*

Fix: Use const void* and remove dependency on JavaVM.framework in Xcode
Upstream fix: https://bugs.webkit.org/show_bug.cgi?id=207871

Test: Build webkit with the Xcode 12 compiler with and without this fix. It should fail without the fix and build with the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257897](https://bugs.openjdk.java.net/browse/JDK-8257897): Fix webkit build for XCode 12


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/365/head:pull/365`
`$ git checkout pull/365`
