### PR TITLE
8265031: Change default macOS min version for x86_64 to 10.12 and aarch64 to 11.0

### DIFF
--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -56,7 +56,7 @@ def defaultSdkPath = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOS
 // Set the minimum API version that we require (developers do not need to override this)
 // Note that this is not necessarily the same as the preferred SDK version
 def isAarch64 = TARGET_ARCH == "aarch64" || TARGET_ARCH == "arm64";
-def macOSMinVersion = (TARGET_ARCH == "aarch64" || TARGET_ARCH == "arm64") ? "11.0" : "10.12";
+def macOSMinVersion = isAarch64 ? "11.0" : "10.12";
 defineProperty("MACOSX_MIN_VERSION", macOSMinVersion);
 
 // Create $buildDir/mac_tools.properties file and load props from it

--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -55,7 +55,9 @@ def defaultSdkPath = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOS
 
 // Set the minimum API version that we require (developers do not need to override this)
 // Note that this is not necessarily the same as the preferred SDK version
-defineProperty("MACOSX_MIN_VERSION", "10.10");
+def isAarch64 = TARGET_ARCH == "aarch64" || TARGET_ARCH == "arm64";
+def macOSMinVersion = (TARGET_ARCH == "aarch64" || TARGET_ARCH == "arm64") ? "11.0" : "10.12";
+defineProperty("MACOSX_MIN_VERSION", macOSMinVersion);
 
 // Create $buildDir/mac_tools.properties file and load props from it
 setupTools("mac_tools",


### PR DESCRIPTION
As noted in the JBS bug, the minimum macOS version on which JavaFX will run is currently set to 10.10 in `mac.gradle`. macOS 10.10 is many years out of support, so we should update this minimum. Further, macOS / aarch64 (aka arm64) requires macOS 11.0 as a minimum in order to run.

The JDK recently updated their minimum for x86_64 to 10.12 and for aarch64 to 11.0. See [make/autoconf/flags.m4#L136](https://github.com/openjdk/jdk/blob/627ad9fe22a153410c14d0b2061bb7dee2c300af/make/autoconf/flags.m4#L136).

This PR will do the same for JavaFX.

To determine whether we are building on `aarch64`, I check the `TARGET_ARCH` property for either `aarch64` or `arm64`, since we currently use the latter for our builds, although we should proably update our build to consistently use `aarch64` everywhere, and map that to `arm64` on usage where required by native tools.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265031](https://bugs.openjdk.java.net/browse/JDK-8265031): Change default macOS min version for x86_64 to 10.12 and aarch64 to 11.0


### Reviewers
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/462/head:pull/462` \
`$ git checkout pull/462`

Update a local copy of the PR: \
`$ git checkout pull/462` \
`$ git pull https://git.openjdk.java.net/jfx pull/462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 462`

View PR using the GUI difftool: \
`$ git pr show -t 462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/462.diff">https://git.openjdk.java.net/jfx/pull/462.diff</a>

</details>
