### PR TITLE
8256983: GitHub actions: specify the version of each platform OS and compiler

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -49,7 +49,7 @@ on:
 jobs:
   linux_x64_build:
     name: Linux x64
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-20.04"
     if: 'true'
 
     env:
@@ -61,6 +61,9 @@ jobs:
       BOOT_JDK_VERSION: "15.0.1"
       BOOT_JDK_FILENAME: "openjdk-15.0.1_linux-x64_bin.tar.gz"
       BOOT_JDK_URL: "https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_linux-x64_bin.tar.gz"
+      ANT_DIR: "apache-ant-1.10.5"
+      ANT_FILENAME: "apache-ant-1.10.5.tar.gz"
+      ANT_URL: "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz"
 
     steps:
       - name: Checkout the source
@@ -71,7 +74,11 @@ jobs:
       - name: Install dependencies
         run: |
           set -x
-          sudo apt-get install libgl1-mesa-dev libx11-dev libxt-dev pkg-config libgtk2.0-dev libgtk-3-dev libxtst-dev
+          sudo apt-get install libgl1-mesa-dev libx11-dev libxxf86vm-dev libxt-dev pkg-config libgtk2.0-dev libgtk-3-dev libxtst-dev gcc-10=10.2.0-5ubuntu1~20.04 g++-10=10.2.0-5ubuntu1~20.04
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+          mkdir -p "${HOME}/build-tools"
+          wget -O "${HOME}/build-tools/${ANT_FILENAME}" "${ANT_URL}"
+          tar -zxf "${HOME}/build-tools/${ANT_FILENAME}" -C "${HOME}/build-tools"
 
 # FIXME: enable cache for boot JDK
 #      - name: Restore boot JDK from cache
@@ -95,10 +102,13 @@ jobs:
           set -x
           export JAVA_HOME="${HOME}/bootjdk/jdk-${BOOT_JDK_VERSION}"
           echo "JAVA_HOME=${JAVA_HOME}" >> "${GITHUB_ENV}"
-          export PATH="$JAVA_HOME/bin:$PATH"
+          export ANT_HOME="${HOME}/build-tools/${ANT_DIR}"
+          echo "ANT_HOME=${ANT_HOME}" >> "${GITHUB_ENV}"
+          export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
           env | sort
           which java
           java -version
+          which ant
           ant -version
           gcc -v
 
@@ -106,7 +116,7 @@ jobs:
         working-directory: jfx
         run: |
           set -x
-          export PATH="$JAVA_HOME/bin:$PATH"
+          export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
           bash gradlew -version
           bash gradlew --info all
 
@@ -114,13 +124,13 @@ jobs:
         working-directory: jfx
         run: |
           set -x
-          export PATH="$JAVA_HOME/bin:$PATH"
+          export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
           bash gradlew --info --continue -PBUILD_SDK_FOR_TEST=false test -x :web:test
 
 
   macos_x64_build:
     name: macOS x64
-    runs-on: "macos-latest"
+    runs-on: "macos-10.15"
     if: 'true'
 
     env:
@@ -132,6 +142,9 @@ jobs:
       BOOT_JDK_VERSION: "15.0.1"
       BOOT_JDK_FILENAME: "openjdk-15.0.1_osx-x64_bin.tar.gz"
       BOOT_JDK_URL: "https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_osx-x64_bin.tar.gz"
+      ANT_DIR: "apache-ant-1.10.5"
+      ANT_FILENAME: "apache-ant-1.10.5.tar.gz"
+      ANT_URL: "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz"
 
     steps:
       - name: Checkout the source
@@ -143,6 +156,9 @@ jobs:
         run: |
           set -x
           echo "NOT NEEDED: brew install make"
+          mkdir -p "${HOME}/build-tools"
+          wget -O "${HOME}/build-tools/${ANT_FILENAME}" "${ANT_URL}"
+          tar -zxf "${HOME}/build-tools/${ANT_FILENAME}" -C "${HOME}/build-tools"
 
 # FIXME: enable cache for boot JDK
 #      - name: Restore boot JDK from cache
@@ -166,18 +182,22 @@ jobs:
           set -x
           export JAVA_HOME="${HOME}/bootjdk/jdk-${BOOT_JDK_VERSION}.jdk/Contents/Home"
           echo "JAVA_HOME=${JAVA_HOME}" >> "${GITHUB_ENV}"
-          export PATH="$JAVA_HOME/bin:$PATH"
+          export ANT_HOME="${HOME}/build-tools/${ANT_DIR}"
+          echo "ANT_HOME=${ANT_HOME}" >> "${GITHUB_ENV}"
+          export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
           env | sort
           which java
           java -version
+          which ant
           ant -version
+          sudo xcode-select --switch /Applications/Xcode_11.3.1.app/Contents/Developer
           xcodebuild -version
 
       - name: Build JavaFX artifacts
         working-directory: jfx
         run: |
           set -x
-          export PATH="$JAVA_HOME/bin:$PATH"
+          export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
           bash gradlew -version
           bash gradlew --info all
 
@@ -185,13 +205,13 @@ jobs:
         working-directory: jfx
         run: |
           set -x
