### PR TITLE
8266860: [macos] Incorrect duration reported for HLS live streams

### DIFF
--- a/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFMediaPlayer.mm
+++ b/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFMediaPlayer.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -377,7 +377,10 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink,
 
 - (double) duration {
     if (self.player.currentItem.status == AVPlayerItemStatusReadyToPlay) {
-        return CMTimeGetSeconds(self.player.currentItem.duration);
+        CMTime dur = self.player.currentItem.duration;
+        if (!CMTIME_IS_INDEFINITE(dur)) {
+            return CMTimeGetSeconds(self.player.currentItem.duration);
+        }
     }
     return -1.0;
 }


### PR DESCRIPTION
For indefinite durations CMTimeGetSeconds was returning NaN (not-a-number double value) and our code expects -1.0. Based on doc we should be using CMTIME_IS_INDEFINITE to test if duration is indefinite. Fixed by using CMTIME_IS_INDEFINITE to test if duration is indefinite and if true -1.0 will be return to our Java layer.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266860](https://bugs.openjdk.java.net/browse/JDK-8266860): [macos] Incorrect duration reported for HLS live streams


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/495/head:pull/495` \
`$ git checkout pull/495`

Update a local copy of the PR: \
`$ git checkout pull/495` \
`$ git pull https://git.openjdk.java.net/jfx pull/495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 495`

View PR using the GUI difftool: \
`$ git pr show -t 495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/495.diff">https://git.openjdk.java.net/jfx/pull/495.diff</a>

</details>
