### PR TITLE
8249737: java.lang.RuntimeException: Too many touch points reported

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
@@ -1265,10 +1265,9 @@ void NotifyTouchInput(
 
     JNIEnv *env = GetEnv();
 
-    // TBD: set to 'true' if source device is a touch screen
-    // and to 'false' if source device is a touch pad.
-    // So far assume source device on Windows is always a touch screen.
-    const bool isDirect = true;
+    // Sets to 'true' if source device is a touch screen
+    // and to 'false' if source device is a touch pad/pen.
+    const bool isDirect = IsTouchEvent();
 
     jint modifiers = GetModifiers();
     env->CallStaticObjectMethod(gestureSupportCls,


### PR DESCRIPTION
Using a digitizer tablet with a pen that works with Windows or MacOS, it works fine on MacOS, but throws a RTE on Windows 10. On MacOS there are only MouseEvents, while on Windows there are both MouseEvents and TouchEvents mixed together. 

Windows only uses [direct](https://github.com/openjdk/jfx/blob/master/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp#L1271) touch events natively, and that works for touch screens. 

But when touch pads are used generate mainly indirect touch events.  

There is already a way to find the source of the touch event (touch screen or touch pad/pen), via [isTouchEvent()](https://github.com/openjdk/jfx/blob/master/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp#L62), so this PR uses that method to set `isDirect` based on the source: true or direct for touch screen and false or indirect for touch pad/pen. 

Tested successfully using a touch screen and a touch pad with pen.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8249737](https://bugs.openjdk.java.net/browse/JDK-8249737): java.lang.RuntimeException: Too many touch points reported


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/394/head:pull/394`
`$ git checkout pull/394`