-          export PATH="$JAVA_HOME/bin:$PATH"
+          export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
           bash gradlew --info --continue -PBUILD_SDK_FOR_TEST=false test -x :web:test
 
 
   windows_x64_build:
     name: Windows x64
-    runs-on: "windows-latest"
+    runs-on: "windows-2019"
     if: 'true'
 
     env:
@@ -203,6 +223,9 @@ jobs:
       BOOT_JDK_VERSION: "15.0.1"
       BOOT_JDK_FILENAME: "openjdk-15.0.1_windows-x64_bin.zip"
       BOOT_JDK_URL: "https://download.java.net/java/GA/jdk15.0.1/51f4f36ad4ef43e39d0dfdbaf6549e32/9/GPL/openjdk-15.0.1_windows-x64_bin.zip"
+      ANT_DIR: "apache-ant-1.10.5"
+      ANT_FILENAME: "apache-ant-1.10.5.tar.gz"
+      ANT_URL: "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz"
       # FIXME: hard-code the location and version of VS 2019 for now
       VS150COMNTOOLS: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build"
       MSVC_VER: "14.28.29333"
@@ -242,6 +265,12 @@ jobs:
           & curl -L "https://www.cygwin.com/setup-x86_64.exe" -o "$HOME/cygwin/setup-x86_64.exe"
           Start-Process -FilePath "$HOME\cygwin\setup-x86_64.exe" -ArgumentList "--quiet-mode --packages make,zip,unzip --root $HOME\cygwin\cygwin64 --local-package-dir $HOME\cygwin\packages --site http://mirrors.kernel.org/sourceware/cygwin --no-desktop --no-shortcuts --no-startmenu --no-admin" -Wait -NoNewWindow
 
+      - name: Install dependencies
+        run: |
+          mkdir -p "$HOME\build-tools"
+          & curl -L "$env:ANT_URL" -o "$HOME/build-tools/$env:ANT_FILENAME"
+          tar -zxf "$HOME/build-tools/$env:ANT_FILENAME" -C "$HOME/build-tools"
+
       - name: Setup environment
         run: |
           echo "VS150COMNTOOLS=$env:VS150COMNTOOLS"
@@ -254,21 +283,25 @@ jobs:
           $env:Path = "$HOME\cygwin\cygwin64\bin;$HOME\cygwin\cygwin64\bin;$env:Path" ;
           $env:JAVA_HOME = "$HOME\bootjdk\jdk-$env:BOOT_JDK_VERSION" ;
           echo "JAVA_HOME=$env:JAVA_HOME"
-          $env:Path = "$env:JAVA_HOME\bin;$env:Path" ;
+          $env:ANT_HOME = "${HOME}\build-tools\$env:ANT_DIR"
+          echo "ANT_HOME=$env:ANT_HOME"
+          $env:Path = "$env:JAVA_HOME\bin;$env:ANT_HOME\bin;$env:Path" ;
           echo "Path=$env:Path"
           which java
           java -version
           which ant
           ant -version
 
-          # Save JAVA_HOME and Path (renamed to THE_PATH) in env variables
+          # Save JAVA_HOME, ANT_HOME, and Path (renamed to THE_PATH) in env variables
           echo "JAVA_HOME=$env:JAVA_HOME" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "ANT_HOME=$env:ANT_HOME" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           echo "THE_PATH=$env:Path" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Build JavaFX artifacts
         working-directory: jfx
         run: |
           echo "JAVA_HOME=$env:JAVA_HOME"
+          echo "ANT_HOME=$env:ANT_HOME"
           $env:Path = "$env:THE_PATH" ;
           echo "Path=$env:Path"
           which java
@@ -280,6 +313,7 @@ jobs:
         working-directory: jfx
         run: |
           echo "JAVA_HOME=$env:JAVA_HOME"
+          echo "ANT_HOME=$env:ANT_HOME"
           $env:Path = "$env:THE_PATH" ;
           echo "Path=$env:Path"
           .\gradlew.bat --info --continue -PBUILD_SDK_FOR_TEST=false test -x :web:test


### PR DESCRIPTION
As described in the [JBS issue](https://bugs.openjdk.java.net/browse/JDK-8256983), we should specify the specific version of each OS and compiler rather than just using the defaults. This will help insulate us from changes to the defaults that can break the build, and has recently done so.

On Linux, we upgraded to 20.04 (18.04 is still the default), which required specifying the version of ant, since the default version for 20.04 is 1.10.7 which has a bug that causes FX apps to fail. I decided to also specify the version of ant (1.10.5) for all three platforms.

The following will be used:

| Platform | OS | Compiler | Ant |
| --- | --- | --- | --- |
| Linux | Ubuntu 20.04 | gcc 10.2 | ant 1.10.5 |
| Mac | macOS 10.15 | Xcode 11.3.1 | ant 1.10.5 |
| Windows | Windows Server 2019 | [1] | ant 1.10.5 |

[1] The Microsoft compiler version is unspecified as there is a dependency on [JDK-8255713](https://bugs.openjdk.java.net/browse/JDK-8255713) in addition to the problem of increasing the build time to download a specific version.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256983](https://bugs.openjdk.java.net/browse/JDK-8256983): GitHub actions: specify the version of each platform OS and compiler


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/366/head:pull/366`
`$ git checkout pull/366`
