### PR TITLE
8267505: {List,Set,Map}PropertyBase::bind should check against identity

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/beans/property/ListPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ListPropertyBase.java
@@ -270,7 +270,7 @@ public abstract class ListPropertyBase<E> extends ListProperty<E> {
             throw new NullPointerException("Cannot bind to null");
         }
 
-        if (!newObservable.equals(observable)) {
+        if (newObservable != observable) {
             unbind();
             observable = newObservable;
             if (listener == null) {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/MapPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/MapPropertyBase.java
@@ -271,7 +271,7 @@ public abstract class MapPropertyBase<K, V> extends MapProperty<K, V> {
         if (newObservable == null) {
             throw new NullPointerException("Cannot bind to null");
         }
-        if (!newObservable.equals(observable)) {
+        if (newObservable != observable) {
             unbind();
             observable = newObservable;
             if (listener == null) {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/SetPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/SetPropertyBase.java
@@ -272,7 +272,7 @@ public abstract class SetPropertyBase<E> extends SetProperty<E> {
             throw new NullPointerException("Cannot bind to null");
         }
 
-        if (!newObservable.equals(this.observable)) {
+        if (newObservable != this.observable) {
             unbind();
             observable = newObservable;
             if (listener == null) {

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ListPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ListPropertyBaseTest.java
@@ -628,6 +628,43 @@ public class ListPropertyBaseTest {
     }
 
     @Test
+    public void testRebind_Identity() {
+        final ListProperty<Object> v1 = new SimpleListProperty<>(FXCollections.observableArrayList());
+        final ListProperty<Object> v2 = new SimpleListProperty<>(FXCollections.observableArrayList());
+        attachListChangeListener();
+
+        // bind
+        property.bind(v1);
+        property.check(1);
+        listChangeListener.check1AddRemove(property, EMPTY_LIST, 0, 0);
+        listChangeListener.clear();
+
+        // rebind to same
+        property.bind(v1);
+        property.check(0);
+        listChangeListener.check0();
+
+        // rebind to other, without explicitly unbinding
+        property.bind(v2);
+        property.check(1);
+        listChangeListener.check1AddRemove(property, EMPTY_LIST, 0, 0);
+        listChangeListener.clear();
+
+        v2.add("One");
+        listChangeListener.check1AddRemove(property, EMPTY_LIST, 0, 1);
+        listChangeListener.clear();
+
+        v2.add("Two");
+        listChangeListener.check1AddRemove(property, EMPTY_LIST, 1, 2);
+        listChangeListener.clear();
+
+        property.check(4);
+        assertTrue(property.isBound());
+        assertEquals(2, property.toArray().length);
+        assertEquals("ListProperty [bound, value: [One, Two]]", property.toString());
+    }
+
+    @Test
     public void testUnbind() {
         attachInvalidationListener();
         final ListProperty<Object> v = new SimpleListProperty<Object>(VALUE_1a);

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/MapPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/MapPropertyBaseTest.java
@@ -651,6 +651,41 @@ public class MapPropertyBaseTest {
     }
 
     @Test
+    public void testRebind_Identity() {
+        final MapProperty<Object, Object> v1 = new SimpleMapProperty<>(FXCollections.observableHashMap());
+        final MapProperty<Object, Object> v2 = new SimpleMapProperty<>(FXCollections.observableHashMap());
+        attachMapChangeListener();
+
+        // bind
+        property.bind(v1);
+        property.check(1);
+        mapChangeListener.clear();
+
+        // rebind to same
+        property.bind(v1);
+        property.check(0);
+        mapChangeListener.check0();
+
+        // rebind to other, without explicitly unbinding
+        property.bind(v2);
+        property.check(1);
+        mapChangeListener.clear();
+
+        v2.put("One", "1");
+        mapChangeListener.assertAdded(MockMapObserver.Tuple.tup("One", "1"));
+        mapChangeListener.clear();
+
+        v2.put("Two", "2");
+        mapChangeListener.assertAdded(MockMapObserver.Tuple.tup("Two", "2"));
+        mapChangeListener.clear();
+
+        property.check(4);
+        assertTrue(property.isBound());
+        assertEquals(2, property.size());
+        assertEquals("MapProperty [bound, value: {One=1, Two=2}]", property.toString());
+    }
+
+    @Test
     public void testUnbind() {
         attachInvalidationListener();
         final MapProperty<Object, Object> v = new SimpleMapProperty<Object, Object>(VALUE_1a);

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/SetPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/SetPropertyBaseTest.java
@@ -588,6 +588,41 @@ public class SetPropertyBaseTest {
     }
 
     @Test
+    public void testRebind_Identity() {
+        final SetProperty<Object> v1 = new SimpleSetProperty<>(FXCollections.observableSet());
+        final SetProperty<Object> v2 = new SimpleSetProperty<>(FXCollections.observableSet());
+        attachSetChangeListener();
+
+        // bind
+        property.bind(v1);
+        property.check(1);
+        setChangeListener.clear();
+
+        // rebind to same
+        property.bind(v1);
+        property.check(0);
+        setChangeListener.check0();
+
+        // rebind to other, without explicitly unbinding
+        property.bind(v2);
+        property.check(1);
+        setChangeListener.clear();
+
+        v2.add("One");
+        setChangeListener.assertAdded(Tuple.tup("One"));
+        setChangeListener.clear();
+
+        v2.add("Two");
+        setChangeListener.assertAdded(Tuple.tup("Two"));
+        setChangeListener.clear();
+
+        property.check(4);
+        assertTrue(property.isBound());
+        assertEquals(2, property.toArray().length);
+        assertEquals("SetProperty [bound, value: [Two, One]]", property.toString());
+    }
+
+    @Test
     public void testUnbind() {
         attachInvalidationListener();
         final SetProperty<Object> v = new SimpleSetProperty<Object>(VALUE_1a);


### PR DESCRIPTION
ListPropertyBase::bind, SetPropertyBase::bind, MapPropertyBase::bind have a check on whether a different instance of the observable is the same, and this PR changes that to check against identity.

Tests are included.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267505](https://bugs.openjdk.java.net/browse/JDK-8267505): {List,Set,Map}PropertyBase::bind should check against identity


### Reviewers
 * [Marius Hanl](https://openjdk.java.net/census#mhanl) (@Maran23 - Author)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/516/head:pull/516` \
`$ git checkout pull/516`

Update a local copy of the PR: \
`$ git checkout pull/516` \
`$ git pull https://git.openjdk.java.net/jfx pull/516/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 516`

View PR using the GUI difftool: \
`$ git pr show -t 516`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/516.diff">https://git.openjdk.java.net/jfx/pull/516.diff</a>

</details>
