### PR TITLE
8259639: GitHub actions: build fails on Linux due to missing apt-get update

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -74,6 +74,7 @@ jobs:
       - name: Install dependencies
         run: |
           set -x
+          sudo apt-get update
           sudo apt-get install libgl1-mesa-dev libx11-dev libxxf86vm-dev libxt-dev pkg-config libgtk2.0-dev libgtk-3-dev libxtst-dev gcc-10=10.2.0-5ubuntu1~20.04 g++-10=10.2.0-5ubuntu1~20.04
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
           mkdir -p "${HOME}/build-tools"


### PR DESCRIPTION
Simple fix to the `submit.yml` script to run `apt-get update` prior to installing needed packages on Linux. Without this, the request to install packages can fail to find the requested pacakges due to an out-of-date cache.

Compare the [failing build](https://github.com/kevinrushforth/jfx/actions/runs/480626290) before the fix with the [successful build](https://github.com/kevinrushforth/jfx/actions/runs/480641431) after the fix.

Note that this is targeted to `jfx16` so that any subsequent pull request for `jfx16` will be able to have a successful build on Linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259639](https://bugs.openjdk.java.net/browse/JDK-8259639): GitHub actions: build fails on Linux due to missing apt-get update


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/375/head:pull/375`
`$ git checkout pull/375`
