### PR TITLE
8264157: Items of non-editable ComboBox cannot be selected using up/down keys

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ComboBoxListViewBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ComboBoxListViewBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,55 @@
 package com.sun.javafx.scene.control.behavior;
 
 import javafx.scene.control.ComboBox;
+import javafx.scene.control.ComboBoxBase;
+import javafx.scene.control.SelectionModel;
+import com.sun.javafx.scene.control.inputmap.InputMap;
+
+import static javafx.scene.input.KeyCode.DOWN;
+import static javafx.scene.input.KeyCode.UP;
 
 public class ComboBoxListViewBehavior<T> extends ComboBoxBaseBehavior<T> {
+
+    /***************************************************************************
+     *                                                                         *
+     * Constructors                                                            *
+     *                                                                         *
+     **************************************************************************/
+
+    /**
+     *
+     */
     public ComboBoxListViewBehavior(final ComboBox<T> comboBox) {
         super(comboBox);
+
+        // Add these bindings as a child input map, so they take precedence
+        InputMap<ComboBoxBase<T>> comboBoxListViewInputMap = new InputMap<>(comboBox);
+        comboBoxListViewInputMap.getMappings().addAll(
+            new InputMap.KeyMapping(UP, e -> selectPrevious()),
+            new InputMap.KeyMapping(DOWN, e -> selectNext())
+        );
+        addDefaultChildMap(getInputMap(), comboBoxListViewInputMap);
+    }
+
+    /***************************************************************************
+     *                                                                         *
+     * Key event handling                                                      *
+     *                                                                         *
+     **************************************************************************/
+
+    private ComboBox<T> getComboBox() {
+        return (ComboBox<T>) getNode();
+    }
+
+    private void selectPrevious() {
+        SelectionModel<T> sm = getComboBox().getSelectionModel();
+        if (sm == null) return;
+        sm.selectPrevious();
+    }
+
+    private void selectNext() {
+        SelectionModel<T> sm = getComboBox().getSelectionModel();
+        if (sm == null) return;
+        sm.selectNext();
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1306,6 +1306,27 @@ public class ComboBoxTest {
         assertFalse(cb.isShowing());
         cbKeyboard.doKeyPress(KeyCode.DOWN, KeyModifier.ALT);  // show the popup
         assertTrue(cb.isShowing());
+    }
+
+    @Test public void testEditorKeyInputsWhenPopupIsNotShowing() {
+        final ComboBox<String> cb = new ComboBox<>(FXCollections.observableArrayList("a", "b"));
+        sl = new StageLoader(cb);
+        KeyEventFirer keyboard = new KeyEventFirer(cb);
+        cb.requestFocus();
+
+        // Sanity
+        assertFalse(cb.isShowing());
+        assertEquals(null, cb.getValue());
+
+        // Test DOWN and UP key
+        keyboard.doKeyPress(KeyCode.DOWN);
+        assertEquals("a", cb.getValue());
+        keyboard.doKeyPress(KeyCode.DOWN);
+        assertEquals("b", cb.getValue());
+        keyboard.doKeyPress(KeyCode.UP);
+        assertEquals("a", cb.getValue());
+        keyboard.doKeyPress(KeyCode.UP);
+        assertEquals("a", cb.getValue());
     }
 
     @Test public void testEditorKeyInputsWhenPopupIsShowing() {


### PR DESCRIPTION
This issue [JDK-8264157](https://bugs.openjdk.java.net/browse/JDK-8264157) is a regression of [JDK-8209788](https://bugs.openjdk.java.net/browse/JDK-8209788), which removed two KeyMappings from `ComboBoxListViewBehavior`. That removal was not required to fix [JDK-8209788](https://bugs.openjdk.java.net/browse/JDK-8209788).
Reverting `ComboBoxListViewBehavior.java` fixes the regression.
Fix includes a new test which fails before and pass with the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264157](https://bugs.openjdk.java.net/browse/JDK-8264157): Items of non-editable ComboBox cannot be selected using up/down keys


### Reviewers
 * [Jeanette Winzenburg](https://openjdk.java.net/census#fastegal) (@kleopatra - Committer)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/485/head:pull/485` \
`$ git checkout pull/485`

Update a local copy of the PR: \
`$ git checkout pull/485` \
`$ git pull https://git.openjdk.java.net/jfx pull/485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 485`

View PR using the GUI difftool: \
`$ git pr show -t 485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/485.diff">https://git.openjdk.java.net/jfx/pull/485.diff</a>

</details>
