### PR TITLE
8262802: Wrong context origin coordinates when using EGL and HiDPI

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2SwapChain.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2SwapChain.java
@@ -272,7 +272,7 @@ class ES2SwapChain implements ES2RenderTarget, Presentable, GraphicsResource {
         // for the x/y offset to use
         if (PlatformUtil.useEGL()) {
             return ((int) (pState.getScreenHeight() * pState.getOutputScaleY())) -
-                    pState.getOutputHeight()  - ((int) (pState.getWindowY() * pState.getOutputScaleY()));
+                    pState.getOutputHeight() - ((int) (pState.getWindowY() * pState.getOutputScaleY()));
         } else {
             return 0;
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2SwapChain.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2SwapChain.java
@@ -260,7 +260,7 @@ class ES2SwapChain implements ES2RenderTarget, Presentable, GraphicsResource {
         // EGL doesn't have a window manager, so we need to ask the window for
         // the x/y offset to use
         if (PlatformUtil.useEGL()) {
-            return pState.getWindowX();
+            return (int) (pState.getWindowX() * pState.getOutputScaleX());
         } else {
             return 0;
         }
@@ -271,8 +271,8 @@ class ES2SwapChain implements ES2RenderTarget, Presentable, GraphicsResource {
         // EGL doesn't have a window manager, so we need to ask the window
         // for the x/y offset to use
         if (PlatformUtil.useEGL()) {
-            return pState.getScreenHeight() -
-                   pState.getOutputHeight() - pState.getWindowY();
+            return ((int) (pState.getScreenHeight() * pState.getOutputScaleY())) -
+                    pState.getOutputHeight()  - ((int) (pState.getWindowY() * pState.getOutputScaleY()));
         } else {
             return 0;
         }


### PR DESCRIPTION
See [issue](https://bugs.openjdk.java.net/browse/JDK-8262802) for detailed description. 

This PR solves the wrong calculations of ContextX and ContextY in ES2SwapChain when EGL is used on HiDPI devices, by using properly scaled dimensions. Without these changes, any popup control is misplaced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8262802](https://bugs.openjdk.java.net/browse/JDK-8262802): Wrong context origin coordinates when using EGL and HiDPI


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/416/head:pull/416`
`$ git checkout pull/416`
