### PR TITLE
8234077: Evaluate ignored unit tests in RenderRootTest

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGNode.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGNode.java
@@ -1642,6 +1642,9 @@ public abstract class NGNode {
         if (cullingIndex < -1 || cullingIndex > 15) {
             throw new IllegalArgumentException("cullingIndex cannot be < -1 or > 15");
         }
+        if (dirtyRegion.isEmpty()) {
+            return;
+        }
 
         // This method must NEVER BE CALLED if the depth buffer is turned on. I don't have a good way to test
         // for that because NGNode doesn't have a reference to the scene it is a part of...

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGNode.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGNode.java
@@ -1642,9 +1642,6 @@ public abstract class NGNode {
         if (cullingIndex < -1 || cullingIndex > 15) {
             throw new IllegalArgumentException("cullingIndex cannot be < -1 or > 15");
         }
-        if (dirtyRegion.isEmpty()) {
-            return;
-        }
 
         // This method must NEVER BE CALLED if the depth buffer is turned on. I don't have a good way to test
         // for that because NGNode doesn't have a reference to the scene it is a part of...

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/sg/prism/RenderRootTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/sg/prism/RenderRootTest.java
@@ -325,19 +325,55 @@ public class RenderRootTest extends NGTestBase {
         assertRenderRoot(root, rootPath);
     }
 
-    // What is the right thing here? It seems that an empty dirty region should result in no rendering?
-    @Ignore("JDK-8234077")
+    // A RectBounds is considered as empty only when maxX < minX or maxY < minY.
+    // see RectBounds.isEmpty() and RectBounds.makeEmpty()
+    // What is the right thing here?
+    // 1. Empty dirty region should result in no rendering.
+    //    It means that getRenderRoot() should return an empty NodePath.
+    //    The change in NGNode file enforeces this behavior.
+    //    Following 2 emptyDirtyRegion tests are modified considering this behavior as expected.
+    // OR
+    // 2. Empty dirty region should result in rendering entire root tree.(This is current behavior)
+    //
+    // Changing this behavior may cause rendering glitches for any application that
+    // relies on this current behavior to render all root tree.
+    // So we need to be extensive in testing before modifying the behavior.
     @Test
-    public void emptyDirtyRegion() {
+    public void emptyDirtyRegion1() {
         NodePath rootPath = getRenderRoot(root, 0, 0, -1, -1);
+        assertRenderRoot(null, rootPath);
+    }
+
+    @Test
+    public void emptyDirtyRegion2() {
+        NodePath rootPath = getRenderRoot(root, -1, -1, -2, -2);
+        assertRenderRoot(null, rootPath);
+    }
+
+    @Test
+    public void invalidDirtyRegionOutsideOpaqueRegion() {
+        NodePath rootPath = getRenderRoot(root, -10, -10, 5, 5);
         assertRenderRoot(root, rootPath);
     }
 
-    // Currently fails because isEmpty doesn't take into account width == 0, height == 0")
-    @Ignore("JDK-8234077")
+    // A RectBounds is considered as empty only when maxX < minX or maxY < minY.
+    // see RectBounds.isEmpty() and RectBounds.makeEmpty()
+    // So a RectBounds with 0 width and 0 height is not considered as an empty rect.
     @Test
     public void zeroSizeDirtyRegionWithinOpaqueRegion() {
         NodePath rootPath = getRenderRoot(root, 20, 20, 0, 0);
+        assertRenderRoot(rect, rootPath);
+    }
+
+    @Test
+    public void zeroSizeDirtyRegionOutsideOpaqueRegion1() {
+        NodePath rootPath = getRenderRoot(root, 0, 0, 0, 0);
+        assertRenderRoot(root, rootPath);
+    }
+
+    @Test
+    public void zeroSizeDirtyRegionOutsideOpaqueRegion2() {
+        NodePath rootPath = getRenderRoot(root, 5, 5, 0, 0);
         assertRenderRoot(root, rootPath);
     }
 

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/sg/prism/RenderRootTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/sg/prism/RenderRootTest.java
@@ -329,31 +329,38 @@ public class RenderRootTest extends NGTestBase {
     // see RectBounds.isEmpty() and RectBounds.makeEmpty()
     // What is the right thing here?
     // 1. Empty dirty region should result in no rendering.
-    //    It means that getRenderRoot() should return an empty NodePath.
-    //    The change in NGNode file enforeces this behavior.
-    //    Following 2 emptyDirtyRegion tests are modified considering this behavior as expected.
+    //    It means that getRenderRoot() should return an empty NodePath when dirty region is an empty rect.
     // OR
     // 2. Empty dirty region should result in rendering entire root tree.(This is current behavior)
     //
     // Changing this behavior may cause rendering glitches for any application that
     // relies on this current behavior to render all root tree.
     // So we need to be extensive in testing before modifying the behavior.
+    @Ignore("New JBS")
     @Test
     public void emptyDirtyRegion1() {
         NodePath rootPath = getRenderRoot(root, 0, 0, -1, -1);
-        assertRenderRoot(null, rootPath);
+        assertRenderRoot(root, rootPath);
+        // OR
+        // assertRenderRoot(null, rootPath);
     }
 
+    @Ignore("New JBS")
     @Test
     public void emptyDirtyRegion2() {
         NodePath rootPath = getRenderRoot(root, -1, -1, -2, -2);
-        assertRenderRoot(null, rootPath);
+        assertRenderRoot(root, rootPath);
+        // OR
+        // assertRenderRoot(null, rootPath);
     }
 
+    @Ignore("New JBS")
     @Test
     public void invalidDirtyRegionOutsideOpaqueRegion() {
         NodePath rootPath = getRenderRoot(root, -10, -10, 5, 5);
         assertRenderRoot(root, rootPath);
+        // OR
+        // assertRenderRoot(null, rootPath);
     }
 
     // A RectBounds is considered as empty only when maxX < minX or maxY < minY.

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/sg/prism/RenderRootTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/sg/prism/RenderRootTest.java
@@ -336,7 +336,7 @@ public class RenderRootTest extends NGTestBase {
     // Changing this behavior may cause rendering glitches for any application that
     // relies on this current behavior to render all root tree.
     // So we need to be extensive in testing before modifying the behavior.
-    @Ignore("New JBS")
+    @Ignore("JDK-8265510")
     @Test
     public void emptyDirtyRegion1() {
         NodePath rootPath = getRenderRoot(root, 0, 0, -1, -1);
@@ -345,7 +345,7 @@ public class RenderRootTest extends NGTestBase {
         // assertRenderRoot(null, rootPath);
     }
 
-    @Ignore("New JBS")
+    @Ignore("JDK-8265510")
     @Test
     public void emptyDirtyRegion2() {
         NodePath rootPath = getRenderRoot(root, -1, -1, -2, -2);
@@ -354,7 +354,7 @@ public class RenderRootTest extends NGTestBase {
         // assertRenderRoot(null, rootPath);
     }
 
-    @Ignore("New JBS")
+    @Ignore("JDK-8265510")
     @Test
     public void invalidDirtyRegionOutsideOpaqueRegion() {
         NodePath rootPath = getRenderRoot(root, -10, -10, 5, 5);


### PR DESCRIPTION
These are 2 corner case test cases for getRenderRoot() method.
1. `emptyDirtyRegion():` When the dirty region rect is empty i.e. (0, 0, -1, -1)
2. `zeroSizeDirtyRegionWithinOpaqueRegion()`: When the dirty region rect is of zero dimensions, for example (20, 20, 0, 0)

- emptyDirtyRegion(): When the dirty region rect is empty i.e. (0, 0, -1, -1)
See `RectBounds.makeEmpty()` and `RectBounds.isEmpty()` for definition of an empty rect. It seems logical to NOT to perform any rendering when dirty region is an empty rect. But current behavior is that when empty dirty region rect is passed to `root.getRenderRoot()`, it returns the root itself in NodePath.
The commit#1 can correct/change this behavior to return an empty NodePath. Commit#1 is only for reference, the change is NGNode.java is a product change which is out of scope of this fix. I shall file a new JBS issue to handle this case.
The test `emptyDirtyRegion1` is modified and another variant(`emptyDirtyRegion2`) of test is added. Additionally a new similar test (`invalidDirtyRegionOutsideOpaqueRegion`) is also included which passes an invalid rect. I think the behavior of this case should also be same as that of empty rect. All these three tests shall be ignored using the new JBS.

- zeroSizeDirtyRegionWithinOpaqueRegion(): When the dirty region rect is of zero dimensions, for example (20, 20, 0, 0)
The dirty rect has 0 width and height but from the methods `RectBounds.makeEmpty()` and `RectBounds.isEmpty()` we can infer that the rect(20, 20, 0, 0) is not an empty rect. (It may be considered as a dirty point). So if we consider this rect as a valid dirty region then the current behavior seems valid. I have added a couple more similar tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8234077](https://bugs.openjdk.java.net/browse/JDK-8234077): Evaluate ignored unit tests in RenderRootTest


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/463/head:pull/463` \
`$ git checkout pull/463`

Update a local copy of the PR: \
`$ git checkout pull/463` \
`$ git pull https://git.openjdk.java.net/jfx pull/463/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 463`

View PR using the GUI difftool: \
`$ git pr show -t 463`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/463.diff">https://git.openjdk.java.net/jfx/pull/463.diff</a>

</details>
