### PR TITLE
8264928: Update to Xcode 12.4

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -90,7 +90,7 @@ jfx.gradle.version.min=5.3
 # Toolchains
 jfx.build.linux.gcc.version=gcc10.2.0-OL6.4+1.0
 jfx.build.windows.msvc.version=VS2019-16.7.2+1.0
-jfx.build.macosx.xcode.version=Xcode11.3.1-MacOSX10.15+1.0
+jfx.build.macosx.xcode.version=Xcode12.4+1.0
 
 # Build tools
 jfx.build.cmake.version=3.13.3

--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -50,7 +50,7 @@ MAC.libDest = "lib"
  * In extreme cases you can provide your own properties in your home dir to
  * override these settings or pass them on the command line.
  */
-def prefSdkVersion = "10.15"
+def prefSdkVersion = "11.1"
 def defaultSdkPath = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${prefSdkVersion}.sdk";
 
 // Set the minimum API version that we require (developers do not need to override this)


### PR DESCRIPTION
This updates the compiler used to build JavaFX on macOS to Xcode 12.4 (which includes the MacOSX11.1 sdk), which matches the compiler that will be used to build JDK 17, once openjdk/jdk#3388 is integrated.

As noted in the bug report, Xcode 12.4 needs macOS 10.15.4 (Catalina) or later to build. The produced artifacts will be able to run on earlier versions of macOS (for x86_64 systems anyway).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264928](https://bugs.openjdk.java.net/browse/JDK-8264928): Update to Xcode 12.4


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/460/head:pull/460` \
`$ git checkout pull/460`

Update a local copy of the PR: \
`$ git checkout pull/460` \
`$ git pull https://git.openjdk.java.net/jfx pull/460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 460`

View PR using the GUI difftool: \
`$ git pr show -t 460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/460.diff">https://git.openjdk.java.net/jfx/pull/460.diff</a>

</details>
