### PR TITLE
8248126: JavaFX ignores HiDPI scaling settings on some linux platforms

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassRobot.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassRobot.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -132,7 +132,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkRobot__1mouseMove
 
     Display *xdisplay = gdk_x11_get_default_xdisplay();
     checkXTest(env);
-    jfloat uiScale = getUIScale();
+    jfloat uiScale = getUIScale(gdk_screen_get_default());
     x = rint(x * uiScale);
     y = rint(y * uiScale);
     XWarpPointer(xdisplay,
@@ -228,7 +228,7 @@ JNIEXPORT jint JNICALL Java_com_sun_glass_ui_gtk_GtkRobot__1getMouseX
 
     jint x;
     glass_gdk_display_get_pointer(gdk_display_get_default(), &x, NULL);
-    x = rint(x / getUIScale());
+    x = rint(x / getUIScale(gdk_screen_get_default()));
     return x;
 }
 
@@ -245,7 +245,7 @@ JNIEXPORT jint JNICALL Java_com_sun_glass_ui_gtk_GtkRobot__1getMouseY
 
     jint y;
     glass_gdk_display_get_pointer(gdk_display_get_default(), NULL, &y);
-    y = rint(y / getUIScale());
+    y = rint(y / getUIScale(gdk_screen_get_default()));
     return y;
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_screen.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_screen.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
  */
 
 #include <stdlib.h>
-
 #include "glass_screen.h"
 #include "glass_general.h"
 
@@ -33,6 +32,7 @@
 #include <gdk/gdkx.h>
 
 jfloat OverrideUIScale = -1.0f;
+int DEFAULT_DPI = 96;
 
 static guint get_current_desktop(GdkScreen *screen) {
     Display* display = gdk_x11_display_get_xdisplay(gdk_display_get_default());
@@ -103,7 +103,7 @@ static GdkRectangle get_screen_workarea(GdkScreen *screen) {
 
 }
 
-jfloat getUIScale() {
+jfloat getUIScale(GdkScreen* screen) {
     jfloat uiScale;
     if (OverrideUIScale > 0.0f) {
         uiScale = OverrideUIScale;
@@ -115,6 +115,9 @@ jfloat getUIScale() {
         } else {
             uiScale = (jfloat) glass_settings_get_guint_opt("org.gnome.desktop.interface",
                                                             "scaling-factor", 0);
+            if (uiScale < 1) {
+                uiScale = (jfloat) (gdk_screen_get_resolution(screen) / DEFAULT_DPI);
+            }
             if (uiScale < 1) {
                 uiScale = 1;
             }
@@ -140,7 +143,8 @@ static jobject createJavaScreen(JNIEnv* env, GdkScreen* screen, gint monitor_idx
     GdkRectangle working_monitor_geometry;
     gdk_rectangle_intersect(&workArea, &monitor_geometry, &working_monitor_geometry);
 
-    jfloat uiScale = getUIScale();
+    jfloat uiScale = getUIScale(screen);
+
 
     jint mx = monitor_geometry.x / uiScale;
     jint my = monitor_geometry.y / uiScale;

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_screen.h
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_screen.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
 #include <gtk/gtk.h>
 
 extern jfloat OverrideUIScale;
-jfloat getUIScale();
+jfloat getUIScale(GdkScreen* screen);
 jobject createJavaScreen(JNIEnv* env, gint monitor_idx);
 glong getScreenPtrForLocation(gint x, gint y);
 jobjectArray rebuild_screens(JNIEnv* env);


### PR DESCRIPTION
JavaFX ignores the HiDPI scaling settings on Fedora 32 and Ubuntu 20.04.

The scale detection in JavaFX assumes that the "scaling-factor" setting in "org.gnome.desktop.interface" has the correct Hi-DPI setting. But this not true for some systems and "scaling-factor" has value of 0. JavaFX should detect the windows level scale factor automatically in this case,  but this logic is missing right now. So, the JavaFX applications are not scaled properly. 
This issue can be reproduced by setting the scale from Settings->Displays->Set Scale. Note, the option for scale may not be present from some resolution settings, so you may need to change it to see the option to scale the full windowing system. The issue can be verified by running some JavaFX applications/samples. The application will not be scaled properly according to the UIScale. https://bugs.openjdk.java.net/browse/JDK-8258464 is similar bug and has been closed as duplicate.

This fix adds the logic to detect the scale from windows system itself.
I have ran all automated unit tests and system tests, this fix is not causing any new failures. I have tested this on fedora 32 VM, Ubuntu 20.04 VM and Ubuntu 20.10 VM.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8248126](https://bugs.openjdk.java.net/browse/JDK-8248126): JavaFX ignores HiDPI scaling settings on some linux platforms


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/396/head:pull/396`
`$ git checkout pull/396`
