### PR TITLE
8263807: Button types of a DialogPane are set twice, returns a wrong button

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/DialogPane.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/DialogPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -218,11 +218,8 @@ public class DialogPane extends Pane {
         contentLabel = createContentLabel("");
         getChildren().add(contentLabel);
 
-        buttonBar = createButtonBar();
-        if (buttonBar != null) {
-            getChildren().add(buttonBar);
-        }
-
+        // Add this listener before calling #createButtonBar, so that the listener added in #createButtonBar will run
+        // after this one.
         buttons.addListener((ListChangeListener<ButtonType>) c -> {
             while (c.next()) {
                 if (c.wasRemoved()) {
@@ -239,6 +236,11 @@ public class DialogPane extends Pane {
                 }
             }
         });
+
+        buttonBar = createButtonBar();
+        if (buttonBar != null) {
+            getChildren().add(buttonBar);
+        }
     }
 
 
@@ -1057,7 +1059,7 @@ public class DialogPane extends Pane {
 
         boolean hasDefault = false;
         for (ButtonType cmd : getButtonTypes()) {
-            Node button = buttonNodes.computeIfAbsent(cmd, dialogButton -> createButton(cmd));
+            Node button = buttonNodes.get(cmd);
 
             // keep only first default button
             if (button instanceof Button) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/DialogPaneTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/DialogPaneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/DialogPaneTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/DialogPaneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,12 @@
 
 package test.javafx.scene.control;
 
+import javafx.collections.ObservableList;
 import javafx.css.PseudoClass;
 import javafx.geometry.Insets;
+import javafx.scene.Node;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.ButtonType;
 import javafx.scene.control.DialogPane;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
@@ -73,5 +77,41 @@ public class DialogPaneTest {
         assertEquals(0, padding.getRight(), 0.0);
         assertEquals(0, padding.getBottom(), 0.0);
         assertEquals(0.833 * fontSize, padding.getLeft(), 0.01);
+    }
+
+    @Test
+    public void testLookupButtonIsReturningCorrectButton() {
+        String id1 = "Test";
+
+        dialogPane.getButtonTypes().setAll(ButtonType.OK);
+        assertEquals(1, dialogPane.getButtonTypes().size());
+
+        Node button = dialogPane.lookupButton(ButtonType.OK);
+        button.setId(id1);
+
+        verifyIdOfButtonInButtonBar(id1);
+
+        String id2 = "Test2";
+
+        dialogPane.getButtonTypes().setAll(ButtonType.OK);
+        assertEquals(1, dialogPane.getButtonTypes().size());
+
+        button = dialogPane.lookupButton(ButtonType.OK);
+        button.setId(id2);
+
+        verifyIdOfButtonInButtonBar(id2);
+    }
+
+    private void verifyIdOfButtonInButtonBar(String id) {
+        for (Node children : dialogPane.getChildren()) {
+            if (children instanceof ButtonBar) {
+                ObservableList<Node> buttons = ((ButtonBar) children).getButtons();
+
+                assertEquals(1, buttons.size());
+
+                Node button = buttons.get(0);
+                assertEquals(id, button.getId());
+            }
+        }
     }
 }


### PR DESCRIPTION
When DialogPane#getButtonTypes().setAll() is called twice with the same argument(s), DialogPane#lookupButton does not return the node which is shown inside the button bar.
This is due DialogPane adding two list change listeners to 'buttons' (#getButtonTypes). They have the wrong order, which will result in the button bar not changing at all and the 'buttonNodes' list will recreate the dialog button(s).
Finally, this will make DialogPane#lookupButton returning the 'wrong' button, which is in fact not used inside the dialog button bar.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263807](https://bugs.openjdk.java.net/browse/JDK-8263807): Button types of a DialogPane are set twice, returns a wrong button


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/432/head:pull/432` \
`$ git checkout pull/432`

Update a local copy of the PR: \
`$ git checkout pull/432` \
`$ git pull https://git.openjdk.java.net/jfx pull/432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 432`

View PR using the GUI difftool: \
`$ git pr show -t 432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/432.diff">https://git.openjdk.java.net/jfx/pull/432.diff</a>

</details>
