### PR TITLE
8256283: IndexOutOfBoundsException when sorting a TreeTableView

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -579,7 +579,7 @@ public class TreeTableView<S> extends Control {
         @Override public Boolean call(TreeTableView table) {
             try {
                 TreeItem rootItem = table.getRoot();
-                if (rootItem == null | rootItem.getChildren().isEmpty()) return false;
+                if (rootItem == null || rootItem.getChildren().isEmpty()) return false;
 
                 TreeSortMode sortMode = table.getSortMode();
                 if (sortMode == null) return false;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -579,7 +579,7 @@ public class TreeTableView<S> extends Control {
         @Override public Boolean call(TreeTableView table) {
             try {
                 TreeItem rootItem = table.getRoot();
-                if (rootItem == null) return false;
+                if (rootItem == null | rootItem.getChildren().isEmpty()) return false;
 
                 TreeSortMode sortMode = table.getSortMode();
                 if (sortMode == null) return false;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -772,6 +772,13 @@ public class TreeTableViewTest {
         });
     }
 
+    @Test public void testNPEWhenRootItemIsNull() {
+        TreeTableView<String> ttv = new TreeTableView<>();
+        ControlTestUtils.runWithExceptionHandler(() -> {
+            ttv.sort();
+        });
+    }
+
     @Test public void testChangingSortPolicyUpdatesItemsList() {
         TreeTableColumn<String, String> col = initSortTestStructure();
         col.setSortType(DESCENDING);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -753,6 +753,25 @@ public class TreeTableViewTest {
         treeTableView.sort();
     }
 
+    @Test public void testNoIOOBEWhenSortingAfterSelectAndClearRootChildren() {
+        TreeTableView<String> ttv = new TreeTableView<>();
+        TreeItem<String> root = new TreeItem<>("root");
+        TreeItem<String> child = new TreeItem<>("child");
+        root.getChildren().add(child);
+        root.setExpanded(true);
+        ttv.setRoot(root);
+        ttv.setShowRoot(false);
+
+        TreeTableColumn<String, String> ttc = new TreeTableColumn<>("Column");
+        ttv.getSortOrder().add(ttc);
+
+        ttv.getSelectionModel().select(0);
+        root.getChildren().remove(0);
+        ControlTestUtils.runWithExceptionHandler(() -> {
+            ttv.sort();
+        });
+    }
+
     @Test public void testChangingSortPolicyUpdatesItemsList() {
         TreeTableColumn<String, String> col = initSortTestStructure();
         col.setSortType(DESCENDING);


### PR DESCRIPTION
This particular issue JDK-8256283, is a specific case of IOOBE when, rootItem is not shown, some children including first child are selected, then all children are removed and sort() is invoked. The sort() fails with an IOOBE.
This PR only addresses this specific IOOBE.
Root cause of this issue is that the selection is not cleared after rootItems children are removed. In addition to this, there are few other scenarios when selection is not updated correctly, which are collected under an umbrella task [JDK-8248217](https://bugs.openjdk.java.net/browse/JDK-8248217). Fix for [JDK-8248217](https://bugs.openjdk.java.net/browse/JDK-8248217) would require good amount refactoring of selection model.

The fix for this issue is to avoid sort() when rootItem.getChildren().isEmpty().
Added a unit test with the fix, which fails without fix and passes with fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8256283](https://bugs.openjdk.java.net/browse/JDK-8256283): IndexOutOfBoundsException when sorting a TreeTableView


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/384/head:pull/384`
`$ git checkout pull/384`
