### PR TITLE
8244075: Accelerator of ContextMenu's MenuItem is not removed when ContextMenu is removed from Scene

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlAcceleratorSupport.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlAcceleratorSupport.java
@@ -78,15 +78,15 @@ public class ControlAcceleratorSupport {
         if (scene != null) {
             doAcceleratorInstall(items, scene);
         }
-        // listen to the scene property on the anchor until it is set, and
-        // then install the accelerators
-        // Scene change listener is added to the anchor to anchor for scenarios like,
-        // 1. Installing the accelerators when Control is added to Scene
+        // Scene change listener is added to the anchor for scenarios like,
+        // 1. Installing accelerators when Control is added to Scene
         // 2. Removing accelerators when Control is removed from Scene
+        // Remove previously added listener if any
         if (sceneChangeListenerMap.containsKey(anchor)) {
             anchor.sceneProperty().removeListener(sceneChangeListenerMap.get(anchor));
             sceneChangeListenerMap.remove(anchor);
         }
+        // Add a new listener
         anchor.sceneProperty().addListener(getSceneChangeListener(anchor, items));
     }
 
@@ -239,9 +239,10 @@ public class ControlAcceleratorSupport {
     public static void removeAcceleratorsFromScene(List<? extends MenuItem> items, Node anchor) {
         Scene scene = anchor.getScene();
         if (scene == null) {
-            ChangeListener<Scene> listener = sceneChangeListenerMap.get(anchor);
-            if (listener != null) {
-                anchor.sceneProperty().removeListener(listener);
+            // The Node is not part of a Scene: Remove the Scene listener that was added
+            // at the time of installing the accelerators.
+            if (sceneChangeListenerMap.containsKey(anchor)) {
+                anchor.sceneProperty().removeListener(sceneChangeListenerMap.get(anchor));
                 sceneChangeListenerMap.remove(anchor);
             }
         }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/AcceleratorParameterizedTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/AcceleratorParameterizedTest.java
@@ -349,7 +349,7 @@ public class AcceleratorParameterizedTest {
         assertEquals(2, eventCounter);
     }
 
-    @Ignore("Passes only for Button")
+    @Ignore("JDK-8268374")
     @Test public void testAcceleratorShouldNotGetFiredWhenControlsIsRemovedFromSceneThenContextMenuIsSetToNullAndControlIsAddedBackToScene() {
         KeyEventFirer kb = new KeyEventFirer(item1, scene);
         kb.doKeyPress(KeyCode.DIGIT1, KeyModifier.ALT);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/AcceleratorParameterizedTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/AcceleratorParameterizedTest.java
@@ -25,6 +25,7 @@
 
 package test.javafx.scene.control;
 
+import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.*;
 import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
 import test.com.sun.javafx.scene.control.infrastructure.KeyModifier;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
@@ -34,12 +35,14 @@ import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyCombination;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.util.Arrays;
 import java.util.Collection;
+import javafx.scene.Group;
 import javafx.scene.control.Button;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Menu;
@@ -296,5 +299,78 @@ public class AcceleratorParameterizedTest {
 
         keyboard.doKeyPress(KeyCode.DIGIT1, KeyModifier.ALT);
         assertEquals(0, eventCounter);
+    }
+
+    @Test public void testAcceleratorShouldNotGetFiredWhenMenuItemRemovedFromScene() {
+        KeyEventFirer kb = new KeyEventFirer(item1, scene);
+
+        kb.doKeyPress(KeyCode.DIGIT1, KeyModifier.ALT);
+        assertEquals(1, eventCounter);
+        assertEquals(1, getListenerCount(item1.acceleratorProperty()));
+
+        // Remove all children from the scene
+        Group root = (Group)scene.getRoot();
+        root.getChildren().clear();
+
+        assertEquals(0, getListenerCount(item1.acceleratorProperty()));
+        kb.doKeyPress(KeyCode.DIGIT1, KeyModifier.ALT);
+        assertEquals(1, eventCounter);
+    }
+
+    @Test public void testAcceleratorShouldGetFiredWhenMenuItemRemovedAndAddedBackToScene() {
+        KeyEventFirer kb = new KeyEventFirer(item1, scene);
+
+        kb.doKeyPress(KeyCode.DIGIT1, KeyModifier.ALT);
+        assertEquals(1, eventCounter);
+
+        Group root = (Group)scene.getRoot();
+        scene.setRoot(new Group()); // Remove all children from the scene
+        scene.setRoot(root); // Add the children to the same scene
+
+        assertEquals(1, getListenerCount(item1.acceleratorProperty()));
+        kb.doKeyPress(KeyCode.DIGIT1, KeyModifier.ALT);
+        assertEquals(2, eventCounter);
+    }
+
+    @Test public void testAcceleratorShouldGetFiredWhenMenuItemRemovedAndAddedToDifferentScene() {
+        KeyEventFirer kb = new KeyEventFirer(item1, scene);
+
+        kb.doKeyPress(KeyCode.DIGIT1, KeyModifier.ALT);
+        assertEquals(1, eventCounter);
+
+        Group root = (Group)scene.getRoot();
+        scene.setRoot(new Group()); // Remove all children from the scene
+        Scene diffScene = new Scene(root); // Add the children to a different scene
+        sl.getStage().setScene(diffScene);
+        kb = new KeyEventFirer(item1, diffScene);
+
+        assertEquals(1, getListenerCount(item1.acceleratorProperty()));
+        kb.doKeyPress(KeyCode.DIGIT1, KeyModifier.ALT);
+        assertEquals(2, eventCounter);
+    }
+
+    @Ignore("Passes only for Button")
+    @Test public void testAcceleratorShouldNotGetFiredWhenControlsIsRemovedFromSceneThenContextMenuIsSetToNullAndControlIsAddedBackToScene() {
+        KeyEventFirer kb = new KeyEventFirer(item1, scene);
+        kb.doKeyPress(KeyCode.DIGIT1, KeyModifier.ALT);
+        assertEquals(1, eventCounter);
+
+        Group root = (Group)scene.getRoot();
+        scene.setRoot(new Group()); // Remove all children from the scene
+
+        if (testClass == Button.class) {
+            btn.setContextMenu(null);
+        } else if (testClass == Tab.class) {
+            tab.setContextMenu(null);
+        } else if (testClass == TableColumn.class) {
+            tableColumn.setContextMenu(null);
+        } else if (testClass == TreeTableColumn.class) {
+            treeTableColumn.setContextMenu(null);
+        }
+        scene.setRoot(root); // Add the children to a different scene
+
+        assertEquals(0, getListenerCount(item1.acceleratorProperty()));
+        kb.doKeyPress(KeyCode.DIGIT1, KeyModifier.ALT);
+        assertEquals(1, eventCounter);
     }
 }


### PR DESCRIPTION
Issue:
There are several issues related to Accelerator of MenuItem of a ConextMenu set on Control.
1. Accelerator of ContextMenu's MenuItem is not removed when ContextMenu is removed from Scene
2. Accelerator is not updated correctly when the Control is removed from a Scene and Added to a different Scene
3. Accelerator is not removed from Scene when the anchor node is removed from Scene and then it's ContextMenu is set to null

Fix:
The accelerator should be added or removed correctly according to the Scene property of the anchor node. 
The issue#3 in above list is only fixed for Button and fails for other Controls. A test is added for this scenario and I shall report a new issue to address it.
Added tests that fails before and pass after the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244075](https://bugs.openjdk.java.net/browse/JDK-8244075): Accelerator of ContextMenu's MenuItem is not removed when ContextMenu is removed from Scene


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/515/head:pull/515` \
`$ git checkout pull/515`

Update a local copy of the PR: \
`$ git checkout pull/515` \
`$ git pull https://git.openjdk.java.net/jfx pull/515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 515`

View PR using the GUI difftool: \
`$ git pr show -t 515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/515.diff">https://git.openjdk.java.net/jfx/pull/515.diff</a>

</details>
