### PR TITLE
8257512: Remove use of deprecated primitive constructors in JavaFX 

### DIFF
--- a/apps/samples/3DViewer/src/main/java/com/javafx/experiments/shape3d/SkinningMesh.java
+++ b/apps/samples/3DViewer/src/main/java/com/javafx/experiments/shape3d/SkinningMesh.java
@@ -107,7 +107,7 @@ public class SkinningMesh extends PolygonMesh {
             weightIndices[j] = new ArrayList<Integer>();
             for (int i = 0; i < nPoints; i++) {
                 if (weights[j][i] != 0.0f) {
-                    weightIndices[j].add(Integer.valueOf(i));
+                    weightIndices[j].add(i);
                 }
             }
         }

--- a/apps/samples/3DViewer/src/main/java/com/javafx/experiments/shape3d/SkinningMesh.java
+++ b/apps/samples/3DViewer/src/main/java/com/javafx/experiments/shape3d/SkinningMesh.java
@@ -107,7 +107,7 @@ public class SkinningMesh extends PolygonMesh {
             weightIndices[j] = new ArrayList<Integer>();
             for (int i = 0; i < nPoints; i++) {
                 if (weights[j][i] != 0.0f) {
-                    weightIndices[j].add(new Integer(i));
+                    weightIndices[j].add(Integer.valueOf(i));
                 }
             }
         }

--- a/apps/samples/Ensemble8/src/app/java/ensemble/samplepage/PieChartDataVisualizer.java
+++ b/apps/samples/Ensemble8/src/app/java/ensemble/samplepage/PieChartDataVisualizer.java
@@ -89,7 +89,7 @@ public class PieChartDataVisualizer extends TableView<Data> {
                         return null;
                     }
                     try {
-                        return (Double) new Double(string);
+                        return (Double) Double.valueOf(string);
                     } catch (Exception ignored) {
                         return 0;
                     }

--- a/apps/samples/Ensemble8/src/app/java/ensemble/samplepage/PieChartDataVisualizer.java
+++ b/apps/samples/Ensemble8/src/app/java/ensemble/samplepage/PieChartDataVisualizer.java
@@ -89,7 +89,7 @@ public class PieChartDataVisualizer extends TableView<Data> {
                         return null;
                     }
                     try {
-                        return (Double) Double.valueOf(string);
+                        return Double.valueOf(string);
                     } catch (Exception ignored) {
                         return 0;
                     }

