### PR TITLE
8267621: Mark HonorDeveloperSettingsTest as unstable on Linux

### DIFF
--- a/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
@@ -45,6 +45,7 @@ import javafx.stage.Window;
 import com.sun.javafx.util.Logging;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import com.sun.javafx.logging.PlatformLogger;
 
@@ -69,6 +70,13 @@ public class HonorDeveloperSettingsTest {
         sm.stylesheetContainerMap.clear();
         sm.cacheContainerMap.clear();
         sm.hasDefaultUserAgentStylesheet = false;
+    }
+
+    @BeforeClass
+    public static void setUpClass() {
+        if (PlatformUtil.isUnix()) {
+            assumeTrue(Boolean.getBoolean("unstable.test")); // JDK-8267425
+        }
     }
 
     @After
@@ -128,9 +136,6 @@ public class HonorDeveloperSettingsTest {
 
     @Test
     public void testOpacityWithManuallyChangedValueAndInlineStyleIsSetToInlineStyle() {
-        if (PlatformUtil.isUnix()) {
-            assumeTrue(Boolean.getBoolean("unstable.test")); // JDK-8267425
-        }
         rect.applyCss();
         assertEquals(.76, rect.getOpacity(), 0.01);
         rect.setStyle("-fx-opacity: 42%;");

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/HonorDeveloperSettingsTest.java
@@ -28,6 +28,7 @@ package test.javafx.css;
 import static org.junit.Assert.*;
 
 import com.sun.javafx.css.StyleManager;
+import com.sun.javafx.PlatformUtil;
 
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
@@ -46,6 +47,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import com.sun.javafx.logging.PlatformLogger;
+
+import static org.junit.Assume.assumeTrue;
 
 /**
  * AKA: RT-7401. Tests that the pattern used works by testing opacity
@@ -125,6 +128,9 @@ public class HonorDeveloperSettingsTest {
 
     @Test
     public void testOpacityWithManuallyChangedValueAndInlineStyleIsSetToInlineStyle() {
+        if (PlatformUtil.isUnix()) {
+            assumeTrue(Boolean.getBoolean("unstable.test")); // JDK-8267425
+        }
         rect.applyCss();
         assertEquals(.76, rect.getOpacity(), 0.01);
         rect.setStyle("-fx-opacity: 42%;");


### PR DESCRIPTION
The test HonorDeveloperSettingsTest.testOpacityWithManuallyChangedValueAndInlineStyleIsSetToInlineStyle is failing intermittently only on GHA build on Linux platform. see: [JDK-8267425](https://bugs.openjdk.java.net/browse/JDK-8267425)

A fix proposed at #509 is a potential fix which adds cleanup of test. But we do not know the root cause of this failure.
Identifying the root cause may take longer which we might push that to next test sprint and the test failure results in failing the Github checks on PR.  So we need to mark this test as unstable.
As of now the test fails only on Linux so we will mark it unstable only for Linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267621](https://bugs.openjdk.java.net/browse/JDK-8267621): Mark HonorDeveloperSettingsTest as unstable on Linux


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/517/head:pull/517` \
`$ git checkout pull/517`

Update a local copy of the PR: \
`$ git checkout pull/517` \
`$ git pull https://git.openjdk.java.net/jfx pull/517/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 517`

View PR using the GUI difftool: \
`$ git pr show -t 517`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/517.diff">https://git.openjdk.java.net/jfx/pull/517.diff</a>

</details>
