### PR TITLE
8266811: Openjfx controls test build broken (Eclipse)

### DIFF
--- a/modules/javafx.controls/.classpath
+++ b/modules/javafx.controls/.classpath
@@ -28,7 +28,7 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/base">
 		<attributes>
 			<attribute name="module" value="true"/>
-			<attribute name="add-exports" value="javafx.base/test.com.sun.javafx.binding=javafx.controls:javafx.base/test.util.memory=javafx.controls"/>
+			<attribute name="add-exports" value="javafx.base/test.com.sun.javafx.binding=javafx.controls:javafx.base/test.util.memory=javafx.controls:javafx.base/test.javafx.collections=javafx.controls"/>
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4">


### PR DESCRIPTION
was introduced with fix [JDK-8189354](https://bugs.openjdk.java.net/browse/JDK-8189354) which uses MockListObserver in tests. Fix is analogous to previous eclipse build problems (f.i. [JDK-8265513](https://bugs.openjdk.java.net/browse/JDK-8265513)): add-exports to allow access to base' test package.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266811](https://bugs.openjdk.java.net/browse/JDK-8266811): Openjfx controls test build broken (Eclipse)


### Reviewers
 * [Nir Lisker](https://openjdk.java.net/census#nlisker) (@nlisker - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/493/head:pull/493` \
`$ git checkout pull/493`

Update a local copy of the PR: \
`$ git checkout pull/493` \
`$ git pull https://git.openjdk.java.net/jfx pull/493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 493`

View PR using the GUI difftool: \
`$ git pr show -t 493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/493.diff">https://git.openjdk.java.net/jfx/pull/493.diff</a>

</details>
