### PR TITLE
8260165: CSSFilterTest.testCSSFilterRendering system test fails

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/page/FrameViewLayoutContext.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/FrameViewLayoutContext.cpp
@@ -407,6 +407,7 @@ void FrameViewLayoutContext::scheduleLayout()
 #endif
 
 #if PLATFORM(JAVA)
+    // scheduleLayout will be called from prePaint in next updateContent cycle.
     const Seconds layoutScheduleThreshold = 250_ms;
     m_layoutTimer.startOneShot(layoutScheduleThreshold);
 #else

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/FrameViewLayoutContext.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/FrameViewLayoutContext.cpp
@@ -406,7 +406,12 @@ void FrameViewLayoutContext::scheduleLayout()
         LOG(Layout, "FrameView %p layout timer scheduled at %.3fs", this, frame().document()->timeSinceDocumentCreation().value());
 #endif
 
+#if PLATFORM(JAVA)
+    const Seconds layoutScheduleThreshold = 250_ms;
+    m_layoutTimer.startOneShot(layoutScheduleThreshold);
+#else
     m_layoutTimer.startOneShot(0_s);
+#endif
 }
 
 void FrameViewLayoutContext::unscheduleLayout()

--- a/tests/system/src/test/java/test/javafx/scene/web/CSSFilterTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/CSSFilterTest.java
@@ -37,7 +37,6 @@ import javafx.stage.Stage;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import test.util.Util;
 
@@ -122,7 +121,6 @@ public class CSSFilterTest {
         });
     }
 
-    @Ignore("JDK-8260165")
     @Test public void testCSSFilterRendering() {
         final CountDownLatch webViewStateLatch = new CountDownLatch(1);
 


### PR DESCRIPTION
Issue: Initial layout delay was removed and layout() is called from layoutTimer instead of WebPage::prePaint().

Fix: Re-introduce the initial layout delay.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8260165](https://bugs.openjdk.java.net/browse/JDK-8260165): CSSFilterTest.testCSSFilterRendering system test fails


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Guru Hb](https://openjdk.java.net/census#ghb) (@guruhb - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/408/head:pull/408`
`$ git checkout pull/408`
