### PR TITLE
8186904: TableColumnHeader: resize cursor lost on right click

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -267,12 +267,12 @@ public class TableColumnHeader extends Region {
     };
 
     private static final EventHandler<MouseEvent> mouseReleasedHandler = me -> {
+        TableColumnHeader header = (TableColumnHeader) me.getSource();
+        header.getTableHeaderRow().columnDragLock = false;
+
         if (me.isPopupTrigger()) return;
         if (me.isConsumed()) return;
         me.consume();
-
-        TableColumnHeader header = (TableColumnHeader) me.getSource();
-        header.getTableHeaderRow().columnDragLock = false;
 
         if (header.getTableHeaderRow().isReordering() && header.isColumnReorderingEnabled()) {
             header.columnReorderingComplete();

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/TableColumnHeaderShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/TableColumnHeaderShim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,10 @@ public class TableColumnHeaderShim {
 
     public static int getSortPos(TableColumnHeader header) {
         return header.sortPos;
+    }
+
+    public static boolean getTableHeaderRowColumnDragLock(TableColumnHeader header) {
+        return header.getTableHeaderRow().columnDragLock;
     }
 
     public static TableColumnHeader getColumnHeaderFor(TableHeaderRow header, final TableColumnBase<?,?> col) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableColumnHeaderTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableColumnHeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,19 +28,24 @@ package test.javafx.scene.control.skin;
 import com.sun.javafx.tk.Toolkit;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.event.Event;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.control.skin.TableColumnHeader;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
 import org.junit.Before;
 import org.junit.After;
 import org.junit.Test;
+import test.com.sun.javafx.scene.control.infrastructure.MouseEventFirer;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
 import test.com.sun.javafx.scene.control.test.Person;
 import javafx.scene.control.skin.TableColumnHeaderShim;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class TableColumnHeaderTest {
@@ -80,6 +85,44 @@ public class TableColumnHeaderTest {
     @After
     public void after() {
         sl.dispose();
+    }
+
+    /**
+     * When a right click is done on a table column header, the column drag lock should be set to true in the
+     * pressed handler, but eventually to false again in the released handler.<br>
+     * By that we guarantee, that the column resizing still works.
+     */
+    @Test
+    public void testColumnRightClickDoesAllowResizing() {
+        MouseEventFirer firer = new MouseEventFirer(firstColumnHeader);
+
+        assertFalse(TableColumnHeaderShim.getTableHeaderRowColumnDragLock(firstColumnHeader));
+
+        firer.fireMousePressed(MouseButton.SECONDARY);
+        assertTrue(TableColumnHeaderShim.getTableHeaderRowColumnDragLock(firstColumnHeader));
+
+        firer.fireMouseReleased(MouseButton.SECONDARY);
+        assertFalse(TableColumnHeaderShim.getTableHeaderRowColumnDragLock(firstColumnHeader));
+    }
+
+    /**
+     * When a right click is done on a table column header and consumed by a self added event handler, the column
+     * drag lock should be set to true in the pressed handler, but still to false again in the released handler.<br>
+     * By that we guarantee, that the column resizing still works.
+     */
+    @Test
+    public void testColumnRightClickDoesAllowResizingWhenConsumed() {
+        firstColumnHeader.addEventHandler(MouseEvent.MOUSE_RELEASED, Event::consume);
+
+        MouseEventFirer firer = new MouseEventFirer(firstColumnHeader);
+
+        assertFalse(TableColumnHeaderShim.getTableHeaderRowColumnDragLock(firstColumnHeader));
+
+        firer.fireMousePressed(MouseButton.SECONDARY);
+        assertTrue(TableColumnHeaderShim.getTableHeaderRowColumnDragLock(firstColumnHeader));
+
+        firer.fireMouseReleased(MouseButton.SECONDARY);
+        assertFalse(TableColumnHeaderShim.getTableHeaderRowColumnDragLock(firstColumnHeader));
     }
 
     /**


### PR DESCRIPTION
This PR is fixing a bug, when a right click on a table column is performed. 
By doing that, the table columns will lose the resize cursor thus they can not be resized anymore.

The reason for that is that the **columnDragLock** will not reset (to false).
This flag is set to true, when a mouse press is detected (on a table column) and to false, when a mouse release is detected. Unfortunately, this flag is not reset on a right click, because a check (**#isPopupTrigger()**) will guard against it.

With this PR, this flag will always reset to false inside the mouse released handler.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8186904](https://bugs.openjdk.java.net/browse/JDK-8186904): TableColumnHeader: resize cursor lost on right click


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/483/head:pull/483` \
`$ git checkout pull/483`

Update a local copy of the PR: \
`$ git checkout pull/483` \
`$ git pull https://git.openjdk.java.net/jfx pull/483/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 483`

View PR using the GUI difftool: \
`$ git pr show -t 483`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/483.diff">https://git.openjdk.java.net/jfx/pull/483.diff</a>

</details>
