### PR TITLE
8252099: JavaFX does not render Myanmar script correctly

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/text/ScriptMapper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/text/ScriptMapper.java
@@ -142,6 +142,9 @@ public class ScriptMapper {
         else if (code <= 0x0fff) { // U+0F00 - U+0FFF Tibetan
             return true;
         }
+        else if (code <= 0x109f) { // U+1000 - U+109F Myanmar
+            return true;
+        }
         else if (code < 0x1100) {
             return false;
         }


### PR DESCRIPTION
This PR allows rendering Myanmar script correctly, following up on https://bugs.openjdk.java.net/browse/JDK-8223558.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252099](https://bugs.openjdk.java.net/browse/JDK-8252099): JavaFX does not render Myanmar script correctly


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/399/head:pull/399`
`$ git checkout pull/399`
