### PR TITLE
JDK-8258381 : [macos] Exception when input emoji using Chinese input method

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
@@ -1119,7 +1119,8 @@ static jstring convertNSStringToJString(id aString, int length)
             free(dataBytes);
         }
     } else {
-        jStr = (*env)->NewStringUTF(env, [aString UTF8String]);
+        NSData *data = [aString dataUsingEncoding:NSUTF16LittleEndianStringEncoding];
+        jStr = (*env)->NewString(env, (jchar *)[data bytes], data.length/2);
     }
 
     GLASS_CHECK_EXCEPTION(env);


### PR DESCRIPTION
The convertNSStringToJString function convert NSString to Java String using NewStringUTF，NewStringUTF accept modified-UTF8 encoded str。This fix using UTF-16 encoding for converting.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258381](https://bugs.openjdk.java.net/browse/JDK-8258381): [macos] Exception when input emoji using Chinese input method


### Reviewers
 * [Jose Pereda](https://openjdk.java.net/census#jpereda) (@jperedadnr - Committer)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/436/head:pull/436` \
`$ git checkout pull/436`

Update a local copy of the PR: \
`$ git checkout pull/436` \
`$ git pull https://git.openjdk.java.net/jfx pull/436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 436`

View PR using the GUI difftool: \
`$ git pr show -t 436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/436.diff">https://git.openjdk.java.net/jfx/pull/436.diff</a>

</details>
