### PR TITLE
8265513: Openjfx graphics build broken (Eclipse)

### DIFF
--- a/modules/javafx.graphics/.classpath
+++ b/modules/javafx.graphics/.classpath
@@ -38,7 +38,7 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/base">
 		<attributes>
 			<attribute name="module" value="true"/>
-			<attribute name="add-exports" value="javafx.base/com.sun.javafx.property=javafx.graphics"/>
+			<attribute name="add-exports" value="javafx.base/com.sun.javafx.property=javafx.graphics:javafx.base/test.util.memory=javafx.graphics"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4">


### PR DESCRIPTION
Issue is usage of JMemoryBuddy in module graphics (SceneTest, added in [JDK-8264330](https://bugs.openjdk.java.net/browse/JDK-8264330). 

Fix is to add-exports in Eclipse .classpath in graphics (same as done for controls in fix of [JDK-8256184](https://bugs.openjdk.java.net/browse/JDK-8256184)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265513](https://bugs.openjdk.java.net/browse/JDK-8265513): Openjfx graphics build broken (Eclipse)


### Reviewers
 * [Nir Lisker](https://openjdk.java.net/census#nlisker) (@nlisker - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/469/head:pull/469` \
`$ git checkout pull/469`

Update a local copy of the PR: \
`$ git checkout pull/469` \
`$ git pull https://git.openjdk.java.net/jfx pull/469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 469`

View PR using the GUI difftool: \
`$ git pr show -t 469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/469.diff">https://git.openjdk.java.net/jfx/pull/469.diff</a>

</details>
