### PR TITLE
8260468: Wrong behavior of LocalDateTimeStringConverter

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/util/converter/LocalDateTimeStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/LocalDateTimeStringConverter.java
@@ -208,11 +208,11 @@ public class LocalDateTimeStringConverter extends StringConverter<LocalDateTime>
             TemporalAccessor temporal = parser.parse(text);
 
             if (type == LocalDate.class) {
-                return (T)LocalDate.from(chronology.date(temporal));
+                return (T) LocalDate.from(temporal);
             } else if (type == LocalTime.class) {
-                return (T)LocalTime.from(temporal);
+                return (T) LocalTime.from(temporal);
             } else {
-                return (T)LocalDateTime.from(chronology.localDateTime(temporal));
+                return (T) LocalDateTime.from(temporal);
             }
         }
 
@@ -228,29 +228,7 @@ public class LocalDateTimeStringConverter extends StringConverter<LocalDateTime>
                 formatter = getDefaultFormatter();
             }
 
-            if (value instanceof LocalDate) {
-                ChronoLocalDate cDate;
-                try {
-                    cDate = chronology.date(value);
-                } catch (DateTimeException ex) {
-                    Logging.getLogger().warning("Converting LocalDate " + value + " to " + chronology + " failed, falling back to IsoChronology.", ex);
-                    chronology = IsoChronology.INSTANCE;
-                    cDate = (LocalDate)value;
-                }
-                return formatter.format(cDate);
-            } else if (value instanceof LocalDateTime) {
-                ChronoLocalDateTime<? extends ChronoLocalDate> cDateTime;
-                try {
-                    cDateTime = chronology.localDateTime(value);
-                } catch (DateTimeException ex) {
-                    Logging.getLogger().warning("Converting LocalDateTime " + value + " to " + chronology + " failed, falling back to IsoChronology.", ex);
-                    chronology = IsoChronology.INSTANCE;
-                    cDateTime = (LocalDateTime)value;
-                }
-                return formatter.format(cDateTime);
-            } else {
-                return formatter.format(value);
-            }
+            return formatter.format(value);
         }
 
 

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
@@ -25,8 +25,8 @@
 
 package test.javafx.util.converter;
 
+import java.time.DateTimeException;
 import java.time.LocalDateTime;
-import java.time.chrono.Chronology;
 import java.time.chrono.IsoChronology;
 import java.time.chrono.JapaneseChronology;
 import java.time.format.DateTimeFormatter;
@@ -37,13 +37,11 @@ import java.util.Locale;
 import static org.junit.Assert.*;
 
 import javafx.util.StringConverter;
-import javafx.util.converter.LocalTimeStringConverterShim;
 import javafx.util.converter.LocalDateTimeStringConverter;
 import javafx.util.converter.LocalDateTimeStringConverterShim;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -51,6 +49,7 @@ import org.junit.runners.Parameterized;
  */
 @RunWith(Parameterized.class)
 public class LocalDateTimeStringConverterTest {
+
     private static final String JAPANESE_DATE_STRING = "Saturday, January 12, 60 Shōwa, 12:34:56 PM";
     private static final LocalDateTime VALID_LDT_WITH_SECONDS    = LocalDateTime.of(1985, 1, 12, 12, 34, 56);
     private static final LocalDateTime VALID_LDT_WITHOUT_SECONDS = LocalDateTime.of(1985, 1, 12, 12, 34, 0);
@@ -164,8 +163,8 @@ public class LocalDateTimeStringConverterTest {
         assertEquals(JAPANESE_DATE_STRING, converter.toString(VALID_LDT_WITH_SECONDS));
         // force a chronology change with an invalid Japanese date
         try {
-            System.out.println(converter.toString(LocalDateTime.of(1, 1, 1, 1, 1, 1)));
-        } catch (Exception e) {}
+            converter.toString(LocalDateTime.of(1, 1, 1, 1, 1, 1));
+        } catch (DateTimeException e) {}
         assertEquals(VALID_LDT_WITH_SECONDS, converter.fromString(JAPANESE_DATE_STRING));
     }
 }

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
@@ -28,6 +28,7 @@ package test.javafx.util.converter;
 import java.time.LocalDateTime;
 import java.time.chrono.Chronology;
 import java.time.chrono.IsoChronology;
+import java.time.chrono.JapaneseChronology;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.Arrays;
@@ -50,6 +51,7 @@ import org.junit.runners.Parameterized;
  */
 @RunWith(Parameterized.class)
 public class LocalDateTimeStringConverterTest {
+    private static final String JAPANESE_DATE_STRING = "Saturday, January 12, 60 Shōwa, 12:34:56 PM";
     private static final LocalDateTime VALID_LDT_WITH_SECONDS    = LocalDateTime.of(1985, 1, 12, 12, 34, 56);
     private static final LocalDateTime VALID_LDT_WITHOUT_SECONDS = LocalDateTime.of(1985, 1, 12, 12, 34, 0);
 
@@ -154,5 +156,16 @@ public class LocalDateTimeStringConverterTest {
         StringConverter<LocalDateTime> converter = new LocalDateTimeStringConverter(formatter, null);
         assertEquals("12 January 1985, 12:34:56", converter.toString(VALID_LDT_WITH_SECONDS));
         assertEquals(VALID_LDT_WITH_SECONDS, converter.fromString("12 January 1985, 12:34:56"));
+    }
+
+    @Test
+    public void testChronologyConsistency() {
+        var converter = new LocalDateTimeStringConverter(FormatStyle.FULL, FormatStyle.MEDIUM, null, JapaneseChronology.INSTANCE);
+        assertEquals(JAPANESE_DATE_STRING, converter.toString(VALID_LDT_WITH_SECONDS));
+        // force a chronology change with an invalid Japanese date
+        try {
+            System.out.println(converter.toString(LocalDateTime.of(1, 1, 1, 1, 1, 1)));
+        } catch (Exception e) {}
+        assertEquals(VALID_LDT_WITH_SECONDS, converter.fromString(JAPANESE_DATE_STRING));
     }
 }


### PR DESCRIPTION
Fixes a mutability issue for `LocalDateTimeStringConverter` (and `LocalDateStringConverter`) where the chronology can change during the lifetime of the instance and cause an inconsistent state. The following changes were made:

* The input is now formatted and parsed directly with the formatter and parser (which are configured with a chronology) without the chronology field value of the class.
* The chronology field value does not change anymore when there is an exception due to inability to format the date.
* Logging on failed formatting was removed as it did not seem useful. The formatter will throw the same exception that the chronology field does anyway, so there is not much use to catching the exception before hand.

Added a test that fails without this patch. The test creates a converter with an explicit `Chronology` and `null` parser and formatter. The default formatter that is created with the given chronology formats a legal date (with respect to the chronology) to a string, which the parser should be able to convert back to a date. However, by forcing an exception in the formatting process using an illegal date, the chronology changes, and now when the parser is used it is configured with the new chronology and it can't parse the string correctly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260468](https://bugs.openjdk.java.net/browse/JDK-8260468): Wrong behavior of LocalDateTimeStringConverter


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - Committer)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/393/head:pull/393`
`$ git checkout pull/393`
