### PR TITLE
8260257: [Linux] WebView no longer reacts to some mouse events

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/ScrollAnimationSmooth.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/ScrollAnimationSmooth.cpp
@@ -65,7 +65,11 @@ ScrollAnimationSmooth::ScrollAnimationSmooth(ScrollExtentsCallback&& scrollExten
     , m_notifyAnimationStoppedFunction(WTFMove(notifyAnimationStoppedFunction))
     , m_horizontalData(HorizontalScrollbar, position, m_scrollExtentsFunction)
     , m_verticalData(VerticalScrollbar, position, m_scrollExtentsFunction)
+#if USE(GENERIC_EVENT_LOOP) && PLATFORM(JAVA)
+    , m_animationTimer(*this, &ScrollAnimationSmooth::animationTimerFired)
+#else
     , m_animationTimer(RunLoop::current(), this, &ScrollAnimationSmooth::animationTimerFired)
+#endif
 {
 #if USE(GLIB_EVENT_LOOP)
     m_animationTimer.setPriority(WTF::RunLoopSourcePriority::DisplayRefreshMonitorTimer);

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/ScrollAnimationSmooth.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/ScrollAnimationSmooth.h
@@ -111,7 +111,11 @@ private:
     PerAxisData m_verticalData;
 
     MonotonicTime m_startTime;
+#if USE(GENERIC_EVENT_LOOP) && PLATFORM(JAVA)
+    Timer m_animationTimer;
+#else
     RunLoop::Timer<ScrollAnimationSmooth> m_animationTimer;
+#endif
 };
 
 } // namespace WebCore

--- a/modules/javafx.web/src/shims/java/com/sun/webkit/WebPageShim.java
+++ b/modules/javafx.web/src/shims/java/com/sun/webkit/WebPageShim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import com.sun.javafx.webkit.prism.WCBufferedContextShim;
 import com.sun.javafx.webkit.prism.PrismInvokerShim;
 import com.sun.webkit.WebPage;
 import com.sun.webkit.event.WCMouseEvent;
+import com.sun.webkit.event.WCMouseWheelEvent;
 import com.sun.webkit.graphics.WCGraphicsContext;
 import com.sun.webkit.graphics.WCGraphicsManager;
 import com.sun.webkit.graphics.WCGraphicsManagerShim;
@@ -86,5 +87,14 @@ public class WebPageShim {
                     false, false, false, false, false);
         page.dispatchMouseEvent(mousePressEvent);
         page.dispatchMouseEvent(mouseReleaseEvent);
+    }
+
+    public static void scroll(WebPage page, int x, int y, int deltaX, int deltaY) {
+        WCMouseWheelEvent mouseWheelEvent =
+                new WCMouseWheelEvent(x, y, x, y,
+                    System.currentTimeMillis(),
+                    false, false, false, false,
+                    deltaX, deltaY);
+        page.dispatchMouseWheelEvent(mouseWheelEvent);
     }
 }

--- a/tests/system/src/test/addExports
+++ b/tests/system/src/test/addExports
@@ -21,5 +21,7 @@
 --add-exports javafx.graphics/com.sun.javafx.sg.prism=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.prism.impl=ALL-UNNAMED
+#
+--add-exports javafx.web/com.sun.webkit=ALL-UNNAMED
 # compilation additions
 --add-exports=javafx.graphics/com.sun.glass.events=ALL-UNNAMED

--- a/tests/system/src/test/java/test/javafx/scene/web/WebPageTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/WebPageTest.java
@@ -132,6 +132,7 @@ public class WebPageTest {
         });
 
         assertTrue("Timeout when waiting for focus change ", Util.await(webViewStateLatch));
