### PR TITLE
8264061: LocalDateTimeStringConverterTest fails in Canada

### DIFF
--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
@@ -57,13 +57,10 @@ public class LocalDateTimeStringConverterTest {
     private static final DateTimeFormatter aFormatter = DateTimeFormatter.ofPattern("dd MM yyyy HH mm ss");
     private static final DateTimeFormatter aParser = DateTimeFormatter.ofPattern("yyyy MM dd hh mm ss a");
 
-    @BeforeClass
-    public static void initDefaultLocale() {
+    @Parameterized.Parameters public static Collection implementations() {
         // Tests require that default locale is en_US
         Locale.setDefault(Locale.US);
-    }
 
-    @Parameterized.Parameters public static Collection implementations() {
         return Arrays.asList(new Object[][] {
             { new LocalDateTimeStringConverter(),
               Locale.getDefault(Locale.Category.FORMAT), FormatStyle.SHORT, FormatStyle.SHORT,


### PR DESCRIPTION
As the comment in the test case mentions, "Tests require that default locale is en_US." The default locale is required by the objects created in the static method `implementations`, marked with the JUnit annotation `@Parameterized.Parameters`. So the static method `initDefaultLocale`, marked with the JUnit annotation `@BeforeClass`, calls the method to set the required default:  `Locale.setDefault(Locale.US)`.

The problem occurs because the `@Parameterized.Parameters` method is called before the `@BeforeClass` method, so the system locale is used as the default instead of `Locale.US`.

The fix is to move the call to the first instruction of the `@Parameterized.Parameters` method so that the default is set before it's required.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264061](https://bugs.openjdk.java.net/browse/JDK-8264061): LocalDateTimeStringConverterTest fails in Canada


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jfx pull/438/head:pull/438`
`$ git checkout pull/438`

To update a local copy of the PR:
`$ git checkout pull/438`
`$ git pull https://git.openjdk.java.net/jfx pull/438/head`
