### PR TITLE
8265758: [TestBug] Remove ignored unit test from CustomMenuItemTest

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/CustomMenuItemTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/CustomMenuItemTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@ import test.com.sun.javafx.pgstub.StubToolkit;
 import com.sun.javafx.tk.Toolkit;
 import javafx.scene.control.CustomMenuItem;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.*;
@@ -262,18 +261,12 @@ public class CustomMenuItemTest {
     @Test public void getUnspecifiedContentProperty1() {
         CustomMenuItem cmi2 = new CustomMenuItem();
         assertNotNull(cmi2.contentProperty());
+        assertNull(cmi2.getContent());
     }
 
     @Test public void getUnspecifiedContentProperty2() {
         CustomMenuItem cmi2 = new CustomMenuItem(null, true);
         assertNotNull(cmi2.contentProperty());
-    }
-
-    @Ignore("I'm not sure what this test was supposed to test, so ignoring for now.")
-    @Test public void unsetContentButNotNull() {
-        CustomMenuItem cmi2 = new CustomMenuItem();
-        cmi2.contentProperty(); // <-- this line is a no-op, what is it for?
-        assertNotNull(cmi2.getContent());
     }
 
     @Test public void contentCanBeBound() {


### PR DESCRIPTION
This PR removes the single ignored test from CustomMenuItemTest.

The test unsetContentButNotNull() was incorrectly asserting on not null content. I have remove this test.
The assert for null content has been added to another test getUnspecifiedContentProperty1().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265758](https://bugs.openjdk.java.net/browse/JDK-8265758): [TestBug] Remove ignored unit test from CustomMenuItemTest


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/477/head:pull/477` \
`$ git checkout pull/477`

Update a local copy of the PR: \
`$ git checkout pull/477` \
`$ git pull https://git.openjdk.java.net/jfx pull/477/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 477`

View PR using the GUI difftool: \
`$ git pr show -t 477`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/477.diff">https://git.openjdk.java.net/jfx/pull/477.diff</a>

</details>
