### PR TITLE
8266539: [TreeView]: Change.getRemoved() contains null item when deselecting a TreeItem

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/MultipleSelectionModelBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/MultipleSelectionModelBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -799,9 +799,10 @@ abstract class MultipleSelectionModelBase<T> extends MultipleSelectionModel<T> {
         public void clear(int index) {
             if (!bitset.get(index)) return;
 
+            int indicesIndex = indexOf(index);
             _beginChange();
             bitset.clear(index);
-            _nextRemove(index, index);
+            _nextRemove(indicesIndex, index);
             _endChange();
         }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/MultipleSelectionModelImplTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/MultipleSelectionModelImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,6 +73,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
+import test.javafx.collections.MockListObserver;
 
 /**
  * Unit tests for the SelectionModel abstract class used by ListView
@@ -340,6 +341,18 @@ public class MultipleSelectionModelImplTest {
         assertTrue(model.isSelected(4));
         assertFalse(model.isSelected(5));
         assertTrue(model.isSelected(6));
+    }
+
+    @Test public void selectedIndicesListenerReportsCorrectIndexOnClearSelection() {
+        model.setSelectionMode(SelectionMode.MULTIPLE);
+        model.select(1);
+        model.select(5);
+        MockListObserver<Integer> observer = new MockListObserver<>();
+        model.getSelectedIndices().addListener(observer);
+        model.clearSelection(5);
+
+        observer.check1();
+        observer.checkAddRemove(0, model.getSelectedIndices(), List.of(5), 1, 1);
     }
 
     @Test public void testSelectedIndicesObservableListIsEmpty() {


### PR DESCRIPTION
This PR contains a fix that was de-scoped from #480 and solves an issue where an incorrect index is used in `MultipleSelectionModelBase.SelectedIndicesList.clear(int)`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266539](https://bugs.openjdk.java.net/browse/JDK-8266539): [TreeView]: Change.getRemoved() contains null item when deselecting a TreeItem


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/492/head:pull/492` \
`$ git checkout pull/492`

Update a local copy of the PR: \
`$ git checkout pull/492` \
`$ git pull https://git.openjdk.java.net/jfx pull/492/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 492`

View PR using the GUI difftool: \
`$ git pr show -t 492`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/492.diff">https://git.openjdk.java.net/jfx/pull/492.diff</a>

</details>
