### PR TITLE
WIP: 8150709: Mac OSX and German Keyboard Layout (Y/Z)

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -762,7 +762,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
         keyCodeForCharMap = [[NSMutableDictionary alloc] initWithCapacity:100];
         // Note: it's never released, just like, say, the jApplication reference...
     }
-    [keyCodeForCharMap setObject:[NSNumber numberWithUnsignedShort:[event keyCode]] forKey:[event characters]];
+    [keyCodeForCharMap setObject:[NSNumber numberWithUnsignedInteger:GetJavaKeyCode(event)] forKey:[event characters]];
 }
 
 + (jint)getKeyCodeForChar:(jchar)c;
@@ -771,7 +771,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
     if (!v) {
         return com_sun_glass_events_KeyEvent_VK_UNDEFINED;
     } else {
-        return GetJavaKeyCodeFor([v unsignedShortValue]);
+        return [v unsignedIntegerValue];
     }
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassKey.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassKey.h
@@ -30,7 +30,6 @@
 jint GetJavaKeyModifiers(NSEvent *event);
 jint GetJavaMouseModifiers(NSUInteger buttons);
 jint GetJavaModifiers(NSEvent *event);
-jint GetJavaKeyCodeFor(unsigned short keyCode);
 jint GetJavaKeyCode(NSEvent *event);
 jcharArray GetJavaKeyChars(JNIEnv *env, NSEvent *event);
 NSString* GetStringForJavaKey(jchar key);


### PR DESCRIPTION
This PR attempts to fix keyboard accelerators on the Mac by using the character information supplied in the key event to generate a Java key code. It is an alternative implementation to PR #425.

In this PR we first use the existing machinery to compute a default Java code based on a hard-coded US QWERTY layout. Then we use the character in the NSEvent to see if we can generate a more accurate Java code. If the Command key is down and the keyboard is non-ASCII  (like Greek or Cyrillic) the OS has swapped in the ASCII character that we should match against so our first attempt uses `event.characters`. If the first attempt fails it may be because the Option key is also down and that can generate an oddball symbol so we try again with `event.charactersIgnoringModifiers`. Unfortunately this also eliminates the ASCII-character swap that the OS provides for non-ASCII keyboards.

When mapping from an ASCII value to a Java code punctuation is ignored. The digit keys on the French keyboard only generate digits when Shift is down; when unshifted they generate punctuation. We want them to map to KeyCode.DIGIT0 to KeyCode.DIGIT1 in all cases so we don't map punctuation and let it fall back to the US QWERTY codes. Ignoring punctuation also reduces gyration on the punctuation keys. For example, if we mapped punctuation the +/= key on US keyboards would generate KeyCode.EQUALS unshifted and KeyCode.PLUS shifted. The slash/question mark key would be KeyCode.SLASH unshifted and UNDEFINED shifted since there is no key code for a question mark.

There are multiple duplicates of these bugs logged against Mac applications built with JavaFX.

https://bugs.openjdk.java.net/browse/JDK-8090257 Mac: Inconsistent KeyEvents with alternative keyboard layouts
https://bugs.openjdk.java.net/browse/JDK-8088120 [Accelerator, Mac] CMD + Z accelerator is not working with French keyboard
https://bugs.openjdk.java.net/browse/JDK-8087915 Mac: accelerator doesn't take into account azerty keyboard layout
https://bugs.openjdk.java.net/browse/JDK-8150709 Mac OSX and German Keyboard Layout (Y/Z)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/519/head:pull/519` \
`$ git checkout pull/519`

Update a local copy of the PR: \
`$ git checkout pull/519` \
`$ git pull https://git.openjdk.java.net/jfx pull/519/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 519`

View PR using the GUI difftool: \
`$ git pr show -t 519`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/519.diff">https://git.openjdk.java.net/jfx/pull/519.diff</a>

</details>
