### PR TITLE
8264138: Replace uses of Class.newInstance

### DIFF
--- a/apps/samples/3DViewer/src/main/java/com/javafx/experiments/importers/Importer3D.java
+++ b/apps/samples/3DViewer/src/main/java/com/javafx/experiments/importers/Importer3D.java
@@ -32,6 +32,7 @@
 package com.javafx.experiments.importers;
 
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.net.URLClassLoader;
 
@@ -122,7 +123,7 @@ public final class Importer3D {
             for (String name : names) {
                 try {
                     Class<?> clazz = Class.forName(name);
-                    Object obj = clazz.newInstance();
+                    Object obj = clazz.getDeclaredConstructor().newInstance();
                     if (obj instanceof Importer) {
                         Importer plugin = (Importer) obj;
                         if (plugin.isSupported(extension)) {
@@ -131,7 +132,8 @@ public final class Importer3D {
                             break;
                         }
                     }
-                } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+                } catch (ClassNotFoundException | InstantiationException | IllegalAccessException
+                         | InvocationTargetException | NoSuchMethodException e) {
                     // FAIL SILENTLY
                 }
             }

--- a/apps/samples/Ensemble8/src/app/java/ensemble/EmbeddedApplication.java
+++ b/apps/samples/Ensemble8/src/app/java/ensemble/EmbeddedApplication.java
@@ -52,7 +52,7 @@ public class EmbeddedApplication {
 //            Class appClass = EmbeddedApplication.class.getClassLoader().loadClass(className);
             Class appClass = InterpolatorApp.class;
             System.out.println("appClass = " + appClass);
-            Application app = (Application)appClass.newInstance();
+            Application app = (Application)appClass.getDeclaredConstructor().newInstance();
             System.out.println("app = " + app);
             app.init();
             app.start(TEMP_STAGE);

--- a/apps/samples/Ensemble8/src/app/java/ensemble/SampleInfo.java
+++ b/apps/samples/Ensemble8/src/app/java/ensemble/SampleInfo.java
@@ -191,7 +191,7 @@ public class SampleInfo {
             Method play = null;
             Method stop = null;
             Class clz = Class.forName(appClass);
-            final Object app = clz.newInstance();
+            final Object app = clz.getDeclaredConstructor().newInstance();
             Parent root = (Parent) clz.getMethod("createContent").invoke(app);
 
             for (Method m : clz.getMethods()) {

--- a/apps/toys/DragDrop/src/dragdrop/Main.java
+++ b/apps/toys/DragDrop/src/dragdrop/Main.java
@@ -82,7 +82,7 @@ public class Main extends Application {
             @Override public void handle(MouseEvent event) {
                 Stage stage = new Stage();
                 try {
-                    ((Application) app.newInstance()).start(stage);
+                    ((Application) app.getDeclaredConstructor().newInstance()).start(stage);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }

--- a/apps/toys/TouchSuite/src/touchsuite/Main.java
+++ b/apps/toys/TouchSuite/src/touchsuite/Main.java
@@ -93,7 +93,7 @@ public class Main extends Application {
             @Override public void handle(MouseEvent event) {
                 Stage stage = new Stage();
                 try {
-                    ((Application) app.newInstance()).start(stage);
+                    ((Application) app.getDeclaredConstructor().newInstance()).start(stage);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -187,7 +187,7 @@ public class Main extends Application {
                     Info.this.setVisible(false);
                     Stage stage = new Stage();
                     try {
-                        ((Application) app.newInstance()).start(stage);
+                        ((Application) app.getDeclaredConstructor().newInstance()).start(stage);
                     } catch (Exception e) {
                         e.printStackTrace();
                     }

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/event/EventDispatchChainTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/event/EventDispatchChainTest.java
@@ -57,8 +57,8 @@ public final class EventDispatchChainTest {
     private EventDispatchChain eventDispatchChain;
 
     public EventDispatchChainTest(final Class<EventDispatchChain> chainClass)
-            throws InstantiationException, IllegalAccessException {
-        eventDispatchChain = chainClass.newInstance();
+            throws Exception {
+        eventDispatchChain = chainClass.getDeclaredConstructor().newInstance();
     }
 
     @Test

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/ParameterizedConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/ParameterizedConverterTest.java
@@ -93,7 +93,7 @@ public class ParameterizedConverterTest {
 
     @Before public void setup() {
         try {
-            converter = converterClass.newInstance();
+            converter = converterClass.getDeclaredConstructor().newInstance();
         } catch (Exception ex) {
             ex.printStackTrace();
         }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellTest.java
@@ -79,7 +79,7 @@ public class CellTest {
     }
 
     @Before public void setup() throws Exception {
-        cell = (Cell<String>) type.newInstance();
+        cell = (Cell<String>) type.getDeclaredConstructor().newInstance();
 
         // Empty TableCells can be selected, as long as the row they exist in
         // is not empty, so here we set a TableRow to ensure testing works

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlTest.java
@@ -1022,10 +1022,8 @@ public class ControlTest {
             String what = someClass.getName();
             try {
                 // should get NoSuchMethodException if ctor is not public
-//                Constructor ctor = someClass.getConstructor((Class[])null);
                 Method m = someClass.getMethod("getClassCssMetaData", (Class[]) null);
-//                Node node = (Node)ctor.newInstance((Object[])null);
-                Node node = (Node)someClass.newInstance();
+                Node node = (Node)someClass.getDeclaredConstructor().newInstance();
                 for (CssMetaData styleable : (List<CssMetaData<? extends Styleable, ?>>) m.invoke(null)) {
 
                     what = someClass.getName() + " " + styleable.getProperty();
@@ -1033,7 +1031,7 @@ public class ControlTest {
                     assertNotNull(what, writable);
 
                     Object defaultValue = writable.getValue();
-                    Object initialValue = styleable.getInitialValue((Node) someClass.newInstance());
+                    Object initialValue = styleable.getInitialValue((Node) someClass.getDeclaredConstructor().newInstance());
 
                     if (defaultValue instanceof Number) {
                         // 5 and 5.0 are not the same according to equals,

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/EventAnyTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/EventAnyTest.java
@@ -92,7 +92,7 @@ public class EventAnyTest {
 
     @Test
     public void testEventDelivery() throws Exception {
-        Node n = (Node) target.newInstance();
+        Node n = (Node) target.getDeclaredConstructor().newInstance();
         delivered = false;
 
         n.addEventHandler(type, event1 -> {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/FireButtonBaseTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/FireButtonBaseTest.java
@@ -70,7 +70,7 @@ public class FireButtonBaseTest {
     }
 
     @Before public void setup() throws Exception {
-        btn = (ButtonBase) type.newInstance();
+        btn = (ButtonBase) type.getDeclaredConstructor().newInstance();
     }
 
     @Test public void onActionCalledWhenButtonIsFired() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextInputControlTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextInputControlTest.java
@@ -86,7 +86,7 @@ public class TextInputControlTest {
     }
 
     @Before public void setup() throws Exception {
-        textInput = (TextInputControl) type.newInstance();
+        textInput = (TextInputControl) type.getDeclaredConstructor().newInstance();
         setUncaughtExceptionHandler();
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/ParameterisedPrebuiltCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/ParameterisedPrebuiltCellTest.java
@@ -69,10 +69,8 @@ public class ParameterisedPrebuiltCellTest {
         count = 0;
 
         try {
-            cell = cellClass.newInstance();
-        } catch (InstantiationException e) {
-            e.printStackTrace();
-        } catch (IllegalAccessException e) {
+            cell = cellClass.getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
             e.printStackTrace();
         }
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/ParameterisedPrebuiltCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/ParameterisedPrebuiltCellTest.java
@@ -65,14 +65,9 @@ public class ParameterisedPrebuiltCellTest {
         this.cellClass = cellClass;
     }
 
-    @Before public void setup() {
+    @Before public void setup() throws Exception {
         count = 0;
-
-        try {
-            cell = cellClass.getDeclaredConstructor().newInstance();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        cell = cellClass.getDeclaredConstructor().newInstance();
     }
 
 

--- a/modules/javafx.fxml/src/main/java/javafx/fxml/FXMLLoader.java
+++ b/modules/javafx.fxml/src/main/java/javafx/fxml/FXMLLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -935,15 +935,14 @@ public class FXMLLoader {
                         try {
                             if (controllerFactory == null) {
                                 ReflectUtil.checkPackageAccess(type);
-                                setController(type.newInstance());
+                                setController(type.getDeclaredConstructor().newInstance());
                             } else {
                                 setController(controllerFactory.call(type));
                             }
-                        } catch (InstantiationException exception) {
-                            throw constructLoadException(exception);
-                        } catch (IllegalAccessException exception) {
-                            throw constructLoadException(exception);
+                        } catch (Exception e) {
+                            throw constructLoadException(e);
                         }
+
                     }
                 } else {
                     throw constructLoadException("Invalid attribute.");
@@ -1018,11 +1017,9 @@ public class FXMLLoader {
                 if (value == null) {
                     try {
                         ReflectUtil.checkPackageAccess(type);
-                        value = type.newInstance();
-                    } catch (InstantiationException exception) {
-                        throw constructLoadException(exception);
-                    } catch (IllegalAccessException exception) {
-                        throw constructLoadException(exception);
+                        value = type.getDeclaredConstructor().newInstance();
+                    } catch (Exception e) {
+                        throw constructLoadException(e);
                     }
                 }
             }
@@ -1328,11 +1325,9 @@ public class FXMLLoader {
                     if (value == null) {
                         try {
                             ReflectUtil.checkPackageAccess(type);
-                            value = type.newInstance();
-                        } catch (InstantiationException exception) {
-                            throw constructLoadException(exception);
-                        } catch (IllegalAccessException exception) {
-                            throw constructLoadException(exception);
+                            value = type.getDeclaredConstructor().newInstance();
+                        } catch (Exception e) {
+                            throw constructLoadException(e);
                         }
                     }
                     root = value;

--- a/modules/javafx.fxml/src/main/java/javafx/fxml/FXMLLoader.java
+++ b/modules/javafx.fxml/src/main/java/javafx/fxml/FXMLLoader.java
@@ -942,7 +942,6 @@ public class FXMLLoader {
                         } catch (Exception e) {
                             throw constructLoadException(e);
                         }
-
                     }
                 } else {
                     throw constructLoadException("Invalid attribute.");

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/PlatformFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/PlatformFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ public abstract class PlatformFactory {
                 String factory = "com.sun.glass.ui." +  platform.toLowerCase(Locale.ROOT) + "."+ platform + "PlatformFactory";
                 // System.out.println("Loading Glass Factory " + factory);
                 Class c = Class.forName(factory);
-                instance = (PlatformFactory) c.newInstance();
+                instance = (PlatformFactory) c.getDeclaredConstructor().newInstance();
             } catch (Exception e) {
                 e.printStackTrace();
                 System.out.println("Failed to load Glass factory class");

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/NativePlatformFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/NativePlatformFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,7 +105,7 @@ public abstract class NativePlatformFactory {
                         throw new IllegalArgumentException("Unrecognized Monocle platform: "
                                 + factoryClassName);
                     }
-                    NativePlatformFactory npf = (NativePlatformFactory) clazz.newInstance();
+                    NativePlatformFactory npf = (NativePlatformFactory) clazz.getDeclaredConstructor().newInstance();
                     if (npf.matches() &&
                         npf.getMajorVersion() == majorVersion &&
                         npf.getMinorVersion() == minorVersion) {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/TouchPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/TouchPipeline.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ class TouchPipeline {
                             + filterName + "TouchFilter";
                 }
                 ClassLoader loader = Thread.currentThread().getContextClassLoader();
-                addFilter((TouchFilter) loader.loadClass(filterName).newInstance());
+                addFilter((TouchFilter) loader.loadClass(filterName).getDeclaredConstructor().newInstance());
             }
         } catch (Exception e) {
             System.err.println(

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -258,7 +258,7 @@ public abstract class Toolkit {
                         + forcedToolkit);
             }
 
-            TOOLKIT = (Toolkit)clz.newInstance();
+            TOOLKIT = (Toolkit)clz.getDeclaredConstructor().newInstance();
             if (TOOLKIT.init()) {
                 if (printToolkit) {
                     System.err.println("JavaFX: using " + forcedToolkit);

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -96,7 +96,7 @@ abstract class GLFactory {
         public GLFactory run() {
             GLFactory factory = null;
             try {
-                factory = (GLFactory) Class.forName(factoryClassName).newInstance();
+                factory = (GLFactory) Class.forName(factoryClassName).getDeclaredConstructor().newInstance();
             } catch (Throwable t) {
                 System.err.println("GLFactory.static - Platform: "
                         + System.getProperty("os.name")

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/prism/ps/PPSRenderer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/prism/ps/PPSRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -450,7 +450,7 @@ public class PPSRenderer extends PrRenderer {
         Class klass = null;
         try {
             klass = Class.forName(name);
-            return (ShaderSource)klass.newInstance();
+            return (ShaderSource)klass.getDeclaredConstructor().newInstance();
         } catch (ClassNotFoundException e) {
             System.err.println(name + " class not found");
             return null;

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/prism/sw/PSWRenderer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/prism/sw/PSWRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,7 +89,7 @@ public class PSWRenderer extends PrRenderer {
         PSWRenderer ret = null;
         try {
             Class klass = Class.forName(rootPkg + ".impl.sw.java.JSWRendererDelegate");
-            RendererDelegate delegate = (RendererDelegate)klass.newInstance();
+            RendererDelegate delegate = (RendererDelegate)klass.getDeclaredConstructor().newInstance();
             ret = new PSWRenderer(screen, delegate);
         } catch (Throwable e) {}
         return ret;
@@ -104,7 +104,7 @@ public class PSWRenderer extends PrRenderer {
         PSWRenderer ret = null;
         try {
             Class klass = Class.forName(rootPkg + ".impl.sw.java.JSWRendererDelegate");
-            RendererDelegate delegate = (RendererDelegate)klass.newInstance();
+            RendererDelegate delegate = (RendererDelegate)klass.getDeclaredConstructor().newInstance();
             ret = new PSWRenderer(factory, delegate);
         } catch (Throwable e) {}
         return ret;
@@ -128,7 +128,7 @@ public class PSWRenderer extends PrRenderer {
         PSWRenderer ret = null;
         try {
             Class klass = Class.forName(rootPkg + ".impl.sw.sse.SSERendererDelegate");
-            RendererDelegate delegate = (RendererDelegate)klass.newInstance();
+            RendererDelegate delegate = (RendererDelegate)klass.getDeclaredConstructor().newInstance();
             ret = new PSWRenderer(screen, delegate);
         } catch (Throwable e) {}
         return ret;

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/test/OnInvalidateMethodsTestBase.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/test/OnInvalidateMethodsTestBase.java
@@ -79,21 +79,21 @@ public abstract class OnInvalidateMethodsTestBase {
             sb.setCharAt(0, Character.toUpperCase(propertyName.charAt(0)));
 
             if (clazz.getSuperclass().equals(PathElement.class)) {
-                PathElement e = (PathElement)clazz.newInstance();
+                PathElement e = (PathElement)clazz.getDeclaredConstructor().newInstance();
                 Path path = new Path();
                 path.getElements().addAll(new MoveTo(0,0), e);
                 NodeTest.syncNode(path);
                 getSetter(clazz, sb.toString()).invoke(e, this.inValue);
                 assertTrue(NodeTest.isDirty(path, (DirtyBits[])this.expectedDirtyBits));
             } else if (clazz.getSuperclass().equals(Transform.class)) {
-                Transform tr = (Transform)clazz.newInstance();
+                Transform tr = (Transform)clazz.getDeclaredConstructor().newInstance();
                 Rectangle rect = new Rectangle();
                 rect.getTransforms().add(tr);
                 NodeTest.syncNode(rect);
                 getSetter(clazz, sb.toString()).invoke(tr, this.inValue);
                 assertTrue(NodeTest.isDirty(rect, (DirtyBits[])this.expectedDirtyBits));
             } else {
-                Node node = (Node)clazz.newInstance();
+                Node node = (Node)clazz.getDeclaredConstructor().newInstance();
                 NodeTest.syncNode(node);
                 getSetter(clazz, sb.toString()).invoke(node, this.inValue);
                 if (this.expectedDirtyBits instanceof DirtyBits[]) {
@@ -109,7 +109,7 @@ public abstract class OnInvalidateMethodsTestBase {
 
         private Path getPathNode(Class<? extends PathElement> pathElementClazz) throws Exception {
             Path p = new Path();
-            p.getElements().addAll(new MoveTo(0,0), pathElementClazz.newInstance());
+            p.getElements().addAll(new MoveTo(0,0), pathElementClazz.getDeclaredConstructor().newInstance());
             return p;
         }
 

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/test/binding/ReflectionHelper.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/test/binding/ReflectionHelper.java
@@ -43,6 +43,8 @@ public final class ReflectionHelper {
     public static Object newInstance(final Class<?> cls) {
         try {
             return cls.getDeclaredConstructor().newInstance();
+        } catch (final RuntimeException e) {
+            throw e;
         } catch (final Exception e) {
             throw convertToRuntimeException(e);
         }

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/test/binding/ReflectionHelper.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/test/binding/ReflectionHelper.java
@@ -42,10 +42,8 @@ public final class ReflectionHelper {
 
     public static Object newInstance(final Class<?> cls) {
         try {
-            return cls.newInstance();
-        } catch (final InstantiationException e) {
-            throw convertToRuntimeException(e);
-        } catch (final IllegalAccessException e) {
+            return cls.getDeclaredConstructor().newInstance();
+        } catch (final Exception e) {
             throw convertToRuntimeException(e);
         }
     }

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/CssMetaDataTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/CssMetaDataTest.java
@@ -1167,10 +1167,8 @@ public class CssMetaDataTest {
             String what = someClass.getName();
             try {
                 // should get NoSuchMethodException if ctor is not public
-                //                Constructor ctor = someClass.getConstructor((Class[])null);
                 Method m = someClass.getMethod("getClassCssMetaData", (Class[]) null);
-                //                Node node = (Node)ctor.newInstance((Object[])null);
-                Node node = (Node)someClass.newInstance();
+                Node node = (Node)someClass.getDeclaredConstructor().newInstance();
                 List<CssMetaData<? extends Styleable, ?>> list = (List<CssMetaData<? extends Styleable, ?>>)m.invoke(null);
                 if(list == null || list.isEmpty()) return;
 
@@ -1181,7 +1179,7 @@ public class CssMetaDataTest {
                     assertNotNull(what, writable);
 
                     Object defaultValue = writable.getValue();
-                    Object initialValue = styleable.getInitialValue((Node) someClass.newInstance());
+                    Object initialValue = styleable.getInitialValue((Node) someClass.getDeclaredConstructor().newInstance());
 
                     if (defaultValue instanceof Number) {
                         // 5 and 5.0 are not the same according to equals,

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/effect/EffectInputTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/effect/EffectInputTest.java
@@ -113,8 +113,8 @@ public class EffectInputTest {
         final Class effect1Class = Class.forName("javafx.scene.effect." + effect1Name);
         final Class effect2Class = Class.forName("javafx.scene.effect." + effect2Name);
 
-        Effect effect1 = (Effect) effect1Class.newInstance();
-        Effect effect2 = (Effect) effect2Class.newInstance();
+        Effect effect1 = (Effect) effect1Class.getDeclaredConstructor().newInstance();
+        Effect effect2 = (Effect) effect2Class.getDeclaredConstructor().newInstance();
         final Method getInput1 = effect1Class.getMethod("getInput");
         final Method setInput1 = effect1Class.getMethod("setInput", Effect.class);
         final Method getInput2 = effect2Class.getMethod("getInput");
@@ -158,8 +158,8 @@ public class EffectInputTest {
         final Class effect1Class = Class.forName("javafx.scene.effect." + effect1Name);
         final Class effect2Class = Class.forName("javafx.scene.effect." + effect2Name);
 
-        Effect effect1 = (Effect) effect1Class.newInstance();
-        Effect effect2 = (Effect) effect2Class.newInstance();
+        Effect effect1 = (Effect) effect1Class.getDeclaredConstructor().newInstance();
+        Effect effect2 = (Effect) effect2Class.getDeclaredConstructor().newInstance();
         final Method getInput1 = effect1Class.getMethod("getInput");
         final Method setInput1 = effect1Class.getMethod("setInput", Effect.class);
         final Method getInput2 = effect2Class.getMethod("getInput");
@@ -198,8 +198,8 @@ public class EffectInputTest {
         final Class effect1Class = Class.forName("javafx.scene.effect." + effect1Name);
         final Class effect2Class = Class.forName("javafx.scene.effect." + effect2Name);
 
-        Effect effect1 = (Effect) effect1Class.newInstance();
-        Effect effect2 = (Effect) effect2Class.newInstance();
+        Effect effect1 = (Effect) effect1Class.getDeclaredConstructor().newInstance();
+        Effect effect2 = (Effect) effect2Class.getDeclaredConstructor().newInstance();
         final Method getInput1 = effect1Class.getMethod("getInput");
         final Method setInput2 = effect2Class.getMethod("setInput", Effect.class);
 


### PR DESCRIPTION
This PR replaces Class.newInstance() deprecated method with Contructor.newinstance().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264138](https://bugs.openjdk.java.net/browse/JDK-8264138): Replace uses of Class.newInstance


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/491/head:pull/491` \
`$ git checkout pull/491`

Update a local copy of the PR: \
`$ git checkout pull/491` \
`$ git pull https://git.openjdk.java.net/jfx pull/491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 491`

View PR using the GUI difftool: \
`$ git pr show -t 491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/491.diff">https://git.openjdk.java.net/jfx/pull/491.diff</a>

</details>
