### PR TITLE
8258777: SkinBase: add api to un-/register invalidation-/listChange listeners

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/LambdaMultiplePropertyChangeListenerHandler.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/LambdaMultiplePropertyChangeListenerHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,23 +25,63 @@
 
 package com.sun.javafx.scene.control;
 
-import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
-import javafx.beans.value.WeakChangeListener;
-
 import java.util.HashMap;
+import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.function.Consumer;
 
-public final class LambdaMultiplePropertyChangeListenerHandler {
+import javafx.beans.InvalidationListener;
+import javafx.beans.Observable;
+import javafx.beans.WeakInvalidationListener;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.beans.value.WeakChangeListener;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ListChangeListener.Change;
+import javafx.collections.ObservableList;
+import javafx.collections.WeakListChangeListener;
 
+/**
+ * Handler to manage multiple listeners to multiple observables. It handles
+ * adding/removing listeners for common notification events (change,
+ * invalidation and list change) on particular instances of observables. The
+ * listeners are wrapped into their weak counterparts to minimize the potential of
+ * memory leaks.
+ * <p>
+ * Clients can register consumers to be invoked on receiving notification.
+ * Un-/Registration api is separate per notification type and per observable.
+ * It is allowed to register multiple consumers per observable. They
+ * are executed in the order of registration. Note that unregistration
+ * of a given observable stops observing that observable (for the notification
+ * type of the unregistration) completely, that is none of the consumers
+ * previously registered with this handler will be executed after unregistering.
+ * <p>
+ * Disposing removes all listeners added by this handler from all registered observables.
+ *
+ */
+public final class LambdaMultiplePropertyChangeListenerHandler {
+// FIXME: name doesn't fit after widening to support more notification event types
+
+    @SuppressWarnings("rawtypes")
+    private  static final Consumer EMPTY_CONSUMER = e -> {};
+
+    // support change listeners
     private final Map<ObservableValue<?>, Consumer<ObservableValue<?>>> propertyReferenceMap;
     private final ChangeListener<Object> propertyChangedListener;
     private final WeakChangeListener<Object> weakPropertyChangedListener;
 
-    private static final Consumer<ObservableValue<?>> EMPTY_CONSUMER = e -> {};
+    // support invalidation listeners
+    private final Map<Observable, Consumer<Observable>> observableReferenceMap;
+    private final InvalidationListener invalidationListener;
+    private final WeakInvalidationListener weakInvalidationListener;
+
+    // support list change listeners
+    private final Map<ObservableList<?>, Consumer<Change<?>>> observableListReferenceMap;
+    private final ListChangeListener<Object> listChangeListener;
+    private final WeakListChangeListener<Object> weakListChangeListener;
 
     public LambdaMultiplePropertyChangeListenerHandler() {
+        // change listening support
         this.propertyReferenceMap = new HashMap<>();
         this.propertyChangedListener = (observable, oldValue, newValue) -> {
             // because all consumers are chained, this calls each consumer for the given property
@@ -49,16 +89,32 @@ public final class LambdaMultiplePropertyChangeListenerHandler {
             propertyReferenceMap.getOrDefault(observable, EMPTY_CONSUMER).accept(observable);
         };
         this.weakPropertyChangedListener = new WeakChangeListener<>(propertyChangedListener);
+
+        // invalidation listening support
+        this.observableReferenceMap = new HashMap<>();
+        this.invalidationListener =  obs -> {
+            observableReferenceMap.getOrDefault(obs, EMPTY_CONSUMER).accept(obs);
+        };
+        this.weakInvalidationListener = new WeakInvalidationListener(invalidationListener);
+
+        // list change listening support
+        this.observableListReferenceMap = new IdentityHashMap<>();
+        this.listChangeListener = change -> {
+            observableListReferenceMap.getOrDefault(change.getList(), EMPTY_CONSUMER).accept(change);
+        };
+        this.weakListChangeListener = new WeakListChangeListener<>(listChangeListener);
     }
 
     /**
-     * Subclasses can invoke this method to register that we want to listen to
-     * property change events for the given property.
+     * Registers a consumer to be invoked on change notification from the given property. Does nothing
+     * if property or consumer is null. Consumers registered to the same property will be executed
+     * in the order they have been registered.
      *
-     * @param property
+     * @param property the property to observe for change notification
+     * @param consumer the consumer to be invoked on change notification from the property
      */
     public final void registerChangeListener(ObservableValue<?> property, Consumer<ObservableValue<?>> consumer) {
-        if (consumer == null) return;
+        if (property == null || consumer == null) return;
 
         // we only add a listener if the propertyReferenceMap does not contain the property
         // (that is, we've added a consumer to this specific property for the first
@@ -70,17 +126,109 @@ public final class LambdaMultiplePropertyChangeListenerHandler {
         propertyReferenceMap.merge(property, consumer, Consumer::andThen);
     }
 
-    // need to be careful here - removing all listeners on the specific property!
+    /**
+     * Stops observing the given property for change notification. Returns
+     * a single chained consumer consisting of all consumers registered with
+     * {@link #registerChangeListener(ObservableValue, Consumer)} in the order they
+     * have been registered.
+     *
+     * @param property the property to stop observing for change notification
+     * @return a single chained consumer consisting of all consumers registered for the given property
+     *    or null if none has been registered or the property is null
+     */
     public final Consumer<ObservableValue<?>> unregisterChangeListeners(ObservableValue<?> property) {
+        if (property == null) return null;
         property.removeListener(weakPropertyChangedListener);
         return propertyReferenceMap.remove(property);
     }
 
+    /**
+     * Registers a consumer to be invoked on invalidation notification from the given observable.
+     * Does nothing if observable or consumer is null. Consumers registered to the same observable will be executed
+     * in the order they have been registered.
+     *
+     * @param observable the observable to observe for invalidation notification
+     * @param consumer the consumer to be invoked on invalidation notification from the observable
+     *
+     */
+    public final void registerInvalidationListener(Observable observable, Consumer<Observable> consumer) {
+        if (observable == null || consumer == null) return;
+        if (!observableReferenceMap.containsKey(observable)) {
+            observable.addListener(weakInvalidationListener);
+        }
+        observableReferenceMap.merge(observable, consumer, Consumer::andThen);
+    }
+
+    /**
+     * Stops observing the given observable for invalidation notification.
+     * Returns a single chained consumer consisting of all consumers registered with
+     * {@link #registerInvalidationListener(Observable, Consumer)} in the
+     * order they have been registered.
+     *
+     * @param observable the observable to stop observing for invalidation notification
+     * @return a single chained consumer consisting of all consumers registered for given observable
+     *    or null if none has been registered or the observable is null
+     *
+     */
+    public final Consumer<Observable> unregisterInvalidationListeners(Observable observable) {
+        if (observable == null) return null;
+        observable.removeListener(weakInvalidationListener);
+        return observableReferenceMap.remove(observable);
+    }
+
+    /**
+     * Registers a consumer to be invoked on list change notification from the given observable list.
+     * Does nothing if list or consumer is null. Consumers registered to the same observable list
+     * will be executed in the order they have been registered.
+     *
+     * @param list the observable list observe for list change notification
+     * @param consumer the consumer to be invoked on list change notification from the list
+     *
+     */
+    public final void registerListChangeListener(ObservableList<?> list, Consumer<Change<?>> consumer) {
+        if (list == null || consumer == null) return;
+        if (!observableListReferenceMap.containsKey(list)) {
+            list.addListener(weakListChangeListener);
+        }
+        observableListReferenceMap.merge(list, consumer, Consumer::andThen);
+    }
+
+    /**
+     * Stops observing the given observable list for list change notification.
+     * Returns a single chained consumer consisting of all consumers registered with
+     * {@link #registerListChangeListener(ObservableList, Consumer)} in the order they have been registered.
+     *
+     * @param list the observable list to stop observing for list change notification
+     * @return a single chained consumer consisting of all consumers added for the given list
+     *    or null if none has been registered or the list is null
+     */
+    public final Consumer<Change<?>> unregisterListChangeListeners(ObservableList<?> list) {
+        if (list == null) return null;
+        list.removeListener(weakListChangeListener);
+        return observableListReferenceMap.remove(list);
+    }
+
+
+    /**
+     * Stops observing all types of notification from all registered observables.
+     * <p>
+     * Note: this handler is still usable after calling this method.
+     */
     public void dispose() {
-        // unhook listeners
+        // unhook change listeners
         for (ObservableValue<?> value : propertyReferenceMap.keySet()) {
             value.removeListener(weakPropertyChangedListener);
         }
         propertyReferenceMap.clear();
+        // unhook invalidation listeners
+        for (Observable value : observableReferenceMap.keySet()) {
+            value.removeListener(weakInvalidationListener);
+        }
+        observableReferenceMap.clear();
+        // unhook list change listeners
+        for (ObservableList<?> list : observableListReferenceMap.keySet()) {
+            list.removeListener(weakListChangeListener);
+        }
+        observableListReferenceMap.clear();
     }
 }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/LambdaMultiplePropertyChangeListenerHandler.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/LambdaMultiplePropertyChangeListenerHandler.java
@@ -57,13 +57,12 @@ import javafx.collections.WeakListChangeListener;
  * previously registered with this handler will be executed after unregistering.
  * <p>
  * Disposing removes all listeners added by this handler from all registered observables.
- *
  */
 public final class LambdaMultiplePropertyChangeListenerHandler {
-// FIXME: name doesn't fit after widening to support more notification event types
+// FIXME JDK-8265401: name doesn't fit after widening to support more notification event types
 
     @SuppressWarnings("rawtypes")
-    private  static final Consumer EMPTY_CONSUMER = e -> {};
+    private static final Consumer EMPTY_CONSUMER = e -> {};
 
     // support change listeners
     private final Map<ObservableValue<?>, Consumer<ObservableValue<?>>> propertyReferenceMap;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
@@ -242,8 +242,8 @@ public abstract class SkinBase<C extends Control> implements Skin<C> {
     }
 
     /**
-     * Registers an operation to perform when the given {@code Observable} sends an invalidation event.
-     * Does nothing if observable or operation is {@code null}.
+     * Registers an operation to perform when the given {@code observable} sends an invalidation event.
+     * Does nothing if either {@code observable} or {@code operation} are {@code null}.
      * If multiple operations are registered on the same observable, they will be performed in the
      * order in which they were registered.
      *
@@ -262,12 +262,12 @@ public abstract class SkinBase<C extends Control> implements Skin<C> {
     /**
      * Unregisters all operations that have been registered using
      * {@link #registerInvalidationListener(Observable, Consumer)}
-     * for the given observable.
+     * for the given {@code observable}. Does nothing if {@code observable} is {@code null}
      *
      * @param observable the observable for which the registered operations should be removed,
      *  may be {@code null}
-     * @return a composed consumer that performs all removed operations or
-     *  {@code null} if none has been registered or the observable is {@null}
+     * @return a composed consumer that performs all removed operations, or
+     *  {@code null} if none have been registered or the observable is {@code null}
      * @since 17
      */
     protected final Consumer<Observable> unregisterInvalidationListeners(Observable observable) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
@@ -243,12 +243,12 @@ public abstract class SkinBase<C extends Control> implements Skin<C> {
 
     /**
      * Registers an operation to perform when the given {@code Observable} sends an invalidation event.
-     * Does nothing if observable or operation is {@code null}. 
-     * If multiple operations are registered on the same observable, they will be performed in the 
+     * Does nothing if observable or operation is {@code null}.
+     * If multiple operations are registered on the same observable, they will be performed in the
      * order in which they were registered.
      *
      * @param observable the observable to observe for invalidation events, may be {@code null}
-     * @param operation the operation to perform when the observable sends an invalidation event, 
+     * @param operation the operation to perform when the observable sends an invalidation event,
      *  may be {@code null}
      * @since 17
      */
@@ -262,11 +262,11 @@ public abstract class SkinBase<C extends Control> implements Skin<C> {
     /**
      * Unregisters all operations that have been registered using
      * {@link #registerInvalidationListener(Observable, Consumer)}
-     * for the given observable. 
+     * for the given observable.
      *
-     * @param observable the observable for which the registered operations should be removed, 
+     * @param observable the observable for which the registered operations should be removed,
      *  may be {@code null}
-     * @return a composed consumer that performs all removed operations or 
+     * @return a composed consumer that performs all removed operations or
      *  {@code null} if none has been registered or the observable is {@null}
      * @since 17
      */

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,18 @@
 
 package javafx.scene.control;
 
-import com.sun.javafx.scene.control.LambdaMultiplePropertyChangeListenerHandler;
-import javafx.beans.value.ObservableValue;
-import javafx.css.CssMetaData;
-import javafx.css.PseudoClass;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
+import com.sun.javafx.scene.control.LambdaMultiplePropertyChangeListenerHandler;
+
+import javafx.beans.Observable;
+import javafx.beans.value.ObservableValue;
+import javafx.collections.ListChangeListener.Change;
 import javafx.collections.ObservableList;
+import javafx.css.CssMetaData;
+import javafx.css.PseudoClass;
 import javafx.css.Styleable;
 import javafx.event.EventHandler;
 import javafx.geometry.HPos;
@@ -238,7 +241,75 @@ public abstract class SkinBase<C extends Control> implements Skin<C> {
         return lambdaChangeListenerHandler.unregisterChangeListeners(property);
     }
 
+    /**
+     * Subclasses can invoke this method to register that they want to listen to
+     * invalidation events for the given observable. Registered {@link Consumer} instances
+     * will be executed in the order in which they are registered.
+     * @param observable the observable to observe for invalidation events
+     * @param consumer the consumer
+     */
+    protected final void registerInvalidationListener(Observable observable, Consumer<Observable> consumer) {
+        if (lambdaChangeListenerHandler == null) {
+            lambdaChangeListenerHandler = new LambdaMultiplePropertyChangeListenerHandler();
+        }
+        lambdaChangeListenerHandler.registerInvalidationListener(observable, consumer);
+    }
 
+    /**
+     * Unregisters all invalidation listeners that have been registered using
+     * {@link #registerInvalidationListener(Observable, Consumer)}
+     * for the given observable. The end result is that the given observable is no longer observed by any of the invalidation
+     * listeners, but it may still have additional listeners registered on it through means outside of
+     * {@link #registerInvalidationListener(Observable, Consumer)}.
+     *
+     * @param observable The observable for which all listeners should be removed.
+     * @return A single chained {@link Consumer} consisting of all {@link Consumer consumers} registered through
+     *      {@link #registerInvalidationListener(Observable, Consumer)}. If no consumers have been registered on this
+     *      property, null will be returned.
+     * @since 9
+     */
+    protected final Consumer<Observable> unregisterInvalidationListeners(Observable observable) {
+        if (lambdaChangeListenerHandler == null) {
+            return null;
+        }
+        return lambdaChangeListenerHandler.unregisterInvalidationListeners(observable);
+    }
+
+
+    /**
+     * Subclasses can invoke this method to register that they want to listen to
+     * list change events for the given observable list. Registered {@link Consumer} instances
+     * will be executed in the order in which they are registered.
+     * @param observableList the observable list to observe for list change events
+     * @param consumer the consumer
+     */
+    protected final void registerListChangeListener(ObservableList<?> observableList, Consumer<Change<?>> consumer) {
+        if (lambdaChangeListenerHandler == null) {
+            lambdaChangeListenerHandler = new LambdaMultiplePropertyChangeListenerHandler();
+        }
+        lambdaChangeListenerHandler.registerListChangeListener(observableList, consumer);
+    }
+
+    /**
+     * Unregisters all list change listeners that have been registered using
+     * {@link #registerListChangeListener(ObservableList, Consumer)}
+     * for the given list. The end result is that the given observable is no longer observed by any of the
+     * list change listeners,
+     * but it may still have additional listeners registered on it through means outside of
+     * {@link #registerListChangeListener(ObservableList, Consumer)}.
+     *
+     * @param observableList The list for which all listeners should be removed.
+     * @return A single chained {@link Consumer} consisting of all {@link Consumer consumers} registered through
+     *      {@link #registerListChangeListener(ObservableList, Consumer)}. If no consumers have been registered on this
+     *      list, null will be returned.
+     * @since 9
+     */
+    protected final Consumer<Change<?>> unregisterListChangeListeners(ObservableList<?> observableList) {
+        if (lambdaChangeListenerHandler == null) {
+            return null;
+        }
+        return lambdaChangeListenerHandler.unregisterListChangeListeners(observableList);
+    }
 
 
     /***************************************************************************

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
@@ -209,29 +209,31 @@ public abstract class SkinBase<C extends Control> implements Skin<C> {
 
 
     /**
-     * Subclasses can invoke this method to register that they want to listen to
-     * property change events for the given property. Registered {@link Consumer} instances
-     * will be executed in the order in which they are registered.
-     * @param property the property
-     * @param consumer the consumer
+     * Registers an operation to perform when the given {@code property} sends a change event.
+     * Does nothing if either {@code property} or {@code operation} are {@code null}.
+     * If multiple operations are registered on the same property, they will be performed in the
+     * order in which they were registered.
+     *
+     * @param property the property to observe for change events, may be {@code null}
+     * @param operation the operation to perform when the property sends a change event,
+     *  may be {@code null}
      */
-    protected final void registerChangeListener(ObservableValue<?> property, Consumer<ObservableValue<?>> consumer) {
+    protected final void registerChangeListener(ObservableValue<?> property, Consumer<ObservableValue<?>> operation) {
         if (lambdaChangeListenerHandler == null) {
             lambdaChangeListenerHandler = new LambdaMultiplePropertyChangeListenerHandler();
         }
-        lambdaChangeListenerHandler.registerChangeListener(property, consumer);
+        lambdaChangeListenerHandler.registerChangeListener(property, operation);
     }
 
     /**
-     * Unregisters all change listeners that have been registered using {@link #registerChangeListener(ObservableValue, Consumer)}
-     * for the given property. The end result is that the given property is no longer observed by any of the change
-     * listeners, but it may still have additional listeners registered on it through means outside of
-     * {@link #registerChangeListener(ObservableValue, Consumer)}.
+     * Unregisters all operations that have been registered using
+     * {@link #registerChangeListener(ObservableValue, Consumer)}
+     * for the given {@code property}. Does nothing if {@code property} is {@code null}.
      *
-     * @param property The property for which all listeners should be removed.
-     * @return A single chained {@link Consumer} consisting of all {@link Consumer consumers} registered through
-     *      {@link #registerChangeListener(ObservableValue, Consumer)}. If no consumers have been registered on this
-     *      property, null will be returned.
+     * @param property the property for which the registered operations should be removed,
+     *  may be {@code null}
+     * @return a composed consumer representing all previously registered operations, or
+     *  {@code null} if none have been registered or the propery is {@code null}
      * @since 9
      */
     protected final Consumer<ObservableValue<?>> unregisterChangeListeners(ObservableValue<?> property) {
@@ -262,7 +264,7 @@ public abstract class SkinBase<C extends Control> implements Skin<C> {
     /**
      * Unregisters all operations that have been registered using
      * {@link #registerInvalidationListener(Observable, Consumer)}
-     * for the given {@code observable}. Does nothing if {@code observable} is {@code null}
+     * for the given {@code observable}. Does nothing if {@code observable} is {@code null}.
      *
      * @param observable the observable for which the registered operations should be removed,
      *  may be {@code null}
@@ -279,33 +281,32 @@ public abstract class SkinBase<C extends Control> implements Skin<C> {
 
 
     /**
-     * Subclasses can invoke this method to register that they want to listen to
-     * list change events for the given observable list. Registered {@link Consumer} instances
-     * will be executed in the order in which they are registered.
+     * Registers an operation to perform when the given {@code observableList} sends a list change event.
+     * Does nothing if either {@code observableList} or {@code operation} are {@code null}.
+     * If multiple operations are registered on the same observableList, they will be performed in the
+     * order in which they were registered.
      *
-     * @param observableList the observable list to observe for list change events
-     * @param consumer the consumer
+     * @param observableList the observableList to observe for list change events, may be {@code null}
+     * @param operation the operation to perform when the observableList sends a list change event,
+     *  may be {@code null}
      * @since 17
      */
-    protected final void registerListChangeListener(ObservableList<?> observableList, Consumer<Change<?>> consumer) {
+    protected final void registerListChangeListener(ObservableList<?> observableList, Consumer<Change<?>> operation) {
         if (lambdaChangeListenerHandler == null) {
             lambdaChangeListenerHandler = new LambdaMultiplePropertyChangeListenerHandler();
         }
-        lambdaChangeListenerHandler.registerListChangeListener(observableList, consumer);
+        lambdaChangeListenerHandler.registerListChangeListener(observableList, operation);
     }
 
     /**
-     * Unregisters all list change listeners that have been registered using
+     * Unregisters all operations that have been registered using
      * {@link #registerListChangeListener(ObservableList, Consumer)}
-     * for the given list. The end result is that the given observable is no longer observed by any of the
-     * list change listeners,
-     * but it may still have additional listeners registered on it through means outside of
-     * {@link #registerListChangeListener(ObservableList, Consumer)}.
+     * for the given {@code observableList}. Does nothing if {@code observableList} is {@code null}.
      *
-     * @param observableList The list for which all listeners should be removed.
-     * @return A single chained {@link Consumer} consisting of all {@link Consumer consumers} registered through
-     *      {@link #registerListChangeListener(ObservableList, Consumer)}. If no consumers have been registered on this
-     *      list, null will be returned.
+     * @param observableList the observableList for which the registered operations should be removed,
+     *  may be {@code null}
+     * @return a composed consumer representing all previously registered operations, or
+     *  {@code null} if none have been registered or the observableList is {@code null}
      * @since 17
      */
     protected final Consumer<Change<?>> unregisterListChangeListeners(ObservableList<?> observableList) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
@@ -283,7 +283,7 @@ public abstract class SkinBase<C extends Control> implements Skin<C> {
     /**
      * Registers an operation to perform when the given {@code observableList} sends a list change event.
      * Does nothing if either {@code observableList} or {@code operation} are {@code null}.
-     * If multiple operations are registered on the same observableList, they will be performed in the
+     * If multiple operations are registered on the same observable list, they will be performed in the
      * order in which they were registered.
      *
      * @param observableList the observableList to observe for list change events, may be {@code null}

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
@@ -245,8 +245,10 @@ public abstract class SkinBase<C extends Control> implements Skin<C> {
      * Subclasses can invoke this method to register that they want to listen to
      * invalidation events for the given observable. Registered {@link Consumer} instances
      * will be executed in the order in which they are registered.
+     *
      * @param observable the observable to observe for invalidation events
      * @param consumer the consumer
+     * @since 17
      */
     protected final void registerInvalidationListener(Observable observable, Consumer<Observable> consumer) {
         if (lambdaChangeListenerHandler == null) {
@@ -266,7 +268,7 @@ public abstract class SkinBase<C extends Control> implements Skin<C> {
      * @return A single chained {@link Consumer} consisting of all {@link Consumer consumers} registered through
      *      {@link #registerInvalidationListener(Observable, Consumer)}. If no consumers have been registered on this
      *      property, null will be returned.
-     * @since 9
+     * @since 17
      */
     protected final Consumer<Observable> unregisterInvalidationListeners(Observable observable) {
         if (lambdaChangeListenerHandler == null) {
@@ -280,8 +282,10 @@ public abstract class SkinBase<C extends Control> implements Skin<C> {
      * Subclasses can invoke this method to register that they want to listen to
      * list change events for the given observable list. Registered {@link Consumer} instances
      * will be executed in the order in which they are registered.
+     *
      * @param observableList the observable list to observe for list change events
      * @param consumer the consumer
+     * @since 17
      */
     protected final void registerListChangeListener(ObservableList<?> observableList, Consumer<Change<?>> consumer) {
         if (lambdaChangeListenerHandler == null) {
@@ -302,7 +306,7 @@ public abstract class SkinBase<C extends Control> implements Skin<C> {
      * @return A single chained {@link Consumer} consisting of all {@link Consumer consumers} registered through
      *      {@link #registerListChangeListener(ObservableList, Consumer)}. If no consumers have been registered on this
      *      list, null will be returned.
-     * @since 9
+     * @since 17
      */
     protected final Consumer<Change<?>> unregisterListChangeListeners(ObservableList<?> observableList) {
         if (lambdaChangeListenerHandler == null) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
@@ -242,32 +242,32 @@ public abstract class SkinBase<C extends Control> implements Skin<C> {
     }
 
     /**
-     * Subclasses can invoke this method to register that they want to listen to
-     * invalidation events for the given observable. Registered {@link Consumer} instances
-     * will be executed in the order in which they are registered.
+     * Registers an operation to perform when the given {@code Observable} sends an invalidation event.
+     * Does nothing if observable or operation is {@code null}. 
+     * If multiple operations are registered on the same observable, they will be performed in the 
+     * order in which they were registered.
      *
-     * @param observable the observable to observe for invalidation events
-     * @param consumer the consumer
+     * @param observable the observable to observe for invalidation events, may be {@code null}
+     * @param operation the operation to perform when the observable sends an invalidation event, 
+     *  may be {@code null}
      * @since 17
      */
-    protected final void registerInvalidationListener(Observable observable, Consumer<Observable> consumer) {
+    protected final void registerInvalidationListener(Observable observable, Consumer<Observable> operation) {
         if (lambdaChangeListenerHandler == null) {
             lambdaChangeListenerHandler = new LambdaMultiplePropertyChangeListenerHandler();
         }
-        lambdaChangeListenerHandler.registerInvalidationListener(observable, consumer);
+        lambdaChangeListenerHandler.registerInvalidationListener(observable, operation);
     }
 
     /**
-     * Unregisters all invalidation listeners that have been registered using
+     * Unregisters all operations that have been registered using
      * {@link #registerInvalidationListener(Observable, Consumer)}
-     * for the given observable. The end result is that the given observable is no longer observed by any of the invalidation
-     * listeners, but it may still have additional listeners registered on it through means outside of
-     * {@link #registerInvalidationListener(Observable, Consumer)}.
+     * for the given observable. 
      *
-     * @param observable The observable for which all listeners should be removed.
-     * @return A single chained {@link Consumer} consisting of all {@link Consumer consumers} registered through
-     *      {@link #registerInvalidationListener(Observable, Consumer)}. If no consumers have been registered on this
-     *      property, null will be returned.
+     * @param observable the observable for which the registered operations should be removed, 
+     *  may be {@code null}
+     * @return a composed consumer that performs all removed operations or 
+     *  {@code null} if none has been registered or the observable is {@null}
      * @since 17
      */
     protected final Consumer<Observable> unregisterInvalidationListeners(Observable observable) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
@@ -209,38 +209,38 @@ public abstract class SkinBase<C extends Control> implements Skin<C> {
 
 
     /**
-     * Registers an operation to perform when the given {@code property} sends a change event.
-     * Does nothing if either {@code property} or {@code operation} are {@code null}.
-     * If multiple operations are registered on the same property, they will be performed in the
+     * Registers an operation to perform when the given {@code observable} sends a change event.
+     * Does nothing if either {@code observable} or {@code operation} are {@code null}.
+     * If multiple operations are registered on the same observable, they will be performed in the
      * order in which they were registered.
      *
-     * @param property the property to observe for change events, may be {@code null}
-     * @param operation the operation to perform when the property sends a change event,
+     * @param observable the observable to observe for change events, may be {@code null}
+     * @param operation the operation to perform when the observable sends a change event,
      *  may be {@code null}
      */
-    protected final void registerChangeListener(ObservableValue<?> property, Consumer<ObservableValue<?>> operation) {
+    protected final void registerChangeListener(ObservableValue<?> observable, Consumer<ObservableValue<?>> operation) {
         if (lambdaChangeListenerHandler == null) {
             lambdaChangeListenerHandler = new LambdaMultiplePropertyChangeListenerHandler();
         }
-        lambdaChangeListenerHandler.registerChangeListener(property, operation);
+        lambdaChangeListenerHandler.registerChangeListener(observable, operation);
     }
 
     /**
      * Unregisters all operations that have been registered using
      * {@link #registerChangeListener(ObservableValue, Consumer)}
-     * for the given {@code property}. Does nothing if {@code property} is {@code null}.
+     * for the given {@code observable}. Does nothing if {@code observable} is {@code null}.
      *
-     * @param property the property for which the registered operations should be removed,
+     * @param observable the observable for which the registered operations should be removed,
      *  may be {@code null}
      * @return a composed consumer representing all previously registered operations, or
-     *  {@code null} if none have been registered or the propery is {@code null}
+     *  {@code null} if none have been registered or the observable is {@code null}
      * @since 9
      */
-    protected final Consumer<ObservableValue<?>> unregisterChangeListeners(ObservableValue<?> property) {
+    protected final Consumer<ObservableValue<?>> unregisterChangeListeners(ObservableValue<?> observable) {
         if (lambdaChangeListenerHandler == null) {
             return null;
         }
-        return lambdaChangeListenerHandler.unregisterChangeListeners(property);
+        return lambdaChangeListenerHandler.unregisterChangeListeners(observable);
     }
 
     /**

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
@@ -266,7 +266,7 @@ public abstract class SkinBase<C extends Control> implements Skin<C> {
      *
      * @param observable the observable for which the registered operations should be removed,
      *  may be {@code null}
-     * @return a composed consumer that performs all removed operations, or
+     * @return a composed consumer representing all previously registered operations, or
      *  {@code null} if none have been registered or the observable is {@code null}
      * @since 17
      */

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/SkinBaseShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/SkinBaseShim.java
@@ -28,7 +28,7 @@ package javafx.scene.control;
 import java.util.List;
 import javafx.scene.Node;
 
-public class SkinBaseShim<C extends Control> extends SkinBase {
+public class SkinBaseShim<C extends Control> extends SkinBase<C> {
 
     public SkinBaseShim(final C control) {
         super(control);

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/LambdaMultipleHandlerTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/LambdaMultipleHandlerTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.javafx.scene.control;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.sun.javafx.scene.control.LambdaMultiplePropertyChangeListenerHandler;
+
+import static org.junit.Assert.*;
+import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory.*;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ListChangeListener.Change;
+import javafx.collections.ObservableList;
+
+/**
+ * Test support of listChange listeners.
+ */
+public class LambdaMultipleHandlerTest {
+
+    private LambdaMultiplePropertyChangeListenerHandler handler;
+    private ObservableList<String> items;
+
+//------------ unregister
+
+    /**
+     * Single consumer for multiple lists: test that
+     * removing from one list doesn't effect listening to other list
+     */
+    @Test
+    public void testUnregistersSingleConsumerMultipleLists() {
+        List<Change<?>> changes = new ArrayList<>();
+        Consumer<Change<?>> consumer = change -> changes.add(change);
+        ObservableList<String> otherList = FXCollections.observableArrayList("other");
+        handler.registerListChangeListener(items, consumer);
+        handler.registerListChangeListener(otherList, consumer);
+        handler.unregisterListChangeListeners(otherList);
+        items.add("added");
+        otherList.add("added other");
+        assertEquals(1, changes.size());
+        assertEquals(items, changes.get(0).getList());
+    }
+
+    /**
+     * Test that all consumers for a single list are removed
+     * and manually adding the removed consumer chain as listener
+     * has the same effect as when invoked via handler.
+     */
+    @Test
+    public void testUnregistersMultipleConsumers() {
+        List<Change<?>> changes = new ArrayList<>();
+        Consumer<Change<?>> consumer = change -> changes.add(change);
+        List<Change<?>> secondChanges = new ArrayList<>();
+        Consumer<Change<?>> secondConsumer = change -> secondChanges.addAll(changes);
+        handler.registerListChangeListener(items, consumer);
+        handler.registerListChangeListener(items, secondConsumer);
+        // remove listener chain
+        Consumer<Change<?>> removedChain = handler.unregisterListChangeListeners(items);
+        items.add("added after removed");
+        assertEquals("none of the removed listeners must be notified",
+                0, changes.size() + secondChanges.size());
+       // manually add the chained listener
+        items.addListener((ListChangeListener)(c -> removedChain.accept(c)));
+        items.add("added");
+        assertEquals(1, changes.size());
+        assertEquals(changes, secondChanges);
+    }
+
+    @Test
+    public void testUnregistersSingleConsumer() {
+        List<Change<?>> changes = new ArrayList<>();
+        Consumer<Change<?>> consumer = change -> changes.add(change);
+        ObservableList<String> otherList = FXCollections.observableArrayList("other");
+        handler.registerListChangeListener(items, consumer);
+        Consumer<Change<?>> removed = handler.unregisterListChangeListeners(items);
+        items.add("added");
+        assertEquals(0, changes.size());
+        assertSame(consumer, removed);
+    }
+
+    /**
+     * Test unregisters not registered list.
+     */
+    @Test
+    public void testUnregistersNotRegistered() {
+        assertNull(handler.unregisterListChangeListeners(items));
+    }
+
+    @Test
+    public void testUnregistersNull() {
+        assertNull(handler.unregisterListChangeListeners(null));
+    }
+
+
+//------------- register
+
+    @Test
+    public void testRegisterConsumerToMultipleLists() {
+        List<Change<?>> changes = new ArrayList<>();
+        Consumer<Change<?>> consumer = change -> changes.add(change);
+        ObservableList<String> otherList = FXCollections.observableArrayList("other");
+        handler.registerListChangeListener(items, consumer);
+        handler.registerListChangeListener(otherList, consumer);
+        items.add("added");
+        otherList.add("added other");
+        assertEquals(2, changes.size());
+        assertEquals(items, changes.get(0).getList());
+        assertEquals(otherList, changes.get(1).getList());
+    }
+
+    /**
+     * Test that multiple consumers to same observable are invoked in order
+     * of registration.
+     */
+    @Test
+    public void testRegisterMultipleConsumerToSingleList() {
+        List<Change<?>> changes = new ArrayList<>();
+        Consumer<Change<?>> consumer = change -> changes.add(change);
+        List<Change<?>> secondChanges = new ArrayList<>();
+        Consumer<Change<?>> secondConsumer = change -> secondChanges.addAll(changes);
+        handler.registerListChangeListener(items, consumer);
+        handler.registerListChangeListener(items, secondConsumer);
+        items.add("added");
+        assertEquals(1, changes.size());
+        assertEquals(changes, secondChanges);
+    }
+
+    @Test
+    public void testRegister() {
+        List<Change<?>> changes = new ArrayList<>();
+        Consumer<Change<?>> consumer = change -> changes.add(change);
+        handler.registerListChangeListener(items, consumer);
+        String added = "added";
+        items.add(added);
+        assertEquals(1, changes.size());
+        Change<?> change = changes.get(0);
+        change.next();
+        assertTrue(change.wasAdded());
+        assertTrue(change.getAddedSubList().contains(added));
+    }
+
+    @Test
+    public void testRegisterNullConsumer() {
+        handler.registerListChangeListener(items, null);
+    }
+
+    @Test
+    public void testRegisterNullList() {
+        handler.registerListChangeListener(null, c -> {});
+    }
+
+//--------- dispose
+
+    @Test
+    public void testDispose() {
+        List<Change<?>> changes = new ArrayList<>();
+        Consumer<Change<?>> consumer = change -> changes.add(change);
+        handler.registerListChangeListener(items, consumer);
+        handler.dispose();
+        items.add("added");
+        assertEquals("listener must not be invoked after dispose", 0, changes.size());
+        handler.registerListChangeListener(items, consumer);
+        items.add("added");
+        assertEquals("listener must be invoked when re-registered after dispose", 1, changes.size());
+    }
+
+
+//--------- test weak registration
+
+    /**
+     * Test that handler is gc'ed and listener no longer notified.
+     */
+    @Test
+    public void testRegisterMemoryLeak() {
+        List<Change<?>> changes = new ArrayList<>();
+        Consumer<Change<?>> consumer = change -> changes.add(change);
+        WeakReference<LambdaMultiplePropertyChangeListenerHandler> ref =
+                new WeakReference<>(new LambdaMultiplePropertyChangeListenerHandler());
+        ref.get().registerListChangeListener(items, consumer);
+        items.add("added");
+        assertEquals(1, changes.size());
+        attemptGC(ref);
+        assertNull("handler must be gc'ed", ref.get());
+        items.add("another");
+        assertEquals("listener must not be invoked after gc", 1, changes.size());
+    }
+
+
+//----------- setup and intial
+
+    @Before
+    public void setup() {
+        handler = new LambdaMultiplePropertyChangeListenerHandler();
+        items = FXCollections.observableArrayList("one", "two", "four");
+    }
+
+    /**
+     * Demonstrating why we need an invalidation listener for list-valued observables.
+     */
+    @Test
+    public void testInvalidationOfListValuedObservable() {
+        String[] data = {"one", "two", "other"};
+        ObservableList<String> first = FXCollections.observableArrayList(data);
+        ObjectProperty<ObservableList<String>> itemsProperty = new SimpleObjectProperty<>(first);
+        assertSame(first, itemsProperty.get());
+        int[] invalidations = new int[] {0};
+        int[] changes = new int[] {0};
+        itemsProperty.addListener(obs -> invalidations[0]++);
+        itemsProperty.addListener((obs, ov, nv) -> changes[0]++);
+        itemsProperty.set(FXCollections.observableArrayList(data));
+        // notifications when newList.equals(oldList)
+        assertEquals("changeListener not notified", 0, changes[0]);
+        assertEquals("invalidationListener notified", 1, invalidations[0]);
+        itemsProperty.get().add("added");
+        // sanity: no notification on modifications to the list
+        assertEquals(0, changes[0]);
+        assertEquals(1, invalidations[0]);
+        // sanity: notification from both when !newList.equals(oldList)
+        itemsProperty.set(first);
+        assertEquals(1, changes[0]);
+        assertEquals(2, invalidations[0]);
+    }
+}

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/LambdaMultipleListHandlerTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/LambdaMultipleListHandlerTest.java
@@ -48,7 +48,7 @@ import javafx.collections.ObservableList;
 /**
  * Test support of listChange listeners.
  */
-public class LambdaMultipleHandlerTest {
+public class LambdaMultipleListHandlerTest {
 
     private LambdaMultiplePropertyChangeListenerHandler handler;
     private ObservableList<String> items;
@@ -206,11 +206,12 @@ public class LambdaMultipleHandlerTest {
     public void testRegisterMemoryLeak() {
         List<Change<?>> changes = new ArrayList<>();
         Consumer<Change<?>> consumer = change -> changes.add(change);
-        WeakReference<LambdaMultiplePropertyChangeListenerHandler> ref =
-                new WeakReference<>(new LambdaMultiplePropertyChangeListenerHandler());
-        ref.get().registerListChangeListener(items, consumer);
+        LambdaMultiplePropertyChangeListenerHandler handler = new LambdaMultiplePropertyChangeListenerHandler();
+        WeakReference<LambdaMultiplePropertyChangeListenerHandler> ref = new WeakReference<>(handler);
+        handler.registerListChangeListener(items, consumer);
         items.add("added");
         assertEquals(1, changes.size());
+        handler = null;
         attemptGC(ref);
         assertNull("handler must be gc'ed", ref.get());
         items.add("another");

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/LambdaMultipleObservableHandlerTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/LambdaMultipleObservableHandlerTest.java
@@ -212,13 +212,15 @@ public class LambdaMultipleObservableHandlerTest {
         IntegerProperty p = new SimpleIntegerProperty();
         int[] count = new int[] {0};
         Consumer<ObservableValue<?>> consumer = c -> count[0]++;
+        LambdaMultiplePropertyChangeListenerHandler handler = new LambdaMultiplePropertyChangeListenerHandler();
         WeakReference<LambdaMultiplePropertyChangeListenerHandler> ref =
-                new WeakReference<>(new LambdaMultiplePropertyChangeListenerHandler());
-        registerListener(ref.get(), p, consumer);
+                new WeakReference<>(handler);
+        registerListener(handler, p, consumer);
         p.setValue(100);
         int notified = count[0];
         assertEquals("sanity: listener invoked", notified, count[0]);
         assertNotNull(ref.get());
+        handler = null;
         attemptGC(ref);
         assertNull("handler must be gc'ed", ref.get());
         p.setValue(200);

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/LambdaMultipleObservableHandlerTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/LambdaMultipleObservableHandlerTest.java
@@ -1,0 +1,364 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.javafx.scene.control;
+
+import java.lang.ref.WeakReference;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.function.Consumer;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import com.sun.javafx.scene.control.LambdaMultiplePropertyChangeListenerHandler;
+
+import static org.junit.Assert.*;
+import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory.*;
+
+import javafx.beans.Observable;
+import javafx.beans.binding.Bindings;
+import javafx.beans.binding.NumberBinding;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.value.ObservableValue;
+
+/**
+ * Test LambdaMultiplePropertyChangeListenerHandler.
+ * <p>
+ *
+ * This test is parameterized in testing change- or invalidationListener api.
+ */
+@RunWith(Parameterized.class)
+public class LambdaMultipleObservableHandlerTest {
+
+    private LambdaMultiplePropertyChangeListenerHandler handler;
+    private boolean useChangeListener;
+
+// -------------- unregister
+
+    /**
+     * Single consumer for multiple observables: test that
+     * removing from one observable doesn't effect listening to other observable
+     */
+    @Test
+    public void testUnregistersSingleConsumerMultipleObservables() {
+        IntegerProperty p = new SimpleIntegerProperty();
+        IntegerProperty other = new SimpleIntegerProperty();
+        int[] count = new int[] {0};
+        Consumer<ObservableValue<?>> consumer = c -> count[0]++;
+        registerListener(p, consumer);
+        registerListener(other, consumer);
+        unregisterListeners(other);
+        p.set(100);
+        other.set(100);
+        assertEquals(1, count[0]);
+    }
+
+    /**
+     * Test that all consumers for a single observable are removed
+     * and manually adding the removed consumer chain as listener
+     * has the same effect as when invoked via handler.
+     */
+    @Test
+    public void testUnregistersMultipleConsumers() {
+        IntegerProperty p = new SimpleIntegerProperty();
+        int[] action = new int[] {0};
+        int actionValue = 10;
+        int[] secondAction = new int[] {0};
+        // register multiple consumers
+        registerListener(p, c -> action[0] = actionValue);
+        registerListener(p, c -> secondAction[0] = action[0]);
+        // remove all
+        Consumer removedChain = unregisterListeners(p);
+        p.set(100);
+        assertEquals("none of the removed listeners must be notified", 0, action[0] + secondAction[0]);
+
+        // manually add the chained consumers
+        addListener(p, removedChain);
+        p.set(200);
+        // assert effect of manually added chain is same
+        assertEquals("effect of removed consumer chain", actionValue, action[0]);
+        assertEquals("effect of removed consumer chain", action[0], secondAction[0]);
+    }
+
+    @Test
+    public void testUnregistersSingleConsumer() {
+        IntegerProperty p = new SimpleIntegerProperty();
+        int[] count = new int[] {0};
+        Consumer<Observable> consumer = c -> count[0]++;
+        registerListener(p, consumer);
+        Consumer<Observable> removed = unregisterListeners(p);
+        p.set(100);
+        assertEquals(0, count[0]);
+        assertSame("single registered listener must be returned", consumer, removed);
+    }
+
+    /**
+     * Test unregisters not registered observable.
+     */
+    @Test
+    public void testUnregistersNotRegistered() {
+        IntegerProperty p = new SimpleIntegerProperty();
+        assertNull(unregisterListeners(p));
+    }
+
+    @Test
+    public void testUnregistersNull() {
+        assertNull(unregisterListeners(null));
+    }
+
+
+//------------ register
+
+    @Test
+    public void testRegisterConsumerToMultipleObservables() {
+        IntegerProperty p = new SimpleIntegerProperty();
+        IntegerProperty other = new SimpleIntegerProperty();
+        int[] count = new int[] {0};
+        Consumer<Observable> consumer = c -> count[0]++;
+        registerListener(p, consumer);
+        registerListener(other, consumer);
+        p.set(100);
+        other.set(100);
+        assertEquals(2, count[0]);
+    }
+
+    /**
+     * Test that multiple consumers to same observable are invoked in order
+     * of registration.
+     */
+    @Test
+    public void testRegisterMultipleConsumerToSingleObservable() {
+        IntegerProperty p = new SimpleIntegerProperty();
+        int[] action = new int[] {0};
+        int actionValue = 10;
+        int[] secondAction = new int[] {0};
+        registerListener(p, c -> action[0] = actionValue);
+        registerListener(p, c -> secondAction[0] = action[0]);
+        p.set(100);
+        assertEquals(actionValue, action[0]);
+        assertEquals(action[0], secondAction[0]);
+    }
+
+    @Test
+    public void testRegister() {
+        IntegerProperty p = new SimpleIntegerProperty();
+        int[] count = new int[] {0};
+        registerListener(p, c -> count[0]++);
+        p.set(100);
+        assertEquals(1, count[0]);
+    }
+
+    @Test
+    public void testRegisterNullConsumer() {
+        IntegerProperty p = new SimpleIntegerProperty();
+        registerListener(p, null);
+    }
+
+    @Test
+    public void testRegisterNullObservable() {
+        registerListener(null, c -> {});
+    }
+
+//--------- dispose
+
+    @Test
+    public void testDispose() {
+        IntegerProperty p = new SimpleIntegerProperty();
+        int[] count = new int[] {0};
+        registerListener(p, c -> count[0]++);
+        handler.dispose();
+        p.set(100);
+        assertEquals("listener must not be invoked after dispose", 0, count[0]);
+        // re-register
+        registerListener(p, c -> count[0]++);
+        p.set(200);
+        assertEquals("listener must be invoked when re-registered after dispose", 1, count[0]);
+    }
+
+
+//--------- test weak registration
+
+    /**
+     * Test that handler is gc'ed and listener no longer notified.
+     */
+    @Test
+    public void testRegisterMemoryLeak() {
+        IntegerProperty p = new SimpleIntegerProperty();
+        int[] count = new int[] {0};
+        Consumer<ObservableValue<?>> consumer = c -> count[0]++;
+        WeakReference<LambdaMultiplePropertyChangeListenerHandler> ref =
+                new WeakReference<>(new LambdaMultiplePropertyChangeListenerHandler());
+        registerListener(ref.get(), p, consumer);
+        p.setValue(100);
+        int notified = count[0];
+        assertEquals("sanity: listener invoked", notified, count[0]);
+        assertNotNull(ref.get());
+        attemptGC(ref);
+        assertNull("handler must be gc'ed", ref.get());
+        p.setValue(200);
+        assertEquals("listener must not be invoked after gc", notified, count[0]);
+    }
+
+
+//-------------- not-parameterized tests
+// guard against cross-over effects for change/invalidationListener on same observable
+
+    /**
+     * Register both invalidation/change listener on same property.
+     */
+    @Test
+    public void testRegisterBoth() {
+        IntegerProperty p = new SimpleIntegerProperty();
+        int[] count = new int[] {0};
+        handler.registerChangeListener(p, c -> count[0]++);
+        handler.registerInvalidationListener(p, c -> count[0]++);
+        p.set(100);
+        assertEquals("both listener types must be invoked", 2, count[0]);
+    }
+
+    /**
+     * Register both invalidation/change listener, remove change listener
+     */
+    @Test
+    public void testRegisterBothRemoveChangeListener() {
+        IntegerProperty p = new SimpleIntegerProperty();
+        int[] count = new int[] {0};
+        handler.registerChangeListener(p, c -> count[0]++);
+        handler.registerInvalidationListener(p, c -> count[0]++);
+        handler.unregisterChangeListeners(p);
+        p.set(200);
+        assertEquals("", 1, count[0]);
+    }
+
+    /**
+     * Register both invalidation/change listener, remove invalidationListener.
+     */
+    @Test
+    public void testRegisterBothRemoveInvalidationListener() {
+        IntegerProperty p = new SimpleIntegerProperty();
+        int[] count = new int[] {0};
+        handler.registerChangeListener(p, c -> count[0]++);
+        handler.registerInvalidationListener(p, c -> count[0]++);
+        handler.unregisterInvalidationListeners(p);
+        p.set(200);
+        assertEquals("", 1, count[0]);
+    }
+
+    /**
+     * Test that binding is invalid.
+     */
+    @Test
+    public void testBindingInvalid() {
+        IntegerProperty num1 = new SimpleIntegerProperty(1);
+        IntegerProperty num2 = new SimpleIntegerProperty(2);
+        NumberBinding p = Bindings.add(num1,num2);
+        int[] count = new int[] {0};
+        handler.registerChangeListener(p, c -> count[0]++);
+        handler.registerInvalidationListener(p, c -> count[0]++);
+        handler.unregisterChangeListeners(p);
+        num1.set(200);
+        assertEquals("sanity: received invalidation", 1, count[0]);
+        assertFalse("binding must not be valid", p.isValid());
+    }
+
+
+//----------------------- helpers to un/registration listeners
+
+    /**
+     * Registers the consumer for notification from the observable,
+     * using the default handler.
+     *
+     */
+    protected void registerListener(Observable p, Consumer consumer) {
+        registerListener(handler, p, consumer);
+    }
+
+    /**
+     * Registers the consumer for notification from the observable,
+     * using the given handler.
+     */
+    protected void registerListener(LambdaMultiplePropertyChangeListenerHandler handler, Observable p, Consumer consumer) {
+        if (useChangeListener) {
+            handler.registerChangeListener((ObservableValue<?>) p, consumer);
+        } else {
+            handler.registerInvalidationListener(p, consumer);
+        }
+    }
+
+    /**
+     * Unregisters listeners from observable, using default handler
+     */
+    protected Consumer unregisterListeners(Observable p) {
+        return unregisterListeners(handler, p);
+    }
+
+    /**
+     * Unregisters listeners from observable, using default handler
+     */
+    protected Consumer unregisterListeners(LambdaMultiplePropertyChangeListenerHandler handler, Observable p) {
+        if (useChangeListener) {
+            return handler.unregisterChangeListeners((ObservableValue<?>) p);
+        }
+        return handler.unregisterInvalidationListeners(p);
+    }
+
+    protected void addListener(ObservableValue<?> p, Consumer<Observable> consumer) {
+        if (useChangeListener) {
+           p.addListener((obs, ov, nv) -> consumer.accept(obs));
+        } else {
+           p.addListener(obs -> consumer.accept(obs));
+        }
+    }
+
+
+//-------------- parameters
+
+    // Note: name property not supported before junit 4.11
+    @Parameterized.Parameters //(name = "{index}: changeListener {0} ")
+    public static Collection<Object[]> data() {
+        Object[][] data = new Object[][] {
+                {true}, // test changeListener api
+                {false} // test invalidationListener api
+        };
+        return Arrays.asList(data);
+    }
+
+    public LambdaMultipleObservableHandlerTest(boolean useChangeListener) {
+        this.useChangeListener = useChangeListener;
+    }
+
+
+//------------ setup and initial
+
+    @Before
+    public void setup() {
+        this.handler = new LambdaMultiplePropertyChangeListenerHandler();
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SkinBaseTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SkinBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,24 @@
 
 package test.javafx.scene.control;
 
-import javafx.scene.control.Control;
-import javafx.scene.control.SkinBaseShim;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
 
 import org.junit.Before;
 import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+import javafx.beans.Observable;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.value.ObservableValue;
+import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener.Change;
+import javafx.collections.ObservableList;
+import javafx.scene.control.Control;
+import javafx.scene.control.SkinBaseShim;
 
 public class SkinBaseTest {
     private ControlStub c;
@@ -57,9 +68,97 @@ public class SkinBaseTest {
         assertNull(s.getSkinnable());
     }
 
-    public static final class SkinBaseStub<C extends Control> extends SkinBaseShim<C> {
+//-------------- testing listener registration
+// Note: the behavior is fully tested in the handler test, here we only verify that the
+// expected methods are actually used
+
+    @Test
+    public void testChangeSupport() {
+        IntegerProperty p = new SimpleIntegerProperty();
+        int[] count = new int[] {0};
+        Consumer<ObservableValue<?>> consumer = c -> count[0]++;
+        s.addChangeListener(p, consumer);
+        p.set(200);
+        assertEquals("change listener must be notified", 1, count[0]);
+        Consumer<ObservableValue<?>> removed = s.removeChangeListeners(p);
+        p.set(100);
+        assertEquals("changeListener must not be notified", 1, count[0]);
+        assertSame(consumer, removed);
+    }
+
+    @Test
+    public void testInvalidationSupport() {
+        IntegerProperty p = new SimpleIntegerProperty();
+        int[] count = new int[] {0};
+        Consumer<Observable> consumer = c -> count[0]++;
+        s.addInvalidationListener(p, consumer);
+        p.set(200);
+        assertEquals("invalidation listener must be notified", 1, count[0]);
+        Consumer<Observable> removed = s.removeInvalidationListeners(p);
+        p.set(100);
+        assertEquals("invalidation listener must not be notified", 1, count[0]);
+        assertSame(consumer, removed);
+    }
+
+    @Test
+    public void testListChangeSupport() {
+        ObservableList<String> list = FXCollections.observableArrayList("one");
+        List<Change<?>> changes = new ArrayList<>();
+        Consumer<Change<?>> consumer = c -> changes.add(c);
+        s.addListChangeListener(list, consumer);
+        list.add("added");
+        assertEquals(1, changes.size());
+        Consumer<Change<?>> removed = s.removeListChangeListeners(list);
+        list.add("another");
+        assertEquals(1, changes.size());
+        assertSame(consumer, removed);
+    }
+
+    @Test
+    public void testRegisterNull() {
+        s.addChangeListener(null, null);
+        s.addInvalidationListener(null, null);
+        s.addListChangeListener(null, null);
+    }
+
+    @Test
+    public void testUnregistersNull() {
+        assertNull(s.removeChangeListeners(null));
+        assertNull(s.removeInvalidationListeners(null));
+        assertNull(s.removeListChangeListeners(null));
+    }
+
+    public static class SkinBaseStub<C extends Control> extends SkinBaseShim<C> {
         public SkinBaseStub(C control) {
             super(control);
         }
+
+        // FIXME: un/registerXXListener are final protected
+        // - how to access without adding a wrapper (with potential of introducing bugs)?
+        void addChangeListener(ObservableValue<?> p, Consumer<ObservableValue<?>> consumer) {
+            registerChangeListener(p, consumer);
+        }
+
+        Consumer<ObservableValue<?>> removeChangeListeners(ObservableValue<?> p) {
+            return unregisterChangeListeners(p);
+        }
+
+        void addInvalidationListener(Observable p, Consumer<Observable> consumer) {
+            registerInvalidationListener(p, consumer);
+        }
+
+        Consumer<Observable> removeInvalidationListeners(Observable p) {
+            return unregisterInvalidationListeners(p);
+        }
+
+        void addListChangeListener(ObservableList<?> list, Consumer<Change<?>> consumer) {
+            registerListChangeListener(list, consumer);
+        }
+
+        Consumer<Change<?>> removeListChangeListeners(ObservableList<?> list) {
+            return unregisterListChangeListeners(list);
+        }
+
     }
+
 }


### PR DESCRIPTION
Changes in Lambda..Handler:
- added api and implemenation to support invalidation and listChange listeners in the same way as changeListeners
- added java doc 
- added tests

Changes in SkinBase
- added api (and implementation delegating to the handler)
- copied java doc from the change listener un/register methods 
- added tests to verify that the new (and old) api is indeed delegating to the handler

Note that the null handling is slightly extended: all methods now can handle both null consumers (as before) and null observables (new) - this allows simplified code on rewiring "path" properties (see reference example in the issue)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258777](https://bugs.openjdk.java.net/browse/JDK-8258777): SkinBase: add api to un-/register invalidation-/listChange listeners


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/409/head:pull/409` \
`$ git checkout pull/409`

Update a local copy of the PR: \
`$ git checkout pull/409` \
`$ git pull https://git.openjdk.java.net/jfx pull/409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 409`

View PR using the GUI difftool: \
`$ git pr show -t 409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/409.diff">https://git.openjdk.java.net/jfx/pull/409.diff</a>

</details>
