### PR TITLE
8266643: Intermittent failure of HonorDeveloperSettingsTest unit test

### DIFF
--- a/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
@@ -57,6 +57,8 @@ public class HonorDeveloperSettingsTest {
     private Scene scene;
     private Rectangle rect;
     private Text text;
+    Stage stage;
+    Group root;
 
     private static void resetStyleManager() {
         StyleManager sm = StyleManager.getInstance();
@@ -69,6 +71,8 @@ public class HonorDeveloperSettingsTest {
 
     @After
     public void cleanup() {
+        root.getChildren().clear();
+        stage.hide();
         resetStyleManager();
     }
 
@@ -80,15 +84,15 @@ public class HonorDeveloperSettingsTest {
         text = new Text();
         text.setId("text");
 
-        Group group = new Group();
-        group.getChildren().addAll(rect, text);
+        root = new Group();
+        root.getChildren().addAll(rect, text);
 
-        scene = new Scene(group);
+        scene = new Scene(root);
         System.setProperty("binary.css", "false");
         String url = getClass().getResource("HonorDeveloperSettingsTest_UA.css").toExternalForm();
         StyleManager.getInstance().setDefaultUserAgentStylesheet(url);
 
-        Stage stage = new Stage();
+        stage = new Stage();
         stage.setScene(scene);
         stage.show();
     }

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
@@ -57,8 +57,6 @@ public class HonorDeveloperSettingsTest {
     private Scene scene;
     private Rectangle rect;
     private Text text;
-    Stage stage;
-    Group root;
 
     private void resetStyleManager() {
         StyleManager sm = StyleManager.getInstance();
@@ -73,8 +71,6 @@ public class HonorDeveloperSettingsTest {
     @After
     public void cleanup() {
         resetStyleManager();
-        //root.getChildren().clear();
-        //stage.hide();
     }
 
     @Before
@@ -85,15 +81,15 @@ public class HonorDeveloperSettingsTest {
         text = new Text();
         text.setId("text");
 
-        root = new Group();
-        root.getChildren().addAll(rect, text);
+        Group group = new Group();
+        group.getChildren().addAll(rect, text);
 
-        scene = new Scene(root);
+        scene = new Scene(group);
         System.setProperty("binary.css", "false");
         String url = getClass().getResource("HonorDeveloperSettingsTest_UA.css").toExternalForm();
         StyleManager.getInstance().setDefaultUserAgentStylesheet(url);
 
-        stage = new Stage();
+        Stage stage = new Stage();
         stage.setScene(scene);
         stage.show();
     }

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
@@ -74,7 +74,7 @@ public class HonorDeveloperSettingsTest {
         resetStyleManager();
         root.getChildren().clear();
         stage.hide();
-        stage.setScene(null);
+        //stage.setScene(null);
     }
 
     @Before

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
@@ -71,9 +71,10 @@ public class HonorDeveloperSettingsTest {
 
     @After
     public void cleanup() {
+        resetStyleManager();
         root.getChildren().clear();
         stage.hide();
-        resetStyleManager();
+        stage.setScene(null);
     }
 
     @Before

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
@@ -60,8 +60,9 @@ public class HonorDeveloperSettingsTest {
     Stage stage;
     Group root;
 
-    private static void resetStyleManager() {
+    private void resetStyleManager() {
         StyleManager sm = StyleManager.getInstance();
+        sm.forget(scene);
         sm.userAgentStylesheetContainers.clear();
         sm.platformUserAgentStylesheetContainers.clear();
         sm.stylesheetContainerMap.clear();
@@ -72,8 +73,8 @@ public class HonorDeveloperSettingsTest {
     @After
     public void cleanup() {
         resetStyleManager();
-        root.getChildren().clear();
-        stage.hide();
+        //root.getChildren().clear();
+        //stage.hide();
     }
 
     @Before

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
@@ -71,9 +71,9 @@ public class HonorDeveloperSettingsTest {
 
     @After
     public void cleanup() {
-        resetStyleManager();
         root.getChildren().clear();
         stage.hide();
+        resetStyleManager();
         //stage.setScene(null);
     }
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
@@ -71,10 +71,9 @@ public class HonorDeveloperSettingsTest {
 
     @After
     public void cleanup() {
+        resetStyleManager();
         root.getChildren().clear();
         stage.hide();
-        resetStyleManager();
-        //stage.setScene(null);
     }
 
     @Before


### PR DESCRIPTION
The test fails intermittently on github build. But I do not observe this issue locally on my Ubuntu20.04 VM.
I am suspecting that the reason of failure is that the test are not cleaned up correctly. The changes in this PR cleans up the test, by removing all children added to root and hiding the stage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266643](https://bugs.openjdk.java.net/browse/JDK-8266643): Intermittent failure of HonorDeveloperSettingsTest unit test


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/496/head:pull/496` \
`$ git checkout pull/496`

Update a local copy of the PR: \
`$ git checkout pull/496` \
`$ git pull https://git.openjdk.java.net/jfx pull/496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 496`

View PR using the GUI difftool: \
`$ git pr show -t 496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/496.diff">https://git.openjdk.java.net/jfx/pull/496.diff</a>

</details>
