### PR TITLE
9069167: Avoid NPE in TabOrderHelper.findNextFocusablePeer()

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/traversal/TabOrderHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/traversal/TabOrderHelper.java
@@ -186,7 +186,7 @@ final class TabOrderHelper {
         ** we've reached the end of the peer nodes, and none have been selected,
         ** time to look at our parents peers.....
         */
-        while (newNode == null && startNode.getParent() != root) {
+        while (newNode == null && startNode != null && startNode.getParent() != root) {
             List<Node> peerNodes;
             int parentIndex;
 


### PR DESCRIPTION
TabOrderHelper.findNextFocusablePeer() will throw a NullPointerException when a parent peer is not found.  It should returning null instead.   The while loop gets the parent and checks it for null.  If it is null, the startNode is set to null.  The next iteration of the loop calls startNode.getParent() and throws a NPE.  I suggest adding a simple null check to avoid this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * ⚠️ Failed to retrieve information on issue `9069167`.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/407/head:pull/407` \
`$ git checkout pull/407`

Update a local copy of the PR: \
`$ git checkout pull/407` \
`$ git pull https://git.openjdk.java.net/jfx pull/407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 407`

View PR using the GUI difftool: \
`$ git pr show -t 407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/407.diff">https://git.openjdk.java.net/jfx/pull/407.diff</a>

</details>
