### PR TITLE
8265206: Tree-/TableCell: editing state not updated on cell re-use

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
@@ -549,7 +549,13 @@ public class TableCell<S,T> extends IndexedCell<T> {
     }
 
     private void updateEditing() {
-        if (getIndex() == -1 || getTableView() == null) return;
+        if (getIndex() == -1 || getTableView() == null) {
+            // JDK-8265206: must cancel edit if index changed to -1 by re-use
+            if (isEditing()) {
+                doCancelEdit();
+            }
+            return;
+        }
 
         TablePosition<S,?> editCell = getTableView().getEditingCell();
         boolean match = match(editCell);
@@ -557,17 +563,26 @@ public class TableCell<S,T> extends IndexedCell<T> {
         if (match && ! isEditing()) {
             startEdit();
         } else if (! match && isEditing()) {
-            // If my index is not the one being edited then I need to cancel
-            // the edit. The tricky thing here is that as part of this call
-            // I cannot end up calling list.edit(-1) the way that the standard
-            // cancelEdit method would do. Yet, I need to call cancelEdit
-            // so that subclasses which override cancelEdit can execute. So,
-            // I have to use a kind of hacky flag workaround.
-            updateEditingIndex = false;
-            cancelEdit();
-            updateEditingIndex = true;
+            doCancelEdit();
         }
     }
+
+    /**
+     * Switches an editing cell into not editing without changing control's
+     * editing state.
+     */
+    private void doCancelEdit() {
+        // If my index is not the one being edited then I need to cancel
+        // the edit. The tricky thing here is that as part of this call
+        // I cannot end up calling list.edit(-1) the way that the standard
+        // cancelEdit method would do. Yet, I need to call cancelEdit
+        // so that subclasses which override cancelEdit can execute. So,
+        // I have to use a kind of hacky flag workaround.
+        updateEditingIndex = false;
+        cancelEdit();
+        updateEditingIndex = true;
+    }
+
     private boolean updateEditingIndex = true;
 
     private boolean match(TablePosition<S,?> pos) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
@@ -578,9 +578,13 @@ public class TableCell<S,T> extends IndexedCell<T> {
         // cancelEdit method would do. Yet, I need to call cancelEdit
         // so that subclasses which override cancelEdit can execute. So,
         // I have to use a kind of hacky flag workaround.
-        updateEditingIndex = false;
-        cancelEdit();
-        updateEditingIndex = true;
+        try {
+            // try-finally to make certain that the flag is reliably reset to true
+            updateEditingIndex = false;
+            cancelEdit();
+        } finally {
+            updateEditingIndex = true;
+        }
     }
 
     private boolean updateEditingIndex = true;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
@@ -552,6 +552,11 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
             doCancelEdit();
         }
     }
+
+    /**
+     * Switches an editing cell into not editing without changing control's
+     * editing state.
+     */
     private void doCancelEdit() {
         // If my index is not the one being edited then I need to cancel
         // the edit. The tricky thing here is that as part of this call
@@ -559,10 +564,15 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
         // cancelEdit method would do. Yet, I need to call cancelEdit
         // so that subclasses which override cancelEdit can execute. So,
         // I have to use a kind of hacky flag workaround.
-        updateEditingIndex = false;
-        cancelEdit();
-        updateEditingIndex = true;
+        try {
+            // try-finally to make certain that the flag is reliably reset to true
+            updateEditingIndex = false;
+            cancelEdit();
+        } finally {
+            updateEditingIndex = true;
+        }
     }
+
     private boolean updateEditingIndex = true;
 
     private boolean match(TreeTablePosition pos) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
