### PR TITLE
8211362: Restrict export of libjpeg symbols from libjavafx_iio.so

### DIFF
--- a/buildSrc/linux.gradle
+++ b/buildSrc/linux.gradle
@@ -278,8 +278,8 @@ LINUX.iio.nativeSource = [
     file("${project("graphics").projectDir}/src/main/native-iio"),
     file("${project("graphics").projectDir}/src/main/native-iio/libjpeg")]
 LINUX.iio.compiler = compiler
-LINUX.iio.ccFlags = [cFlags].flatten()
-LINUX.iio.linker = linker
+LINUX.iio.ccFlags = [cFlags, "-fvisibility=hidden"].flatten()
+LINUX.iio.linker = IS_STATIC_BUILD ? "ld" : linker
 LINUX.iio.linkFlags = [linkFlags].flatten()
 LINUX.iio.lib = "javafx_iio"
 

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/LinkTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/LinkTask.groovy
@@ -41,8 +41,8 @@ class LinkTask extends DefaultTask {
             commandLine(linker);
             if ((project.IS_LINUX) && (project.IS_STATIC_BUILD)) {
                 if (linker.equals("ld")) {
-                    args("-r"); 
-                    args("-o"); 
+                    args("-r");
+                    args("-o");
                 } else {
                     args("rcs");
                 }

--- a/buildSrc/src/main/groovy/com/sun/javafx/gradle/LinkTask.groovy
+++ b/buildSrc/src/main/groovy/com/sun/javafx/gradle/LinkTask.groovy
@@ -40,8 +40,13 @@ class LinkTask extends DefaultTask {
         project.exec({
             commandLine(linker);
             if ((project.IS_LINUX) && (project.IS_STATIC_BUILD)) {
-              args("rcs");
-              args("$lib");
+                if (linker.equals("ld")) {
+                    args("-r"); 
+                    args("-o"); 
+                } else {
+                    args("rcs");
+                }
+                args("$lib");
             }
             // Exclude parfait files (.bc)
             args(objectDir.listFiles().findAll{ !it.getAbsolutePath().endsWith(".bc") });


### PR DESCRIPTION
Fix for JDK-8211362

Compile javafx-iio native files with -f-visibiliy=hidden in order
not to export the non-JNI symbols.
Although this issue was about libjavafx_iio.so only (and not about libjavafx_iio.a), this PR allows fixing the static build as well.

For static builds, we also use ld -r to build a static library, so that objcopy or similar can be used to remove the names of the
hidden symbols.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8211362](https://bugs.openjdk.java.net/browse/JDK-8211362): Restrict export of libjpeg symbols from libjavafx_iio.so


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Download
To checkout this PR locally:
`$ git fetch https://git.openjdk.java.net/jfx pull/442/head:pull/442`
`$ git checkout pull/442`

To update a local copy of the PR:
`$ git checkout pull/442`
`$ git pull https://git.openjdk.java.net/jfx pull/442/head`
