### PR TITLE
8206253: No/Wrong scroll events from touch input in window mode

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ScrollGestureRecognizer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ScrollGestureRecognizer.java
@@ -262,7 +262,7 @@ class ScrollGestureRecognizer implements GestureRecognizer {
         }
     }
 
-    private void sendScrollStartedEvent(double centerX, double centerY, int touchCount) {
+    private void sendScrollStartedEvent(double centerAbsX, double centerAbsY, int touchCount) {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             if (scene.sceneListener != null) {
                 scene.sceneListener.scrollEvent(ScrollEvent.SCROLL_STARTED,
@@ -283,7 +283,7 @@ class ScrollGestureRecognizer implements GestureRecognizer {
         }, scene.getAccessControlContext());
     }
 
-    private void sendScrollEvent(boolean isInertia, double centerX, double centerY, int touchCount) {
+    private void sendScrollEvent(boolean isInertia, double centerAbsX, double centerAbsY, int touchCount) {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             if (scene.sceneListener != null) {
                 scene.sceneListener.scrollEvent(ScrollEvent.SCROLL,
@@ -304,7 +304,7 @@ class ScrollGestureRecognizer implements GestureRecognizer {
         }, scene.getAccessControlContext());
     }
 
-    private void sendScrollFinishedEvent(double centerX, double centerY, int touchCount) {
+    private void sendScrollFinishedEvent(double centerAbsX, double centerAbsY, int touchCount) {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             if (scene.sceneListener != null) {
                 scene.sceneListener.scrollEvent(ScrollEvent.SCROLL_FINISHED,

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ScrollGestureRecognizer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ScrollGestureRecognizer.java
@@ -262,7 +262,7 @@ class ScrollGestureRecognizer implements GestureRecognizer {
         }
     }
 
-    private void sendScrollStartedEvent(double centerAbsX, double centerAbsY, int touchCount) {
+    private void sendScrollStartedEvent(double xAbs, double yAbs, int touchCount) {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             if (scene.sceneListener != null) {
                 scene.sceneListener.scrollEvent(ScrollEvent.SCROLL_STARTED,
@@ -272,7 +272,7 @@ class ScrollGestureRecognizer implements GestureRecognizer {
                     touchCount,
                     0 /*scrollTextX*/, 0 /*scrollTextY*/,
                     0 /*defaultTextX*/, 0 /*defaultTextY*/,
-                    centerX, centerY, centerAbsX, centerAbsY,
+                    centerX, centerY, xAbs, yAbs,
                     (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
                     (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
                     (modifiers & KeyEvent.MODIFIER_ALT) != 0,
@@ -283,7 +283,7 @@ class ScrollGestureRecognizer implements GestureRecognizer {
         }, scene.getAccessControlContext());
     }
 
-    private void sendScrollEvent(boolean isInertia, double centerAbsX, double centerAbsY, int touchCount) {
+    private void sendScrollEvent(boolean isInertia, double xAbs, double yAbs, int touchCount) {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             if (scene.sceneListener != null) {
                 scene.sceneListener.scrollEvent(ScrollEvent.SCROLL,
@@ -293,7 +293,7 @@ class ScrollGestureRecognizer implements GestureRecognizer {
                     touchCount,
                     0 /*scrollTextX*/, 0 /*scrollTextY*/,
                     0 /*defaultTextX*/, 0 /*defaultTextY*/,
-                    centerX, centerY, centerAbsX, centerAbsY,
+                    centerX, centerY, xAbs, yAbs,
                     (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
                     (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
                     (modifiers & KeyEvent.MODIFIER_ALT) != 0,
@@ -304,7 +304,7 @@ class ScrollGestureRecognizer implements GestureRecognizer {
         }, scene.getAccessControlContext());
     }
 
-    private void sendScrollFinishedEvent(double centerAbsX, double centerAbsY, int touchCount) {
+    private void sendScrollFinishedEvent(double xAbs, double yAbs, int touchCount) {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             if (scene.sceneListener != null) {
                 scene.sceneListener.scrollEvent(ScrollEvent.SCROLL_FINISHED,
@@ -314,7 +314,7 @@ class ScrollGestureRecognizer implements GestureRecognizer {
                     touchCount,
                     0 /*scrollTextX*/, 0 /*scrollTextY*/,
                     0 /*defaultTextX*/, 0 /*defaultTextY*/,
-                    centerX, centerY, centerAbsX, centerAbsY,
+                    centerX, centerY, xAbs, yAbs,
                     (modifiers & KeyEvent.MODIFIER_SHIFT) != 0,
                     (modifiers & KeyEvent.MODIFIER_CONTROL) != 0,
                     (modifiers & KeyEvent.MODIFIER_ALT) != 0,


### PR DESCRIPTION
This PR changes the parameter names to accommodate class calculations related to screen event coordinates (AbsX, AbsY).

As [discussed](https://bugs.openjdk.java.net/browse/JDK-8206253?focusedCommentId=14405707&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14405707), the sendScrollXXXEvent methods are currently passing the screen coordinates (AbsX, AbsY) to the local ones, but they shouldn't modify those, but the screen ones.

Tested successfully on Android with ComboBox controls in different positions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8206253](https://bugs.openjdk.java.net/browse/JDK-8206253): No/Wrong scroll events from touch input in window mode


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/420/head:pull/420`
`$ git checkout pull/420`
