### PR TITLE
8217955: Problems with touch input and JavaFX 11

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.cpp
@@ -742,7 +742,7 @@ grab_mouse_device(GdkDevice *device, DeviceGrabContext *context) {
                                                context->window,
                                                GDK_OWNERSHIP_NONE,
                                                TRUE,
-                                               GDK_ALL_EVENTS_MASK,
+                                               GDK_FILTERED_EVENTS_MASK,
                                                NULL,
                                                GDK_CURRENT_TIME);
 #else
@@ -752,7 +752,7 @@ grab_mouse_device(GdkDevice *device, DeviceGrabContext *context) {
                                                context->window,
                                                GDK_OWNERSHIP_NONE,
                                                TRUE,
-                                               GDK_ALL_EVENTS_MASK,
+                                               GDK_FILTERED_EVENTS_MASK,
                                                NULL,
                                                GDK_CURRENT_TIME);
                                        */

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.h
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.h
@@ -42,6 +42,13 @@
 #define GLASS_GTK3
 #endif
 
+#ifndef GDK_TOUCH_MASK
+#define GDK_TOUCH_MASK (1 << 22)
+#endif
+
+#define GDK_FILTERED_EVENTS_MASK static_cast<GdkEventMask>(GDK_ALL_EVENTS_MASK \
+                & ~GDK_TOUCH_MASK)
+
 #define JLONG_TO_PTR(value) ((void*)(intptr_t)(value))
 #define PTR_TO_JLONG(value) ((jlong)(intptr_t)(value))
 

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
@@ -751,7 +751,7 @@ WindowContextTop::WindowContextTop(jobject _jwindow, WindowContext* _owner, long
     }
 
     gtk_widget_set_size_request(gtk_widget, 0, 0);
-    gtk_widget_set_events(gtk_widget, GDK_ALL_EVENTS_MASK);
+    gtk_widget_set_events(gtk_widget, GDK_FILTERED_EVENTS_MASK);
     gtk_widget_set_app_paintable(gtk_widget, TRUE);
     if (frame_type != TITLED) {
         gtk_window_set_decorated(GTK_WINDOW(gtk_widget), FALSE);
@@ -761,6 +761,7 @@ WindowContextTop::WindowContextTop(jobject _jwindow, WindowContext* _owner, long
     gtk_window_set_title(GTK_WINDOW(gtk_widget), "");
 
     gdk_window = gtk_widget_get_window(gtk_widget);
+    gdk_window_set_events(gdk_window, GDK_FILTERED_EVENTS_MASK);
 
     g_object_set_data_full(G_OBJECT(gdk_window), GDK_WINDOW_DATA_CONTEXT, this, NULL);
 
@@ -1543,12 +1544,13 @@ WindowContextPlug::WindowContextPlug(jobject _jwindow, void* _owner) :
     g_signal_connect(G_OBJECT(gtk_widget), "configure-event", G_CALLBACK(plug_configure), this);
 
     gtk_widget_set_size_request(gtk_widget, 0, 0);
-    gtk_widget_set_events(gtk_widget, GDK_ALL_EVENTS_MASK);
+    gtk_widget_set_events(gtk_widget, GDK_FILTERED_EVENTS_MASK);
     gtk_widget_set_can_focus(GTK_WIDGET(gtk_widget), TRUE);
     gtk_widget_set_app_paintable(gtk_widget, TRUE);
 
     gtk_widget_realize(gtk_widget);
     gdk_window = gtk_widget_get_window(gtk_widget);
+    gdk_window_set_events(gdk_window, GDK_FILTERED_EVENTS_MASK);
 
     g_object_set_data_full(G_OBJECT(gdk_window), GDK_WINDOW_DATA_CONTEXT, this, NULL);
     gdk_window_register_dnd(gdk_window);
@@ -1711,12 +1713,13 @@ WindowContextChild::WindowContextChild(jobject _jwindow,
         glass_gtk_window_configure_from_visual(gtk_widget, visual);
     }
 
-    gtk_widget_set_events(gtk_widget, GDK_ALL_EVENTS_MASK);
+    gtk_widget_set_events(gtk_widget, GDK_FILTERED_EVENTS_MASK);
     gtk_widget_set_can_focus(GTK_WIDGET(gtk_widget), TRUE);
     gtk_widget_set_app_paintable(gtk_widget, TRUE);
     gtk_container_add (GTK_CONTAINER(parent_widget), gtk_widget);
     gtk_widget_realize(gtk_widget);
     gdk_window = gtk_widget_get_window(gtk_widget);
+    gdk_window_set_events(gdk_window, GDK_FILTERED_EVENTS_MASK);
     g_object_set_data_full(G_OBJECT(gdk_window), GDK_WINDOW_DATA_CONTEXT, this, NULL);
     gdk_window_register_dnd(gdk_window);
     g_signal_connect(gtk_widget, "focus-in-event", G_CALLBACK(child_focus_callback), this);


### PR DESCRIPTION
This PR filters out `GDK_TOUCH_EVENT_MASK` from `GDK_ALL_EVENTS_MASK` to prevent touch events from being used instead of regular mouse events on Linux platforms. Note that the touch events will be delivered as mouse pressed/dragged events.

Since we still compile with GTK 2.x the bit flag (that was introduced in GTK 3.4) needs to be defined.

This PR has been tested on Ubuntu 20.04 with a touch enabled display.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8217955](https://bugs.openjdk.java.net/browse/JDK-8217955): Problems with touch input and JavaFX 11


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/457/head:pull/457` \
`$ git checkout pull/457`

Update a local copy of the PR: \
`$ git checkout pull/457` \
`$ git pull https://git.openjdk.java.net/jfx pull/457/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 457`

View PR using the GUI difftool: \
`$ git pr show -t 457`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/457.diff">https://git.openjdk.java.net/jfx/pull/457.diff</a>

</details>
