### PR TITLE
8265514: Openjfx controls running tests broken (Eclipse)

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/PropertySizeTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/PropertySizeTest.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-package test.javafx.css;
+package test.javafx.scene.control;
 
 import javafx.scene.Scene;
 import javafx.scene.control.Label;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/css/PropertySizeTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/css/PropertySizeTest.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-package test.javafx.scene.control;
+package test.javafx.scene.control.css;
 
 import javafx.scene.Scene;
 import javafx.scene.control.Label;


### PR DESCRIPTION
As mentioned in JBS the unit test execution fails when tests have a duplicate package name.
This was introduced by JDK-8204568: it created a test in a new package `test.javafx.css` in controls tests. A similar package already existed in graphics unit tests.
This is a simple fix to rename the package. Test is moved to existing package in controls test under `test.javafx.scene.control`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265514](https://bugs.openjdk.java.net/browse/JDK-8265514): Openjfx controls running tests broken (Eclipse)


### Reviewers
 * [Jeanette Winzenburg](https://openjdk.java.net/census#fastegal) (@kleopatra - Committer)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/472/head:pull/472` \
`$ git checkout pull/472`

Update a local copy of the PR: \
`$ git checkout pull/472` \
`$ git pull https://git.openjdk.java.net/jfx pull/472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 472`

View PR using the GUI difftool: \
`$ git pr show -t 472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/472.diff">https://git.openjdk.java.net/jfx/pull/472.diff</a>

</details>
