### PR TITLE
8264770: BidirectionalBinding should use InvalidationListener to prevent boxing

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/BidirectionalBinding.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/BidirectionalBinding.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,10 @@
 
 package com.sun.javafx.binding;
 
+import javafx.beans.InvalidationListener;
+import javafx.beans.Observable;
 import javafx.beans.WeakListener;
 import javafx.beans.property.*;
-import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.util.StringConverter;
 
@@ -36,7 +37,7 @@ import java.text.Format;
 import java.text.ParseException;
 import java.util.Objects;
 
-public abstract class BidirectionalBinding<T> implements ChangeListener<T>, WeakListener {
+public abstract class BidirectionalBinding implements InvalidationListener, WeakListener {
 
     private static void checkParameters(Object property1, Object property2) {
         Objects.requireNonNull(property1, "Both properties must be specified.");
@@ -97,10 +98,10 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
         checkParameters(property1, property2);
         final BidirectionalBinding binding = new UntypedGenericBidirectionalBinding(property1, property2);
         if (property1 instanceof ObservableValue) {
-            ((ObservableValue) property1).removeListener(binding);
+            ((ObservableValue<?>)property1).removeListener(binding);
         }
         if (property2 instanceof ObservableValue) {
-            ((ObservableValue) property2).removeListener(binding);
+            ((ObservableValue<?>)property2).removeListener(binding);
         }
     }
 
@@ -139,7 +140,7 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
     private static <T extends Number> BidirectionalBinding bindNumberObject(Property<Number> property1, Property<T> property2) {
         checkParameters(property1, property2);
 
-        final BidirectionalBinding<Number> binding = new TypedNumberBidirectionalBinding<T>(property2, property1);
+        final BidirectionalBinding binding = new TypedNumberBidirectionalBinding<>(property2, property1);
 
         property1.setValue(property2.getValue());
         property1.addListener(binding);
@@ -150,7 +151,7 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
     private static <T extends Number> BidirectionalBinding bindNumber(Property<T> property1, Property<Number> property2) {
         checkParameters(property1, property2);
 
-        final BidirectionalBinding<Number> binding = new TypedNumberBidirectionalBinding<T>(property1, property2);
+        final BidirectionalBinding binding = new TypedNumberBidirectionalBinding<>(property1, property2);
 
         property1.setValue((T)property2.getValue());
         property1.addListener(binding);
@@ -208,15 +209,17 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
         return false;
     }
 
-    private static class BidirectionalBooleanBinding extends BidirectionalBinding<Boolean> {
+    private static class BidirectionalBooleanBinding extends BidirectionalBinding {
         private final WeakReference<BooleanProperty> propertyRef1;
         private final WeakReference<BooleanProperty> propertyRef2;
-        private boolean updating = false;
+        private boolean oldValue;
+        private boolean updating;
 
         private BidirectionalBooleanBinding(BooleanProperty property1, BooleanProperty property2) {
             super(property1, property2);
-            propertyRef1 = new WeakReference<BooleanProperty>(property1);
-            propertyRef2 = new WeakReference<BooleanProperty>(property2);
+            oldValue = property1.get();
+            propertyRef1 = new WeakReference<>(property1);
+            propertyRef2 = new WeakReference<>(property2);
         }
 
         @Override
@@ -230,7 +233,7 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
         }
 
         @Override
-        public void changed(ObservableValue<? extends Boolean> sourceProperty, Boolean oldValue, Boolean newValue) {
+        public void invalidated(Observable sourceProperty) {
             if (!updating) {
                 final BooleanProperty property1 = propertyRef1.get();
                 final BooleanProperty property2 = propertyRef2.get();
@@ -245,9 +248,13 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
                     try {
                         updating = true;
                         if (property1 == sourceProperty) {
+                            boolean newValue = property1.get();
                             property2.set(newValue);
+                            oldValue = newValue;
                         } else {
+                            boolean newValue = property2.get();
                             property1.set(newValue);
+                            oldValue = newValue;
                         }
                     } catch (RuntimeException e) {
                         try {
@@ -275,15 +282,17 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
         }
     }
 
-    private static class BidirectionalDoubleBinding extends BidirectionalBinding<Number> {
+    private static class BidirectionalDoubleBinding extends BidirectionalBinding {
         private final WeakReference<DoubleProperty> propertyRef1;
         private final WeakReference<DoubleProperty> propertyRef2;
+        private double oldValue;
         private boolean updating = false;
 
         private BidirectionalDoubleBinding(DoubleProperty property1, DoubleProperty property2) {
             super(property1, property2);
-            propertyRef1 = new WeakReference<DoubleProperty>(property1);
-            propertyRef2 = new WeakReference<DoubleProperty>(property2);
+            oldValue = property1.get();
+            propertyRef1 = new WeakReference<>(property1);
+            propertyRef2 = new WeakReference<>(property2);
         }
 
         @Override
@@ -297,7 +306,7 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
         }
 
         @Override
-        public void changed(ObservableValue<? extends Number> sourceProperty, Number oldValue, Number newValue) {
+        public void invalidated(Observable sourceProperty) {
             if (!updating) {
                 final DoubleProperty property1 = propertyRef1.get();
                 final DoubleProperty property2 = propertyRef2.get();
@@ -312,16 +321,20 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
                     try {
                         updating = true;
                         if (property1 == sourceProperty) {
-                            property2.set(newValue.doubleValue());
+                            double newValue = property1.get();
+                            property2.set(newValue);
+                            oldValue = newValue;
                         } else {
-                            property1.set(newValue.doubleValue());
+                            double newValue = property2.get();
+                            property1.set(newValue);
+                            oldValue = newValue;
                         }
                     } catch (RuntimeException e) {
                         try {
                             if (property1 == sourceProperty) {
-                                property1.set(oldValue.doubleValue());
+                                property1.set(oldValue);
                             } else {
-                                property2.set(oldValue.doubleValue());
+                                property2.set(oldValue);
                             }
                         } catch (Exception e2) {
                             e2.addSuppressed(e);
@@ -342,15 +355,17 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
         }
     }
 
-    private static class BidirectionalFloatBinding extends BidirectionalBinding<Number> {
+    private static class BidirectionalFloatBinding extends BidirectionalBinding {
         private final WeakReference<FloatProperty> propertyRef1;
         private final WeakReference<FloatProperty> propertyRef2;
+        private float oldValue;
         private boolean updating = false;
 
         private BidirectionalFloatBinding(FloatProperty property1, FloatProperty property2) {
             super(property1, property2);
-            propertyRef1 = new WeakReference<FloatProperty>(property1);
-            propertyRef2 = new WeakReference<FloatProperty>(property2);
+            oldValue = property1.get();
+            propertyRef1 = new WeakReference<>(property1);
+            propertyRef2 = new WeakReference<>(property2);
         }
 
         @Override
@@ -364,7 +379,7 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
         }
 
         @Override
-        public void changed(ObservableValue<? extends Number> sourceProperty, Number oldValue, Number newValue) {
+        public void invalidated(Observable sourceProperty) {
             if (!updating) {
                 final FloatProperty property1 = propertyRef1.get();
                 final FloatProperty property2 = propertyRef2.get();
@@ -379,16 +394,20 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
                     try {
                         updating = true;
                         if (property1 == sourceProperty) {
-                            property2.set(newValue.floatValue());
+                            float newValue = property1.get();
+                            property2.set(newValue);
+                            oldValue = newValue;
                         } else {
-                            property1.set(newValue.floatValue());
+                            float newValue = property2.get();
+                            property1.set(newValue);
+                            oldValue = newValue;
                         }
                     } catch (RuntimeException e) {
                         try {
                             if (property1 == sourceProperty) {
-                                property1.set(oldValue.floatValue());
+                                property1.set(oldValue);
                             } else {
-                                property2.set(oldValue.floatValue());
+                                property2.set(oldValue);
                             }
                         } catch (Exception e2) {
                             e2.addSuppressed(e);
@@ -409,15 +428,17 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
         }
     }
 
-    private static class BidirectionalIntegerBinding extends BidirectionalBinding<Number>{
+    private static class BidirectionalIntegerBinding extends BidirectionalBinding {
         private final WeakReference<IntegerProperty> propertyRef1;
         private final WeakReference<IntegerProperty> propertyRef2;
+        private int oldValue;
         private boolean updating = false;
 
         private BidirectionalIntegerBinding(IntegerProperty property1, IntegerProperty property2) {
             super(property1, property2);
-            propertyRef1 = new WeakReference<IntegerProperty>(property1);
-            propertyRef2 = new WeakReference<IntegerProperty>(property2);
+            oldValue = property1.get();
+            propertyRef1 = new WeakReference<>(property1);
+            propertyRef2 = new WeakReference<>(property2);
         }
 
         @Override
@@ -431,7 +452,7 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
         }
 
         @Override
-        public void changed(ObservableValue<? extends Number> sourceProperty, Number oldValue, Number newValue) {
+        public void invalidated(Observable sourceProperty) {
             if (!updating) {
                 final IntegerProperty property1 = propertyRef1.get();
                 final IntegerProperty property2 = propertyRef2.get();
@@ -446,16 +467,20 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
                     try {
                         updating = true;
                         if (property1 == sourceProperty) {
-                            property2.set(newValue.intValue());
+                            int newValue = property1.get();
+                            property2.set(newValue);
+                            oldValue = newValue;
                         } else {
-                            property1.set(newValue.intValue());
+                            int newValue = property2.get();
+                            property1.set(newValue);
+                            oldValue = newValue;
                         }
                     } catch (RuntimeException e) {
                         try {
                             if (property1 == sourceProperty) {
-                                property1.set(oldValue.intValue());
+                                property1.set(oldValue);
                             } else {
-                                property2.set(oldValue.intValue());
+                                property2.set(oldValue);
                             }
                         } catch (Exception e2) {
                             e2.addSuppressed(e);
@@ -476,15 +501,17 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
         }
     }
 
-    private static class BidirectionalLongBinding extends BidirectionalBinding<Number> {
+    private static class BidirectionalLongBinding extends BidirectionalBinding {
         private final WeakReference<LongProperty> propertyRef1;
         private final WeakReference<LongProperty> propertyRef2;
+        private long oldValue;
         private boolean updating = false;
 
         private BidirectionalLongBinding(LongProperty property1, LongProperty property2) {
             super(property1, property2);
-            propertyRef1 = new WeakReference<LongProperty>(property1);
-            propertyRef2 = new WeakReference<LongProperty>(property2);
+            oldValue = property1.get();
+            propertyRef1 = new WeakReference<>(property1);
+            propertyRef2 = new WeakReference<>(property2);
         }
 
         @Override
@@ -498,7 +525,7 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
         }
 
         @Override
-        public void changed(ObservableValue<? extends Number> sourceProperty, Number oldValue, Number newValue) {
+        public void invalidated(Observable sourceProperty) {
             if (!updating) {
                 final LongProperty property1 = propertyRef1.get();
                 final LongProperty property2 = propertyRef2.get();
@@ -513,16 +540,20 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
                     try {
                         updating = true;
                         if (property1 == sourceProperty) {
-                            property2.set(newValue.longValue());
+                            long newValue = property1.get();
+                            property2.set(newValue);
+                            oldValue = newValue;
                         } else {
-                            property1.set(newValue.longValue());
+                            long newValue = property2.get();
+                            property1.set(newValue);
+                            oldValue = newValue;
                         }
                     } catch (RuntimeException e) {
                         try {
                             if (property1 == sourceProperty) {
-                                property1.set(oldValue.longValue());
+                                property1.set(oldValue);
                             } else {
-                                property2.set(oldValue.longValue());
+                                property2.set(oldValue);
                             }
                         } catch (Exception e2) {
                             e2.addSuppressed(e);
@@ -543,15 +574,16 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
         }
     }
 
-    private static class TypedGenericBidirectionalBinding<T> extends BidirectionalBinding<T> {
+    private static class TypedGenericBidirectionalBinding<T> extends BidirectionalBinding {
         private final WeakReference<Property<T>> propertyRef1;
         private final WeakReference<Property<T>> propertyRef2;
+        private T oldValue;
         private boolean updating = false;
 
         private TypedGenericBidirectionalBinding(Property<T> property1, Property<T> property2) {
             super(property1, property2);
-            propertyRef1 = new WeakReference<Property<T>>(property1);
-            propertyRef2 = new WeakReference<Property<T>>(property2);
+            propertyRef1 = new WeakReference<>(property1);
+            propertyRef2 = new WeakReference<>(property2);
         }
 
         @Override
@@ -565,7 +597,7 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
         }
 
         @Override
-        public void changed(ObservableValue<? extends T> sourceProperty, T oldValue, T newValue) {
+        public void invalidated(Observable sourceProperty) {
             if (!updating) {
                 final Property<T> property1 = propertyRef1.get();
                 final Property<T> property2 = propertyRef2.get();
@@ -580,9 +612,13 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
                     try {
                         updating = true;
                         if (property1 == sourceProperty) {
+                            T newValue = property1.getValue();
                             property2.setValue(newValue);
+                            oldValue = newValue;
                         } else {
+                            T newValue = property2.getValue();
                             property1.setValue(newValue);
+                            oldValue = newValue;
                         }
                     } catch (RuntimeException e) {
                         try {
@@ -610,15 +646,16 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
         }
     }
 
-    private static class TypedNumberBidirectionalBinding<T extends Number> extends BidirectionalBinding<Number> {
+    private static class TypedNumberBidirectionalBinding<T extends Number> extends BidirectionalBinding {
         private final WeakReference<Property<T>> propertyRef1;
         private final WeakReference<Property<Number>> propertyRef2;
+        private T oldValue;
         private boolean updating = false;
 
         private TypedNumberBidirectionalBinding(Property<T> property1, Property<Number> property2) {
             super(property1, property2);
-            propertyRef1 = new WeakReference<Property<T>>(property1);
-            propertyRef2 = new WeakReference<Property<Number>>(property2);
+            propertyRef1 = new WeakReference<>(property1);
+            propertyRef2 = new WeakReference<>(property2);
         }
 
         @Override
@@ -632,7 +669,7 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
         }
 
         @Override
-        public void changed(ObservableValue<? extends Number> sourceProperty, Number oldValue, Number newValue) {
+        public void invalidated(Observable sourceProperty) {
             if (!updating) {
                 final Property<T> property1 = propertyRef1.get();
                 final Property<Number> property2 = propertyRef2.get();
@@ -647,9 +684,13 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
                     try {
                         updating = true;
                         if (property1 == sourceProperty) {
+                            T newValue = property1.getValue();
                             property2.setValue(newValue);
+                            oldValue = newValue;
                         } else {
-                            property1.setValue((T)newValue);
+                            T newValue = (T)property2.getValue();
+                            property1.setValue(newValue);
+                            oldValue = newValue;
                         }
                     } catch (RuntimeException e) {
                         try {
@@ -677,8 +718,7 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
         }
     }
 
-    private static class UntypedGenericBidirectionalBinding extends BidirectionalBinding<Object> {
-
+    private static class UntypedGenericBidirectionalBinding extends BidirectionalBinding {
         private final Object property1;
         private final Object property2;
 
@@ -699,21 +739,20 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
         }
 
         @Override
-        public void changed(ObservableValue<? extends Object> sourceProperty, Object oldValue, Object newValue) {
+        public void invalidated(Observable sourceProperty) {
             throw new RuntimeException("Should not reach here");
         }
     }
 
-    public abstract static class StringConversionBidirectionalBinding<T> extends BidirectionalBinding<Object> {
-
+    public abstract static class StringConversionBidirectionalBinding<T> extends BidirectionalBinding {
         private final WeakReference<Property<String>> stringPropertyRef;
         private final WeakReference<Property<T>> otherPropertyRef;
         private boolean updating;
 
         public StringConversionBidirectionalBinding(Property<String> stringProperty, Property<T> otherProperty) {
             super(stringProperty, otherProperty);
-            stringPropertyRef = new WeakReference<Property<String>>(stringProperty);
-            otherPropertyRef = new WeakReference<Property<T>>(otherProperty);
+            stringPropertyRef = new WeakReference<>(stringProperty);
+            otherPropertyRef = new WeakReference<>(otherProperty);
         }
 
         protected abstract String toString(T value);
@@ -731,7 +770,7 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
         }
 
         @Override
-        public void changed(ObservableValue<? extends Object> observable, Object oldValue, Object newValue) {
+        public void invalidated(Observable observable) {
             if (!updating) {
                 final Property<String> property1 = stringPropertyRef.get();
                 final Property<T> property2 = otherPropertyRef.get();
@@ -769,7 +808,6 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
     }
 
     private static class StringFormatBidirectionalBinding extends StringConversionBidirectionalBinding {
-
         private final Format format;
 
         @SuppressWarnings("unchecked")
@@ -790,7 +828,6 @@ public abstract class BidirectionalBinding<T> implements ChangeListener<T>, Weak
     }
 
     private static class StringConverterBidirectionalBinding<T> extends StringConversionBidirectionalBinding<T> {
-
         private final StringConverter<T> converter;
 
         public StringConverterBidirectionalBinding(Property<String> stringProperty, Property<T> otherProperty, StringConverter<T> converter) {

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/BidirectionalBinding.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/BidirectionalBinding.java
@@ -582,6 +582,7 @@ public abstract class BidirectionalBinding implements InvalidationListener, Weak
 
         private TypedGenericBidirectionalBinding(Property<T> property1, Property<T> property2) {
             super(property1, property2);
+            oldValue = property1.getValue();
             propertyRef1 = new WeakReference<>(property1);
             propertyRef2 = new WeakReference<>(property2);
         }
@@ -654,6 +655,7 @@ public abstract class BidirectionalBinding implements InvalidationListener, Weak
 
         private TypedNumberBidirectionalBinding(Property<T> property1, Property<Number> property2) {
             super(property1, property2);
+            oldValue = property1.getValue();
             propertyRef1 = new WeakReference<>(property1);
             propertyRef2 = new WeakReference<>(property2);
         }

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/BidirectionalBindingTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/BidirectionalBindingTest.java
@@ -176,7 +176,7 @@ public class BidirectionalBindingTest<T> {
     }
 
     private int getListenerCount(ObservableValue<T> v) {
-        return ExpressionHelperUtility.getChangeListeners(v).size();
+        return ExpressionHelperUtility.getInvalidationListeners(v).size();
     }
 
     @Test

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/BidirectionalBindingWithConversionTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/BidirectionalBindingWithConversionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -281,13 +281,13 @@ public class BidirectionalBindingWithConversionTest<S, T> {
         }
 
         @Override
-        public void addListener(ChangeListener<? super T> listener) {
+        public void addListener(InvalidationListener listener) {
             super.addListener(listener);
             listenerCount++;
         }
 
         @Override
-        public void removeListener(ChangeListener<? super T> listener) {
+        public void removeListener(InvalidationListener listener) {
             super.removeListener(listener);
             listenerCount--;
         }
@@ -303,13 +303,13 @@ public class BidirectionalBindingWithConversionTest<S, T> {
         }
 
         @Override
-        public void addListener(ChangeListener<? super String> listener) {
+        public void addListener(InvalidationListener listener) {
             super.addListener(listener);
             listenerCount++;
         }
 
         @Override
-        public void removeListener(ChangeListener<? super String> listener) {
+        public void removeListener(InvalidationListener listener) {
             super.removeListener(listener);
             listenerCount--;
         }


### PR DESCRIPTION
The internal BidirectionalBinding class implements bidirectional bindings for JavaFX properties. The design intent of this class is to provide specializations for primitive value types to prevent boxing conversions (cf. specializations of the Property class with a similar design intent).

However, the primitive BidirectionalBinding implementations do not meet the design goal of preventing boxing conversions, because they implement ChangeListener.

ChangeListener is a generic SAM interface, which makes it impossibe to invoke an implementation of ChangeListener::changed with a primitive value (i.e. any primitive value will be auto-boxed).

The boxing conversion happens, as with all ChangeListeners, at the invocation site (for example, in ExpressionHelper). Since the boxing conversion has already happened by the time any of the BidirectionalBinding implementations is invoked, there's no point in using primitive specializations of BidirectionalBinding after the fact.

This issue can be solved by having BidirectionalBinding implement InvalidationListener instead, which by itself does not incur a boxing conversion. Because bidirectional bindings are eagerly evaluated, the observable behavior remains the same.

I've filed a bug report with the same title.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264770](https://bugs.openjdk.java.net/browse/JDK-8264770): BidirectionalBinding should use InvalidationListener to prevent boxing


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/454/head:pull/454` \
`$ git checkout pull/454`

Update a local copy of the PR: \
`$ git checkout pull/454` \
`$ git pull https://git.openjdk.java.net/jfx pull/454/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 454`

View PR using the GUI difftool: \
`$ git pr show -t 454`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/454.diff">https://git.openjdk.java.net/jfx/pull/454.diff</a>

</details>
