### PR TITLE
8259356: MediaPlayer's seek freezes video

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-base/gst-libs/gst/app/gstappsink.c
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-base/gst-libs/gst/app/gstappsink.c
@@ -670,6 +670,7 @@ gst_app_sink_flush_unlocked (GstAppSink * appsink)
         GstEvent *event = GST_EVENT_CAST (obj);
         gst_event_parse_caps (event, &caps);
         gst_caps_replace (&priv->last_caps, caps);
+        gst_sample_set_caps(priv->sample, priv->last_caps);
       }
     }
     gst_mini_object_unref (obj);


### PR DESCRIPTION
This is regression (introduced) by JDK-8199527. JDK-8199527 added fix for HLS streams (unfortunately I was not able to find repro case and more details on why it was added) in gstappsink.c line 659-678 to store current caps which can be lost during seek/flush. However, this workaround broke code in gst_app_sink_render_common() line 939 which was restoring caps if they were flushed, since we set last_caps to non NULL value. Since code in gst_app_sink_render_common() did not work to propagate caps to sample our rendering code was dropping frames without caps. Fixed by setting caps on sample in HLS workaround code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8259356](https://bugs.openjdk.java.net/browse/JDK-8259356): MediaPlayer's seek freezes video


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/464/head:pull/464` \
`$ git checkout pull/464`

Update a local copy of the PR: \
`$ git checkout pull/464` \
`$ git pull https://git.openjdk.java.net/jfx pull/464/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 464`

View PR using the GUI difftool: \
`$ git pr show -t 464`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/464.diff">https://git.openjdk.java.net/jfx/pull/464.diff</a>

</details>
