### PR TITLE
8267160: Monocle mouse never get ENTERED state

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MouseInput.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MouseInput.java
@@ -89,9 +89,9 @@ class MouseInput {
         newState.setY(y);
         // Get the cached window for the old state and compute the window for
         // the new state
-        MonocleWindow oldWindow = state.getWindow(false);
+        MonocleWindow oldWindow = state.getWindow(false, null);
         boolean recalculateWindow = state.getButtonsPressed().isEmpty();
-        MonocleWindow window = newState.getWindow(recalculateWindow);
+        MonocleWindow window = newState.getWindow(recalculateWindow, null);
         MonocleView view = (window == null) ? null : (MonocleView) window.getView();
         // send exit event
         if (oldWindow != window && oldWindow != null) {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MouseState.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MouseState.java
@@ -78,18 +78,25 @@ class MouseState {
         buttonsPressed.removeInt(button);
     }
 
-    /** Returns the Glass window on which the coordinates of this state are located.
+    /**
+     * Returns the Glass window on which the coordinates of this state are located.
      * @param recalculateCache true if the cached value for the target window
      *                         should be recalculated; false if the cached
      *                         value should be used to determine the result
      *                         of this method.
+     * @param fallback if the original window is null, or if no window can
+     * be found, return the fallback window
      * @return the MonocleWindow at the top of the stack at the coordinates
-     * described by this state object.
+     * described by this state object, or the fallback window in case the
+     * current window is null or no window can be found for the supplied coordinates.
      */
-    MonocleWindow getWindow(boolean recalculateCache) {
-        if (window == null || recalculateCache) {
+    MonocleWindow getWindow(boolean recalculateCache, MonocleWindow fallback) {
+        if (recalculateCache) {
             window = (MonocleWindow)
                     MonocleWindowManager.getInstance().getWindowForLocation(x, y);
+        }
+        if (window == null) {
+            window = fallback;
         }
         return window;
     }


### PR DESCRIPTION
allow to pass a fallback window in case the existing one is null (or can't be computed).

Fix for JDK-8267160

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267160](https://bugs.openjdk.java.net/browse/JDK-8267160): Monocle mouse never get ENTERED state


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/502/head:pull/502` \
`$ git checkout pull/502`

Update a local copy of the PR: \
`$ git checkout pull/502` \
`$ git pull https://git.openjdk.java.net/jfx pull/502/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 502`

View PR using the GUI difftool: \
`$ git pr show -t 502`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/502.diff">https://git.openjdk.java.net/jfx/pull/502.diff</a>

</details>
