### PR TITLE
8260475: Deprecate for removal protected access members in DateTimeStringConverter

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/util/converter/DateTimeStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/DateTimeStringConverter.java
@@ -43,18 +43,24 @@ import javafx.util.StringConverter;
 public class DateTimeStringConverter extends StringConverter<Date> {
 
     // ------------------------------------------------------ Private properties
+
+    @Deprecated(forRemoval = true, since = "17")
     protected final Locale locale;
+    @Deprecated(forRemoval = true, since = "17")
     protected final String pattern;
+    @Deprecated(forRemoval = true, since = "17")
     protected final DateFormat dateFormat;
 
     /**
      * @since JavaFX 8u40
      */
+    @Deprecated(forRemoval = true, since = "17")
     protected final int dateStyle;
 
     /**
      * @since JavaFX 8u40
      */
+    @Deprecated(forRemoval = true, since = "17")
     protected final int timeStyle;
 
 
@@ -200,6 +206,7 @@ public class DateTimeStringConverter extends StringConverter<Date> {
      * @return a {@code DateFormat} instance for formatting and parsing in this
      * {@link StringConverter}
      */
+    @Deprecated(forRemoval = true, since = "17")
     protected DateFormat getDateFormat() {
         DateFormat df = null;
 

--- a/modules/javafx.base/src/main/java/javafx/util/converter/DateTimeStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/DateTimeStringConverter.java
@@ -44,20 +44,33 @@ public class DateTimeStringConverter extends StringConverter<Date> {
 
     // ------------------------------------------------------ Private properties
 
+    /**
+     * @deprecated This field was exposed erroneously and will be removed in a future version.
+     */
     @Deprecated(forRemoval = true, since = "17")
     protected final Locale locale;
+
+    /**
+     * @deprecated This field was exposed erroneously and will be removed in a future version.
+     */
     @Deprecated(forRemoval = true, since = "17")
     protected final String pattern;
+
+    /**
+     * @deprecated This field was exposed erroneously and will be removed in a future version.
+     */
     @Deprecated(forRemoval = true, since = "17")
     protected final DateFormat dateFormat;
 
     /**
+     * @deprecated This field was exposed erroneously and will be removed in a future version.
      * @since JavaFX 8u40
      */
     @Deprecated(forRemoval = true, since = "17")
     protected final int dateStyle;
 
     /**
+     * @deprecated This field was exposed erroneously and will be removed in a future version.
      * @since JavaFX 8u40
      */
     @Deprecated(forRemoval = true, since = "17")
@@ -205,6 +218,8 @@ public class DateTimeStringConverter extends StringConverter<Date> {
      *
      * @return a {@code DateFormat} instance for formatting and parsing in this
      * {@link StringConverter}
+     *
+     * @deprecated This method exposes internal implementation details and will be removed in a future version.
      */
     @Deprecated(forRemoval = true, since = "17")
     protected DateFormat getDateFormat() {


### PR DESCRIPTION
Deprecating protected members in DateTimeStringConverter. Internal implementation should not be exposed (similar to `NumberStringConverter` and others).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260475](https://bugs.openjdk.java.net/browse/JDK-8260475): Deprecate for removal protected access members in DateTimeStringConverter


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/390/head:pull/390`
`$ git checkout pull/390`
