### PR TITLE
8232379: Need to remove large icudt64l.zip binary file from source repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3451,10 +3451,8 @@ project(":web") {
         def getICUFile = task("copyICUFile", type: Copy) {
             enabled = IS_COMPILE_WEBKIT
 
-            configurations.icu.files.each { f ->
-                from "f.getPath()"
-                into "$webkitOutputDir/$webkitConfig/icu/data"
-            }
+            from configurations.icu.files
+            into "$webkitOutputDir/$webkitConfig/icu/data"
         }
 
         def compileNativeTask = task("compileNative${t.capital}", dependsOn: [compileJava, getICUFile]) {

--- a/build.gradle
+++ b/build.gradle
@@ -3339,6 +3339,8 @@ project(":web") {
     project.ext.moduleRuntime = true
     project.ext.moduleName = "javafx.web"
 
+    getConfigurations().create("icu");
+
     sourceSets {
         main
         shims {
@@ -3360,7 +3362,11 @@ project(":web") {
 
     commonModuleSetup(project, [ 'base', 'graphics', 'controls', 'media', 'web' ])
 
+    def icuVersion = "64l"
     dependencies {
+        if (IS_COMPILE_WEBKIT) {
+            icu group: "org.openjfx", name: "icudt", version: icuVersion, ext: "zip"
+        }
         compile project(":base")
         compile project(":graphics")
         compile project(":controls")
@@ -3442,7 +3448,16 @@ project(":web") {
         File nativeBuildDir = new File("${webkitOutputDir}")
         nativeBuildDir.mkdirs()
 
-        def compileNativeTask = task("compileNative${t.capital}", dependsOn: [compileJava]) {
+        def getICUFile = task("copyICUFile", type: Copy) {
+            enabled = IS_COMPILE_WEBKIT
+
+            configurations.icu.files.each { f ->
+                from "f.getPath()"
+                into "$webkitOutputDir/$webkitConfig/icu/data"
+            }
+        }
+
+        def compileNativeTask = task("compileNative${t.capital}", dependsOn: [compileJava, getICUFile]) {
             println "Building Webkit configuration /$webkitConfig/ into $webkitOutputDir"
             enabled =  (IS_COMPILE_WEBKIT)
 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/icu/CMakeLists.txt
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/icu/CMakeLists.txt
@@ -565,12 +565,11 @@ target_link_libraries(data_as_asm icuuc icui18n)
 ###### tools END ####
 
 ###### data BEGIN ####
-file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/icu/data")
-file(GLOB ICU_DATA_ZIP_FILE "java/data/icudt*l.zip")
+set(ICU_VERSION 64l)
+file(GLOB ICU_DATA_ZIP_FILE "${CMAKE_BINARY_DIR}/icu/data/icudt-${ICU_VERSION}.zip")
 
-get_filename_component(ICU_DATA_FILE_NAME ${ICU_DATA_ZIP_FILE} NAME)
 # Get just file name without extension
-string(REGEX REPLACE ".zip" "" ICU_DATA_FILE_NAME ${ICU_DATA_FILE_NAME})
+set(ICU_DATA_FILE_NAME "icudt${ICU_VERSION}")
 
 # Use jar instead of unzip, it will be helpful to get rid of cygwin dependency
 find_package(Java)


### PR DESCRIPTION
We need to remove the following large binary file from the repo and instead host and download it from a server: `modules/javafx.web/src/main/native/Source/ThirdParty/icu/java/data/icudt64l.zip`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8232379](https://bugs.openjdk.java.net/browse/JDK-8232379): Need to remove large icudt64l.zip binary file from source repository


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/450/head:pull/450` \
`$ git checkout pull/450`

Update a local copy of the PR: \
`$ git checkout pull/450` \
`$ git pull https://git.openjdk.java.net/jfx pull/450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 450`

View PR using the GUI difftool: \
`$ git pr show -t 450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/450.diff">https://git.openjdk.java.net/jfx/pull/450.diff</a>

</details>
