### PR TITLE
8253356: JavaFX Terminology Refresh

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -29,7 +29,7 @@ jbs=jdk
 tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9]((\.\d{1,3}){0,2})-((b\d{2,3})|(ga))|[1-9]u(\d{1,3})-((b\d{2,3})|(ga))
 
 [checks]
-error=blacklist,author,reviewers,merge,message,issues,whitespace,executable
+error=author,reviewers,merge,message,issues,whitespace,executable
 
 [census]
 version=0

--- a/apps/samples/Ensemble8/build.gradle
+++ b/apps/samples/Ensemble8/build.gradle
@@ -36,7 +36,7 @@ jar {
     //exclude 'META-INF/*'
 }
 
-// Merge the Apache Lucene jars into our master jar.
+// Merge the Apache Lucene jars into our main jar.
 jar.doLast() {
     ant.zip(destfile: jar.archivePath, update: true, duplicate: "preserve") {
         zipgroupfileset(dir: new File("./lib"), includes:"*.jar")

--- a/modules/javafx.base/src/main/version-info/VersionInfo.java
+++ b/modules/javafx.base/src/main/version-info/VersionInfo.java
@@ -54,18 +54,13 @@ package com.sun.javafx.runtime;
  * These methods can be used to uniquely identify a particular build
  * for internal test and deployment:
  *
- * The method getHudsonJobName() will returns the name of the hudson job.
- * For example, a master build will have the name as "presidio", and a
- * graphics-scrum will have the name as "presidio-graphics" and so for.
- * An empty string is returned if the build isn't build on Hudson, such as a
+ * The method getHudsonJobName() returns the name of the Hudson job.
+ * An empty string is returned if the build isn't built on Hudson, such as a
  * local build on a developer machine.
  *
- * The method getHudsonBuildNumber() will returns the number of the hudson job
- * on a particular build scrum. The job number is sequentially incremented for
- * each build job.
- * For example, a master build job number of 25 was built before master job
- * number 26.
- * A string of zeros is returned if the build isn't build on Hudson, such as a
+ * The method getHudsonBuildNumber() returns the number of the Hudson build
+ * for a particular job.
+ * A string of zeros is returned if the build isn't built on Hudson, such as a
  * local build on a developer machine.
  *
  * The method getBuildTimestamp() will returns the timestamp of the build.

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/ShapeEvaluator.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/ShapeEvaluator.java
@@ -103,9 +103,9 @@ class ShapeEvaluator {
         geom1 = new Geometry(v1);
         float tvals0[] = geom0.getTvals();
         float tvals1[] = geom1.getTvals();
-        float masterTvals[] = mergeTvals(tvals0, tvals1);
-        geom0.setTvals(masterTvals);
-        geom1.setTvals(masterTvals);
+        float combinedTvals[] = mergeTvals(tvals0, tvals1);
+        geom0.setTvals(combinedTvals);
+        geom1.setTvals(combinedTvals);
     }
 
     private Shape getShape(float fraction) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/DummyToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/DummyToolkit.java
@@ -64,7 +64,7 @@ import com.sun.javafx.runtime.async.AsyncOperation;
 import com.sun.javafx.runtime.async.AsyncOperationListener;
 import com.sun.javafx.scene.text.TextLayoutFactory;
 import com.sun.scenario.DelayedRunnable;
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 import com.sun.scenario.effect.FilterContext;
 import com.sun.scenario.effect.Filterable;
 
@@ -282,7 +282,7 @@ final public class DummyToolkit extends Toolkit {
     }
 
     @Override
-    public AbstractMasterTimer getMasterTimer() {
+    public AbstractPrimaryTimer getPrimaryTimer() {
         return null;
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -89,7 +89,7 @@ import com.sun.javafx.sg.prism.NGLightBase;
 import com.sun.javafx.sg.prism.NGNode;
 import com.sun.javafx.util.Utils;
 import com.sun.scenario.DelayedRunnable;
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 import com.sun.scenario.effect.AbstractShadow.ShadowMode;
 import com.sun.scenario.effect.Color4f;
 import com.sun.scenario.effect.FilterContext;
@@ -715,7 +715,7 @@ public abstract class Toolkit {
     public abstract boolean isForwardTraversalKey(KeyEvent e);
     public abstract boolean isBackwardTraversalKey(KeyEvent e);
 
-    public abstract AbstractMasterTimer getMasterTimer();
+    public abstract AbstractPrimaryTimer getPrimaryTimer();
 
     public abstract FontLoader getFontLoader();
     public abstract TextLayoutFactory getTextLayoutFactory();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PerformanceTrackerHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PerformanceTrackerHelper.java
@@ -90,7 +90,7 @@ abstract class PerformanceTrackerHelper {
     public abstract boolean isPerfLoggingEnabled();
 
     public final long nanoTime() {
-        return Toolkit.getToolkit().getMasterTimer().nanos();
+        return Toolkit.getToolkit().getPrimaryTimer().nanos();
     }
 
     private static final class PerformanceTrackerDefaultImpl

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PrimaryTimer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PrimaryTimer.java
@@ -30,7 +30,7 @@ import javafx.animation.Timeline;
 import com.sun.javafx.tk.Toolkit;
 import com.sun.scenario.DelayedRunnable;
 import com.sun.scenario.Settings;
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 import com.sun.scenario.animation.AnimationPulse;
 
 /**
@@ -42,21 +42,21 @@ import com.sun.scenario.animation.AnimationPulse;
  *
  * For now it is hidden until we have some use to expose it.
  */
-public final class MasterTimer extends AbstractMasterTimer {
+public final class PrimaryTimer extends AbstractPrimaryTimer {
 
-    /** Prevent external instantiation of MasterTimer */
-    private MasterTimer() {
+    /** Prevent external instantiation of PrimaryTimer */
+    private PrimaryTimer() {
     }
 
-    private static final Object MASTER_TIMER_KEY = new StringBuilder(
-            "MasterTimerKey");
+    private static final Object PRIMARY_TIMER_KEY = new StringBuilder(
+            "PrimaryTimerKey");
 
-    public static synchronized MasterTimer getInstance() {
+    public static synchronized PrimaryTimer getInstance() {
         Map<Object, Object> contextMap = Toolkit.getToolkit().getContextMap();
-        MasterTimer instance = (MasterTimer) contextMap.get(MASTER_TIMER_KEY);
+        PrimaryTimer instance = (PrimaryTimer) contextMap.get(PRIMARY_TIMER_KEY);
         if (instance == null) {
-            instance = new MasterTimer();
-            contextMap.put(MASTER_TIMER_KEY, instance);
+            instance = new PrimaryTimer();
+            contextMap.put(PRIMARY_TIMER_KEY, instance);
             if (Settings.getBoolean(ANIMATION_MBEAN_ENABLED,
                                     enableAnimationMBean)) {
                 AnimationPulse.getDefaultBean().setEnabled(true);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
@@ -125,7 +125,7 @@ import com.sun.prism.Texture.WrapMode;
 import com.sun.prism.impl.Disposer;
 import com.sun.prism.impl.PrismSettings;
 import com.sun.scenario.DelayedRunnable;
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 import com.sun.scenario.effect.FilterContext;
 import com.sun.scenario.effect.Filterable;
 import com.sun.scenario.effect.impl.prism.PrFilterContext;
@@ -365,7 +365,7 @@ public final class QuantumToolkit extends Toolkit {
         try {
             Application.invokeAndWait(this.userRunnable);
 
-            if (getMasterTimer().isFullspeed()) {
+            if (getPrimaryTimer().isFullspeed()) {
                 /*
                  * FULLSPEED_INTVERVAL workaround
                  *
@@ -1129,8 +1129,8 @@ public final class QuantumToolkit extends Toolkit {
         return PrFilterContext.getInstance(screen);
     }
 
-    @Override public AbstractMasterTimer getMasterTimer() {
-        return MasterTimer.getInstance();
+    @Override public AbstractPrimaryTimer getPrimaryTimer() {
+        return PrimaryTimer.getInstance();
     }
 
     @Override public FontLoader getFontLoader() {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/EGLFBGLFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/EGLFBGLFactory.java
@@ -42,7 +42,7 @@ class EGLFBGLFactory extends GLFactory {
     // Entries must be in lowercase and null string is a wild card
     // For Linux Beta release we will limit es2 pipe qualification check to NVidia GPUs only
     private GLGPUInfo preQualificationFilter[] = null;
-    private GLGPUInfo blackList[] = null;
+    private GLGPUInfo rejectList[] = null;
 
     @Override
     GLGPUInfo[] getPreQualificationFilter() {
@@ -50,8 +50,8 @@ class EGLFBGLFactory extends GLFactory {
     }
 
     @Override
-    GLGPUInfo[] getBlackList() {
-        return blackList;
+    GLGPUInfo[] getRejectList() {
+        return rejectList;
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/EGLX11GLFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/EGLX11GLFactory.java
@@ -42,7 +42,7 @@ class EGLX11GLFactory extends GLFactory {
 
     // Entries must be in lowercase and null string is a wild card
     private GLGPUInfo preQualificationFilter[] = null;
-    private GLGPUInfo blackList[] = null;
+    private GLGPUInfo rejectList[] = null;
 
     @Override
     GLGPUInfo[] getPreQualificationFilter() {
@@ -50,8 +50,8 @@ class EGLX11GLFactory extends GLFactory {
     }
 
     @Override
-    GLGPUInfo[] getBlackList() {
-        return blackList;
+    GLGPUInfo[] getRejectList() {
+        return rejectList;
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLFactory.java
@@ -133,8 +133,8 @@ abstract class GLFactory {
     // A null preQualificationFilter implies we may consider any GPU
     abstract GLGPUInfo[] getPreQualificationFilter();
 
-    // Consists of a list of GPUs that we will block from using the es2 pipe.
-    abstract GLGPUInfo[] getBlackList();
+    // Consists of a list of GPUs that we will not use for the es2 pipe.
+    abstract GLGPUInfo[] getRejectList();
 
     private static GLGPUInfo readGPUInfo(long nativeCtxInfo) {
         String glVendor = nGetGLVendor(nativeCtxInfo);
@@ -163,14 +163,13 @@ abstract class GLFactory {
         return matches(gpuInfo, preQualificationFilter);
     }
 
-    private boolean inBlackList(GLGPUInfo gpuInfo) {
-        return matches(gpuInfo, getBlackList());
+    private boolean inRejectList(GLGPUInfo gpuInfo) {
+        return matches(gpuInfo, getRejectList());
     }
 
     boolean isQualified(long nativeCtxInfo) {
         // Read the GPU (graphics hardware) information and qualifying it by
-        // checking against the preQualificationFilter and the "blocking"
-        // blackLis.
+        // checking against the preQualificationFilter and the rejectList.
         GLGPUInfo gpuInfo = readGPUInfo(nativeCtxInfo);
 
         if (gpuInfo.vendor == null || gpuInfo.model == null
@@ -181,7 +180,7 @@ abstract class GLFactory {
             return false;
         }
 
-        return inPreQualificationFilter(gpuInfo) && !inBlackList(gpuInfo);
+        return inPreQualificationFilter(gpuInfo) && !inRejectList(gpuInfo);
     }
 
     abstract GLContext createGLContext(long nativeCtxInfo);

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLGPUInfo.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLGPUInfo.java
@@ -40,10 +40,10 @@ class GLGPUInfo {
     }
 
     /**
-     * Check this GPU information against an entry stored in the whiteList and
-     * blackList of ES2Qualifier
+     * Check this GPU information against an entry stored in the preQualificationFilter and
+     * rejectList of ES2Qualifier
      *
-     * @param gi entry stored in the whiteList or blackList of ES2Qualifier
+     * @param gi entry stored in the preQualificationFilter or rejectList of ES2Qualifier
      * @return true if sub-string matches otherwise false
      */
     boolean matches(GLGPUInfo gi) {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/IOSGLFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/IOSGLFactory.java
@@ -37,7 +37,7 @@ class IOSGLFactory extends GLFactory {
     // Entries must be in lowercase and null string is a wild card
     private GLGPUInfo preQualificationFilter[] = null;
 
-    private GLGPUInfo blackList[] = {
+    private GLGPUInfo rejectList[] = {
     };
 
     @Override
@@ -46,8 +46,8 @@ class IOSGLFactory extends GLFactory {
     }
 
     @Override
-    GLGPUInfo[] getBlackList() {
-        return blackList;
+    GLGPUInfo[] getRejectList() {
+        return rejectList;
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/MacGLFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/MacGLFactory.java
@@ -39,7 +39,7 @@ class MacGLFactory extends GLFactory {
 
     // These are older GPUs that users have reported problem in using the es2 pipe.
     // We don't have these units in-house to verify or maintain.
-    private GLGPUInfo blackList[] = {
+    private GLGPUInfo rejectList[] = {
         new GLGPUInfo("ati", "radeon x1600 opengl engine"),
         new GLGPUInfo("ati", "radeon x1900 opengl engine"),
         new GLGPUInfo("intel", "gma x3100 opengl engine")
@@ -51,8 +51,8 @@ class MacGLFactory extends GLFactory {
     }
 
     @Override
-    GLGPUInfo[] getBlackList() {
-        return blackList;
+    GLGPUInfo[] getRejectList() {
+        return rejectList;
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/MonocleGLFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/MonocleGLFactory.java
@@ -46,7 +46,7 @@ class MonocleGLFactory extends GLFactory {
     // Entries must be in lowercase and null string is a wild card
     // For Linux Beta release we will limit es2 pipe qualification check to NVidia GPUs only
     private GLGPUInfo preQualificationFilter[] = null;
-    private GLGPUInfo blackList[] = null;
+    private GLGPUInfo rejectList[] = null;
 
     private AcceleratedScreen accScreen = null;
 
@@ -56,8 +56,8 @@ class MonocleGLFactory extends GLFactory {
     }
 
     @Override
-    GLGPUInfo[] getBlackList() {
-        return blackList;
+    GLGPUInfo[] getRejectList() {
+        return rejectList;
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/WinGLFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/WinGLFactory.java
@@ -37,7 +37,7 @@ class WinGLFactory extends GLFactory {
 
     // Entries must be in lowercase and null string is a wild card
     private GLGPUInfo preQualificationFilter[] = null;
-    private GLGPUInfo blackList[] = null;
+    private GLGPUInfo rejectList[] = null;
 
     @Override
     GLGPUInfo[] getPreQualificationFilter() {
@@ -45,8 +45,8 @@ class WinGLFactory extends GLFactory {
     }
 
     @Override
-    GLGPUInfo[] getBlackList() {
-        return blackList;
+    GLGPUInfo[] getRejectList() {
+        return rejectList;
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/X11GLFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/X11GLFactory.java
@@ -48,7 +48,7 @@ class X11GLFactory extends GLFactory {
         new GLGPUInfo("x.org", null)
     };
 
-    private GLGPUInfo blackList[] = {
+    private GLGPUInfo rejectList[] = {
         new GLGPUInfo("ati", "radeon x1300"),
         new GLGPUInfo("ati", "radeon x1350"),
         new GLGPUInfo("ati", "radeon x1400"),
@@ -97,8 +97,8 @@ class X11GLFactory extends GLFactory {
     }
 
     @Override
-    GLGPUInfo[] getBlackList() {
-        return blackList;
+    GLGPUInfo[] getRejectList() {
+        return rejectList;
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/Settings.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/Settings.java
@@ -52,10 +52,10 @@ public class Settings {
     static {
         SETTINGS_KEY = new StringBuilder("SettingsKey");
 
-        // It seems no longer necessary to force loading of MasterTimer to pick
+        // It seems no longer necessary to force loading of PrimaryTimer to pick
         // up the hi-res timer workaround. Also, this is causing some init
         // order problems (RT-5572), so it's being commented out.
-        // Object obj = ToolkitAccessor.getMasterTimer();
+        // Object obj = ToolkitAccessor.getPrimaryTimer();
     }
 
     private static synchronized Settings getInstance() {

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/AbstractPrimaryTimer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/AbstractPrimaryTimer.java
@@ -33,7 +33,7 @@ import com.sun.scenario.Settings;
 import com.sun.scenario.animation.shared.PulseReceiver;
 import com.sun.scenario.animation.shared.TimerReceiver;
 
-public abstract class AbstractMasterTimer {
+public abstract class AbstractPrimaryTimer {
 
     protected final static String FULLSPEED_PROP = "javafx.animation.fullspeed";
     private static boolean fullspeed = Settings.getBoolean(FULLSPEED_PROP);
@@ -105,7 +105,7 @@ public abstract class AbstractMasterTimer {
     private final long fixedPulseLength = Boolean.getBoolean(FIXED_PULSE_LENGTH_PROP) ? PULSE_DURATION_NS : 0;
     private long debugNanos = 0;
 
-    private final MainLoop theMaster = new MainLoop();
+    private final MainLoop theMainLoop = new MainLoop();
 
 
     static {
@@ -148,8 +148,7 @@ public abstract class AbstractMasterTimer {
         return fullspeed;
     }
 
-    /** Prevent external instantiation of MasterTimer. */
-    protected AbstractMasterTimer() {
+    protected AbstractPrimaryTimer() {
     }
 
     /**
@@ -158,7 +157,7 @@ public abstract class AbstractMasterTimer {
      * recorded in it and that time will be used to start the clip at the
      * appropriate wall clock time as defined by milliTime().
      *
-     * Note that pulseReceiver cannot be removed from the MasterTimer directly.
+     * Note that pulseReceiver cannot be removed from the PrimaryTimer directly.
      * It is removed automatically in the timePulse-iteration if timePulse
      * returns true.
      *
@@ -173,7 +172,7 @@ public abstract class AbstractMasterTimer {
         }
         receivers[receiversLength++] = target;
         if (receiversLength == 1) {
-            theMaster.updateAnimationRunnable();
+            theMainLoop.updateAnimationRunnable();
         }
     }
 
@@ -195,7 +194,7 @@ public abstract class AbstractMasterTimer {
             }
         }
         if (receiversLength == 0) {
-            theMaster.updateAnimationRunnable();
+            theMainLoop.updateAnimationRunnable();
         }
     }
 
@@ -207,7 +206,7 @@ public abstract class AbstractMasterTimer {
         }
         animationTimers[animationTimersLength++] = timer;
         if (animationTimersLength == 1) {
-            theMaster.updateAnimationRunnable();
+            theMainLoop.updateAnimationRunnable();
         }
     }
 
@@ -229,13 +228,13 @@ public abstract class AbstractMasterTimer {
             }
         }
         if (animationTimersLength == 0) {
-            theMaster.updateAnimationRunnable();
+            theMainLoop.updateAnimationRunnable();
         }
     }
 
     /*
      * methods to record times for different stages of a pulse overriden in
-     * MasterTimer to collect data for AnimationPulse Mbean
+     * PrimaryTimer to collect data for AnimationPulse Mbean
      */
     protected void recordStart(long shiftMillis) {
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/AnimationPulse.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/AnimationPulse.java
@@ -54,7 +54,7 @@ public class AnimationPulse implements AnimationPulseMBean {
         private long endNanos = Long.MIN_VALUE;
 
         PulseData(long shiftNanos) {
-            startNanos = Toolkit.getToolkit().getMasterTimer().nanos();
+            startNanos = Toolkit.getToolkit().getPrimaryTimer().nanos();
             scheduledNanos = startNanos + shiftNanos;
         }
 
@@ -64,7 +64,7 @@ public class AnimationPulse implements AnimationPulseMBean {
         }
 
         void recordAnimationEnd() {
-            animationEndNanos = Toolkit.getToolkit().getMasterTimer().nanos();
+            animationEndNanos = Toolkit.getToolkit().getPrimaryTimer().nanos();
         }
 
         long getAnimationDuration(TimeUnit unit) {
@@ -92,7 +92,7 @@ public class AnimationPulse implements AnimationPulseMBean {
         }
 
         void recordEnd() {
-            endNanos = Toolkit.getToolkit().getMasterTimer().nanos();
+            endNanos = Toolkit.getToolkit().getPrimaryTimer().nanos();
         }
 
         long getPulseDuration(TimeUnit unit) {
@@ -106,7 +106,7 @@ public class AnimationPulse implements AnimationPulseMBean {
         }
 
         long getPulseStartFromNow(TimeUnit unit) {
-            return unit.convert(Toolkit.getToolkit().getMasterTimer().nanos() - startNanos,
+            return unit.convert(Toolkit.getToolkit().getPrimaryTimer().nanos() - startNanos,
                     TimeUnit.NANOSECONDS);
         }
 
@@ -172,7 +172,7 @@ public class AnimationPulse implements AnimationPulseMBean {
 
     @Override
     public long getPULSE_DURATION() {
-        return Toolkit.getToolkit().getMasterTimer().getPulseDuration(1000);
+        return Toolkit.getToolkit().getPrimaryTimer().getPulseDuration(1000);
     }
 
 

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/PulseReceiver.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/PulseReceiver.java
@@ -26,8 +26,8 @@
 package com.sun.scenario.animation.shared;
 
 /**
- * A PulseReceiver can receive regular pulses from the MasterTimer. Removing
- * receivers from the MasterTimer needs to be in-sync with the
+ * A PulseReceiver can receive regular pulses from the PrimaryTimer. Removing
+ * receivers from the PrimaryTimer needs to be in-sync with the
  * timePulse-iteration. The receiver is removed if timePulse returns true.
  * The reason we do not use Callback or some other pre-existing interface
  * is that we want an interface that takes a primitive long, whereas Callback
@@ -39,7 +39,7 @@ public interface PulseReceiver {
      *
      * @param now
      *            Timestamp of the pulse.
-     * @return true if PulseReceiver should be removed from the MasterTimer.
+     * @return true if PulseReceiver should be removed from the PrimaryTimer.
      */
     void timePulse(long now);
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/TimerReceiver.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/shared/TimerReceiver.java
@@ -26,7 +26,7 @@
 package com.sun.scenario.animation.shared;
 
 /**
- * A TimerReceiver receives per-frame pulses from the MasterTimer.
+ * A TimerReceiver receives per-frame pulses from the PrimaryTimer.
  */
 public interface TimerReceiver {
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
@@ -48,7 +48,7 @@ import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.util.Duration;
 import com.sun.javafx.animation.TickCalculation;
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 import com.sun.scenario.animation.shared.ClipEnvelope;
 import com.sun.scenario.animation.shared.PulseReceiver;
 
@@ -149,10 +149,10 @@ public abstract class Animation {
     private long startTime;
     private long pauseTime;
     private boolean paused = false;
-    private final AbstractMasterTimer timer;
+    private final AbstractPrimaryTimer timer;
 
     // Access control context, captured whenever we add this pulse receiver to
-    // the master timer (which is called when an animation is played or resumed)
+    // the PrimaryTimer (which is called when an animation is played or resumed)
     private AccessControlContext accessCtrlCtx = null;
 
     private long now() {
@@ -1133,7 +1133,7 @@ public abstract class Animation {
         this.targetFramerate = targetFramerate;
         this.resolution = (int) Math.max(1, Math.round(TickCalculation.TICKS_PER_SECOND / targetFramerate));
         this.clipEnvelope = ClipEnvelope.create(this);
-        this.timer = Toolkit.getToolkit().getMasterTimer();
+        this.timer = Toolkit.getToolkit().getPrimaryTimer();
     }
 
     /**
@@ -1141,13 +1141,13 @@ public abstract class Animation {
      */
     protected Animation() {
         this.resolution = 1;
-        this.targetFramerate = TickCalculation.TICKS_PER_SECOND / Toolkit.getToolkit().getMasterTimer().getDefaultResolution();
+        this.targetFramerate = TickCalculation.TICKS_PER_SECOND / Toolkit.getToolkit().getPrimaryTimer().getDefaultResolution();
         this.clipEnvelope = ClipEnvelope.create(this);
-        this.timer = Toolkit.getToolkit().getMasterTimer();
+        this.timer = Toolkit.getToolkit().getPrimaryTimer();
     }
 
     // These constructors are only for testing purposes
-    Animation(AbstractMasterTimer timer) {
+    Animation(AbstractPrimaryTimer timer) {
         this.resolution = 1;
         this.targetFramerate = TickCalculation.TICKS_PER_SECOND / timer.getDefaultResolution();
         this.clipEnvelope = ClipEnvelope.create(this);
@@ -1155,7 +1155,7 @@ public abstract class Animation {
     }
 
     // These constructors are only for testing purposes
-    Animation(AbstractMasterTimer timer, ClipEnvelope clipEnvelope, int resolution) {
+    Animation(AbstractPrimaryTimer timer, ClipEnvelope clipEnvelope, int resolution) {
         this.resolution = resolution;
         this.targetFramerate = TickCalculation.TICKS_PER_SECOND / resolution;
         this.clipEnvelope = clipEnvelope;

--- a/modules/javafx.graphics/src/main/java/javafx/animation/AnimationTimer.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/AnimationTimer.java
@@ -26,7 +26,7 @@
 package javafx.animation;
 
 import com.sun.javafx.tk.Toolkit;
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 import com.sun.scenario.animation.shared.TimerReceiver;
 import java.security.AccessControlContext;
 import java.security.AccessController;
@@ -60,7 +60,7 @@ public abstract class AnimationTimer {
         }
     }
 
-    private final AbstractMasterTimer timer;
+    private final AbstractPrimaryTimer timer;
     private final AnimationTimerReceiver timerReceiver = new AnimationTimerReceiver();
     private boolean active;
 
@@ -71,11 +71,11 @@ public abstract class AnimationTimer {
      * Creates a new timer.
      */
     public AnimationTimer() {
-        timer = Toolkit.getToolkit().getMasterTimer();
+        timer = Toolkit.getToolkit().getPrimaryTimer();
     }
 
     // For testing only
-    AnimationTimer(AbstractMasterTimer timer) {
+    AnimationTimer(AbstractPrimaryTimer timer) {
         this.timer = timer;
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/animation/ParallelTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/ParallelTransition.java
@@ -40,7 +40,7 @@ import javafx.util.Duration;
 
 import com.sun.javafx.collections.TrackableObservableList;
 import com.sun.javafx.collections.VetoableListDecorator;
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -297,7 +297,7 @@ public final class ParallelTransition extends Transition {
     }
 
     // For testing purposes
-    ParallelTransition(AbstractMasterTimer timer) {
+    ParallelTransition(AbstractPrimaryTimer timer) {
         super(timer);
         setInterpolator(Interpolator.LINEAR);
     }

--- a/modules/javafx.graphics/src/main/java/javafx/animation/SequentialTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/SequentialTransition.java
@@ -43,7 +43,7 @@ import javafx.util.Duration;
 
 import com.sun.javafx.collections.TrackableObservableList;
 import com.sun.javafx.collections.VetoableListDecorator;
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -304,7 +304,7 @@ public final class SequentialTransition extends Transition {
     }
 
     // For testing purposes
-    SequentialTransition(AbstractMasterTimer timer) {
+    SequentialTransition(AbstractPrimaryTimer timer) {
         super(timer);
         setInterpolator(Interpolator.LINEAR);
     }

--- a/modules/javafx.graphics/src/main/java/javafx/animation/Timeline.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/Timeline.java
@@ -30,7 +30,7 @@ import javafx.collections.ObservableList;
 import javafx.util.Duration;
 
 import com.sun.javafx.collections.TrackableObservableList;
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 import com.sun.scenario.animation.shared.TimelineClipCore;
 
 /**
@@ -162,7 +162,7 @@ public final class Timeline extends Animation {
     }
 
     // This constructor is only for testing purposes
-    Timeline(final AbstractMasterTimer timer) {
+    Timeline(final AbstractPrimaryTimer timer) {
         super(timer);
         clipCore = new TimelineClipCore(this);
     }

--- a/modules/javafx.graphics/src/main/java/javafx/animation/Transition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/Transition.java
@@ -25,7 +25,7 @@
 
 package javafx.animation;
 
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.Node;
@@ -148,7 +148,7 @@ public abstract class Transition extends Animation {
     }
 
     // For testing purposes
-    Transition(AbstractMasterTimer timer) {
+    Transition(AbstractPrimaryTimer timer) {
         super(timer);
     }
 

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassDragDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassDragDelegate.m
@@ -56,7 +56,7 @@ static BOOL          dragging = NO;// Are we inside drag and drop session?
 
 static UIImageView * dragImage = nil;// Image(s) shown during drag and drop
 
-static UIView      * dragViewParent;// parental UIView of all GlassWindows (aka masterHostView); do not retain
+static UIView      * dragViewParent;// parental UIView of all GlassWindows (aka mainHostView); do not retain
 static UIView *      dragSourceView;// GlassView where drag operation started
 
 static jobject lastJavaViewDragTarget = NULL; // last view where mouse occured during dragging session

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassRobot.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassRobot.m
@@ -307,7 +307,7 @@ static inline void DumpImage(CGImageRef image)
 
 - (void)mousePress
 {
-     touch = [[UITouch alloc] initInView:[GlassWindow getMasterWindowHost] :touchLocation];
+     touch = [[UITouch alloc] initInView:[GlassWindow getMainWindowHost] :touchLocation];
     UIEvent *eventDown = [[UIEvent alloc] initWithTouch:touch];
 
     [touch.view touchesBegan:[eventDown allTouches] withEvent:eventDown];
@@ -363,7 +363,7 @@ static inline void DumpImage(CGImageRef image)
     // On iOS 4 and later, use UIGraphicsBeginImageContextWithOptions to take the scale into consideration
     // Set the scale parameter to your OpenGL ES view's contentScaleFactor
     // so that you get a high-resolution snapshot when its value is greater than 1.0
-    CGFloat scale = [GlassWindow getMasterWindowHost].contentScaleFactor;
+    CGFloat scale = [GlassWindow getMainWindowHost].contentScaleFactor;
     NSInteger widthInPoints = width / scale;
     NSInteger heightInPoints = height / scale;
     UIGraphicsBeginImageContextWithOptions(CGSizeMake(widthInPoints, heightInPoints), NO, scale);
@@ -412,7 +412,7 @@ static inline void DumpImage(CGImageRef image)
 }
 
 - (void)keyPress:(NSString *)chr {
-    UIView *subview = [[[GlassWindow getMasterWindowHost] subviews] objectAtIndex:0];
+    UIView *subview = [[[GlassWindow getMainWindowHost] subviews] objectAtIndex:0];
     if (subview != NULL) {
         subview = [[subview subviews] objectAtIndex:0];
         if (subview != NULL) {

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassViewDelegate.m
@@ -741,7 +741,7 @@ static BOOL isTouchEnded(int phase)
                                           unicode:(char)13
                                         modifiers:0];
 
-    [[GlassWindow getMasterWindow] resignFocusOwner];
+    [[GlassWindow getMainWindow] resignFocusOwner];
 
     return YES;
 }

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassWindow.h
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassWindow.h
@@ -72,11 +72,11 @@
 }
 
 // Toplevel containers of all GlassWindows
-// once we support multiple screens on iOS - there will be one masterWindow/
-// masterWindowHost per screen; These windows are not part of FX/Glass window hierarchy, they
+// once we support multiple screens on iOS - there will be one mainWindow/
+// mainWindowHost per screen; These windows are not part of FX/Glass window hierarchy, they
 // serve us as OS containers. They allow us to easily change orientation for all GlassWindows, etc.
-+(GlassMainWindow *)  getMasterWindow;
-+(GlassMainView *) getMasterWindowHost;
++(GlassMainWindow *)  getMainWindow;
++(GlassMainView *) getMainWindowHost;
 
 - (void)setEnabled:(BOOL)enabled; // see isFocusable
 - (void)_setTransparent:(BOOL)state;

--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassWindow.m
@@ -105,10 +105,10 @@ static GlassWindow   * focusOwner; // currently focused GlassWindow - i.e. key e
 @end
 
 //Toplevel containers of all GlassWindows
-//once we support multiple screens on iOS - there will be one masterWindow/
-//masterWindowHost per screen
-static GlassMainWindow * masterWindow = nil;
-static GlassMainView * masterWindowHost = nil;
+//once we support multiple screens on iOS - there will be one mainWindow/
+//mainWindowHost per screen
+static GlassMainWindow * mainWindow = nil;
+static GlassMainView * mainWindowHost = nil;
 
 @interface GlassWindow (JavaAdditions)
 - (void)displaySubviews;
@@ -206,12 +206,12 @@ static inline void setWindowFrame(GlassWindow *window, CGFloat x, CGFloat y, CGF
 
 @implementation GlassWindow
 
-+(GlassMainWindow *)  getMasterWindow {
-    return masterWindow;
++(GlassMainWindow *)  getMainWindow {
+    return mainWindow;
 }
 
-+(GlassMainView *) getMasterWindowHost {
-    return masterWindowHost;
++(GlassMainView *) getMainWindowHost {
+    return mainWindowHost;
 }
 
 - (BOOL) canBecomeFirstResponder {return YES;}
@@ -283,8 +283,8 @@ JNIEXPORT void JNICALL Java_javafx_scene_control_skin_TextAreaSkinIos_hideSoftwa
 
     [self windowWillClose];
 
-    [masterWindowHost release];
-    [masterWindow release];//decrease retaincount
+    [mainWindowHost release];
+    [mainWindow release];//decrease retaincount
 }
 
 
@@ -828,7 +828,7 @@ jlong _1createWindow(JNIEnv *env, jobject jWindow, jlong jOwnerPtr, jlong jScree
         }
 
 
-        if (masterWindow == nil) {
+        if (mainWindow == nil) {
             //We have to remove rootViewController of splashscreen UIWindow in order to avoid
             //StatusBar orientation change ...
             UIWindow *splashScreen = [[UIApplication sharedApplication] keyWindow];
@@ -838,26 +838,26 @@ jlong _1createWindow(JNIEnv *env, jobject jWindow, jlong jOwnerPtr, jlong jScree
             CGRect applicationFrame = [screen bounds];
             GLASS_LOG("FRAME: %@", applicationFrame);
 
-            masterWindow = [[GlassMainWindow alloc] initWithFrame:applicationFrame];
-            masterWindowHost = [[GlassMainView alloc] initWithFrame:CGRectMake(0.0, 0.0, applicationFrame.size.width, applicationFrame.size.height)];
+            mainWindow = [[GlassMainWindow alloc] initWithFrame:applicationFrame];
+            mainWindowHost = [[GlassMainView alloc] initWithFrame:CGRectMake(0.0, 0.0, applicationFrame.size.width, applicationFrame.size.height)];
 
             // Set GlassViewController - responsible for orientation change, etc.
             GlassViewController *rvc = [[GlassViewController alloc] init];
-            [rvc setView:masterWindowHost];
-            [masterWindow setRootViewController:rvc];
+            [rvc setView:mainWindowHost];
+            [mainWindow setRootViewController:rvc];
             [rvc release];
 
-            [masterWindow setHidden:NO];
-            [masterWindowHost setHidden:NO];
+            [mainWindow setHidden:NO];
+            [mainWindowHost setHidden:NO];
         } else {
-            masterWindow = [masterWindow retain];//increase retain count per each GlassWindow
-            masterWindowHost = [masterWindowHost retain];
+            mainWindow = [mainWindow retain];//increase retain count per each GlassWindow
+            mainWindowHost = [mainWindowHost retain];
         }
 
-        [masterWindow setAutoresizesSubviews:YES];
-        [masterWindowHost setAutoresizesSubviews:NO];
+        [mainWindow setAutoresizesSubviews:YES];
+        [mainWindowHost setAutoresizesSubviews:NO];
 
-        [masterWindow makeKeyWindow];
+        [mainWindow makeKeyWindow];
 
         GLASS_LOG("GlassWindow _1createWindow");
         window = [[GlassWindow alloc] initWithScreen:screen jwindow:jWindow];
@@ -880,14 +880,14 @@ jlong _1createWindow(JNIEnv *env, jobject jWindow, jlong jOwnerPtr, jlong jScree
             [window _setTransparent:NO];
         }
 
-        [masterWindowHost addSubview:window];
+        [mainWindowHost addSubview:window];
 
         if (jOwnerPtr != 0L)
         {
             GLASS_LOG("Adding %p window as usbview of owner window %lld", window, jOwnerPtr);
             window->owner = (UIWindow*)jlong_to_ptr(jOwnerPtr);
         } else {
-            NSArray *views = [masterWindowHost subviews];
+            NSArray *views = [mainWindowHost subviews];
             // if there exists any secondary stage, its owner is primary stage internally if
             // not set explicitly
             if ([views count] > 1) {

--- a/modules/javafx.graphics/src/shims/java/com/sun/scenario/animation/AbstractPrimaryTimerShim.java
+++ b/modules/javafx.graphics/src/shims/java/com/sun/scenario/animation/AbstractPrimaryTimerShim.java
@@ -25,17 +25,17 @@
 
 package com.sun.scenario.animation;
 
-public class AbstractMasterTimerShim {
+public class AbstractPrimaryTimerShim {
 
-    public static boolean isPaused(AbstractMasterTimer amt) {
+    public static boolean isPaused(AbstractPrimaryTimer amt) {
         return amt.isPaused();
     }
 
-    public static long getTotalPausedTime(AbstractMasterTimer amt) {
+    public static long getTotalPausedTime(AbstractPrimaryTimer amt) {
         return amt.getTotalPausedTime();
     }
 
-    public static long getStartPauseTime(AbstractMasterTimer amt) {
+    public static long getStartPauseTime(AbstractPrimaryTimer amt) {
         return amt.getStartPauseTime();
     }
 

--- a/modules/javafx.graphics/src/shims/java/javafx/animation/AnimationShim.java
+++ b/modules/javafx.graphics/src/shims/java/javafx/animation/AnimationShim.java
@@ -25,7 +25,7 @@
 
 package javafx.animation;
 
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 import com.sun.scenario.animation.shared.ClipEnvelope;
 import com.sun.scenario.animation.shared.PulseReceiver;
 import javafx.util.Duration;
@@ -36,11 +36,11 @@ public abstract class AnimationShim extends Animation {
         super();
     }
 
-    public AnimationShim(AbstractMasterTimer timer) {
+    public AnimationShim(AbstractPrimaryTimer timer) {
         super(timer);
     }
 
-    public AnimationShim(AbstractMasterTimer timer, ClipEnvelope clipEnvelope, int resolution) {
+    public AnimationShim(AbstractPrimaryTimer timer, ClipEnvelope clipEnvelope, int resolution) {
         super(timer, clipEnvelope, resolution);
     }
 

--- a/modules/javafx.graphics/src/shims/java/javafx/animation/ParallelTransitionShim.java
+++ b/modules/javafx.graphics/src/shims/java/javafx/animation/ParallelTransitionShim.java
@@ -25,12 +25,12 @@
 
 package javafx.animation;
 
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 
 public class ParallelTransitionShim {
 
     public static ParallelTransition getParallelTransition(
-            AbstractMasterTimer timer) {
+            AbstractPrimaryTimer timer) {
         return new ParallelTransition(timer);
     }
 

--- a/modules/javafx.graphics/src/shims/java/javafx/animation/SequentialTransitionShim.java
+++ b/modules/javafx.graphics/src/shims/java/javafx/animation/SequentialTransitionShim.java
@@ -25,11 +25,11 @@
 
 package javafx.animation;
 
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 
 public class SequentialTransitionShim {
 
-    public static SequentialTransition getSequentialTransition(AbstractMasterTimer timer) {
+    public static SequentialTransition getSequentialTransition(AbstractPrimaryTimer timer) {
         return new SequentialTransition(timer);
 
     }

--- a/modules/javafx.graphics/src/shims/java/javafx/animation/TimelineShim.java
+++ b/modules/javafx.graphics/src/shims/java/javafx/animation/TimelineShim.java
@@ -25,7 +25,7 @@
 
 package javafx.animation;
 
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 import com.sun.scenario.animation.shared.TimelineClipCore;
 
 public class TimelineShim {
@@ -34,7 +34,7 @@ public class TimelineShim {
         return timeline.clipCore;
     }
 
-    public static Timeline getTimeline( AbstractMasterTimer timer) {
+    public static Timeline getTimeline( AbstractPrimaryTimer timer) {
         return new Timeline(timer);
     }
 

--- a/modules/javafx.graphics/src/shims/java/javafx/animation/TransitionShim.java
+++ b/modules/javafx.graphics/src/shims/java/javafx/animation/TransitionShim.java
@@ -25,7 +25,7 @@
 
 package javafx.animation;
 
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 import javafx.scene.Node;
 
 public abstract class TransitionShim extends Transition {
@@ -38,7 +38,7 @@ public abstract class TransitionShim extends Transition {
         super(targetFramerate);
     }
 
-    protected TransitionShim(AbstractMasterTimer timer) {
+    protected TransitionShim(AbstractPrimaryTimer timer) {
         super(timer);
     }
 

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/PseudoClassTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/PseudoClassTest.java
@@ -1009,12 +1009,12 @@ public class PseudoClassTest {
             other.add(pseudoClassesToRemove[n]);
         };
 
-        ObservableSet<PseudoClass> master = new PseudoClassState();
+        ObservableSet<PseudoClass> primary = new PseudoClassState();
         for (int n=0; n<pseudoClasses.length; n++) {
-            master.add(pseudoClasses[n]);
+            primary.add(pseudoClasses[n]);
         };
 
-        master.addListener((SetChangeListener.Change<? extends PseudoClass> change) -> {
+        primary.addListener((SetChangeListener.Change<? extends PseudoClass> change) -> {
             if (change.wasRemoved()) {
                 assert (nObservations < nObservationsExpected);
                 PseudoClass observed = change.getElementRemoved();
@@ -1025,10 +1025,10 @@ public class PseudoClassTest {
             }
         });
 
-        master.removeAll(other);
+        primary.removeAll(other);
 
         assertEquals(nObservationsExpected, nObservations);
-        assertEquals(pseudoClasses.length-pseudoClassesToRemove.length, master.size());
+        assertEquals(pseudoClasses.length-pseudoClassesToRemove.length, primary.size());
 
     }
 
@@ -1063,12 +1063,12 @@ public class PseudoClassTest {
             other.add(pseudoClassesToRetain[n]);
         };
 
-        ObservableSet<PseudoClass> master = new PseudoClassState();
+        ObservableSet<PseudoClass> primary = new PseudoClassState();
         for (int n=0; n<pseudoClasses.length; n++) {
-            master.add(pseudoClasses[n]);
+            primary.add(pseudoClasses[n]);
         };
 
-        master.addListener((SetChangeListener.Change<? extends PseudoClass> change) -> {
+        primary.addListener((SetChangeListener.Change<? extends PseudoClass> change) -> {
             if (change.wasRemoved()) {
                 assert (nObservations < nObservationsExpected);
                 PseudoClass observed = change.getElementRemoved();
@@ -1079,10 +1079,10 @@ public class PseudoClassTest {
             }
         });
 
-        master.retainAll(other);
+        primary.retainAll(other);
 
         assertEquals(nObservationsExpected, nObservations);
-        assertEquals(pseudoClassesToRetain.length, master.size());
+        assertEquals(pseudoClassesToRetain.length, primary.size());
 
     }
 
@@ -1100,12 +1100,12 @@ public class PseudoClassTest {
         final int nObservationsExpected = pseudoClasses.length;
         nObservations = 0;
 
-        ObservableSet<PseudoClass> master = new PseudoClassState();
+        ObservableSet<PseudoClass> primary = new PseudoClassState();
         for (int n=0; n<pseudoClasses.length; n++) {
-            master.add(pseudoClasses[n]);
+            primary.add(pseudoClasses[n]);
         };
 
-        master.addListener((SetChangeListener.Change<? extends PseudoClass> change) -> {
+        primary.addListener((SetChangeListener.Change<? extends PseudoClass> change) -> {
             if (change.wasRemoved()) {
                 assert (nObservations < nObservationsExpected);
                 PseudoClass observed = change.getElementRemoved();
@@ -1116,22 +1116,22 @@ public class PseudoClassTest {
             }
         });
 
-        master.clear();
+        primary.clear();
 
         assertEquals(nObservationsExpected, nObservations);
-        assertTrue(master.isEmpty());
+        assertTrue(primary.isEmpty());
 
     }
 
     @Test public void testObservablePseudoClass_listener_getSet_unmodifiable() {
 
-        final ObservableSet<PseudoClass> master = new PseudoClassState();
+        final ObservableSet<PseudoClass> primary = new PseudoClassState();
 
-        master.addListener(new SetChangeListener<PseudoClass>() {
+        primary.addListener(new SetChangeListener<PseudoClass>() {
 
             @Override
             public void onChanged(SetChangeListener.Change<? extends PseudoClass> change) {
-                master.removeListener(this);
+                primary.removeListener(this);
                 try {
                     ObservableSet set = change.getSet();
                     set.add(PseudoClass.getPseudoClass("TWO"));
@@ -1144,7 +1144,7 @@ public class PseudoClassTest {
             }
         });
 
-        master.add(PseudoClass.getPseudoClass("ONE"));
+        primary.add(PseudoClass.getPseudoClass("ONE"));
 
     }
 

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubPrimaryTimer.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubPrimaryTimer.java
@@ -27,16 +27,16 @@ package test.com.sun.javafx.pgstub;
 
 import com.sun.javafx.tk.Toolkit;
 import com.sun.scenario.DelayedRunnable;
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 
 /**
- * Stubbed implementation of AbstractMasterTimer. An instance
- * of this is returned by Toolkit.getMasterTimer().
+ * Stubbed implementation of AbstractPrimaryTimer. An instance
+ * of this is returned by Toolkit.getPrimaryTimer().
  */
-public class StubMasterTimer extends AbstractMasterTimer {
+public class StubPrimaryTimer extends AbstractPrimaryTimer {
     private long currentTimeMillis;
 
-    protected StubMasterTimer() {
+    protected StubPrimaryTimer() {
     }
 
     protected int getPulseDuration(int precision) {

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubToolkit.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubToolkit.java
@@ -45,7 +45,7 @@ import com.sun.javafx.scene.text.TextLayoutFactory;
 import com.sun.javafx.tk.*;
 import com.sun.prism.BasicStroke;
 import com.sun.scenario.DelayedRunnable;
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 import com.sun.scenario.effect.FilterContext;
 import com.sun.scenario.effect.Filterable;
 import javafx.application.ConditionalFeature;
@@ -78,7 +78,7 @@ public class StubToolkit extends Toolkit {
 
     private Map<Object, Object> contextMap = new HashMap<Object, Object>();
 
-    private StubMasterTimer masterTimer = new StubMasterTimer();
+    private StubPrimaryTimer primaryTimer = new StubPrimaryTimer();
 
     private PerformanceTracker performanceTracker = new StubPerformanceTracker();
 
@@ -335,8 +335,8 @@ public class StubToolkit extends Toolkit {
     }
 
     @Override
-    public AbstractMasterTimer getMasterTimer() {
-        return masterTimer;
+    public AbstractPrimaryTimer getPrimaryTimer() {
+        return primaryTimer;
     }
 
     @Override
@@ -373,7 +373,7 @@ public class StubToolkit extends Toolkit {
         pulseRequested = false;
     }
 
-    // do nothing -- bringing in FrameJob and MasterTimer also bring in
+    // do nothing -- bringing in FrameJob and PrimaryTimer also bring in
     // Settings and crap which isn't setup for the testing stuff because
     // we don't run through a RuntimeProvider or do normal startup
     // public @Override public void triggerNextPulse():Void { }
@@ -680,7 +680,7 @@ public class StubToolkit extends Toolkit {
     }
 
     public void setCurrentTime(long millis) {
-        masterTimer.setCurrentTime(millis);
+        primaryTimer.setCurrentTime(millis);
     }
 
     public void handleAnimation() {

--- a/modules/javafx.graphics/src/test/java/test/com/sun/scenario/animation/AbstractPrimaryTimerTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/scenario/animation/AbstractPrimaryTimerTest.java
@@ -27,8 +27,8 @@ package test.com.sun.scenario.animation;
 
 import javafx.animation.AnimationTimer;
 import com.sun.scenario.DelayedRunnable;
-import com.sun.scenario.animation.AbstractMasterTimer;
-import com.sun.scenario.animation.AbstractMasterTimerShim;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimerShim;
 import com.sun.scenario.animation.shared.PulseReceiver;
 import com.sun.scenario.animation.shared.TimerReceiver;
 import org.junit.Before;
@@ -36,14 +36,14 @@ import org.junit.Test;
 
 import static org.junit.Assert.*;
 
-public class AbstractMasterTimerTest {
+public class AbstractPrimaryTimerTest {
 
-    private AbstractMasterTimerStub timer;
+    private AbstractPrimaryTimerStub timer;
 
 
     @Before
     public void setUp() {
-        timer = new AbstractMasterTimerStub();
+        timer = new AbstractPrimaryTimerStub();
     }
 
     @Test
@@ -153,7 +153,7 @@ public class AbstractMasterTimerTest {
         }
     }
 
-    private static class AbstractMasterTimerStub extends AbstractMasterTimer {
+    private static class AbstractPrimaryTimerStub extends AbstractPrimaryTimer {
 
         private long nanos;
         private DelayedRunnable animationRunnable;
@@ -169,9 +169,9 @@ public class AbstractMasterTimerTest {
         }
 
         @Override public long nanos() {
-            return AbstractMasterTimerShim.isPaused(this) ?
-                    AbstractMasterTimerShim.getStartPauseTime(this) :
-                    nanos - AbstractMasterTimerShim.getTotalPausedTime(this);
+            return AbstractPrimaryTimerShim.isPaused(this) ?
+                    AbstractPrimaryTimerShim.getStartPauseTime(this) :
+                    nanos - AbstractPrimaryTimerShim.getTotalPausedTime(this);
         }
 
         @Override

--- a/modules/javafx.graphics/src/test/java/test/com/sun/scenario/animation/shared/FiniteClipEnvelopeTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/scenario/animation/shared/FiniteClipEnvelopeTest.java
@@ -50,7 +50,7 @@ public class FiniteClipEnvelopeTest {
 
     @Before
     public void setUp() {
-        animation = new AnimationMock(Toolkit.getToolkit().getMasterTimer(), AnimationMock.DEFAULT_DURATION, AnimationMock.DEFAULT_RATE, 9, AnimationMock.DEFAULT_AUTOREVERSE);
+        animation = new AnimationMock(Toolkit.getToolkit().getPrimaryTimer(), AnimationMock.DEFAULT_DURATION, AnimationMock.DEFAULT_RATE, 9, AnimationMock.DEFAULT_AUTOREVERSE);
         clip = new FiniteClipEnvelopeShim(animation);
     }
 

--- a/modules/javafx.graphics/src/test/java/test/com/sun/scenario/animation/shared/InfiniteClipEnvelopeTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/scenario/animation/shared/InfiniteClipEnvelopeTest.java
@@ -50,7 +50,7 @@ public class InfiniteClipEnvelopeTest {
 
     @Before
     public void setUp() {
-        animation = new AnimationMock(Toolkit.getToolkit().getMasterTimer(), AnimationMock.DEFAULT_DURATION, AnimationMock.DEFAULT_RATE, Animation.INDEFINITE, AnimationMock.DEFAULT_AUTOREVERSE);
+        animation = new AnimationMock(Toolkit.getToolkit().getPrimaryTimer(), AnimationMock.DEFAULT_DURATION, AnimationMock.DEFAULT_RATE, Animation.INDEFINITE, AnimationMock.DEFAULT_AUTOREVERSE);
         clip = new InfiniteClipEnvelopeShim(animation);
     }
 

--- a/modules/javafx.graphics/src/test/java/test/com/sun/scenario/animation/shared/SingleLoopClipEnvelopeTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/scenario/animation/shared/SingleLoopClipEnvelopeTest.java
@@ -48,7 +48,7 @@ public class SingleLoopClipEnvelopeTest {
 
     @Before
     public void setUp() {
-        animation = new AnimationMock(Toolkit.getToolkit().getMasterTimer(), AnimationMock.DEFAULT_DURATION, AnimationMock.DEFAULT_RATE, 1, AnimationMock.DEFAULT_AUTOREVERSE);
+        animation = new AnimationMock(Toolkit.getToolkit().getPrimaryTimer(), AnimationMock.DEFAULT_DURATION, AnimationMock.DEFAULT_RATE, 1, AnimationMock.DEFAULT_AUTOREVERSE);
         clip = new SingleLoopClipEnvelopeShim(animation);
     }
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/animation/AbstractPrimaryTimerMock.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/animation/AbstractPrimaryTimerMock.java
@@ -29,10 +29,10 @@ import java.util.HashSet;
 import java.util.Set;
 import com.sun.javafx.animation.TickCalculation;
 import com.sun.scenario.DelayedRunnable;
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 import com.sun.scenario.animation.shared.PulseReceiver;
 
-public class AbstractMasterTimerMock extends AbstractMasterTimer {
+public class AbstractPrimaryTimerMock extends AbstractPrimaryTimer {
 
     private final Set<PulseReceiver> targets = new HashSet<PulseReceiver>();
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/animation/AnimationImpl.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/animation/AnimationImpl.java
@@ -25,13 +25,13 @@
 
 package test.javafx.animation;
 
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 import com.sun.scenario.animation.shared.ClipEnvelope;
 import javafx.animation.AnimationShim;
 
 public class AnimationImpl extends AnimationShim {
 
-    public AnimationImpl(AbstractMasterTimer timer, ClipEnvelope clipEnvelope, int resolution) {
+    public AnimationImpl(AbstractPrimaryTimer timer, ClipEnvelope clipEnvelope, int resolution) {
         super(timer, clipEnvelope, resolution);
     }
 
@@ -39,7 +39,7 @@ public class AnimationImpl extends AnimationShim {
         super();
     }
 
-    public AnimationImpl(AbstractMasterTimer timer) {
+    public AnimationImpl(AbstractPrimaryTimer timer) {
         super(timer);
     }
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/animation/AnimationMock.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/animation/AnimationMock.java
@@ -26,7 +26,7 @@
 package test.javafx.animation;
 
 import javafx.util.Duration;
-import com.sun.scenario.animation.AbstractMasterTimer;
+import com.sun.scenario.animation.AbstractPrimaryTimer;
 
 import static org.junit.Assert.*;
 
@@ -53,7 +53,7 @@ public class AnimationMock extends AnimationImpl {
         shim_setCycleDuration(duration);
     }
 
-    public AnimationMock(AbstractMasterTimer timer, Duration cycleDuration, double rate, int cycleCount, boolean autoReverse) {
+    public AnimationMock(AbstractPrimaryTimer timer, Duration cycleDuration, double rate, int cycleCount, boolean autoReverse) {
         super(timer);
         shim_setCycleDuration(cycleDuration);
         setRate(rate);

--- a/modules/javafx.graphics/src/test/java/test/javafx/animation/AnimationPulseReceiverTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/animation/AnimationPulseReceiverTest.java
@@ -40,14 +40,14 @@ import javafx.util.Duration;
 
 public class AnimationPulseReceiverTest {
 
-    private static final int DEFAULT_RESOLUTION = Toolkit.getToolkit().getMasterTimer().getDefaultResolution();
+    private static final int DEFAULT_RESOLUTION = Toolkit.getToolkit().getPrimaryTimer().getDefaultResolution();
     private static final double TICKS_2_NANOS = 1.0 / 6e-6;
-    private AbstractMasterTimerMock timer;
+    private AbstractPrimaryTimerMock timer;
     private AnimationMock animation;
 
     @Before
     public void setUp() {
-        timer = new AbstractMasterTimerMock();
+        timer = new AbstractPrimaryTimerMock();
         animation = new AnimationMock(timer, Duration.INDEFINITE, 1.0, 1, false);
     }
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/animation/AnimationSetRateTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/animation/AnimationSetRateTest.java
@@ -40,24 +40,24 @@ public class AnimationSetRateTest {
 
     private static final double EPSILON = 1e-12;
 
-    private AbstractMasterTimerMock timer;
+    private AbstractPrimaryTimerMock timer;
     private AnimationImpl animation;
     private ClipEnvelopeMock clipEnvelope;
 
     @Before
     public void setUp() throws Exception {
-        timer = new AbstractMasterTimerMock();
+        timer = new AbstractPrimaryTimerMock();
         clipEnvelope = new ClipEnvelopeMock();
         animation = new AnimationImpl(timer, clipEnvelope, 1);
         animation.shim_setCycleDuration(Duration.millis(1000));
         clipEnvelope.setAnimation(animation);
     }
 
-    private void assertAnimation(double rate, double currentRate, Status status, boolean addedToMasterTimer) {
+    private void assertAnimation(double rate, double currentRate, Status status, boolean addedToPrimaryTimer) {
         assertEquals(rate, animation.getRate(), EPSILON);
         assertEquals(currentRate, animation.getCurrentRate(), EPSILON);
         assertEquals(status, animation.getStatus());
-        assertEquals(addedToMasterTimer, timer.containsPulseReceiver(animation.shim_pulseReceiver()));
+        assertEquals(addedToPrimaryTimer, timer.containsPulseReceiver(animation.shim_pulseReceiver()));
     }
 
     @Test

--- a/modules/javafx.graphics/src/test/java/test/javafx/animation/AnimationTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/animation/AnimationTest.java
@@ -55,13 +55,13 @@ public class AnimationTest {
 
     private static final double EPSILON = 1e-12;
 
-    private AbstractMasterTimerMock timer;
+    private AbstractPrimaryTimerMock timer;
     private AnimationImpl animation;
     private ClipEnvelopeMock clipEnvelope;
 
     @Before
     public void setUp() {
-        timer = new AbstractMasterTimerMock();
+        timer = new AbstractPrimaryTimerMock();
         clipEnvelope = new ClipEnvelopeMock();
         animation = new AnimationImpl(timer, clipEnvelope, 1);
         animation.shim_setCycleDuration(ONE_SEC);
@@ -84,7 +84,7 @@ public class AnimationTest {
         assertEquals(DEFAULT_REPEAT_COUNT, animation0.getCycleCount());
         assertEquals(DEFAULT_AUTO_REVERSE, animation0.isAutoReverse());
         assertEquals(Status.STOPPED, animation0.getStatus());
-        assertEquals(6000.0 / Toolkit.getToolkit().getMasterTimer().getDefaultResolution(), animation0.getTargetFramerate(), EPSILON);
+        assertEquals(6000.0 / Toolkit.getToolkit().getPrimaryTimer().getDefaultResolution(), animation0.getTargetFramerate(), EPSILON);
         assertEquals(null, animation0.getOnFinished());
         assertEquals(0, animation0.getCuePoints().size());
 
@@ -586,7 +586,7 @@ public class AnimationTest {
 
     @Test
     public void testFullSpeedResolution() {
-        final int resolution = Toolkit.getToolkit().getMasterTimer().getDefaultResolution();
+        final int resolution = Toolkit.getToolkit().getPrimaryTimer().getDefaultResolution();
 
         // send pulse
         animation.doTimePulse(4 * resolution);

--- a/modules/javafx.graphics/src/test/java/test/javafx/animation/ParallelTransitionPlayTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/animation/ParallelTransitionPlayTest.java
@@ -46,7 +46,7 @@ public class ParallelTransitionPlayTest {
     LongProperty xProperty = new SimpleLongProperty();
     LongProperty yProperty = new SimpleLongProperty();
 
-    AbstractMasterTimerMock amt;
+    AbstractPrimaryTimerMock amt;
     ParallelTransition pt;
 
     Transition child1X;
@@ -56,7 +56,7 @@ public class ParallelTransitionPlayTest {
 
     @Before
     public void setUp() {
-        amt = new AbstractMasterTimerMock();
+        amt = new AbstractPrimaryTimerMock();
         pt = ParallelTransitionShim.getParallelTransition(amt);
         child1X = new TransitionShim() {
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/animation/SequentialTransitionPlayTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/animation/SequentialTransitionPlayTest.java
@@ -47,7 +47,7 @@ public class SequentialTransitionPlayTest {
 
     LongProperty xProperty = new SimpleLongProperty();
     LongProperty yProperty = new SimpleLongProperty();
-    AbstractMasterTimerMock amt;
+    AbstractPrimaryTimerMock amt;
     SequentialTransition st;
     Transition child1X;
     Transition child1Y;
@@ -56,7 +56,7 @@ public class SequentialTransitionPlayTest {
 
     @Before
     public void setUp() {
-        amt = new AbstractMasterTimerMock();
+        amt = new AbstractPrimaryTimerMock();
         st = SequentialTransitionShim.getSequentialTransition(amt);
         child1X = new TransitionShim() {
             {

--- a/modules/javafx.graphics/src/test/java/test/javafx/animation/TimelinePlayTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/animation/TimelinePlayTest.java
@@ -43,7 +43,7 @@ import static org.junit.Assert.*;
 
 public class TimelinePlayTest {
 
-    private AbstractMasterTimerMock amt;
+    private AbstractPrimaryTimerMock amt;
     private Timeline timeline;
     private LongProperty property = new SimpleLongProperty();
 
@@ -53,7 +53,7 @@ public class TimelinePlayTest {
 
     @Before
     public void setUp() {
-        amt = new AbstractMasterTimerMock();
+        amt = new AbstractPrimaryTimerMock();
         timeline = TimelineShim.getTimeline(amt);
     }
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/animation/TimelineTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/animation/TimelineTest.java
@@ -76,7 +76,7 @@ public class TimelineTest {
         assertEquals(DEFAULT_REPEAT_COUNT, timeline0.getCycleCount());
         assertEquals(DEFAULT_AUTO_REVERSE, timeline0.isAutoReverse());
         assertEquals(Status.STOPPED, timeline0.getStatus());
-        assertEquals(6000.0 / Toolkit.getToolkit().getMasterTimer().getDefaultResolution(), timeline0.getTargetFramerate(), EPSILON);
+        assertEquals(6000.0 / Toolkit.getToolkit().getPrimaryTimer().getDefaultResolution(), timeline0.getTargetFramerate(), EPSILON);
         assertEquals(null, timeline0.getOnFinished());
         assertTrue(timeline0.getCuePoints().isEmpty());
 
@@ -106,7 +106,7 @@ public class TimelineTest {
         assertEquals(DEFAULT_REPEAT_COUNT, timeline2.getCycleCount());
         assertEquals(DEFAULT_AUTO_REVERSE, timeline2.isAutoReverse());
         assertEquals(Status.STOPPED, timeline2.getStatus());
-        assertEquals(6000.0 / Toolkit.getToolkit().getMasterTimer().getDefaultResolution(), timeline2.getTargetFramerate(), EPSILON);
+        assertEquals(6000.0 / Toolkit.getToolkit().getPrimaryTimer().getDefaultResolution(), timeline2.getTargetFramerate(), EPSILON);
         assertEquals(null, timeline2.getOnFinished());
         assertEquals(Collections.singletonMap("oneSec", oneSec), timeline2.getCuePoints());
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/animation/TransitionTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/animation/TransitionTest.java
@@ -58,7 +58,7 @@ public class TransitionTest {
         // emtpy ctor
         Transition t0 = new TransitionImpl(Duration.millis(1000));
         assertEquals(DEFAULT_INTERPOLATOR, t0.getInterpolator());
-        assertEquals(6000.0 / Toolkit.getToolkit().getMasterTimer().getDefaultResolution(), t0.getTargetFramerate(), EPSILON);
+        assertEquals(6000.0 / Toolkit.getToolkit().getPrimaryTimer().getDefaultResolution(), t0.getTargetFramerate(), EPSILON);
 
         // setting targetFramerate
         Transition t1 = new TransitionImpl(Duration.millis(1000), 10);

--- a/modules/javafx.media/src/main/java/com/sun/javafx/media/PrismMediaFrameHandler.java
+++ b/modules/javafx.media/src/main/java/com/sun/javafx/media/PrismMediaFrameHandler.java
@@ -186,15 +186,15 @@ public class PrismMediaFrameHandler implements ResourceFactoryListener {
      */
     private class PrismFrameBuffer implements MediaFrame {
         private final PixelFormat videoFormat;
-        private final VideoDataBuffer master;
+        private final VideoDataBuffer primary;
 
         public PrismFrameBuffer(VideoDataBuffer sourceBuffer) {
             if (null == sourceBuffer) {
                 throw new NullPointerException();
             }
 
-            master = sourceBuffer;
-            switch (master.getFormat()) {
+            primary = sourceBuffer;
+            switch (primary.getFormat()) {
                 case BGRA_PRE:
                     videoFormat = PixelFormat.INT_ARGB_PRE;
                     break;
@@ -207,23 +207,23 @@ public class PrismMediaFrameHandler implements ResourceFactoryListener {
                 // ARGB isn't supported in prism, there's no corresponding PixelFormat
                 case ARGB:
                 default:
-                    throw new IllegalArgumentException("Unsupported video format "+master.getFormat());
+                    throw new IllegalArgumentException("Unsupported video format "+primary.getFormat());
             }
         }
 
         @Override
         public ByteBuffer getBufferForPlane(int plane) {
-            return master.getBufferForPlane(plane);
+            return primary.getBufferForPlane(plane);
         }
 
         @Override
         public void holdFrame() {
-            master.holdFrame();
+            primary.holdFrame();
         }
 
         @Override
         public void releaseFrame() {
-            master.releaseFrame();
+            primary.releaseFrame();
         }
 
         @Override
@@ -233,37 +233,37 @@ public class PrismMediaFrameHandler implements ResourceFactoryListener {
 
         @Override
         public int getWidth() {
-            return master.getWidth();
+            return primary.getWidth();
         }
 
         @Override
         public int getHeight() {
-            return master.getHeight();
+            return primary.getHeight();
         }
 
         @Override
         public int getEncodedWidth() {
-            return master.getEncodedWidth();
+            return primary.getEncodedWidth();
         }
 
         @Override
         public int getEncodedHeight() {
-            return master.getEncodedHeight();
+            return primary.getEncodedHeight();
         }
 
         @Override
         public int planeCount() {
-            return master.getPlaneCount();
+            return primary.getPlaneCount();
         }
 
         @Override
         public int[] planeStrides() {
-            return master.getPlaneStrides();
+            return primary.getPlaneStrides();
         }
 
         @Override
         public int strideForPlane(int planeIndex) {
-            return master.getStrideForPlane(planeIndex);
+            return primary.getStrideForPlane(planeIndex);
         }
 
         @Override
@@ -277,7 +277,7 @@ public class PrismMediaFrameHandler implements ResourceFactoryListener {
                 return null;
             }
 
-            VideoDataBuffer newVDB = master.convertToFormat(VideoFormat.BGRA_PRE);
+            VideoDataBuffer newVDB = primary.convertToFormat(VideoFormat.BGRA_PRE);
             if (null == newVDB) {
                 return null;
             }

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/MediaPlayer.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/MediaPlayer.java
@@ -291,7 +291,7 @@ public interface MediaPlayer {
     public void setBalance(float balance);
 
     /**
-     * Gets the master audio equalizer for the player.
+     * Gets the audio equalizer for the player.
      *
      * @return AudioEqualizer object
      */

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/effects/AudioEqualizer.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/effects/AudioEqualizer.java
@@ -26,7 +26,7 @@
 package com.sun.media.jfxmedia.effects;
 
 /**
- * Provides a master audio equalizer with up to 15 bands.  Each band can have the center frequency,
+ * Provides an audio equalizer with up to 15 bands.  Each band can have the center frequency,
  * bandwidth, and gain set.
  */
 public interface AudioEqualizer

--- a/modules/javafx.web/src/ios/native/WebViewImpl.m
+++ b/modules/javafx.web/src/ios/native/WebViewImpl.m
@@ -62,8 +62,8 @@ jstring createJString(JNIEnv *env, NSString *nsStr) {
 
 @implementation WebViewImpl
 
-@synthesize window;     //known as masterWindow in glass
-@synthesize windowView; //known as masterWindowHost in glass
+@synthesize window;     //known as mainWindow in glass
+@synthesize windowView; //known as mainWindowHost in glass
 
 - (void)setWidth:(CGFloat)value {
     width = value;
@@ -141,8 +141,8 @@ jstring createJString(JNIEnv *env, NSString *nsStr) {
     loadingLabel.textAlignment = UITextAlignmentCenter;
     //[loadingLabel.layer setAnchorPoint:CGPointMake(0.0f, 0.0f)];
 
-    window = [self getWindow];                          //known as masterWindow in glass
-    windowView = [[window rootViewController] view];    //known as masterWindowHost in glass
+    window = [self getWindow];                          //known as mainWindow in glass
+    windowView = [[window rootViewController] view];    //known as mainWindowHost in glass
 }
 
 - (JNIEnv *)getJNIEnv {

--- a/modules/javafx.web/src/main/java/com/sun/webkit/Utilities.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/Utilities.java
@@ -58,8 +58,8 @@ public abstract class Utilities {
         return new HashSet(Arrays.asList(items));
     }
 
-    // Whitelist of Class methods to allow
-    private static final Set<String> classMethodsWhitelist = asSet(
+    // List of Class methods to allow
+    private static final Set<String> classMethodsAllowList = asSet(
         "getCanonicalName",
         "getEnumConstants",
         "getFields",
@@ -83,16 +83,16 @@ public abstract class Utilities {
         "toString"
     );
 
-    // Blacklist of classes to disallow
-    private static final Set<String> classesBlacklist = asSet(
+    // List of classes to reject
+    private static final Set<String> classesRejectList = asSet(
         "java.lang.ClassLoader",
         "java.lang.Module",
         "java.lang.Runtime",
         "java.lang.System"
     );
 
-    // Blacklist of packages to disallow
-    private static final List<String> packagesBlacklist = Arrays.asList(
+    // List of packages to reject
+    private static final List<String> packagesRejectList = Arrays.asList(
         "java.lang.invoke",
         "java.lang.module",
         "java.lang.reflect",
@@ -108,18 +108,18 @@ public abstract class Utilities {
 
         final Class<?> clazz = method.getDeclaringClass();
         if (clazz.equals(java.lang.Class.class)) {
-            // check whitelist of allowable Class methods
-            if (!classMethodsWhitelist.contains(method.getName())) {
+            // check list of allowed Class methods
+            if (!classMethodsAllowList.contains(method.getName())) {
                 throw new UnsupportedOperationException("invocation not supported");
             }
         } else {
-            // check blacklist of class names
+            // check list of rejected class names
             final String className = clazz.getName();
-            if (classesBlacklist.contains(className)) {
+            if (classesRejectList.contains(className)) {
                 throw new UnsupportedOperationException("invocation not supported");
             }
-            // check blacklist of packages
-            packagesBlacklist.forEach(packageName -> {
+            // check list of rejected packages
+            packagesRejectList.forEach(packageName -> {
                 if (className.startsWith(packageName + ".")) {
                     throw new UnsupportedOperationException("invocation not supported");
                 }

--- a/modules/javafx.web/src/main/java/com/sun/webkit/text/TextCodec.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/text/TextCodec.java
@@ -78,7 +78,7 @@ final class TextCodec {
             encodings.add(e);
             Charset c = entry.getValue();
             for (String a : c.aliases()) {
-                // 8859_1 is blacklisted in TextEncodingRegistry.cpp:isUndesiredAlias()
+                // 8859_1 is rejected in TextEncodingRegistry.cpp:isUndesiredAlias()
                 // See also https://bugs.webkit.org/show_bug.cgi?id=43554
                 if (a.equals("8859_1")) continue;
 


### PR DESCRIPTION
Replace archaic/non-inclusive words in JavaFX with more neutral terms. See [JDK-8253315](https://bugs.openjdk.java.net/browse/JDK-8253315) for background information.

The following changes are made:

1. Rename whitelist/blacklist to allowlist/rejectlist
2. Rename `MasterTimer` to `PrimaryTimer` in animation and toolkit implementation
3. Rename local variable master in a couple places
4. Remove master from comments in a few other places

This PR doesn't remove uses of the word master where there is no connotation of slavery.

Note that it is out of scope of this PR to address similar issues in 3rd-party code, such as WebKit or GStreamer. We will pick up any relevant changes after they are available in the upstream sources.

/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8253356](https://bugs.openjdk.java.net/browse/JDK-8253356): JavaFX Terminology Refresh


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/368/head:pull/368`
`$ git checkout pull/368`
