### PR TITLE
8267819: CoInitialize/CoUninitialize should be called on same thread

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/sys/directsound/gstdirectsoundnotify.h
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/sys/directsound/gstdirectsoundnotify.h
@@ -46,7 +46,6 @@ class GSTDirectSoundNotify : IMMNotificationClient
 {
 public:
   GSTDirectSoundNotify();
-  ~GSTDirectSoundNotify();
 
   bool Init(GSTDSNotfierCallback pCallback, void *pData);
   void Dispose();
@@ -67,7 +66,6 @@ private:
   IMMDeviceEnumerator* m_pEnumerator;
   GSTDSNotfierCallback m_pCallback;
   void *m_pData;
-  HRESULT m_hrCoInit;
 
   // IUnknown
   IFACEMETHODIMP QueryInterface(const IID& iid, void** ppUnk);


### PR DESCRIPTION
JDK-8264737 introduced new code for audio device removal/arrival notifications which calls CoInitialize/CoUninitialize on separate threads. CoInitialize/CoUninitialize should be called on same thread, since initialization is per thread. Doing it on separate thread will result in unloading COM libraries on that thread and if it uses COM libraries it might not work correctly. Fixed by calling it on same thread in same way it is done in dshowwrapper.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267819](https://bugs.openjdk.java.net/browse/JDK-8267819): CoInitialize/CoUninitialize should be called on same thread


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/521/head:pull/521` \
`$ git checkout pull/521`

Update a local copy of the PR: \
`$ git checkout pull/521` \
`$ git pull https://git.openjdk.java.net/jfx pull/521/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 521`

View PR using the GUI difftool: \
`$ git pr show -t 521`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/521.diff">https://git.openjdk.java.net/jfx/pull/521.diff</a>

</details>
