### PR TITLE
8264162: PickResult.toString() is missing the closing square bracket

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/PickResult.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/PickResult.java
@@ -195,13 +195,13 @@ public class PickResult {
                 .append(", point = ").append(getIntersectedPoint())
                 .append(", distance = ").append(getIntersectedDistance());
         if (getIntersectedFace() != FACE_UNDEFINED) {
-                sb.append(", face = ").append(getIntersectedFace());
+            sb.append(", face = ").append(getIntersectedFace());
         }
         if (getIntersectedNormal() != null) {
-                sb.append(", normal = ").append(getIntersectedNormal());
+            sb.append(", normal = ").append(getIntersectedNormal());
         }
         if (getIntersectedTexCoord() != null) {
-                sb.append(", texCoord = ").append(getIntersectedTexCoord());
+            sb.append(", texCoord = ").append(getIntersectedTexCoord());
         }
         sb.append("]");
         return sb.toString();

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/PickResult.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/PickResult.java
@@ -203,6 +203,7 @@ public class PickResult {
         if (getIntersectedTexCoord() != null) {
                 sb.append(", texCoord = ").append(getIntersectedTexCoord());
         }
+        sb.append("]");
         return sb.toString();
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/input/MouseEventTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/input/MouseEventTest.java
@@ -127,6 +127,12 @@ public class MouseEventTest {
 
         assertSame(pickRes, e.getPickResult());
 
+        // Check the String returned by MouseEvent::toString method to ensure
+        // that all of the square brackets are matching.
+        // Note that this will fail if the toString method of any of the
+        // components that make up the MouseEvent returns a String with
+        // mismatched brackets, including the source and target
+        // objects, the PickResult, the picked Node, or the picked Point3D.
         String str = e.toString();
         int bracketCount = 0;
         for (int i = 0; i < str.length(); i++) {

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/input/MouseEventTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/input/MouseEventTest.java
@@ -111,6 +111,38 @@ public class MouseEventTest {
         assertFalse(e.isStillSincePress());
     }
 
+    @Test public void testToStringMatchingBrackets() {
+        Rectangle node = new Rectangle();
+        node.setTranslateX(3);
+        node.setTranslateY(2);
+        node.setTranslateZ(50);
+
+        PickResult pickRes = new PickResult(node, new Point3D(15, 25, 100), 33);
+
+        MouseEvent e = new MouseEvent(MouseEvent.MOUSE_PRESSED,
+                10, 20, 30, 40, MouseButton.PRIMARY, 1,
+                false, false, false, false,
+                true, false, false,
+                false, false, false, pickRes);
+
+        assertSame(pickRes, e.getPickResult());
+
+        String str = e.toString();
+        int bracketCount = 0;
+        for (int i = 0; i < str.length(); i++) {
+            switch (str.charAt(i)) {
+                case '[':
+                    ++bracketCount;
+                    break;
+                case ']':
+                    --bracketCount;
+                    assertTrue("Too many closing brackets: " + str, bracketCount >= 0);
+                    break;
+            }
+        }
+        assertEquals("Too few closing brackets: " + str, 0, bracketCount);
+    }
+
     @Test public void testShortConstructorWithoutPickResult() {
         MouseDragEvent e = new MouseDragEvent(MouseDragEvent.MOUSE_DRAG_OVER,
                 10, 20, 30, 40, MouseButton.MIDDLE, 3,


### PR DESCRIPTION
Simple fix to add a missing closing bracket to `PickResult::toString`. This includes a unit test that fails without the fix and passes with the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264162](https://bugs.openjdk.java.net/browse/JDK-8264162): PickResult.toString() is missing the closing square bracket


### Reviewers
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)
 * [Nir Lisker](https://openjdk.java.net/census#nlisker) (@nlisker - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/443/head:pull/443` \
`$ git checkout pull/443`

Update a local copy of the PR: \
`$ git checkout pull/443` \
`$ git pull https://git.openjdk.java.net/jfx pull/443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 443`

View PR using the GUI difftool: \
`$ git pr show -t 443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/443.diff">https://git.openjdk.java.net/jfx/pull/443.diff</a>

</details>
