### PR TITLE
8268120: Allow hardware cursor to be used on Monocle-EGL platforms

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLCursor.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLCursor.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.glass.ui.monocle;
+
+import com.sun.glass.ui.Size;
+
+class EGLCursor extends NativeCursor {
+
+    private static final int CURSOR_WIDTH = 16;
+    private static final int CURSOR_HEIGHT = 16;
+
+
+    private native void _initEGLCursor(int cursorWidth, int cursorHeight);
+    private native void _setVisible(boolean visible);
+    private native void _setLocation(int x, int y);
+    private native void _setImage(byte[] cursorImage);
+
+    EGLCursor() {
+        _initEGLCursor(CURSOR_WIDTH, CURSOR_HEIGHT);
+    }
+
+    @Override
+    Size getBestSize() {
+        return new Size(CURSOR_WIDTH, CURSOR_HEIGHT);
+    }
+
+    @Override
+    void setVisibility(boolean visibility) {
+        isVisible = visibility;
+        _setVisible(visibility);
+    }
+
+    private void updateImage(boolean always) {
+        System.out.println("EGLCursor.updateImage: not implemented");
+    }
+
+    @Override
+    void setImage(byte[] cursorImage) {
+        _setImage(cursorImage);
+    }
+
+    @Override
+    void setLocation(int x, int y) {
+        _setLocation(x, y);
+    }
+
+    @Override
+    void setHotSpot(int hotspotX, int hotspotY) {
+    }
+
+    @Override
+    void shutdown() {
+    }
+}

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLPlatform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLPlatform.java
@@ -47,6 +47,16 @@ public class EGLPlatform extends LinuxPlatform {
     }
 
     @Override
