### PR TITLE
8264127: ListCell editing status is true, when index changes while editing

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -540,11 +540,11 @@ public class ListCell<T> extends IndexedCell<T> {
         final ListView<T> list = getListView();
         final int editIndex = list == null ? -1 : list.getEditingIndex();
         final boolean editing = isEditing();
-        final boolean match = list != null && index != -1 && index == editIndex;
+        final boolean match = (list != null) && (index != -1) && (index == editIndex);
 
-        if (match && ! editing) {
+        if (match && !editing) {
             startEdit();
-        } else if (! match && editing) {
+        } else if (!match && editing) {
             // If my index is not the one being edited then I need to cancel
             // the edit. The tricky thing here is that as part of this call
             // I cannot end up calling list.edit(-1) the way that the standard

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -326,7 +326,6 @@ public class ListCell<T> extends IndexedCell<T> {
         super.indexChanged(oldIndex, newIndex);
 
         if (isEditing() && newIndex == oldIndex) {
-            updateEditing();
             // no-op
             // Fix for RT-31165 - if we (needlessly) update the index whilst the
             // cell is being edited it will no longer be in an editing state.
@@ -337,9 +336,9 @@ public class ListCell<T> extends IndexedCell<T> {
         } else {
             updateItem(oldIndex);
             updateSelection();
-            updateEditing();
             updateFocus();
         }
+        updateEditing();
     }
 
     /** {@inheritDoc} */

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -189,7 +189,6 @@ public class ListCell<T> extends IndexedCell<T> {
             if (items != null) {
                 items.addListener(weakItemsListener);
             }
-            System.out.println("Update item 333");
             updateItem(-1);
         }
     };
@@ -356,7 +355,6 @@ public class ListCell<T> extends IndexedCell<T> {
 
     /** {@inheritDoc} */
     @Override public void startEdit() {
-        System.out.println("Start edit called!");
         final ListView<T> list = getListView();
         if (!isEditable() || (list != null && ! list.isEditable())) {
             return;
@@ -365,7 +363,6 @@ public class ListCell<T> extends IndexedCell<T> {
         // it makes sense to get the cell into its editing state before firing
         // the event to the ListView below, so that's what we're doing here
         // by calling super.startEdit().
-        System.out.println("super.Start edit called!");
         super.startEdit();
 
          // Inform the ListView of the edit starting.
@@ -534,9 +531,7 @@ public class ListCell<T> extends IndexedCell<T> {
             setFocused(false);
             return;
         }
-
-        System.out.println("calling setFocused (" + fm.isFocused(index) + ")");
-        System.out.println("fm.getFocusedIndex " + fm.getFocusedIndex());
+        
         setFocused(fm.isFocused(index));
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -549,9 +549,13 @@ public class ListCell<T> extends IndexedCell<T> {
             // cancelEdit method would do. Yet, I need to call cancelEdit
             // so that subclasses which override cancelEdit can execute. So,
             // I have to use a kind of hacky flag workaround.
-            updateEditingIndex = false;
-            cancelEdit();
-            updateEditingIndex = true;
+            try {
+                // try-finally to make certain that the flag is reliably reset to true
+                updateEditingIndex = false;
+                cancelEdit();
+            } finally {
+                updateEditingIndex = true;
+            }
         }
         if(!editing && list != null && index != -1 && index == editIndex) {
             // If my index is the index being edited and I'm not currently in

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -325,6 +325,7 @@ public class ListCell<T> extends IndexedCell<T> {
     @Override void indexChanged(int oldIndex, int newIndex) {
         super.indexChanged(oldIndex, newIndex);
 
+        updateEditing();
         if (isEditing() && newIndex == oldIndex) {
             // no-op
             // Fix for RT-31165 - if we (needlessly) update the index whilst the

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -541,10 +541,11 @@ public class ListCell<T> extends IndexedCell<T> {
         final int editIndex = list == null ? -1 : list.getEditingIndex();
         final boolean editing = isEditing();
 
-        // Check that the list is specified, and my index is not -1
         if (index == -1 || list == null) {
-            if(isEditing()) {
+            if(editing) {
+                updateEditingIndex = false;
                 cancelEdit();
+                updateEditingIndex = true;
             }
         } else {
             // If my index is the index being edited and I'm not currently in

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -189,6 +189,7 @@ public class ListCell<T> extends IndexedCell<T> {
             if (items != null) {
                 items.addListener(weakItemsListener);
             }
+            System.out.println("Update item 333");
             updateItem(-1);
         }
     };
@@ -355,6 +356,7 @@ public class ListCell<T> extends IndexedCell<T> {
 
     /** {@inheritDoc} */
     @Override public void startEdit() {
+        System.out.println("Start edit called!");
         final ListView<T> list = getListView();
         if (!isEditable() || (list != null && ! list.isEditable())) {
             return;
@@ -363,6 +365,7 @@ public class ListCell<T> extends IndexedCell<T> {
         // it makes sense to get the cell into its editing state before firing
         // the event to the ListView below, so that's what we're doing here
         // by calling super.startEdit().
+        System.out.println("super.Start edit called!");
         super.startEdit();
 
          // Inform the ListView of the edit starting.
@@ -532,6 +535,8 @@ public class ListCell<T> extends IndexedCell<T> {
             return;
         }
 
+        System.out.println("calling setFocused (" + fm.isFocused(index) + ")");
+        System.out.println("fm.getFocusedIndex " + fm.getFocusedIndex());
         setFocused(fm.isFocused(index));
     }
 
@@ -541,28 +546,22 @@ public class ListCell<T> extends IndexedCell<T> {
         final int editIndex = list == null ? -1 : list.getEditingIndex();
         final boolean editing = isEditing();
 
-        if (index == -1 || list == null) {
-            if(editing) {
-                updateEditingIndex = false;
-                cancelEdit();
-                updateEditingIndex = true;
-            }
-        } else {
+
+        if (editing && (index == -1 || list == null || index != editIndex)) {
+            // If my index is not the one being edited then I need to cancel
+            // the edit. The tricky thing here is that as part of this call
+            // I cannot end up calling list.edit(-1) the way that the standard
+            // cancelEdit method would do. Yet, I need to call cancelEdit
+            // so that subclasses which override cancelEdit can execute. So,
+            // I have to use a kind of hacky flag workaround.
+            updateEditingIndex = false;
+            cancelEdit();
+            updateEditingIndex = true;
+        }
+        if(!editing && list != null && index != -1 && index == editIndex) {
             // If my index is the index being edited and I'm not currently in
             // the edit mode, then I need to enter the edit mode
-            if (index == editIndex && !editing) {
-                startEdit();
-            } else if (index != editIndex && editing) {
-                // If my index is not the one being edited then I need to cancel
-                // the edit. The tricky thing here is that as part of this call
-                // I cannot end up calling list.edit(-1) the way that the standard
-                // cancelEdit method would do. Yet, I need to call cancelEdit
-                // so that subclasses which override cancelEdit can execute. So,
-                // I have to use a kind of hacky flag workaround.
-                updateEditingIndex = false;
-                cancelEdit();
-                updateEditingIndex = true;
-            }
+            startEdit();
         }
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -325,8 +325,8 @@ public class ListCell<T> extends IndexedCell<T> {
     @Override void indexChanged(int oldIndex, int newIndex) {
         super.indexChanged(oldIndex, newIndex);
 
-        updateEditing();
         if (isEditing() && newIndex == oldIndex) {
+            updateEditing();
             // no-op
             // Fix for RT-31165 - if we (needlessly) update the index whilst the
             // cell is being edited it will no longer be in an editing state.
@@ -337,6 +337,7 @@ public class ListCell<T> extends IndexedCell<T> {
         } else {
             updateItem(oldIndex);
             updateSelection();
+            updateEditing();
             updateFocus();
         }
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -337,8 +337,8 @@ public class ListCell<T> extends IndexedCell<T> {
             updateItem(oldIndex);
             updateSelection();
             updateFocus();
+            updateEditing();
         }
-        updateEditing();
     }
 
     /** {@inheritDoc} */
@@ -540,9 +540,11 @@ public class ListCell<T> extends IndexedCell<T> {
         final ListView<T> list = getListView();
         final int editIndex = list == null ? -1 : list.getEditingIndex();
         final boolean editing = isEditing();
+        final boolean match = list != null && index != -1 && index == editIndex;
 
-
-        if (editing && (index == -1 || list == null || index != editIndex)) {
+        if (match && ! editing) {
+            startEdit();
+        } else if (! match && editing) {
             // If my index is not the one being edited then I need to cancel
             // the edit. The tricky thing here is that as part of this call
             // I cannot end up calling list.edit(-1) the way that the standard
@@ -556,11 +558,6 @@ public class ListCell<T> extends IndexedCell<T> {
             } finally {
                 updateEditingIndex = true;
             }
-        }
-        if(!editing && list != null && index != -1 && index == editIndex) {
-            // If my index is the index being edited and I'm not currently in
-            // the edit mode, then I need to enter the edit mode
-            startEdit();
         }
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -531,7 +531,7 @@ public class ListCell<T> extends IndexedCell<T> {
             setFocused(false);
             return;
         }
-        
+
         setFocused(fm.isFocused(index));
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -542,7 +542,11 @@ public class ListCell<T> extends IndexedCell<T> {
         final boolean editing = isEditing();
 
         // Check that the list is specified, and my index is not -1
-        if (index != -1 && list != null) {
+        if (index == -1 || list == null) {
+            if(isEditing()) {
+                cancelEdit();
+            }
+        } else {
             // If my index is the index being edited and I'm not currently in
             // the edit mode, then I need to enter the edit mode
             if (index == editIndex && !editing) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -848,14 +848,33 @@ public class ListCellTest {
     }
 
     @Test
-    public void testChangeIndexWhileNotEditing_jdk_8264127() {
+    public void testChangeIndexToEditing1_jdk_8264127() {
+        list.getFocusModel().focus(-1);
+        assertChangeIndexToEditing(0, 1);
+    }
+
+    @Test
+    public void testChangeIndexToEditing2_jdk_8264127() {
+        assertChangeIndexToEditing(1, 0);
+    }
+
+    @Test
+    public void testChangeIndexToEditing3_jdk_8264127() {
+        //list.getFocusModel().focus(-1);
+        assertChangeIndexToEditing(-1, 0);
+    }
+
+    private void assertChangeIndexToEditing(int initialCellIndex, int listEditingIndex) {
         list.setEditable(true);
         cell.updateListView(list);
-        cell.updateIndex(1);
-        list.edit(0);
-        cell.updateIndex(0);
+        cell.updateIndex(initialCellIndex);
+        list.edit(listEditingIndex);
+        assertEquals("sanity: list editingIndex ", listEditingIndex, list.getEditingIndex());
+        assertFalse("sanity: cell must not be editing", cell.isEditing());
+        cell.updateIndex(listEditingIndex);
+        assertEquals("sanity: index updated ", listEditingIndex, cell.getIndex());
+        assertEquals("list editingIndex unchanged by cell", listEditingIndex, list.getEditingIndex());
         assertTrue(cell.isEditing());
-        assertEquals("Should still be editing 0", list.getEditingIndex(), 0);
     }
 
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -843,23 +843,20 @@ public class ListCellTest {
 
     @Test
     public void testChangeIndexToEditing2_jdk_8264127() {
-        assertChangeIndexToEditing(1, 0);
+        assertChangeIndexToEditing(-1, 1);
     }
 
     @Test
     public void testChangeIndexToEditing3_jdk_8264127() {
-        assertChangeIndexToEditing(1, -1);
+        assertChangeIndexToEditing(1, 0);
     }
 
     @Test
     public void testChangeIndexToEditing4_jdk_8264127() {
-        assertChangeIndexToEditing(0, -1);
-    }
-
-    @Test
-    public void testChangeIndexToEditing5_jdk_8264127() {
         assertChangeIndexToEditing(-1, 0);
     }
+
+
 
     private void assertChangeIndexToEditing(int initialCellIndex, int listEditingIndex) {
         list.getFocusModel().focus(-1);
@@ -876,14 +873,8 @@ public class ListCellTest {
         cell.updateIndex(listEditingIndex);
         assertEquals("sanity: index updated ", listEditingIndex, cell.getIndex());
         assertEquals("list editingIndex unchanged by cell", listEditingIndex, list.getEditingIndex());
-        if(listEditingIndex != -1) {
-            assertTrue(cell.isEditing());
-            assertEquals(1, events.size());
-        } else {
-            // -1 represents "not editing" for the listview and "no index" for the list cell.
-            assertFalse(cell.isEditing());
-            assertEquals(0, events.size());
-        }
+        assertTrue(cell.isEditing());
+        assertEquals(1, events.size());
     }
 
     @Test

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -853,6 +853,11 @@ public class ListCellTest {
 
     @Test
     public void testChangeIndexToEditing4_jdk_8264127() {
+        assertChangeIndexToEditing(0, -1);
+    }
+
+    @Test
+    public void testChangeIndexToEditing5_jdk_8264127() {
         assertChangeIndexToEditing(-1, 0);
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -41,6 +41,7 @@ import javafx.scene.control.MultipleSelectionModelBaseShim;
 import javafx.scene.control.SelectionMode;
 import java.util.List;
 import java.util.ArrayList;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -56,9 +57,21 @@ public class ListCellTest {
     private ObservableList<String> model;
 
     @Before public void setup() {
+        Thread.currentThread().setUncaughtExceptionHandler((thread, throwable) -> {
+            if (throwable instanceof RuntimeException) {
+                throw (RuntimeException)throwable;
+            } else {
+                Thread.currentThread().getThreadGroup().uncaughtException(thread, throwable);
+            }
+        });
+
         cell = new ListCell<String>();
         model = FXCollections.observableArrayList("Apples", "Oranges", "Pears");
         list = new ListView<String>(model);
+    }
+
+    @After public void cleanup() {
+        Thread.currentThread().setUncaughtExceptionHandler(null);
     }
 
     /*********************************************************************
@@ -932,7 +945,7 @@ public class ListCellTest {
             // just catching to test in finally
         } finally {
             assertFalse("cell must not be editing", cell.isEditing());
-            assertEquals("table must be editing at intermediate index", intermediate, list.getEditingIndex());
+            assertEquals("list must be editing at intermediate index", intermediate, list.getEditingIndex());
         }
         // test editing: second round
         // switch cell off editing by cell api
@@ -944,7 +957,7 @@ public class ListCellTest {
             // just catching to test in finally
         } finally {
             assertFalse("cell must not be editing", cell.isEditing());
-            assertEquals("table editing must be cancelled by cell", notEditingIndex, list.getEditingIndex());
+            assertEquals("list editing must be cancelled by cell", notEditingIndex, list.getEditingIndex());
         }
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -833,5 +833,15 @@ public class ListCellTest {
                 cell.maxHeight(-1), 1);
     }
 
+    @Test
+    public void testChangeIndexWhileEditing_jdk_8264127() {
+        list.setEditable(true);
+        cell.updateListView(list);
+        cell.updateIndex(1);
+        list.edit(1);
+        cell.updateIndex(0);
+        assertTrue(!cell.isEditing());
+    }
+
 
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -837,22 +837,6 @@ public class ListCellTest {
     }
 
     @Test
-    public void testChangeIndexWhileEditing_jdk_8264127() {
-        List<EditEvent> events = new ArrayList<EditEvent>();
-        list.setOnEditCancel(e -> {
-            events.add(e);
-        });
-        list.setEditable(true);
-        cell.updateListView(list);
-        cell.updateIndex(1);
-        list.edit(1);
-        cell.updateIndex(0);
-        assertTrue(!cell.isEditing());
-        assertEquals("Should still be editing 1", list.getEditingIndex(), 1);
-        assertTrue("cell re-use must trigger cancel events", events.size() == 1);
-    }
-
-    @Test
     public void testChangeIndexToEditing1_jdk_8264127() {
         assertChangeIndexToEditing(0, 1);
     }
@@ -889,26 +873,46 @@ public class ListCellTest {
         assertEquals("list editingIndex unchanged by cell", listEditingIndex, list.getEditingIndex());
         if(listEditingIndex != -1) {
             assertTrue(cell.isEditing());
-            assertTrue("cell re-use must trigger edit events", events.size() == 1);
+            assertEquals(1, events.size());
         } else {
             // -1 represents "not editing" for the listview and "no index" for the list cell.
-            assertTrue(!cell.isEditing());
-            assertTrue("cell re-use must trigger edit events", events.size() == 0);
+            assertFalse(cell.isEditing());
+            assertEquals(0, events.size());
         }
     }
 
     @Test
-    public void testUpdateCellIndexOffEditing() {
+    public void testChangeIndexOffEditing0_jdk_8264127() {
+        assertUpdateCellIndexOffEditing(1, 0);
+    }
+    @Test
+    public void testChangeIndexOffEditing1_jdk_8264127() {
+        assertUpdateCellIndexOffEditing(1, -1);
+    }
+    @Test
+    public void testChangeIndexOffEditing2_jdk_8264127() {
+        assertUpdateCellIndexOffEditing(0, 1);
+    }
+    @Test
+    public void testChangeIndexOffEditing3_jdk_8264127() {
+        assertUpdateCellIndexOffEditing(0, -1);
+    }
+
+    public void assertUpdateCellIndexOffEditing(int editingIndex, int cancelIndex) {
         list.getFocusModel().focus(-1);
+        List<EditEvent> events = new ArrayList<EditEvent>();
+        list.setOnEditCancel(e -> {
+            events.add(e);
+        });
         list.setEditable(true);
         cell.updateListView(list);
-        int editingIndex = 1; // list editing
         cell.updateIndex(editingIndex);
         list.edit(editingIndex);
         // here we are certain that the cell is in editing state
         assertTrue("sanity: cell must be editing", cell.isEditing());
-        cell.updateIndex(-1); // change cell index to negative
+        cell.updateIndex(cancelIndex); // change cell index to negative
         assertFalse("cell must not be editing if cell index is " + cell.getIndex(), cell.isEditing());
+        assertEquals(1, events.size());
     }
 
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -856,7 +856,6 @@ public class ListCellTest {
         cell.updateIndex(0);
         assertTrue(cell.isEditing());
         assertEquals("Should still be editing 0", list.getEditingIndex(), 0);
-        assertTrue(false);
     }
 
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -904,9 +904,11 @@ public class ListCellTest {
         cell.updateListView(list);
         cell.updateIndex(editingIndex);
         list.edit(editingIndex);
-        // here we are certain that the cell is in editing state
+        assertEquals("sanity: list editingIndex ", editingIndex, list.getEditingIndex());
         assertTrue("sanity: cell must be editing", cell.isEditing());
         cell.updateIndex(cancelIndex); // change cell index to negative
+        assertEquals("sanity: index updated ", cancelIndex, cell.getIndex());
+        assertEquals("list editingIndex unchanged by cell", editingIndex, list.getEditingIndex());
         assertFalse("cell must not be editing if cell index is " + cell.getIndex(), cell.isEditing());
         assertEquals(1, events.size());
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -35,9 +35,12 @@ import javafx.scene.control.FocusModel;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListCellShim;
 import javafx.scene.control.ListView;
+import javafx.scene.control.ListView.EditEvent;
 import javafx.scene.control.MultipleSelectionModel;
 import javafx.scene.control.MultipleSelectionModelBaseShim;
 import javafx.scene.control.SelectionMode;
+import java.util.List;
+import java.util.ArrayList;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -841,7 +844,19 @@ public class ListCellTest {
         list.edit(1);
         cell.updateIndex(0);
         assertTrue(!cell.isEditing());
+        assertEquals("Should still be editing 1", list.getEditingIndex(), 1);
     }
 
+    @Test
+    public void testChangeIndexWhileNotEditing_jdk_8264127() {
+        list.setEditable(true);
+        cell.updateListView(list);
+        cell.updateIndex(1);
+        list.edit(0);
+        cell.updateIndex(0);
+        assertTrue(cell.isEditing());
+        assertEquals("Should still be editing 0", list.getEditingIndex(), 0);
+        assertTrue(false);
+    }
 
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -854,7 +854,6 @@ public class ListCellTest {
 
     @Test
     public void testChangeIndexToEditing1_jdk_8264127() {
-        list.getFocusModel().focus(-1);
         assertChangeIndexToEditing(0, 1);
     }
 
@@ -896,6 +895,20 @@ public class ListCellTest {
             assertTrue(!cell.isEditing());
             assertTrue("cell re-use must trigger edit events", events.size() == 0);
         }
+    }
+
+    @Test
+    public void testUpdateCellIndexOffEditing() {
+        list.getFocusModel().focus(-1);
+        list.setEditable(true);
+        cell.updateListView(list);
+        int editingIndex = 1; // list editing
+        cell.updateIndex(editingIndex);
+        list.edit(editingIndex);
+        // here we are certain that the cell is in editing state
+        assertTrue("sanity: cell must be editing", cell.isEditing());
+        cell.updateIndex(-1); // change cell index to negative
+        assertFalse("cell must not be editing if cell index is " + cell.getIndex(), cell.isEditing());
     }
 
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -865,11 +865,16 @@ public class ListCellTest {
 
     @Test
     public void testChangeIndexToEditing3_jdk_8264127() {
-        //list.getFocusModel().focus(-1);
+        assertChangeIndexToEditing(1, -1);
+    }
+
+    @Test
+    public void testChangeIndexToEditing4_jdk_8264127() {
         assertChangeIndexToEditing(-1, 0);
     }
 
     private void assertChangeIndexToEditing(int initialCellIndex, int listEditingIndex) {
+        list.getFocusModel().focus(-1);
         List<EditEvent> events = new ArrayList<EditEvent>();
         list.setOnEditStart(e -> {
             events.add(e);
@@ -883,8 +888,14 @@ public class ListCellTest {
         cell.updateIndex(listEditingIndex);
         assertEquals("sanity: index updated ", listEditingIndex, cell.getIndex());
         assertEquals("list editingIndex unchanged by cell", listEditingIndex, list.getEditingIndex());
-        assertTrue(cell.isEditing());
-        assertTrue("cell re-use must trigger edit events", events.size() == 1);
+        if(listEditingIndex != -1) {
+            assertTrue(cell.isEditing());
+            assertTrue("cell re-use must trigger edit events", events.size() == 1);
+        } else {
+            // -1 represents "not editing" for the listview and "no index" for the list cell.
+            assertTrue(!cell.isEditing());
+            assertTrue("cell re-use must trigger edit events", events.size() == 0);
+        }
     }
 
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -913,4 +913,47 @@ public class ListCellTest {
         assertEquals(1, events.size());
     }
 
+    @Test
+    public void testMisbehavingCancelEditTerminatesEdit() {
+        ListCell<String> cell = new MisbehavingOnCancelListCell<>();
+
+        list.setEditable(true);
+        cell.updateListView(list);
+
+        int editingIndex = 1;
+        int intermediate = 0;
+        int notEditingIndex = -1;
+        cell.updateIndex(editingIndex);
+        list.edit(editingIndex);
+        assertTrue("sanity: ", cell.isEditing());
+        try {
+            list.edit(intermediate);
+        } catch (Exception ex) {
+            // just catching to test in finally
+        } finally {
+            assertFalse("cell must not be editing", cell.isEditing());
+            assertEquals("table must be editing at intermediate index", intermediate, list.getEditingIndex());
+        }
+        // test editing: second round
+        // switch cell off editing by cell api
+        list.edit(editingIndex);
+        assertTrue("sanity: ", cell.isEditing());
+        try {
+            cell.cancelEdit();
+        } catch (Exception ex) {
+            // just catching to test in finally
+        } finally {
+            assertFalse("cell must not be editing", cell.isEditing());
+            assertEquals("table editing must be cancelled by cell", notEditingIndex, list.getEditingIndex());
+        }
+    }
+
+    public static class MisbehavingOnCancelListCell<T> extends ListCell<T> {
+        @Override
+        public void cancelEdit() {
+            super.cancelEdit();
+            throw new RuntimeException("violating contract");
+        }
+    }
+
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -838,6 +838,10 @@ public class ListCellTest {
 
     @Test
     public void testChangeIndexWhileEditing_jdk_8264127() {
+        List<EditEvent> events = new ArrayList<EditEvent>();
+        list.setOnEditCancel(e -> {
+            events.add(e);
+        });
         list.setEditable(true);
         cell.updateListView(list);
         cell.updateIndex(1);
@@ -845,6 +849,7 @@ public class ListCellTest {
         cell.updateIndex(0);
         assertTrue(!cell.isEditing());
         assertEquals("Should still be editing 1", list.getEditingIndex(), 1);
+        assertTrue("cell re-use must trigger cancel events", events.size() == 1);
     }
 
     @Test
@@ -865,6 +870,10 @@ public class ListCellTest {
     }
 
     private void assertChangeIndexToEditing(int initialCellIndex, int listEditingIndex) {
+        List<EditEvent> events = new ArrayList<EditEvent>();
+        list.setOnEditStart(e -> {
+            events.add(e);
+        });
         list.setEditable(true);
         cell.updateListView(list);
         cell.updateIndex(initialCellIndex);
@@ -875,6 +884,7 @@ public class ListCellTest {
         assertEquals("sanity: index updated ", listEditingIndex, cell.getIndex());
         assertEquals("list editingIndex unchanged by cell", listEditingIndex, list.getEditingIndex());
         assertTrue(cell.isEditing());
+        assertTrue("cell re-use must trigger edit events", events.size() == 1);
     }
 
 }


### PR DESCRIPTION
Fixing ListCell editing status is true, when index changes while editing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264127](https://bugs.openjdk.java.net/browse/JDK-8264127): ListCell editing status is true, when index changes while editing


### Reviewers
 * [Jeanette Winzenburg](https://openjdk.java.net/census#fastegal) (@kleopatra - Committer)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/441/head:pull/441` \
`$ git checkout pull/441`

Update a local copy of the PR: \
`$ git checkout pull/441` \
`$ git pull https://git.openjdk.java.net/jfx pull/441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 441`

View PR using the GUI difftool: \
`$ git pr show -t 441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/441.diff">https://git.openjdk.java.net/jfx/pull/441.diff</a>

</details>
