### PR TITLE
8092439: [Monocle] Refactor monocle SPI to allow support for multiple screens

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLPlatform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,12 @@
  */
 package com.sun.glass.ui.monocle;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class EGLPlatform extends LinuxPlatform {
+
+    private List<NativeScreen> screens;
 
     /**
      * Create an <code>EGLPlatform</code>. If a library with specific native code is needed for this platform,
@@ -42,6 +47,23 @@ public class EGLPlatform extends LinuxPlatform {
     }
 
     @Override
+    protected NativeScreen createScreen() {
+        return new EGLScreen(0);
+    }
+
+    @Override
+    protected synchronized List<NativeScreen> createScreens() {
+        if (screens == null) {
+            int numScreens = nGetNumberOfScreens();
+            screens = new ArrayList<>(numScreens);
+            for (int i = 0; i < numScreens; i++) {
+                screens.add(new EGLScreen(i));
+            }
+        }
+        return screens;
+    }
+
+    @Override
     public synchronized AcceleratedScreen getAcceleratedScreen(int[] attributes) throws GLException {
         if (accScreen == null) {
             accScreen = new EGLAcceleratedScreen(attributes);
@@ -49,5 +71,7 @@ public class EGLPlatform extends LinuxPlatform {
         return accScreen;
 
     }
+
+    private native int nGetNumberOfScreens();
 
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLScreen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLScreen.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.glass.ui.monocle;
+
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+
+public class EGLScreen implements NativeScreen {
+
+    final int depth;
+    final int nativeFormat;
+    final int width, height;
+    final int offsetX, offsetY;
+    final int dpi;
+    final long handle;
+    final float scale;
+
+    public EGLScreen(int idx) {
+        this.handle = nGetHandle(idx);
+        this.depth = nGetDepth(idx);
+        this.nativeFormat = nGetNativeFormat(idx);
+        this.width = nGetWidth(idx);
+        this.height = nGetHeight(idx);
+        this.offsetX = nGetOffsetX(idx);
+        this.offsetY = nGetOffsetY(idx);
+        this.dpi = nGetDpi(idx);
+        this.scale = nGetScale(idx);
+    }
+
+    @Override
+    public int getDepth() {
+        return this.depth;
+    }
+
+    @Override
+    public int getNativeFormat() {
+        return this.nativeFormat;
+    }
+
+    @Override
+    public int getWidth() {
+         return this.width;
+    }
+
+    @Override
+    public int getHeight() {
+         return this.height;
+    }
+
+    @Override
+    public int getOffsetX() {
+         return this.offsetX;
+    }
+
+    @Override
+    public int getOffsetY() {
+         return this.offsetY;
+    }
+
+    @Override
+    public int getDPI() {
+         return this.dpi;
+    }
+
+    @Override
+    public long getNativeHandle() {
+        return handle;
+    }
+
+    @Override
+    public void shutdown() {
+    }
+
+    @Override
+    public void uploadPixels(Buffer b, int x, int y, int width, int height, float alpha) {
+    }
+
+    @Override
+    public void swapBuffers() {
+    }
+
+    @Override
+    public ByteBuffer getScreenCapture() {
+        throw new UnsupportedOperationException("No screencapture on EGL platforms");
+    }
+
+    @Override
+    public float getScale() {
+        return this.scale;
+    }
+
+    private native long nGetHandle(int idx);
+    private native int nGetDepth(int idx);
+    private native int nGetWidth(int idx);
+    private native int nGetHeight(int idx);
+    private native int nGetOffsetX(int idx);
+    private native int nGetOffsetY(int idx);
+    private native int nGetDpi(int idx);
+    private native int nGetNativeFormat(int idx);
+    private native float nGetScale(int idx);
+
+}

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleApplication.java
@@ -42,6 +42,7 @@ import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.List;
 
 public final class MonocleApplication extends Application {
 
@@ -219,20 +220,29 @@ public final class MonocleApplication extends Application {
 
     @Override
     protected Screen[] staticScreen_getScreens() {
-        NativeScreen ns = platform.getScreen();
-        Screen screen = new Screen(1l, // dummy native pointer;
-                                   ns.getDepth(),
-                                   0, 0, ns.getWidth(), ns.getHeight(),
-                                   0, 0, ns.getWidth(), ns.getHeight(),
-                                   0, 0, ns.getWidth(), ns.getHeight(),
-                                   ns.getDPI(), ns.getDPI(),
-                                   1.f, 1.f, ns.getScale(), ns.getScale());
-        // Move the cursor to the middle of the screen
-        MouseState mouseState = new MouseState();
-        mouseState.setX(ns.getWidth() / 2);
-        mouseState.setY(ns.getHeight() / 2);
-        MouseInput.getInstance().setState(mouseState, false);
-        return new Screen[] { screen };
+        List<NativeScreen> screens = platform.getScreens();
+        Screen[] answer = new Screen[screens.size()];
+        int cnt = 0;
+        for (NativeScreen ns: screens) {
+            Screen screen = new Screen(ns.getNativeHandle(),
+                    ns.getDepth(),
+                    ns.getOffsetX(), ns.getOffsetY(), ns.getWidth(), ns.getHeight(),
+                    ns.getOffsetX(), ns.getOffsetY(), ns.getWidth(), ns.getHeight(),
+                    ns.getOffsetX(), ns.getOffsetY(), ns.getWidth(), ns.getHeight(),
+                    ns.getDPI(), ns.getDPI(),
+                    1.f, 1.f, ns.getScale(), ns.getScale());
+            answer[cnt] = screen;
+            // The first screen is the primaryscreen, we set the cursor to that one.
+            if (cnt == 0) {
+                // Move the cursor to the middle of the screen
+                MouseState mouseState = new MouseState();
+                mouseState.setX(ns.getWidth() / 2);
+                mouseState.setY(ns.getHeight() / 2);
+                MouseInput.getInstance().setState(mouseState, false);
+            }
+            cnt++;
+        }
+        return answer;
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/NativeScreen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/NativeScreen.java
@@ -53,6 +53,22 @@ public interface NativeScreen {
     int getHeight();
 
     /**
+     * Returns the horizontal start position of this screen relative to the total
+     * combined screen size.
+     */
+    default int getOffsetX() {
+        return 0;
+    }
+
+    /**
+     * Returns the vertical start position of this screen relative to the total
+     * combined screen size.
+     */
+    default int getOffsetY() {
+        return 0;
+    }
+
+    /**
      * Returns the number of pixels per inch in the screen.
      */
     int getDPI();

--- a/modules/javafx.graphics/src/main/native-glass/monocle/egl/eglBridge.c
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/egl/eglBridge.c
@@ -88,3 +88,52 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_monocle_EGLAcceleratedScreen_nE
     return answer;
 }
 
+JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_monocle_EGLScreen_nGetHandle
+(JNIEnv *env, jclass clazz, jint idx)  {
+    return doGetHandle(idx);
+}
+
+JNIEXPORT jint JNICALL Java_com_sun_glass_ui_monocle_EGLScreen_nGetDepth
+(JNIEnv *env, jclass clazz, jint idx)  {
+    return doGetDepth(idx);
+}
+
+JNIEXPORT jint JNICALL Java_com_sun_glass_ui_monocle_EGLScreen_nGetWidth
+(JNIEnv *env, jclass clazz, jint idx)  {
+    return doGetWidth(idx);
+}
+
+JNIEXPORT jint JNICALL Java_com_sun_glass_ui_monocle_EGLScreen_nGetHeight
+(JNIEnv *env, jclass clazz, jint idx)  {
+    return doGetHeight(idx);
+}
+
+JNIEXPORT jint JNICALL Java_com_sun_glass_ui_monocle_EGLScreen_nGetOffsetX
+(JNIEnv *env, jclass clazz, jint idx)  {
+    return doGetOffsetX(idx);
+}
+
+JNIEXPORT jint JNICALL Java_com_sun_glass_ui_monocle_EGLScreen_nGetOffsetY
+(JNIEnv *env, jclass clazz, jint idx)  {
+    return doGetOffsetY(idx);
+}
+
+JNIEXPORT jint JNICALL Java_com_sun_glass_ui_monocle_EGLScreen_nGetDpi
+(JNIEnv *env, jclass clazz, jint idx)  {
+    return doGetDpi(idx);
+}
+
+JNIEXPORT jint JNICALL Java_com_sun_glass_ui_monocle_EGLScreen_nGetNativeFormat
+(JNIEnv *env, jclass clazz, jint idx)  {
+    return doGetNativeFormat(idx);
+}
+
+JNIEXPORT jfloat JNICALL Java_com_sun_glass_ui_monocle_EGLScreen_nGetScale
+(JNIEnv *env, jclass clazz, jint idx)  {
+    return doGetScale(idx);
+}
+
+JNIEXPORT jint JNICALL Java_com_sun_glass_ui_monocle_EGLPlatform_nGetNumberOfScreens
+(JNIEnv *env, jclass clazz) {
+    return doGetNumberOfScreens();
+}

--- a/modules/javafx.graphics/src/main/native-glass/monocle/egl/egl_ext.h
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/egl/egl_ext.h
@@ -40,4 +40,16 @@ extern jboolean doEglMakeCurrent(jlong eglDisplay, jlong drawSurface,
      jlong readSurface, jlong eglContext);
 
 extern jboolean doEglSwapBuffers(jlong eglDisplay, jlong eglSurface);
+
+extern jlong doGetHandle(jint idx);
+extern jint doGetDepth(jint idx);
+extern jint doGetWidth(jint idx);
+extern jint doGetHeight(jint idx);
+extern jint doGetOffsetX(jint idx);
+extern jint doGetOffsetY(jint idx);
+extern jint doGetDpi(jint idx);
+extern jint doGetNativeFormat(jint idx);
+extern jfloat doGetScale(jint idx);
+extern jint doGetNumberOfScreens();
+
 #endif // EGL_EXT


### PR DESCRIPTION
Fix for JDK-8092439 and JDK-8092064
Monocle currently hard-codes a single Screen, and the `staticScreen_getScreens()` method will never return more than 1 Screen.

This PR introduces the possibility to deal with multiple screens, which is not uncommon on embedded systems. By default, the `staticScreen_getScreens()` method will still return a single screen, but the sub-platforms can now return multiple screens.

The EGL subplatform will now query the low-level drivers, and if they detect multiple displays, multiple `Screen` instances will be configured.
The low-level native implementation for getting the number of physical screens and there characteristics is deferred to the real low-level libraries (for example, an X11 based approach can do it in a different way then a DRM based approach).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8092439](https://bugs.openjdk.java.net/browse/JDK-8092439): [Monocle] Refactor monocle SPI to allow support for multiple screens


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jfx pull/426/head:pull/426`
`$ git checkout pull/426`

To update a local copy of the PR:
`$ git checkout pull/426`
`$ git pull https://git.openjdk.java.net/jfx pull/426/head`
