### PR TITLE
8263402: MemoryLeak: Node hardreferences it's previous Parent after csslayout and getting removed from the scene

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/CssStyleHelper.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/CssStyleHelper.java
@@ -24,6 +24,7 @@
  */
 package javafx.scene;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -176,7 +177,7 @@ final class CssStyleHelper {
 
         helper.cacheContainer = new CacheContainer(node, styleMap, depth);
 
-        helper.firstStyleableAncestor = findFirstStyleableAncestor(node);
+        helper.firstStyleableAncestor = new WeakReference<>(findFirstStyleableAncestor(node));
 
         // If this node had a style helper, then reset properties to their initial value
         // since the style map might now be different
@@ -209,7 +210,7 @@ final class CssStyleHelper {
                 // TODO : check why calling createStyleHelper(parentNode) does not work here?
                 if (parentNode.styleHelper == null) {
                     parentNode.styleHelper = new CssStyleHelper();
-                    parentNode.styleHelper.firstStyleableAncestor = findFirstStyleableAncestor(parentNode) ;
+                    parentNode.styleHelper.firstStyleableAncestor = new WeakReference(findFirstStyleableAncestor(parentNode)) ;
                 }
                 parentNode.styleHelper.triggerStates.addAll(triggerState);
 
@@ -232,8 +233,8 @@ final class CssStyleHelper {
             if (fontStyleableProperty != null && fontStyleableProperty.getStyleOrigin() == StyleOrigin.USER) return true;
         }
 
-        Styleable styleableParent = firstStyleableAncestor;
-        CssStyleHelper parentStyleHelper = getStyleHelper(firstStyleableAncestor);
+        Styleable styleableParent = firstStyleableAncestor.get();
+        CssStyleHelper parentStyleHelper = getStyleHelper(firstStyleableAncestor.get());
 
         if (parentStyleHelper != null) {
             return parentStyleHelper.isUserSetFont(styleableParent);
@@ -300,7 +301,7 @@ final class CssStyleHelper {
         }
 
         //update ancestor since this node may have changed positions in the scene graph (JDK-8237469)
-        node.styleHelper.firstStyleableAncestor = findFirstStyleableAncestor(node);
+        node.styleHelper.firstStyleableAncestor = new WeakReference<>(findFirstStyleableAncestor(node));
 
         // If the style maps are the same instance, we can re-use the current styleHelper if the cacheContainer is null.
         // Under this condition, there are no styles for this node _and_ no styles inherit.
@@ -322,7 +323,7 @@ final class CssStyleHelper {
             return true;
         }
 
-        CssStyleHelper parentHelper = getStyleHelper(node.styleHelper.firstStyleableAncestor);
+        CssStyleHelper parentHelper = getStyleHelper(node.styleHelper.firstStyleableAncestor.get());
 
         if (parentHelper != null && parentHelper.cacheContainer != null) {
 
@@ -351,7 +352,7 @@ final class CssStyleHelper {
 
     /* This is the first Styleable parent (of Node this StyleHelper belongs to)
      * having a valid StyleHelper */
-    private Node firstStyleableAncestor;
+    private WeakReference<Node> firstStyleableAncestor = null;
 
     private CacheContainer cacheContainer;
 
@@ -1221,7 +1222,7 @@ final class CssStyleHelper {
             final Styleable styleable,
             final String property) {
 
-        Styleable parent = ((Node)styleable).styleHelper.firstStyleableAncestor;
+        Styleable parent = ((Node)styleable).styleHelper.firstStyleableAncestor.get();
         CssStyleHelper parentStyleHelper = getStyleHelper((Node) parent);
 
         if (parent != null && parentStyleHelper != null) {
@@ -1266,7 +1267,7 @@ final class CssStyleHelper {
             } else {
                 // TODO: This block was copied from inherit. Both should use same code somehow.
 
-                Styleable styleableParent = ((Node)styleable).styleHelper.firstStyleableAncestor;
+                Styleable styleableParent = ((Node)styleable).styleHelper.firstStyleableAncestor.get();
                 CssStyleHelper parentStyleHelper = getStyleHelper((Node) styleableParent);
 
                 if (styleableParent == null || parentStyleHelper == null) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/CssStyleHelper.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/CssStyleHelper.java
@@ -350,9 +350,11 @@ final class CssStyleHelper {
         return false;
     }
 
+    private static final WeakReference<Node> EMPTY_NODE = new WeakReference<>(null);
+
     /* This is the first Styleable parent (of Node this StyleHelper belongs to)
      * having a valid StyleHelper */
-    private WeakReference<Node> firstStyleableAncestor = null;
+    private WeakReference<Node> firstStyleableAncestor = EMPTY_NODE;
 
     private CacheContainer cacheContainer;
 

--- a/tests/system/src/test/java/test/javafx/scene/StyleMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/StyleMemoryLeakTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Group;
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.control.Button;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+import junit.framework.Assert;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import test.util.Util;
+import test.util.memory.JMemoryBuddy;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import static org.junit.Assert.fail;
+
+
+public class StyleMemoryLeakTest {
+
+    static CountDownLatch startupLatch;
+    static Stage stage;
+
+    public static class TestApp extends Application {
+
+        @Override
+        public void start(Stage primaryStage) throws Exception {
+            stage = primaryStage;
+            startupLatch.countDown();
+        }
+    }
+
+    @BeforeClass
+    public static void initFX() {
+        startupLatch = new CountDownLatch(1);
+        new Thread(() -> Application.launch(StyleMemoryLeakTest.TestApp.class, (String[])null)).start();
+        try {
+            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
+                fail("Timeout waiting for FX runtime to start");
+            }
+        } catch (InterruptedException ex) {
+            fail("Unexpected exception: " + ex);
+        }
+    }
+
+    @Test
+    public void testRootNodeMemoryLeak() throws Exception {
+        JMemoryBuddy.memoryTest((checker) -> {
+            Parent toBeRemoved = new Button();
+            Group root = new Group();
+            root.getChildren().add(toBeRemoved);
+            Util.runAndWait(() -> {
+                stage.setScene(new Scene(root));
+                stage.show();
+            });
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+            Util.runAndWait(() -> {
+                root.getChildren().clear();
+                stage.close();
+            });
+            checker.assertCollectable(stage);
+            checker.setAsReferenced(toBeRemoved);
+            stage = null;
+        });
+    }
+
+    @AfterClass
+    public static void teardownOnce() {
+        Platform.runLater(() -> {
+            stage.hide();
+            Platform.exit();
+        });
+    }
+}

--- a/tests/system/src/test/java/test/javafx/scene/StyleMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/StyleMemoryLeakTest.java
@@ -25,11 +25,8 @@
 
 package test.javafx.scene;
 
-import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Group;
-import javafx.scene.Node;
-import javafx.scene.Parent;
 import javafx.scene.control.Button;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
@@ -95,8 +92,6 @@ public class StyleMemoryLeakTest {
 
     @AfterClass
     public static void teardownOnce() {
-        Platform.runLater(() -> {
-            Platform.exit();
-        });
+        Platform.exit();
     }
 }


### PR DESCRIPTION
Fixing a memory leak. 
A node hard references its old parent after CSS layout and getting removed. 
This shouldn't be the case, this is very counterintuitive.

The fix uses a WeakReference in CSSStyleHelper for firstStyleableAncestor.
This should be fine because the CSS should only depend on it if it's still the real parent. 
In that case, it doesn't get collected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263402](https://bugs.openjdk.java.net/browse/JDK-8263402): MemoryLeak: Node hardreferences it's previous Parent after csslayout and getting removed from the scene


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/424/head:pull/424` \
`$ git checkout pull/424`

Update a local copy of the PR: \
`$ git checkout pull/424` \
`$ git pull https://git.openjdk.java.net/jfx pull/424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 424`

View PR using the GUI difftool: \
`$ git pr show -t 424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/424.diff">https://git.openjdk.java.net/jfx/pull/424.diff</a>

</details>
