### PR TITLE
8266968: Ignore test.com.sun.webkit.LocalStorageAccessTest

### DIFF
--- a/tests/system/src/test/java/test/com/sun/webkit/LocalStorageAccessTest.java
+++ b/tests/system/src/test/java/test/com/sun/webkit/LocalStorageAccessTest.java
@@ -25,10 +25,13 @@
 
 package test.com.sun.webkit;
 
+import com.sun.javafx.PlatformUtil;
+
 import java.io.File;
 import static java.util.Arrays.asList;
 import java.util.List;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 import org.junit.Test;
 
 /**
@@ -39,6 +42,10 @@ import org.junit.Test;
 public class LocalStorageAccessTest {
     @Test (timeout = 15000)
     public void testMainThreadDoesNotSegfault() throws Exception {
+        if (PlatformUtil.isWindows()) {
+            assumeTrue(Boolean.getBoolean("unstable.test")); // JDK-8265661
+        }
+
         // This is an indirect test of the webkit file system implementation.
         // It was observed, that accessing local storage causes a segfault
         // in the JVM. That case is executed by this test.


### PR DESCRIPTION
The system test test.com.sun.webkit.LocalStorageAccessTest fails on Windows as mentioned in [JDK-8265661](https://bugs.openjdk.java.net/browse/JDK-8265661). We should skip this test until it is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266968](https://bugs.openjdk.java.net/browse/JDK-8266968): Ignore test.com.sun.webkit.LocalStorageAccessTest


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/497/head:pull/497` \
`$ git checkout pull/497`

Update a local copy of the PR: \
`$ git checkout pull/497` \
`$ git pull https://git.openjdk.java.net/jfx pull/497/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 497`

View PR using the GUI difftool: \
`$ git pr show -t 497`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/497.diff">https://git.openjdk.java.net/jfx/pull/497.diff</a>

</details>
