### PR TITLE
8267121: Illegal access to private "size" field of ArrayList from build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -693,7 +693,7 @@ void fetchExternalTools(String configName, List packages, File destdir, boolean 
         }
 
         //fetch all the missing packages
-        if (fetchedPackages.size > 0) {
+        if (fetchedPackages.size() > 0) {
             destdir.mkdirs()
 
             logger.quiet "fetching missing packages $fetchedPackages"
@@ -752,7 +752,7 @@ void fetchExternalTools(String configName, List packages, File destdir, boolean 
                 errors.add(pkgname)
             }
         }
-        if (errors.size > 0) {
+        if (errors.size() > 0) {
             throw new GradleException("Error: missing tool packages: $errors")
         } else {
             logger.quiet "all tool packages are present $packages"


### PR DESCRIPTION
A test of our CI build with gradle 7.0.1 and JDK 16.0.1 revealed a latent bug in `build.gradle` in the `fetchExternalTools()` method. It checks the size of an `ArrayList` in two places, but rather than calling the `size()` method it omits the `()` which means it is accessing the private `size` field.

Starting in JDK 16, which has default strong encapsulation, this no longer works, so we need to fix this before switching. We really should fix it anyway, since accessing the internal field is both unnecessary and wrong.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267121](https://bugs.openjdk.java.net/browse/JDK-8267121): Illegal access to private "size" field of ArrayList from build.gradle


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/503/head:pull/503` \
`$ git checkout pull/503`

Update a local copy of the PR: \
`$ git checkout pull/503` \
`$ git pull https://git.openjdk.java.net/jfx pull/503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 503`

View PR using the GUI difftool: \
`$ git pr show -t 503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/503.diff">https://git.openjdk.java.net/jfx/pull/503.diff</a>

</details>
