### PR TITLE
8264330: Scene MouseHandler is referencing removed nodes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2089,6 +2089,7 @@ project(":graphics") {
         stubCompile group: "junit", name: "junit", version: "4.8.2"
 
         antlr group: "org.antlr", name: "antlr4", version: "4.7.2", classifier: "complete"
+        testCompile project(":base").sourceSets.test.output
         compile project(':base')
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -3630,7 +3630,7 @@ public class Scene implements EventTarget {
             currentEventTarget = currentEventTargets.size() > 0
                     ? currentEventTargets.get(0) : null;
             pdrEventTarget.clear();
-            pdrEventTargets.clear();  // clear to remove potentially removed nodes, see JDK-8264330
+            pdrEventTargets.clear();
         }
 
         public void enterFullPDR(EventTarget gestureSource) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -3630,6 +3630,7 @@ public class Scene implements EventTarget {
             currentEventTarget = currentEventTargets.size() > 0
                     ? currentEventTargets.get(0) : null;
             pdrEventTarget.clear();
+            pdrEventTargets.clear();  // clear to remove potentially removed nodes, see JDK-8264330
         }
 
         public void enterFullPDR(EventTarget gestureSource) {

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/SceneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/SceneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,6 +70,7 @@ import javafx.scene.PerspectiveCamera;
 import javafx.scene.Scene;
 import javafx.scene.SceneShim;
 import javafx.scene.SubScene;
+import test.util.memory.JMemoryBuddy;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
@@ -976,7 +977,6 @@ public class SceneTest {
 
     @Test public void testNoReferencesRemainToRemovedNodeAfterBeingClicked() {
         StubToolkit toolkit = (StubToolkit) Toolkit.getToolkit();
-        MouseEventGenerator generator = new MouseEventGenerator();
         TilePane pane = new TilePane();
         VBox vbox = new VBox(pane);
         Scene scene = new Scene(vbox, 300, 200);
@@ -989,13 +989,13 @@ public class SceneTest {
         // Press mouse on TilePane so it gets picked up as a potential node to drag:
         SceneHelper.processMouseEvent(
             scene,
-            generator.generateMouseEvent(MouseEvent.MOUSE_PRESSED, 100, 100)
+            MouseEventGenerator.generateMouseEvent(MouseEvent.MOUSE_PRESSED, 100, 100)
         );
 
         // Release mouse on TilePane to trigger clean up code as there will be no dragging:
         SceneHelper.processMouseEvent(
             scene,
-            generator.generateMouseEvent(MouseEvent.MOUSE_RELEASED, 100, 100)
+            MouseEventGenerator.generateMouseEvent(MouseEvent.MOUSE_RELEASED, 100, 100)
         );
 
         // Remove TilePane, and replace with something else:
@@ -1013,12 +1013,10 @@ public class SceneTest {
 
         toolkit.firePulse();
 
-        // Clear our own reference and call GC to see if the TilePane is now not referenced anywhere:
+        // Clear our own reference and see if the TilePane is now not referenced anywhere:
         pane = null;
 
-        System.gc();
-
         // Verify TilePane was GC'd:
-        assertNull(ref.get());
+        JMemoryBuddy.assertCollectable(ref);
     }
 }


### PR DESCRIPTION
Small fix to clear a reference to a removed node left by Scene$MouseHandler.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264330](https://bugs.openjdk.java.net/browse/JDK-8264330): Scene MouseHandler is referencing removed nodes


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/448/head:pull/448` \
`$ git checkout pull/448`

Update a local copy of the PR: \
`$ git checkout pull/448` \
`$ git pull https://git.openjdk.java.net/jfx pull/448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 448`

View PR using the GUI difftool: \
`$ git pr show -t 448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/448.diff">https://git.openjdk.java.net/jfx/pull/448.diff</a>

</details>
