### PR TITLE
PoC: Fluent bindings for ObservableValue

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/beans/binding/ObjectBinding.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/binding/ObjectBinding.java
@@ -155,7 +155,10 @@ public abstract class ObjectBinding<T> extends ObjectExpression<T> implements
     public final T get() {
         if (!valid) {
             value = computeValue();
-            valid = true;
+
+            if (allowValidation()) {
+                valid = true;
+            }
         }
         return value;
     }
@@ -180,6 +183,28 @@ public abstract class ObjectBinding<T> extends ObjectExpression<T> implements
     @Override
     public final boolean isValid() {
         return valid;
+    }
+
+    /**
+     * Returns {@code true} when this binding currently has one or more
+     * listeners, otherwise {@code false}.
+     *
+     * @return {@code true} when this binding currently has one or more
+     *     listeners, otherwise {@code false}
+     */
+    protected final boolean isObserved() {
+        return helper != null;
+    }
+
+    /**
+     * Can be overriden in extending classes to prevent a binding from becoming
+     * valid. The default implementation always allows bindings to become valid.
+     *
+     * @return {@code true} if this binding is allowed to become valid, otherwise
+     *     {@code false}
+     */
+    protected boolean allowValidation() {
+        return true;
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/beans/value/Bindings.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/value/Bindings.java
@@ -1,0 +1,35 @@
+package javafx.beans.value;
+
+import java.util.function.Function;
+
+/**
+ * Support class which supplies varies types of bindings.
+ */
+class Bindings {
+
+  public static <T, U> ObservableValue<U> mapping(ObservableValue<T> source, Function<? super T, ? extends U> mapper) {
+    return nullableMapping(source, v -> v == null ? null : mapper.apply(v));
+  }
+
+  public static <T> ObservableValue<T> conditional(ObservableValue<T> source, ObservableValue<Boolean> condition) {
+    return new ConditionalBinding<>(condition, source);
+  }
+
+  public static <T, U> ObservableValue<U> flatMapping(ObservableValue<T> source, Function<? super T, ? extends ObservableValue<? extends U>> mapper) {
+    return new FlatMapBinding<>(source, mapper);
+  }
+
+  public static <T, U> ObservableValue<U> nullableMapping(ObservableValue<T> source, Function<? super T, ? extends U> mapper) {
+    return new LazyObjectBinding<>() {
+      @Override
+      protected Subscription observeInputs() {
+        return source.subscribeInvalidations(() -> invalidate());  // start observing source
+      }
+
+      @Override
+      protected U computeValue() {
+        return mapper.apply(source.getValue());
+      }
+    };
+  }
+}

--- a/modules/javafx.base/src/main/java/javafx/beans/value/ConditionalBinding.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/value/ConditionalBinding.java
@@ -1,0 +1,58 @@
+package javafx.beans.value;
+
+import java.util.Objects;
+
+public class ConditionalBinding<T> extends LazyObjectBinding<T> {
+  private final ObservableValue<Boolean> condition;
+  private final ObservableValue<T> source;
+
+  private Subscription subscription;
+
+  public ConditionalBinding(ObservableValue<Boolean> condition, ObservableValue<T> source) {
+    this.source = Objects.requireNonNull(source);
+    this.condition = Objects.requireNonNull(condition);
+
+    condition.subscribeInvalidations(() -> {
+      invalidate();
+
+      if(!isActive()) {
+        getValue();  // make valid so last value is cached while conditional is false
+      }
+    });
+  }
+
+  @Override
+  protected boolean allowValidation() {
+    // This binding is valid when it is itself observed, or is currently inactive.
+    // When inactive, the binding has the value of its source at the time it became
+    // inactive.
+    return super.allowValidation() || !isActive();
+  }
+
+  @Override
+  protected T computeValue() {
+    unsubscribe();
+
+    if(isObserved() && isActive()) {
+      subscription = source.subscribeInvalidations(this::invalidate);
+    }
+
+    return source.getValue();
+  }
+
+  @Override
+  protected Subscription observeInputs() {
+    return this::unsubscribe;  // condition is always observed and never unsubscribed
+  }
+
+  private boolean isActive() {
+    return Boolean.TRUE.equals(condition.getValue());
+  }
+
+  private void unsubscribe() {
+    if(subscription != null) {
+      subscription.unsubscribe();
+      subscription = null;
+    }
+  }
+}

--- a/modules/javafx.base/src/main/java/javafx/beans/value/FlatMapBinding.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/value/FlatMapBinding.java
@@ -1,0 +1,43 @@
+package javafx.beans.value;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+public class FlatMapBinding<S, T> extends LazyObjectBinding<T> {
+  private final ObservableValue<S> source;
+  private final Function<? super S, ? extends ObservableValue<? extends T>> mapper;
+
+  private Subscription mappedSubscription = Subscription.EMPTY;
+
+  public FlatMapBinding(
+      ObservableValue<S> source,
+      Function<? super S, ? extends ObservableValue<? extends T>> mapper
+  ) {
+    this.source = Objects.requireNonNull(source);
+    this.mapper = Objects.requireNonNull(mapper);
+  }
+
+  @Override
+  protected T computeValue() {
+    S value = source.getValue();
+    ObservableValue<? extends T> mapped = value == null ? null : mapper.apply(value);
+
+    if(isObserved()) {
+      mappedSubscription.unsubscribe();
+      mappedSubscription = mapped == null ? Subscription.EMPTY : mapped.subscribeInvalidations(this::invalidate);
+    }
+
+    return mapped == null ? null : mapped.getValue();
+  }
+
+  @Override
+  protected Subscription observeInputs() {
+    Subscription subscription = source.subscribeInvalidations(this::invalidate);
+
+    return () -> {
+      subscription.unsubscribe();
+      mappedSubscription.unsubscribe();
+      mappedSubscription = Subscription.EMPTY;
+    };
+  }
+}

--- a/modules/javafx.base/src/main/java/javafx/beans/value/LazyObjectBinding.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/value/LazyObjectBinding.java
@@ -1,0 +1,84 @@
+package javafx.beans.value;
+
+import javafx.beans.InvalidationListener;
+import javafx.beans.binding.ObjectBinding;
+
+/**
+ * Extends {@link ObjectBinding} with the ability to lazily register
+ * and eagerly unregister listeners on its dependencies.
+ *
+ * @param <T> the type of the wrapped {@code Object}
+ */
+public abstract class LazyObjectBinding<T> extends ObjectBinding<T> {
+  private Subscription subscription;
+  private boolean wasObserved;
+
+  @Override
+  public void addListener(ChangeListener<? super T> listener) {
+    super.addListener(listener);
+
+    updateSubcription();
+  }
+
+  @Override
+  public void removeListener(ChangeListener<? super T> listener) {
+    super.removeListener(listener);
+
+    updateSubcription();
+  }
+
+  @Override
+  public void addListener(InvalidationListener listener) {
+    super.addListener(listener);
+
+    updateSubcription();
+  }
+
+  @Override
+  public void removeListener(InvalidationListener listener) {
+    super.removeListener(listener);
+
+    updateSubcription();
+  }
+
+  @Override
+  protected boolean allowValidation() {
+    return isObserved();
+  }
+
+  private void updateSubcription() {
+    boolean isObserved = isObserved();
+
+    if(!wasObserved && isObserved) {  // was first observer registered?
+      subscription = observeInputs();  // start observing source
+
+      /*
+       * Although the act of registering a listener already attempts to make
+       * this binding valid, allowValidation won't allow it as the binding is
+       * not observed yet. This is because isObserved will not yet return true
+       * when the process of registering the listener hasn't completed yet.
+       *
+       * As the binding must be valid after it becomes observed the first time
+       * 'get' is called again.
+       */
+
+      get();  // make binding valid as source wasn't tracked until now
+    }
+    else if(wasObserved && !isObserved) {  // was last observer unregistered?
+      subscription.unsubscribe();
+      subscription = null;
+      invalidate();  // make binding invalid as source is no longer tracked
+    }
+
+    wasObserved = isObserved;
+  }
+
+  /**
+   * Called when this binding was previously not observed and a new observer was added. Implementors
+   * must return a {@link Subscription} which will be cancelled when this binding no longer has any
+   * observers.
+   *
+   * @return a {@link Subscription} which will be cancelled when this binding no longer has any observers, never null
+   */
+  protected abstract Subscription observeInputs();
+}

--- a/modules/javafx.base/src/main/java/javafx/beans/value/Subscription.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/value/Subscription.java
@@ -1,0 +1,43 @@
+package javafx.beans.value;
+
+import java.util.Objects;
+
+/**
+ * A subscription encapsulates how to cancel it without having
+ * to keep track of how it was created.<p>
+ *
+ * For example:<p>
+ * <pre>Subscription s = property.subscribe(System.out::println)</pre>
+ * The function passed in to {@code subscribe} does not need to be stored
+ * in order to clean up the subscription later.
+ */
+public interface Subscription {
+
+    /**
+     * An empty subscription. Does nothing when cancelled.
+     */
+    static final Subscription EMPTY = () -> {};
+
+    /**
+     * Cancels this subscription.
+     */
+    void unsubscribe();
+
+    /**
+     * Combines this {@link Subscription} with the given {@code Subscription}
+     * and returns a new {@code Subscription} which will cancel both when
+     * cancelled.
+     *
+     * @param other another {@link Subscription}, cannot be null
+     * @return a combined {@link Subscription} which will cancel both when
+     *   cancelled, never null
+     */
+    default Subscription and(Subscription other) {
+      Objects.requireNonNull(other);
+
+      return () -> {
+        unsubscribe();
+        other.unsubscribe();
+      };
+    }
+}


### PR DESCRIPTION
This is a proof of concept of how fluent bindings could be introduced to JavaFX.  The main benefit of fluent bindings are ease of use, type safety and less surprises.  Features:

**Flexible Mappings**
Map the contents of a property any way you like with `map`, or map nested properties with `flatMap`.

**Lazy**
The bindings created are lazy, which means they are always _invalid_ when not themselves observed. This allows for easier garbage collection (once the last observer is removed, a chain of bindings will stop observing their parents) and less listener management when dealing with nested properties.  Furthermore, this allows inclusion of such bindings in classes such as `Node` without listeners being created when the binding itself is not used (this would allow for the inclusion of a `treeShowingProperty` in `Node` without creating excessive listeners, see this fix I did in an earlier PR: https://github.com/openjdk/jfx/pull/185)

**Null Safe**
The `map` and `flatMap` methods are skipped, similar to `java.util.Optional` when the value they would be mapping is `null`. This makes mapping nested properties with `flatMap` trivial as the `null` case does not need to be taken into account in a chain like this: `node.sceneProperty().flatMap(Scene::windowProperty).flatMap(Window::showingProperty)`.  Instead a default can be provided with `orElse` or `orElseGet`.

**Conditional Bindings**
Bindings can be made conditional using the `conditionOn` method. A conditional binding retains its last value when its condition is `false`. Conditional bindings donot observe their source when the condition is `false`, allowing developers to automatically stop listening to properties when a certain condition is met.  A major use of this feature is to have UI components that need to keep models updated which may outlive the UI conditionally update the long lived model only when the UI is showing.

Some examples:

    void mapProperty() {
      // Standard JavaFX:
      label.textProperty().bind(Bindings.createStringBinding(() -> text.getValueSafe().toUpperCase(), text));

      // Fluent: much more compact, no need to handle null
      label.textProperty().bind(text.map(String::toUpperCase));
    }

    void calculateCharactersLeft() {
      // Standard JavaFX:
      label.textProperty().bind(text.length().negate().add(100).asString().concat(" characters left"));

      // Fluent: slightly more compact and more clear (no negate needed)
      label.textProperty().bind(text.orElse("").map(v -> 100 - v.length() + " characters left"));
    }

    void mapNestedValue() {
      // Standard JavaFX:
      label.textProperty().bind(Bindings.createStringBinding(
        () -> employee.get() == null ? ""
            : employee.get().getCompany() == null ? ""
            : employee.get().getCompany().getName(),
        employee
      ));

      // Fluent: no need to handle nulls everywhere
      label.textProperty().bind(
        employee.map(Employee::getCompany)
                .map(Company::getName)
                .orElse("")
      );
    }

    void mapNestedProperty() {
      // Standard JavaFX:
      label.textProperty().bind(
        Bindings.when(Bindings.selectBoolean(label.sceneProperty(), "window", "showing"))
          .then("Visible")
          .otherwise("Not Visible")
      );

      // Fluent: type safe
      label.textProperty().bind(label.sceneProperty()
        .flatMap(Scene::windowProperty)
        .flatMap(Window::showingProperty)
        .orElse(false)
        .map(showing -> showing ? "Visible" : "Not Visible")
      );
    }

    void updateLongLivedModelWhileAvoidingMemoryLeaks() {
      // Standard JavaFX: naive, memory leak; UI won't get garbage collected
      listView.getSelectionModel().selectedItemProperty().addListener(
        (obs, old, current) -> longLivedModel.lastSelectedProperty().set(current)
      );

      // Standard JavaFX: no leak, but stops updating after a while
      listView.getSelectionModel().selectedItemProperty().addListener(
        new WeakChangeListener<>(
          (obs, old, current) -> longLivedModel.lastSelectedProperty().set(current)
        )
      );

      // Standard JavaFX: fixed version
      listenerReference = (obs, old, current) -> longLivedModel.lastSelectedProperty().set(current);

      listView.getSelectionModel().selectedItemProperty().addListener(
        new WeakChangeListener<>(listenerReference)
      );

      // Fluent: naive, memory leak... fluent won't solve this...
      listView.getSelectionModel().selectedItemProperty()
          .subscribe(longLivedModel.lastSelectedProperty()::set);

      // Fluent: conditional update when control visible

      // Create a property which is only true when the UI is visible:
      ObservableValue<Boolean> showing = listView.sceneProperty()
          .flatMap(Scene::windowProperty)
          .flatMap(Window::showingProperty)
          .orElse(false);

      // Use showing property to automatically disconnect long lived model
      // allowing garbage collection of the UI:
      listView.getSelectionModel().selectedItemProperty()
        .conditionOn(showing)
        .subscribe(longLivedModel.lastSelectedProperty()::set);

      // Note that the 'showing' property can be provided in multiple ways:
      // - create manually (can be re-used for multiple bindings though)
      // - create with a helper: Nodes.showing(Node node) -> ObservableValue<Boolean>
      // - make it part of the Node class; as the fluent bindings only bind themselves
      //   to their source when needed (lazy binding), this won't create overhead
      //   for each node in the scene
    }

Note that this is based on ideas in ReactFX and my own experiments in https://github.com/hjohn/hs.jfx.eventstream.  I've come to the conclusion that this is much better directly integrated into JavaFX, and I'm hoping this proof of concept will be able to move such an effort forward.

I've created tests for this as well, but they're written in JUnit 5, which I noticed is not yet part of OpenJFX.  A screenshot:

![image](https://user-images.githubusercontent.com/995917/111858133-d6ce0f80-8936-11eb-9724-be2c15150590.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jfx pull/434/head:pull/434`
`$ git checkout pull/434`

To update a local copy of the PR:
`$ git checkout pull/434`
`$ git pull https://git.openjdk.java.net/jfx pull/434/head`
