### PR TITLE
8252783: Remove the css Selector and ShapeConverter constructors

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
@@ -43,10 +43,9 @@ import java.util.Set;
 abstract public class Selector {
 
     /**
-     * @deprecated This constructor was exposed erroneously and will be removed in the next version. Use {@link #createSelector(String)} instead.
+     * Package scoped constructor.
      */
-    @Deprecated(since="16", forRemoval=true)
-    public Selector() {
+    Selector() {
     }
 
     private static class UniversalSelector {

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/ShapeConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/ShapeConverter.java
@@ -43,11 +43,7 @@ public class ShapeConverter extends StyleConverter<String, Shape> {
 
     public static StyleConverter<String, Shape> getInstance() { return INSTANCE; }
 
-    /**
-     * @deprecated This constructor was exposed erroneously and will be removed in the next version. Use {@link #getInstance()} instead.
-     */
-    @Deprecated(since="16", forRemoval=true)
-    public ShapeConverter() {
+    private ShapeConverter() {
     }
 
     @Override public Shape convert(ParsedValue<String, Shape> value, Font font) {


### PR DESCRIPTION
The javafx.css.Selector and javafx.css.converter.ShapeConverter constructors were deprecated for removal in openjfx16.
This PR removes these constructors (targeted for openjfx17).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252783](https://bugs.openjdk.java.net/browse/JDK-8252783): Remove the css Selector and ShapeConverter constructors


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/512/head:pull/512` \
`$ git checkout pull/512`

Update a local copy of the PR: \
`$ git checkout pull/512` \
`$ git pull https://git.openjdk.java.net/jfx pull/512/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 512`

View PR using the GUI difftool: \
`$ git pr show -t 512`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/512.diff">https://git.openjdk.java.net/jfx/pull/512.diff</a>

</details>
