### PR TITLE
8239880: CSS tests should cleanup any global state they modify

### DIFF
--- a/modules/javafx.graphics/src/test/java/test/javafx/css/CssMetaDataTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/CssMetaDataTest.java
@@ -79,6 +79,8 @@ import javafx.css.Styleable;
 import javafx.css.StyleableProperty;
 import javafx.css.Stylesheet;
 import javafx.css.StylesheetShim;
+
+import org.junit.After;
 import org.junit.Test;
 import org.junit.Ignore;
 
@@ -101,6 +103,20 @@ public class CssMetaDataTest {
             if (prop.equals(styleable.getProperty())) return styleable;
         }
         return null;
+    }
+
+    private static void resetStyleManager() {
+        StyleManager sm = StyleManager.getInstance();
+        sm.userAgentStylesheetContainers.clear();
+        sm.platformUserAgentStylesheetContainers.clear();
+        sm.stylesheetContainerMap.clear();
+        sm.cacheContainerMap.clear();
+        sm.hasDefaultUserAgentStylesheet = false;
+    }
+
+    @After
+    public void cleanup() {
+        resetStyleManager();
     }
 
     /**
@@ -268,7 +284,7 @@ public class CssMetaDataTest {
 
         final Stylesheet stylesheet = StylesheetShim.getStylesheet();
         stylesheet.setOrigin(StyleOrigin.USER_AGENT);
-        StyleManager.getInstance().getInstance().setDefaultUserAgentStylesheet(stylesheet);
+        StyleManager.getInstance().setDefaultUserAgentStylesheet(stylesheet);
 
         final List<Rule> rules = stylesheet.getRules();
 
@@ -371,10 +387,9 @@ public class CssMetaDataTest {
     @Test
     public void testGetMatchingStylesWithInlineStyleOnParent() {
 
-
         final Stylesheet stylesheet = StylesheetShim.getStylesheet();
         stylesheet.setOrigin(StyleOrigin.USER_AGENT);
-        StyleManager.getInstance().getInstance().setDefaultUserAgentStylesheet(stylesheet);
+        StyleManager.getInstance().setDefaultUserAgentStylesheet(stylesheet);
 
         final List<Rule> rules = stylesheet.getRules();
 
@@ -498,7 +513,7 @@ public class CssMetaDataTest {
 
         final Stylesheet stylesheet = StylesheetShim.getStylesheet();
         stylesheet.setOrigin(StyleOrigin.USER_AGENT);
-        StyleManager.getInstance().getInstance().setDefaultUserAgentStylesheet(stylesheet);
+        StyleManager.getInstance().setDefaultUserAgentStylesheet(stylesheet);
 
         final List<Rule> rules = stylesheet.getRules();
 
@@ -622,7 +637,7 @@ public class CssMetaDataTest {
 
         final Stylesheet stylesheet = StylesheetShim.getStylesheet();
         stylesheet.setOrigin(StyleOrigin.USER_AGENT);
-        StyleManager.getInstance().getInstance().setDefaultUserAgentStylesheet(stylesheet);
+        StyleManager.getInstance().setDefaultUserAgentStylesheet(stylesheet);
 
         final List<Rule> rules = stylesheet.getRules();
 
@@ -750,7 +765,7 @@ public class CssMetaDataTest {
 
         final Stylesheet stylesheet = StylesheetShim.getStylesheet();
         stylesheet.setOrigin(StyleOrigin.USER_AGENT);
-        StyleManager.getInstance().getInstance().setDefaultUserAgentStylesheet(stylesheet);
+        StyleManager.getInstance().setDefaultUserAgentStylesheet(stylesheet);
 
         final List<Rule> rules = stylesheet.getRules();
 
@@ -961,7 +976,6 @@ public class CssMetaDataTest {
     @Ignore("JDK-8234142")
     @Test
     public void testGetMatchingStylesReturnsInheritedProperty() {
-
 
         final Stylesheet stylesheet = StylesheetShim.getStylesheet();
         stylesheet.setOrigin(StyleOrigin.USER_AGENT);

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
@@ -42,6 +42,7 @@ import javafx.stage.Stage;
 import javafx.stage.Window;
 
 import com.sun.javafx.util.Logging;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import com.sun.javafx.logging.PlatformLogger;
@@ -57,12 +58,18 @@ public class HonorDeveloperSettingsTest {
     private Rectangle rect;
     private Text text;
 
-    // Scene must have a Window for CSS to load the stylesheet.
-    // And Window must have a Scene for StyleManager to find the right scene
-    static class TestWindow extends Window {
-        @Override public void setScene(Scene value) {
-            super.setScene(value);
-        }
+    private static void resetStyleManager() {
+        StyleManager sm = StyleManager.getInstance();
+        sm.userAgentStylesheetContainers.clear();
+        sm.platformUserAgentStylesheetContainers.clear();
+        sm.stylesheetContainerMap.clear();
+        sm.cacheContainerMap.clear();
+        sm.hasDefaultUserAgentStylesheet = false;
+    }
+
+    @After
+    public void cleanup() {
+        resetStyleManager();
     }
 
     @Before
@@ -76,18 +83,10 @@ public class HonorDeveloperSettingsTest {
         Group group = new Group();
         group.getChildren().addAll(rect, text);
 
-        scene = new Scene(group);/* {
-            TestWindow window;
-            {
-                window = new TestWindow();
-                window.setScene(HonorDeveloperSettingsTest.this.scene);
-                impl_setWindow(window);
-            }
-        };*/
-
+        scene = new Scene(group);
         System.setProperty("binary.css", "false");
         String url = getClass().getResource("HonorDeveloperSettingsTest_UA.css").toExternalForm();
