### PR TITLE
8265469: Allow to build media and webkit for Linux-AArch64

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3461,8 +3461,6 @@ project(":web") {
     compileTargets { t ->
         def targetProperties = project.rootProject.ext[t.upper]
         def webkitProperties = targetProperties.webkit
-        def classifier = (t.name != "linux" && t.name != "win") ? t.name :
-                          IS_64 ? IS_AARCH64 ? "${t.name}-aarch64" : "${t.name}-amd64" : "${t.name}-i586"
 
         def webkitOutputDir = cygpath("$buildDir/${t.name}")
         def webkitConfig = IS_DEBUG_NATIVE ? "Debug" : "Release"

--- a/build.gradle
+++ b/build.gradle
@@ -292,6 +292,7 @@ ext.MODULESOURCEPATH = "modulesourcepath.args"
 ext.OS_NAME = System.getProperty("os.name").toLowerCase()
 ext.OS_ARCH = System.getProperty("os.arch")
 ext.IS_64 = OS_ARCH.toLowerCase().contains("64")
+ext.IS_AARCH64 = OS_ARCH.toLowerCase().contains("aarch64")
 ext.IS_MAC = OS_NAME.contains("mac") || OS_NAME.contains("darwin")
 ext.IS_WINDOWS = OS_NAME.contains("windows")
 ext.IS_LINUX = OS_NAME.contains("linux")
@@ -307,7 +308,7 @@ if (IS_WINDOWS && OS_ARCH != "x86" && OS_ARCH != "amd64") {
     fail("Unknown and unsupported build architecture: $OS_ARCH")
 } else if (IS_MAC && OS_ARCH != "x86_64" && OS_ARCH != "aarch64") {
     fail("Unknown and unsupported build architecture: $OS_ARCH")
-} else if (IS_LINUX && OS_ARCH != "i386" && OS_ARCH != "amd64") {
+} else if (IS_LINUX && OS_ARCH != "i386" && OS_ARCH != "amd64" && OS_ARCH != "aarch64") {
     fail("Unknown and unsupported build architecture: $OS_ARCH")
 }
 
@@ -2861,7 +2862,7 @@ project(":media") {
                     args("JAVA_HOME=${JDK_HOME}", "GENERATED_HEADERS_DIR=${generatedHeadersDir}",
                          "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=jfxmedia",
                          "COMPILE_PARFAIT=${compileParfait}",
-                         IS_64 ? "ARCH=x64" : "ARCH=x32",
+                         IS_64 ? IS_AARCH64 ? "ARCH=aarch64" : "ARCH=x64" : "ARCH=x32",
                         "CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}")
 
                     if (t.name == "win") {
@@ -2888,7 +2889,7 @@ project(":media") {
                     exec {
                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/gstreamer-lite")
                         args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=gstreamer-lite",
-                             IS_64 ? "ARCH=x64" : "ARCH=x32", "CC=${mediaProperties.compiler}",
+                             IS_64 ? IS_AARCH64 ? "ARCH=aarch64" : "ARCH=x64" : "ARCH=x32", "CC=${mediaProperties.compiler}",
                              "AR=${mediaProperties.ar}", "LINKER=${mediaProperties.linker}")
 
                         if (t.name == "win") {
@@ -2906,7 +2907,7 @@ project(":media") {
                     exec {
                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/fxplugins")
                         args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=fxplugins",
-                             IS_64 ? "ARCH=x64" : "ARCH=x32",
+                             IS_64 ? IS_AARCH64 ? "ARCH=aarch64" : "ARCH=x64" : "ARCH=x32",
                              "CC=${mediaProperties.compiler}", "AR=${mediaProperties.ar}", "LINKER=${mediaProperties.linker}")
 
                         if (t.name == "win") {
@@ -3216,7 +3217,8 @@ project(":media") {
                                         args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
                                              "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
                                              "BASE_NAME=avplugin", "VERSION=${version}", "LIBAV_DIR=${libavDir}",
-                                             "SUFFIX=", IS_64 ? "ARCH=x64" : "ARCH=x32")
+                                             "SUFFIX=", IS_64 ? IS_AARCH64 ? "ARCH=aarch64" : "ARCH=x64" : "ARCH=x32",
+                                             "STATIC=${IS_STATIC_BUILD}")
                                     }
                                 }
                             }
@@ -3230,7 +3232,8 @@ project(":media") {
                                         args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
                                              "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
                                              "BASE_NAME=avplugin", "VERSION=${version}", "LIBAV_DIR=${libavDir}",
-                                             "SUFFIX=-ffmpeg", IS_64 ? "ARCH=x64" : "ARCH=x32")
+                                             "SUFFIX=-ffmpeg",
+                                             IS_64 ? IS_AARCH64 ? "ARCH=aarch64" : "ARCH=x64" : "ARCH=x32")
                                     }
                                 }
                             }
@@ -3244,7 +3247,8 @@ project(":media") {
                                         args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
                                              "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
                                              "BASE_NAME=avplugin", "VERSION=${version}", "LIBAV_DIR=${libavDir}",
-                                             "SUFFIX=-ffmpeg", IS_64 ? "ARCH=x64" : "ARCH=x32")
+                                             "SUFFIX=-ffmpeg",
+                                             IS_64 ? IS_AARCH64 ? "ARCH=aarch64" : "ARCH=x64" : "ARCH=x32")
                                     }
                                 }
                             }