+        Util.sleep(1000);
 
         Util.runAndWait(() -> {
             final WebPage page = WebEngineShim.getPage(webView.getEngine());
@@ -139,7 +140,7 @@ public class WebPageTest {
             WebPageShim.scroll(page, 1, 1, 0, 100);
         });
 
-        Util.sleep(100);
+        Util.sleep(500);
 
         Util.runAndWait(() -> {
             assertEquals("WebPage should display pass: ", "Pass", webView.getEngine().executeScript("document.getElementById('test').innerHTML"));

--- a/tests/system/src/test/java/test/javafx/scene/web/WebPageTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/WebPageTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.web;
+
+import java.util.concurrent.CountDownLatch;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.web.WebEngineShim;
+import javafx.scene.web.WebView;
+import javafx.stage.Stage;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import test.util.Util;
+
+import com.sun.webkit.WebPage;
+import com.sun.webkit.WebPageShim;
+
+import static javafx.concurrent.Worker.State.SUCCEEDED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class WebPageTest {
+    private static final CountDownLatch launchLatch = new CountDownLatch(1);
+
+    // Maintain one application instance
+    static WebPageTestApp webPageTestApp;
+
+    private WebView webView;
+
+    public static class WebPageTestApp extends Application {
+        Stage primaryStage = null;
+
+        @Override
+        public void init() {
+            WebPageTest.webPageTestApp = this;
+        }
+
+        @Override
+        public void start(Stage primaryStage) throws Exception {
+            Platform.setImplicitExit(false);
+            this.primaryStage = primaryStage;
+            launchLatch.countDown();
+        }
+    }
+
+    @BeforeClass
+    public static void setupOnce() {
+        // Start the Test Application
+        new Thread(() -> Application.launch(WebPageTestApp.class, (String[])null)).start();
+
+        assertTrue("Timeout waiting for FX runtime to start", Util.await(launchLatch));
+    }
+
+    @AfterClass
+    public static void tearDownOnce() {
+        Platform.exit();
+    }
+
+    @Before
+    public void setupTestObjects() {
+        Platform.runLater(() -> {
+            webView = new WebView();
+            webPageTestApp.primaryStage.setScene(new Scene(webView));
+            webPageTestApp.primaryStage.show();
+        });
+    }
+
+    /**
+     * @test
+     * @bug 8260257
+     * summary Checks if scrolling is possible
+     */
+    @Test public void testScroll() {
+        final CountDownLatch webViewStateLatch = new CountDownLatch(1);
+        final String htmlContent = "\n"
+            + "<html>\n"
+            + "<body style='height:1500px'>\n"
+            + "<p id='test'>Fail</p>\n"
+            + "<script>\n"
+            + "window.onscroll = function() {scrollFunc()};\n"
+            + "function scrollFunc() {\n"
+            + "document.getElementById('test').innerHTML = 'Pass';\n"
+            + "}\n"
+            + "</script>\n"
+            + "</body>\n"
+            + "</html>";
+
+        Util.runAndWait(() -> {
+            assertNotNull(webView);
+            webView.getEngine().getLoadWorker().stateProperty().
+                addListener((observable, oldValue, newValue) -> {
+                if (newValue == SUCCEEDED) {
+                    webView.requestFocus();
+                }
+            });
+
+            webView.focusedProperty().
+                addListener((observable, oldValue, newValue) -> {
+                if (newValue) {
+                    webViewStateLatch.countDown();
+                }
+            });
+
+            webView.getEngine().loadContent(htmlContent);
+        });
+
+        assertTrue("Timeout when waiting for focus change ", Util.await(webViewStateLatch));
+
+        Util.runAndWait(() -> {
+            final WebPage page = WebEngineShim.getPage(webView.getEngine());
+            assertNotNull(page);
+            WebPageShim.scroll(page, 1, 1, 0, 100);
+        });
+
+        Util.sleep(100);
+
+        Util.runAndWait(() -> {
+            assertEquals("WebPage should display pass: ", "Pass", webView.getEngine().executeScript("document.getElementById('test').innerHTML"));
+        });
+    }
+}


### PR DESCRIPTION
Timer in RunLoopGeneric has an open bug in WebKit (https://bugs.webkit.org/show_bug.cgi?id=189335) causing the timer to remain active even after firing.

Reverting back to WebCore Timer for ScrollAnimation in Linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260257](https://bugs.openjdk.java.net/browse/JDK-8260257): [Linux] WebView no longer reacts to some mouse events


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Guru Hb](https://openjdk.java.net/census#ghb) (@guruhb - **Reviewer**) 🔄 Re-review required (review applies to 480c0d98672c90588eb426c03d08ee8b9707f394)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/404/head:pull/404`
`$ git checkout pull/404`
