### PR TITLE
8264952: [TestBug] Controls unit tests - ControlTest and SpinnerTest fail for non US Locale

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/DatePickerTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/DatePickerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,7 +53,9 @@ import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.
 
 import javafx.scene.control.skin.DatePickerSkin;
 
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -62,6 +64,7 @@ import static org.junit.Assert.assertEquals;
 public class DatePickerTest {
     private DatePicker datePicker;
     private final LocalDate today = LocalDate.now();
+    private static Locale defaultLocale;
 
 
     /*********************************************************************
@@ -82,12 +85,18 @@ public class DatePickerTest {
      *                                                                   *
      ********************************************************************/
 
-    @Before public void setup() {
+    @BeforeClass public static void setupOnce() {
+        defaultLocale = Locale.getDefault();
         Locale.setDefault(Locale.forLanguageTag("en-US"));
-        datePicker = new DatePicker();
     }
 
+    @AfterClass public static void tearDownOnce() {
+        Locale.setDefault(defaultLocale);
+    }
 
+    @Before public void setup() {
+        datePicker = new DatePicker();
+    }
 
     /*********************************************************************
      *                                                                   *

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,13 +28,18 @@ import static junit.framework.Assert.*;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
+
+import java.util.Locale;
+
 import javafx.scene.control.Button;
 import javafx.scene.control.skin.SpinnerSkin;
 import javafx.scene.control.Spinner;
@@ -82,6 +87,16 @@ public class SpinnerTest {
     // used in tests for counting events, reset to zero in setup()
     private int eventCount;
 
+    private static Locale defaultLocale;
+
+    @BeforeClass public static void setupOnce() {
+        defaultLocale = Locale.getDefault();
+        Locale.setDefault(Locale.US);
+    }
+
+    @AfterClass public static void tearDownOnce() {
+        Locale.setDefault(defaultLocale);
+    }
 
     @Before public void setup() {
         eventCount = 0;


### PR DESCRIPTION
This PR fixes controls unit test failures that are observed with German locale.

Fix :
Code added to use US locale while running SpinnerTest and DatePicker test & restore locale to default after these tests are executed.

test.javafx.scene.control.ControlTest.testRT18097 fails for DatePicker control. Fixing DatePickerTest fixes this. This reveals the fact that our unit tests run in a single VM and any test that changes the Locale setting should restore it to the default at the end.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264952](https://bugs.openjdk.java.net/browse/JDK-8264952): [TestBug] Controls unit tests - ControlTest and SpinnerTest fail for non US Locale


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/476/head:pull/476` \
`$ git checkout pull/476`

Update a local copy of the PR: \
`$ git checkout pull/476` \
`$ git pull https://git.openjdk.java.net/jfx pull/476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 476`

View PR using the GUI difftool: \
`$ git pr show -t 476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/476.diff">https://git.openjdk.java.net/jfx/pull/476.diff</a>

</details>
