### PR TITLE
8261927: WebKit build fails with Visual Studio 2017

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -230,10 +230,41 @@ static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& ke
             if (!ruleSet)
                 ruleSet = RuleSet::create();
             ruleSet->addRule(*feature.styleRule, feature.selectorIndex, feature.selectorListIndex);
-            if constexpr (std::is_same<RuleFeatureType, RuleFeatureWithInvalidationSelector>::value) {
+            /*if constexpr (std::is_same<RuleFeatureType, RuleFeatureWithInvalidationSelector>::value) {
                 if (feature.invalidationSelector)
                     invalidationSelectorArray[arrayIndex].append(feature.invalidationSelector);
-            }
+            }*/
+        }
+        auto invalidationRuleSets = makeUnique<Vector<InvalidationRuleSet>>();
+        for (unsigned i = 0; i < matchElementArray.size(); ++i) {
+            if (matchElementArray[i])
+                invalidationRuleSets->append({ static_cast<MatchElement>(i), *matchElementArray[i], WTFMove(invalidationSelectorArray[i]) });
+        }
+        return invalidationRuleSets;
+    }).iterator->value.get();
+}
+
+template<typename KeyType, typename Hash, typename HashTraits>
+static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& key, HashMap<KeyType, std::unique_ptr<Vector<InvalidationRuleSet>>, Hash, HashTraits>& ruleSetMap, const HashMap<KeyType, std::unique_ptr<Vector<RuleFeatureWithInvalidationSelector>>, Hash, HashTraits>& ruleFeatures)
+{
+    return ruleSetMap.ensure(key, [&]() -> std::unique_ptr<Vector<InvalidationRuleSet>> {
+        auto* features = ruleFeatures.get(key);
+        if (!features)
+            return nullptr;
+
+        std::array<RefPtr<RuleSet>, matchElementCount> matchElementArray;
+        std::array<Vector<const CSSSelector*>, matchElementCount> invalidationSelectorArray;
+        for (auto& feature : *features) {
+            auto arrayIndex = static_cast<unsigned>(*feature.matchElement);
+            auto& ruleSet = matchElementArray[arrayIndex];
+            if (!ruleSet)
+                ruleSet = RuleSet::create();
+            ruleSet->addRule(*feature.styleRule, feature.selectorIndex, feature.selectorListIndex);
+            // TODO : Visual studio 2017 doesn't support if constexpr in lamda, once updated to 2019, remove this function and uncomment above function's code
+            //if constexpr (std::is_same<RuleFeatureType, RuleFeatureWithInvalidationSelector>::value) {
+                if (feature.invalidationSelector)
+                    invalidationSelectorArray[arrayIndex].append(feature.invalidationSelector);
+            //}
         }
         auto invalidationRuleSets = makeUnique<Vector<InvalidationRuleSet>>();
         for (unsigned i = 0; i < matchElementArray.size(); ++i) {


### PR DESCRIPTION
The WebKit build fails with Visual Studio 2017.

Issue: Visual Studio 2017 doesn't support if constexpr in lambda

Test: Build webkit with the VS2017 compiler with and without this fix. It should fail without the fix and build with the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8261927](https://bugs.openjdk.java.net/browse/JDK-8261927): WebKit build fails with Visual Studio 2017


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Guru Hb](https://openjdk.java.net/census#ghb) (@guruhb - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/405/head:pull/405`
`$ git checkout pull/405`
