### PR TITLE
8265210: TreeCell: cell editing state not updated on cell re-use

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellEditingTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellEditingTest.java
@@ -85,6 +85,8 @@ public class TableCellEditingTest {
         assertEquals("cell must have fired edit cancel", 1, events.size());
         assertEquals("cancel event index must be same as editingIndex", editingIndex,
                 events.get(0).getTablePosition().getRow());
+        assertEquals("cancel event index must be same as editingIndex",
+                editingIndex, table.getEditingCell().getRow());
     }
 
 //--------------- change to editing index

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellEditingTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellEditingTest.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -39,23 +40,23 @@ import static org.junit.Assert.*;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.scene.control.TreeCell;
 import javafx.scene.control.TreeItem;
-import javafx.scene.control.TreeTableCell;
-import javafx.scene.control.TreeTableColumn;
-import javafx.scene.control.TreeTableColumn.CellEditEvent;
-import javafx.scene.control.TreeTableView;
+//import javafx.scene.control.TableColumn;
+//import javafx.scene.control.TreeTableColumn.CellEditEvent;
+import javafx.scene.control.TreeView;
+import javafx.scene.control.TreeView.EditEvent;
 
 /**
- * Test TreeTableCell editing state updated on re-use (aka after updateIndex(old, new)).
+ * Test TreeCell editing state updated on re-use (aka: updateIndex(old, new)).
  *
  * This test is parameterized in cellIndex and editingIndex.
  *
  */
 @RunWith(Parameterized.class)
