### PR TITLE
8268152: gstmpegaudioparse does not provides timestamps for HLS MP3 streams

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-base/gst-libs/gst/audio/gstaudiobasesink.c
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-base/gst-libs/gst/audio/gstaudiobasesink.c
@@ -1883,8 +1883,14 @@ gst_audio_base_sink_render (GstBaseSink * bsink, GstBuffer * buf)
   /* Last ditch attempt to ensure that we only play silence if
    * we are in trickmode no-audio mode (or if a buffer is marked as a GAP)
    * by dropping the buffer contents and rendering as a gap event instead */
+#ifndef GSTREAMER_LITE
   if (G_UNLIKELY ((bsink->segment.flags & GST_SEGMENT_FLAG_TRICKMODE_NO_AUDIO)
           || (buf && GST_BUFFER_FLAG_IS_SET (buf, GST_BUFFER_FLAG_GAP)))) {
+#else // GSTREAMER_LITE
+  if (G_UNLIKELY ((bsink->segment.flags & GST_SEGMENT_FLAG_TRICKMODE_NO_AUDIO)
+          || (buf && GST_BUFFER_FLAG_IS_SET (buf, GST_BUFFER_FLAG_GAP)))
+          && GST_BUFFER_TIMESTAMP_IS_VALID(buf)) {
+#endif // GSTREAMER_LITE
     GstClockTime duration;
     GstEvent *event;
     GstBaseSinkClass *bclass;

--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gstreamer/libs/gst/base/gstbaseparse.c
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gstreamer/libs/gst/base/gstbaseparse.c
@@ -1336,7 +1336,11 @@ gst_base_parse_sink_event_default (GstBaseParse * parse, GstEvent * event)
         /* not considered BYTE seekable if it is talking to us in TIME,
          * whatever else it might claim */
         parse->priv->upstream_seekable = FALSE;
+#ifndef GSTREAMER_LITE
         next_dts = GST_CLOCK_TIME_NONE;
+#else // GSTREAMER_LITE
+        next_dts = in_segment->start;
+#endif // GSTREAMER_LITE
         gst_event_copy_segment (event, &out_segment);
       }
 


### PR DESCRIPTION
With recent GStreamer update gstmpegaudioparse no longer provides audio buffers with valid timestamps. This issue is only reproducible with MP3 HTTP Live Stream and was noticed on Linux. I think Windows audio decoder handles such case better and thus MP3 HLS works fine. I did not figure out why it behaves this way and for now fix is reverting gstmpegaudioparse changeset which caused it. Follow up issue will be filed to investigate why javasource and/or hlsprogressbuffer no longer compatible with gstmpegaudioparse and gstmpegaudioparse cannot figure out correct PTS. Also, fixed potential null pointer reference for buffers with invalid PTS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268152](https://bugs.openjdk.java.net/browse/JDK-8268152): gstmpegaudioparse does not provides timestamps for HLS MP3 streams


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/526/head:pull/526` \
`$ git checkout pull/526`

Update a local copy of the PR: \
`$ git checkout pull/526` \
`$ git pull https://git.openjdk.java.net/jfx pull/526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 526`

View PR using the GUI difftool: \
`$ git pr show -t 526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/526.diff">https://git.openjdk.java.net/jfx/pull/526.diff</a>

</details>
