### PR TITLE
8089589: [ListView] ScrollBar content moves toward-backward during scrolling.

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -1042,7 +1042,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
         if (viewportLength >= estimatedSize) {
             setPosition(0.);
         } else {
-            setPosition(absoluteOffset/(estimatedSize - viewportLength));
+            setPosition(absoluteOffset / (estimatedSize - viewportLength));
         }
     }
 
@@ -1587,8 +1587,6 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
 
         if (! posSet) {
             adjustPositionToIndex(index);
-//            double offset = - computeOffsetForCell(index);
-//            adjustByPixelAmount(offset);
         }
 
         requestLayout();
@@ -1900,7 +1898,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
     private double viewportLength;
     void setViewportLength(double value) {
         this.viewportLength = value;
-        this.absoluteOffset = getPosition() * (estimatedSize -viewportLength);
+        this.absoluteOffset = getPosition() * (estimatedSize - viewportLength);
     }
     double getViewportLength() {
         return viewportLength;
@@ -2561,7 +2559,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
                 // only a single row and it is bigger than the viewport
                 lengthBar.setVisibleAmount(flowLength / sumCellLength);
             } else {
-                lengthBar.setVisibleAmount(viewportLength/estimatedSize);
+                lengthBar.setVisibleAmount(viewportLength / estimatedSize);
             }
         }
 
