### PR TITLE
8267094: TreeCell: cancelEvent must return correct editing location

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeCell.java
@@ -427,6 +427,7 @@ public class TreeCell<T> extends IndexedCell<T> {
             // It would be rude of us to request it back again.
             ControlUtils.requestFocusOnControlOnlyIfCurrentFocusOwnerIsChild(tree);
         }
+        treeItemAtStartEdit = null;
     }
 
     /** {@inheritDoc} */
@@ -456,6 +457,7 @@ public class TreeCell<T> extends IndexedCell<T> {
                     value,
                     null));
         }
+        treeItemAtStartEdit = null;
     }
 
     /** {@inheritDoc} */

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeCell.java
@@ -351,6 +351,8 @@ public class TreeCell<T> extends IndexedCell<T> {
      * Public API                                                              *
      *                                                                         *
      **************************************************************************/
+    // treeItem at time of startEdit - fix for JDK-8267094
+    private TreeItem<T> treeItemAtStartEdit;
 
     /** {@inheritDoc} */
     @Override public void startEdit() {
@@ -384,6 +386,7 @@ public class TreeCell<T> extends IndexedCell<T> {
 
             tree.requestFocus();
         }
+        treeItemAtStartEdit = getTreeItem();
     }
 
      /** {@inheritDoc} */
@@ -435,6 +438,9 @@ public class TreeCell<T> extends IndexedCell<T> {
         super.cancelEdit();
 
         if (tree != null) {
+            TreeItem<T> editingItem = treeItemAtStartEdit;
+            T value = editingItem != null ? editingItem.getValue() : null;
+
             // reset the editing index on the TreeView
             if (updateEditingIndex) tree.edit(null);
 
@@ -446,8 +452,8 @@ public class TreeCell<T> extends IndexedCell<T> {
 
             tree.fireEvent(new TreeView.EditEvent<T>(tree,
                     TreeView.<T>editCancelEvent(),
-                    getTreeItem(),
-                    getItem(),
+                    editingItem,
+                    value,
                     null));
         }
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellEditingTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellEditingTest.java
@@ -31,7 +31,6 @@ import java.util.Collection;
 import java.util.List;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -85,21 +84,6 @@ public class TreeCellEditingTest {
         assertEquals("sanity: tree editing unchanged", editingItem, tree.getEditingItem());
         assertEquals("sanity: editingIndex unchanged", editingIndex, tree.getRow(editingItem));
         assertEquals("cell must have fired edit cancel", 1, events.size());
-    }
-
-    /**
-     * Extracted from testCancelOffEditingIndex to formally ignore
-     * FIXME: move the assert to the other method, once the issue is solved
-     */
-    @Ignore("JDK-8267094")
-    @Test
-    public void testCancelOffEditingIndexEventIndex() {
-        cell.updateIndex(editingIndex);
-        TreeItem<String> editingItem = tree.getTreeItem(editingIndex);
-        tree.edit(editingItem);
-        List<EditEvent<String>> events = new ArrayList<>();
-        tree.setOnEditCancel(events::add);
-        cell.updateIndex(cellIndex);
         assertEquals("cancel on updateIndex from " + editingIndex + " to " + cellIndex + "\n  ",
                 editingItem, events.get(0).getTreeItem());
     }


### PR DESCRIPTION
the bug is an incorrect edit location (for tree: treeItem) in edit cancel events - expected is the location at the time the cell edit was started, actual was the location of at the time the edit was cancelled. See the report for details.

Fixed by storing the edit location in startEdit and use that in cancelEdit.

Added tests that failed before and passed after and tests that (accidentally :) passed before and still pass after.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267094](https://bugs.openjdk.java.net/browse/JDK-8267094): TreeCell: cancelEvent must return correct editing location


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/524/head:pull/524` \
`$ git checkout pull/524`

Update a local copy of the PR: \
`$ git checkout pull/524` \
`$ git pull https://git.openjdk.java.net/jfx pull/524/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 524`

View PR using the GUI difftool: \
`$ git pr show -t 524`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/524.diff">https://git.openjdk.java.net/jfx/pull/524.diff</a>

</details>
