### PR TITLE
8265425: Hard failure when building OpenJFX for Linux AArch64

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -307,7 +307,7 @@ if (IS_WINDOWS && OS_ARCH != "x86" && OS_ARCH != "amd64") {
     fail("Unknown and unsupported build architecture: $OS_ARCH")
 } else if (IS_MAC && OS_ARCH != "x86_64" && OS_ARCH != "aarch64") {
     fail("Unknown and unsupported build architecture: $OS_ARCH")
-} else if (IS_LINUX && OS_ARCH != "i386" && OS_ARCH != "amd64") {
+} else if (IS_LINUX && OS_ARCH != "i386" && OS_ARCH != "amd64" && OS_ARCH != "aarch64") {
     fail("Unknown and unsupported build architecture: $OS_ARCH")
 }
 


### PR DESCRIPTION
For building on aarch64 linux systems we need it added to the buuld.gradle to stop ignoring it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265425](https://bugs.openjdk.java.net/browse/JDK-8265425): Hard failure when building OpenJFX for Linux AArch64


### Reviewers
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/465/head:pull/465` \
`$ git checkout pull/465`

Update a local copy of the PR: \
`$ git checkout pull/465` \
`$ git pull https://git.openjdk.java.net/jfx pull/465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 465`

View PR using the GUI difftool: \
`$ git pr show -t 465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/465.diff">https://git.openjdk.java.net/jfx/pull/465.diff</a>

</details>