-public class TreeTableCellEditingTest {
-    private TreeTableCell<String,String> cell;
-    private TreeTableView<String> table;
-    private TreeTableColumn<String, String> editingColumn;
+public class TreeCellEditingTest {
+    private TreeCell<String> cell;
+    private TreeView<String> tree;
     private ObservableList<TreeItem<String>> model;
 
     private int cellIndex;
@@ -66,29 +67,43 @@ public class TreeTableCellEditingTest {
     @Test
     public void testOffEditingIndex() {
         cell.updateIndex(editingIndex);
-        table.edit(editingIndex, editingColumn);
+        TreeItem<String> editingItem = tree.getTreeItem(editingIndex);
+        tree.edit(editingItem);
+        assertTrue("sanity: cell is editing", cell.isEditing());
         cell.updateIndex(cellIndex);
         assertEquals("sanity: cell index changed", cellIndex, cell.getIndex());
-        assertEquals("sanity: treeTable editingIndex must be unchanged", editingIndex, table.getEditingCell().getRow());
-        assertEquals("sanity: treeTable editingColumn must be unchanged", editingColumn, table.getEditingCell().getTableColumn());
-        assertFalse("cell must not be editing on update from editingIndex" + editingIndex
+        assertFalse("cell must not be editing on update from editingIndex " + editingIndex
                 + " to cellIndex " + cellIndex, cell.isEditing());
     }
 
     @Test
     public void testCancelOffEditingIndex() {
         cell.updateIndex(editingIndex);
-        table.edit(editingIndex, editingColumn);
-        List<CellEditEvent<String, String>> events = new ArrayList<>();
-        editingColumn.setOnEditCancel(e -> {
-            events.add(e);
-        });
+        TreeItem<String> editingItem = tree.getTreeItem(editingIndex);
+        tree.edit(editingItem);
+        List<EditEvent<String>> events = new ArrayList<>();
+        tree.setOnEditCancel(events::add);
         cell.updateIndex(cellIndex);
+        assertEquals("sanity: tree editing unchanged", editingItem, tree.getEditingItem());
+        assertEquals("sanity: editingIndex unchanged", editingIndex, tree.getRow(editingItem));
         assertEquals("cell must have fired edit cancel", 1, events.size());
-        assertEquals("cancel event index must be same as editingIndex", editingIndex,
-                events.get(0).getTreeTablePosition().getRow());
-        assertEquals("cancel event index must be same as editingIndex",
-                editingIndex, table.getEditingCell().getRow());
+    }
+
+    /**
+     * Extracted from testCancelOffEditingIndex to formally ignore
+     * FIXME: move the assert to the other method, once the issue is solved
+     */
+    @Ignore("JDK-8267094")
+    @Test
+    public void testCancelOffEditingIndexEventIndex() {
+        cell.updateIndex(editingIndex);
+        TreeItem<String> editingItem = tree.getTreeItem(editingIndex);
+        tree.edit(editingItem);
+        List<EditEvent<String>> events = new ArrayList<>();
+        tree.setOnEditCancel(events::add);
+        cell.updateIndex(cellIndex);
+        assertEquals("cancel on updateIndex from " + editingIndex + " to " + cellIndex + "\n  ",
+                editingItem, events.get(0).getTreeItem());
     }
 
 //--------------- change to editing index
@@ -96,11 +111,11 @@ public class TreeTableCellEditingTest {
     @Test
     public void testToEditingIndex() {
         cell.updateIndex(cellIndex);
-        table.edit(editingIndex, editingColumn);
+        TreeItem<String> editingItem = tree.getTreeItem(editingIndex);
+        tree.edit(editingItem);
+        assertFalse("sanity: cell must not be editing", cell.isEditing());
         cell.updateIndex(editingIndex);
         assertEquals("sanity: cell at editing index", editingIndex, cell.getIndex());
-        assertEquals("sanity: treeTable editingIndex must be unchanged", editingIndex, table.getEditingCell().getRow());
-        assertEquals("sanity: treeTable editingColumn must be unchanged", editingColumn, table.getEditingCell().getTableColumn());
         assertTrue("cell must be editing on update from " + cellIndex
                 + " to editingIndex " + editingIndex, cell.isEditing());
     }
@@ -108,16 +123,14 @@ public class TreeTableCellEditingTest {
     @Test
     public void testStartEvent() {
         cell.updateIndex(cellIndex);
-        table.edit(editingIndex, editingColumn);
-        List<CellEditEvent<String, String>> events = new ArrayList<>();
-        editingColumn.setOnEditStart(e -> {
-            events.add(e);
-        });
+        TreeItem<String> editingItem = tree.getTreeItem(editingIndex);
+        tree.edit(editingItem);
+        List<EditEvent<String>> events = new ArrayList<>();
+        tree.setOnEditStart(events::add);
         cell.updateIndex(editingIndex);
         assertEquals("cell must have fired edit start on update from " + cellIndex + " to " + editingIndex,
                 1, events.size());
-        assertEquals("start event index must be same as editingIndex", editingIndex,
-                events.get(0).getTreeTablePosition().getRow());
+        assertEquals("treeItem of start event ", editingItem, events.get(0).getTreeItem());
     }
 
 //------------- parameterized
@@ -130,12 +143,12 @@ public class TreeTableCellEditingTest {
             {1, 2}, // normal
             {0, 1}, // zero cell index
             {1, 0}, // zero editing index
-            {-1, 1}, // negative cell - JDK-8265206
+            {-1, 1}, // negative cell
         };
         return Arrays.asList(data);
     }
 
-    public TreeTableCellEditingTest(int cellIndex, int editingIndex) {
+    public TreeCellEditingTest(int cellIndex, int editingIndex) {
         this.cellIndex = cellIndex;
         this.editingIndex = editingIndex;
     }
@@ -148,7 +161,8 @@ public class TreeTableCellEditingTest {
     @Test
     public void testEditOnCellIndex() {
         cell.updateIndex(editingIndex);
-        table.edit(editingIndex, editingColumn);
+        TreeItem<String> editingItem = tree.getTreeItem(editingIndex);
+        tree.edit(editingItem);
         assertTrue("sanity: cell must be editing", cell.isEditing());
     }
 
@@ -158,31 +172,61 @@ public class TreeTableCellEditingTest {
     @Test
     public void testEditOffCellIndex() {
         cell.updateIndex(cellIndex);
-        table.edit(editingIndex, editingColumn);
+        TreeItem<String> editingItem = tree.getTreeItem(editingIndex);
+        tree.edit(editingItem);
         assertFalse("sanity: cell editing must be unchanged", cell.isEditing());
     }
 
-    @Before
-    public void setup() {
-        cell = new TreeTableCell<String,String>();
-        model = FXCollections.observableArrayList(new TreeItem<>("Four"),
-                new TreeItem<>("Five"), new TreeItem<>("Fear")); // "Flop", "Food", "Fizz"
+    /**
+     * Test do-nothing block in indexChanged (was RT-31165, is JDK-8123482)
+     */
+    @Test
+    public void testUpdateSameIndexWhileEdititing() {
+        cell.updateIndex(editingIndex);
+        TreeItem<String> editingItem = tree.getTreeItem(editingIndex);
+        tree.edit(editingItem);
+        List<EditEvent<String>> events = new ArrayList<>();
+        tree.setOnEditCancel(events::add);
+        tree.setOnEditCommit(events::add);
+        tree.setOnEditStart(events::add);
+        cell.updateIndex(editingIndex);
+        assertEquals(editingItem, tree.getEditingItem());
+        assertTrue(cell.isEditing());
+        assertEquals(0, events.size());
+    }
+
+    /**
+     * Test do-nothing block in indexChanged (was RT-31165, is JDK-8123482)
+     */
+    @Test
+    public void testUpdateSameIndexWhileNotEdititing() {
+        cell.updateIndex(cellIndex);
+        TreeItem<String> editingItem = tree.getTreeItem(editingIndex);
+        tree.edit(editingItem);
+        List<EditEvent<String>> events = new ArrayList<>();
+        tree.setOnEditCancel(events::add);
+        tree.setOnEditCommit(events::add);
+        tree.setOnEditStart(events::add);
+        cell.updateIndex(cellIndex);
+        assertEquals(editingItem, tree.getEditingItem());
+        assertFalse(cell.isEditing());
+        assertEquals(0, events.size());
+    }
+
+    @Before public void setup() {
+        cell = new TreeCell<String>();
+        model = FXCollections.observableArrayList(new TreeItem<String>("zero"),
+                new TreeItem<String>("one"), new TreeItem<String>("two"));
         TreeItem<String> root = new TreeItem<>("root");
         root.getChildren().addAll(model);
         root.setExpanded(true);
-        table = new TreeTableView<String>(root);
-        table.setEditable(true);
-        editingColumn = new TreeTableColumn<>("TEST");
-        editingColumn.setCellValueFactory(param -> null);
-        table.getColumns().add(editingColumn);
-        cell.updateTreeTableView(table);
-        cell.updateTreeTableColumn(editingColumn);
+        tree = new TreeView<String>(root);
+        tree.setEditable(true);
+        tree.setShowRoot(false);
         // make sure that focus change doesn't interfere with tests
         // (editing cell loosing focus will be canceled from focusListener in Cell)
-        // Note: not really needed for Tree/TableCell because the cell is never focused
-        // if !cellSelectionEnabled nor if not in Tree/TableRow
-        // done here for consistency across analogous tests for List/Tree/Cell
-        table.getFocusModel().focus(-1);
+        tree.getFocusModel().focus(-1);
+        cell.updateTreeView(tree);
         assertFalse("sanity: cellIndex not same as editingIndex", cellIndex == editingIndex);
         assertTrue("sanity: valid editingIndex", editingIndex < model.size());
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellEditingTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellEditingTest.java
@@ -42,8 +42,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.control.TreeCell;
 import javafx.scene.control.TreeItem;
-//import javafx.scene.control.TableColumn;
-//import javafx.scene.control.TreeTableColumn.CellEditEvent;
 import javafx.scene.control.TreeView;
 import javafx.scene.control.TreeView.EditEvent;
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
@@ -25,32 +25,29 @@
 
 package test.javafx.scene.control;
 
-import com.sun.javafx.application.PlatformImpl;
-import com.sun.javafx.scene.control.behavior.TreeCellBehavior;
-import javafx.beans.property.ReadOnlyStringWrapper;
-import javafx.scene.control.*;
-import test.javafx.collections.MockListObserver;
-import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
-import test.com.sun.javafx.scene.control.infrastructure.KeyModifier;
-import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
-import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
-import javafx.scene.control.skin.TextFieldSkin;
-import test.com.sun.javafx.scene.control.test.Employee;
-import test.com.sun.javafx.scene.control.test.Person;
-import test.com.sun.javafx.scene.control.test.RT_22463_Person;
-import com.sun.javafx.tk.Toolkit;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.sun.javafx.application.PlatformImpl;
+import com.sun.javafx.scene.control.VirtualScrollBar;
+import com.sun.javafx.scene.control.behavior.TreeCellBehavior;
+import com.sun.javafx.tk.Toolkit;
+
+import static org.junit.Assert.*;
+import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.*;
 
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
-import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.assertStyleClassContains;
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
-
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyBooleanWrapper;
@@ -62,9 +59,21 @@ import javafx.event.ActionEvent;
 import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.FocusModel;
+import javafx.scene.control.IndexedCell;
+import javafx.scene.control.MultipleSelectionModel;
+import javafx.scene.control.SelectionMode;
+import javafx.scene.control.SelectionModel;
+import javafx.scene.control.TextField;
+import javafx.scene.control.TreeCell;
+import javafx.scene.control.TreeCellShim;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeView;
+import javafx.scene.control.TreeViewShim;
 import javafx.scene.control.cell.CheckBoxTreeCell;
 import javafx.scene.control.cell.TextFieldTreeCell;
-import com.sun.javafx.scene.control.VirtualScrollBar;
+import javafx.scene.control.skin.TextFieldSkin;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.VBox;
@@ -73,10 +82,14 @@ import javafx.scene.shape.Circle;
 import javafx.scene.shape.Rectangle;
 import javafx.stage.Stage;
 import javafx.util.Callback;
-
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
+import test.com.sun.javafx.scene.control.infrastructure.KeyModifier;
+import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
+import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
+import test.com.sun.javafx.scene.control.test.Employee;
+import test.com.sun.javafx.scene.control.test.Person;
+import test.com.sun.javafx.scene.control.test.RT_22463_Person;
+import test.javafx.collections.MockListObserver;
 
 public class TreeViewTest {
     private TreeView<String> treeView;
@@ -119,6 +132,14 @@ public class TreeViewTest {
     }
 
     @Before public void setup() {
+        Thread.currentThread().setUncaughtExceptionHandler((thread, throwable) -> {
+            if (throwable instanceof RuntimeException) {
+                throw (RuntimeException)throwable;
+            } else {
+                Thread.currentThread().getThreadGroup().uncaughtException(thread, throwable);
+            }
+        });
+
         treeView = new TreeView<String>();
         sm = treeView.getSelectionModel();
         fm = treeView.getFocusModel();
@@ -155,6 +176,11 @@ public class TreeViewTest {
             judyMayer,
             gregorySmith
         );
+    }
+
+    @After
+    public void cleanup() {
+        Thread.currentThread().setUncaughtExceptionHandler(null);
     }
 
     private void installChildren() {
@@ -3702,4 +3728,63 @@ public class TreeViewTest {
         observer.check1();
         observer.checkAddRemove(0, treeView.getSelectionModel().getSelectedItems(), List.of(c1, c2, c3), 1, 1);
     }
+
+
+
+    /**
+     * Test that cell.cancelEdit can switch tree editing off
+     * even if a subclass violates its contract.
+     *
+     * For details, see https://bugs.openjdk.java.net/browse/JDK-8265206
+     *
+     */
+    @Test
+    public void testMisbehavingCancelEditTerminatesEdit() {
+        // setup for editing
+        TreeCell<String> cell = new MisbehavingOnCancelTreeCell<>();
+        treeView.setEditable(true);
+        installChildren();
+        cell.updateTreeView(treeView);
+        // test editing: first round
+        // switch cell off editing by table api
+        int editingIndex = 1;
+        int intermediate = 0;
+        cell.updateIndex(editingIndex);
+        TreeItem editingItem = treeView.getTreeItem(editingIndex);
+        TreeItem intermediateTreeItem = treeView.getTreeItem(intermediate);
+        treeView.edit(editingItem);
+        assertTrue("sanity: ", cell.isEditing());
+        try {
+            treeView.edit(intermediateTreeItem);
+        } catch (Exception ex) {
+            // catching to test in finally
+        } finally {
+            assertFalse("cell must not be editing", cell.isEditing());
+            assertEquals("table must be editing at intermediate index",
+                    intermediateTreeItem, treeView.getEditingItem());
+        }
+        // test editing: second round
+        // switch cell off editing by cell api
+        treeView.edit(editingItem);
+        assertTrue("sanity: ", cell.isEditing());
+        try {
+            cell.cancelEdit();
+        } catch (Exception ex) {
+            // catching to test in finally
+        } finally {
+            assertFalse("cell must not be editing", cell.isEditing());
+            assertNull("table editing must be cancelled by cell", treeView.getEditingItem());
+        }
+    }
+
+    public static class MisbehavingOnCancelTreeCell<S> extends TreeCell<S> {
+
+        @Override
+        public void cancelEdit() {
+            super.cancelEdit();
+            throw new RuntimeException("violating contract");
+        }
+
+    }
+
 }


### PR DESCRIPTION
fix is analogous to similar issues for Tree/TableCell (combined [JDK-8150525](https://bugs.openjdk.java.net/browse/JDK-8150525) and [JDK-8265206](https://bugs.openjdk.java.net/browse/JDK-8265206))

added tests that failed before and passed after the fix

note: this PR also adds two asserts (which I forgot in the previous [PR 473](https://github.com/openjdk/jfx/pull/473);) in Tree/TableEditingTest which are unrelated to this fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265210](https://bugs.openjdk.java.net/browse/JDK-8265210): TreeCell: cell editing state not updated on cell re-use


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/501/head:pull/501` \
`$ git checkout pull/501`

Update a local copy of the PR: \
`$ git checkout pull/501` \
`$ git pull https://git.openjdk.java.net/jfx pull/501/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 501`

View PR using the GUI difftool: \
`$ git pr show -t 501`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/501.diff">https://git.openjdk.java.net/jfx/pull/501.diff</a>

</details>
