### PR TITLE
8264536: Building OpenJFX on Apple AARCH64 not possible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -305,7 +305,7 @@ ext.MAVEN_GROUP_ID = "org.openjfx"
 if (!IS_MAC && !IS_WINDOWS && !IS_LINUX) fail("Unsupported build OS ${OS_NAME}")
 if (IS_WINDOWS && OS_ARCH != "x86" && OS_ARCH != "amd64") {
     fail("Unknown and unsupported build architecture: $OS_ARCH")
-} else if (IS_MAC && OS_ARCH != "x86_64") {
+} else if (IS_MAC && OS_ARCH != "x86_64" && OS_ARCH != "aarch64") {
     fail("Unknown and unsupported build architecture: $OS_ARCH")
 } else if (IS_LINUX && OS_ARCH != "i386" && OS_ARCH != "amd64") {
     fail("Unknown and unsupported build architecture: $OS_ARCH")


### PR DESCRIPTION
don't bail when building on Apple M1 systems
Fix for JDK-8264536

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264536](https://bugs.openjdk.java.net/browse/JDK-8264536): Building OpenJFX on Apple AARCH64 not possible


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/451/head:pull/451` \
`$ git checkout pull/451`

Update a local copy of the PR: \
`$ git checkout pull/451` \
`$ git pull https://git.openjdk.java.net/jfx pull/451/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 451`

View PR using the GUI difftool: \
`$ git pr show -t 451`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/451.diff">https://git.openjdk.java.net/jfx/pull/451.diff</a>

</details>
