### PR TITLE
8264998: Empty Jars shouldn't have Automatic-Module-Name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4769,11 +4769,6 @@ compileTargets { t ->
         def modularEmptyPublicationJarTask = project.task("moduleEmptyPublicationJar${t.capital}", type: Jar) {
             destinationDir = file("${dstModularJarDir}")
             archiveName = modularEmptyPublicationJarName
-            manifest {
-                attributes(
-                    'Automatic-Module-Name':"${moduleName}Empty"
-                )
-            }
         }
 
         def modularPublicationJarName = "${moduleName}-${t.name}.jar"


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264998](https://bugs.openjdk.java.net/browse/JDK-8264998): Empty Jars shouldn't have Automatic-Module-Name


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/484/head:pull/484` \
`$ git checkout pull/484`

Update a local copy of the PR: \
`$ git checkout pull/484` \
`$ git pull https://git.openjdk.java.net/jfx pull/484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 484`

View PR using the GUI difftool: \
`$ git pr show -t 484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/484.diff">https://git.openjdk.java.net/jfx/pull/484.diff</a>

</details>
