### PR TITLE
8265669: AccumCell should not be visible

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -2661,6 +2661,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
      */
     private void releaseCell(T cell) {
         if (accumCell != null && cell == accumCell) {
+            accumCell.setVisible(false);
             accumCell.updateIndex(-1);
         }
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -1305,6 +1305,18 @@ public class VirtualFlowTest {
             position = newPosition;
         }
     }
+
+    @Test public void testAccumCellInvisible() {
+        VirtualFlowShim vf = createCircleFlow();
+        Node cell = vf.get_accumCell();
+        if (cell != null) assertFalse(cell.isVisible());
+        vf.resize(600,400);
+        for (int i = 0; i < 50; i++) {
+            vf.scrollPixels(1);
+            cell = vf.get_accumCell();
+            if (cell != null) assertFalse(cell.isVisible());
+        }
+    }
 }
 
 class GraphicalCellStub extends IndexedCellShim<Node> {


### PR DESCRIPTION
Hide accumCell when the cell is released.
Fix for JDK-8265669

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265669](https://bugs.openjdk.java.net/browse/JDK-8265669): AccumCell should not be visible


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/474/head:pull/474` \
`$ git checkout pull/474`

Update a local copy of the PR: \
`$ git checkout pull/474` \
`$ git pull https://git.openjdk.java.net/jfx pull/474/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 474`

View PR using the GUI difftool: \
`$ git pr show -t 474`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/474.diff">https://git.openjdk.java.net/jfx/pull/474.diff</a>

</details>
