### PR TITLE
8267392: ENTER key press on editable TableView throws NPE

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableViewBehaviorBase.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableViewBehaviorBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -891,15 +891,20 @@ public abstract class TableViewBehaviorBase<C extends Control, T, TC extends Tab
         if (fm == null) return;
 
         TablePositionBase<TC> cell = getFocusedCell();
-        sm.select(cell.getRow(), cell.getTableColumn());
+        TC tableColumn = cell.getTableColumn();
+        sm.select(cell.getRow(), tableColumn);
         setAnchor(cell);
 
+        if (tableColumn == null) {
+           return;
+        }
+
         // check if we are editable
-        boolean isEditable = isControlEditable() && cell.getTableColumn().isEditable();
+        boolean isEditable = isControlEditable() && tableColumn.isEditable();
 
         // edit this row also
         if (isEditable && cell.getRow() >= 0) {
-            editCell(cell.getRow(), cell.getTableColumn());
+            editCell(cell.getRow(), tableColumn);
             e.consume();
         }
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewKeyInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewKeyInputTest.java
@@ -185,24 +185,24 @@ public class TableViewKeyInputTest {
      * Tests for row-based single selection
      **************************************************************************/
 
-    @Test public void testDownArrowChangesSelection() {
-        sm.clearAndSelect(0);
-        keyboard.doDownArrowPress();
-        assertFalse(sm.isSelected(0));
-        assertTrue(sm.isSelected(1));
-    }
-
     @Test
-    public void testEnterOnFocusedRowDoesNotThrowNP() {
+    public void testEnterOnFocusedRowDoesNotThrowNPE() {
         tableView.setEditable(true);
 
         assertNull(tableView.getSelectionModel().getSelectedItem());
         assertEquals(0, tableView.getFocusModel().getFocusedCell().getRow());
 
-        // Fire an ENTER event on the focused row. This should not throw a NP!
+        // Fire an ENTER event on the focused row. This should not throw a NPE!
         keyboard.doKeyPress(KeyCode.ENTER);
 
         assertNotNull(tableView.getSelectionModel().getSelectedItem());
+    }
+
+    @Test public void testDownArrowChangesSelection() {
+        sm.clearAndSelect(0);
+        keyboard.doDownArrowPress();
+        assertFalse(sm.isSelected(0));
+        assertTrue(sm.isSelected(1));
     }
 
     @Test public void testDownArrowDoesNotChangeSelectionWhenAtLastIndex() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewKeyInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewKeyInputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,6 +63,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -189,6 +190,19 @@ public class TableViewKeyInputTest {
         keyboard.doDownArrowPress();
         assertFalse(sm.isSelected(0));
         assertTrue(sm.isSelected(1));
+    }
+
+    @Test
+    public void testEnterOnFocusedRowDoesNotThrowNP() {
+        tableView.setEditable(true);
+
+        assertNull(tableView.getSelectionModel().getSelectedItem());
+        assertEquals(0, tableView.getFocusModel().getFocusedCell().getRow());
+
+        // Fire an ENTER event on the focused row. This should not throw a NP!
+        keyboard.doKeyPress(KeyCode.ENTER);
+
+        assertNotNull(tableView.getSelectionModel().getSelectedItem());
     }
 
     @Test public void testDownArrowDoesNotChangeSelectionWhenAtLastIndex() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewKeyInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewKeyInputTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -241,6 +242,19 @@ public class TreeTableViewKeyInputTest {
     /***************************************************************************
      * Tests for row-based single selection
      **************************************************************************/
+
+    @Test
+    public void testEnterOnFocusedRowDoesNotThrowNP() {
+        tableView.setEditable(true);
+
+        assertNull(tableView.getSelectionModel().getSelectedItem());
+        assertEquals(0, tableView.getFocusModel().getFocusedCell().getRow());
+
+        // Fire an ENTER event on the focused row. This should not throw a NP!
+        keyboard.doKeyPress(KeyCode.ENTER);
+
+        assertNotNull(tableView.getSelectionModel().getSelectedItem());
+    }
 
     @Test public void testDownArrowChangesSelection() {
         sm.clearAndSelect(0);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewKeyInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewKeyInputTest.java
@@ -244,13 +244,13 @@ public class TreeTableViewKeyInputTest {
      **************************************************************************/
 
     @Test
-    public void testEnterOnFocusedRowDoesNotThrowNP() {
+    public void testEnterOnFocusedRowDoesNotThrowNPE() {
         tableView.setEditable(true);
 
         assertNull(tableView.getSelectionModel().getSelectedItem());
         assertEquals(0, tableView.getFocusModel().getFocusedCell().getRow());
 
-        // Fire an ENTER event on the focused row. This should not throw a NP!
+        // Fire an ENTER event on the focused row. This should not throw a NPE!
         keyboard.doKeyPress(KeyCode.ENTER);
 
         assertNotNull(tableView.getSelectionModel().getSelectedItem());


### PR DESCRIPTION
~~Note: I reported the bug already, waiting for approval. Internal tracking id: 9070318. I will update the title as soon as the ticket is created.~~
EDIT: Changed the title. :)

This PR is fixing a NP, which is thrown when you press ENTER on an editbale table, after it is initially shown.

When pressing ENTER, **TableViewBehaviorBase#activate** is retrieving the current focused row (**getFocusedCell()**) and from there the corresponding table column.
This is null, when a table is initially shown. It can also be null, when the items from the underlying table are changed (e.g. **setItems()**) or when **getFocusModel().focus(row)** is used. 
Therefore, null is a valid value and we should guard against it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267392](https://bugs.openjdk.java.net/browse/JDK-8267392): ENTER key press on editable TableView throws NPE


### Reviewers
 * [Jeanette Winzenburg](https://openjdk.java.net/census#fastegal) (@kleopatra - Committer)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/505/head:pull/505` \
`$ git checkout pull/505`

Update a local copy of the PR: \
`$ git checkout pull/505` \
`$ git pull https://git.openjdk.java.net/jfx pull/505/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 505`

View PR using the GUI difftool: \
`$ git pr show -t 505`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/505.diff">https://git.openjdk.java.net/jfx/pull/505.diff</a>

</details>
