### PR TITLE
JDK-8266396: Add VSCMD_DEBUG for solving WINSDK_DIR build error

### DIFF
--- a/buildSrc/win.gradle
+++ b/buildSrc/win.gradle
@@ -59,6 +59,9 @@ setupTools("windows_tools",
                         "CONF"       : "/$CONF", // TODO does this mean the generated properties must be reset when in a different configuration?
                         "VCARCH"     : IS_CROSS ? "${HOST_ARCH}_${TARGET_ARCH}" : TARGET_ARCH,
                         "SDKARCH"    : "/$TARGET_ARCH",
+                        // Debug logging levels: basic (1), detailed (2), trace (3).
+                        // Use "3" for debugging "FAIL: WINSDK_DIR not defined".
+                        "VSCMD_DEBUG": "",
                 ]);
                 commandLine("cmd", "/q", "/c", "buildSrc\\genVSproperties.bat");
                 setStandardOutput(results);


### PR DESCRIPTION
The Windows build calls a series of batch files to get the Visual Studio paths and environment variables. The batch files are a black box: any messages they print are discarded. If anything goes wrong, the only signs are a vague Gradle exception and a corrupted properties file.

This has been causing problems for years. There are at least 49 messages on the mailing since 2017 that discuss the exception and ways to work around it.

This pull request lets you enable the batch file messages, shedding light on their internal workings and allowing you to catch any errors at their source. Specifically, it adds the variable `VSCMD_DEBUG` to the environment of `genVSproperties.bat` and documents its use.

### Before

For example, if your `PATH` environment variable is missing `C:/Windows/System32`, like mine was, you'll see the following errors:

```ShellSession
$ gradle sdk
Dependency verification is an incubating feature.

FAILURE: Build failed with an exception.

* Where:
Script 'C:\cygwin64\home\john\src\jfx\buildSrc\win.gradle' line: 108

* What went wrong:
A problem occurred evaluating script.
> FAIL: WINSDK_DIR not defined

    ︙

BUILD FAILED in 4s
```

*Me:* What's a `WINSDK_DIR`? The Wiki says, "This means that you will have to define these paths manually." I guess this is normal. 😕️

### After

With this change, you can set the debug level to "3" in the `win.gradle` file and get a better picture of the problem:

```ShellSession
$ gradle sdk
Dependency verification is an incubating feature.

> Configure project :
'reg' is not recognized as an internal or external command,
operable program or batch file.
'reg' is not recognized as an internal or external command,
operable program or batch file.
'reg' is not recognized as an internal or external command,
operable program or batch file.

    ︙

'powershell.exe' is not recognized as an internal or external command,
operable program or batch file.

FAILURE: Build failed with an exception.

* Where:
Script 'C:\cygwin64\home\john\src\jfx\buildSrc\win.gradle' line: 108

* What went wrong:
A problem occurred evaluating script.
> FAIL: WINSDK_DIR not defined

    ︙

BUILD FAILED in 3s
```

*Me:* Oh, it's just a "command not found" error. I'll check my `PATH`. 🤓
