### PR TITLE
8264064: Cross compile JavaFX graphics and controls modules for Windows AArch64 (ARM64)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2202,7 +2202,9 @@ project(":graphics") {
     addNative(project, "prismSW")
     addNative(project, "font")
     addNative(project, "iio")
-    addNative(project, "prismES2")
+    if (IS_INCLUDE_ES2) {
+        addNative(project, "prismES2")
+    }
 
     if (IS_COMPILE_PANGO) {
         addNative(project, "fontFreetype")

--- a/build.gradle
+++ b/build.gradle
@@ -250,6 +250,20 @@ void fail(String msg) {
     throw new GradleException("FAIL: " + msg);
 }
 
+/**
+ * Converts the given OS architecture to unified form
+ *
+ * @param arch OS architecture
+ * @return unified OS architecture which is used for JavaFX building
+ */
+String getConvertedOsArch(String arch) {
+    switch (arch) {
+        case "aarch64" : return "arm64"
+        case "amd64" : return "x64"
+        default: return arch
+    }
+}
+
 /******************************************************************************
  *                                                                            *
  *                   Definition of project properties                         *
@@ -291,6 +305,7 @@ ext.MODULESOURCEPATH = "modulesourcepath.args"
 // this build running on a Mac, Windows, or Linux machine? 32 or 64 bit?
 ext.OS_NAME = System.getProperty("os.name").toLowerCase()
 ext.OS_ARCH = System.getProperty("os.arch")
+ext.CONVERTED_OS_ARCH = getConvertedOsArch(OS_ARCH)
 ext.IS_64 = OS_ARCH.toLowerCase().contains("64")
 ext.IS_MAC = OS_NAME.contains("mac") || OS_NAME.contains("darwin")
 ext.IS_WINDOWS = OS_NAME.contains("windows")
@@ -405,6 +420,7 @@ if (IS_STATIC_BUILD && IS_COMPILE_MEDIA) {
 
 // By default, target architecture = host architecture, but we allow different ones.
 defineProperty("TARGET_ARCH", OS_ARCH)
+ext.CONVERTED_TARGET_ARCH = getConvertedOsArch(TARGET_ARCH)
 
 // BUILD_TOOLS_DOWNLOAD_SCRIPT specifies a path of a gradle script which downloads
 // required build tools.
@@ -1307,6 +1323,9 @@ ext.UPDATE_STUB_CACHE = (BUILD_CLOSED && STUB_RUNTIME != "" && !file(STUB_RUNTIM
 logger.quiet("gradle.gradleVersion: $gradle.gradleVersion")
 logger.quiet("OS_NAME: $OS_NAME")
 logger.quiet("OS_ARCH: $OS_ARCH")
+logger.quiet("TARGET_ARCH: $TARGET_ARCH")
+logger.quiet("CONVERTED_OS_ARCH: $CONVERTED_OS_ARCH")
+logger.quiet("CONVERTED_TARGET_ARCH: $CONVERTED_TARGET_ARCH")
 logger.quiet("JAVA_HOME: $JAVA_HOME")
 logger.quiet("JDK_HOME: $JDK_HOME")
 logger.quiet("java.runtime.version: ${javaRuntimeVersion}")

--- a/build.gradle
+++ b/build.gradle
@@ -250,20 +250,6 @@ void fail(String msg) {
     throw new GradleException("FAIL: " + msg);
 }
 
-/**
- * Converts the given OS architecture to unified form
- *
- * @param arch OS architecture
- * @return unified OS architecture which is used for JavaFX building
- */
-String getConvertedOsArch(String arch) {
-    switch (arch) {
-        case "aarch64" : return "arm64"
-        case "amd64" : return "x64"
-        default: return arch
-    }
-}
-
 /******************************************************************************
  *                                                                            *
  *                   Definition of project properties                         *
@@ -305,7 +291,6 @@ ext.MODULESOURCEPATH = "modulesourcepath.args"
 // this build running on a Mac, Windows, or Linux machine? 32 or 64 bit?
 ext.OS_NAME = System.getProperty("os.name").toLowerCase()
 ext.OS_ARCH = System.getProperty("os.arch")
-ext.CONVERTED_OS_ARCH = getConvertedOsArch(OS_ARCH)
 ext.IS_64 = OS_ARCH.toLowerCase().contains("64")
 ext.IS_MAC = OS_NAME.contains("mac") || OS_NAME.contains("darwin")
 ext.IS_WINDOWS = OS_NAME.contains("windows")
@@ -420,7 +405,6 @@ if (IS_STATIC_BUILD && IS_COMPILE_MEDIA) {
 
 // By default, target architecture = host architecture, but we allow different ones.
 defineProperty("TARGET_ARCH", OS_ARCH)
-ext.CONVERTED_TARGET_ARCH = getConvertedOsArch(TARGET_ARCH)
 
 // BUILD_TOOLS_DOWNLOAD_SCRIPT specifies a path of a gradle script which downloads
 // required build tools.
@@ -1323,9 +1307,6 @@ ext.UPDATE_STUB_CACHE = (BUILD_CLOSED && STUB_RUNTIME != "" && !file(STUB_RUNTIM
 logger.quiet("gradle.gradleVersion: $gradle.gradleVersion")
 logger.quiet("OS_NAME: $OS_NAME")
 logger.quiet("OS_ARCH: $OS_ARCH")
-logger.quiet("TARGET_ARCH: $TARGET_ARCH")
-logger.quiet("CONVERTED_OS_ARCH: $CONVERTED_OS_ARCH")
-logger.quiet("CONVERTED_TARGET_ARCH: $CONVERTED_TARGET_ARCH")
 logger.quiet("JAVA_HOME: $JAVA_HOME")
 logger.quiet("JDK_HOME: $JDK_HOME")
 logger.quiet("java.runtime.version: ${javaRuntimeVersion}")

--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -41,6 +41,10 @@ WIN.modLibDest = "lib"
 
 def CPU_BITS = IS_64 ? "x64" : "x86"
 
+def HOST_ARCH = getWinArch(ext.OS_ARCH)
+def TARGET_ARCH = getWinArch(ext.TARGET_ARCH)
+def IS_CROSS = HOST_ARCH != TARGET_ARCH
+
 setupTools("windows_tools",
     { propFile ->
         if (project.hasProperty('setupWinTools')) {
@@ -53,8 +57,8 @@ setupTools("windows_tools",
                 environment([
                         "WINSDKPATH" : winsdkDir == null ? "" : winsdkDir,
                         "CONF"       : "/$CONF", // TODO does this mean the generated properties must be reset when in a different configuration?
-                        "VCARCH"     : IS_64 ? "amd64" : "x86",
-                        "SDKARCH"    : IS_64 ? "/x64" : "/x86",
+                        "VCARCH"     : IS_CROSS ? "${HOST_ARCH}_${TARGET_ARCH}" : TARGET_ARCH,
+                        "SDKARCH"    : "/$TARGET_ARCH",
                 ]);
                 commandLine("cmd", "/q", "/c", "buildSrc\\genVSproperties.bat");
                 setStandardOutput(results);
@@ -147,7 +151,7 @@ ext.WINDOWS_NATIVE_COMPILE_ENVIRONMENT = [
 def msvcVer = System.getenv("MSVC_VER")
 def msvcBinDir = ""
 if (hasProperty('toolchainDir')) {
-    msvcBinDir = "$WINDOWS_VS_VSINSTALLDIR/VC/bin/$CPU_BITS"
+    msvcBinDir = "$WINDOWS_VS_VSINSTALLDIR/VC/bin/$TARGET_ARCH"
 } else if (winVsVer == 150) {
     def msvcInstallDir = ""
     if (msvcVer) {
@@ -155,7 +159,7 @@ if (hasProperty('toolchainDir')) {
     } else {
         msvcInstallDir = "$WINDOWS_VS_VC_TOOLS_INSTALL_DIR"
     }
-    msvcBinDir = "$msvcInstallDir/bin/Host${CPU_BITS}/$CPU_BITS"
+    msvcBinDir = "$msvcInstallDir/bin/Host${CPU_BITS}/$TARGET_ARCH"
 } else if (winVsVer <= 120) {
     msvcBinDir = (IS_64
                       ? "$WINDOWS_VS_VSINSTALLDIR/VC/BIN/amd64"
@@ -165,17 +169,20 @@ def compiler = IS_COMPILE_PARFAIT ? "cl.exe" : cygpath("$msvcBinDir/cl.exe")
 def linker = IS_STATIC_BUILD ? (IS_COMPILE_PARFAIT ? "lib.exe" : cygpath("$msvcBinDir/lib.exe")) : (IS_COMPILE_PARFAIT ? "link.exe" : cygpath("$msvcBinDir/link.exe"))
 def winSdkBinDir = "$WINDOWS_SDK_DIR/Bin"
 if (WINDOWS_VS_VER != "100") {
-    winSdkBinDir += "/$CPU_BITS"
+    winSdkBinDir += "/$TARGET_ARCH"
 }
 
 if (!file(cygpath("$winSdkBinDir/RC.Exe")).exists()) {
     winSdkBinDir = "$WINDOWS_SDK_DIR/Bin/$WINDOWS_SDK_VERSION"
     if (WINDOWS_VS_VER != "100") {
-        winSdkBinDir += "/$CPU_BITS"
+        winSdkBinDir += "/$TARGET_ARCH"
     }
 }
 
 ext.RC = cygpath("$winSdkBinDir/rc.exe")
+// Use rc from host system if it is not possible to run it from target system
+def hostWinSdkBinDir = "$WINDOWS_SDK_DIR/Bin/$WINDOWS_SDK_VERSION/$HOST_ARCH"
+ext.RC = !isExecutable(RC) ? cygpath("$hostWinSdkBinDir/rc.exe") : RC
 def rcCompiler = RC
 ext.FXC = cygpath("$winSdkBinDir/fxc.exe")
 
@@ -186,6 +193,9 @@ if (!file(FXC).exists()) {
     ext.FXC = cygpath("$WINDOWS_DXSDK_DIR/utilities/bin/x86/fxc.exe")
 }
 
+// Use fxc from host system if it is not possible to run it from target system
+ext.FXC = !isExecutable(FXC) ? cygpath("$hostWinSdkBinDir/fxc.exe") : FXC
+
 ext.MC = cygpath("$winSdkBinDir/mt.exe")
 
 if (!file(RC).exists()) throw new GradleException("FAIL: cannot find RC: " + RC)
@@ -193,17 +203,17 @@ if (!file(FXC).exists()) throw new GradleException("FAIL: cannot find FXC: " + F
 
 def msvcRedstDir
 if (hasProperty('toolchainDir')) {
-    msvcRedstDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Redist/$CPU_BITS"
+    msvcRedstDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Redist/$TARGET_ARCH"
 } else {
     def msvcRedistVer = System.getenv("MSVC_REDIST_VER")
     if (msvcRedistVer) {
-        msvcRedstDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Redist/MSVC/$msvcRedistVer/$CPU_BITS"
+        msvcRedstDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Redist/MSVC/$msvcRedistVer/$TARGET_ARCH"
     } else {
-        msvcRedstDir = "$WINDOWS_VS_VC_TOOLS_REDIST_DIR/$CPU_BITS"
+        msvcRedstDir = "$WINDOWS_VS_VC_TOOLS_REDIST_DIR/$TARGET_ARCH"
     }
 }
 
-def winSdkDllDir = "$WINDOWS_VS_WINSDKDLLINSTALLDIR/$CPU_BITS"
+def winSdkDllDir = "$WINDOWS_VS_WINSDKDLLINSTALLDIR/$TARGET_ARCH"
 
 def WINDOWS_DLL_VER = WINDOWS_VS_VER
 
@@ -452,3 +462,20 @@ WIN.webkit.linker = linker
 WIN.webkit.rcCompiler = rcCompiler
 WIN.webkit.rcSource = defaultRcSource
 WIN.webkit.rcFlags = ["/d", "JFX_FNAME=jfxwebkit.dll", "/d", "JFX_INTERNAL_NAME=webkit", rcFlags].flatten();
+
+String getWinArch(String arch) {
+    switch (arch) {
+        case "aarch64" : return "arm64"
+        case "amd64" : return "x64"
+        default: return arch
+    }
+}
+
+boolean isExecutable(String file) {
+    try {
+        Runtime.runtime.exec(file)
+        return true
+    } catch (IOException e) {
+        return false
+    }
+}

--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -41,9 +41,8 @@ WIN.modLibDest = "lib"
 
 def CPU_BITS = IS_64 ? "x64" : "x86"
 
-def HOST_ARCH = getWinArch(ext.OS_ARCH)
-def TARGET_ARCH = getWinArch(ext.TARGET_ARCH)
-def IS_CROSS = HOST_ARCH != TARGET_ARCH
+def IS_CROSS = CONVERTED_OS_ARCH != CONVERTED_TARGET_ARCH
+def VC_ARCH = IS_CROSS ? "${CONVERTED_OS_ARCH}_${CONVERTED_TARGET_ARCH}" : CONVERTED_TARGET_ARCH
 
 setupTools("windows_tools",
     { propFile ->
@@ -57,8 +56,8 @@ setupTools("windows_tools",
                 environment([
                         "WINSDKPATH" : winsdkDir == null ? "" : winsdkDir,
                         "CONF"       : "/$CONF", // TODO does this mean the generated properties must be reset when in a different configuration?
-                        "VCARCH"     : IS_CROSS ? "${HOST_ARCH}_${TARGET_ARCH}" : TARGET_ARCH,
-                        "SDKARCH"    : "/$TARGET_ARCH",
+                        "VCARCH"     : VC_ARCH,
+                        "SDKARCH"    : "/$CONVERTED_TARGET_ARCH",
                 ]);
                 commandLine("cmd", "/q", "/c", "buildSrc\\genVSproperties.bat");
                 setStandardOutput(results);
@@ -151,7 +150,7 @@ ext.WINDOWS_NATIVE_COMPILE_ENVIRONMENT = [
 def msvcVer = System.getenv("MSVC_VER")
 def msvcBinDir = ""
 if (hasProperty('toolchainDir')) {
-    msvcBinDir = "$WINDOWS_VS_VSINSTALLDIR/VC/bin/$TARGET_ARCH"
+    msvcBinDir = "$WINDOWS_VS_VSINSTALLDIR/VC/bin/$CONVERTED_TARGET_ARCH"
 } else if (winVsVer == 150) {
     def msvcInstallDir = ""
     if (msvcVer) {
@@ -159,7 +158,7 @@ if (hasProperty('toolchainDir')) {
     } else {
         msvcInstallDir = "$WINDOWS_VS_VC_TOOLS_INSTALL_DIR"
     }
-    msvcBinDir = "$msvcInstallDir/bin/Host${CPU_BITS}/$TARGET_ARCH"
+    msvcBinDir = "$msvcInstallDir/bin/Host${CPU_BITS}/$CONVERTED_TARGET_ARCH"
 } else if (winVsVer <= 120) {
     msvcBinDir = (IS_64
                       ? "$WINDOWS_VS_VSINSTALLDIR/VC/BIN/amd64"
@@ -169,19 +168,19 @@ def compiler = IS_COMPILE_PARFAIT ? "cl.exe" : cygpath("$msvcBinDir/cl.exe")
 def linker = IS_STATIC_BUILD ? (IS_COMPILE_PARFAIT ? "lib.exe" : cygpath("$msvcBinDir/lib.exe")) : (IS_COMPILE_PARFAIT ? "link.exe" : cygpath("$msvcBinDir/link.exe"))
 def winSdkBinDir = "$WINDOWS_SDK_DIR/Bin"
 if (WINDOWS_VS_VER != "100") {
-    winSdkBinDir += "/$TARGET_ARCH"
+    winSdkBinDir += "/$CONVERTED_TARGET_ARCH"
 }
 
 if (!file(cygpath("$winSdkBinDir/RC.Exe")).exists()) {
     winSdkBinDir = "$WINDOWS_SDK_DIR/Bin/$WINDOWS_SDK_VERSION"
     if (WINDOWS_VS_VER != "100") {
-        winSdkBinDir += "/$TARGET_ARCH"
+        winSdkBinDir += "/$CONVERTED_TARGET_ARCH"
     }
 }
 
 ext.RC = cygpath("$winSdkBinDir/rc.exe")
 // Use rc from host system if it is not possible to run it from target system
-def hostWinSdkBinDir = "$WINDOWS_SDK_DIR/Bin/$WINDOWS_SDK_VERSION/$HOST_ARCH"
+def hostWinSdkBinDir = "$WINDOWS_SDK_DIR/Bin/$WINDOWS_SDK_VERSION/$CONVERTED_OS_ARCH"
 ext.RC = !isExecutable(RC) ? cygpath("$hostWinSdkBinDir/rc.exe") : RC
 def rcCompiler = RC
 ext.FXC = cygpath("$winSdkBinDir/fxc.exe")
@@ -201,17 +200,17 @@ if (!file(FXC).exists()) throw new GradleException("FAIL: cannot find FXC: " + F
 
 def msvcRedstDir
 if (hasProperty('toolchainDir')) {
-    msvcRedstDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Redist/$TARGET_ARCH"
+    msvcRedstDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Redist/$CONVERTED_TARGET_ARCH"
 } else {
     def msvcRedistVer = System.getenv("MSVC_REDIST_VER")
     if (msvcRedistVer) {
-        msvcRedstDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Redist/MSVC/$msvcRedistVer/$TARGET_ARCH"
+        msvcRedstDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Redist/MSVC/$msvcRedistVer/$CONVERTED_TARGET_ARCH"
     } else {
-        msvcRedstDir = "$WINDOWS_VS_VC_TOOLS_REDIST_DIR/$TARGET_ARCH"
+        msvcRedstDir = "$WINDOWS_VS_VC_TOOLS_REDIST_DIR/$CONVERTED_TARGET_ARCH"
     }
 }
 
-def winSdkDllDir = "$WINDOWS_VS_WINSDKDLLINSTALLDIR/$TARGET_ARCH"
+def winSdkDllDir = "$WINDOWS_VS_WINSDKDLLINSTALLDIR/$CONVERTED_TARGET_ARCH"
 
 def WINDOWS_DLL_VER = WINDOWS_VS_VER
 
@@ -460,14 +459,6 @@ WIN.webkit.linker = linker
 WIN.webkit.rcCompiler = rcCompiler
 WIN.webkit.rcSource = defaultRcSource
 WIN.webkit.rcFlags = ["/d", "JFX_FNAME=jfxwebkit.dll", "/d", "JFX_INTERNAL_NAME=webkit", rcFlags].flatten();
-
-String getWinArch(String arch) {
-    switch (arch) {
-        case "aarch64" : return "arm64"
-        case "amd64" : return "x64"
-        default: return arch
-    }
-}
 
 boolean isExecutable(String file) {
     try {

--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -41,8 +41,9 @@ WIN.modLibDest = "lib"
 
 def CPU_BITS = IS_64 ? "x64" : "x86"
 
-def IS_CROSS = CONVERTED_OS_ARCH != CONVERTED_TARGET_ARCH
-def VC_ARCH = IS_CROSS ? "${CONVERTED_OS_ARCH}_${CONVERTED_TARGET_ARCH}" : CONVERTED_TARGET_ARCH
+def HOST_ARCH = getWinArch(ext.OS_ARCH)
+def TARGET_ARCH = getWinArch(ext.TARGET_ARCH)
+def IS_CROSS = HOST_ARCH != TARGET_ARCH
 
 setupTools("windows_tools",
     { propFile ->
@@ -56,8 +57,8 @@ setupTools("windows_tools",
                 environment([
                         "WINSDKPATH" : winsdkDir == null ? "" : winsdkDir,
                         "CONF"       : "/$CONF", // TODO does this mean the generated properties must be reset when in a different configuration?
-                        "VCARCH"     : VC_ARCH,
-                        "SDKARCH"    : "/$CONVERTED_TARGET_ARCH",
+                        "VCARCH"     : IS_CROSS ? "${HOST_ARCH}_${TARGET_ARCH}" : TARGET_ARCH,
+                        "SDKARCH"    : "/$TARGET_ARCH",
                 ]);
                 commandLine("cmd", "/q", "/c", "buildSrc\\genVSproperties.bat");
                 setStandardOutput(results);
@@ -150,7 +151,7 @@ ext.WINDOWS_NATIVE_COMPILE_ENVIRONMENT = [
 def msvcVer = System.getenv("MSVC_VER")
 def msvcBinDir = ""
 if (hasProperty('toolchainDir')) {
-    msvcBinDir = "$WINDOWS_VS_VSINSTALLDIR/VC/bin/$CONVERTED_TARGET_ARCH"
+    msvcBinDir = "$WINDOWS_VS_VSINSTALLDIR/VC/bin/$TARGET_ARCH"
 } else if (winVsVer == 150) {
     def msvcInstallDir = ""
     if (msvcVer) {
@@ -158,7 +159,7 @@ if (hasProperty('toolchainDir')) {
     } else {
         msvcInstallDir = "$WINDOWS_VS_VC_TOOLS_INSTALL_DIR"
     }
-    msvcBinDir = "$msvcInstallDir/bin/Host${CPU_BITS}/$CONVERTED_TARGET_ARCH"
+    msvcBinDir = "$msvcInstallDir/bin/Host${CPU_BITS}/$TARGET_ARCH"
 } else if (winVsVer <= 120) {
     msvcBinDir = (IS_64
                       ? "$WINDOWS_VS_VSINSTALLDIR/VC/BIN/amd64"
@@ -168,19 +169,19 @@ def compiler = IS_COMPILE_PARFAIT ? "cl.exe" : cygpath("$msvcBinDir/cl.exe")
 def linker = IS_STATIC_BUILD ? (IS_COMPILE_PARFAIT ? "lib.exe" : cygpath("$msvcBinDir/lib.exe")) : (IS_COMPILE_PARFAIT ? "link.exe" : cygpath("$msvcBinDir/link.exe"))
 def winSdkBinDir = "$WINDOWS_SDK_DIR/Bin"
 if (WINDOWS_VS_VER != "100") {
-    winSdkBinDir += "/$CONVERTED_TARGET_ARCH"
+    winSdkBinDir += "/$TARGET_ARCH"
 }
 
 if (!file(cygpath("$winSdkBinDir/RC.Exe")).exists()) {
     winSdkBinDir = "$WINDOWS_SDK_DIR/Bin/$WINDOWS_SDK_VERSION"
     if (WINDOWS_VS_VER != "100") {
-        winSdkBinDir += "/$CONVERTED_TARGET_ARCH"
+        winSdkBinDir += "/$TARGET_ARCH"
     }
 }
 
 ext.RC = cygpath("$winSdkBinDir/rc.exe")
 // Use rc from host system if it is not possible to run it from target system
-def hostWinSdkBinDir = "$WINDOWS_SDK_DIR/Bin/$WINDOWS_SDK_VERSION/$CONVERTED_OS_ARCH"
+def hostWinSdkBinDir = "$WINDOWS_SDK_DIR/Bin/$WINDOWS_SDK_VERSION/$HOST_ARCH"
 ext.RC = !isExecutable(RC) ? cygpath("$hostWinSdkBinDir/rc.exe") : RC
 def rcCompiler = RC
 ext.FXC = cygpath("$winSdkBinDir/fxc.exe")
@@ -200,17 +201,17 @@ if (!file(FXC).exists()) throw new GradleException("FAIL: cannot find FXC: " + F
 
 def msvcRedstDir
 if (hasProperty('toolchainDir')) {
-    msvcRedstDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Redist/$CONVERTED_TARGET_ARCH"
+    msvcRedstDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Redist/$TARGET_ARCH"
 } else {
     def msvcRedistVer = System.getenv("MSVC_REDIST_VER")
     if (msvcRedistVer) {
-        msvcRedstDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Redist/MSVC/$msvcRedistVer/$CONVERTED_TARGET_ARCH"
+        msvcRedstDir = "$WINDOWS_VS_VSINSTALLDIR/VC/Redist/MSVC/$msvcRedistVer/$TARGET_ARCH"
     } else {
-        msvcRedstDir = "$WINDOWS_VS_VC_TOOLS_REDIST_DIR/$CONVERTED_TARGET_ARCH"
+        msvcRedstDir = "$WINDOWS_VS_VC_TOOLS_REDIST_DIR/$TARGET_ARCH"
     }
 }
 
-def winSdkDllDir = "$WINDOWS_VS_WINSDKDLLINSTALLDIR/$CONVERTED_TARGET_ARCH"
+def winSdkDllDir = "$WINDOWS_VS_WINSDKDLLINSTALLDIR/$TARGET_ARCH"
 
 def WINDOWS_DLL_VER = WINDOWS_VS_VER
 
@@ -459,6 +460,14 @@ WIN.webkit.linker = linker
 WIN.webkit.rcCompiler = rcCompiler
 WIN.webkit.rcSource = defaultRcSource
 WIN.webkit.rcFlags = ["/d", "JFX_FNAME=jfxwebkit.dll", "/d", "JFX_INTERNAL_NAME=webkit", rcFlags].flatten();
+
+String getWinArch(String arch) {
+    switch (arch) {
+        case "aarch64" : return "arm64"
+        case "amd64" : return "x64"
+        default: return arch
+    }
+}
 
 boolean isExecutable(String file) {
     try {

--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -196,8 +196,6 @@ if (!file(FXC).exists()) {
 // Use fxc from host system if it is not possible to run it from target system
 ext.FXC = !isExecutable(FXC) ? cygpath("$hostWinSdkBinDir/fxc.exe") : FXC
 
-ext.MC = cygpath("$winSdkBinDir/mt.exe")
-
 if (!file(RC).exists()) throw new GradleException("FAIL: cannot find RC: " + RC)
 if (!file(FXC).exists()) throw new GradleException("FAIL: cannot find FXC: " + FXC)
 


### PR DESCRIPTION
This is a proposal for cross compiling JavaFX base modules (excluding media and webkit) for Windows AArch64 (ARM64).

Main changes:
- prismES2 native compilation is moved under IS_INCLUDE_ES2 condition
- HOST_ARCH and TARGET_ARCH are retrieved from  ext.OS_ARCH and ext.TARGET_ARCH using substitution aarch64 to arm64 and amd64 to x64
- VCARCH is set to  "${HOST_ARCH}_${TARGET_ARCH}" architecture for cross compilation. VCARCH is set to x64 for amd64 target architecture (according to the [vcvarsall.bat doc](https://docs.microsoft.com/en-us/cpp/build/building-on-the-command-line?view=msvc-160#developer_command_file_locations) x64 and amd64 are interchangeable)
- arm64 rc.exe and fxc.exe execution fails on non arm64 host. The fix checks that and falls back to host rc.exe and fxc.exe. The right way would be to use rc.exe and fxc.exe from arm64 but I did not find a right way to run them on host system.

I also looked which changes are required to build media module for Windows aarch64.
The main changes could be using:
- `ARCH=arm64` for building media libs in build.gradle file
- `-MACHINE:arm64` LDFLAGS in media make files
- `msvc_build/aarch64/aarch64_include` header files for include, `src/aarch64/win64_armasm.S` for ASM_SOURCES, `armasm64.exe` for ML in gstreamer/projects/win/glib-lite/Makefile.glib file and corresponding include in gstreamer/projects/win/glib-lite/Makefile.gobject file
- setting `ENABLE_SIMD_SSE2` to 0 in ColorConverter.c in the similar way how it is done for Apple Silicon port

In this way the media is build but it is crashed when I run a JavaFX sample with video.
Is it possible to send the media Windows aarch64 port to review and investigate the crash in the separate fix?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264064](https://bugs.openjdk.java.net/browse/JDK-8264064): Cross compile JavaFX graphics and controls modules for Windows AArch64 (ARM64)


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/439/head:pull/439` \
`$ git checkout pull/439`

Update a local copy of the PR: \
`$ git checkout pull/439` \
`$ git pull https://git.openjdk.java.net/jfx pull/439/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 439`

View PR using the GUI difftool: \
`$ git pr show -t 439`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/439.diff">https://git.openjdk.java.net/jfx/pull/439.diff</a>

</details>
