### PR TITLE
8137323: Incorrect parsing of mnemonic in controls text

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.OverrunStyle;
 import javafx.scene.control.SkinBaseShim;
 import javafx.scene.control.skin.LabelSkin;
+import javafx.scene.control.skin.LabelSkinBaseShim;
 import javafx.scene.control.skin.LabeledSkinBaseShim;
 import javafx.scene.effect.BlendMode;
 import javafx.scene.paint.Color;
@@ -2062,8 +2063,50 @@ public class LabelSkinTest {
      *                                                                          *
      ***************************************************************************/
 
-    // tests for updateDisplayedText (not even sure how to test it exactly yet)
+    @Test
+    public void mnemonicSymbolIsRemovedFromDisplayedText() {
+        label.setMnemonicParsing(true);
+        label.setText("foo _bar");
+        label.autosize();
+        skin.updateDisplayedText();
+        assertEquals("foo bar", LabelSkinBaseShim.getText(label).getText());
+    }
 
+    @Test
+    public void extendedMnemonicIsRemovedFromDisplayedText() {
+        label.setMnemonicParsing(true);
+        label.setText("foo _(x)bar");
+        label.autosize();
+        skin.updateDisplayedText();
+        assertEquals("foo bar", LabelSkinBaseShim.getText(label).getText());
+    }
+
+    @Test
+    public void escapedMnemonicSymbolIsRetainedInDisplayedText() {
+        label.setMnemonicParsing(true);
+        label.setText("foo __bar");
+        label.autosize();
+        skin.updateDisplayedText();
+        assertEquals("foo _bar", LabelSkinBaseShim.getText(label).getText());
+    }
+
+    @Test
+    public void underscoreNotFollowedByAlphabeticCharIsNotAMnemonic() {
+        label.setMnemonicParsing(true);
+        label.setText("foo_ bar");
+        label.autosize();
+        skin.updateDisplayedText();
+        assertEquals("foo_ bar", LabelSkinBaseShim.getText(label).getText());
+    }
+
+    @Test
+    public void underscoreAtEndOfTextIsNotAMnemonic() {
+        label.setMnemonicParsing(true);
+        label.setText("foo_");
+        label.autosize();
+        skin.updateDisplayedText();
+        assertEquals("foo_", LabelSkinBaseShim.getText(label).getText());
+    }
 
     public static final class LabelSkinMock extends LabelSkin {
         boolean propertyChanged = false;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
@@ -2091,6 +2091,15 @@ public class LabelSkinTest {
     }
 
     @Test
+    public void escapedMnemonicSymbolIsNotProcessedWhenMnemonicParsingIsDisabled() {
+        label.setMnemonicParsing(false);
+        label.setText("foo __bar");
+        label.autosize();
+        skin.updateDisplayedText();
+        assertEquals("foo __bar", LabelSkinBaseShim.getText(label).getText());
+    }
+
+    @Test
     public void underscoreNotFollowedByAlphabeticCharIsNotAMnemonic() {
         label.setMnemonicParsing(true);
         label.setText("foo_ bar");


### PR DESCRIPTION
This PR fixes incorrect parsing of mnemonic symbols in the following cases:
1. an escaped double underscore incorrectly shows up as a double underscore in displayed text
2. an extended mnemonic incorrectly removes a part of adjacent text

As a side effect, this PR also fixes another undocumented issue for multiline text where text metrics calculations incorrectly operate on text for which mnemonic symbols have not been processed.

This can lead to a glitch where the mnemonic underscore makes a text just long enough to wrap to a new line, but when the text is rendered, the second line shows up entirely empty. The reason for this is that for rendering, the text is laid out _after_ mnemonic symbols have been removed.

The solution is to _always_ use processed text ("_clean text_") when laying out text.