@@ -3254,7 +3258,7 @@ project(":media") {
                                 commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/linux/avplugin")
                                 args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
                                      "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
-                                     "BASE_NAME=avplugin", IS_64 ? "ARCH=x64" : "ARCH=x32")
+                                     "BASE_NAME=avplugin", IS_64 ? IS_AARCH64 ? "ARCH=aarch64" : "ARCH=x64" : "ARCH=x32")
                             }
                         }
                     }
@@ -3458,7 +3462,7 @@ project(":web") {
         def targetProperties = project.rootProject.ext[t.upper]
         def webkitProperties = targetProperties.webkit
         def classifier = (t.name != "linux" && t.name != "win") ? t.name :
-                          IS_64 ? "${t.name}-amd64" : "${t.name}-i586"
+                          IS_64 ? IS_AARCH64 ? "${t.name}-aarch64" : "${t.name}-amd64" : "${t.name}-i586"
 
         def webkitOutputDir = cygpath("$buildDir/${t.name}")
         def webkitConfig = IS_DEBUG_NATIVE ? "Debug" : "Release"
@@ -3499,7 +3503,11 @@ project(":web") {
                     } else if (t.name == "linux") {
                         cmakeArgs = " $cmakeArgs -DCMAKE_SYSTEM_NAME=Linux"
                         if (IS_64) {
-                            cmakeArgs = "$cmakeArgs -DCMAKE_SYSTEM_PROCESSOR=x86_64"
+                            if (IS_AARCH64) {
+                                cmakeArgs = "$cmakeArgs -DCMAKE_SYSTEM_PROCESSOR=aarch64"
+                            } else {
+                                cmakeArgs = "$cmakeArgs -DCMAKE_SYSTEM_PROCESSOR=x86_64"
+                            }
                         } else {
                             cmakeArgs = "$cmakeArgs -DCMAKE_SYSTEM_PROCESSOR=i586"
                         }

--- a/modules/javafx.media/src/main/native/gstreamer/projects/linux/avplugin/Makefile
+++ b/modules/javafx.media/src/main/native/gstreamer/projects/linux/avplugin/Makefile
@@ -24,13 +24,16 @@ CFLAGS = -fPIC                   \
          -fstack-protector       \
          -Werror=implicit-function-declaration \
          -Werror=trampolines     \
-         -msse2                  \
          -fbuiltin               \
          -DHAVE_STDINT_H         \
          -DLINUX                 \
          -DGST_DISABLE_LOADSAVE  \
          -DGSTREAMER_LITE \
          -ffunction-sections -fdata-sections
+
+ifneq ($(ARCH), aarch64)
+    CFLAGS += -msse2
+endif
 
 ifeq ($(BUILD_TYPE), Release)
     CFLAGS += -Os

--- a/modules/javafx.media/src/main/native/gstreamer/projects/linux/fxplugins/Makefile
+++ b/modules/javafx.media/src/main/native/gstreamer/projects/linux/fxplugins/Makefile
@@ -21,7 +21,6 @@ CFLAGS = -fPIC                   \
          -fstack-protector       \
          -Werror=implicit-function-declaration \
          -Werror=trampolines     \
-         -msse2                  \
          -fbuiltin               \
          -DHAVE_STDINT_H         \
          -DLINUX                 \
@@ -32,6 +31,10 @@ CFLAGS = -fPIC                   \
          -DGST_DISABLE_GST_DEBUG \
          -DGSTREAMER_LITE \
          -ffunction-sections -fdata-sections
+
+ifneq ($(ARCH), aarch64)
+    CFLAGS += -msse2
+endif
 
 ifeq ($(BUILD_TYPE), Release)
     CFLAGS += -Os

--- a/modules/javafx.media/src/main/native/jfxmedia/projects/linux/Makefile
+++ b/modules/javafx.media/src/main/native/jfxmedia/projects/linux/Makefile
@@ -42,8 +42,11 @@ ifdef HOST_COMPILE
                   -Wformat-security \
                   -fstack-protector \
                   -Werror=trampolines \
-		  -msse2 \
 	          -DGSTREAMER_LITE
+        ifneq ($(ARCH), aarch64)
+            CFLAGS += -msse2
+        endif
+
 
 	PACKAGES_INCLUDES := $(shell pkg-config --cflags glib-2.0)
 	PACKAGES_LIBS := $(shell pkg-config --libs glib-2.0 gobject-2.0 gmodule-2.0 gthread-2.0)


### PR DESCRIPTION
Changes that allow to build linux configuration on Linux AArch64
This PR introduces an `IS_AARCH64` parameter in build.gradle.
This PR already contains the change from PR #465 so if this one gets integrated, that change needs to removed from this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265469](https://bugs.openjdk.java.net/browse/JDK-8265469): Allow to build media and webkit for Linux-AArch64


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Alexander Matveev](https://openjdk.java.net/census#almatvee) (@sashamatveev - **Reviewer**) 🔄 Re-review required (review applies to e67b13cfd9169ae6b8ca32f5dfe203bff0da468c)
 * [Arun Joseph](https://openjdk.java.net/census#ajoseph) (@arun-Joseph - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/467/head:pull/467` \
`$ git checkout pull/467`

Update a local copy of the PR: \
`$ git checkout pull/467` \
`$ git pull https://git.openjdk.java.net/jfx pull/467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 467`

View PR using the GUI difftool: \
`$ git pr show -t 467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/467.diff">https://git.openjdk.java.net/jfx/pull/467.diff</a>

</details>
