### PR TITLE
8263788: JavaFX application freezes completely after some time when using the WebView

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/webkit/MainThread.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/MainThread.java
@@ -36,9 +36,5 @@ final class MainThread {
         });
     }
 
-    private static boolean fwkIsMainThread() {
-        return Invoker.getInvoker().isEventThread();
-    }
-
     private static native void twkScheduleDispatchFunctions();
 }

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/win/ThreadingWin.cpp
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/win/ThreadingWin.cpp
@@ -271,10 +271,8 @@ struct Thread::ThreadHolder {
         // after Windows terminates other threads. If the terminated
         // thread was holding a mutex, trying to lock the mutex causes
         // deadlock.
-#if !PLATFORM(JAVA)
         if (isMainThread())
             return;
-#endif
         if (thread) {
             thread->specificStorage().destroySlots();
             thread->didExit();


### PR DESCRIPTION
Issue: Java application (with WebView) will completely freeze after using it for a while.

Fix: Use native isMainThread functions instead of JNI call.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8263788](https://bugs.openjdk.java.net/browse/JDK-8263788): JavaFX application freezes completely after some time when using the WebView


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Guru Hb](https://openjdk.java.net/census#ghb) (@guruhb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/461/head:pull/461` \
`$ git checkout pull/461`

Update a local copy of the PR: \
`$ git checkout pull/461` \
`$ git pull https://git.openjdk.java.net/jfx pull/461/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 461`

View PR using the GUI difftool: \
`$ git pr show -t 461`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/461.diff">https://git.openjdk.java.net/jfx/pull/461.diff</a>

</details>
