### PR TITLE
8267314: Loading some animated GIFs fails with ArrayIndexOutOfBoundsException: Index 4096 out of bounds for length 4096

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/gif/GIFImageLoader2.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/gif/GIFImageLoader2.java
@@ -370,27 +370,29 @@ public class GIFImageLoader2 extends ImageLoaderImpl {
                 }
             } else {
                 int newSuffixIndex;
-                int ti = tableIndex;
-                if (code < ti) {
+                if (code < tableIndex) {
                     newSuffixIndex = code;
                 } else { // code == tableIndex
                     newSuffixIndex = oldCode;
-                    if (code != ti) {
+                    if (code != tableIndex) {
                         throw new IOException("Bad GIF LZW: Out-of-sequence code!");
                     }
                 }
 
-                int oc = oldCode;
+                if (tableIndex < 4096) {
+                    int ti = tableIndex;
+                    int oc = oldCode;
 
-                prefix[ti] = oc;
-                suffix[ti] = initial[newSuffixIndex];
-                initial[ti] = initial[oc];
-                length[ti] = length[oc] + 1;
+                    prefix[ti] = oc;
+                    suffix[ti] = initial[newSuffixIndex];
+                    initial[ti] = initial[oc];
+                    length[ti] = length[oc] + 1;
 
-                ++tableIndex;
-                if ((tableIndex == (1 << codeSize)) && (tableIndex < 4096)) {
-                    ++codeSize;
-                    codeMask = (1 << codeSize) - 1;
+                    ++tableIndex;
+                    if ((tableIndex == (1 << codeSize)) && (tableIndex < 4096)) {
+                        ++codeSize;
+                        codeMask = (1 << codeSize) - 1;
+                    }
                 }
             }
             // Reverse code

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/iio/ImageStorageTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/iio/ImageStorageTest.java
@@ -29,6 +29,7 @@ import com.sun.javafx.iio.ImageFrame;
 import com.sun.javafx.iio.ImageStorage;
 import com.sun.javafx.iio.ImageStorageException;
 import com.sun.javafx.iio.common.ImageTools;
+import com.sun.javafx.iio.gif.GIFImageLoader2;
 import static org.junit.Assert.*;
 import org.junit.ComparisonFailure;
 import org.junit.Test;
@@ -83,5 +84,12 @@ public class ImageStorageTest {
     public void testCorruptFirstFrame() throws ImageStorageException  {
         String path = getResourcePath("gif/animation/testBad.gif");
         ImageStorage.loadAll(path, null, 0, 0, false, 1.0f, false);
+    }
+
+    @Test
+    public void testLoadAllFramesAnimatedGIF() throws ImageStorageException {
+        String path = "https://upload.wikimedia.org/wikipedia/commons/2/2c/Rotating_earth_%28large%29.gif";
+        ImageFrame[] frames = ImageStorage.loadAll(path, null, 0, 0, true, 1.0f, true);
+        assertEquals(44, frames.length);
     }
 }


### PR DESCRIPTION
This PR limits the `tableIndex` value, used by the LZWDecoder algorithm in `GIFImageLoader2`, to avoid a potential AIOOB exception that happens on some animated GIFs, to the maximum size of the tables used (4096). 

In some occasions loading an animated GIF like the one used in the included test, doesn't throw such exception, because we `allow partially loaded animated images` in `ImageStorage`, but only a few frames are loaded.

In theory, greater values of such index would operate over completely full tables, so there is no need to add new values in this case, and therefore, there is no risk in limiting the value to 4096.

This PR will prevent the exception and all the frames should load. The included test passes now (and fails loading only 10 frames out of 44 without the proposed fix).
