### PR TITLE
Fix macOS menu at launch

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -241,6 +241,10 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     {
+        NSApplication *app = [NSApplication sharedApplication];
+        [app setActivationPolicy:NSApplicationActivationPolicyRegular];
+        [app activateIgnoringOtherApps:true];
+
         (*env)->CallVoidMethod(env, self->jApplication, [GlassHelper ApplicationNotifyDidFinishLaunchingMethod]);
     }
     [pool drain];


### PR DESCRIPTION
When a Java application launches, the menu is not immediately clickable. A
recent change in macOS broke the functionality used before, which calls
`activateWithOptions` outside of the `applicationDidFinishLaunching` delegate
call.

As per https://stackoverflow.com/questions/62739862 this can be fixed by
moving the `activateWithOptions` calls into the delegate's callback.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/386/head:pull/386`
`$ git checkout pull/386`