-        StyleManager.getInstance().getInstance().setDefaultUserAgentStylesheet(url);
+        StyleManager.getInstance().setDefaultUserAgentStylesheet(url);
 
         Stage stage = new Stage();
         stage.setScene(scene);

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/Node_cssStyleMap_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/Node_cssStyleMap_Test.java
@@ -62,6 +62,7 @@ import javafx.scene.text.Text;
 
 import static org.junit.Assert.*;
 
+import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -98,6 +99,20 @@ public class Node_cssStyleMap_Test {
 
         assert(style.getDeclaration() == declaration);
 
+    }
+
+    private static void resetStyleManager() {
+        StyleManager sm = StyleManager.getInstance();
+        sm.userAgentStylesheetContainers.clear();
+        sm.platformUserAgentStylesheetContainers.clear();
+        sm.stylesheetContainerMap.clear();
+        sm.cacheContainerMap.clear();
+        sm.hasDefaultUserAgentStylesheet = false;
+    }
+
+    @After
+    public void cleanup() {
+        resetStyleManager();
     }
 
     @Ignore("JDK-8234241")

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_effectiveOrientation_Css_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_effectiveOrientation_Css_Test.java
@@ -63,7 +63,17 @@ public class Node_effectiveOrientation_Css_Test {
 
     @After
     public void tearDown() {
+        resetStyleManager();
         stage.hide();
+    }
+
+    private static void resetStyleManager() {
+        StyleManager sm = StyleManager.getInstance();
+        sm.userAgentStylesheetContainers.clear();
+        sm.platformUserAgentStylesheetContainers.clear();
+        sm.stylesheetContainerMap.clear();
+        sm.cacheContainerMap.clear();
+        sm.hasDefaultUserAgentStylesheet = false;
     }
 
     public Node_effectiveOrientation_Css_Test() {}


### PR DESCRIPTION
The tests that are modified in this PR set a stylesheet using API `StyleManager.getInstance().setDefaultUserAgentStylesheet()`.
This is a global state and should be reset after execution of each test.
It does not cause any test failures currently, but this has caused a test failure in past reported here [JDK-8239822](https://bugs.openjdk.java.net/browse/JDK-8239822) which was fixed with a similar change like in this PR.

A reset method like following seems sufficient to undo the changes made by `StyleManager.getInstance().setDefaultUserAgentStylesheet()`.
But this fix uses the same method definition of `resetStyleManager()` like in the [fix](https://git.openjdk.java.net/jfx/commit/c3ee1a30) for [JDK-8239822](https://bugs.openjdk.java.net/browse/JDK-8239822)

```
private static void resetStyleManager() {
    StyleManager sm = StyleManager.getInstance();
    sm.platformUserAgentStylesheetContainers.clear();
    sm.hasDefaultUserAgentStylesheet = false;
}
```

Fix also has 2 cleanup changes,
1. A minor typo correction in code, `StyleManager.getInstance().getInstance()` is replaced with `StyleManager.getInstance()`.
2. In test file _HonorDeveloperSettingsTest.java_: Unused class `TestWindow` is removed and few line of commented out code(which used the TestWindow class) is removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8239880](https://bugs.openjdk.java.net/browse/JDK-8239880): CSS tests should cleanup any global state they modify


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/470/head:pull/470` \
`$ git checkout pull/470`

Update a local copy of the PR: \
`$ git checkout pull/470` \
`$ git pull https://git.openjdk.java.net/jfx pull/470/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 470`

View PR using the GUI difftool: \
`$ git pr show -t 470`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/470.diff">https://git.openjdk.java.net/jfx/pull/470.diff</a>

</details>
