### PR TITLE
8259277: Change JavaFX release version to 17

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -39,7 +39,7 @@
 jfx.release.suffix=-ea
 
 # UPDATE THE FOLLOWING VALUES FOR A NEW RELEASE
-jfx.release.major.version=16
+jfx.release.major.version=17
 jfx.release.minor.version=0
 jfx.release.security.version=0
 jfx.release.patch.version=0
@@ -56,8 +56,8 @@ jfx.release.patch.version=0
 
 javadoc.bottom=<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2021, Oracle and/or its affiliates. All rights reserved.</small>
 
-javadoc.title=JavaFX 16
-javadoc.header=JavaFX&nbsp;16
+javadoc.title=JavaFX 17
+javadoc.header=JavaFX&nbsp;17
 
 ##############################################################################
 #

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
@@ -89,7 +89,7 @@ public class VersionInfoTest {
         String version = VersionInfo.getVersion();
         // Need to update major version number when we develop the next
         // major release.
-        assertTrue(version.startsWith("16"));
+        assertTrue(version.startsWith("17"));
         String runtimeVersion = VersionInfo.getRuntimeVersion();
         assertTrue(runtimeVersion.startsWith(version));
     }


### PR DESCRIPTION
Bump the version number of JavaFX to 17. I will integrate this immediately after forking the `jfx16` stabilization branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259277](https://bugs.openjdk.java.net/browse/JDK-8259277): Change JavaFX release version to 17


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - Committer)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/371/head:pull/371`
`$ git checkout pull/371`
