### PR TITLE
8165749: java.lang.RuntimeException: dndGesture.dragboard is null in dragDrop

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -3785,7 +3785,7 @@ public class Scene implements EventTarget {
                             backButtonDown || forwardButtonDown)) {
                         //old gesture ended and new one started
                         gestureStarted = true;
-                        if (!PLATFORM_DRAG_GESTURE_INITIATION) {
+                        if (!PLATFORM_DRAG_GESTURE_INITIATION && Scene.this.dndGesture == null) {
                             Scene.this.dndGesture = new DnDGesture();
                         }
                         clearPDREventTargets();

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -3782,10 +3782,11 @@ public class Scene implements EventTarget {
             if (!onPulse) {
                 if (e.getEventType() == MouseEvent.MOUSE_PRESSED) {
                     if (!(primaryButtonDown || secondaryButtonDown || middleButtonDown ||
-                            backButtonDown || forwardButtonDown)) {
+                            backButtonDown || forwardButtonDown) &&
+                            Scene.this.dndGesture == null) {
                         //old gesture ended and new one started
                         gestureStarted = true;
-                        if (!PLATFORM_DRAG_GESTURE_INITIATION && Scene.this.dndGesture == null) {
+                        if (!PLATFORM_DRAG_GESTURE_INITIATION) {
                             Scene.this.dndGesture = new DnDGesture();
                         }
                         clearPDREventTargets();


### PR DESCRIPTION
As commented in the JBS issue, there is one single `dndGesture` object in `Scene`, that can be instantiated from three different ways: 

- DropTargetListener, on dragEnter 
- DragGestureListener, on dragGestureRecognized or 
- MouseHandler, processing a right mouse click (these two are mutually exclusive).  

This PR prevents that, for two almost simultaneous drag events (for instance via mouse and touchpad), the `dndGesture` for the last of these events gets initialized again, losing all existing drag info (`dndGesture.dragboard`) that was added to the first one, avoiding the RTE.

The existing manual test [DndTest](https://github.com/openjdk/jfx/blob/master/tests/manual/dnd/DndTest.java) has been used on MacOS to verify the PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8165749](https://bugs.openjdk.java.net/browse/JDK-8165749): java.lang.RuntimeException: dndGesture.dragboard is null in dragDrop


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/372/head:pull/372`
`$ git checkout pull/372`
