### PR TITLE
8265439: [TestBug] Enable and fix ignored unit tests in MenuItemTest

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuItemTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuItemTest.java
@@ -406,22 +406,6 @@ public class MenuItemTest {
         assertEquals(other.get(), menuItem.isVisible());
     }
 
-    @Test(expected=NullPointerException.class)
-    public void setSpecifiedAccelerator_nullKeyCombination1() {
-        Modifier[] modifierArray = {};
-        KeyCombination kc = new KeyCodeCombination(null, modifierArray);
-        menuItem.setAccelerator(kc);
-        assertEquals(kc, menuItem.getAccelerator());
-    }
-
-    @Test(expected=NullPointerException.class)
-    public void setSpecifiedAccelerator_nullKeyCombination2() {
-        Modifier[] modifierArray = {};
-        KeyCombination kc = new KeyCharacterCombination(null, modifierArray);
-        menuItem.setAccelerator(kc);
-        assertEquals(kc, menuItem.getAccelerator());
-    }
-
     @Test public void setSpecifiedAccelerator1() {
         Modifier[] modifierArray = {};
         KeyCombination kc = new KeyCodeCombination(KeyCode.A, modifierArray);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuItemTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuItemTest.java
@@ -58,7 +58,6 @@ import javafx.scene.shape.Rectangle;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 
@@ -228,18 +227,12 @@ public class MenuItemTest {
     @Test public void getUnspecifiedTextProperty1() {
         MenuItem mi2 = new MenuItem();
         assertNotNull(mi2.textProperty());
+        assertNull(mi2.getText());
     }
 
     @Test public void getUnspecifiedTextProperty2() {
         MenuItem mi2 = new MenuItem("");
         assertEquals("", mi2.getText());
-    }
-
-    @Ignore // calling textProperty will no ensure text value is non null
-    @Test public void unsetTextButNotNull() {
-        MenuItem mi2 = new MenuItem();
-        mi2.textProperty();
-        assertNotNull(mi2.getText());
     }
 
     @Test public void textCanBeBound() {
@@ -275,19 +268,13 @@ public class MenuItemTest {
     @Test public void getUnspecifiedGraphicProperty1() {
         MenuItem mi2 = new MenuItem();
         assertNotNull(mi2.graphicProperty());
+        assertNull(mi2.getGraphic());
     }
 
     @Test public void getUnspecifiedGraphicProperty2() {
         MenuItem mi2 = new MenuItem("",null);
         assertNotNull(mi2.graphicProperty());
-    }
-
-    @Ignore // Again, calling graphicPropery() is not ensuring a non null graphic
-    // node.
-    @Test public void unsetGraphicButNotNull() {
-        MenuItem mi2 = new MenuItem();
-        mi2.graphicProperty();
-        assertNotNull(mi2.getGraphic());
+        assertNull(mi2.getGraphic());
     }
 
     @Test public void graphicCanBeBound() {
@@ -419,18 +406,32 @@ public class MenuItemTest {
         assertEquals(other.get(), menuItem.isVisible());
     }
 
-    @Ignore // keyCharacter for keyCodeCombination cannot be null
-    @Test public void setSpecifiedAccelerator1() {
+    @Test(expected=NullPointerException.class)
+    public void setSpecifiedAccelerator_nullKeyCombination1() {
         Modifier[] modifierArray = {};
         KeyCombination kc = new KeyCodeCombination(null, modifierArray);
         menuItem.setAccelerator(kc);
         assertEquals(kc, menuItem.getAccelerator());
     }
 
-    @Ignore // keyCharacter for keyCodeCombination cannot be null
-    @Test public void setSpecifiedAccelerator2() {
+    @Test(expected=NullPointerException.class)
+    public void setSpecifiedAccelerator_nullKeyCombination2() {
         Modifier[] modifierArray = {};
         KeyCombination kc = new KeyCharacterCombination(null, modifierArray);
+        menuItem.setAccelerator(kc);
+        assertEquals(kc, menuItem.getAccelerator());
+    }
+
+    public void setSpecifiedAccelerator1() {
+        Modifier[] modifierArray = {};
+        KeyCombination kc = new KeyCodeCombination(KeyCode.A, modifierArray);
+        menuItem.setAccelerator(kc);
+        assertEquals(kc, menuItem.getAccelerator());
+    }
+
+    public void setSpecifiedAccelerator2() {
+        Modifier[] modifierArray = {};
+        KeyCombination kc = new KeyCharacterCombination("A", modifierArray);
         menuItem.setAccelerator(kc);
         assertEquals(kc, menuItem.getAccelerator());
     }
@@ -453,18 +454,15 @@ public class MenuItemTest {
         assertNotNull(menuItem.acceleratorProperty());
     }
 
-    @Ignore // keyCharacter cannot be null for keyCharacterCombination
-    @Test public void acceleratorCanBeBound() {
-        Modifier[] modifierArray = {};
-        KeyCombination kc = new KeyCharacterCombination(null, modifierArray);
+    public void acceleratorCanBeBound() {
+        KeyCombination kc = new KeyCharacterCombination("A", KeyCombination.ALT_DOWN);
         SimpleObjectProperty<KeyCombination> other = new SimpleObjectProperty<KeyCombination>(menuItem, "accelerator", kc);
         menuItem.acceleratorProperty().bind(other);
         assertEquals(kc, menuItem.getAccelerator());
     }
 
-    @Ignore
     @Test public void getUnspecifiedMnemonicParsing() {
-        assertEquals(false, menuItem.isMnemonicParsing());
+        assertEquals(true, menuItem.isMnemonicParsing());
     }
 
     @Test public void setTrueMnemonicParsing() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuItemTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/MenuItemTest.java
@@ -422,14 +422,14 @@ public class MenuItemTest {
         assertEquals(kc, menuItem.getAccelerator());
     }
 
-    public void setSpecifiedAccelerator1() {
+    @Test public void setSpecifiedAccelerator1() {
         Modifier[] modifierArray = {};
         KeyCombination kc = new KeyCodeCombination(KeyCode.A, modifierArray);
         menuItem.setAccelerator(kc);
         assertEquals(kc, menuItem.getAccelerator());
     }
 
-    public void setSpecifiedAccelerator2() {
+    @Test public void setSpecifiedAccelerator2() {
         Modifier[] modifierArray = {};
         KeyCombination kc = new KeyCharacterCombination("A", modifierArray);
         menuItem.setAccelerator(kc);
@@ -454,7 +454,7 @@ public class MenuItemTest {
         assertNotNull(menuItem.acceleratorProperty());
     }
 
-    public void acceleratorCanBeBound() {
+    @Test public void acceleratorCanBeBound() {
         KeyCombination kc = new KeyCharacterCombination("A", KeyCombination.ALT_DOWN);
         SimpleObjectProperty<KeyCombination> other = new SimpleObjectProperty<KeyCombination>(menuItem, "accelerator", kc);
         menuItem.acceleratorProperty().bind(other);


### PR DESCRIPTION
This PR enables ignored unit tests from MenuItemTest and fixes them.
4 ignored tests are fixed. 
2 ignored tests are removed.


**Before fix :**
total tests = 89
failures = 0
ignored tests =  6

**After fix :**
total tests = 87
failures = 0
ignored tests =  0

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265439](https://bugs.openjdk.java.net/browse/JDK-8265439): [TestBug] Enable and fix ignored unit tests in MenuItemTest


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/466/head:pull/466` \
`$ git checkout pull/466`

Update a local copy of the PR: \
`$ git checkout pull/466` \
`$ git pull https://git.openjdk.java.net/jfx pull/466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 466`

View PR using the GUI difftool: \
`$ git pr show -t 466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/466.diff">https://git.openjdk.java.net/jfx/pull/466.diff</a>

</details>
