### PR TITLE
8265399: Update to Visual Studio 2019 version 16.9.3

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -89,7 +89,7 @@ jfx.gradle.version.min=5.3
 
 # Toolchains
 jfx.build.linux.gcc.version=gcc10.2.0-OL6.4+1.0
-jfx.build.windows.msvc.version=VS2019-16.7.2+1.0
+jfx.build.windows.msvc.version=VS2019-16.9.3+1.0
 jfx.build.macosx.xcode.version=Xcode12.4+1.0
 
 # Build tools


### PR DESCRIPTION
This patch updates the compiler to Visual Studio 2019 version 16.9.3 on Windows, in order to match JDK 17 -- see [JDK-8265371](https://bugs.openjdk.java.net/browse/JDK-8265371).

I ran a full build and test, including media and WebKit.

NOTE: I also have PR #481 out for review to update the Linux gcc compiler. I intend to integrate that one first, at which time I will need to merge `master` into this branch to resolve a trivial merge conflict (the changes are on adjacent lines).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265399](https://bugs.openjdk.java.net/browse/JDK-8265399): Update to Visual Studio 2019 version 16.9.3


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Joeri Sykora](https://openjdk.java.net/census#sykora) (@tiainen - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/482/head:pull/482` \
`$ git checkout pull/482`

Update a local copy of the PR: \
`$ git checkout pull/482` \
`$ git pull https://git.openjdk.java.net/jfx pull/482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 482`

View PR using the GUI difftool: \
`$ git pr show -t 482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/482.diff">https://git.openjdk.java.net/jfx/pull/482.diff</a>

</details>
