### PR TITLE
8264677 MemoryLeak: Progressindicator leaks, when treeShowing is false

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ProgressIndicatorSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ProgressIndicatorSkin.java
@@ -742,7 +742,10 @@ public class ProgressIndicatorSkin extends SkinBase<ProgressIndicator> {
                 }
 
                 ((Timeline)indeterminateTransition).getKeyFrames().setAll(keyFrames);
-                indeterminateTransition.playFromStart();
+
+                if(NodeHelper.isTreeShowing(control)) {
+                    indeterminateTransition.playFromStart();
+                }
             } else {
                 if (indeterminateTransition != null) {
                     indeterminateTransition.stop();

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ProgressIndicatorSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ProgressIndicatorSkin.java
@@ -743,8 +743,10 @@ public class ProgressIndicatorSkin extends SkinBase<ProgressIndicator> {
 
                 ((Timeline)indeterminateTransition).getKeyFrames().setAll(keyFrames);
 
-                if(NodeHelper.isTreeShowing(control)) {
+                if (NodeHelper.isTreeShowing(control)) {
                     indeterminateTransition.playFromStart();
+                } else {
+                    indeterminateTransition.jumpTo(Duration.ZERO);
                 }
             } else {
                 if (indeterminateTransition != null) {


### PR DESCRIPTION
Fixing leak in ProgressIndicator when treeShowing is false

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264677](https://bugs.openjdk.java.net/browse/JDK-8264677): MemoryLeak: Progressindicator leaks, when treeShowing is false


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/455/head:pull/455` \
`$ git checkout pull/455`

Update a local copy of the PR: \
`$ git checkout pull/455` \
`$ git pull https://git.openjdk.java.net/jfx pull/455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 455`

View PR using the GUI difftool: \
`$ git pr show -t 455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/455.diff">https://git.openjdk.java.net/jfx/pull/455.diff</a>

</details>