@@ -2831,13 +2829,13 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
     private double computeViewportOffset(double position) {
         double p = com.sun.javafx.util.Utils.clamp(0, position, 1);
         double bound = 0d;
-        double estSize = estimatedSize/getCellCount();
+        double estSize = estimatedSize / getCellCount();
 
         for (int i = 0; i < getCellCount(); i++) {
             double h = getCellSize(i);
             if (h < 0) h = estSize;
-            if (bound +h > absoluteOffset) {
-                return absoluteOffset-bound;
+            if (bound + h > absoluteOffset) {
+                return absoluteOffset - bound;
             }
             bound += h;
         }
@@ -2851,7 +2849,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
         } else {
             double targetOffset = 0;
             double estSize = estimatedSize/cellCount;
-            for (int i = 0; i < index;i++) {
+            for (int i = 0; i < index; i++) {
                 double cz = getCellSize(i);
                 if (cz < 0) cz = estSize;
                 targetOffset = targetOffset+ cz;
@@ -2878,7 +2876,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
         // start with applying the requested modification
         double origAbsoluteOffset = this.absoluteOffset;
         this.absoluteOffset = Math.max(0.d, this.absoluteOffset + numPixels);
-        double newPosition = Math.min(1.0d, absoluteOffset/(estimatedSize - viewportLength));
+        double newPosition = Math.min(1.0d, absoluteOffset / (estimatedSize - viewportLength));
         // estimatedSize changes may result in opposite effect on position
         // in that case, modify current position 1% in the requested direction
         if ((numPixels > 0) && (newPosition < getPosition())) {
@@ -3032,7 +3030,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
                 cnt++;
             }
         }
-        this.estimatedSize = cnt == 0 ? 1d: tot * itemCount/cnt;
+        this.estimatedSize = cnt == 0 ? 1d: tot * itemCount / cnt;
     }
 
     private void resetSizeEstimates() {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -980,11 +980,14 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             cellFactory = new SimpleObjectProperty<Callback<VirtualFlow<T>, T>>(this, "cellFactory") {
                 @Override protected void invalidated() {
                     if (get() != null) {
-                        accumCell = null;
                         setNeedsLayout(true);
                         recreateCells();
                         if (getParent() != null) getParent().requestLayout();
                     }
+                    if (accumCellParent != null) {
+                        accumCellParent.getChildren().clear();
+                    }
+                    accumCell = null;
                 }
             };
         }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -251,7 +251,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
      * node.
      * The following relation should always be true:
      * 0 <= absoluteOffset <= (estimatedSize - viewportLength)
-     * Based on this relation, he position p is defined as
+     * Based on this relation, the position p is defined as
      * 0 <= absoluteOffset/(estimatedSize - viewportLength) <= 1
      * As a consequence, whenever p, estimatedSize, or viewportLength
      * changes, the absoluteOffset needs to change as well.
@@ -1031,7 +1031,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
      * match the (new) position.
      */
     void adjustAbsoluteOffset() {
-        absoluteOffset = (estimatedSize - viewportLength)* getPosition();
+        absoluteOffset = (estimatedSize - viewportLength) * getPosition();
     }
 
     /**
@@ -2898,7 +2898,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             recalculateEstimatedSize();
         }
 
-        // if we are at or beyond the edge, correct the absolteOffset
+        // if we are at or beyond the edge, correct the absoluteOffset
         if (newPosition >= 1.d) {
             absoluteOffset = estimatedSize - viewportLength;
         }
@@ -2911,7 +2911,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
     private int computeCurrentIndex() {
         double total = 0;
         int currentCellCount = getCellCount();
-        double estSize = estimatedSize/currentCellCount;
+        double estSize = estimatedSize / currentCellCount;
         for (int i = 0; i < currentCellCount; i++) {
             double nextSize = getCellSize(i);
             if (nextSize < 0) nextSize = estSize;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -1024,7 +1024,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
     }
 
     /**
-     * Keep the position constant and adjust the absoluteOffset to 
+     * Keep the position constant and adjust the absoluteOffset to
      * match the (new) position.
      */
     void adjustAbsoluteOffset() {
@@ -2822,7 +2822,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
      * We calculate the total size until the absoluteoffset is reached.
      * For this calculation, we use the cached sizes for each item, or an
      * educated guess in case we don't have a cached size yet. While we could
-     * fill the cache with the size here, we do not do it as it will affect 
+     * fill the cache with the size here, we do not do it as it will affect
      * performance.
      */
     private double computeViewportOffset(double position) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -3013,7 +3013,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
     private void recalculateEstimatedSize() {
         recalculateAndImproveEstimatedSize(DEFAULT_IMPROVEMENT);
     }
-    
+
     private void recalculateAndImproveEstimatedSize(int improve) {
         int itemCount = getCellCount();
         int cacheCount = itemSizeCache.size();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
@@ -632,7 +632,10 @@ public class ListViewTest {
 
         // this next test is likely to be brittle, but we'll see...If it is the
         // cause of failure then it can be commented out
-        assertEquals(0.125, scrollBar.getVisibleAmount(), 0.0);
+        // assertEquals(0.125, scrollBar.getVisibleAmount(), 0.0);
+        assertTrue(scrollBar.getVisibleAmount() > 0.15);
+        assertTrue(scrollBar.getVisibleAmount() < 0.17);
+
     }
 
     @Test public void test_rt30400() {
@@ -1126,7 +1129,7 @@ public class ListViewTest {
                                 listView.scrollTo(55);
                                 Platform.runLater(() -> {
                                     Toolkit.getToolkit().firePulse();
-                                    assertEquals(useFixedCellSize ? 17 : 53, rt_35395_counter);
+                                    assertEquals(useFixedCellSize ? 21 : 23, rt_35395_counter);
                                     sl.dispose();
                                 });
                             });

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -1447,14 +1447,14 @@ public class TableViewTest {
 
         StageLoader sl = new StageLoader(tableView);
 
-        assertEquals(14, rt_31200_count);
+        assertEquals(17, rt_31200_count);
 
         // resize the stage
         sl.getStage().setHeight(250);
         Toolkit.getToolkit().firePulse();
         sl.getStage().setHeight(50);
         Toolkit.getToolkit().firePulse();
-        assertEquals(14, rt_31200_count);
+        assertEquals(17, rt_31200_count);
 
         sl.dispose();
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -2501,14 +2501,14 @@ public class TreeTableViewTest {
 
         StageLoader sl = new StageLoader(treeTableView);
 
-        assertEquals(12, rt_31200_count);
+        assertEquals(15, rt_31200_count);
 
         // resize the stage
         sl.getStage().setHeight(250);
         Toolkit.getToolkit().firePulse();
         sl.getStage().setHeight(50);
         Toolkit.getToolkit().firePulse();
-        assertEquals(12, rt_31200_count);
+        assertEquals(15, rt_31200_count);
 
         sl.dispose();
     }
@@ -3645,7 +3645,7 @@ public class TreeTableViewTest {
         // However, for now, we'll test on the assumption that across all
         // platforms we only get one extra cell created, and we can loosen this
         // up if necessary.
-        assertEquals(cellCountAtStart + 1, rt36452_instanceCount);
+        assertEquals(cellCountAtStart + 13, rt36452_instanceCount);
 
         sl.dispose();
     }
@@ -4238,13 +4238,13 @@ public class TreeTableViewTest {
                     treeTableView.scrollTo(5);
                     Platform.runLater(() -> {
                         Toolkit.getToolkit().firePulse();
-                        assertEquals(useFixedCellSize ? 5 : 5, rt_35395_counter);
+                        assertEquals(useFixedCellSize ? 3 : 5, rt_35395_counter);
                         rt_35395_counter = 0;
                         treeTableView.scrollTo(55);
                         Platform.runLater(() -> {
                             Toolkit.getToolkit().firePulse();
 
-                            assertEquals(useFixedCellSize ? 7 : 59, rt_35395_counter);
+                            assertEquals(useFixedCellSize ? 22 : 22, rt_35395_counter);
                             sl.dispose();
                         });
                     });

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
@@ -906,7 +906,9 @@ public class TreeViewTest {
 
         // this next test is likely to be brittle, but we'll see...If it is the
         // cause of failure then it can be commented out
-        assertEquals(0.125, scrollBar.getVisibleAmount(), 0.0);
+        // assertEquals(0.125, scrollBar.getVisibleAmount(), 0.0);
+        assertTrue(scrollBar.getVisibleAmount() > 0.15);
+        assertTrue(scrollBar.getVisibleAmount() < 0.17);
     }
 
     @Test public void test_rt27180_collapseBranch_childSelected_singleSelection() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -655,8 +655,7 @@ public class VirtualFlowTest {
      * Tests the size and position of all the cells to make sure they were
      * laid out properly.
      */
-    @Test
-    public void testCellLayout_CellSizes_AfterLayout() {
+    @Test public void testCellLayout_CellSizes_AfterLayout() {
         double offset = 0.0;
         for (int i = 0; i < VirtualFlowShim.cells_size(flow.cells); i++) {
             IndexedCell cell = VirtualFlowShim.<IndexedCell>cells_get(flow.cells, i);
@@ -1230,7 +1229,7 @@ public class VirtualFlowTest {
 
     private VirtualFlowShim createCircleFlow() {
         // The second VirtualFlow we are going to test, with 7 cells. Each cell
-        // contains a Circle whith a radius that varies between cells.
+        // contains a Circle with a radius that varies between cells.
         VirtualFlowShim<IndexedCell> circleFlow;
         circleFlow = new VirtualFlowShim();
 
@@ -1279,7 +1278,7 @@ public class VirtualFlowTest {
         assertFalse("Moving in positive direction should not decrease position", pos < orig);
         flow.scrollPixels(-50);
         double neg = flow.getPosition();
-        assertFalse("Moving in negative direction should not decrease position", neg > pos);
+        assertFalse("Moving in negative direction should not increase position", neg > pos);
     }
 
     @Test
@@ -1291,7 +1290,7 @@ public class VirtualFlowTest {
         assertFalse("Moving in positive direction should not decrease position", pos < orig);
         vf.scrollPixels(-50);
         double neg = vf.getPosition();
-        assertFalse("Moving in negative direction should not decrease position", neg > pos);
+        assertFalse("Moving in negative direction should not increase position", neg > pos);
     }
 
     @Test

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -72,7 +72,7 @@ public class VirtualFlowTest {
     // and each cell is 100 wide and 25 tall, except for the 30th cell, which
     // is 200 wide and 100 tall.
     private VirtualFlowShim<IndexedCell> flow;
-    
+
 
     @Before public void setUp() {
         list = new ArrayLinkedListShim<CellStub>();
@@ -525,7 +525,7 @@ public class VirtualFlowTest {
     /**
      * Tests that changes to the vertical property will clear the maxPrefBreadth
      */
-    //@Test 
+    //@Test
     public void testGeneralLayout_VerticalChangeClearsmaxPrefBreadth() {
         flow.setVertical(false);
         assertEquals(-1, flow.shim_getMaxPrefBreadth(), 0.0);
@@ -556,7 +556,7 @@ public class VirtualFlowTest {
      * all the way to the end, in which case it will remain scrolled to the
      * end.
      */
-    @Test 
+    @Test
     public void testGeneralLayout_maxPrefBreadthScrollBarValueInteraction() {
         flow.resize(50, flow.getHeight());
         flow.shim_getHbar().setValue(30);
@@ -601,7 +601,7 @@ public class VirtualFlowTest {
         assertEquals(flow.shim_getVbar().getMax(), flow.shim_getVbar().getValue(), 0.0);
     }
 
-    @Test 
+    @Test
     public void testGeneralLayout_ScrollToEndOfVirtual_BarStillVisible() {
         assertTrue("The vbar was expected to be visible", flow.shim_getVbar().isVisible());
         flow.setPosition(1);
@@ -641,7 +641,7 @@ public class VirtualFlowTest {
      * Test to make sure that we are virtual -- that all cells are not being
      * created.
      */
-    @Test 
+    @Test
     public void testCellLayout_NotAllCellsAreCreated() {
         // due to the initial size of the VirtualFlow and the number of cells
         // and their heights, we should have more cells than we have space to
@@ -655,7 +655,7 @@ public class VirtualFlowTest {
      * Tests the size and position of all the cells to make sure they were
      * laid out properly.
      */
-    @Test 
+    @Test
     public void testCellLayout_CellSizes_AfterLayout() {
         double offset = 0.0;
         for (int i = 0; i < VirtualFlowShim.cells_size(flow.cells); i++) {
@@ -681,8 +681,7 @@ public class VirtualFlowTest {
      * max pref width/height. They should be uniform, and should be the
      * width of the viewport.
      */
-    @Test 
-    public void testCellLayout_ViewportWiderThanmaxPrefBreadth() {
+    @Test public void testCellLayout_ViewportWiderThanmaxPrefBreadth() {
         // Note that the pref width of everything is 100, but the actual
         // available width is much larger (300 - hbar.width or
         // 300 - vbar.height) and so the non-virtual dimension of the cell
@@ -707,8 +706,7 @@ public class VirtualFlowTest {
      * max pref width/height. They should be uniform, and should be the max
      * pref.
      */
-    @Test 
-    public void testCellLayout_ViewportShorterThanmaxPrefBreadth() {
+    @Test public void testCellLayout_ViewportShorterThanmaxPrefBreadth() {
         flow.resize(50, flow.getHeight());
         pulse();
         assertEquals(100, flow.shim_getMaxPrefBreadth(), 0.0);
@@ -761,8 +759,7 @@ public class VirtualFlowTest {
      * Checks that the initial set of cells (the first page of cells) are
      * indexed starting with cell #0 and working up from there.
      */
-    @Test 
-    public void testCellLayout_CellIndexes_FirstPage() {
+    @Test public void testCellLayout_CellIndexes_FirstPage() {
         for (int i = 0; i < VirtualFlowShim.cells_size(flow.cells); i++) {
             assertEquals(i, VirtualFlowShim.<IndexedCell>cells_get(flow.cells, i).getIndex());
         }
@@ -779,8 +776,7 @@ public class VirtualFlowTest {
      * event was delivered to a different cell than expected and misbehavior
      * took place.
      */
-    @Test 
-    public void testCellLayout_LayoutWithoutChangingThingsUsesCellsInSameOrderAsBefore() {
+    @Test public void testCellLayout_LayoutWithoutChangingThingsUsesCellsInSameOrderAsBefore() {
         List<IndexedCell> cells = new LinkedList<IndexedCell>();
         for (int i = 0; i < VirtualFlowShim.cells_size(flow.cells); i++) {
             cells.add(VirtualFlowShim.<IndexedCell>cells_get(flow.cells, i));
@@ -801,8 +797,7 @@ public class VirtualFlowTest {
     }
 
 
-    @Test
-    public void testCellLayout_BiasedCellAndLengthBar() {
+    @Test public void testCellLayout_BiasedCellAndLengthBar() {
         flow.setCellFactory(param -> new CellStub(flow) {
             @Override
             protected double computeMinWidth(double height) {
@@ -857,8 +852,7 @@ public class VirtualFlowTest {
     //
     ////////////////////////////////////////////////////////////////////////////
 
-    @Test 
-    public void testCellLifeCycle_CellsAreCreatedOnLayout() {
+    @Test public void testCellLifeCycle_CellsAreCreatedOnLayout() {
         // when the flow was first created in setUp we do a layout()
         assertTrue("The cells didn't get created", VirtualFlowShim.cells_size(flow.cells) > 0);
     }
@@ -938,8 +932,7 @@ public class VirtualFlowTest {
     /**
      * Tests that when the createCell method changes, it results in layout
      */
-    @Test
-    public void testCreateCellFunctionChangesResultInNeedsLayoutAndNoCellsAndNoAccumCell() {
+    @Test public void testCreateCellFunctionChangesResultInNeedsLayoutAndNoCellsAndNoAccumCell() {
         assertFalse(flow.isNeedsLayout());
         flow.getCellLength(49); // forces accum cell to be created
         assertNotNull("Accum cell was null", flow.get_accumCell());
@@ -955,8 +948,7 @@ public class VirtualFlowTest {
     //
     ////////////////////////////////////////////////////////////////////////////
 
-    @Test 
-    public void test_getCellLength() {
+    @Test public void test_getCellLength() {
         assertEquals(100, flow.getCellCount());
         for (int i = 0; i < 50; i++) {
             if (i != 29) assertEquals(25, flow.getCellLength(i), 0.0);
@@ -975,8 +967,7 @@ public class VirtualFlowTest {
     ** without having done anything to select a cell
     ** the flow should scroll.
     */
-    @Test 
-    public void testInitialScrollEventActuallyScrolls() {
+    @Test public void testInitialScrollEventActuallyScrolls() {
         /*
         ** re-initialize this, as it must be the first
         ** interaction with the flow
@@ -1034,8 +1025,7 @@ public class VirtualFlowTest {
         assertTrue(originalValue != flow.getPosition());
     }
 
-    @Test
-    public void test_RT_36507() {
+    @Test public void test_RT_36507() {
         flow = new VirtualFlowShim();
         flow.setVertical(true);
         // Worst case scenario is that the cells have height = 0.
@@ -1235,9 +1225,9 @@ public class VirtualFlowTest {
         sheetChildrenSize = flow.sheetChildren.size();
         assertEquals("Wrong number of sheet children after removing all items", 12, sheetChildrenSize);
     }
-    
+
     private ArrayLinkedListShim<GraphicalCellStub> circlelist= new ArrayLinkedListShim<GraphicalCellStub>();
-        
+
     private VirtualFlowShim createCircleFlow() {
             // The second VirtualFlow we are going to test, with 7 cells. Each cell
     // contains a Circle whith a radius that varies between cells.
@@ -1271,7 +1261,6 @@ public class VirtualFlowTest {
                 return computePrefHeight(width);
             }
 
-        
         });
         circleFlow.setCellCount(7);
         circleFlow.resize(300, 300);
@@ -1279,7 +1268,7 @@ public class VirtualFlowTest {
         circleFlow.layout();
         return circleFlow;
     }
-    
+
     // when moving the flow in one direction, the position of the flow
     // should not increase in the opposite direction
     @Test
@@ -1322,7 +1311,7 @@ public class VirtualFlowTest {
             vf.layout();
             newPosition = vf.getPosition();
             s1 = sb.getLayoutY();
-            newDelta = newPosition - position; 
+            newDelta = newPosition - position;
             System.err.println("s0 = "+s0+", s1 = "+s1);
             System.err.println("newDelta = "+newDelta+", delta = "+delta);
             if (i > 0) {
@@ -1394,7 +1383,7 @@ class GraphicalCellStub extends IndexedCellShim<Node> {
         return answer;
     }
 
-    @Override 
+    @Override
     public String toString() {
         return "GraphicCell with item = "+myItem+" at "+super.toString();
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -234,8 +234,7 @@ public class VirtualFlowTest {
      * that the scroll bars and corner are not visible, and the clip view fills
      * the entire width/height of the VirtualFlow.
      */
-    @Test
-    public void testGeneralLayout_NoCells() {
+    @Test public void testGeneralLayout_NoCells() {
         flow.setCellCount(0);
         pulse();
         assertFalse("The hbar should have been invisible", flow.shim_getHbar().isVisible());
@@ -262,8 +261,7 @@ public class VirtualFlowTest {
      * to make sure there is no virtual scroll bar. In this test case the cells
      * are not wider than the viewport so no horizontal bar either.
      */
-    @Test
-    public void testGeneralLayout_FewCells() {
+    @Test public void testGeneralLayout_FewCells() {
         flow.setCellCount(3);
         pulse();
         assertFalse("The hbar should have been invisible", flow.shim_getHbar().isVisible());
@@ -290,8 +288,7 @@ public class VirtualFlowTest {
      * but the cells are wider than the viewport so a horizontal scroll bar is
      * required.
      */
-    @Test
-    public void testGeneralLayout_FewCellsButWide() {
+    @Test public void testGeneralLayout_FewCellsButWide() {
         flow.setCellCount(3);
         flow.resize(50, flow.getHeight());
         pulse();
@@ -320,8 +317,7 @@ public class VirtualFlowTest {
      * necessary (due to wide cells) will end up hiding the hbar if the flow
      * becomes wide enough that the hbar is no longer necessary.
      */
-    @Test
-    public void testGeneralLayout_FewCellsButWide_ThenNarrow() {
+    @Test public void testGeneralLayout_FewCellsButWide_ThenNarrow() {
         flow.setCellCount(3);
         flow.resize(50, flow.getHeight());
         pulse();
@@ -355,8 +351,7 @@ public class VirtualFlowTest {
      * exactly on the bottom edge of the flow and the vbar was not made visible.
      * Be sure to test for this explicitly some time!
      */
-    @Test
-    public void testGeneralLayout_ManyCells() {
+    @Test public void testGeneralLayout_ManyCells() {
         assertFalse("The hbar should have been invisible", flow.shim_getHbar().isVisible());
         assertTrue("The vbar should have been visible", flow.shim_getVbar().isVisible());
         assertFalse("The corner should have been invisible", flow.get_corner().isVisible());
@@ -380,8 +375,7 @@ public class VirtualFlowTest {
      * Test that after having only a few cells, if I then have many cells, that
      * the vbar is shown appropriately.
      */
-    @Test
-    public void testGeneralLayout_FewCells_ThenMany() {
+    @Test public void testGeneralLayout_FewCells_ThenMany() {
         flow.setCellCount(3);
         pulse();
         flow.setCellCount(100);
@@ -412,8 +406,7 @@ public class VirtualFlowTest {
      * Test the case where there are many cells and they are wider than the
      * viewport. We should have the hbar, vbar, and corner region in this case.
      */
-    @Test
-    public void testGeneralLayout_ManyCellsAndWide() {
+    @Test public void testGeneralLayout_ManyCellsAndWide() {
         flow.resize(50, flow.getHeight());
         pulse();
         assertTrue("The hbar should have been visible", flow.shim_getHbar().isVisible());
@@ -451,8 +444,7 @@ public class VirtualFlowTest {
     /**
      * Tests that when the vertical flag changes, it results in layout
      */
-    @Test
-    public void testGeneralLayout_VerticalChangeResultsInNeedsLayout() {
+    @Test public void testGeneralLayout_VerticalChangeResultsInNeedsLayout() {
         assertFalse(flow.isNeedsLayout());
         flow.setVertical(false);
         assertTrue(flow.isNeedsLayout());
@@ -461,8 +453,7 @@ public class VirtualFlowTest {
     /**
      * Tests that the range of the non-virtual scroll bar is valid
      */
-    @Test
-    public void testGeneralLayout_NonVirtualScrollBarRange() {
+    @Test public void testGeneralLayout_NonVirtualScrollBarRange() {
         flow.resize(50, flow.getHeight());
         pulse();
         assertEquals(0, flow.shim_getHbar().getMin(), 0.0);
@@ -492,8 +483,7 @@ public class VirtualFlowTest {
      * Tests that the maxPrefBreadth is computed correctly for the first page of cells.
      * In our test case, the first page of cells have a uniform pref.
      */
-    @Test
-    public void testGeneralLayout_maxPrefBreadth() {
+    @Test public void testGeneralLayout_maxPrefBreadth() {
         assertEquals(100, flow.shim_getMaxPrefBreadth(), 0.0);
     }
 
@@ -525,8 +515,7 @@ public class VirtualFlowTest {
     /**
      * Tests that changes to the vertical property will clear the maxPrefBreadth
      */
-    //@Test
-    public void testGeneralLayout_VerticalChangeClearsmaxPrefBreadth() {
+    @Test public void testGeneralLayout_VerticalChangeClearsmaxPrefBreadth() {
         flow.setVertical(false);
         assertEquals(-1, flow.shim_getMaxPrefBreadth(), 0.0);
     }
@@ -556,8 +545,7 @@ public class VirtualFlowTest {
      * all the way to the end, in which case it will remain scrolled to the
      * end.
      */
-    @Test
-    public void testGeneralLayout_maxPrefBreadthScrollBarValueInteraction() {
+    @Test public void testGeneralLayout_maxPrefBreadthScrollBarValueInteraction() {
         flow.resize(50, flow.getHeight());
         flow.shim_getHbar().setValue(30);
         pulse();
@@ -601,8 +589,7 @@ public class VirtualFlowTest {
         assertEquals(flow.shim_getVbar().getMax(), flow.shim_getVbar().getValue(), 0.0);
     }
 
-    @Test
-    public void testGeneralLayout_ScrollToEndOfVirtual_BarStillVisible() {
+    @Test public void testGeneralLayout_ScrollToEndOfVirtual_BarStillVisible() {
         assertTrue("The vbar was expected to be visible", flow.shim_getVbar().isVisible());
         flow.setPosition(1);
         pulse();
@@ -641,8 +628,7 @@ public class VirtualFlowTest {
      * Test to make sure that we are virtual -- that all cells are not being
      * created.
      */
-    @Test
-    public void testCellLayout_NotAllCellsAreCreated() {
+    @Test public void testCellLayout_NotAllCellsAreCreated() {
         // due to the initial size of the VirtualFlow and the number of cells
         // and their heights, we should have more cells than we have space to
         // fit them and so only enough cells should be created to meet our
@@ -1059,8 +1045,7 @@ public class VirtualFlowTest {
     }
 
     private int rt36556_instanceCount;
-    @Test
-    public void test_rt36556() {
+    @Test public void test_rt36556() {
         rt36556_instanceCount = 0;
         flow = new VirtualFlowShim();
         flow.setVertical(true);
@@ -1079,8 +1064,7 @@ public class VirtualFlowTest {
         assertMinimalNumberOfCellsAreUsed(flow);
     }
 
-    @Test
-    public void test_rt36556_scrollto() {
+    @Test public void test_rt36556_scrollto() {
         rt36556_instanceCount = 0;
         flow = new VirtualFlowShim();
         flow.setVertical(true);
@@ -1099,8 +1083,7 @@ public class VirtualFlowTest {
         assertMinimalNumberOfCellsAreUsed(flow);
     }
 
-    @Test
-    public void test_RT39035() {
+    @Test public void test_RT39035() {
         flow.scrollPixels(250);
         pulse();
         flow.scrollPixels(500);
@@ -1109,8 +1092,7 @@ public class VirtualFlowTest {
         assertMinimalNumberOfCellsAreUsed(flow);
     }
 
-    @Test
-    public void test_RT37421() {
+    @Test public void test_RT37421() {
         flow.setPosition(0.98);
         pulse();
         flow.scrollPixels(100);
@@ -1119,8 +1101,7 @@ public class VirtualFlowTest {
         assertMinimalNumberOfCellsAreUsed(flow);
     }
 
-    @Test
-    public void test_RT39568() {
+    @Test public void test_RT39568() {
         flow.shim_getHbar().setPrefHeight(16);
         flow.resize(50, flow.getHeight());
         flow.setPosition(1);
@@ -1270,8 +1251,7 @@ public class VirtualFlowTest {
 
     // when moving the flow in one direction, the position of the flow
     // should not increase in the opposite direction
-    @Test
-    public void testReverseOrder() {
+    @Test public void testReverseOrder() {
         double orig = flow.getPosition();
         flow.scrollPixels(10);
         double pos = flow.getPosition();
@@ -1281,8 +1261,7 @@ public class VirtualFlowTest {
         assertFalse("Moving in negative direction should not increase position", neg > pos);
     }
 
-    @Test
-    public void testReverseOrderForCircleFlow() {
+    @Test public void testReverseOrderForCircleFlow() {
         VirtualFlowShim vf = createCircleFlow();
         double orig = vf.getPosition();
         vf.scrollPixels(10);
@@ -1293,8 +1272,7 @@ public class VirtualFlowTest {
         assertFalse("Moving in negative direction should not increase position", neg > pos);
     }
 
-    @Test
-    public void testGradualMoveForCircleFlow() {
+    @Test public void testGradualMoveForCircleFlow() {
         VirtualFlowShim vf = createCircleFlow();
         vf.resize(600,400);
         ScrollBar sb = vf.shim_getVbar();
@@ -1311,16 +1289,16 @@ public class VirtualFlowTest {
             newPosition = vf.getPosition();
             s1 = sb.getLayoutY();
             newDelta = newPosition - position;
-            System.err.println("s0 = "+s0+", s1 = "+s1);
-            System.err.println("newDelta = "+newDelta+", delta = "+delta);
+            // System.err.println("s0 = "+s0+", s1 = "+s1);
+            // System.err.println("newDelta = "+newDelta+", delta = "+delta);
             if (i > 0) {
                 double diff = Math.abs((newDelta-delta)/newDelta);
-                System.err.println("diff = "+diff);
+                // System.err.println("diff = "+diff);
                 // maximum 10% difference allowed
                 assertTrue("Too much variation while scrolling (from "+s0+" to "+s1+")", diff < 0.1);
             }
-            System.err.println("S1 = "+s1);
-            System.err.println("pos = "+vf.getPosition());
+            // System.err.println("S1 = "+s1);
+            // System.err.println("pos = "+vf.getPosition());
             assertFalse("Thumb moving in the wrong direction at index ", s1 < s0);
             s0 = s1;
             delta = newDelta;
@@ -1346,7 +1324,7 @@ class GraphicalCellStub extends IndexedCellShim<Node> {
     public GraphicalCellStub() { init(); }
 
     private void init() {
-        System.err.println("Init vf cell "+this);
+        // System.err.println("Init vf cell "+this);
         setSkin(new SkinStub<GraphicalCellStub>(this));
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -39,6 +39,9 @@ import java.util.LinkedList;
 import javafx.beans.InvalidationListener;
 import javafx.event.Event;
 import javafx.scene.control.IndexedCell;
+import javafx.scene.Node;
+import javafx.scene.shape.Circle;
+
 import test.javafx.scene.control.SkinStub;
 import javafx.scene.input.ScrollEvent;
 
@@ -46,8 +49,11 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+
+import java.util.ArrayList;
 import java.util.List;
 import javafx.scene.control.IndexedCellShim;
+import javafx.scene.control.ScrollBar;
 import javafx.scene.control.skin.VirtualFlowShim;
 import javafx.scene.control.skin.VirtualFlowShim.ArrayLinkedListShim;
 
@@ -66,7 +72,7 @@ public class VirtualFlowTest {
     // and each cell is 100 wide and 25 tall, except for the 30th cell, which
     // is 200 wide and 100 tall.
     private VirtualFlowShim<IndexedCell> flow;
-//    private Scene scene;
+    
 
     @Before public void setUp() {
         list = new ArrayLinkedListShim<CellStub>();
@@ -228,7 +234,8 @@ public class VirtualFlowTest {
      * that the scroll bars and corner are not visible, and the clip view fills
      * the entire width/height of the VirtualFlow.
      */
-    @Test public void testGeneralLayout_NoCells() {
+    @Test
+    public void testGeneralLayout_NoCells() {
         flow.setCellCount(0);
         pulse();
         assertFalse("The hbar should have been invisible", flow.shim_getHbar().isVisible());
@@ -255,7 +262,8 @@ public class VirtualFlowTest {
      * to make sure there is no virtual scroll bar. In this test case the cells
      * are not wider than the viewport so no horizontal bar either.
      */
-    @Test public void testGeneralLayout_FewCells() {
+    @Test
+    public void testGeneralLayout_FewCells() {
         flow.setCellCount(3);
         pulse();
         assertFalse("The hbar should have been invisible", flow.shim_getHbar().isVisible());
@@ -282,7 +290,8 @@ public class VirtualFlowTest {
      * but the cells are wider than the viewport so a horizontal scroll bar is
      * required.
      */
-    @Test public void testGeneralLayout_FewCellsButWide() {
+    @Test
+    public void testGeneralLayout_FewCellsButWide() {
         flow.setCellCount(3);
         flow.resize(50, flow.getHeight());
         pulse();
@@ -311,7 +320,8 @@ public class VirtualFlowTest {
      * necessary (due to wide cells) will end up hiding the hbar if the flow
      * becomes wide enough that the hbar is no longer necessary.
      */
-    @Test public void testGeneralLayout_FewCellsButWide_ThenNarrow() {
+    @Test
+    public void testGeneralLayout_FewCellsButWide_ThenNarrow() {
         flow.setCellCount(3);
         flow.resize(50, flow.getHeight());
         pulse();
@@ -345,7 +355,8 @@ public class VirtualFlowTest {
      * exactly on the bottom edge of the flow and the vbar was not made visible.
      * Be sure to test for this explicitly some time!
      */
-    @Test public void testGeneralLayout_ManyCells() {
+    @Test
+    public void testGeneralLayout_ManyCells() {
         assertFalse("The hbar should have been invisible", flow.shim_getHbar().isVisible());
         assertTrue("The vbar should have been visible", flow.shim_getVbar().isVisible());
         assertFalse("The corner should have been invisible", flow.get_corner().isVisible());
@@ -369,7 +380,8 @@ public class VirtualFlowTest {
      * Test that after having only a few cells, if I then have many cells, that
      * the vbar is shown appropriately.
      */
-    @Test public void testGeneralLayout_FewCells_ThenMany() {
+    @Test
+    public void testGeneralLayout_FewCells_ThenMany() {
         flow.setCellCount(3);
         pulse();
         flow.setCellCount(100);
@@ -400,7 +412,8 @@ public class VirtualFlowTest {
      * Test the case where there are many cells and they are wider than the
      * viewport. We should have the hbar, vbar, and corner region in this case.
      */
-    @Test public void testGeneralLayout_ManyCellsAndWide() {
+    @Test
+    public void testGeneralLayout_ManyCellsAndWide() {
         flow.resize(50, flow.getHeight());
         pulse();
         assertTrue("The hbar should have been visible", flow.shim_getHbar().isVisible());
@@ -438,7 +451,8 @@ public class VirtualFlowTest {
     /**
      * Tests that when the vertical flag changes, it results in layout
      */
-    @Test public void testGeneralLayout_VerticalChangeResultsInNeedsLayout() {
+    @Test
+    public void testGeneralLayout_VerticalChangeResultsInNeedsLayout() {
         assertFalse(flow.isNeedsLayout());
         flow.setVertical(false);
         assertTrue(flow.isNeedsLayout());
@@ -447,7 +461,8 @@ public class VirtualFlowTest {
     /**
      * Tests that the range of the non-virtual scroll bar is valid
      */
-    @Test public void testGeneralLayout_NonVirtualScrollBarRange() {
+    @Test
+    public void testGeneralLayout_NonVirtualScrollBarRange() {
         flow.resize(50, flow.getHeight());
         pulse();
         assertEquals(0, flow.shim_getHbar().getMin(), 0.0);
@@ -477,7 +492,8 @@ public class VirtualFlowTest {
      * Tests that the maxPrefBreadth is computed correctly for the first page of cells.
      * In our test case, the first page of cells have a uniform pref.
      */
-    @Test public void testGeneralLayout_maxPrefBreadth() {
+    @Test
+    public void testGeneralLayout_maxPrefBreadth() {
         assertEquals(100, flow.shim_getMaxPrefBreadth(), 0.0);
     }
 
@@ -509,7 +525,8 @@ public class VirtualFlowTest {
     /**
      * Tests that changes to the vertical property will clear the maxPrefBreadth
      */
-    @Test public void testGeneralLayout_VerticalChangeClearsmaxPrefBreadth() {
+    //@Test 
+    public void testGeneralLayout_VerticalChangeClearsmaxPrefBreadth() {
         flow.setVertical(false);
         assertEquals(-1, flow.shim_getMaxPrefBreadth(), 0.0);
     }
@@ -539,7 +556,8 @@ public class VirtualFlowTest {
      * all the way to the end, in which case it will remain scrolled to the
      * end.
      */
-    @Test public void testGeneralLayout_maxPrefBreadthScrollBarValueInteraction() {
+    @Test 
+    public void testGeneralLayout_maxPrefBreadthScrollBarValueInteraction() {
         flow.resize(50, flow.getHeight());
         flow.shim_getHbar().setValue(30);
         pulse();
@@ -583,7 +601,8 @@ public class VirtualFlowTest {
         assertEquals(flow.shim_getVbar().getMax(), flow.shim_getVbar().getValue(), 0.0);
     }
 
-    @Test public void testGeneralLayout_ScrollToEndOfVirtual_BarStillVisible() {
+    @Test 
+    public void testGeneralLayout_ScrollToEndOfVirtual_BarStillVisible() {
         assertTrue("The vbar was expected to be visible", flow.shim_getVbar().isVisible());
         flow.setPosition(1);
         pulse();
@@ -622,7 +641,8 @@ public class VirtualFlowTest {
      * Test to make sure that we are virtual -- that all cells are not being
      * created.
      */
-    @Test public void testCellLayout_NotAllCellsAreCreated() {
+    @Test 
+    public void testCellLayout_NotAllCellsAreCreated() {
         // due to the initial size of the VirtualFlow and the number of cells
         // and their heights, we should have more cells than we have space to
         // fit them and so only enough cells should be created to meet our
@@ -635,7 +655,8 @@ public class VirtualFlowTest {
      * Tests the size and position of all the cells to make sure they were
      * laid out properly.
      */
-    @Test public void testCellLayout_CellSizes_AfterLayout() {
+    @Test 
+    public void testCellLayout_CellSizes_AfterLayout() {
         double offset = 0.0;
         for (int i = 0; i < VirtualFlowShim.cells_size(flow.cells); i++) {
             IndexedCell cell = VirtualFlowShim.<IndexedCell>cells_get(flow.cells, i);
@@ -660,7 +681,8 @@ public class VirtualFlowTest {
      * max pref width/height. They should be uniform, and should be the
      * width of the viewport.
      */
-    @Test public void testCellLayout_ViewportWiderThanmaxPrefBreadth() {
+    @Test 
+    public void testCellLayout_ViewportWiderThanmaxPrefBreadth() {
         // Note that the pref width of everything is 100, but the actual
         // available width is much larger (300 - hbar.width or
         // 300 - vbar.height) and so the non-virtual dimension of the cell
@@ -685,7 +707,8 @@ public class VirtualFlowTest {
      * max pref width/height. They should be uniform, and should be the max
      * pref.
      */
-    @Test public void testCellLayout_ViewportShorterThanmaxPrefBreadth() {
+    @Test 
+    public void testCellLayout_ViewportShorterThanmaxPrefBreadth() {
         flow.resize(50, flow.getHeight());
         pulse();
         assertEquals(100, flow.shim_getMaxPrefBreadth(), 0.0);
@@ -738,7 +761,8 @@ public class VirtualFlowTest {
      * Checks that the initial set of cells (the first page of cells) are
      * indexed starting with cell #0 and working up from there.
      */
-    @Test public void testCellLayout_CellIndexes_FirstPage() {
+    @Test 
+    public void testCellLayout_CellIndexes_FirstPage() {
         for (int i = 0; i < VirtualFlowShim.cells_size(flow.cells); i++) {
             assertEquals(i, VirtualFlowShim.<IndexedCell>cells_get(flow.cells, i).getIndex());
         }
@@ -755,7 +779,8 @@ public class VirtualFlowTest {
      * event was delivered to a different cell than expected and misbehavior
      * took place.
      */
-    @Test public void testCellLayout_LayoutWithoutChangingThingsUsesCellsInSameOrderAsBefore() {
+    @Test 
+    public void testCellLayout_LayoutWithoutChangingThingsUsesCellsInSameOrderAsBefore() {
         List<IndexedCell> cells = new LinkedList<IndexedCell>();
         for (int i = 0; i < VirtualFlowShim.cells_size(flow.cells); i++) {
             cells.add(VirtualFlowShim.<IndexedCell>cells_get(flow.cells, i));
@@ -832,7 +857,8 @@ public class VirtualFlowTest {
     //
     ////////////////////////////////////////////////////////////////////////////
 
-    @Test public void testCellLifeCycle_CellsAreCreatedOnLayout() {
+    @Test 
+    public void testCellLifeCycle_CellsAreCreatedOnLayout() {
         // when the flow was first created in setUp we do a layout()
         assertTrue("The cells didn't get created", VirtualFlowShim.cells_size(flow.cells) > 0);
     }
@@ -912,7 +938,8 @@ public class VirtualFlowTest {
     /**
      * Tests that when the createCell method changes, it results in layout
      */
-    @Test public void testCreateCellFunctionChangesResultInNeedsLayoutAndNoCellsAndNoAccumCell() {
+    @Test
+    public void testCreateCellFunctionChangesResultInNeedsLayoutAndNoCellsAndNoAccumCell() {
         assertFalse(flow.isNeedsLayout());
         flow.getCellLength(49); // forces accum cell to be created
         assertNotNull("Accum cell was null", flow.get_accumCell());
@@ -928,7 +955,8 @@ public class VirtualFlowTest {
     //
     ////////////////////////////////////////////////////////////////////////////
 
-    @Test public void test_getCellLength() {
+    @Test 
+    public void test_getCellLength() {
         assertEquals(100, flow.getCellCount());
         for (int i = 0; i < 50; i++) {
             if (i != 29) assertEquals(25, flow.getCellLength(i), 0.0);
@@ -947,7 +975,8 @@ public class VirtualFlowTest {
     ** without having done anything to select a cell
     ** the flow should scroll.
     */
-    @Test public void testInitialScrollEventActuallyScrolls() {
+    @Test 
+    public void testInitialScrollEventActuallyScrolls() {
         /*
         ** re-initialize this, as it must be the first
         ** interaction with the flow
@@ -1206,18 +1235,180 @@ public class VirtualFlowTest {
         sheetChildrenSize = flow.sheetChildren.size();
         assertEquals("Wrong number of sheet children after removing all items", 12, sheetChildrenSize);
     }
+    
+    private ArrayLinkedListShim<GraphicalCellStub> circlelist= new ArrayLinkedListShim<GraphicalCellStub>();
+        
+    private VirtualFlowShim createCircleFlow() {
+            // The second VirtualFlow we are going to test, with 7 cells. Each cell
+    // contains a Circle whith a radius that varies between cells.
+        VirtualFlowShim<IndexedCell> circleFlow;
+        circleFlow = new VirtualFlowShim();
 
+        circleFlow.setVertical(true);
+        circleFlow.setCellFactory(p -> new GraphicalCellStub() {
+            @Override
+            protected double computeMinWidth(double height) {
+                return computePrefWidth(height);
+            }
+
+            @Override
+            protected double computeMaxWidth(double height) {
+                return computePrefWidth(height);
+            }
+
+            @Override
+            protected double computePrefWidth(double height) {
+                return super.computePrefWidth(height);
+            }
+
+            @Override
+            protected double computeMinHeight(double width) {
+                return computePrefHeight(width);
+            }
+
+            @Override
+            protected double computeMaxHeight(double width) {
+                return computePrefHeight(width);
+            }
+
+        
+        });
+        circleFlow.setCellCount(7);
+        circleFlow.resize(300, 300);
+        circleFlow.layout();
+        circleFlow.layout();
+        return circleFlow;
+    }
+    
+    // when moving the flow in one direction, the position of the flow
+    // should not increase in the opposite direction
+    @Test
+    public void testReverseOrder() {
+        double orig = flow.getPosition();
+        flow.scrollPixels(10);
+        double pos = flow.getPosition();
+        assertFalse("Moving in positive direction should not decrease position", pos < orig);
+        flow.scrollPixels(-50);
+        double neg = flow.getPosition();
+        assertFalse("Moving in negative direction should not decrease position", neg > pos);
+    }
+
+    @Test
+    public void testReverseOrderForCircleFlow() {
+        VirtualFlowShim vf = createCircleFlow();
+        double orig = vf.getPosition();
+        vf.scrollPixels(10);
+        double pos = vf.getPosition();
+        assertFalse("Moving in positive direction should not decrease position", pos < orig);
+        vf.scrollPixels(-50);
+        double neg = vf.getPosition();
+        assertFalse("Moving in negative direction should not decrease position", neg > pos);
+    }
+
+    @Test
+    public void testGradualMoveForCircleFlow() {
+        VirtualFlowShim vf = createCircleFlow();
+        vf.resize(600,400);
+        ScrollBar sb = vf.shim_getVbar();
+        double s0 = sb.getLayoutY();
+        double s1 = s0;
+        double position = vf.getPosition();
+        double newPosition =0d;
+        double delta = 0;
+        double newDelta = 0;
+        vf.layout();
+        for (int i = 0; i < 50; i++) {
+            vf.scrollPixels(10);
+            vf.layout();
+            newPosition = vf.getPosition();
+            s1 = sb.getLayoutY();
+            newDelta = newPosition - position; 
+            System.err.println("s0 = "+s0+", s1 = "+s1);
+            System.err.println("newDelta = "+newDelta+", delta = "+delta);
+            if (i > 0) {
+                double diff = Math.abs((newDelta-delta)/newDelta);
+                System.err.println("diff = "+diff);
+                // maximum 10% difference allowed
+                assertTrue("Too much variation while scrolling (from "+s0+" to "+s1+")", diff < 0.1);
+            }
+            System.err.println("S1 = "+s1);
+            System.err.println("pos = "+vf.getPosition());
+            assertFalse("Thumb moving in the wrong direction at index ", s1 < s0);
+            s0 = s1;
+            delta = newDelta;
+            position = newPosition;
+        }
+    }
+}
+
+class GraphicalCellStub extends IndexedCellShim<Node> {
+    static ArrayList<Circle> circleList = new ArrayList<>();
+    static {
+        circleList.add(new Circle(10));
+        circleList.add(new Circle(20));
+        circleList.add(new Circle(100));
+        circleList.add(new Circle(30));
+        circleList.add(new Circle(50));
+        circleList.add(new Circle(200));
+        circleList.add(new Circle(60));
+    }
+
+    private int idx = -1;
+    Node myItem = null;
+
+    public GraphicalCellStub() { init(); }
+
+    private void init( ) {
+        System.err.println("Init vf cell "+this);
+        setSkin(new SkinStub<GraphicalCellStub>(this));
+    }
+
+    @Override
+    public void updateItem(Node item, boolean empty) {
+        super.updateItem(item, empty);
+        if (empty || item == null) {
+            setText(null);
+            setGraphic(null);
+        } else {
+            setGraphic(item);
+        }
+    }
+
+    @Override
+    public void updateIndex(int i) {
+        super.updateIndex(i);
+        if ((i > -1) && (circleList.size() > i)) {
+            this.idx = i;
+            updateItem(circleList.get(i), false);
+        } else {
+            updateItem(null, true);
+        }
+    }
+
+    @Override
+    protected double computePrefHeight(double width) {
+        double answer = super.computePrefHeight(width);
+        if ((idx > -1) && (idx < circleList.size())){
+            answer = 2* circleList.get(idx).getRadius()+ 6;
+        }
+        return answer;
+    }
+
+    @Override 
+    public String toString() {
+        return "GraphicCell with item = "+myItem+" at "+super.toString();
+    }
 }
 
 class CellStub extends IndexedCellShim {
     String s;
-    VirtualFlowShim flow;
+   // VirtualFlowShim flow;
 
     public CellStub(VirtualFlowShim flow) { init(flow); }
     public CellStub(VirtualFlowShim flow, String s) { init(flow); this.s = s; }
 
     private void init(VirtualFlowShim flow) {
-        this.flow = flow;
+     //   this.flow = flow;
         setSkin(new SkinStub<CellStub>(this));
         updateItem(this, false);
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -1226,11 +1226,11 @@ public class VirtualFlowTest {
         assertEquals("Wrong number of sheet children after removing all items", 12, sheetChildrenSize);
     }
 
-    private ArrayLinkedListShim<GraphicalCellStub> circlelist= new ArrayLinkedListShim<GraphicalCellStub>();
+    private ArrayLinkedListShim<GraphicalCellStub> circlelist = new ArrayLinkedListShim<GraphicalCellStub>();
 
     private VirtualFlowShim createCircleFlow() {
-            // The second VirtualFlow we are going to test, with 7 cells. Each cell
-    // contains a Circle whith a radius that varies between cells.
+        // The second VirtualFlow we are going to test, with 7 cells. Each cell
+        // contains a Circle whith a radius that varies between cells.
         VirtualFlowShim<IndexedCell> circleFlow;
         circleFlow = new VirtualFlowShim();
 
@@ -1302,7 +1302,7 @@ public class VirtualFlowTest {
         double s0 = sb.getLayoutY();
         double s1 = s0;
         double position = vf.getPosition();
-        double newPosition =0d;
+        double newPosition = 0d;
         double delta = 0;
         double newDelta = 0;
         vf.layout();
@@ -1331,23 +1331,22 @@ public class VirtualFlowTest {
 }
 
 class GraphicalCellStub extends IndexedCellShim<Node> {
-    static ArrayList<Circle> circleList = new ArrayList<>();
-    static {
-        circleList.add(new Circle(10));
-        circleList.add(new Circle(20));
-        circleList.add(new Circle(100));
-        circleList.add(new Circle(30));
-        circleList.add(new Circle(50));
-        circleList.add(new Circle(200));
-        circleList.add(new Circle(60));
-    }
+    static List<Circle> circleList = List.of(
+        new Circle(10),
+        new Circle(20),
+        new Circle(100),
+        new Circle(30),
+        new Circle(50),
+        new Circle(200),
+        new Circle(60)
+    );
 
     private int idx = -1;
     Node myItem = null;
 
     public GraphicalCellStub() { init(); }
 
-    private void init( ) {
+    private void init() {
         System.err.println("Init vf cell "+this);
         setSkin(new SkinStub<GraphicalCellStub>(this));
     }
@@ -1377,8 +1376,8 @@ class GraphicalCellStub extends IndexedCellShim<Node> {
     @Override
     protected double computePrefHeight(double width) {
         double answer = super.computePrefHeight(width);
-        if ((idx > -1) && (idx < circleList.size())){
-            answer = 2* circleList.get(idx).getRadius()+ 6;
+        if ((idx > -1) && (idx < circleList.size())) {
+            answer = 2 * circleList.get(idx).getRadius() + 6;
         }
         return answer;
     }


### PR DESCRIPTION
This PR introduces a refactory for VirtualFlow, fixing a number of issues reported about inconsistent scrolling speed (see https://bugs.openjdk.java.net/browse/JDK-8089589)
The problem mentioned in the JBS issue (and in related issues) is that the VirtualFlow implementation depends on cell index and cell count, instead of on pixel count. The latter is unknown when the VirtualFlow is created, and pre-calculating the size of a large set of items would be very expensive.
Therefore, this PR uses a combination of a gradual calculation of the total size in pixels (estimatedSize) and a smoothing part that prevents the scrollback to scroll in the reverse direction as the requested change.
This PR currently breaks a number of tests that hard-coded depend on a number of evaluations. This is inherit to the approach of this PR: if we want to estimate the total size, we need to do some additional calculations. In this PR, I try to balance between consistent behavior and performance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8089589](https://bugs.openjdk.java.net/browse/JDK-8089589): [ListView] ScrollBar content moves toward-backward during scrolling.


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/398/head:pull/398` \
`$ git checkout pull/398`

Update a local copy of the PR: \
`$ git checkout pull/398` \
`$ git pull https://git.openjdk.java.net/jfx pull/398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 398`

View PR using the GUI difftool: \
`$ git pr show -t 398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/398.diff">https://git.openjdk.java.net/jfx/pull/398.diff</a>

</details>
