### PR TITLE
8262236: Configure Gradle checksum verification

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-bin.zip
+distributionSha256Sum=038794feef1f4745c6347107b6726279d1c824f3fc634b60f86ace1e9fbd1768
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The recent supply-chain attacks in the news are making me nervous! 😟

The Gradle 6.3 distribution is the only software on my OpenJFX build system that doesn't come from an Ubuntu package or a GitHub repository. Ubuntu uses digital signatures to authenticate each package, and Git uses a secure hash algorithm to ensure the integrity of each file, but there is no such check of the Gradle distribution before running it. During my OpenJFX builds, Gradle is downloaded from a Cloudflare server through an HTTPS proxy server, and there's no guarantee that it's the same file as the one published by the Gradle developers.

This pull requests adds the additional step of verifying the Gradle distribution on the build system before extracting its archive and running it.

We might also consider adding the [Gradle Wrapper Validation](https://github.com/marketplace/actions/gradle-wrapper-validation) GitHub Action to the OpenJFX repository.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262236](https://bugs.openjdk.java.net/browse/JDK-8262236): Configure Gradle checksum verification


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/411/head:pull/411`
`$ git checkout pull/411`