+    protected NativeCursor createCursor() {
+        // By default, hardware cursor will be used
+        // Fallback to software cursor will be used in case monocle.egl.swcursor is set to true
+        boolean swcursor = Boolean.getBoolean("monocle.egl.swcursor");
+        final NativeCursor c = useCursor ? (swcursor ? new SoftwareCursor() : new EGLCursor) : new NullCursor();
+        return c;
+    }
+
+
+    @Override
     protected NativeScreen createScreen() {
         return new EGLScreen(0);
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLPlatform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLPlatform.java
@@ -52,7 +52,7 @@ public class EGLPlatform extends LinuxPlatform {
         // Fallback to software cursor will be used in case monocle.egl.swcursor is set to true
         boolean swcursor = Boolean.getBoolean("monocle.egl.swcursor");
         final NativeCursor c = useCursor ? (swcursor ? new SoftwareCursor() : new EGLCursor()) : new NullCursor();
-        return c;
+        return logSelectedCursor(c);
     }
 
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLPlatform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGLPlatform.java
@@ -51,7 +51,7 @@ public class EGLPlatform extends LinuxPlatform {
         // By default, hardware cursor will be used
         // Fallback to software cursor will be used in case monocle.egl.swcursor is set to true
         boolean swcursor = Boolean.getBoolean("monocle.egl.swcursor");
-        final NativeCursor c = useCursor ? (swcursor ? new SoftwareCursor() : new EGLCursor) : new NullCursor();
+        final NativeCursor c = useCursor ? (swcursor ? new SoftwareCursor() : new EGLCursor()) : new NullCursor();
         return c;
     }
 

--- a/modules/javafx.graphics/src/main/native-glass/monocle/egl/eglBridge.c
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/egl/eglBridge.c
@@ -161,7 +161,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_monocle_EGLCursor__1setImage
     int length = (*env)->GetArrayLength(env, jarr);
     jbyte *attrArray = (*env)->GetByteArrayElements(env, jarr, JNI_FALSE);
     if (attrArray == 0) {
-        fprintf(stderr, "Fatal error getting char* from jbyteArray\n");
+        fprintf(stderr, "Fatal error getting jbyte* from jbyteArray\n");
         return;
     }
     doSetCursorImage(attrArray, length);

--- a/modules/javafx.graphics/src/main/native-glass/monocle/egl/eglBridge.c
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/egl/eglBridge.c
@@ -22,6 +22,7 @@
  * questions.
  */
 #include "com_sun_glass_ui_monocle_EGLAcceleratedScreen.h"
+#include "com_sun_glass_ui_monocle_EGLCursor.h"
 #include "com_sun_glass_ui_monocle_EGLPlatform.h"
 #include "com_sun_glass_ui_monocle_EGLScreen.h"
 #include "Monocle.h"
@@ -138,4 +139,32 @@ JNIEXPORT jfloat JNICALL Java_com_sun_glass_ui_monocle_EGLScreen_nGetScale
 JNIEXPORT jint JNICALL Java_com_sun_glass_ui_monocle_EGLPlatform_nGetNumberOfScreens
 (JNIEnv *UNUSED(env), jobject UNUSED(obj)) {
     return doGetNumberOfScreens();
+}
+
+JNIEXPORT void JNICALL Java_com_sun_glass_ui_monocle_EGLCursor__1initEGLCursor
+  (JNIEnv *env, jobject obj, jint width, jint height) {
+    doInitCursor(width, height);
+}
+
+JNIEXPORT void JNICALL Java_com_sun_glass_ui_monocle_EGLCursor__1setVisible
+  (JNIEnv *env, jobject obj, jboolean val) {
+    doSetCursorVisibility(val);
+}
+
+JNIEXPORT void JNICALL Java_com_sun_glass_ui_monocle_EGLCursor__1setLocation
+  (JNIEnv *env, jobject obj, jint x, jint y) {
+    doSetLocation(x, y);
+}
+
+JNIEXPORT void JNICALL Java_com_sun_glass_ui_monocle_EGLCursor__1setImage
+  (JNIEnv *env, jobject obj, jbyteArray jarr) {
+    int length = (*env)->GetArrayLength(env, jarr);
+    jbyte *attrArray = (*env)->GetByteArrayElements(env, jarr, JNI_FALSE);
+    if (attrArray == 0) {
+        fprintf(stderr, "Fatal error getting char* from jbyteArray\n");
+        return;
+    }
+    doSetCursorImage(attrArray, length);
+    (*env)->ReleaseByteArrayElements(env, jarr, attrArray, JNI_ABORT);
+
 }

--- a/modules/javafx.graphics/src/main/native-glass/monocle/egl/egl_ext.h
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/egl/egl_ext.h
@@ -25,22 +25,44 @@
 #ifndef __EGL_EXT__
 #define __EGL_EXT__
 #include <jni.h>
+
+// This header file declares functions that need to be provided by low-level
+// drivers or libraries.
+
+// get a handle to the native window (without specifying what window is)
 extern jlong getNativeWindowHandle(const char *v);
+
+// get a handle to the EGL display
 extern jlong getEglDisplayHandle();
+
+// initialize the EGL system with the specified handle
 extern jboolean doEglInitialize(void* handle);
+
+// bind a specific API to the EGL system
 extern jboolean doEglBindApi(int api);
+
+// instruct the system to choose an EGL configuration matching the provided attributes
 extern jlong doEglChooseConfig (jlong eglDisplay, int* attribs);
 
+// create an EGL Surface for the given display, configuration and window
 extern jlong doEglCreateWindowSurface(jlong eglDisplay, jlong config,
      jlong nativeWindow);
 
+// create an EGL Context for the given display and configuration
 extern jlong doEglCreateContext(jlong eglDisplay, jlong config);
 
+// enable the specified EGL system
 extern jboolean doEglMakeCurrent(jlong eglDisplay, jlong drawSurface,
      jlong readSurface, jlong eglContext);
 
+// swap buffers (and render frontbuffer)
 extern jboolean doEglSwapBuffers(jlong eglDisplay, jlong eglSurface);
 
+// get the number of native screens in the current configuration
+extern jint doGetNumberOfScreens();
+
+// get specific information about each screen
+// the idx parameter specifies which screen needs to be queried 
 extern jlong doGetHandle(jint idx);
 extern jint doGetDepth(jint idx);
 extern jint doGetWidth(jint idx);
@@ -50,6 +72,17 @@ extern jint doGetOffsetY(jint idx);
 extern jint doGetDpi(jint idx);
 extern jint doGetNativeFormat(jint idx);
 extern jfloat doGetScale(jint idx);
-extern jint doGetNumberOfScreens();
+
+// initialize a hardware cursor with specified dimensions
+extern void doInitCursor(jint width, jint height);
+
+// show/hide the hardware cursor
+extern void doSetCursorVisibility(jboolean val);
+
+// point the hardware cursor to the provided location
+extern void doSetLocation(jint x, jint y);
+
+// use the specified image as cursor image
+extern void doSetCursorImage(jbyte* img, int length);
 
 #endif // EGL_EXT

--- a/modules/javafx.graphics/src/main/native-glass/monocle/egl/egl_ext.h
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/egl/egl_ext.h
@@ -62,7 +62,7 @@ extern jboolean doEglSwapBuffers(jlong eglDisplay, jlong eglSurface);
 extern jint doGetNumberOfScreens();
 
 // get specific information about each screen
-// the idx parameter specifies which screen needs to be queried 
+// the idx parameter specifies which screen needs to be queried
 extern jlong doGetHandle(jint idx);
 extern jint doGetDepth(jint idx);
 extern jint doGetWidth(jint idx);


### PR DESCRIPTION
Add EGL cursor implementation (Java + native) and the link to low-level drivers.
Fix for JDK-8268120

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268120](https://bugs.openjdk.java.net/browse/JDK-8268120): Allow hardware cursor to be used on Monocle-EGL platforms


### Reviewers
 * [Jose Pereda](https://openjdk.java.net/census#jpereda) (@jperedadnr - Committer)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/527/head:pull/527` \
`$ git checkout pull/527`

Update a local copy of the PR: \
`$ git checkout pull/527` \
`$ git pull https://git.openjdk.java.net/jfx pull/527/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 527`

View PR using the GUI difftool: \
`$ git pr show -t 527`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/527.diff">https://git.openjdk.java.net/jfx/pull/527.diff</a>

</details>
