### PR TITLE
8255713: JavaFX build should discover Visual Studio compiler on system

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -235,9 +235,8 @@ jobs:
       ANT_DIR: "apache-ant-1.10.5"
       ANT_FILENAME: "apache-ant-1.10.5.tar.gz"
       ANT_URL: "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz"
-      # FIXME: hard-code the location and version of VS 2019 for now
+      # FIXME: hard-code the location of VS 2019 for now
       VS150COMNTOOLS: "C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Enterprise\\VC\\Auxiliary\\Build"
-      MSVC_VER: "14.28.29333"
 
     steps:
       - name: Checkout the source
@@ -283,7 +282,10 @@ jobs:
       - name: Setup environment
         run: |
           echo "VS150COMNTOOLS=$env:VS150COMNTOOLS"
-          echo "MSVC_VER=$env:MSVC_VER"
+          echo "dir ...\VC\Tools\MSVC"
+          dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC"
+          echo "dir VS150COMNTOOLS"
+          dir "$env:VS150COMNTOOLS"
           # echo "dir ...\VC\Tools\MSVC"
           # dir "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC"
           # echo "dir VS150COMNTOOLS"

--- a/buildSrc/genVSproperties.bat
+++ b/buildSrc/genVSproperties.bat
@@ -94,7 +94,8 @@ echo windows.vs.LIB=%LIB%@@ENDOFLINE@@
 echo windows.vs.LIBPATH=%LIBPATH%@@ENDOFLINE@@
 echo windows.vs.PATH=%PARFAIT_PATH%;%PATH%@@ENDOFLINE@@
 echo windows.vs.VER=%VSVER%@@ENDOFLINE@@
+echo windows.vs.VC_TOOLS_INSTALL_DIR=%VCToolsInstallDir%@@ENDOFLINE@@
+echo windows.vs.VC_TOOLS_REDIST_DIR=%VCToolsRedistDir%@@ENDOFLINE@@
 echo WINDOWS_SDK_DIR=%WindowsSdkDir%@@ENDOFLINE@@
 echo WINDOWS_SDK_VERSION=%WindowsSDKVersion%@@ENDOFLINE@@
 echo ############################################################
-

--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -78,6 +78,8 @@ setupTools("windows_tools",
         defineProperty("WINDOWS_VS_DEVENVDIR", properties, "$WINDOWS_VS_VSINSTALLDIR/Common7/IDE")
         defineProperty("WINDOWS_VS_DEVENVCMD", properties, "$WINDOWS_VS_DEVENVDIR/VCExpress.exe")
         defineProperty("WINDOWS_VS_MSVCDIR", properties, WINDOWS_VS_VCINSTALLDIR)
+        defineProperty("WINDOWS_VS_VC_TOOLS_INSTALL_DIR", properties, "")
+        defineProperty("WINDOWS_VS_VC_TOOLS_REDIST_DIR", properties, "")
         defineProperty("WINDOWS_DXSDK_DIR", properties, System.getenv().get("DXSDK_DIR"))
         defineProperty("WINDOWS_VS_INCLUDE", properties, "$WINDOWS_VS_VCINSTALLDIR/INCLUDE;" + "$WINDOWS_SDK_DIR/include;")
         defineProperty("WINDOWS_VS_VER", properties, "150")
@@ -142,12 +144,18 @@ ext.WINDOWS_NATIVE_COMPILE_ENVIRONMENT = [
         "LIBPATH"              : WINDOWS_VS_LIBPATH,
         "DXSDK_DIR"            : WINDOWS_DXSDK_DIR
 ];
-def msvcVer = System.getenv("MSVC_VER") ?: "14.10.25017"
+def msvcVer = System.getenv("MSVC_VER")
 def msvcBinDir = ""
 if (hasProperty('toolchainDir')) {
     msvcBinDir = "$WINDOWS_VS_VSINSTALLDIR/VC/bin/$CPU_BITS"
 } else if (winVsVer == 150) {
-    msvcBinDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Tools/MSVC/$msvcVer/bin/Host${CPU_BITS}/$CPU_BITS"
+    def msvcInstallDir = ""
+    if (msvcVer) {
+        msvcInstallDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Tools/MSVC/$msvcVer"
+    } else {
+        msvcInstallDir = "$WINDOWS_VS_VC_TOOLS_INSTALL_DIR"
+    }
+    msvcBinDir = "$msvcInstallDir/bin/Host${CPU_BITS}/$CPU_BITS"
 } else if (winVsVer <= 120) {
     msvcBinDir = (IS_64
                       ? "$WINDOWS_VS_VSINSTALLDIR/VC/BIN/amd64"
@@ -187,8 +195,12 @@ def msvcRedstDir
 if (hasProperty('toolchainDir')) {
     msvcRedstDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Redist/$CPU_BITS"
 } else {
-    def msvcRedistVer = System.getenv("MSVC_REDIST_VER") ?: "14.10.25008"
-    msvcRedstDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Redist/MSVC/$msvcRedistVer/$CPU_BITS"
+    def msvcRedistVer = System.getenv("MSVC_REDIST_VER")
+    if (msvcRedistVer) {
+        msvcRedstDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Redist/MSVC/$msvcRedistVer/$CPU_BITS"
+    } else {
+        msvcRedstDir = "$WINDOWS_VS_VC_TOOLS_REDIST_DIR/$CPU_BITS"
+    }
 }
 
 def winSdkDllDir = "$WINDOWS_VS_WINSDKDLLINSTALLDIR/$CPU_BITS"


### PR DESCRIPTION
We currently hard-code the default version of Visual Studio in both `win.gradle` and `.github/workflows/submit.yml`. This hard-coding of the specific version of MSVC is fragile, particularly for GitHub action builds. The last time Microsoft changed the environment, our Windows builds started failing (because we hard-coded it). I temporarily bumped it to the then-current version as a fix for [JDK-8256686](https://bugs.openjdk.java.net/browse/JDK-8256686), and filed this bug -- [JDK-8255713](https://bugs.openjdk.java.net/browse/JDK-8255713) -- as a followup. It's failing again because of another update to the GitHub actions environment, so it's time to fix it to discover the latest version rather than hardcode it.

NOTE to reviewers: This will need to be tested with local and CI builds as well as GitHub actions, since there are changes in the `win.gradle` script (and associated `genVSproperties.bat` script).

/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8255713](https://bugs.openjdk.java.net/browse/JDK-8255713): JavaFX build should discover Visual Studio compiler on system


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jfx pull/427/head:pull/427`
`$ git checkout pull/427`

To update a local copy of the PR:
`$ git checkout pull/427`
`$ git pull https://git.openjdk.java.net/jfx pull/427/head`
