### PR TITLE
8258663: Fixed size TableCells are not removed from sene graph when column is removed

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
@@ -548,7 +548,7 @@ public abstract class TableRowSkinBase<T,
             for (Node cell : getChildren()) {
                 if (!(cell instanceof IndexedCell)) continue;
                 TableColumnBase<T, ?> tableColumn = getTableColumn((R) cell);
-                if (!getVisibleLeafColumns().contains(tableColumn) || !tableColumn.isVisible()) {
+                if (!getVisibleLeafColumns().contains(tableColumn)) {
                     toRemove.add(cell);
                 }
             }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -542,18 +542,18 @@ public abstract class TableRowSkinBase<T,
 
         // update children of each row
         if (fixedCellSizeEnabled) {
-            // we leave the adding / removing up to the layoutChildren method mostly,
-            // but here we remove any children cells that refer to columns that are
-            // not visible
+            // we leave the adding / removing up to the layoutChildren method mostly, but here we remove any children
+            // cells that refer to columns that are removed or not visible.
             List<Node> toRemove = new ArrayList<>();
             for (Node cell : getChildren()) {
-                if (! (cell instanceof IndexedCell)) continue;
-                if (!getTableColumn((R)cell).isVisible()) {
+                if (!(cell instanceof IndexedCell)) continue;
+                TableColumnBase<T, ?> tableColumn = getTableColumn((R) cell);
+                if (!getVisibleLeafColumns().contains(tableColumn) || !tableColumn.isVisible()) {
                     toRemove.add(cell);
                 }
             }
             getChildren().removeAll(toRemove);
-        } else if (!fixedCellSizeEnabled && (resetChildren || cellsEmpty)) {
+        } else if (resetChildren || cellsEmpty) {
             getChildren().setAll(cells);
         }
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableRowSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableRowSkinTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.control.skin;
+
+import com.sun.javafx.tk.Toolkit;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableRow;
+import javafx.scene.control.TableView;
+import javafx.scene.control.cell.PropertyValueFactory;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
+import test.com.sun.javafx.scene.control.test.Person;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+
+public class TableRowSkinTest {
+
+    private TableView<Person> tableView;
+    private StageLoader stageLoader;
+
+    @Before
+    public void before() {
+        tableView = new TableView<>();
+
+        TableColumn<Person, String> firstNameCol = new TableColumn<>("Firstname");
+        firstNameCol.setCellValueFactory(new PropertyValueFactory<>("firstName"));
+        TableColumn<Person, String> lastNameCol = new TableColumn<>("Lastname");
+        lastNameCol.setCellValueFactory(new PropertyValueFactory<>("lastName"));
+        TableColumn<Person, String> emailCol = new TableColumn<>("Email");
+        emailCol.setCellValueFactory(new PropertyValueFactory<>("email"));
+        TableColumn<Person, Integer> ageCol = new TableColumn<>("Age");
+        ageCol.setCellValueFactory(new PropertyValueFactory<>("age"));
+
+        tableView.getColumns().addAll(firstNameCol, lastNameCol, emailCol, ageCol);
+
+        ObservableList<Person> items = FXCollections.observableArrayList(
+                new Person("firstName1", "lastName1","email1@javafx.com",1),
+                new Person("firstName2", "lastName2","email2@javafx.com",2),
+                new Person("firstName3", "lastName3","email3@javafx.com",3),
+                new Person("firstName4", "lastName4","email4@javafx.com",4)
+        );
+
+        tableView.setItems(items);
+
+        stageLoader = new StageLoader(tableView);
+    }
+
+    @Test
+    public void removedColumnsShouldRemoveCorrespondingCellsInRowFixedCellSize() {
+        removedColumnsShouldRemoveCorrespondingCellsInRow(true);
+    }
+
+    @Test
+    public void removedColumnsShouldRemoveCorrespondingCellsInRow() {
+        removedColumnsShouldRemoveCorrespondingCellsInRow(false);
+    }
+
+    @Test
+    public void invisibleColumnsShouldRemoveCorrespondingCellsInRowFixedCellSize() {
+        invisibleColumnsShouldRemoveCorrespondingCellsInRow(true);
+    }
+
+    @Test
+    public void invisibleColumnsShouldRemoveCorrespondingCellsInRow() {
+        invisibleColumnsShouldRemoveCorrespondingCellsInRow(false);
+    }
+
+    @After
+    public void after() {
+        stageLoader.dispose();
+    }
+
+    private void invisibleColumnsShouldRemoveCorrespondingCellsInRow(boolean useFixedCellSize) {
+        TableRow<Person> tableRow = setRowFactoryVerifyReturnFirstRow(useFixedCellSize);
+
+        // Set the last 2 columns invisible.
+        tableView.getColumns().get(tableView.getColumns().size() - 1).setVisible(false);
+        tableView.getColumns().get(tableView.getColumns().size() - 2).setVisible(false);
+
+        Toolkit.getToolkit().firePulse();
+
+        // We set 2 columns to invisible, so the cell count should be decremented by 2 as well.
+        assertEquals(tableView.getColumns().size() - 2, tableRow.getChildrenUnmodifiable().size());
+    }
+
+    private void removedColumnsShouldRemoveCorrespondingCellsInRow(boolean useFixedCellSize) {
+        TableRow<Person> tableRow = setRowFactoryVerifyReturnFirstRow(useFixedCellSize);
+
+        // Remove the last 2 columns.
+        tableView.getColumns().remove(tableView.getColumns().size() - 1);
+        tableView.getColumns().remove(tableView.getColumns().size() - 1);
+
+        Toolkit.getToolkit().firePulse();
+
+        // We removed 2 columns, so the cell count should be decremented by 2 as well.
+        assertEquals(tableView.getColumns().size(), tableRow.getChildrenUnmodifiable().size());
+    }
+
+    private TableRow<Person> setRowFactoryVerifyReturnFirstRow(boolean useFixedCellSize) {
+        // We save the first table row to check it later.
+        AtomicReference<TableRow<Person>> tableRowRef = new AtomicReference<>();
+
+        if (useFixedCellSize) {
+            tableView.setFixedCellSize(24);
+        }
+
+        tableView.setRowFactory(tableView -> {
+            TableRow<Person> tableRow = new TableRow<>();
+            if (tableRowRef.get() == null) {
+                tableRowRef.set(tableRow);
+            }
+            return tableRow;
+        });
+
+        // Refresh the table so that the rows are recreated.
+        tableView.refresh();
+
+        Toolkit.getToolkit().firePulse();
+
+        TableRow<Person> tableRow = tableRowRef.get();
+        assertNotNull(tableRow);
+
+        // Column count should match the cell count.
+        assertEquals(tableView.getColumns().size(), tableRow.getChildrenUnmodifiable().size());
+        return tableRow;
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableRowSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableRowSkinTest.java
@@ -38,7 +38,7 @@ import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
 import test.com.sun.javafx.scene.control.test.Person;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 public class TableRowSkinTest {
 
@@ -113,7 +113,7 @@ public class TableRowSkinTest {
 
     private void removedColumnsShouldRemoveCorrespondingCellsInRowImpl() {
         // Remove the last 2 columns.
-        tableView.getColumns().remove(tableView.getColumns().size() - 2, tableView.getColumns().size() - 1);
+        tableView.getColumns().remove(tableView.getColumns().size() - 1, tableView.getColumns().size());
 
         Toolkit.getToolkit().firePulse();
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableRowSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableRowSkinTest.java
@@ -29,19 +29,16 @@ import com.sun.javafx.tk.Toolkit;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.control.TableColumn;
-import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
 import javafx.scene.control.cell.PropertyValueFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
+import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
 import test.com.sun.javafx.scene.control.test.Person;
 
-import java.util.concurrent.atomic.AtomicReference;
-
 import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
 
 public class TableRowSkinTest {
 
@@ -64,10 +61,10 @@ public class TableRowSkinTest {
         tableView.getColumns().addAll(firstNameCol, lastNameCol, emailCol, ageCol);
 
         ObservableList<Person> items = FXCollections.observableArrayList(
-                new Person("firstName1", "lastName1","email1@javafx.com",1),
-                new Person("firstName2", "lastName2","email2@javafx.com",2),
-                new Person("firstName3", "lastName3","email3@javafx.com",3),
-                new Person("firstName4", "lastName4","email4@javafx.com",4)
+                new Person("firstName1", "lastName1", "email1@javafx.com", 1),
+                new Person("firstName2", "lastName2", "email2@javafx.com", 2),
+                new Person("firstName3", "lastName3", "email3@javafx.com", 3),
+                new Person("firstName4", "lastName4", "email4@javafx.com", 4)
         );
 
         tableView.setItems(items);
@@ -77,22 +74,24 @@ public class TableRowSkinTest {
 
     @Test
     public void removedColumnsShouldRemoveCorrespondingCellsInRowFixedCellSize() {
-        removedColumnsShouldRemoveCorrespondingCellsInRow(true);
+        tableView.setFixedCellSize(24);
+        removedColumnsShouldRemoveCorrespondingCellsInRowImpl();
     }
 
     @Test
     public void removedColumnsShouldRemoveCorrespondingCellsInRow() {
-        removedColumnsShouldRemoveCorrespondingCellsInRow(false);
+        removedColumnsShouldRemoveCorrespondingCellsInRowImpl();
     }
 
     @Test
     public void invisibleColumnsShouldRemoveCorrespondingCellsInRowFixedCellSize() {
-        invisibleColumnsShouldRemoveCorrespondingCellsInRow(true);
+        tableView.setFixedCellSize(24);
+        invisibleColumnsShouldRemoveCorrespondingCellsInRowImpl();
     }
 
     @Test
     public void invisibleColumnsShouldRemoveCorrespondingCellsInRow() {
-        invisibleColumnsShouldRemoveCorrespondingCellsInRow(false);
+        invisibleColumnsShouldRemoveCorrespondingCellsInRowImpl();
     }
 
     @After
@@ -100,9 +99,7 @@ public class TableRowSkinTest {
         stageLoader.dispose();
     }
 
-    private void invisibleColumnsShouldRemoveCorrespondingCellsInRow(boolean useFixedCellSize) {
-        TableRow<Person> tableRow = setRowFactoryVerifyReturnFirstRow(useFixedCellSize);
-
+    private void invisibleColumnsShouldRemoveCorrespondingCellsInRowImpl() {
         // Set the last 2 columns invisible.
         tableView.getColumns().get(tableView.getColumns().size() - 1).setVisible(false);
         tableView.getColumns().get(tableView.getColumns().size() - 2).setVisible(false);
@@ -110,49 +107,19 @@ public class TableRowSkinTest {
         Toolkit.getToolkit().firePulse();
 
         // We set 2 columns to invisible, so the cell count should be decremented by 2 as well.
-        assertEquals(tableView.getColumns().size() - 2, tableRow.getChildrenUnmodifiable().size());
+        assertEquals(tableView.getColumns().size() - 2,
+                VirtualFlowTestUtils.getCell(tableView, 0).getChildrenUnmodifiable().size());
     }
 
-    private void removedColumnsShouldRemoveCorrespondingCellsInRow(boolean useFixedCellSize) {
-        TableRow<Person> tableRow = setRowFactoryVerifyReturnFirstRow(useFixedCellSize);
-
+    private void removedColumnsShouldRemoveCorrespondingCellsInRowImpl() {
         // Remove the last 2 columns.
-        tableView.getColumns().remove(tableView.getColumns().size() - 1);
-        tableView.getColumns().remove(tableView.getColumns().size() - 1);
+        tableView.getColumns().remove(tableView.getColumns().size() - 2, tableView.getColumns().size() - 1);
 
         Toolkit.getToolkit().firePulse();
 
         // We removed 2 columns, so the cell count should be decremented by 2 as well.
-        assertEquals(tableView.getColumns().size(), tableRow.getChildrenUnmodifiable().size());
-    }
-
-    private TableRow<Person> setRowFactoryVerifyReturnFirstRow(boolean useFixedCellSize) {
-        // We save the first table row to check it later.
-        AtomicReference<TableRow<Person>> tableRowRef = new AtomicReference<>();
-
-        if (useFixedCellSize) {
-            tableView.setFixedCellSize(24);
-        }
-
-        tableView.setRowFactory(tableView -> {
-            TableRow<Person> tableRow = new TableRow<>();
-            if (tableRowRef.get() == null) {
-                tableRowRef.set(tableRow);
-            }
-            return tableRow;
-        });
-
-        // Refresh the table so that the rows are recreated.
-        tableView.refresh();
-
-        Toolkit.getToolkit().firePulse();
-
-        TableRow<Person> tableRow = tableRowRef.get();
-        assertNotNull(tableRow);
-
-        // Column count should match the cell count.
-        assertEquals(tableView.getColumns().size(), tableRow.getChildrenUnmodifiable().size());
-        return tableRow;
+        assertEquals(tableView.getColumns().size(),
+                VirtualFlowTestUtils.getCell(tableView, 0).getChildrenUnmodifiable().size());
     }
 
 }


### PR DESCRIPTION
This PR fixes an issue, where table cells are not removed from the table row when the corresponding table column got removed. This will lead to empty "ghost" cells laying around in the table.
This bug only occurs, when a fixed cell size is set to the table.

I also added 3 more tests beside the mandatory test, which tests my fix.
1 alternative test, which tests the same with no fixed cell size set.
The other 2 tests are testing the same, but the table columns are set invisible instead.

-> Either the removal or setVisible(false) of a column should both do the same: Remove the corresponding cells, so that there are no empty cells.
Therefore, the additional tests make sure, that the other use cases (still) works and won't break in future (at least, without red tests ;)).
See also: TableRowSkinBase#updateCells(boolean)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258663](https://bugs.openjdk.java.net/browse/JDK-8258663): Fixed size TableCells are not removed from sene graph when column is removed


### Reviewers
 * [Jeanette Winzenburg](https://openjdk.java.net/census#fastegal) (@kleopatra - Committer)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/444/head:pull/444` \
`$ git checkout pull/444`

Update a local copy of the PR: \
`$ git checkout pull/444` \
`$ git pull https://git.openjdk.java.net/jfx pull/444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 444`

View PR using the GUI difftool: \
`$ git pr show -t 444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/444.diff">https://git.openjdk.java.net/jfx/pull/444.diff</a>

</details>
