### PR TITLE
8266516: One label typo in the properties for bi-directional text

### DIFF
--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/controls/text/bidi/BidiApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/controls/text/bidi/BidiApp.java
@@ -53,7 +53,7 @@ import javafx.stage.Stage;
  * @playground text1.rotate (name="He said... rotate", min=-180, max=180)
  * @playground text1.translateX (name="He said... translateX")
  * @playground text1.translateY (name="He said... translateY")
- * @playground text2.strikethrough (name="He said... strikethrough")
+ * @playground text2.strikethrough (name="...to me. strikethrough")
  * @playground text2.underline (name="...to me. underline")
  * @playground text2.fill (name="...to me. fill")
  * @playground text2.rotate (name="...to me. rotate", min=-180, max=180)


### PR DESCRIPTION
A typo in one of the labels of Bidi text has been corrected. This is located in Samples > Controls > Text > Bidi

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266516](https://bugs.openjdk.java.net/browse/JDK-8266516): One label typo in the properties for bi-directional text


### Reviewers
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - Committer)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/500/head:pull/500` \
`$ git checkout pull/500`

Update a local copy of the PR: \
`$ git checkout pull/500` \
`$ git pull https://git.openjdk.java.net/jfx pull/500/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 500`

View PR using the GUI difftool: \
`$ git pr show -t 500`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/500.diff">https://git.openjdk.java.net/jfx/pull/500.diff</a>

</details>