--- a/apps/samples/Ensemble8/src/app/java/ensemble/samplepage/XYDataVisualizer.java
+++ b/apps/samples/Ensemble8/src/app/java/ensemble/samplepage/XYDataVisualizer.java
@@ -132,9 +132,9 @@ public class XYDataVisualizer<X, Y> extends TreeTableView<XYChartItem<X, Y>> {
                             if (clzX.isAssignableFrom(String.class)) {
                                 return (X) string;
                             } else if (clzX.isAssignableFrom(Double.class)) {
-                                return (X) new Double(string);
+                                return (X) Double.valueOf(string);
                             } else if (clzX.isAssignableFrom(Integer.class)) {
-                                return (X) new Integer(string);
+                                return (X) Integer.valueOf(string);
                             }
                         } catch (NumberFormatException ex) {
                             Logger.getLogger(XYDataVisualizer.class.getName()).log(Level.FINE,
@@ -172,7 +172,7 @@ public class XYDataVisualizer<X, Y> extends TreeTableView<XYChartItem<X, Y>> {
                 if (string == null) {
                     return null;
                 }
-                Y y = (Y) new Double(string);
+                Y y = (Y) Double.valueOf(string);
                 return y;
             }
         }));

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/language/swing/SampleTableModel.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/language/swing/SampleTableModel.java
@@ -49,9 +49,9 @@ public class SampleTableModel extends AbstractTableModel {
     private static ObservableList<BarChart.Series> bcData;
     private final String[] names = {"2007", "2008", "2009"};
     private Object[][] data = {
-        {new Double(567), new Double(956), new Double(1154)},
-        {new Double(1292), new Double(1665), new Double(1927)},
-        {new Double(1292), new Double(2559), new Double(2774)}
+        {Double.valueOf(567), Double.valueOf(956), Double.valueOf(1154)},
+        {Double.valueOf(1292), Double.valueOf(1665), Double.valueOf(1927)},
+        {Double.valueOf(1292), Double.valueOf(2559), Double.valueOf(2774)}
     };
 
     public double getTickUnit() {

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/language/swing/SwingInterop.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/language/swing/SwingInterop.java
@@ -218,8 +218,8 @@ public class SwingInterop extends JPanel {
     }
 
     private Pane createBrowser() {
-        Double widthDouble = Integer.valueOf(PANEL_WIDTH).doubleValue();
-        Double heightDouble = Integer.valueOf(PANEL_HEIGHT).doubleValue();
+        Double widthDouble = Double.valueOf(PANEL_WIDTH);
+        Double heightDouble = Double.valueOf(PANEL_HEIGHT);
         WebView view = new WebView();
         view.setMinSize(widthDouble, heightDouble);
         view.setPrefSize(widthDouble, heightDouble);

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/language/swing/SwingInterop.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/language/swing/SwingInterop.java
@@ -218,8 +218,8 @@ public class SwingInterop extends JPanel {
     }
 
     private Pane createBrowser() {
-        Double widthDouble = new Integer(PANEL_WIDTH).doubleValue();
-        Double heightDouble = new Integer(PANEL_HEIGHT).doubleValue();
+        Double widthDouble = Integer.valueOf(PANEL_WIDTH).doubleValue();
+        Double heightDouble = Integer.valueOf(PANEL_HEIGHT).doubleValue();
         WebView view = new WebView();
         view.setMinSize(widthDouble, heightDouble);
         view.setPrefSize(widthDouble, heightDouble);

--- a/apps/toys/LayoutDemo/src/layout/CustomHBox.java
+++ b/apps/toys/LayoutDemo/src/layout/CustomHBox.java
@@ -176,8 +176,8 @@ public class CustomHBox extends HBox {
 //    @Override protected void layoutChildren() {
 //        List<Node> sortedChidlren = new ArrayList<>(getChildren());
 //        Collections.sort(sortedChidlren, (c1, c2)
-//                -> new Double(c2.prefHeight(-1)).compareTo(
-//                        new Double(c1.prefHeight(-1))));
+//                -> Double.valueOf(c2.prefHeight(-1)).compareTo(
+//                        Double.valueOf(c1.prefHeight(-1))));
 //        double currentX = pad;
 //        for (Node c : sortedChidlren) {
 //            double width = c.prefWidth(-1);

--- a/apps/toys/LayoutDemo/src/layout/CustomPane.java
+++ b/apps/toys/LayoutDemo/src/layout/CustomPane.java
@@ -88,8 +88,8 @@ public class CustomPane extends Pane {
     @Override protected void layoutChildren() {
         List<Node> sortedManagedChidlren = new ArrayList<>(getManagedChildren());
         Collections.sort(sortedManagedChidlren, (c1, c2)
-                -> new Double(c2.prefHeight(-1)).compareTo(
-                        new Double(c1.prefHeight(-1))));
+                -> Double.valueOf(c2.prefHeight(-1)).compareTo(
+                        Double.valueOf(c1.prefHeight(-1))));
         double currentX = pad;
         for (Node c : sortedManagedChidlren) {
             double width = c.prefWidth(-1);

--- a/apps/toys/LayoutDemo/src/layout/CustomTilePane.java
+++ b/apps/toys/LayoutDemo/src/layout/CustomTilePane.java
@@ -92,8 +92,8 @@ public class CustomTilePane extends TilePane {
 //    @Override protected void layoutChildren() {
 //        List<Node> sortedChidlren = new ArrayList<>(getChildren());
 //        Collections.sort(sortedChidlren, (c1, c2)
-//                -> new Double(c2.prefHeight(-1)).compareTo(
-//                        new Double(c1.prefHeight(-1))));
+//                -> Double.valueOf(c2.prefHeight(-1)).compareTo(
+//                        Double.valueOf(c1.prefHeight(-1))));
 //        double currentX = pad;
 //        for (Node c : sortedChidlren) {
 //            double width = c.prefWidth(-1);
@@ -172,8 +172,8 @@ public class CustomTilePane extends TilePane {
 
         List<Node> sortedManagedChidlren = new ArrayList<>(getManagedChildren());
         Collections.sort(sortedManagedChidlren, (c1, c2)
-                -> new Double(c2.prefHeight(-1)).compareTo(
-                        new Double(c1.prefHeight(-1))));
+                -> Double.valueOf(c2.prefHeight(-1)).compareTo(
+                        Double.valueOf(c1.prefHeight(-1))));
         List<Node> managed = sortedManagedChidlren;
         HPos hpos = getAlignmentInternal().getHpos();
         VPos vpos = getAlignmentInternal().getVpos();

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/collections/MappingChangeTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/collections/MappingChangeTest.java
@@ -49,7 +49,7 @@ public class MappingChangeTest {
 
     @Test
     public void testAddRemove() {
-        Change<Integer> change = new NonIterableChange.SimpleRemovedChange<Integer>(0, 1, new Integer(5), originalList);
+        Change<Integer> change = new NonIterableChange.SimpleRemovedChange<Integer>(0, 1, Integer.valueOf(5), originalList);
         MappingChange<Integer, String> mapChange = new MappingChange<Integer, String>(change,
                 e -> e.toString(), list);
 

--- a/modules/javafx.base/src/test/java/test/javafx/util/DurationTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/DurationTest.java
@@ -286,7 +286,7 @@ public class DurationTest {
 
     @Test public void add_ZERO_and_INDEFINITE_ResultsInIndefinite() {
         //assertTrue(0.0 + Double.POSITIVE_INFINITY == Double.POSITIVE_INFINITY); // sanity check
-        assertEquals(new Double(Double.POSITIVE_INFINITY), new Double(0.0 + Double.POSITIVE_INFINITY)); // sanity check
+        assertEquals(Double.valueOf(Double.POSITIVE_INFINITY), Double.valueOf(0.0 + Double.POSITIVE_INFINITY)); // sanity check
 
         assertTrue(Duration.ZERO.add(Duration.INDEFINITE).isIndefinite());
         assertFalse(Duration.ZERO.add(Duration.INDEFINITE).isUnknown());
@@ -294,7 +294,7 @@ public class DurationTest {
 
     @Test public void add_ONE_and_INDEFINITE_ResultsInIndefinite() {
         //assertTrue(1.0 + Double.POSITIVE_INFINITY == Double.POSITIVE_INFINITY); // sanity check
-        assertEquals(new Double(Double.POSITIVE_INFINITY), new Double(1.0 + Double.POSITIVE_INFINITY)); // sanity check
+        assertEquals(Double.valueOf(Double.POSITIVE_INFINITY), Double.valueOf(1.0 + Double.POSITIVE_INFINITY)); // sanity check
 
         assertTrue(Duration.ONE.add(Duration.INDEFINITE).isIndefinite());
         assertFalse(Duration.ONE.add(Duration.INDEFINITE).isUnknown());
@@ -302,7 +302,7 @@ public class DurationTest {
 
     @Test public void add_INDEFINITE_and_INDEFINITE_ResultsInIndefinite() {
         //assertTrue(Double.POSITIVE_INFINITY + Double.POSITIVE_INFINITY == Double.POSITIVE_INFINITY); // sanity check
-        assertEquals(new Double(Double.POSITIVE_INFINITY), new Double(Double.POSITIVE_INFINITY + Double.POSITIVE_INFINITY)); // sanity check
+        assertEquals(Double.valueOf(Double.POSITIVE_INFINITY), Double.valueOf(Double.POSITIVE_INFINITY + Double.POSITIVE_INFINITY)); // sanity check
 
         assertTrue(Duration.INDEFINITE.add(Duration.INDEFINITE).isIndefinite());
         assertFalse(Duration.INDEFINITE.add(Duration.INDEFINITE).isUnknown());
@@ -310,7 +310,7 @@ public class DurationTest {
 
     @Test public void add_UNKNOWN_and_INDEFINITE_ResultsInUnknown() {
         assertTrue(Double.isNaN(Double.NaN + Double.POSITIVE_INFINITY)); // sanity check
-        assertEquals(new Double(Double.NaN), new Double(Double.NaN + Double.POSITIVE_INFINITY)); // sanity check
+        assertEquals(Double.valueOf(Double.NaN), Double.valueOf(Double.NaN + Double.POSITIVE_INFINITY)); // sanity check
 
         assertFalse(Duration.UNKNOWN.add(Duration.INDEFINITE).isIndefinite());
         assertTrue(Duration.UNKNOWN.add(Duration.INDEFINITE).isUnknown());
@@ -318,7 +318,7 @@ public class DurationTest {
 
     @Test public void add_ZERO_and_UNKNOWN_ResultsInUnknown() {
         assertTrue(Double.isNaN(0.0 + Double.NaN)); // sanity check
-        assertEquals(new Double(Double.NaN), new Double(0.0 + Double.NaN)); // sanity check
+        assertEquals(Double.valueOf(Double.NaN), Double.valueOf(0.0 + Double.NaN)); // sanity check
 
         assertFalse(Duration.ZERO.add(Duration.UNKNOWN).isIndefinite());
         assertTrue(Duration.ZERO.add(Duration.UNKNOWN).isUnknown());
@@ -326,7 +326,7 @@ public class DurationTest {
 
     @Test public void add_ONE_and_UNKNOWN_ResultsInUnknown() {
         assertTrue(Double.isNaN(1.0 + Double.NaN)); // sanity check
-        assertEquals(new Double(Double.NaN), new Double(1.0 + Double.NaN)); // sanity check
+        assertEquals(Double.valueOf(Double.NaN), Double.valueOf(1.0 + Double.NaN)); // sanity check
 
         assertFalse(Duration.ONE.add(Duration.UNKNOWN).isIndefinite());
         assertTrue(Duration.ONE.add(Duration.UNKNOWN).isUnknown());
@@ -381,7 +381,7 @@ public class DurationTest {
 
     @Test public void subtract_ZERO_and_INDEFINITE_ResultsInNegativeInfinity() {
         //assertTrue(0.0 - Double.POSITIVE_INFINITY == Double.NEGATIVE_INFINITY); // sanity check
-        assertEquals(new Double(Double.NEGATIVE_INFINITY), new Double(0.0 - Double.POSITIVE_INFINITY)); // sanity check
+        assertEquals(Double.valueOf(Double.NEGATIVE_INFINITY), Double.valueOf(0.0 - Double.POSITIVE_INFINITY)); // sanity check
 
         final Duration result = Duration.ZERO.subtract(Duration.INDEFINITE);
         assertFalse(result.isIndefinite());
@@ -391,7 +391,7 @@ public class DurationTest {
 
     @Test public void subtract_ONE_and_INDEFINITE_ResultsInNegativeInfinity() {
         //assertTrue(1.0 - Double.POSITIVE_INFINITY == Double.NEGATIVE_INFINITY); // sanity check
-        assertEquals(new Double(Double.NEGATIVE_INFINITY), new Double(1.0 - Double.POSITIVE_INFINITY)); // sanity check
+        assertEquals(Double.valueOf(Double.NEGATIVE_INFINITY), Double.valueOf(1.0 - Double.POSITIVE_INFINITY)); // sanity check
 
         final Duration result = Duration.ONE.subtract(Duration.INDEFINITE);
         assertFalse(result.isIndefinite());
@@ -401,7 +401,7 @@ public class DurationTest {
 
     @Test public void subtract_INDEFINITE_and_INDEFINITE_ResultsInUnknown() {
         assertTrue(Double.isNaN(Double.POSITIVE_INFINITY - Double.POSITIVE_INFINITY)); // sanity check
-        assertEquals(new Double(Double.NaN), new Double(Double.POSITIVE_INFINITY - Double.POSITIVE_INFINITY)); // sanity check
+        assertEquals(Double.valueOf(Double.NaN), Double.valueOf(Double.POSITIVE_INFINITY - Double.POSITIVE_INFINITY)); // sanity check
 
         assertFalse(Duration.INDEFINITE.subtract(Duration.INDEFINITE).isIndefinite());
         assertTrue(Duration.INDEFINITE.subtract(Duration.INDEFINITE).isUnknown());
@@ -409,7 +409,7 @@ public class DurationTest {
 
     @Test public void subtract_UNKNOWN_and_INDEFINITE_ResultsInUnknown() {
         assertTrue(Double.isNaN(Double.NaN - Double.POSITIVE_INFINITY)); // sanity check
-        assertEquals(new Double(Double.NaN), new Double(Double.NaN - Double.POSITIVE_INFINITY)); // sanity check
+        assertEquals(Double.valueOf(Double.NaN), Double.valueOf(Double.NaN - Double.POSITIVE_INFINITY)); // sanity check
 
         assertFalse(Duration.UNKNOWN.subtract(Duration.INDEFINITE).isIndefinite());
         assertTrue(Duration.UNKNOWN.subtract(Duration.INDEFINITE).isUnknown());
@@ -417,7 +417,7 @@ public class DurationTest {
 
     @Test public void subtract_ZERO_and_UNKNOWN_ResultsInUnknown() {
         assertTrue(Double.isNaN(0 - Double.NaN)); // sanity check
-        assertEquals(new Double(Double.NaN), new Double(0.0 - Double.NaN)); // sanity check
+        assertEquals(Double.valueOf(Double.NaN), Double.valueOf(0.0 - Double.NaN)); // sanity check
 
         assertFalse(Duration.ZERO.subtract(Duration.UNKNOWN).isIndefinite());
         assertTrue(Duration.ZERO.subtract(Duration.UNKNOWN).isUnknown());
@@ -425,7 +425,7 @@ public class DurationTest {
 
     @Test public void subtract_ONE_and_UNKNOWN_ResultsInUnknown() {
         assertTrue(Double.isNaN(1.0 - Double.NaN)); // sanity check
-        assertEquals(new Double(Double.NaN), new Double(1.0 - Double.NaN)); // sanity check
+        assertEquals(Double.valueOf(Double.NaN), Double.valueOf(1.0 - Double.NaN)); // sanity check
 
         assertFalse(Duration.ONE.subtract(Duration.UNKNOWN).isIndefinite());
         assertTrue(Duration.ONE.subtract(Duration.UNKNOWN).isUnknown());
@@ -472,7 +472,7 @@ public class DurationTest {
 
     @Test public void multiply_ZERO_and_INDEFINITE_ResultsInUnknown() {
         assertTrue(Double.isNaN(0.0 * Double.POSITIVE_INFINITY)); // sanity check
-        assertEquals(new Double(Double.NaN), new Double(0.0 * Double.POSITIVE_INFINITY)); // sanity check
+        assertEquals(Double.valueOf(Double.NaN), Double.valueOf(0.0 * Double.POSITIVE_INFINITY)); // sanity check
 
         assertFalse(Duration.ZERO.multiply(Double.POSITIVE_INFINITY).isIndefinite());
         assertTrue(Duration.ZERO.multiply(Double.POSITIVE_INFINITY).isUnknown());
@@ -480,7 +480,7 @@ public class DurationTest {
 
     @Test public void multiply_ONE_and_INDEFINITE_ResultsInIndefinite() {
         //assertTrue(1.0 * Double.POSITIVE_INFINITY == Double.POSITIVE_INFINITY); // sanity check
-        assertEquals(new Double(Double.POSITIVE_INFINITY), new Double(1.0 * Double.POSITIVE_INFINITY)); // sanity check
+        assertEquals(Double.valueOf(Double.POSITIVE_INFINITY), Double.valueOf(1.0 * Double.POSITIVE_INFINITY)); // sanity check
 
         assertTrue(Duration.ONE.multiply(Double.POSITIVE_INFINITY).isIndefinite());
         assertFalse(Duration.ONE.multiply(Double.POSITIVE_INFINITY).isUnknown());
@@ -488,7 +488,7 @@ public class DurationTest {
 
     @Test public void multiply_INDEFINITE_and_INDEFINITE_ResultsInIndefinite() {
         //assertTrue(Double.POSITIVE_INFINITY * Double.POSITIVE_INFINITY == Double.POSITIVE_INFINITY); // sanity check
-        assertEquals(new Double(Double.POSITIVE_INFINITY), new Double(Double.POSITIVE_INFINITY * Double.POSITIVE_INFINITY)); // sanity check
+        assertEquals(Double.valueOf(Double.POSITIVE_INFINITY), Double.valueOf(Double.POSITIVE_INFINITY * Double.POSITIVE_INFINITY)); // sanity check
 
         assertTrue(Duration.INDEFINITE.multiply(Double.POSITIVE_INFINITY).isIndefinite());
         assertFalse(Duration.INDEFINITE.multiply(Double.POSITIVE_INFINITY).isUnknown());
@@ -496,7 +496,7 @@ public class DurationTest {
 
     @Test public void multiply_UNKNOWN_and_INDEFINITE_ResultsInUnknown() {
         assertTrue(Double.isNaN(Double.NaN * Double.POSITIVE_INFINITY)); // sanity check
-        assertEquals(new Double(Double.NaN), new Double(Double.NaN * Double.POSITIVE_INFINITY)); // sanity check
+        assertEquals(Double.valueOf(Double.NaN), Double.valueOf(Double.NaN * Double.POSITIVE_INFINITY)); // sanity check
 
         assertFalse(Duration.UNKNOWN.multiply(Double.POSITIVE_INFINITY).isIndefinite());
         assertTrue(Duration.UNKNOWN.multiply(Double.POSITIVE_INFINITY).isUnknown());
@@ -504,7 +504,7 @@ public class DurationTest {
 
     @Test public void multiply_ZERO_and_UNKNOWN_ResultsInUnknown() {
         assertTrue(Double.isNaN(0 * Double.NaN)); // sanity check
-        assertEquals(new Double(Double.NaN), new Double(0.0 * Double.NaN)); // sanity check
+        assertEquals(Double.valueOf(Double.NaN), Double.valueOf(0.0 * Double.NaN)); // sanity check
 
         assertFalse(Duration.ZERO.multiply(Double.NaN).isIndefinite());
         assertTrue(Duration.ZERO.multiply(Double.NaN).isUnknown());
@@ -512,7 +512,7 @@ public class DurationTest {
 
     @Test public void multiply_ONE_and_UNKNOWN_ResultsInUnknown() {
         assertTrue(Double.isNaN(1.0 * Double.NaN)); // sanity check
-        assertEquals(new Double(Double.NaN), new Double(1.0 * Double.NaN)); // sanity check
+        assertEquals(Double.valueOf(Double.NaN), Double.valueOf(1.0 * Double.NaN)); // sanity check
 
         assertFalse(Duration.ONE.multiply(Double.NaN).isIndefinite());
         assertTrue(Duration.ONE.multiply(Double.NaN).isUnknown());
@@ -560,21 +560,21 @@ public class DurationTest {
 
     @Test public void divide_ZERO_by_INDEFINITE_ResultsIn_ZERO() {
         //assertTrue(0.0 / Double.POSITIVE_INFINITY == 0.0); // sanity check
-        assertEquals(new Double(0.0), new Double(0.0 / Double.POSITIVE_INFINITY)); // sanity check
+        assertEquals(Double.valueOf(0.0), Double.valueOf(0.0 / Double.POSITIVE_INFINITY)); // sanity check
 
         assertSame(Duration.ZERO, Duration.ZERO.divide(Double.POSITIVE_INFINITY));
     }
 
     @Test public void divide_ONE_by_INDEFINITE_ResultsIn_ZERO() {
         //assertTrue(1.0 / Double.POSITIVE_INFINITY == 0.0); // sanity check
-        assertEquals(new Double(0.0), new Double(1.0 / Double.POSITIVE_INFINITY)); // sanity check
+        assertEquals(Double.valueOf(0.0), Double.valueOf(1.0 / Double.POSITIVE_INFINITY)); // sanity check
 
         assertSame(Duration.ZERO, Duration.ONE.divide(Double.POSITIVE_INFINITY));
     }
 
     @Test public void divide_INDEFINITE_by_INDEFINITE_ResultsInUnknown() {
         assertTrue(Double.isNaN(Double.POSITIVE_INFINITY / Double.POSITIVE_INFINITY)); // sanity check
-        assertEquals(new Double(Double.NaN), new Double(Double.POSITIVE_INFINITY / Double.POSITIVE_INFINITY)); // sanity check
+        assertEquals(Double.valueOf(Double.NaN), Double.valueOf(Double.POSITIVE_INFINITY / Double.POSITIVE_INFINITY)); // sanity check
 
         assertFalse(Duration.INDEFINITE.divide(Double.POSITIVE_INFINITY).isIndefinite());
         assertTrue(Duration.INDEFINITE.divide(Double.POSITIVE_INFINITY).isUnknown());
@@ -582,7 +582,7 @@ public class DurationTest {
 
     @Test public void divide_UNKNOWN_by_INDEFINITE_ResultsInUnknown() {
         assertTrue(Double.isNaN(Double.NaN / Double.POSITIVE_INFINITY)); // sanity check
-        assertEquals(new Double(Double.NaN), new Double(Double.NaN / Double.POSITIVE_INFINITY)); // sanity check
+        assertEquals(Double.valueOf(Double.NaN), Double.valueOf(Double.NaN / Double.POSITIVE_INFINITY)); // sanity check
 
         assertFalse(Duration.UNKNOWN.divide(Double.POSITIVE_INFINITY).isIndefinite());
         assertTrue(Duration.UNKNOWN.divide(Double.POSITIVE_INFINITY).isUnknown());
@@ -590,7 +590,7 @@ public class DurationTest {
 
     @Test public void divide_ZERO_by_UNKNOWN_ResultsInUnknown() {
         assertTrue(Double.isNaN(0.0 / Double.NaN)); // sanity check
-        assertEquals(new Double(Double.NaN), new Double(0.0 / Double.NaN)); // sanity check
+        assertEquals(Double.valueOf(Double.NaN), Double.valueOf(0.0 / Double.NaN)); // sanity check
 
         assertFalse(Duration.ZERO.divide(Double.NaN).isIndefinite());
         assertTrue(Duration.ZERO.divide(Double.NaN).isUnknown());
@@ -598,7 +598,7 @@ public class DurationTest {
 
     @Test public void divide_ONE_by_UNKNOWN_ResultsInUnknown() {
         assertTrue(Double.isNaN(1.0 / Double.NaN)); // sanity check
-        assertEquals(new Double(Double.NaN), new Double(1.0 / Double.NaN)); // sanity check
+        assertEquals(Double.valueOf(Double.NaN), Double.valueOf(1.0 / Double.NaN)); // sanity check
 
         assertFalse(Duration.ONE.divide(Double.NaN).isIndefinite());
         assertTrue(Duration.ONE.divide(Double.NaN).isUnknown());

--- a/modules/javafx.controls/src/main/java/javafx/scene/chart/ValueAxis.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/chart/ValueAxis.java
@@ -517,7 +517,7 @@ public abstract class ValueAxis<T extends Number> extends Axis<T> {
      */
     @Override public T toRealValue(double value) {
         //noinspection unchecked
-        return (T)new Double(value);
+        return (T)Double.valueOf(value);
     }
 
     // -------------- STYLESHEET HANDLING ------------------------------------------------------------------------------

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYChartDataTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYChartDataTest.java
@@ -85,8 +85,8 @@ public class XYChartDataTest {
     @Test
     public void testSeriesAddDelete() {
         XYChart.Series<String, Number> series = new XYChart.Series<String, Number>();
-        Number value1 = Integer.valueOf(5);
-        Number value2 = Integer.valueOf(6);
+        Number value1 = 5;
+        Number value2 = 6;
         XYChart.Data<String, Number> point1 = new XYChart.Data<String, Number>("Something", value1);
         XYChart.Data<String, Number> point2 = new XYChart.Data<String, Number>("Something", value2);
         series.getData().add(point1);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYChartDataTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYChartDataTest.java
@@ -85,8 +85,8 @@ public class XYChartDataTest {
     @Test
     public void testSeriesAddDelete() {
         XYChart.Series<String, Number> series = new XYChart.Series<String, Number>();
-        Number value1 = new Integer(5);
-        Number value2 = new Integer(6);
+        Number value1 = Integer.valueOf(5);
+        Number value2 = Integer.valueOf(6);
         XYChart.Data<String, Number> point1 = new XYChart.Data<String, Number>("Something", value1);
         XYChart.Data<String, Number> point2 = new XYChart.Data<String, Number>("Something", value2);
         series.getData().add(point1);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYChartTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYChartTest.java
@@ -82,8 +82,8 @@ public class XYChartTest extends ChartTestBase {
         startApp();
         Font f = yaxis.getTickLabelFont();
         // default caspian value for font size = 10
-        assertEquals(10, new Double(f.getSize()).intValue());
-        assertEquals(10, new Double(AxisShim.get_measure(yaxis).getFont().getSize()).intValue());
+        assertEquals(10, Double.valueOf(f.getSize()).intValue());
+        assertEquals(10, Double.valueOf(AxisShim.get_measure(yaxis).getFont().getSize()).intValue());
 
         // set tick label font via css and test if ticklabelfont, measure and tick textnode follow.
         ParsedValue pv = new CssParserShim().parseExpr("-fx-tick-label-font","0.916667em System");
@@ -91,16 +91,16 @@ public class XYChartTest extends ChartTestBase {
         CssMetaData prop = ((StyleableProperty)yaxis.tickLabelFontProperty()).getCssMetaData();
         prop.set(yaxis, val, null);
         // confirm tickLabelFont, measure and tick's textnode all are in sync with -fx-tick-label-font
-        assertEquals(11, new Double(yaxis.getTickLabelFont().getSize()).intValue());
-        assertEquals(11, new Double(AxisShim.get_measure(yaxis).getFont().getSize()).intValue());
+        assertEquals(11, Double.valueOf(yaxis.getTickLabelFont().getSize()).intValue());
+        assertEquals(11, Double.valueOf(AxisShim.get_measure(yaxis).getFont().getSize()).intValue());
         final ObservableList<Axis.TickMark<Number>> yaTickMarks = yaxis.getTickMarks();
         TickMark tm = yaTickMarks.get(0);
-        assertEquals(11, new Double(AxisShim.TickMark_get_textNode(tm).getFont().getSize()).intValue());
+        assertEquals(11, Double.valueOf(AxisShim.TickMark_get_textNode(tm).getFont().getSize()).intValue());
         // set tick label font programmatically and test.
         yaxis.setTickLabelFont(new Font(12.0f));
-        assertEquals(12, new Double(yaxis.getTickLabelFont().getSize()).intValue());
-        assertEquals(12, new Double(AxisShim.get_measure(yaxis).getFont().getSize()).intValue());
-        assertEquals(12, new Double(AxisShim.TickMark_get_textNode(tm).getFont().getSize()).intValue());
+        assertEquals(12, Double.valueOf(yaxis.getTickLabelFont().getSize()).intValue());
+        assertEquals(12, Double.valueOf(AxisShim.get_measure(yaxis).getFont().getSize()).intValue());
+        assertEquals(12, Double.valueOf(AxisShim.TickMark_get_textNode(tm).getFont().getSize()).intValue());
     }
 
     @Test public void testSetTickLabelFill() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -640,7 +640,7 @@ public class ComboBoxTest {
     @Test public void defaultConverterCanHandleIncorrectType_1() {
         ComboBox cb = new ComboBox();
         StringConverter sc = cb.getConverter();
-        assertEquals("42", sc.toString(new Integer(42)));
+        assertEquals("42", sc.toString(Integer.valueOf(42)));
     }
 
     @Test(expected=ClassCastException.class)

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuBarTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuBarTest.java
@@ -579,7 +579,7 @@ public class MenuBarTest {
         double yval = (menuBar.localToScene(menuBar.getLayoutBounds())).getMinY();
 
         boolean click = true;
-        final Boolean firstClick = new Boolean(click);
+        final Boolean firstClick = Boolean.valueOf(click);
 
         menu.setOnShowing(t -> {
             // we should not get here when the menu is hidden

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuBarTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuBarTest.java
@@ -579,7 +579,7 @@ public class MenuBarTest {
         double yval = (menuBar.localToScene(menuBar.getLayoutBounds())).getMinY();
 
         boolean click = true;
-        final Boolean firstClick = Boolean.valueOf(click);
+        final Boolean firstClick = click;
 
         menu.setOnShowing(t -> {
             // we should not get here when the menu is hidden

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/X11GLFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/X11GLFactory.java
@@ -166,8 +166,8 @@ class X11GLFactory extends GLFactory {
 
     @Override
     void updateDeviceDetails(HashMap deviceDetails) {
-        deviceDetails.put("XVisualID", new Long(nGetVisualID(nativeCtxInfo)));
-        deviceDetails.put("XDisplay", new Long(nGetDisplay(nativeCtxInfo)));
-        deviceDetails.put("XScreenID", new Integer(nGetDefaultScreen(nativeCtxInfo)));
+        deviceDetails.put("XVisualID", Long.valueOf(nGetVisualID(nativeCtxInfo)));
+        deviceDetails.put("XDisplay", Long.valueOf(nGetDisplay(nativeCtxInfo)));
+        deviceDetails.put("XScreenID", Integer.valueOf(nGetDefaultScreen(nativeCtxInfo)));
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/J2DPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/J2DPipeline.java
@@ -61,7 +61,7 @@ public class J2DPipeline extends GraphicsPipeline {
 
     @Override
     public ResourceFactory getResourceFactory(Screen screen) {
-        Integer index = new Integer(screen.getAdapterOrdinal());
+        Integer index = Integer.valueOf(screen.getAdapterOrdinal());
         J2DResourceFactory factory = factories.get(index);
         if (factory == null) {
             factory = new J2DResourceFactory(screen);

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/null3d/NULL3DPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/null3d/NULL3DPipeline.java
@@ -69,7 +69,7 @@ public class NULL3DPipeline extends GraphicsPipeline {
 
     @Override
     public ResourceFactory getResourceFactory(Screen screen) {
-        Integer index = new Integer(screen.getAdapterOrdinal());
+        Integer index = Integer.valueOf(screen.getAdapterOrdinal());
         DummyResourceFactory factory = factories.get(index);
         if (factory == null) {
             factory = new DummyResourceFactory(screen);

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWPipeline.java
@@ -69,7 +69,7 @@ public final class SWPipeline extends GraphicsPipeline {
     }
 
     @Override public ResourceFactory getResourceFactory(Screen screen) {
-        Integer index = new Integer(screen.getAdapterOrdinal());
+        Integer index = Integer.valueOf(screen.getAdapterOrdinal());
         SWResourceFactory factory = factories.get(index);
         if (factory == null) {
             factory = new SWResourceFactory(screen);

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/NodeTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/NodeTest.java
@@ -474,7 +474,7 @@ public class NodeTest {
 
         v.set(value);
         NodeTest.syncNode(node);
-        assertTrue(numbersEquals(Integer.valueOf(value),
+        assertTrue(numbersEquals(value,
                 (Number)TestUtils.getObjectValue(node, pgPropertyName)));
     }
 
@@ -519,7 +519,7 @@ public class NodeTest {
 
         v.set(value);
         NodeTest.syncNode(node);
-        assertTrue(numbersEquals(Double.valueOf(value),
+        assertTrue(numbersEquals(value,
                 (Number)TestUtils.getObjectValue(node, pgPropertyName)));
     }
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/NodeTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/NodeTest.java
@@ -474,7 +474,7 @@ public class NodeTest {
 
         v.set(value);
         NodeTest.syncNode(node);
-        assertTrue(numbersEquals(new Integer(value),
+        assertTrue(numbersEquals(Integer.valueOf(value),
                 (Number)TestUtils.getObjectValue(node, pgPropertyName)));
     }
 
@@ -519,7 +519,7 @@ public class NodeTest {
 
         v.set(value);
         NodeTest.syncNode(node);
-        assertTrue(numbersEquals(new Double(value),
+        assertTrue(numbersEquals(Double.valueOf(value),
                 (Number)TestUtils.getObjectValue(node, pgPropertyName)));
     }
 

--- a/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/JumpStatementTest.java
+++ b/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/JumpStatementTest.java
@@ -73,7 +73,7 @@ public class JumpStatementTest extends ParserBase {
         ReturnStmt ret = (ReturnStmt)tree;
         assertTrue(ret.getExpr() instanceof LiteralExpr);
         LiteralExpr lit = (LiteralExpr)ret.getExpr();
-        assertEquals(lit.getValue(), new Integer(3));
+        assertEquals(lit.getValue(), Integer.valueOf(3));
     }
 
     @Test(expected = ParseCancellationException.class)

--- a/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/PrimaryExprTest.java
+++ b/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/PrimaryExprTest.java
@@ -65,7 +65,7 @@ public class PrimaryExprTest extends ParserBase {
     public void floatLiteral() throws Exception {
         Expr tree = parseTreeFor("1.234");
         assertTrue(tree instanceof LiteralExpr);
-        assertEquals(((LiteralExpr)tree).getValue(), Float.valueOf(1.234));
+        assertEquals(((LiteralExpr)tree).getValue(), Float.valueOf(1.234f));
     }
 
     @Test

--- a/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/PrimaryExprTest.java
+++ b/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/PrimaryExprTest.java
@@ -58,14 +58,14 @@ public class PrimaryExprTest extends ParserBase {
     public void intLiteral() throws Exception {
         Expr tree = parseTreeFor("123");
         assertTrue(tree instanceof LiteralExpr);
-        assertEquals(((LiteralExpr)tree).getValue(), new Integer(123));
+        assertEquals(((LiteralExpr)tree).getValue(), Integer.valueOf(123));
     }
 
     @Test
     public void floatLiteral() throws Exception {
         Expr tree = parseTreeFor("1.234");
         assertTrue(tree instanceof LiteralExpr);
-        assertEquals(((LiteralExpr)tree).getValue(), new Float(1.234));
+        assertEquals(((LiteralExpr)tree).getValue(), Float.valueOf(1.234));
     }
 
     @Test

--- a/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/UnaryExprTest.java
+++ b/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/UnaryExprTest.java
@@ -59,14 +59,14 @@ public class UnaryExprTest extends PrimaryExprTest {
     public void positive() throws Exception {
         UnaryExpr tree = parseTreeFor("+72.4");
         assertEquals(tree.getOp(), UnaryOpType.PLUS);
-        assertEquals(((LiteralExpr)tree.getExpr()).getValue(), new Float(72.4));
+        assertEquals(((LiteralExpr)tree.getExpr()).getValue(), Float.valueOf(72.4));
     }
 
     @Test
     public void negative() throws Exception {
         UnaryExpr tree = parseTreeFor("-72.4");
         assertEquals(tree.getOp(), UnaryOpType.MINUS);
-        assertEquals(((LiteralExpr)tree.getExpr()).getValue(), new Float(72.4));
+        assertEquals(((LiteralExpr)tree.getExpr()).getValue(), Float.valueOf(72.4));
     }
 
     @Test

--- a/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/UnaryExprTest.java
+++ b/modules/javafx.graphics/src/test/jslc/com/sun/scenario/effect/compiler/parser/UnaryExprTest.java
@@ -59,14 +59,14 @@ public class UnaryExprTest extends PrimaryExprTest {
     public void positive() throws Exception {
         UnaryExpr tree = parseTreeFor("+72.4");
         assertEquals(tree.getOp(), UnaryOpType.PLUS);
-        assertEquals(((LiteralExpr)tree.getExpr()).getValue(), Float.valueOf(72.4));
+        assertEquals(((LiteralExpr)tree.getExpr()).getValue(), Float.valueOf(72.4f));
     }
 
     @Test
     public void negative() throws Exception {
         UnaryExpr tree = parseTreeFor("-72.4");
         assertEquals(tree.getOp(), UnaryOpType.MINUS);
-        assertEquals(((LiteralExpr)tree.getExpr()).getValue(), Float.valueOf(72.4));
+        assertEquals(((LiteralExpr)tree.getExpr()).getValue(), Float.valueOf(72.4f));
     }
 
     @Test

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/platform/ios/IOSMediaPlayer.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/platform/ios/IOSMediaPlayer.java
@@ -275,7 +275,7 @@ public final class IOSMediaPlayer extends NativeMediaPlayer {
         }
 
         public EqualizerBand addBand(double centerFrequency, double bandwidth, double gain) {
-            Double key = Double.valueOf(centerFrequency);
+            Double key = centerFrequency;
             if (bands.containsKey(key)) {
                 removeBand(centerFrequency);
             }
@@ -286,7 +286,7 @@ public final class IOSMediaPlayer extends NativeMediaPlayer {
         }
 
         public boolean removeBand(double centerFrequency) {
-            Double key = Double.valueOf(centerFrequency);
+            Double key = centerFrequency;
             if (bands.containsKey(key)) {
                 bands.remove(key);
                 return true;

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/platform/ios/IOSMediaPlayer.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/platform/ios/IOSMediaPlayer.java
@@ -275,7 +275,7 @@ public final class IOSMediaPlayer extends NativeMediaPlayer {
         }
 
         public EqualizerBand addBand(double centerFrequency, double bandwidth, double gain) {
-            Double key = new Double(centerFrequency);
+            Double key = Double.valueOf(centerFrequency);
             if (bands.containsKey(key)) {
                 removeBand(centerFrequency);
             }
@@ -286,7 +286,7 @@ public final class IOSMediaPlayer extends NativeMediaPlayer {
         }
 
         public boolean removeBand(double centerFrequency) {
-            Double key = new Double(centerFrequency);
+            Double key = Double.valueOf(centerFrequency);
             if (bands.containsKey(key)) {
                 bands.remove(key);
                 return true;

--- a/modules/javafx.web/src/android/java/netscape/javascript/JSObject.java
+++ b/modules/javafx.web/src/android/java/netscape/javascript/JSObject.java
@@ -144,7 +144,7 @@ public abstract class JSObject {
 
                 // Comment out MAYSCRIPT check because Internet Explorer doesn't support
                 // it.
-//              if (obj != null && (obj.equals("") || (new Boolean(obj).booleanValue() == true)))
+//              if (obj != null && (obj.equals("") || (Boolean.valueOf(obj).booleanValue() == true)))
                 {
                     // MAYSCRIPT is enabled
 

--- a/modules/javafx.web/src/ios/java/javafx/scene/web/JSONDecoder.java
+++ b/modules/javafx.web/src/ios/java/javafx/scene/web/JSONDecoder.java
@@ -98,7 +98,7 @@ class JSONDecoder {
         } else {
             long val = Long.parseLong(sNum);
             if ((val <= Integer.MAX_VALUE) && (Integer.MIN_VALUE <= val)) {
-                return Integer.valueOf(int) val);
+                return Integer.valueOf((int) val);
             } else {
                 return Double.valueOf(val);
             }

--- a/modules/javafx.web/src/ios/java/javafx/scene/web/JSONDecoder.java
+++ b/modules/javafx.web/src/ios/java/javafx/scene/web/JSONDecoder.java
@@ -98,9 +98,9 @@ class JSONDecoder {
         } else {
             long val = Long.parseLong(sNum);
             if ((val <= Integer.MAX_VALUE) && (Integer.MIN_VALUE <= val)) {
-                return new Integer((int) val);
+                return Integer.valueOf(int) val);
             } else {
-                return new Double(val);
+                return Double.valueOf(val);
             }
         }
     }

--- a/tests/functional/animation/javafx/animation/Timeline_TS012_01_Test.java
+++ b/tests/functional/animation/javafx/animation/Timeline_TS012_01_Test.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 public class Timeline_TS012_01_Test extends AnimationFunctionalTestBase {
     private Timeline t;
     private SimpleKeyValueTarget target = new SimpleKeyValueTarget(1);
-    private Integer newVal = Integer.valueOf(3);
+    private Integer newVal = 3;
 
     public Timeline_TS012_01_Test() {
         super("Timeline with repeatCount=0 should never start");

--- a/tests/functional/animation/javafx/animation/Timeline_TS012_01_Test.java
+++ b/tests/functional/animation/javafx/animation/Timeline_TS012_01_Test.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 public class Timeline_TS012_01_Test extends AnimationFunctionalTestBase {
     private Timeline t;
     private SimpleKeyValueTarget target = new SimpleKeyValueTarget(1);
-    private Integer newVal = new Integer(3);
+    private Integer newVal = Integer.valueOf(3);
 
     public Timeline_TS012_01_Test() {
         super("Timeline with repeatCount=0 should never start");


### PR DESCRIPTION
The following primitive constructors were deprecated in JDK 9 and are deprecated for removal in JDK 16.

```
java.lang.Byte
java.lang.Short
java.lang.Integer
java.lang.Long
java.lang.Float
java.lang.Double
java.lang.Character
java.lang.Boolean
```

This change removes call to the primitive constructors with the `valueOf()` factory method of respective class.
Calls like the following to create array get autoboxed so it does not require a change.

`Double dArr[] = new Double[] {10.1, 20.2};`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8257512](https://bugs.openjdk.java.net/browse/JDK-8257512): Remove use of deprecated primitive constructors in JavaFX


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Nir Lisker](https://openjdk.java.net/census#nlisker) (@nlisker - **Reviewer**)

### Download
`$ git fetch https://git.openjdk.java.net/jfx pull/423/head:pull/423`
`$ git checkout pull/423`
