### PR TITLE
8262023: Scrolled button is pressed using Monocle on Raspberry Pi with Touchscreen

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ButtonBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ButtonBehavior.java
@@ -85,6 +85,7 @@ public class ButtonBehavior<C extends ButtonBase> extends BehaviorBase<C> {
             new MouseMapping(MouseEvent.MOUSE_RELEASED, this::mouseReleased),
             new MouseMapping(MouseEvent.MOUSE_ENTERED, this::mouseEntered),
             new MouseMapping(MouseEvent.MOUSE_EXITED, this::mouseExited),
+            new MouseMapping(MouseEvent.MOUSE_DRAGGED, this::mouseDragged, false),
 
             // on non-Mac OS platforms, we support pressing the ENTER key to activate the button
             new KeyMapping(new KeyBinding(ENTER, KeyEvent.KEY_PRESSED), this::keyPressed, event -> PlatformUtil.isMac()),
@@ -230,6 +231,18 @@ public class ButtonBehavior<C extends ButtonBase> extends BehaviorBase<C> {
     protected void mouseExited(MouseEvent e) {
         // Disarm if necessary
         if (! keyDown && getNode().isArmed()) {
+            getNode().disarm();
+        }
+    }
+
+    /**
+     * Invoked when the the Button is dragged. If the Button had been armed
+     * by a touch event or a mouse press and the mouse is still pressed,
+     * then this will cause the button to be rearmed. This allows not to fire
+     * the button's action after dragging or scrolling the button.
+     */
+    protected void mouseDragged(MouseEvent e) {
+        if (e.isSynthesized() && getNode().isArmed()) {
             getNode().disarm();
         }
     }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ChoiceBoxBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ChoiceBoxBehavior.java
@@ -44,6 +44,7 @@ public class ChoiceBoxBehavior<T> extends BehaviorBase<ChoiceBox<T>> {
     private final InputMap<ChoiceBox<T>> choiceBoxInputMap;
 
     private TwoLevelFocusComboBehavior tlFocus;
+    private boolean showPopupOnMouseRelease = true;
 
     /**************************************************************************
      *                          Setup KeyBindings                             *
@@ -66,7 +67,8 @@ public class ChoiceBoxBehavior<T> extends BehaviorBase<ChoiceBox<T>> {
             new KeyMapping(CANCEL, KeyEvent.KEY_RELEASED, e -> cancel()),
 
             new MouseMapping(MouseEvent.MOUSE_PRESSED, this::mousePressed),
-            new MouseMapping(MouseEvent.MOUSE_RELEASED, this::mouseReleased)
+            new MouseMapping(MouseEvent.MOUSE_RELEASED, this::mouseReleased),
+            new MouseMapping(MouseEvent.MOUSE_DRAGGED, this::mouseDragged, false)
         );
 
         // add some special two-level focus mappings
@@ -113,6 +115,7 @@ public class ChoiceBoxBehavior<T> extends BehaviorBase<ChoiceBox<T>> {
      * potentially arming the Button, this will transfer focus to the box
      */
     public void mousePressed(MouseEvent e) {
+        showPopupOnMouseRelease = true;
         ChoiceBox<T> choiceButton = getNode();
         if (choiceButton.isFocusTraversable()) choiceButton.requestFocus();
     }
@@ -127,9 +130,10 @@ public class ChoiceBoxBehavior<T> extends BehaviorBase<ChoiceBox<T>> {
         if (choiceButton.isShowing() || !choiceButton.contains(e.getX(), e.getY())) {
             choiceButton.hide(); // hide if already showing
         }
-        else if (e.getButton() == MouseButton.PRIMARY) {
+        else if (e.getButton() == MouseButton.PRIMARY && showPopupOnMouseRelease) {
             choiceButton.show();
         }
+        showPopupOnMouseRelease = true;
     }
 
     /**
@@ -149,6 +153,18 @@ public class ChoiceBoxBehavior<T> extends BehaviorBase<ChoiceBox<T>> {
      * to fire if it was armed by a keyPress.
      */
     private void keyReleased(KeyEvent e) {
+    }
+
+    /**
+     * Invoked when the the ChoiceBox is dragged. If the box had been armed
+     * by a touch event or a mouse press and the mouse is still pressed,
+     * then this will cause the ChoiceBox to fire the box's action. This allows not to fire
+     * the box's action after dragging or scrolling the box.
+     */
+    protected void mouseDragged(MouseEvent e) {
+        if(e.isSynthesized()) {
+            showPopupOnMouseRelease = false;
+        }
     }
 
     // no-op

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ComboBoxBaseBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ComboBoxBaseBehavior.java
@@ -97,7 +97,8 @@ public class ComboBoxBaseBehavior<T> extends BehaviorBase<ComboBoxBase<T>> {
             new MouseMapping(MouseEvent.MOUSE_PRESSED, this::mousePressed),
             new MouseMapping(MouseEvent.MOUSE_RELEASED, this::mouseReleased),
             new MouseMapping(MouseEvent.MOUSE_ENTERED, this::mouseEntered),
-            new MouseMapping(MouseEvent.MOUSE_EXITED, this::mouseExited)
+            new MouseMapping(MouseEvent.MOUSE_EXITED, this::mouseExited),
+            new MouseMapping(MouseEvent.MOUSE_DRAGGED, this::mouseDragged, false)
         );
 
         // we don't want to consume events on enter press - let them carry on through
@@ -261,6 +262,18 @@ public class ComboBoxBaseBehavior<T> extends BehaviorBase<ComboBoxBase<T>> {
     public void mouseExited(MouseEvent e) {
         mouseInsideButton = false;
         disarm();
+    }
+
+    /**
+     * Invoked when the the ComboBox is dragged. If the box had been armed
+     * by a touch event or a mouse press and the mouse is still pressed,
+     * then this will cause the box to be rearmed. This allows not to fire
+     * the box's action after dragging or scrolling the box.
+     */
+    public void mouseDragged(MouseEvent e) {
+        if(e.isSynthesized()) {
+            showPopupOnMouseRelease = false;
+        }
     }
 
 //    private void getFocus() {

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/inputmap/InputMap.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/inputmap/InputMap.java
@@ -860,10 +860,34 @@ public class InputMap<N extends Node> implements EventHandler<Event> {
          *           {@link MouseEvent} is observed.
          */
         public MouseMapping(final EventType<MouseEvent> eventType, final EventHandler<MouseEvent> eventHandler) {
+            this(eventType, eventHandler, true);
+        }
+
+        /**
+         * Creates a new MouseMapping instance that will fire when the given
+         * {@link MouseEvent} is entered into the application by the user, and this
+         * will result in the given {@link EventHandler} being fired. The
+         * eventType argument can be any of the {@link MouseEvent} event types,
+         * but typically it is one of the following:
+         *
+         * <ul>
+         *     <li>{@link MouseEvent#ANY}</li>
+         *     <li>{@link MouseEvent#MOUSE_PRESSED}</li>
+         *     <li>{@link MouseEvent#MOUSE_CLICKED}</li>
+         *     <li>{@link MouseEvent#MOUSE_RELEASED}</li>
+         * </ul>
+         *
+         * @param eventType The type of {@link MouseEvent} to listen for.
+         * @param eventHandler The {@link EventHandler} to fire when the
+         *           {@link MouseEvent} is observed.
+         * @param autoConsume Auto consume mouse events
+         */
+        public MouseMapping(final EventType<MouseEvent> eventType, final EventHandler<MouseEvent> eventHandler, boolean autoConsume) {
             super(eventType, eventHandler);
             if (eventType == null) {
                 throw new IllegalArgumentException("MouseMapping eventType constructor argument can not be null");
             }
+            setAutoConsume(autoConsume);
         }
 
 


### PR DESCRIPTION
The issue is reproduced on Raspberry Pi 3 B+ with Touchscreen display.

To reproduce the issue run the [ScrollPaneSample](https://bugs.openjdk.java.net/secure/attachment/93270/ScrollPaneSample.java) with Monocle:
> sudo jdk/bin/java -Dprism.verbose=true -Djavafx.platform=monocle -Dembedded=monocle -Dglass.platform=Monocle ScrollPaneSample


An application consists of a ScrollPane with buttons. if a button is touched by a finger, moved up/down and released, the button is scrolled and the button's action is fired.

This happens because Monocle generates mouse pressed, mouse dragged, scroll, mouse released events when touch events are received.
Even a  button is scrolled on a ScrollPane it still fires the button's action on the synthesized mouse release event.

My first attempt was to add a scroll event listener to a ButtonBehavior class and disarm the button when the scroll event is received.
This does work not in the case where buttons are small and scrolling buttons leads that a finger is released on the next button (the scrolling process is remained a slightly behind the touched finger so the finger is touched on one button and released on another).
In this case all scroll events goes to the first button and the second button still fires its action (it does not disarmed because it does not receive scroll events).

The current fix adds drag event listener to ButtonBehavior to disarm the button. Drag events goes to the touched and released buttons.

Than I checked the fix on the same Raspberry Pi using GTK  with touchscreen.
>  sudo jdk/bin/java -Dprism.verbose=true -Djavafx.platform=gtk ScrollPaneSample

I have not seen scroll events using GTK (even using -Dgtk.com.sun.javafx.gestures.scroll=true option), but GTK sends mouse drag events on a button touch.
The mouse drag event between a button touch and release events would disarm the button in the proposed ButtonBehavior drag event handler. So I added the check if the mouse drag is synthesized. If the mouse drag is synthesized (Monocle case on touchscreen) it disarms the button, otherwise (GTK case) not.

I checked the fix for the following controls placed on a ScrollPane (see [ScrollPaneControlsSample](https://bugs.openjdk.java.net/secure/attachment/93271/ScrollPaneControlsSample.java) sample) :
- Fixed in corresponding behavior classes or its parents: Button, ToggleButton, CheckBox, ComboBox, ChoiceBox, ColorPicker, DatePicker, RadioButton 
- Works because an action is not fired on mouse release event: TextField 
- Does not work: Slider

The Slider control does not work with the fix because it reacts not only on mouse release event but on mouse drag event as well. It requires a separate fix.

I checked the Ensemble8 sample with the fix. It works with Monocle on Raspberry Pi 3B+ on Touchscreen. Scrolling the main page by a finger does not makes it to be pressed.

The Ensemble8 sample does not work with GTK on Raspberry Pi 3B+ with Touchscreen. I see it generates scroll events ( it has its own [ScrollEventSynthesizer](https://github.com/openjdk/jfx/blob/master/apps/samples/Ensemble8/src/app/java/ensemble/ScrollEventSynthesizer.java)) and action events and it can makes the Ensemble8 buttons on a ScrollPane to be pressed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8262023](https://bugs.openjdk.org/browse/JDK-8262023): Scrolled button is pressed using Monocle on Raspberry Pi with Touchscreen


### Reviewers
 * @m7snxx (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/406/head:pull/406` \
`$ git checkout pull/406`

Update a local copy of the PR: \
`$ git checkout pull/406` \
`$ git pull https://git.openjdk.org/jfx.git pull/406/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 406`

View PR using the GUI difftool: \
`$ git pr show -t 406`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/406.diff">https://git.openjdk.org/jfx/pull/406.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/406#issuecomment-782105922)