@@ -535,7 +535,13 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
 
     private void updateEditing() {
         final TreeTableView<S> tv = getTreeTableView();
-        if (getIndex() == -1 || tv == null) return;
+        if (getIndex() == -1 || tv == null) {
+            // JDK-8265206: must cancel edit if index changed to -1 by re-use
+            if (isEditing()) {
+                doCancelEdit();
+            }
+            return;
+        }
 
         TreeTablePosition<S,?> editCell = tv.getEditingCell();
         boolean match = match(editCell);
@@ -543,16 +549,19 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
         if (match && ! isEditing()) {
             startEdit();
         } else if (! match && isEditing()) {
-            // If my index is not the one being edited then I need to cancel
-            // the edit. The tricky thing here is that as part of this call
-            // I cannot end up calling list.edit(-1) the way that the standard
-            // cancelEdit method would do. Yet, I need to call cancelEdit
-            // so that subclasses which override cancelEdit can execute. So,
-            // I have to use a kind of hacky flag workaround.
-            updateEditingIndex = false;
-            cancelEdit();
-            updateEditingIndex = true;
+            doCancelEdit();
         }
+    }
+    private void doCancelEdit() {
+        // If my index is not the one being edited then I need to cancel
+        // the edit. The tricky thing here is that as part of this call
+        // I cannot end up calling list.edit(-1) the way that the standard
+        // cancelEdit method would do. Yet, I need to call cancelEdit
+        // so that subclasses which override cancelEdit can execute. So,
+        // I have to use a kind of hacky flag workaround.
+        updateEditingIndex = false;
+        cancelEdit();
+        updateEditingIndex = true;
     }
     private boolean updateEditingIndex = true;
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellEditingTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellEditingTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.control;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.*;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableColumn.CellEditEvent;
+import javafx.scene.control.TableView;
+
+/**
+ * Test TableCell editing state updated on re-use (aka after updateIndex(old, new)).
+ *
+ * This test is parameterized in cellIndex and editingIndex.
+ */
+@RunWith(Parameterized.class)
+public class TableCellEditingTest {
+    private TableCell<String,String> cell;
+    private TableView<String> table;
+    private TableColumn<String, String> editingColumn;
+    private ObservableList<String> model;
+
+    private int cellIndex;
+    private int editingIndex;
+
+//--------------- change off editing index
+
+    @Test
+    public void testOffEditingIndex() {
+        cell.updateIndex(editingIndex);
+        table.edit(editingIndex, editingColumn);
+        cell.updateIndex(cellIndex);
+        assertEquals("sanity: cell index changed", cellIndex, cell.getIndex());
+        assertEquals("sanity: table editingIndex must be unchanged", editingIndex, table.getEditingCell().getRow());
+        assertEquals("sanity: table editingColumn must be unchanged", editingColumn, table.getEditingCell().getTableColumn());
+        assertFalse("cell must not be editing on update from editingIndex" + editingIndex
+                + " to cellIndex " + cellIndex, cell.isEditing());
+    }
+
+    @Test
+    public void testCancelOffEditingIndex() {
+        cell.updateIndex(editingIndex);
+        table.edit(editingIndex, editingColumn);
+        List<CellEditEvent<String, String>> events = new ArrayList<>();
+        editingColumn.setOnEditCancel(e -> {
+            events.add(e);
+        });
+        cell.updateIndex(cellIndex);
+        assertEquals("cell must have fired edit cancel", 1, events.size());
+        assertEquals("cancel event index must be same as editingIndex", editingIndex,
+                events.get(0).getTablePosition().getRow());
+    }
+
+//--------------- change to editing index
+
+    @Test
+    public void testToEditingIndex() {
+        cell.updateIndex(cellIndex);
+        table.edit(editingIndex, editingColumn);
+        cell.updateIndex(editingIndex);
+        assertEquals("sanity: cell at editing index", editingIndex, cell.getIndex());
+        assertEquals("sanity: table editingIndex must be unchanged", editingIndex, table.getEditingCell().getRow());
+        assertEquals("sanity: table editingColumn must be unchanged", editingColumn, table.getEditingCell().getTableColumn());
+        assertTrue("cell must be editing on update from " + cellIndex
+                + " to editingIndex " + editingIndex, cell.isEditing());
+    }
+
+    @Test
+    public void testStartEvent() {
+        cell.updateIndex(cellIndex);
+        table.edit(editingIndex, editingColumn);
+        List<CellEditEvent<String, String>> events = new ArrayList<>();
+        editingColumn.setOnEditStart(e -> {
+            events.add(e);
+        });
+        cell.updateIndex(editingIndex);
+        assertEquals("cell must have fired edit start on update from " + cellIndex + " to " + editingIndex,
+                1, events.size());
+        assertEquals("start event index must be same as editingIndex", editingIndex,
+                events.get(0).getTablePosition().getRow());
+    }
+
+//------------- parameterized
+
+    // Note: name property not supported before junit 4.11
+    @Parameterized.Parameters // (name = "{index}: cellIndex {0}, editingIndex {1}")
+    public static Collection<Object[]> data() {
+     // [0] is cellIndex, [1] is editingIndex
+        Object[][] data = new Object[][] {
+            {1, 2}, // normal
+            {0, 1}, // zero cell index
+            {1, 0}, // zero editing index
+            {-1, 1}, // negative cell - JDK-8265206
+        };
+        return Arrays.asList(data);
+    }
+
+    public TableCellEditingTest(int cellIndex, int editingIndex) {
+        this.cellIndex = cellIndex;
+        this.editingIndex = editingIndex;
+    }
+
+//-------------- setup and sanity
+
+    /**
+     * Sanity: cell editing state updated when on editing index.
+     */
+    @Test
+    public void testEditOnCellIndex() {
+        cell.updateIndex(editingIndex);
+        table.edit(editingIndex, editingColumn);
+        assertTrue("sanity: cell must be editing", cell.isEditing());
+    }
+
+    /**
+     * Sanity: cell editing state unchanged when off editing index.
+     */
+    @Test
+    public void testEditOffCellIndex() {
+        cell.updateIndex(cellIndex);
+        table.edit(editingIndex, editingColumn);
+        assertFalse("sanity: cell editing must be unchanged", cell.isEditing());
+    }
+
+    @Before
+    public void setup() {
+        cell = new TableCell<String,String>();
+        model = FXCollections.observableArrayList("Four", "Five", "Fear"); // "Flop", "Food", "Fizz"
+        table = new TableView<String>(model);
+        table.setEditable(true);
+        editingColumn = new TableColumn<>("TEST");
+        editingColumn.setCellValueFactory(param -> null);
+        table.getColumns().add(editingColumn);
+        cell.updateTableView(table);
+        cell.updateTableColumn(editingColumn);
+        // make sure that focus change doesn't interfere with tests
+        // (editing cell loosing focus will be canceled from focusListener in Cell)
+        // Note: not really needed for Tree/TableCell because the cell is never focused
+        // if !cellSelectionEnabled nor if not in Tree/TableRow
+        // done here for consistency across analogous tests for List/Tree/Cell
+        table.getFocusModel().focus(-1);
+        assertFalse("sanity: cellIndex not same as editingIndex", cellIndex == editingIndex);
+        assertTrue("sanity: valid editingIndex", editingIndex < model.size());
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellEditingTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellEditingTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.control;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.*;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeTableCell;
+import javafx.scene.control.TreeTableColumn;
+import javafx.scene.control.TreeTableColumn.CellEditEvent;
+import javafx.scene.control.TreeTableView;
+
+/**
+ * Test TreeTableCell editing state updated on re-use (aka after updateIndex(old, new)).
+ *
+ * This test is parameterized in cellIndex and editingIndex.
+ *
+ */
+@RunWith(Parameterized.class)
+public class TreeTableCellEditingTest {
+    private TreeTableCell<String,String> cell;
+    private TreeTableView<String> table;
+    private TreeTableColumn<String, String> editingColumn;
+    private ObservableList<TreeItem<String>> model;
+
+    private int cellIndex;
+    private int editingIndex;
+
+//--------------- change off editing index
+
+    @Test
+    public void testOffEditingIndex() {
+        cell.updateIndex(editingIndex);
+        table.edit(editingIndex, editingColumn);
+        cell.updateIndex(cellIndex);
+        assertEquals("sanity: cell index changed", cellIndex, cell.getIndex());
+        assertEquals("sanity: treeTable editingIndex must be unchanged", editingIndex, table.getEditingCell().getRow());
+        assertEquals("sanity: treeTable editingColumn must be unchanged", editingColumn, table.getEditingCell().getTableColumn());
+        assertFalse("cell must not be editing on update from editingIndex" + editingIndex
+                + " to cellIndex " + cellIndex, cell.isEditing());
+    }
+
+    @Test
+    public void testCancelOffEditingIndex() {
+        cell.updateIndex(editingIndex);
+        table.edit(editingIndex, editingColumn);
+        List<CellEditEvent<String, String>> events = new ArrayList<>();
+        editingColumn.setOnEditCancel(e -> {
+            events.add(e);
+        });
+        cell.updateIndex(cellIndex);
+        assertEquals("cell must have fired edit cancel", 1, events.size());
+        assertEquals("cancel event index must be same as editingIndex", editingIndex,
+                events.get(0).getTreeTablePosition().getRow());
+    }
+
+//--------------- change to editing index
+
+    @Test
+    public void testToEditingIndex() {
+        cell.updateIndex(cellIndex);
+        table.edit(editingIndex, editingColumn);
+        cell.updateIndex(editingIndex);
+        assertEquals("sanity: cell at editing index", editingIndex, cell.getIndex());
+        assertEquals("sanity: treeTable editingIndex must be unchanged", editingIndex, table.getEditingCell().getRow());
+        assertEquals("sanity: treeTable editingColumn must be unchanged", editingColumn, table.getEditingCell().getTableColumn());
+        assertTrue("cell must be editing on update from " + cellIndex
+                + " to editingIndex " + editingIndex, cell.isEditing());
+    }
+
+    @Test
+    public void testStartEvent() {
+        cell.updateIndex(cellIndex);
+        table.edit(editingIndex, editingColumn);
+        List<CellEditEvent<String, String>> events = new ArrayList<>();
+        editingColumn.setOnEditStart(e -> {
+            events.add(e);
+        });
+        cell.updateIndex(editingIndex);
+        assertEquals("cell must have fired edit start on update from " + cellIndex + " to " + editingIndex,
+                1, events.size());
+        assertEquals("start event index must be same as editingIndex", editingIndex,
+                events.get(0).getTreeTablePosition().getRow());
+    }
+
+//------------- parameterized
+
+    // Note: name property not supported before junit 4.11
+    @Parameterized.Parameters //(name = "{index}: cellIndex {0}, editingIndex {1}")
+    public static Collection<Object[]> data() {
+     // [0] is cellIndex, [1] is editingIndex
+        Object[][] data = new Object[][] {
+            {1, 2}, // normal
+            {0, 1}, // zero cell index
+            {1, 0}, // zero editing index
+            {-1, 1}, // negative cell - JDK-8265206
+        };
+        return Arrays.asList(data);
+    }
+
+    public TreeTableCellEditingTest(int cellIndex, int editingIndex) {
+        this.cellIndex = cellIndex;
+        this.editingIndex = editingIndex;
+    }
+
+//-------------- setup and sanity
+
+    /**
+     * Sanity: cell editing state updated when on editing index.
+     */
+    @Test
+    public void testEditOnCellIndex() {
+        cell.updateIndex(editingIndex);
+        table.edit(editingIndex, editingColumn);
+        assertTrue("sanity: cell must be editing", cell.isEditing());
+    }
+
+    /**
+     * Sanity: cell editing state unchanged when off editing index.
+     */
+    @Test
+    public void testEditOffCellIndex() {
+        cell.updateIndex(cellIndex);
+        table.edit(editingIndex, editingColumn);
+        assertFalse("sanity: cell editing must be unchanged", cell.isEditing());
+    }
+
+    @Before
+    public void setup() {
+        cell = new TreeTableCell<String,String>();
+        model = FXCollections.observableArrayList(new TreeItem<>("Four"),
+                new TreeItem<>("Five"), new TreeItem<>("Fear")); // "Flop", "Food", "Fizz"
+        TreeItem<String> root = new TreeItem<>("root");
+        root.getChildren().addAll(model);
+        root.setExpanded(true);
+        table = new TreeTableView<String>(root);
+        table.setEditable(true);
+        editingColumn = new TreeTableColumn<>("TEST");
+        editingColumn.setCellValueFactory(param -> null);
+        table.getColumns().add(editingColumn);
+        cell.updateTreeTableView(table);
+        cell.updateTreeTableColumn(editingColumn);
+        // make sure that focus change doesn't interfere with tests
+        // (editing cell loosing focus will be canceled from focusListener in Cell)
+        // Note: not really needed for Tree/TableCell because the cell is never focused
+        // if !cellSelectionEnabled nor if not in Tree/TableRow
+        // done here for consistency across analogous tests for List/Tree/Cell
+        table.getFocusModel().focus(-1);
+        assertFalse("sanity: cellIndex not same as editingIndex", cellIndex == editingIndex);
+        assertTrue("sanity: valid editingIndex", editingIndex < model.size());
+    }
+
+}


### PR DESCRIPTION
Issue is missing update of Tree-/TableCell's editiable state when changing its index from editingIndex to -1. 

Seems to be a left-over from fixing cell's editing update - done in [JDK-8150525](https://bugs.openjdk.java.net/browse/JDK-8150525) - on index change for the special case of new index -1.

Fixed by cleaning out editing state in that corner case also, added tests that were failing before and passing after the fix. Note that there are also tests that passed before: the previous fix didn't add any tests, so added them here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265206](https://bugs.openjdk.java.net/browse/JDK-8265206): Tree-/TableCell: editing state not updated on cell re-use


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/473/head:pull/473` \
`$ git checkout pull/473`

Update a local copy of the PR: \
`$ git checkout pull/473` \
`$ git pull https://git.openjdk.java.net/jfx pull/473/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 473`

View PR using the GUI difftool: \
`$ git pr show -t 473`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/473.diff">https://git.openjdk.java.net/jfx/pull/473.diff</a>

</details>
