### PR TITLE
8259046: ViewPainter.ROOT_PATHS holds reference to Scene causing memory leak

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ViewPainter.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ViewPainter.java
@@ -319,6 +319,7 @@ abstract class ViewPainter implements Runnable {
                     g.setClipRect(dirtyRect);
                     g.setClipRectIndex(i);
                     doPaint(g, getRootPath(i));
+                    getRootPath(i).clear();
                 }
             }
         } else {

--- a/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/ViewPainterLeakTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/ViewPainterLeakTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.javafx.tk.quantum;
+
+import java.lang.ref.WeakReference;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.layout.StackPane;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
+import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import test.util.Util;
+import test.util.memory.JMemoryBuddy;
+
+import static org.junit.Assert.*;
+
+public class ViewPainterLeakTest {
+
+    private static CountDownLatch startupLatch;
+    private static Stage stage;
+    private static ScrollPane scrollPane;
+    private static WeakReference<Scene> sceneRef;
+
+    private static final String text =
+            "The quick brown fox jumps over the lazy dog." +
+            " " +
+            "The quick brown fox jumps over the lazy dog.";
+
+    public static class TestApp extends Application {
+        @Override
+        public void start(Stage stage) {
+            ViewPainterLeakTest.stage = stage;
+
+            Platform.setImplicitExit(false);
+
+            TextFlow content = new TextFlow(new Text(text));
+            scrollPane = new ScrollPane(content);
+            StackPane root = new StackPane(scrollPane);
+
+            Scene scene = new Scene(root, 200, 100);
+            sceneRef = new WeakReference<>(scene);
+            stage.setScene(scene);
+
+            stage.addEventHandler(WindowEvent.WINDOW_SHOWN, e -> {
+                Platform.runLater(() -> {
+                    startupLatch.countDown();
+                });
+            });
+            stage.show();
+        }
+    }
+
+    @BeforeClass
+    public static void setupOnce() throws Exception {
+        startupLatch = new CountDownLatch(1);
+        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
+        assertTrue("Timeout waiting for FX runtime to start",
+                startupLatch.await(15, TimeUnit.SECONDS));
+    }
+
+    @AfterClass
+    public static void teardown() {
+        Platform.exit();
+    }
+
+    @Test
+    public void testViewPainterLeak() {
+        // Wait for some time to make sure the initial content is displayed
+        Util.sleep(500);
+
+        // This will trigger the leak
+        Util.runAndWait(() -> scrollPane.setHvalue(0.5));
+
+        // Wait for some time to make sure the scrolled content is displayed
+        Util.sleep(500);
+        Util.runAndWait(() -> {
+            stage.hide();
+            stage = null;
+            scrollPane = null;
+        });
+        JMemoryBuddy.assertCollectable(sceneRef);
+    }
+
+}


### PR DESCRIPTION
Prism implements a dirty region optimization, where in many cases, only part of the scene graph is re-rendered when something changes. In support of this, the `ViewPainter` class in the Quantum Toolkit keeps an array of node paths, `ROOT_PATHS`, which is a list of sub-trees in the scene graph that need to be rendered based on a change to that node. The entries in the `ROOT_PATHS` array are intended to be transient during the rendering of a single pass of a single scene. They are recreated every time a scene is rendered. The leak occurs because the entries are not cleared after being used. The fix is to clear each entry after it is rendered. In addition to static analysis, which shows that the entries are never used again after a frame is rendered, I have done a full build and test, including manual tests, to be sure that there is no regression.

I have added a test that will fail consistently on Mac and Windows (and intermittently on Linux) without the fix. It passes consistently on all platforms with the fix.

Even though this is a simple change, it is in an area that has historically been fragile, so I would like two reviewers.

/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259046](https://bugs.openjdk.java.net/browse/JDK-8259046): ViewPainter.ROOT_PATHS holds reference to Scene causing memory leak


### Reviewers
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - Committer)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/388/head:pull/388`
`$ git checkout pull/388`
