### PR TITLE
8264139: Suppress removal warnings for Security Manager methods

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/PlatformUtil.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/PlatformUtil.java
@@ -35,7 +35,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Properties;
 
-@SuppressWarnings("removal")
 public class PlatformUtil {
 
     // NOTE: since this class can be initialized by application code in some
@@ -53,13 +52,28 @@ public class PlatformUtil {
     private static String javafxPlatform;
 
     static {
-        javafxPlatform = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("javafx.platform"));
+        @SuppressWarnings("removal")
+        String str1 = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("javafx.platform"));
+        javafxPlatform = str1;
+
         loadProperties();
-        embedded = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("com.sun.javafx.isEmbedded"));
-        embeddedType = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("embedded"));
-        useEGL = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("use.egl"));
+
+        @SuppressWarnings("removal")
+        boolean bool1 = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("com.sun.javafx.isEmbedded"));
+        embedded = bool1;
+
+        @SuppressWarnings("removal")
+        String str2 = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("embedded"));
+        embeddedType = str2;
+
+        @SuppressWarnings("removal")
+        boolean bool2 = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("use.egl"));
+        useEGL = bool2;
+
         if (useEGL) {
-            doEGLCompositing = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("doNativeComposite"));
+            @SuppressWarnings("removal")
+            boolean bool3 = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("doNativeComposite"));
+            doEGLCompositing = bool3;
         } else
             doEGLCompositing = false;
     }
@@ -135,8 +149,8 @@ public class PlatformUtil {
     }
 
     public static boolean useGLES2() {
-        String useGles2 = "false";
-        useGles2 =
+        @SuppressWarnings("removal")
+        String useGles2 =
                 AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("use.gles2"));
         if ("true".equals(useGles2))
             return true;
@@ -245,6 +259,7 @@ public class PlatformUtil {
         }
     }
 
+    @SuppressWarnings("removal")
     private static void loadProperties() {
         final String vmname = System.getProperty("java.vm.name");
         final String arch = System.getProperty("os.arch");

--- a/modules/javafx.base/src/main/java/com/sun/javafx/PlatformUtil.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/PlatformUtil.java
@@ -35,6 +35,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Properties;
 
+@SuppressWarnings("removal")
 public class PlatformUtil {
 
     // NOTE: since this class can be initialized by application code in some

--- a/modules/javafx.base/src/main/java/com/sun/javafx/logging/PrintLogger.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/logging/PrintLogger.java
@@ -54,12 +54,14 @@ class PrintLogger extends Logger {
      * the threshold, then it is logged, otherwise an abbreviated representation including
      * only the time of the pulse is logged.
      */
+    @SuppressWarnings("removal")
     private static long THRESHOLD = (long)
             AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Integer.getInteger("javafx.pulseLogger.threshold", 17));
 
     /**
      * Optionally exit after a given number of pulses
      */
+    @SuppressWarnings("removal")
     private static final int EXIT_ON_PULSE =
             AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Integer.getInteger("javafx.pulseLogger.exitOnPulse", 0));
 

--- a/modules/javafx.base/src/main/java/com/sun/javafx/logging/PulseLogger.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/logging/PulseLogger.java
@@ -102,6 +102,7 @@ public class PulseLogger {
      * @return true if the user requested pulse logging by setting the system
      *         property javafx.pulseLogger to true, false otherwise.
      */
+    @SuppressWarnings("removal")
     public static boolean isPulseLoggingRequested() {
         return AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("javafx.pulseLogger"));
     }

--- a/modules/javafx.base/src/main/java/com/sun/javafx/property/MethodHelper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/property/MethodHelper.java
@@ -36,6 +36,7 @@ import com.sun.javafx.reflect.ReflectUtil;
  * Utility class to wrap method invocation.
  */
 public class MethodHelper {
+    @SuppressWarnings("removal")
     private static final boolean logAccessErrors
             = AccessController.doPrivileged((PrivilegedAction<Boolean>) ()
                     -> Boolean.getBoolean("sun.reflect.debugModuleAccessChecks"));

--- a/modules/javafx.base/src/main/java/com/sun/javafx/property/PropertyReference.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/property/PropertyReference.java
@@ -25,11 +25,8 @@
 
 package com.sun.javafx.property;
 
-import static java.security.AccessController.doPrivileged;
-
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.security.PrivilegedAction;
 
 import javafx.beans.property.ReadOnlyProperty;
 

--- a/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/Disposer.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/Disposer.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * When the object becomes phantom-reachable, the run() method
  * of the associated Runnable object will be called.
  */
+@SuppressWarnings("removal")
 public class Disposer implements Runnable {
     private static final ReferenceQueue queue = new ReferenceQueue();
     private static final Map<Object, Runnable> records = new ConcurrentHashMap<>();

--- a/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/Disposer.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/Disposer.java
@@ -42,7 +42,6 @@ import java.util.concurrent.ConcurrentHashMap;
  * When the object becomes phantom-reachable, the run() method
  * of the associated Runnable object will be called.
  */
-@SuppressWarnings("removal")
 public class Disposer implements Runnable {
     private static final ReferenceQueue queue = new ReferenceQueue();
     private static final Map<Object, Runnable> records = new ConcurrentHashMap<>();
@@ -51,7 +50,8 @@ public class Disposer implements Runnable {
     static {
         disposerInstance = new Disposer();
 
-        java.security.AccessController.doPrivileged(
+        @SuppressWarnings("removal")
+        var dummy = java.security.AccessController.doPrivileged(
             new java.security.PrivilegedAction() {
                 public Object run() {
                     /* The thread must be a member of a thread group

--- a/modules/javafx.base/src/main/java/com/sun/javafx/reflect/MethodUtil.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/reflect/MethodUtil.java
@@ -58,6 +58,7 @@ class Trampoline {
         }
     }
 
+    @SuppressWarnings("removal")
     private static void ensureInvocableMethod(Method m)
         throws InvocationTargetException
     {
@@ -107,6 +108,7 @@ public final class MethodUtil extends SecureClassLoader {
      * we're done.
      */
     /*public*/
+    @SuppressWarnings("removal")
     static Method[] getPublicMethods(Class<?> cls) {
         // compatibility for update release
         if (System.getSecurityManager() == null) {
@@ -291,6 +293,7 @@ public final class MethodUtil extends SecureClassLoader {
         }
     }
 
+    @SuppressWarnings("removal")
     private static Method getTrampoline() {
         try {
             return AccessController.doPrivileged(

--- a/modules/javafx.base/src/main/java/com/sun/javafx/reflect/ReflectUtil.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/reflect/ReflectUtil.java
@@ -41,6 +41,7 @@ public final class ReflectUtil {
      * also check the package access on the proxy interfaces.
      */
     public static void checkPackageAccess(Class<?> clazz) {
+        @SuppressWarnings("removal")
         SecurityManager s = System.getSecurityManager();
         if (s != null) {
             privateCheckPackageAccess(s, clazz);
@@ -50,7 +51,7 @@ public final class ReflectUtil {
     /**
      * NOTE: should only be called if a SecurityManager is installed
      */
-    private static void privateCheckPackageAccess(SecurityManager s, Class<?> clazz) {
+    private static void privateCheckPackageAccess(@SuppressWarnings("removal") SecurityManager s, Class<?> clazz) {
         while (clazz.isArray()) {
             clazz = clazz.getComponentType();
         }
@@ -72,6 +73,7 @@ public final class ReflectUtil {
      * the true caller (application).
      */
     public static void checkPackageAccess(String name) {
+        @SuppressWarnings("removal")
         SecurityManager s = System.getSecurityManager();
         if (s != null) {
             String cname = name.replace('/', '.');
@@ -100,7 +102,7 @@ public final class ReflectUtil {
     /**
      * NOTE: should only be called if a SecurityManager is installed
      */
-    private static void privateCheckProxyPackageAccess(SecurityManager s, Class<?> clazz) {
+    private static void privateCheckProxyPackageAccess(@SuppressWarnings("removal") SecurityManager s, Class<?> clazz) {
         // check proxy interfaces if the given class is a proxy class
         if (Proxy.isProxyClass(clazz)) {
             for (Class<?> intf : clazz.getInterfaces()) {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanBooleanProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanBooleanProperty.java
@@ -96,6 +96,7 @@ public final class JavaBeanBooleanProperty extends BooleanProperty implements Ja
     private ObservableValue<? extends Boolean> observable = null;
     private ExpressionHelper<Boolean> helper = null;
 
+    @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
     JavaBeanBooleanProperty(PropertyDescriptor descriptor, Object bean) {
@@ -112,6 +113,7 @@ public final class JavaBeanBooleanProperty extends BooleanProperty implements Ja
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public boolean get() {
         return AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
@@ -132,6 +134,7 @@ public final class JavaBeanBooleanProperty extends BooleanProperty implements Ja
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public void set(final boolean value) {
         if (isBound()) {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanDoubleProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanDoubleProperty.java
@@ -96,6 +96,7 @@ public final class JavaBeanDoubleProperty extends DoubleProperty implements Java
     private ObservableValue<? extends Number> observable = null;
     private ExpressionHelper<Number> helper = null;
 
+    @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
     JavaBeanDoubleProperty(PropertyDescriptor descriptor, Object bean) {
@@ -112,6 +113,7 @@ public final class JavaBeanDoubleProperty extends DoubleProperty implements Java
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public double get() {
         return AccessController.doPrivileged((PrivilegedAction<Double>) () -> {
@@ -133,6 +135,7 @@ public final class JavaBeanDoubleProperty extends DoubleProperty implements Java
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public void set(final double value) {
         if (isBound()) {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanFloatProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanFloatProperty.java
@@ -96,6 +96,7 @@ public final class JavaBeanFloatProperty extends FloatProperty implements JavaBe
     private ObservableValue<? extends Number> observable = null;
     private ExpressionHelper<Number> helper = null;
 
+    @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
     JavaBeanFloatProperty(PropertyDescriptor descriptor, Object bean) {
@@ -112,6 +113,7 @@ public final class JavaBeanFloatProperty extends FloatProperty implements JavaBe
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public float get() {
         return AccessController.doPrivileged((PrivilegedAction<Float>) () -> {
@@ -133,6 +135,7 @@ public final class JavaBeanFloatProperty extends FloatProperty implements JavaBe
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public void set(final float value) {
         if (isBound()) {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanIntegerProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanIntegerProperty.java
@@ -96,6 +96,7 @@ public final class JavaBeanIntegerProperty extends IntegerProperty implements Ja
     private ObservableValue<? extends Number> observable = null;
     private ExpressionHelper<Number> helper = null;
 
+    @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
     JavaBeanIntegerProperty(PropertyDescriptor descriptor, Object bean) {
@@ -112,6 +113,7 @@ public final class JavaBeanIntegerProperty extends IntegerProperty implements Ja
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public int get() {
         return AccessController.doPrivileged((PrivilegedAction<Integer>) () -> {
@@ -133,6 +135,7 @@ public final class JavaBeanIntegerProperty extends IntegerProperty implements Ja
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public void set(final int value) {
         if (isBound()) {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanLongProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanLongProperty.java
@@ -96,6 +96,7 @@ public final class JavaBeanLongProperty extends LongProperty implements JavaBean
     private ObservableValue<? extends Number> observable = null;
     private ExpressionHelper<Number> helper = null;
 
+    @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
     JavaBeanLongProperty(PropertyDescriptor descriptor, Object bean) {
@@ -112,6 +113,7 @@ public final class JavaBeanLongProperty extends LongProperty implements JavaBean
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public long get() {
         return AccessController.doPrivileged((PrivilegedAction<Long>) () -> {
@@ -133,6 +135,7 @@ public final class JavaBeanLongProperty extends LongProperty implements JavaBean
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public void set(final long value) {
         if (isBound()) {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanObjectProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanObjectProperty.java
@@ -98,6 +98,7 @@ public final class JavaBeanObjectProperty<T> extends ObjectProperty<T> implement
     private ObservableValue<? extends T> observable = null;
     private ExpressionHelper<T> helper = null;
 
+    @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
     JavaBeanObjectProperty(PropertyDescriptor descriptor, Object bean) {
@@ -114,7 +115,7 @@ public final class JavaBeanObjectProperty<T> extends ObjectProperty<T> implement
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({"removal","unchecked"})
     @Override
     public T get() {
         return AccessController.doPrivileged((PrivilegedAction<T>) () -> {
@@ -135,6 +136,7 @@ public final class JavaBeanObjectProperty<T> extends ObjectProperty<T> implement
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public void set(final T value) {
         if (isBound()) {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanStringProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanStringProperty.java
@@ -96,6 +96,7 @@ public final class JavaBeanStringProperty extends StringProperty implements Java
     private ObservableValue<? extends String> observable = null;
     private ExpressionHelper<String> helper = null;
 
+    @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
     JavaBeanStringProperty(PropertyDescriptor descriptor, Object bean) {
@@ -112,6 +113,7 @@ public final class JavaBeanStringProperty extends StringProperty implements Java
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public String get() {
         return AccessController.doPrivileged((PrivilegedAction<String>) () -> {
@@ -132,6 +134,7 @@ public final class JavaBeanStringProperty extends StringProperty implements Java
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public void set(final String value) {
         if (isBound()) {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanBooleanProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanBooleanProperty.java
@@ -85,6 +85,7 @@ public final class ReadOnlyJavaBeanBooleanProperty extends ReadOnlyBooleanProper
     private final ReadOnlyPropertyDescriptor descriptor;
     private final ReadOnlyPropertyDescriptor.ReadOnlyListener<Boolean> listener;
 
+    @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
     ReadOnlyJavaBeanBooleanProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
@@ -101,6 +102,7 @@ public final class ReadOnlyJavaBeanBooleanProperty extends ReadOnlyBooleanProper
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public boolean get() {
         return AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanDoubleProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanDoubleProperty.java
@@ -85,6 +85,7 @@ public final class ReadOnlyJavaBeanDoubleProperty extends ReadOnlyDoubleProperty
     private final ReadOnlyPropertyDescriptor descriptor;
     private final ReadOnlyPropertyDescriptor.ReadOnlyListener<Number> listener;
 
+    @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
     ReadOnlyJavaBeanDoubleProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
@@ -101,6 +102,7 @@ public final class ReadOnlyJavaBeanDoubleProperty extends ReadOnlyDoubleProperty
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public double get() {
         return AccessController.doPrivileged((PrivilegedAction<Double>) () -> {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanFloatProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanFloatProperty.java
@@ -85,6 +85,7 @@ public final class ReadOnlyJavaBeanFloatProperty extends ReadOnlyFloatPropertyBa
     private final ReadOnlyPropertyDescriptor descriptor;
     private final ReadOnlyPropertyDescriptor.ReadOnlyListener<Number> listener;
 
+    @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
     ReadOnlyJavaBeanFloatProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
@@ -101,6 +102,7 @@ public final class ReadOnlyJavaBeanFloatProperty extends ReadOnlyFloatPropertyBa
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public float get() {
         return AccessController.doPrivileged((PrivilegedAction<Float>) () -> {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanIntegerProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanIntegerProperty.java
@@ -85,6 +85,7 @@ public final class ReadOnlyJavaBeanIntegerProperty extends ReadOnlyIntegerProper
     private final ReadOnlyPropertyDescriptor descriptor;
     private final ReadOnlyPropertyDescriptor.ReadOnlyListener<Number> listener;
 
+    @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
     ReadOnlyJavaBeanIntegerProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
@@ -101,6 +102,7 @@ public final class ReadOnlyJavaBeanIntegerProperty extends ReadOnlyIntegerProper
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public int get() {
         return AccessController.doPrivileged((PrivilegedAction<Integer>) () -> {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanLongProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanLongProperty.java
@@ -85,6 +85,7 @@ public final class ReadOnlyJavaBeanLongProperty extends ReadOnlyLongPropertyBase
     private final ReadOnlyPropertyDescriptor descriptor;
     private final ReadOnlyPropertyDescriptor.ReadOnlyListener<Number> listener;
 
+    @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
     ReadOnlyJavaBeanLongProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
@@ -101,6 +102,7 @@ public final class ReadOnlyJavaBeanLongProperty extends ReadOnlyLongPropertyBase
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public long get() {
         return AccessController.doPrivileged((PrivilegedAction<Long>) () -> {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanObjectProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanObjectProperty.java
@@ -87,6 +87,7 @@ public final class ReadOnlyJavaBeanObjectProperty<T> extends ReadOnlyObjectPrope
     private final ReadOnlyPropertyDescriptor descriptor;
     private final ReadOnlyPropertyDescriptor.ReadOnlyListener<T> listener;
 
+    @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
     ReadOnlyJavaBeanObjectProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
@@ -103,6 +104,7 @@ public final class ReadOnlyJavaBeanObjectProperty<T> extends ReadOnlyObjectPrope
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public T get() {
         return AccessController.doPrivileged((PrivilegedAction<T>) () -> {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanStringProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanStringProperty.java
@@ -85,6 +85,7 @@ public final class ReadOnlyJavaBeanStringProperty extends ReadOnlyStringProperty
     private final ReadOnlyPropertyDescriptor descriptor;
     private final ReadOnlyPropertyDescriptor.ReadOnlyListener<String> listener;
 
+    @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
     ReadOnlyJavaBeanStringProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
@@ -101,6 +102,7 @@ public final class ReadOnlyJavaBeanStringProperty extends ReadOnlyStringProperty
      * property throws an {@code IllegalAccessException} or an
      * {@code InvocationTargetException}.
      */
+    @SuppressWarnings("removal")
     @Override
     public String get() {
         return AccessController.doPrivileged((PrivilegedAction<String>) () -> {

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/skin/FXVKSkin.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/skin/FXVKSkin.java
@@ -76,6 +76,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 
 
+@SuppressWarnings("removal")
 public class FXVKSkin extends SkinBase<FXVK> {
 
     private static final int GAP = 6;

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/skin/FXVKSkin.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/skin/FXVKSkin.java
@@ -76,7 +76,6 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 
 
-@SuppressWarnings("removal")
 public class FXVKSkin extends SkinBase<FXVK> {
 
     private static final int GAP = 6;
@@ -191,7 +190,8 @@ public class FXVKSkin extends SkinBase<FXVK> {
     static boolean vkLookup = false;
 
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             String s = System.getProperty("com.sun.javafx.vk.adjustwindow");
             if (s != null) {
                 vkAdjustWindow = Boolean.valueOf(s);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ListViewSkin.java
@@ -79,6 +79,7 @@ public class ListViewSkin<T> extends VirtualContainerBase<ListView<T>, ListCell<
     // is set to true. This is done in order to make ListView functional
     // on embedded systems with touch screens which do not generate scroll
     // events for touch drag gestures.
+    @SuppressWarnings("removal")
     private static final boolean IS_PANNABLE =
             AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("javafx.scene.control.skin.ListViewSkin.pannable"));
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
@@ -110,6 +110,7 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
 
     static {
         final Predicate<Window> findStage = (w) -> w instanceof Stage;
+        @SuppressWarnings("removal")
         ObservableList<Window> windows = AccessController.doPrivileged(
             (PrivilegedAction<ObservableList<Window>>) () -> Window.getWindows(),
             null,

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
@@ -92,6 +92,7 @@ public abstract class TableViewSkinBase<M, S, C extends Control, I extends Index
     // is set to true. This is done in order to make TableView functional
     // on embedded systems with touch screens which do not generate scroll
     // events for touch drag gestures.
+    @SuppressWarnings("removal")
     private static final boolean IS_PANNABLE =
             AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("javafx.scene.control.skin.TableViewSkin.pannable"));
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextInputControlSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextInputControlSkin.java
@@ -93,6 +93,7 @@ import java.security.PrivilegedAction;
  * @see TextFieldSkin
  * @see TextAreaSkin
  */
+@SuppressWarnings("removal")
 public abstract class TextInputControlSkin<T extends TextInputControl> extends SkinBase<T> {
 
     /**************************************************************************

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextInputControlSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextInputControlSkin.java
@@ -93,7 +93,6 @@ import java.security.PrivilegedAction;
  * @see TextFieldSkin
  * @see TextAreaSkin
  */
-@SuppressWarnings("removal")
 public abstract class TextInputControlSkin<T extends TextInputControl> extends SkinBase<T> {
 
     /**************************************************************************
@@ -118,7 +117,8 @@ public abstract class TextInputControlSkin<T extends TextInputControl> extends S
 
     static boolean preload = false;
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             String s = System.getProperty("com.sun.javafx.virtualKeyboard.preload");
             if (s != null) {
                 if (s.equalsIgnoreCase("PRERENDER")) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeViewSkin.java
@@ -71,6 +71,7 @@ public class TreeViewSkin<T> extends VirtualContainerBase<TreeView<T>, TreeCell<
     // is set to true. This is done in order to make TreeView functional
     // on embedded systems with touch screens which do not generate scroll
     // events for touch drag gestures.
+    @SuppressWarnings("removal")
     private static final boolean IS_PANNABLE =
             AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("javafx.scene.control.skin.TreeViewSkin.pannable"));
 

--- a/modules/javafx.fxml/src/main/java/com/sun/javafx/fxml/BeanAdapter.java
+++ b/modules/javafx.fxml/src/main/java/com/sun/javafx/fxml/BeanAdapter.java
@@ -119,6 +119,7 @@ public class BeanAdapter extends AbstractMap<String, Object> {
             if (Modifier.isPublic(type.getModifiers())) {
                 // only interested in public methods in public classes in
                 // non-restricted packages
+                @SuppressWarnings("removal")
                 final Method[] declaredMethods =
                         AccessController.doPrivileged(
                                 new PrivilegedAction<Method[]>() {

--- a/modules/javafx.fxml/src/main/java/com/sun/javafx/fxml/MethodHelper.java
+++ b/modules/javafx.fxml/src/main/java/com/sun/javafx/fxml/MethodHelper.java
@@ -36,6 +36,7 @@ import com.sun.javafx.reflect.ReflectUtil;
  * Utility class to wrap method invocation.
  */
 public class MethodHelper {
+    @SuppressWarnings("removal")
     private static final boolean logAccessErrors
             = AccessController.doPrivileged((PrivilegedAction<Boolean>) ()
                     -> Boolean.getBoolean("sun.reflect.debugModuleAccessChecks"));

--- a/modules/javafx.fxml/src/main/java/com/sun/javafx/fxml/ModuleHelper.java
+++ b/modules/javafx.fxml/src/main/java/com/sun/javafx/fxml/ModuleHelper.java
@@ -31,7 +31,6 @@ import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-@SuppressWarnings("removal")
 public class ModuleHelper {
     private static final Method getModuleMethod;
     private static final Method getResourceAsStreamMethod;
@@ -39,8 +38,10 @@ public class ModuleHelper {
     private static final boolean verbose;
 
     static {
-        verbose = AccessController.doPrivileged((PrivilegedAction<Boolean>) () ->
+        @SuppressWarnings("removal")
+        boolean tmp = AccessController.doPrivileged((PrivilegedAction<Boolean>) () ->
                 Boolean.getBoolean("javafx.verbose"));
+        verbose = tmp;
 
         if (verbose) {
             System.err.println("" + ModuleHelper.class.getName() + " : <clinit>");

--- a/modules/javafx.fxml/src/main/java/com/sun/javafx/fxml/ModuleHelper.java
+++ b/modules/javafx.fxml/src/main/java/com/sun/javafx/fxml/ModuleHelper.java
@@ -31,6 +31,7 @@ import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+@SuppressWarnings("removal")
 public class ModuleHelper {
     private static final Method getModuleMethod;
     private static final Method getResourceAsStreamMethod;

--- a/modules/javafx.fxml/src/main/java/javafx/fxml/FXMLLoader.java
+++ b/modules/javafx.fxml/src/main/java/javafx/fxml/FXMLLoader.java
@@ -104,6 +104,7 @@ import com.sun.javafx.reflect.ReflectUtil;
  *
  * @since JavaFX 2.0
  */
+@SuppressWarnings("removal")
 public class FXMLLoader {
 
     // Indicates permission to get the ClassLoader

--- a/modules/javafx.fxml/src/main/java/javafx/fxml/FXMLLoader.java
+++ b/modules/javafx.fxml/src/main/java/javafx/fxml/FXMLLoader.java
@@ -104,7 +104,6 @@ import com.sun.javafx.reflect.ReflectUtil;
  *
  * @since JavaFX 2.0
  */
-@SuppressWarnings("removal")
 public class FXMLLoader {
 
     // Indicates permission to get the ClassLoader
@@ -112,6 +111,7 @@ public class FXMLLoader {
         new RuntimePermission("getClassLoader");
 
     // Instance of StackWalker used to get caller class (must be private)
+    @SuppressWarnings("removal")
     private static final StackWalker walker =
         AccessController.doPrivileged((PrivilegedAction<StackWalker>) () ->
             StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE));
@@ -2123,12 +2123,14 @@ public class FXMLLoader {
     public static final String FX_NAMESPACE_VERSION = "1";
 
     static {
-        JAVAFX_VERSION = AccessController.doPrivileged(new PrivilegedAction<String>() {
+        @SuppressWarnings("removal")
+        String tmp = AccessController.doPrivileged(new PrivilegedAction<String>() {
             @Override
             public String run() {
                 return System.getProperty("javafx.version");
             }
         });
+        JAVAFX_VERSION = tmp;
 
         FXMLLoaderHelper.setFXMLLoaderAccessor(new FXMLLoaderHelper.FXMLLoaderAccessor() {
             @Override
@@ -2429,6 +2431,7 @@ public class FXMLLoader {
      */
     public ClassLoader getClassLoader() {
         if (classLoader == null) {
+            @SuppressWarnings("removal")
             final SecurityManager sm = System.getSecurityManager();
             final Class caller = (sm != null) ?
                     walker.getCallerClass() :
@@ -2508,6 +2511,7 @@ public class FXMLLoader {
      *
      * @since JavaFX 2.1
      */
+    @SuppressWarnings("removal")
     public <T> T load() throws IOException {
         return loadImpl((System.getSecurityManager() != null)
                             ? walker.getCallerClass()
@@ -2523,6 +2527,7 @@ public class FXMLLoader {
      * @throws IOException if an error occurs during loading
      * @return the loaded object hierarchy
      */
+    @SuppressWarnings("removal")
     public <T> T load(InputStream inputStream) throws IOException {
         return loadImpl(inputStream, (System.getSecurityManager() != null)
                                          ? walker.getCallerClass()
@@ -3131,6 +3136,7 @@ public class FXMLLoader {
 
     private static ClassLoader getDefaultClassLoader(Class caller) {
         if (defaultClassLoader == null) {
+            @SuppressWarnings("removal")
             final SecurityManager sm = System.getSecurityManager();
             if (sm != null) {
                 if (needsClassLoaderPermissionCheck(caller)) {
@@ -3148,6 +3154,7 @@ public class FXMLLoader {
      * @since JavaFX 2.1
      */
     public static ClassLoader getDefaultClassLoader() {
+        @SuppressWarnings("removal")
         final SecurityManager sm = System.getSecurityManager();
         final Class caller = (sm != null) ?
                 walker.getCallerClass() :
@@ -3166,6 +3173,7 @@ public class FXMLLoader {
         if (defaultClassLoader == null) {
             throw new NullPointerException();
         }
+        @SuppressWarnings("removal")
         final SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
             sm.checkPermission(MODIFY_FXML_CLASS_LOADER_PERMISSION);
@@ -3183,6 +3191,7 @@ public class FXMLLoader {
      * @throws IOException if an error occurs during loading
      * @return the loaded object hierarchy
      */
+    @SuppressWarnings("removal")
     public static <T> T load(URL location) throws IOException {
         return loadImpl(location, (System.getSecurityManager() != null)
                                       ? walker.getCallerClass()
@@ -3204,6 +3213,7 @@ public class FXMLLoader {
      * @throws IOException if an error occurs during loading
      * @return the loaded object hierarchy
      */
+    @SuppressWarnings("removal")
     public static <T> T load(URL location, ResourceBundle resources)
                                      throws IOException {
         return loadImpl(location, resources,
@@ -3229,6 +3239,7 @@ public class FXMLLoader {
      * @throws IOException if an error occurs during loading
      * @return the loaded object hierarchy
      */
+    @SuppressWarnings("removal")
     public static <T> T load(URL location, ResourceBundle resources,
                              BuilderFactory builderFactory)
                                      throws IOException {
@@ -3258,6 +3269,7 @@ public class FXMLLoader {
      *
      * @since JavaFX 2.1
      */
+    @SuppressWarnings("removal")
     public static <T> T load(URL location, ResourceBundle resources,
                              BuilderFactory builderFactory,
                              Callback<Class<?>, Object> controllerFactory)
@@ -3291,6 +3303,7 @@ public class FXMLLoader {
      *
      * @since JavaFX 2.1
      */
+    @SuppressWarnings("removal")
     public static <T> T load(URL location, ResourceBundle resources,
                              BuilderFactory builderFactory,
                              Callback<Class<?>, Object> controllerFactory,
@@ -3397,6 +3410,7 @@ public class FXMLLoader {
     }
 
     private static void checkClassLoaderPermission() {
+        @SuppressWarnings("removal")
         final SecurityManager securityManager = System.getSecurityManager();
         if (securityManager != null) {
             securityManager.checkPermission(MODIFY_FXML_CLASS_LOADER_PERMISSION);
@@ -3517,7 +3531,8 @@ public class FXMLLoader {
                                  membersType);
 
             final int finalAllowedMemberAccess = allowedMemberAccess;
-            AccessController.doPrivileged(
+            @SuppressWarnings("removal")
+            var dummy = AccessController.doPrivileged(
                     new PrivilegedAction<Void>() {
                         @Override
                         public Void run() {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Accessible.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Accessible.java
@@ -52,6 +52,7 @@ public abstract class Accessible {
         public void executeAction(AccessibleAction action, Object... parameters) {
         }
 
+        @SuppressWarnings("removal")
         public abstract AccessControlContext getAccessControlContext();
     }
 
@@ -125,6 +126,7 @@ public abstract class Accessible {
      * IMPORTANT: Calling to the user code should not proceed if
      * this method returns NULL.
      */
+    @SuppressWarnings("removal")
     private final AccessControlContext getAccessControlContext() {
         AccessControlContext acc = null;
         try {
@@ -160,6 +162,7 @@ public abstract class Accessible {
 
     private GetAttribute getAttribute = new GetAttribute();
 
+    @SuppressWarnings("removal")
     public Object getAttribute(AccessibleAttribute attribute, Object... parameters) {
         AccessControlContext acc = getAccessControlContext();
         if (acc == null) return null;
@@ -181,6 +184,7 @@ public abstract class Accessible {
 
     private ExecuteAction executeAction = new ExecuteAction();
 
+    @SuppressWarnings("removal")
     public void executeAction(AccessibleAction action, Object... parameters) {
         AccessControlContext acc = getAccessControlContext();
         if (acc == null) return;

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
@@ -96,6 +96,7 @@ public abstract class Application {
     private static boolean loaded = false;
     private static Application application;
     private static Thread eventThread;
+    @SuppressWarnings("removal")
     private static final boolean disableThreadChecks =
         AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
             final String str =
@@ -214,6 +215,7 @@ public abstract class Application {
      */
     public String getDataDirectory() {
         checkEventThread();
+        @SuppressWarnings("removal")
         String userHome = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("user.home"));
         return userHome + File.separator + "." + name + File.separator;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Platform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Platform.java
@@ -42,6 +42,7 @@ final class Platform {
         if (type == null) {
 
             // Provide for a runtime override, allowing EGL for example
+            @SuppressWarnings("removal")
             String userPlatform =
                 AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("glass.platform"));
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Screen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Screen.java
@@ -37,13 +37,9 @@ public final class Screen {
     private static volatile List<Screen> screens = null ;
 
     // If dpiOverride is non-zero, use its value as screen DPI
-    private static final int dpiOverride;
-
-    static {
-        @SuppressWarnings("removal")
-        int tmp = AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Integer.getInteger("com.sun.javafx.screenDPI", 0)).intValue();
-        dpiOverride = tmp;
-    }
+    @SuppressWarnings("removal")
+    private static final int dpiOverride = AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
+        Integer.getInteger("com.sun.javafx.screenDPI", 0)).intValue();
 
     public static class EventHandler {
         public void handleSettingsChanged() {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Screen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Screen.java
@@ -30,7 +30,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-@SuppressWarnings("removal")
 public final class Screen {
 
     // the list of attached screens provided by native.
@@ -41,7 +40,9 @@ public final class Screen {
     private static final int dpiOverride;
 
     static {
-        dpiOverride = AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Integer.getInteger("com.sun.javafx.screenDPI", 0)).intValue();
+        @SuppressWarnings("removal")
+        int tmp = AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Integer.getInteger("com.sun.javafx.screenDPI", 0)).intValue();
+        dpiOverride = tmp;
     }
 
     public static class EventHandler {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Screen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Screen.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+@SuppressWarnings("removal")
 public final class Screen {
 
     // the list of attached screens provided by native.

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/View.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/View.java
@@ -44,6 +44,7 @@ public abstract class View {
     @Native public final static byte IME_ATTR_TARGET_NOTCONVERTED   = 0x03;
     @Native public final static byte IME_ATTR_INPUT_ERROR           = 0x04;
 
+    @SuppressWarnings("removal")
     final static boolean accessible = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
         String force = System.getProperty("glass.accessible.force");
         if (force != null) return Boolean.parseBoolean(force);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
@@ -51,6 +51,7 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.lang.annotation.Native;
 
+@SuppressWarnings("removal")
 final class GtkApplication extends Application implements
                                     InvokeLaterDispatcher.InvokeLaterSubmitter {
     private static final String SWT_INTERNAL_CLASS =

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
@@ -51,7 +51,6 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.lang.annotation.Native;
 
-@SuppressWarnings("removal")
 final class GtkApplication extends Application implements
                                     InvokeLaterDispatcher.InvokeLaterSubmitter {
     private static final String SWT_INTERNAL_CLASS =
@@ -61,6 +60,7 @@ final class GtkApplication extends Application implements
 
     static  {
         //check for SWT-GTK lib presence
+        @SuppressWarnings("removal")
         Class<?> OS = AccessController.
                 doPrivileged((PrivilegedAction<Class<?>>) () -> {
                     try {
@@ -76,6 +76,7 @@ final class GtkApplication extends Application implements
         if (OS != null) {
             PlatformLogger logger = Logging.getJavaFXLogger();
             logger.fine("SWT-GTK library found. Try to obtain GTK version.");
+            @SuppressWarnings("removal")
             Method method = AccessController.
                     doPrivileged((PrivilegedAction<Method>) () -> {
                         try {
@@ -106,7 +107,8 @@ final class GtkApplication extends Application implements
             forcedGtkVersion = 0;
         }
 
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             Application.loadNativeLibrary();
             return null;
         });
@@ -145,6 +147,7 @@ final class GtkApplication extends Application implements
 
     GtkApplication() {
 
+        @SuppressWarnings("removal")
         final int gtkVersion = forcedGtkVersion == 0 ?
             AccessController.doPrivileged((PrivilegedAction<Integer>) () -> {
                 String v = System.getProperty("jdk.gtk.version","3");
@@ -156,20 +159,24 @@ final class GtkApplication extends Application implements
                 }
                 return ret;
             }) : forcedGtkVersion;
+        @SuppressWarnings("removal")
         boolean gtkVersionVerbose =
                 AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
             return Boolean.getBoolean("jdk.gtk.verbose");
         });
         if (PrismSettings.allowHiDPIScaling) {
-            overrideUIScale = AccessController.doPrivileged((PrivilegedAction<Float>) () ->
+            @SuppressWarnings("removal")
+            float tmp = AccessController.doPrivileged((PrivilegedAction<Float>) () ->
                     getFloat("glass.gtk.uiScale", -1.0f, "Forcing UI scaling factor: "));
+            overrideUIScale = tmp;
         } else {
             overrideUIScale = -1.0f;
         }
 
         int libraryToLoad = _queryLibrary(gtkVersion, gtkVersionVerbose);
 
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             if (libraryToLoad == QUERY_NO_DISPLAY) {
                 throw new UnsupportedOperationException("Unable to open DISPLAY");
             } else if (libraryToLoad == QUERY_USE_CURRENT) {
@@ -199,6 +206,7 @@ final class GtkApplication extends Application implements
         }
 
         // Embedded in SWT, with shared event thread
+        @SuppressWarnings("removal")
         boolean isEventThread = AccessController
                 .doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("javafx.embed.isEventThread"));
         if (!isEventThread) {
@@ -250,6 +258,7 @@ final class GtkApplication extends Application implements
             eventProc = result == null ? 0 : result;
         }
 
+        @SuppressWarnings("removal")
         final boolean disableGrab = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("sun.awt.disablegrab") ||
                Boolean.getBoolean("glass.disableGrab"));
 
@@ -259,6 +268,7 @@ final class GtkApplication extends Application implements
     @Override
     protected void runLoop(final Runnable launchable) {
         // Embedded in SWT, with shared event thread
+        @SuppressWarnings("removal")
         final boolean isEventThread = AccessController
             .doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("javafx.embed.isEventThread"));
 
@@ -269,9 +279,11 @@ final class GtkApplication extends Application implements
             return;
         }
 
+        @SuppressWarnings("removal")
         final boolean noErrorTrap = AccessController
             .doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("glass.noErrorTrap"));
 
+        @SuppressWarnings("removal")
         final Thread toolkitThread =
             AccessController.doPrivileged((PrivilegedAction<Thread>) () -> new Thread(() -> {
                 init();

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosApplication.java
@@ -35,12 +35,12 @@ import java.nio.IntBuffer;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-@SuppressWarnings("removal")
 public final class IosApplication extends Application {
 
     private static native void _initIDs(); // init IDs for java callbacks from native
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             Application.loadNativeLibrary();
             return null;
         });

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosApplication.java
@@ -35,6 +35,7 @@ import java.nio.IntBuffer;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+@SuppressWarnings("removal")
 public final class IosApplication extends Application {
 
     private static native void _initIDs(); // init IDs for java callbacks from native

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
@@ -39,6 +39,7 @@ import java.security.PrivilegedAction;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+@SuppressWarnings("removal")
 final class MacApplication extends Application implements InvokeLaterDispatcher.InvokeLaterSubmitter {
 
     private native static void _initIDs(boolean disableSyncRendering);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
@@ -39,15 +39,16 @@ import java.security.PrivilegedAction;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-@SuppressWarnings("removal")
 final class MacApplication extends Application implements InvokeLaterDispatcher.InvokeLaterSubmitter {
 
     private native static void _initIDs(boolean disableSyncRendering);
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             Application.loadNativeLibrary();
             return null;
         });
+        @SuppressWarnings("removal")
         boolean disableSyncRendering = AccessController
                 .doPrivileged((PrivilegedAction<Boolean>) () ->
                         Boolean.getBoolean("glass.disableSyncRendering"));
@@ -61,6 +62,7 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
 
     MacApplication() {
         // Embedded in SWT, with shared event thread
+        @SuppressWarnings("removal")
         boolean isEventThread = AccessController
                 .doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("javafx.embed.isEventThread"));
         if (!isEventThread) {
@@ -89,11 +91,13 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
             launchable.run();
         };
 
-        isTaskbarApplication =
+        @SuppressWarnings("removal")
+        boolean tmp =
             AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
                 String taskbarAppProp = System.getProperty("glass.taskbarApplication");
                 return  !"false".equalsIgnoreCase(taskbarAppProp);
             });
+        isTaskbarApplication = tmp;
 
         ClassLoader classLoader = MacApplication.class.getClassLoader();
         _runLoop(classLoader, wrappedRunnable, isTaskbarApplication);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacCommonDialogs.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacCommonDialogs.java
@@ -69,6 +69,7 @@ final class MacCommonDialogs {
         return _showFolderChooser(ownerPtr, folder, title);
     }
 
+    @SuppressWarnings("removal")
     static boolean isFileNSURLEnabled() {
         // The check is dynamic since an app may want to toggle it dynamically.
         // The performance is not critical for FileChoosers.

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/AndroidInputDeviceRegistry.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/AndroidInputDeviceRegistry.java
@@ -128,6 +128,7 @@ public class AndroidInputDeviceRegistry extends InputDeviceRegistry {
     }
 
     void removeDevice(AndroidInputDevice device) {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkPermission(new AllPermission());

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/AndroidPlatformFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/AndroidPlatformFactory.java
@@ -33,6 +33,7 @@ class AndroidPlatformFactory extends NativePlatformFactory {
 
     @Override
     protected boolean matches() {
+       @SuppressWarnings("removal")
        String platform = AccessController.doPrivileged(
                 (PrivilegedAction<String>) () -> System.getProperty("javafx.platform"));
         return platform != null && platform.equals("android");

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/C.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/C.java
@@ -51,6 +51,7 @@ class C {
     }
 
     private static void checkPermissions() {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkPermission(permission);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/DispmanAcceleratedScreen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/DispmanAcceleratedScreen.java
@@ -38,9 +38,11 @@ class DispmanAcceleratedScreen extends AcceleratedScreen {
 
     @Override
     protected long platformGetNativeWindow() {
+        @SuppressWarnings("removal")
         int displayID = AccessController.doPrivileged(
                 (PrivilegedAction<Integer>)
                         () -> Integer.getInteger("dispman.display", 0 /* LCD */));
+        @SuppressWarnings("removal")
         int layerID = AccessController.doPrivileged(
                 (PrivilegedAction<Integer>)
                         () -> Integer.getInteger("dispman.layer", 1));

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGL.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EGL.java
@@ -165,6 +165,7 @@ class EGL {
     }
 
     private static void checkPermissions() {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkPermission(permission);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDPlatformFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDPlatformFactory.java
@@ -72,6 +72,7 @@ class EPDPlatformFactory extends NativePlatformFactory {
 
     @Override
     protected boolean matches() {
+        @SuppressWarnings("removal")
         String fbinfo = AccessController.doPrivileged((PrivilegedAction<String>) () -> {
             String line = null;
             try (var reader = new BufferedReader(new FileReader(FB_FILE))) {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDScreen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDScreen.java
@@ -89,6 +89,7 @@ class EPDScreen implements NativeScreen {
      *
      * @throws IllegalStateException if an error occurs opening the frame buffer
      */
+    @SuppressWarnings("removal")
     EPDScreen() {
         fbPath = AccessController.doPrivileged((PrivilegedAction<String>) ()
                 -> System.getProperty(FB_PATH_KEY, FB_PATH_DEFAULT));

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDScreen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDScreen.java
@@ -89,10 +89,11 @@ class EPDScreen implements NativeScreen {
      *
      * @throws IllegalStateException if an error occurs opening the frame buffer
      */
-    @SuppressWarnings("removal")
     EPDScreen() {
-        fbPath = AccessController.doPrivileged((PrivilegedAction<String>) ()
+        @SuppressWarnings("removal")
+        String tmp = AccessController.doPrivileged((PrivilegedAction<String>) ()
                 -> System.getProperty(FB_PATH_KEY, FB_PATH_DEFAULT));
+        fbPath = tmp;
         try {
             fbDevice = new EPDFrameBuffer(fbPath);
             fbDevice.init();

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDSettings.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDSettings.java
@@ -204,6 +204,7 @@ class EPDSettings {
      *
      * @return a new {@code EPDSettings} instance
      */
+    @SuppressWarnings("removal")
     static EPDSettings newInstance() {
         return AccessController.doPrivileged(
                 (PrivilegedAction<EPDSettings>) () -> new EPDSettings());

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDSystem.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDSystem.java
@@ -249,6 +249,7 @@ class EPDSystem {
      * security manager.
      */
     private static void checkPermissions() {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkPermission(PERMISSION);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/FBDevScreen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/FBDevScreen.java
@@ -54,11 +54,12 @@ class FBDevScreen implements NativeScreen {
     private LinuxFrameBuffer linuxFB;
     private final String fbDevPath;
 
-    @SuppressWarnings("removal")
     FBDevScreen() {
-        fbDevPath = AccessController.doPrivileged(
+        @SuppressWarnings("removal")
+        String tmp = AccessController.doPrivileged(
                 (PrivilegedAction<String>) () ->
                         System.getProperty("monocle.screen.fb", "/dev/fb0"));
+        fbDevPath = tmp;
         try {
             linuxFB = new LinuxFrameBuffer(fbDevPath);
             nativeHandle = 1l;

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/FBDevScreen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/FBDevScreen.java
@@ -54,6 +54,7 @@ class FBDevScreen implements NativeScreen {
     private LinuxFrameBuffer linuxFB;
     private final String fbDevPath;
 
+    @SuppressWarnings("removal")
     FBDevScreen() {
         fbDevPath = AccessController.doPrivileged(
                 (PrivilegedAction<String>) () ->

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/HeadlessScreen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/HeadlessScreen.java
@@ -50,6 +50,7 @@ class HeadlessScreen implements NativeScreen {
         this.width = defaultWidth;
         this.height = defaultHeight;
         this.depth = defaultDepth;
+        @SuppressWarnings("removal")
         String geometry = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("headless.geometry"));
         if (geometry != null && geometry.indexOf('x') > 0) {
             try {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/KeyInput.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/KeyInput.java
@@ -61,6 +61,7 @@ class KeyInput {
      *
      * @param newState The updated key state
      */
+    @SuppressWarnings("removal")
     void setState(KeyState newState) {
         if (MonocleSettings.settings.traceEvents) {
             MonocleTrace.traceEvent("Set %s", newState);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/KeyInput.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/KeyInput.java
@@ -61,7 +61,6 @@ class KeyInput {
      *
      * @param newState The updated key state
      */
-    @SuppressWarnings("removal")
     void setState(KeyState newState) {
         if (MonocleSettings.settings.traceEvents) {
             MonocleTrace.traceEvent("Set %s", newState);
@@ -86,7 +85,8 @@ class KeyInput {
                 } else if (key == KeyEvent.VK_NUM_LOCK) {
                     numLock = !numLock;
                 } else if (key == KeyEvent.VK_C && newState.isControlPressed()) {
-                    AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                    @SuppressWarnings("removal")
+                    var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
                         if ("1".equals(System.getenv("JAVAFX_DEBUG"))) {
                             System.exit(0);
                         }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxArch.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxArch.java
@@ -30,16 +30,11 @@ import java.security.PrivilegedAction;
 
 public class LinuxArch {
 
-    private static final int bits;
-
-    static {
-        @SuppressWarnings("removal")
-        int tmp = AccessController.doPrivileged((PrivilegedAction<Integer>) () -> {
-            LinuxSystem system = LinuxSystem.getLinuxSystem();
-            return (int) system.sysconf(LinuxSystem._SC_LONG_BIT);
-        });
-        bits = tmp;
-    }
+    @SuppressWarnings("removal")
+    private static final int bits = AccessController.doPrivileged((PrivilegedAction<Integer>) () -> {
+        LinuxSystem system = LinuxSystem.getLinuxSystem();
+        return (int) system.sysconf(LinuxSystem._SC_LONG_BIT);
+    });;
 
     static boolean is64Bit() {
         return bits == 64;

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxArch.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxArch.java
@@ -28,16 +28,17 @@ package com.sun.glass.ui.monocle;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-@SuppressWarnings("removal")
 public class LinuxArch {
 
     private static final int bits;
 
     static {
-        bits = AccessController.doPrivileged((PrivilegedAction<Integer>) () -> {
+        @SuppressWarnings("removal")
+        int tmp = AccessController.doPrivileged((PrivilegedAction<Integer>) () -> {
             LinuxSystem system = LinuxSystem.getLinuxSystem();
             return (int) system.sysconf(LinuxSystem._SC_LONG_BIT);
         });
+        bits = tmp;
     }
 
     static boolean is64Bit() {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxArch.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxArch.java
@@ -28,6 +28,7 @@ package com.sun.glass.ui.monocle;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+@SuppressWarnings("removal")
 public class LinuxArch {
 
     private static final int bits;

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxInputDeviceRegistry.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxInputDeviceRegistry.java
@@ -84,6 +84,7 @@ class LinuxInputDeviceRegistry extends InputDeviceRegistry {
     }
 
     LinuxInputDevice addDevice(LinuxInputDevice device, String name) {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkPermission(new AllPermission());
@@ -107,6 +108,7 @@ class LinuxInputDeviceRegistry extends InputDeviceRegistry {
     }
 
     void removeDevice(LinuxInputDevice device) {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkPermission(new AllPermission());

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxPlatformFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxPlatformFactory.java
@@ -32,6 +32,7 @@ class LinuxPlatformFactory extends NativePlatformFactory {
 
     @Override
     protected boolean matches() {
+        @SuppressWarnings("removal")
         String os = AccessController.doPrivileged(
                 (PrivilegedAction<String>) () -> System.getProperty("os.name"));
         return os != null && os.equals("Linux");

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxSystem.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxSystem.java
@@ -57,6 +57,7 @@ class LinuxSystem {
     }
 
     private static void checkPermissions() {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkPermission(permission);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxTouchProcessor.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxTouchProcessor.java
@@ -34,6 +34,7 @@ abstract class LinuxTouchProcessor implements LinuxInputProcessor {
     final TouchPipeline pipeline;
     final LinuxTouchTransform transform;
 
+    @SuppressWarnings("removal")
     LinuxTouchProcessor(LinuxInputDevice device) {
         transform = new LinuxTouchTransform(device);
         PrivilegedAction<String> getFilterProperty =

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxTouchTransform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxTouchTransform.java
@@ -52,6 +52,7 @@ class LinuxTouchTransform {
     private int[] mins = new int[2];
     private int[] maxs = new int[2];
 
+    @SuppressWarnings("removal")
     LinuxTouchTransform(LinuxInputDevice device) {
         this.device = device;
         Arrays.fill(axes, -1);
@@ -113,6 +114,7 @@ class LinuxTouchTransform {
         }
     }
 
+    @SuppressWarnings("removal")
     private void initTransform(int axis, int index) {
         double range;
         String axisName;

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxTouchTransform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxTouchTransform.java
@@ -114,7 +114,6 @@ class LinuxTouchTransform {
         }
     }
 
-    @SuppressWarnings("removal")
     private void initTransform(int axis, int index) {
         double range;
         String axisName;
@@ -140,7 +139,8 @@ class LinuxTouchTransform {
         }
         LinuxAbsoluteInputCapabilities caps = device.getAbsoluteInputCapabilities(axis);
         String product = device.getProduct();
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             int minimum = Integer.getInteger(
                     "monocle.input." + product + ".min" + axisName,
                     caps.getMinimum());

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleApplication.java
@@ -111,6 +111,7 @@ public final class MonocleApplication extends Application {
     @Override
     protected void runLoop(Runnable launchable) {
         runnableProcessor.invokeLater(launchable);
+        @SuppressWarnings("removal")
         long stackSize = AccessController.doPrivileged(
                 (PrivilegedAction<Long>)
                         () -> Long.getLong("monocle.stackSize", 0));

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleSettings.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleSettings.java
@@ -30,6 +30,7 @@ import java.security.PrivilegedAction;
 
 class MonocleSettings {
 
+    @SuppressWarnings("removal")
     static final MonocleSettings settings = AccessController.doPrivileged(
             (PrivilegedAction<MonocleSettings>) () -> new MonocleSettings());
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/NativePlatform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/NativePlatform.java
@@ -46,6 +46,7 @@ public abstract class NativePlatform {
     protected AcceleratedScreen accScreen;
 
 
+    @SuppressWarnings("removal")
     protected static final boolean useCursor =
         AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
             final String str =

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/NativePlatformFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/NativePlatformFactory.java
@@ -81,6 +81,7 @@ public abstract class NativePlatformFactory {
      */
     public static synchronized NativePlatform getNativePlatform() {
         if (platform == null) {
+            @SuppressWarnings("removal")
             String platformFactoryProperty =
                     AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("monocle.platform",
                                               "MX6,OMAP,Dispman,Android,X11,Linux,Headless"));

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/TouchInput.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/TouchInput.java
@@ -46,6 +46,7 @@ class TouchInput {
      * events with a delta smaller then the value of this property will be
      * filtered out.The value of the property is in pixels.
      */
+    @SuppressWarnings("removal")
     private final int touchRadius = AccessController.doPrivileged(
             (PrivilegedAction<Integer>) () -> Integer.getInteger(
                     "monocle.input.touchRadius", 20)
@@ -70,6 +71,7 @@ class TouchInput {
     TouchPipeline getBasePipeline() {
         if (basePipeline == null) {
             basePipeline = new TouchPipeline();
+            @SuppressWarnings("removal")
             String[] touchFilterNames = AccessController.doPrivileged(
                     (PrivilegedAction<String>) () -> System.getProperty(
                             "monocle.input.touchFilters",

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/VNCScreen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/VNCScreen.java
@@ -54,6 +54,7 @@ class VNCScreen extends HeadlessScreen {
         super(1024, 600, 32);
         try {
             server = ServerSocketChannel.open();
+            @SuppressWarnings("removal")
             int vncPort = AccessController.doPrivileged(
                     (PrivilegedAction<Integer>)
                             () -> Integer.getInteger("vnc.port", 5901));

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/X.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/X.java
@@ -56,6 +56,7 @@ class X {
     }
 
     private static void checkPermissions() {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkPermission(permission);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/X11AcceleratedScreen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/X11AcceleratedScreen.java
@@ -51,6 +51,7 @@ class X11AcceleratedScreen extends AcceleratedScreen {
          * This workaround can be removed when the bug in the drivers is fixed.
          */
         if (nativeDisplay == null) {
+            @SuppressWarnings("removal")
             boolean doMaliWorkaround =
                     AccessController.doPrivileged(
                             (PrivilegedAction<Boolean>) () ->

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/X11Platform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/X11Platform.java
@@ -35,6 +35,7 @@ class X11Platform extends NativePlatform {
 
     private final boolean x11Input;
 
+    @SuppressWarnings("removal")
     X11Platform() {
         LinuxSystem.getLinuxSystem().loadLibrary();
         x11Input = AccessController.doPrivileged((PrivilegedAction<Boolean>)

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/X11PlatformFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/X11PlatformFactory.java
@@ -35,6 +35,7 @@ class X11PlatformFactory extends NativePlatformFactory {
 
     @Override
     protected boolean matches() {
+        @SuppressWarnings("removal")
         String display = AccessController.doPrivileged(
                 (PrivilegedAction<String>) () -> System.getenv("DISPLAY"));
         return display != null;

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/X11Screen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/X11Screen.java
@@ -74,6 +74,7 @@ class X11Screen implements NativeScreen {
         int w = xLib.WidthOfScreen(screen);
         int h = xLib.HeightOfScreen(screen);
         boolean fullScreen = true;
+        @SuppressWarnings("removal")
         String geometry =
                 AccessController.doPrivileged((PrivilegedAction<String>) () ->
                         System.getProperty("x11.geometry"));

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
@@ -36,6 +36,7 @@ import java.nio.IntBuffer;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+@SuppressWarnings("removal")
 final class WinApplication extends Application implements InvokeLaterDispatcher.InvokeLaterSubmitter {
     static float   overrideUIScale;
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
@@ -36,7 +36,6 @@ import java.nio.IntBuffer;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-@SuppressWarnings("removal")
 final class WinApplication extends Application implements InvokeLaterDispatcher.InvokeLaterSubmitter {
     static float   overrideUIScale;
 
@@ -80,7 +79,8 @@ final class WinApplication extends Application implements InvokeLaterDispatcher.
 
     private static native void initIDs(float overrideUIScale);
     static {
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged(new PrivilegedAction<Void>() {
             public Void run() {
                 verbose = Boolean.getBoolean("javafx.verbose");
                 if (PrismSettings.allowHiDPIScaling) {
@@ -109,6 +109,7 @@ final class WinApplication extends Application implements InvokeLaterDispatcher.
     private final InvokeLaterDispatcher invokeLaterDispatcher;
     WinApplication() {
         // Embedded in SWT, with shared event thread
+        @SuppressWarnings("removal")
         boolean isEventThread = AccessController
                 .doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("javafx.embed.isEventThread"));
         if (!isEventThread) {
@@ -135,6 +136,7 @@ final class WinApplication extends Application implements InvokeLaterDispatcher.
         if (!PrismSettings.allowHiDPIScaling) {
             return Process_DPI_Unaware;
         }
+        @SuppressWarnings("removal")
         String awareRequested = AccessController
             .doPrivileged((PrivilegedAction<String>) () ->
                           System.getProperty("javafx.glass.winDPIawareness"));
@@ -156,6 +158,7 @@ final class WinApplication extends Application implements InvokeLaterDispatcher.
 
     @Override
     protected void runLoop(final Runnable launchable) {
+        @SuppressWarnings("removal")
         boolean isEventThread = AccessController
             .doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("javafx.embed.isEventThread"));
         int awareness = getDesiredAwarenesslevel();
@@ -169,6 +172,7 @@ final class WinApplication extends Application implements InvokeLaterDispatcher.
             launchable.run();
             return;
         }
+        @SuppressWarnings("removal")
         final Thread toolkitThread =
             AccessController.doPrivileged((PrivilegedAction<Thread>) () -> new Thread(() -> {
                 _init(awareness);
@@ -350,6 +354,7 @@ final class WinApplication extends Application implements InvokeLaterDispatcher.
 
     public String getDataDirectory() {
         checkEventThread();
+        @SuppressWarnings("removal")
         String baseDirectory = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getenv("APPDATA"));
         if (baseDirectory == null || baseDirectory.length() == 0) {
             return super.getDataDirectory();

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
@@ -41,6 +41,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 
+@SuppressWarnings("removal")
 public class NativeLibLoader {
 
     private static final HashSet<String> loaded = new HashSet<String>();

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
@@ -41,13 +41,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 
-@SuppressWarnings("removal")
 public class NativeLibLoader {
 
     private static final HashSet<String> loaded = new HashSet<String>();
 
     public static synchronized void loadLibrary(String libname) {
         if (!loaded.contains(libname)) {
+            @SuppressWarnings("removal")
             StackWalker walker = AccessController.doPrivileged((PrivilegedAction<StackWalker>) () ->
             StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE));
             Class caller = walker.getCallerClass();
@@ -58,6 +58,7 @@ public class NativeLibLoader {
 
     public static synchronized void loadLibrary(String libname, List<String> dependencies) {
         if (!loaded.contains(libname)) {
+            @SuppressWarnings("removal")
             StackWalker walker = AccessController.doPrivileged((PrivilegedAction<StackWalker>) () ->
             StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE));
             Class caller = walker.getCallerClass();
@@ -74,7 +75,8 @@ public class NativeLibLoader {
     private static String libSuffix = "";
 
     static {
-        AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
             verbose = Boolean.getBoolean("javafx.verbose");
             return null;
         });

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/LauncherImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/LauncherImpl.java
@@ -56,7 +56,6 @@ import java.util.Optional;
 import com.sun.javafx.stage.StageHelper;
 
 
-@SuppressWarnings("removal")
 public class LauncherImpl {
     /**
      * When passed as launchMode to launchApplication, tells the method that
@@ -119,8 +118,10 @@ public class LauncherImpl {
     private static ClassLoader savedMainCcl = null;
 
     static {
-        verbose = AccessController.doPrivileged((PrivilegedAction<Boolean>) () ->
+        @SuppressWarnings("removal")
+        boolean tmp = AccessController.doPrivileged((PrivilegedAction<Boolean>) () ->
                 Boolean.getBoolean("javafx.verbose"));
+        verbose = tmp;
     }
 
     /**
@@ -140,6 +141,7 @@ public class LauncherImpl {
         Class<? extends Preloader> preloaderClass = savedPreloaderClass;
 
         if (preloaderClass == null) {
+            @SuppressWarnings("removal")
             String preloaderByProperty = AccessController.doPrivileged((PrivilegedAction<String>) () ->
                     System.getProperty("javafx.preloader"));
             if (preloaderByProperty != null) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/LauncherImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/LauncherImpl.java
@@ -56,6 +56,7 @@ import java.util.Optional;
 import com.sun.javafx.stage.StageHelper;
 
 
+@SuppressWarnings("removal")
 public class LauncherImpl {
     /**
      * When passed as launchMode to launchApplication, tells the method that

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/LauncherImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/LauncherImpl.java
@@ -81,7 +81,9 @@ public class LauncherImpl {
     private static final boolean trace = false;
 
     // set system property javafx.verbose to true to make the launcher noisy
-    private static final boolean verbose;
+    @SuppressWarnings("removal")
+    private static final boolean verbose = AccessController.doPrivileged((PrivilegedAction<Boolean>) () ->
+        Boolean.getBoolean("javafx.verbose"));
 
     private static final String MF_MAIN_CLASS = "Main-Class";
     private static final String MF_JAVAFX_MAIN = "JavaFX-Application-Class";
@@ -116,13 +118,6 @@ public class LauncherImpl {
     // has set the CCL in the case where main is called after the FX toolkit
     // is started.
     private static ClassLoader savedMainCcl = null;
-
-    static {
-        @SuppressWarnings("removal")
-        boolean tmp = AccessController.doPrivileged((PrivilegedAction<Boolean>) () ->
-                Boolean.getBoolean("javafx.verbose"));
-        verbose = tmp;
-    }
 
     /**
      * This method is called by the Application.launch method.

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
@@ -95,10 +95,12 @@ public class PlatformImpl {
     private static BooleanProperty accessibilityActive = new SimpleBooleanProperty();
     private static CountDownLatch allNestedLoopsExitedLatch = new CountDownLatch(1);
 
+    @SuppressWarnings("removal")
     private static final boolean verbose
             = AccessController.doPrivileged((PrivilegedAction<Boolean>) () ->
                 Boolean.getBoolean("javafx.verbose"));
 
+    @SuppressWarnings("removal")
     private static final boolean DEBUG
             = AccessController.doPrivileged((PrivilegedAction<Boolean>) ()
                     -> Boolean.getBoolean("com.sun.javafx.application.debug"));
@@ -170,6 +172,7 @@ public class PlatformImpl {
      * @param r
      * @param preventDuplicateCalls
      */
+    @SuppressWarnings("removal")
     public static void startup(final Runnable r, boolean preventDuplicateCalls) {
 
         // NOTE: if we ever support re-launching an application and/or
@@ -301,6 +304,7 @@ public class PlatformImpl {
         // Read the javafx.embed.eventProc system property and store
         // it in an entry in the glass Application device details map
         final String eventProcProperty = "javafx.embed.eventProc";
+        @SuppressWarnings("removal")
         final long eventProc = AccessController.doPrivileged((PrivilegedAction<Long>) () ->
                 Long.getLong(eventProcProperty, 0));
         if (eventProc != 0L) {
@@ -344,6 +348,7 @@ public class PlatformImpl {
     // FXCanvas-specific initialization
     private static void initFXCanvas() {
         // Verify that we have the appropriate permission
+        @SuppressWarnings("removal")
         final SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
             try {
@@ -360,6 +365,7 @@ public class PlatformImpl {
                 !f.getClassName().startsWith("javafx.application.")
                         && !f.getClassName().startsWith("com.sun.javafx.application.");
 
+        @SuppressWarnings("removal")
         final StackWalker walker = AccessController.doPrivileged((PrivilegedAction<StackWalker>) () ->
                 StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE));
         Optional<StackWalker.StackFrame> frame = walker.walk(
@@ -424,6 +430,7 @@ public class PlatformImpl {
         runLater(r, false);
     }
 
+    @SuppressWarnings("removal")
     private static void runLater(final Runnable r, boolean exiting) {
         if (!initialized.get()) {
             throw new IllegalStateException("Toolkit not initialized");
@@ -648,6 +655,7 @@ public class PlatformImpl {
             // some features require the application to have the corresponding
             // permissions, if the application doesn't have them, the platform
             // will behave as if the feature wasn't supported
+            @SuppressWarnings("removal")
             final SecurityManager securityManager =
                     System.getSecurityManager();
             if (securityManager != null) {
@@ -736,6 +744,7 @@ public class PlatformImpl {
     private static void _setAccessibilityTheme(String platformTheme) {
 
         // check to see if there is an override to enable a high-contrast theme
+        @SuppressWarnings("removal")
         final String userTheme = AccessController.doPrivileged(
                 (PrivilegedAction<String>) () -> System.getProperty("com.sun.javafx.highContrastTheme"));
 
@@ -780,6 +789,7 @@ public class PlatformImpl {
         }
     }
 
+    @SuppressWarnings("removal")
     private static void _setPlatformUserAgentStylesheet(String stylesheetUrl) {
         isModena = isCaspian = false;
         // check for command line override
@@ -871,6 +881,7 @@ public class PlatformImpl {
 
     }
 
+    @SuppressWarnings("removal")
     public static void addNoTransparencyStylesheetToScene(final Scene scene) {
         if (PlatformImpl.isCaspian()) {
             AccessController.doPrivileged((PrivilegedAction) () -> {
@@ -887,6 +898,7 @@ public class PlatformImpl {
         }
     }
 
+    @SuppressWarnings("removal")
     private static boolean isSupportedImpl(ConditionalFeature feature) {
         switch (feature) {
             case GRAPHICS:

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
@@ -172,7 +172,6 @@ public class PlatformImpl {
      * @param r
      * @param preventDuplicateCalls
      */
-    @SuppressWarnings("removal")
     public static void startup(final Runnable r, boolean preventDuplicateCalls) {
 
         // NOTE: if we ever support re-launching an application and/or
@@ -209,7 +208,8 @@ public class PlatformImpl {
             Logging.getJavaFXLogger().warning(warningStr);
         }
 
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             applicationType = System.getProperty("com.sun.javafx.application.type");
             if (applicationType == null) applicationType = "";
 
@@ -264,7 +264,8 @@ public class PlatformImpl {
         }
 
         if (!taskbarApplication) {
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            @SuppressWarnings("removal")
+            var dummy2 = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
                 System.setProperty("glass.taskbarApplication", "false");
                 return null;
             });
@@ -430,7 +431,6 @@ public class PlatformImpl {
         runLater(r, false);
     }
 
-    @SuppressWarnings("removal")
     private static void runLater(final Runnable r, boolean exiting) {
         if (!initialized.get()) {
             throw new IllegalStateException("Toolkit not initialized");
@@ -446,11 +446,13 @@ public class PlatformImpl {
                 return;
             }
 
+            @SuppressWarnings("removal")
             final AccessControlContext acc = AccessController.getContext();
             // Don't catch exceptions, they are handled by Toolkit.defer()
             Toolkit.getToolkit().defer(() -> {
                 try {
-                    AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                    @SuppressWarnings("removal")
+                    var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
                         r.run();
                         return null;
                     }, acc);
@@ -789,10 +791,10 @@ public class PlatformImpl {
         }
     }
 
-    @SuppressWarnings("removal")
     private static void _setPlatformUserAgentStylesheet(String stylesheetUrl) {
         isModena = isCaspian = false;
         // check for command line override
+        @SuppressWarnings("removal")
         final String overrideStylesheetUrl = AccessController.doPrivileged(
                 (PrivilegedAction<String>) () -> System.getProperty("javafx.userAgentStylesheetUrl"));
 
@@ -874,7 +876,8 @@ public class PlatformImpl {
             uaStylesheets.add(accessibilityTheme);
         }
 
-        AccessController.doPrivileged((PrivilegedAction) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction) () -> {
             StyleManager.getInstance().setUserAgentStylesheets(uaStylesheets);
             return null;
         });
@@ -898,7 +901,6 @@ public class PlatformImpl {
         }
     }
 
-    @SuppressWarnings("removal")
     private static boolean isSupportedImpl(ConditionalFeature feature) {
         switch (feature) {
             case GRAPHICS:
@@ -917,7 +919,8 @@ public class PlatformImpl {
                     isMediaSupported = checkForClass(
                             "javafx.scene.media.MediaView");
                     if (isMediaSupported && PlatformUtil.isEmbedded()) {
-                        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                        @SuppressWarnings("removal")
+                        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
                             String s = System.getProperty(
                                     "com.sun.javafx.experimental.embedded.media",
                                     "false");
@@ -932,7 +935,8 @@ public class PlatformImpl {
                 if (isWebSupported == null) {
                     isWebSupported = checkForClass("javafx.scene.web.WebView");
                     if (isWebSupported && PlatformUtil.isEmbedded()) {
-                        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                        @SuppressWarnings("removal")
+                        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
                             String s = System.getProperty(
                                     "com.sun.javafx.experimental.embedded.web",
                                     "false");

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/StyleManager.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/StyleManager.java
@@ -939,6 +939,7 @@ final public class StyleManager {
         return new byte[0];
     }
 
+    @SuppressWarnings("removal")
     public static Stylesheet loadStylesheet(final String fname) {
         try {
             return loadStylesheetUnPrivileged(fname);
@@ -1065,6 +1066,7 @@ final public class StyleManager {
     private static Stylesheet loadStylesheetUnPrivileged(final String fname) {
 
         synchronized (styleLock) {
+            @SuppressWarnings("removal")
             Boolean parse = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
 
                 final String bss = System.getProperty("binary.css");

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/AndroidFontFinder.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/AndroidFontFinder.java
@@ -53,6 +53,7 @@ import com.sun.glass.utils.NativeLibLoader;
  * defines some basic mappings based on best guess which fonts are mandatory on
  * platforms lower than 4.0 and how they map to typefaces.
  */
+@SuppressWarnings("removal")
 class AndroidFontFinder {
 
     private final static String SYSTEM_FONT_NAME    = "sans serif";

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/AndroidFontFinder.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/AndroidFontFinder.java
@@ -53,7 +53,6 @@ import com.sun.glass.utils.NativeLibLoader;
  * defines some basic mappings based on best guess which fonts are mandatory on
  * platforms lower than 4.0 and how they map to typefaces.
  */
-@SuppressWarnings("removal")
 class AndroidFontFinder {
 
     private final static String SYSTEM_FONT_NAME    = "sans serif";
@@ -64,7 +63,8 @@ class AndroidFontFinder {
     final static String systemFontsDir = "/system/fonts";
 
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             NativeLibLoader.loadLibrary("javafx_font");
             return null;
         });

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/DFontDecoder.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/DFontDecoder.java
@@ -31,10 +31,10 @@ import java.security.PrivilegedAction;
 
 import com.sun.glass.utils.NativeLibLoader;
 
-@SuppressWarnings("removal")
 class DFontDecoder extends FontFileWriter {
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             NativeLibLoader.loadLibrary("javafx_font");
             return null;
         });

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/DFontDecoder.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/DFontDecoder.java
@@ -31,6 +31,7 @@ import java.security.PrivilegedAction;
 
 import com.sun.glass.utils.NativeLibLoader;
 
+@SuppressWarnings("removal")
 class DFontDecoder extends FontFileWriter {
     static {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/Disposer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/Disposer.java
@@ -43,7 +43,6 @@ import java.util.Hashtable;
  *
  * @see DisposerRecord
  */
-@SuppressWarnings("removal")
 public class Disposer implements Runnable {
     private static final ReferenceQueue queue = new ReferenceQueue();
     private static final Hashtable records = new Hashtable();
@@ -53,7 +52,8 @@ public class Disposer implements Runnable {
         disposerInstance = new Disposer();
 
         ThreadGroup tg = Thread.currentThread().getThreadGroup();
-        java.security.AccessController.doPrivileged(
+        @SuppressWarnings("removal")
+        var dummy = java.security.AccessController.doPrivileged(
             new java.security.PrivilegedAction() {
                 public Object run() {
                     /* The thread must be a member of a thread group

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/Disposer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/Disposer.java
@@ -43,6 +43,7 @@ import java.util.Hashtable;
  *
  * @see DisposerRecord
  */
+@SuppressWarnings("removal")
 public class Disposer implements Runnable {
     private static final ReferenceQueue queue = new ReferenceQueue();
     private static final Hashtable records = new Hashtable();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontConfigManager.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontConfigManager.java
@@ -36,7 +36,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Properties;
 
-@SuppressWarnings("removal")
 class FontConfigManager {
 
     static boolean debugFonts = false;
@@ -45,7 +44,8 @@ class FontConfigManager {
     static boolean useEmbeddedFontSupport = false;
 
     static {
-        AccessController.doPrivileged(
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged(
                 (PrivilegedAction<Void>) () -> {
                     String dbg = System.getProperty("prism.debugfonts", "");
                     debugFonts = "true".equals(dbg);
@@ -348,7 +348,8 @@ class FontConfigManager {
         private static boolean fontDirFromJRE = false;
 
         static {
-            AccessController.doPrivileged(
+            @SuppressWarnings("removal")
+            var dummy = AccessController.doPrivileged(
                     (PrivilegedAction<Void>) () -> {
                         initEmbeddedFonts();
                     return null;
@@ -398,6 +399,7 @@ class FontConfigManager {
         }
 
 
+        @SuppressWarnings("removal")
         private static boolean exists(final File f) {
             return AccessController.doPrivileged(
                     (PrivilegedAction<Boolean>) () -> f.exists()
@@ -543,7 +545,8 @@ class FontConfigManager {
              Locale locale)
         {
             final Properties props = new Properties();
-            AccessController.doPrivileged(
+            @SuppressWarnings("removal")
+            var dummy = AccessController.doPrivileged(
                     (PrivilegedAction<Void>) () -> {
                         try {
                             String lFile = fontDir+"/allfonts.properties";

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontConfigManager.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontConfigManager.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Properties;
 
+@SuppressWarnings("removal")
 class FontConfigManager {
 
     static boolean debugFonts = false;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFileReader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFileReader.java
@@ -54,6 +54,7 @@ class FontFileReader implements FontConstants {
      *  already or if it failed to open the file.
      * @throws PrivilegedActionException
      */
+    @SuppressWarnings("removal")
     public synchronized boolean openFile() throws PrivilegedActionException {
         if (raFile != null) {
             return false;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFileWriter.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFileWriter.java
@@ -80,6 +80,7 @@ class FontFileWriter implements FontConstants {
         return file;
     }
 
+    @SuppressWarnings("removal")
     public File openFile() throws PrivilegedActionException {
         pos = 0;
         writtenBytes = 0;
@@ -123,6 +124,7 @@ class FontFileWriter implements FontConstants {
         }
     }
 
+    @SuppressWarnings("removal")
     public void deleteFile() {
         if (file != null) {
             if (tracker != null) {
@@ -252,6 +254,7 @@ class FontFileWriter implements FontConstants {
      * If a thread can create temp files anyway, there is no point in counting
      * font bytes.
      */
+    @SuppressWarnings("removal")
     static boolean hasTempPermission() {
         if (System.getSecurityManager() == null) {
             return true;
@@ -342,6 +345,7 @@ class FontFileWriter implements FontConstants {
                 new HashMap<File, RandomAccessFile>();
 
             private static Thread t = null;
+            @SuppressWarnings("removal")
             static void init() {
                 if (t == null) {
                     // Add a shutdown hook to remove the temp file.

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/MacFontFinder.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/MacFontFinder.java
@@ -33,6 +33,7 @@ import java.util.Locale;
 
 import com.sun.glass.utils.NativeLibLoader;
 
+@SuppressWarnings("removal")
 class MacFontFinder {
 
     static {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/MacFontFinder.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/MacFontFinder.java
@@ -33,11 +33,11 @@ import java.util.Locale;
 
 import com.sun.glass.utils.NativeLibLoader;
 
-@SuppressWarnings("removal")
 class MacFontFinder {
 
     static {
-        AccessController.doPrivileged(
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged(
                 (PrivilegedAction<Void>) () -> {
                     NativeLibLoader.loadLibrary("javafx_font");
                     return null;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
@@ -46,7 +46,6 @@ import com.sun.javafx.PlatformUtil;
 import com.sun.javafx.text.GlyphLayout;
 import static com.sun.javafx.FXPermissions.LOAD_FONT_PERMISSION;
 
-@SuppressWarnings("removal")
 public abstract class PrismFontFactory implements FontFactory {
 
     public static final boolean debugFonts;
@@ -94,7 +93,8 @@ public abstract class PrismFontFactory implements FontFactory {
         isEmbedded = PlatformUtil.isEmbedded();
         int[] tempCacheLayoutSize = {0x10000};
 
-        debugFonts = AccessController.doPrivileged(
+        @SuppressWarnings("removal")
+        boolean tmp = AccessController.doPrivileged(
                 (PrivilegedAction<Boolean>) () -> {
                     NativeLibLoader.loadLibrary("javafx_font");
                     String dbg = System.getProperty("prism.debugfonts", "");
@@ -154,6 +154,7 @@ public abstract class PrismFontFactory implements FontFactory {
                     return debug;
                 }
         );
+        debugFonts = tmp;
         cacheLayoutSize = tempCacheLayoutSize[0];
     }
 
@@ -1234,6 +1235,7 @@ public abstract class PrismFontFactory implements FontFactory {
             return sysFontDir+"\\"+filename;
         }
 
+        @SuppressWarnings("removal")
         String path = AccessController.doPrivileged(
             new PrivilegedAction<String>() {
                 public String run() {
@@ -1412,7 +1414,8 @@ public abstract class PrismFontFactory implements FontFactory {
                     }
                 }
             };
-            java.security.AccessController.doPrivileged(
+            @SuppressWarnings("removal")
+            var dummy = java.security.AccessController.doPrivileged(
                     (PrivilegedAction<Object>) () -> {
                         /* The thread must be a member of a thread group
                          * which will not get GCed before VM exit.
@@ -1818,6 +1821,7 @@ public abstract class PrismFontFactory implements FontFactory {
         return fontToFileMap;
     }
 
+    @SuppressWarnings("removal")
     public final boolean hasPermission() {
         try {
             SecurityManager sm = System.getSecurityManager();
@@ -1888,9 +1892,11 @@ public abstract class PrismFontFactory implements FontFactory {
         final File dir = new File(fontDir);
         String[] files = null;
         try {
-            files = AccessController.doPrivileged(
+            @SuppressWarnings("removal")
+            String[] tmp = AccessController.doPrivileged(
                     (PrivilegedExceptionAction<String[]>) () -> dir.list(TTFilter.getInstance())
             );
+            files = tmp;
         } catch (Exception e) {
         }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
@@ -46,6 +46,7 @@ import com.sun.javafx.PlatformUtil;
 import com.sun.javafx.text.GlyphLayout;
 import static com.sun.javafx.FXPermissions.LOAD_FONT_PERMISSION;
 
+@SuppressWarnings("removal")
 public abstract class PrismFontFactory implements FontFactory {
 
     public static final boolean debugFonts;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFile.java
@@ -117,6 +117,7 @@ public abstract class PrismFontFile implements FontResource, FontConstants {
 
     /* This is called only for fonts where a temp file was created
      */
+    @SuppressWarnings("removal")
     protected synchronized void disposeOnShutdown() {
         if (isCopy || isDecoded) {
             AccessController.doPrivileged(
@@ -227,6 +228,7 @@ public abstract class PrismFontFile implements FontResource, FontConstants {
             this.refKey = refKey;
         }
 
+        @SuppressWarnings("removal")
         public synchronized void dispose() {
             if (fileName != null) {
                 AccessController.doPrivileged(

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/OS.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/OS.java
@@ -32,6 +32,7 @@ import java.security.PrivilegedAction;
 import com.sun.glass.utils.NativeLibLoader;
 import com.sun.javafx.geom.Path2D;
 
+@SuppressWarnings("removal")
 class OS {
     static {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/OS.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/OS.java
@@ -32,10 +32,10 @@ import java.security.PrivilegedAction;
 import com.sun.glass.utils.NativeLibLoader;
 import com.sun.javafx.geom.Path2D;
 
-@SuppressWarnings("removal")
 class OS {
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             NativeLibLoader.loadLibrary("javafx_font");
             return null;
         });

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/OS.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/OS.java
@@ -31,6 +31,7 @@ import java.security.PrivilegedAction;
 import com.sun.glass.utils.NativeLibLoader;
 import com.sun.javafx.geom.Path2D;
 
+@SuppressWarnings("removal")
 class OS {
     static {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/OS.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/OS.java
@@ -31,10 +31,10 @@ import java.security.PrivilegedAction;
 import com.sun.glass.utils.NativeLibLoader;
 import com.sun.javafx.geom.Path2D;
 
-@SuppressWarnings("removal")
 class OS {
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             NativeLibLoader.loadLibrary("javafx_font");
             return null;
         });

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/OSFreetype.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/OSFreetype.java
@@ -30,6 +30,7 @@ import java.security.PrivilegedAction;
 import com.sun.glass.utils.NativeLibLoader;
 import com.sun.javafx.geom.Path2D;
 
+@SuppressWarnings("removal")
 class OSFreetype {
 
     static {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/OSFreetype.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/OSFreetype.java
@@ -30,11 +30,11 @@ import java.security.PrivilegedAction;
 import com.sun.glass.utils.NativeLibLoader;
 import com.sun.javafx.geom.Path2D;
 
-@SuppressWarnings("removal")
 class OSFreetype {
 
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             NativeLibLoader.loadLibrary("javafx_font_freetype");
             return null;
         });

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/OSPango.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/OSPango.java
@@ -29,11 +29,11 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import com.sun.glass.utils.NativeLibLoader;
 
-@SuppressWarnings("removal")
 class OSPango {
 
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             NativeLibLoader.loadLibrary("javafx_font_pango");
             return null;
         });

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/OSPango.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/OSPango.java
@@ -29,6 +29,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import com.sun.glass.utils.NativeLibLoader;
 
+@SuppressWarnings("removal")
 class OSPango {
 
     static {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ios/IosImageLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ios/IosImageLoader.java
@@ -47,6 +47,7 @@ import java.net.MalformedURLException;
 /**
  * A loader for images on iOS platform.
  */
+@SuppressWarnings("removal")
 public class IosImageLoader extends ImageLoaderImpl {
 
     /** These constants must match with those in native */

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ios/IosImageLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ios/IosImageLoader.java
@@ -47,7 +47,6 @@ import java.net.MalformedURLException;
 /**
  * A loader for images on iOS platform.
  */
-@SuppressWarnings("removal")
 public class IosImageLoader extends ImageLoaderImpl {
 
     /** These constants must match with those in native */
@@ -110,7 +109,8 @@ public class IosImageLoader extends ImageLoaderImpl {
 
 
     static {
-        AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
             NativeLibLoader.loadLibrary("nativeiio");
             return null;
         });

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/jpeg/JPEGImageLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/jpeg/JPEGImageLoader.java
@@ -37,7 +37,6 @@ import java.nio.ByteBuffer;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-@SuppressWarnings("removal")
 public class JPEGImageLoader extends ImageLoaderImpl {
 
     // IJG Color codes.
@@ -104,7 +103,8 @@ public class JPEGImageLoader extends ImageLoaderImpl {
     private native boolean decompressIndirect(long structPointer, boolean reportProgress, byte[] array) throws IOException;
 
     static {
-        AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
             NativeLibLoader.loadLibrary("javafx_iio");
             return null;
         });

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/jpeg/JPEGImageLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/jpeg/JPEGImageLoader.java
@@ -37,6 +37,7 @@ import java.nio.ByteBuffer;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+@SuppressWarnings("removal")
 public class JPEGImageLoader extends ImageLoaderImpl {
 
     // IJG Color codes.

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/WindowHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/WindowHelper.java
@@ -130,6 +130,7 @@ public class WindowHelper {
         windowAccessor.notifyScaleChanged(window, newOutputScaleX, newOutputScaleY);
     }
 
+    @SuppressWarnings("removal")
     static AccessControlContext getAccessControlContext(Window window) {
         return windowAccessor.getAccessControlContext(window);
     }
@@ -169,6 +170,7 @@ public class WindowHelper {
 
         ReadOnlyObjectProperty<Screen> screenProperty(Window window);
 
+        @SuppressWarnings("removal")
         AccessControlContext getAccessControlContext(Window window);
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/DummyToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/DummyToolkit.java
@@ -103,17 +103,17 @@ final public class DummyToolkit extends Toolkit {
     }
 
     @Override
-    public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl, AccessControlContext acc) {
+    public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl, @SuppressWarnings("removal") AccessControlContext acc) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
-    public TKStage createTKPopupStage(Window peerWindow, StageStyle popupStyle, TKStage owner, AccessControlContext acc) {
+    public TKStage createTKPopupStage(Window peerWindow, StageStyle popupStyle, TKStage owner, @SuppressWarnings("removal") AccessControlContext acc) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 
     @Override
-    public TKStage createTKEmbeddedStage(HostInterface host, AccessControlContext acc) {
+    public TKStage createTKEmbeddedStage(HostInterface host, @SuppressWarnings("removal") AccessControlContext acc) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/LocalClipboard.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/LocalClipboard.java
@@ -44,7 +44,7 @@ final class LocalClipboard implements TKClipboard {
     }
 
     @Override
-    public void setSecurityContext(final AccessControlContext ctx) {
+    public void setSecurityContext(@SuppressWarnings("removal") final AccessControlContext ctx) {
         // ctx not needed
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/PermissionHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/PermissionHelper.java
@@ -62,6 +62,7 @@ public class PermissionHelper {
     }
 
     public static void checkClipboardPermission() {
+        @SuppressWarnings("removal")
         final SecurityManager securityManager = System.getSecurityManager();
 
         // Always succeed if no security manager installed
@@ -84,6 +85,7 @@ public class PermissionHelper {
         }
     }
 
+    @SuppressWarnings("removal")
     public static void checkClipboardPermission(AccessControlContext context) {
         final SecurityManager securityManager = System.getSecurityManager();
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKClipboard.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKClipboard.java
@@ -43,7 +43,7 @@ public interface TKClipboard {
     /**
      * This method is used to set security context of the Stage.
      */
-    public void setSecurityContext(AccessControlContext ctx);
+    public void setSecurityContext(@SuppressWarnings("removal") AccessControlContext ctx);
 
     /**
      * Gets the set of DataFormat types on this Clipboard instance which have

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKScene.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKScene.java
@@ -87,5 +87,6 @@ public interface TKScene {
 
     public TKClipboard createDragboard(boolean isDragSource);
 
+    @SuppressWarnings("removal")
     public AccessControlContext getAccessControlContext();
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKStage.java
@@ -47,7 +47,7 @@ public interface TKStage {
      *
      * @return scenePeer The peer of the scene to be displayed
      */
-    public TKScene createTKScene(boolean depthBuffer, boolean msaa, AccessControlContext acc);
+    public TKScene createTKScene(boolean depthBuffer, boolean msaa, @SuppressWarnings("removal") AccessControlContext acc);
 
     /**
      * Set the scene to be displayed in this stage

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -198,13 +198,13 @@ public abstract class Toolkit {
         throw new UnsupportedOperationException(System.getProperty("os.name") + " is not supported");
     }
 
-    @SuppressWarnings("removal")
     public static synchronized Toolkit getToolkit() {
         if (TOOLKIT != null) {
             return TOOLKIT;
         }
 
-        AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
             // Get the javafx.version and javafx.runtime.version from a preconstructed
             // java class, VersionInfo, created at build time.
             VersionInfo.setupSystemProperties();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -107,6 +107,7 @@ public abstract class Toolkit {
 
     private static final Map gradientMap = new WeakHashMap();
 
+    @SuppressWarnings("removal")
     private static final boolean verbose = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("javafx.verbose"));
 
     private static final String[] msLibNames = {
@@ -197,6 +198,7 @@ public abstract class Toolkit {
         throw new UnsupportedOperationException(System.getProperty("os.name") + " is not supported");
     }
 
+    @SuppressWarnings("removal")
     public static synchronized Toolkit getToolkit() {
         if (TOOLKIT != null) {
             return TOOLKIT;
@@ -368,10 +370,10 @@ public abstract class Toolkit {
 
     public abstract boolean isNestedLoopRunning();
 
-    public abstract TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl, AccessControlContext acc);
+    public abstract TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl, @SuppressWarnings("removal") AccessControlContext acc);
 
-    public abstract TKStage createTKPopupStage(Window peerWindow, StageStyle popupStyle, TKStage owner, AccessControlContext acc);
-    public abstract TKStage createTKEmbeddedStage(HostInterface host, AccessControlContext acc);
+    public abstract TKStage createTKPopupStage(Window peerWindow, StageStyle popupStyle, TKStage owner, @SuppressWarnings("removal") AccessControlContext acc);
+    public abstract TKStage createTKEmbeddedStage(HostInterface host, @SuppressWarnings("removal") AccessControlContext acc);
 
     /**
      * Creates an AppletWindow using the provided window pointer as the parent
@@ -391,18 +393,23 @@ public abstract class Toolkit {
      */
     public abstract void closeAppletWindow();
 
+    @SuppressWarnings("removal")
     private final Map<TKPulseListener,AccessControlContext> stagePulseListeners =
             new WeakHashMap<TKPulseListener,AccessControlContext>();
+    @SuppressWarnings("removal")
     private final Map<TKPulseListener,AccessControlContext> scenePulseListeners =
             new WeakHashMap<TKPulseListener,AccessControlContext>();
+    @SuppressWarnings("removal")
     private final Map<TKPulseListener,AccessControlContext> postScenePulseListeners =
             new WeakHashMap<TKPulseListener,AccessControlContext>();
+    @SuppressWarnings("removal")
     private final Map<TKListener,AccessControlContext> toolkitListeners =
             new WeakHashMap<TKListener,AccessControlContext>();
 
     // The set of shutdown hooks is strongly held to avoid premature GC.
     private final Set<Runnable> shutdownHooks = new HashSet<Runnable>();
 
+    @SuppressWarnings("removal")
     private void runPulse(final TKPulseListener listener,
             final AccessControlContext acc) {
 
@@ -421,10 +428,13 @@ public abstract class Toolkit {
         // and those changes propogated to scene before it gets its pulse to update
 
         // Copy of listener map
+        @SuppressWarnings("removal")
         final Map<TKPulseListener,AccessControlContext> stagePulseList =
                 new WeakHashMap<TKPulseListener,AccessControlContext>();
+        @SuppressWarnings("removal")
         final Map<TKPulseListener,AccessControlContext> scenePulseList =
                 new WeakHashMap<TKPulseListener,AccessControlContext>();
+        @SuppressWarnings("removal")
         final Map<TKPulseListener,AccessControlContext> postScenePulseList =
                 new WeakHashMap<TKPulseListener,AccessControlContext>();
 
@@ -433,13 +443,13 @@ public abstract class Toolkit {
             scenePulseList.putAll(scenePulseListeners);
             postScenePulseList.putAll(postScenePulseListeners);
         }
-        for (Map.Entry<TKPulseListener,AccessControlContext> entry : stagePulseList.entrySet()) {
+        for (@SuppressWarnings("removal") Map.Entry<TKPulseListener,AccessControlContext> entry : stagePulseList.entrySet()) {
             runPulse(entry.getKey(), entry.getValue());
         }
-        for (Map.Entry<TKPulseListener,AccessControlContext> entry : scenePulseList.entrySet()) {
+        for (@SuppressWarnings("removal") Map.Entry<TKPulseListener,AccessControlContext> entry : scenePulseList.entrySet()) {
             runPulse(entry.getKey(), entry.getValue());
         }
-        for (Map.Entry<TKPulseListener,AccessControlContext> entry : postScenePulseList.entrySet()) {
+        for (@SuppressWarnings("removal") Map.Entry<TKPulseListener,AccessControlContext> entry : postScenePulseList.entrySet()) {
             runPulse(entry.getKey(), entry.getValue());
         }
 
@@ -452,6 +462,7 @@ public abstract class Toolkit {
             return;
         }
         synchronized (this) {
+            @SuppressWarnings("removal")
             AccessControlContext acc = AccessController.getContext();
             stagePulseListeners.put(listener, acc);
         }
@@ -466,6 +477,7 @@ public abstract class Toolkit {
             return;
         }
         synchronized (this) {
+            @SuppressWarnings("removal")
             AccessControlContext acc = AccessController.getContext();
             scenePulseListeners.put(listener, acc);
         }
@@ -480,6 +492,7 @@ public abstract class Toolkit {
             return;
         }
         synchronized (this) {
+            @SuppressWarnings("removal")
             AccessControlContext acc = AccessController.getContext();
             postScenePulseListeners.put(listener, acc);
         }
@@ -494,6 +507,7 @@ public abstract class Toolkit {
         if (listener == null) {
             return;
         }
+        @SuppressWarnings("removal")
         AccessControlContext acc = AccessController.getContext();
         toolkitListeners.put(listener, acc);
     }
@@ -503,7 +517,9 @@ public abstract class Toolkit {
     }
 
     private TKPulseListener lastTkPulseListener = null;
+    @SuppressWarnings("removal")
     private AccessControlContext lastTkPulseAcc = null;
+    @SuppressWarnings("removal")
     public void setLastTkPulseListener(TKPulseListener listener) {
         lastTkPulseAcc = AccessController.getContext();
         lastTkPulseListener = listener;
@@ -536,6 +552,7 @@ public abstract class Toolkit {
         }
     }
 
+    @SuppressWarnings("removal")
     public void notifyWindowListeners(final List<TKStage> windows) {
         for (Map.Entry<TKListener,AccessControlContext> entry : toolkitListeners.entrySet()) {
             final TKListener listener = entry.getKey();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/EmbeddedScene.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/EmbeddedScene.java
@@ -199,6 +199,7 @@ final class EmbeddedScene extends GlassScene implements EmbeddedSceneInterface {
         return false;
     }
 
+    @SuppressWarnings("removal")
     @Override
     public void setSize(final int width, final int height) {
         Platform.runLater(() -> {
@@ -268,6 +269,7 @@ final class EmbeddedScene extends GlassScene implements EmbeddedSceneInterface {
         return super.getClearColor();
     }
 
+    @SuppressWarnings("removal")
     @Override
     public void mouseEvent(final int type, final int button,
                            final boolean primaryBtnDown, final boolean middleBtnDown, final boolean secondaryBtnDown,
@@ -296,6 +298,7 @@ final class EmbeddedScene extends GlassScene implements EmbeddedSceneInterface {
         });
     }
 
+    @SuppressWarnings("removal")
     @Override
     public void scrollEvent(final int type,
                             final double scrollX, final double scrollY,
@@ -319,6 +322,7 @@ final class EmbeddedScene extends GlassScene implements EmbeddedSceneInterface {
         }
     }
 
+    @SuppressWarnings("removal")
     @Override
     public void inputMethodEvent(final EventType<InputMethodEvent> type,
                                  final ObservableList<InputMethodTextRun> composed, final String committed,
@@ -333,6 +337,7 @@ final class EmbeddedScene extends GlassScene implements EmbeddedSceneInterface {
         });
     }
 
+    @SuppressWarnings("removal")
     @Override
     public void menuEvent(final int x, final int y, final int xAbs, final int yAbs, final boolean isKeyboardTrigger) {
         Platform.runLater(() -> {
@@ -345,6 +350,7 @@ final class EmbeddedScene extends GlassScene implements EmbeddedSceneInterface {
         });
     }
 
+    @SuppressWarnings("removal")
     @Override
     public void keyEvent(final int type, final int key, final char[] ch, final int modifiers) {
         Platform.runLater(() -> {
@@ -369,6 +375,7 @@ final class EmbeddedScene extends GlassScene implements EmbeddedSceneInterface {
         });
     }
 
+    @SuppressWarnings("removal")
     @Override
     public void zoomEvent(final int type, final double zoomFactor, final double totalZoomFactor,
                           final double x, final double y, final double screenX, final double screenY,
@@ -388,6 +395,7 @@ final class EmbeddedScene extends GlassScene implements EmbeddedSceneInterface {
         });
     }
 
+    @SuppressWarnings("removal")
     @Override
     public void rotateEvent(final int type, final double angle, final double totalAngle,
                           final double x, final double y, final double screenX, final double screenY,
@@ -407,6 +415,7 @@ final class EmbeddedScene extends GlassScene implements EmbeddedSceneInterface {
         });
     }
 
+    @SuppressWarnings("removal")
     @Override
     public void swipeEvent(final int type, final double x, final double y, final double screenX, final double screenY,
                             boolean shift, boolean ctrl, boolean alt, boolean meta)

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/EmbeddedStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/EmbeddedStage.java
@@ -48,7 +48,7 @@ final class EmbeddedStage extends GlassStage implements EmbeddedStageInterface {
     // TKStage methods
 
     @Override
-    public TKScene createTKScene(boolean depthBuffer, boolean msaa, AccessControlContext acc) {
+    public TKScene createTKScene(boolean depthBuffer, boolean msaa, @SuppressWarnings("removal") AccessControlContext acc) {
         EmbeddedScene scene = new EmbeddedScene(host, depthBuffer, msaa);
         scene.setSecurityContext(acc);
         return scene;
@@ -220,6 +220,7 @@ final class EmbeddedStage extends GlassStage implements EmbeddedStageInterface {
         host.ungrabFocus();
     }
 
+    @SuppressWarnings("removal")
     private void notifyStageListener(final Runnable r) {
         AccessControlContext acc = getAccessControlContext();
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassScene.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassScene.java
@@ -75,6 +75,7 @@ abstract class GlassScene implements TKScene {
 
     SceneState sceneState;
 
+    @SuppressWarnings("removal")
     private AccessControlContext accessCtrlCtx = null;
 
     protected GlassScene(boolean depthBuffer, boolean msaa) {
@@ -99,6 +100,7 @@ abstract class GlassScene implements TKScene {
     }
 
     // To be used by subclasses to enforce context check
+    @SuppressWarnings("removal")
     @Override
     public final AccessControlContext getAccessControlContext() {
         if (accessCtrlCtx == null) {
@@ -107,6 +109,7 @@ abstract class GlassScene implements TKScene {
         return accessCtrlCtx;
     }
 
+    @SuppressWarnings("removal")
     public final void setSecurityContext(AccessControlContext ctx) {
         if (accessCtrlCtx != null) {
             throw new RuntimeException("Scene security context has been already set!");
@@ -239,6 +242,7 @@ abstract class GlassScene implements TKScene {
 
     @Override
     public TKClipboard createDragboard(boolean isDragSource) {
+        @SuppressWarnings("removal")
         ClipboardAssistance assistant = new ClipboardAssistance(Clipboard.DND) {
             @Override
             public void actionPerformed(final int performedAction) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassSceneDnDEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassSceneDnDEventHandler.java
@@ -68,6 +68,7 @@ class GlassSceneDnDEventHandler {
         return 1.0;
     }
 
+    @SuppressWarnings("removal")
     public TransferMode handleDragEnter(final int x, final int y, final int xAbs, final int yAbs,
                                         final TransferMode recommendedTransferMode,
                                         final ClipboardAssistance dropTargetAssistant)
@@ -86,6 +87,7 @@ class GlassSceneDnDEventHandler {
         }, scene.getAccessControlContext());
     }
 
+    @SuppressWarnings("removal")
     public void handleDragLeave(final ClipboardAssistance dropTargetAssistant) {
         assert Platform.isFxApplicationThread();
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
@@ -96,6 +98,7 @@ class GlassSceneDnDEventHandler {
         }, scene.getAccessControlContext());
     }
 
+    @SuppressWarnings("removal")
     public TransferMode handleDragDrop(final int x, final int y, final int xAbs, final int yAbs,
                                        final TransferMode recommendedTransferMode,
                                        final ClipboardAssistance dropTargetAssistant)
@@ -112,6 +115,7 @@ class GlassSceneDnDEventHandler {
         }, scene.getAccessControlContext());
     }
 
+    @SuppressWarnings("removal")
     public TransferMode handleDragOver(final int x, final int y, final int xAbs, final int yAbs,
                                        final TransferMode recommendedTransferMode,
                                        final ClipboardAssistance dropTargetAssistant)
@@ -134,6 +138,7 @@ class GlassSceneDnDEventHandler {
     // detected. This mechanism is currently not used in FX, as we have
     // a custom gesture recognizer in Scene, and DnD is started with
     // Toolkit.startDrag().
+    @SuppressWarnings("removal")
     public void handleDragStart(final int button, final int x, final int y, final int xAbs, final int yAbs,
                                 final ClipboardAssistance dragSourceAssistant)
     {
@@ -154,6 +159,7 @@ class GlassSceneDnDEventHandler {
     // This is a callback from the native platform, when the drag was started
     // from handleDragStart() above, or when FX as a drag source is embedded
     // to Swing/SWT.
+    @SuppressWarnings("removal")
     public void handleDragEnd(final TransferMode performedTransferMode,
                               final ClipboardAssistance dragSourceAssistant)
     {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassStage.java
@@ -57,6 +57,7 @@ abstract class GlassStage implements TKStage {
 
     private boolean important = true;
 
+    @SuppressWarnings("removal")
     private AccessControlContext accessCtrlCtx = null;
 
     protected static final AtomicReference<GlassStage> activeFSWindow = new AtomicReference<>();
@@ -96,6 +97,7 @@ abstract class GlassStage implements TKStage {
     }
 
     // To be used by subclasses to enforce context check
+    @SuppressWarnings("removal")
     final AccessControlContext getAccessControlContext() {
         if (accessCtrlCtx == null) {
             throw new RuntimeException("Stage security context has not been set!");
@@ -103,6 +105,7 @@ abstract class GlassStage implements TKStage {
         return accessCtrlCtx;
     }
 
+    @SuppressWarnings("removal")
     static AccessControlContext doIntersectionPrivilege(PrivilegedAction<AccessControlContext> action,
                                                        AccessControlContext stack,
                                                        AccessControlContext context) {
@@ -113,6 +116,7 @@ abstract class GlassStage implements TKStage {
         },  context);
     }
 
+    @SuppressWarnings("removal")
     public final void setSecurityContext(AccessControlContext ctx) {
         if (accessCtrlCtx != null) {
             throw new RuntimeException("Stage security context has been already set!");
@@ -187,6 +191,7 @@ abstract class GlassStage implements TKStage {
     }
 
     // Cmd+Q action
+    @SuppressWarnings("removal")
     static void requestClosingAllWindows() {
         GlassStage fsWindow = activeFSWindow.get();
         if (fsWindow != null) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
@@ -63,14 +63,14 @@ import javafx.scene.input.ZoomEvent;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-@SuppressWarnings("removal")
 class GlassViewEventHandler extends View.EventHandler {
 
     static boolean zoomGestureEnabled;
     static boolean rotateGestureEnabled;
     static boolean scrollGestureEnabled;
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             zoomGestureEnabled = Boolean.valueOf(System.getProperty("com.sun.javafx.gestures.zoom", "false"));
             rotateGestureEnabled = Boolean.valueOf(System.getProperty("com.sun.javafx.gestures.rotate", "false"));
             scrollGestureEnabled = Boolean.valueOf(System.getProperty("com.sun.javafx.gestures.scroll", "false"));
@@ -235,6 +235,7 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
+    @SuppressWarnings("removal")
     @Override public void handleKeyEvent(View view, long time, int type, int key,
                                          char[] chars, int modifiers)
     {
@@ -427,6 +428,7 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
+    @SuppressWarnings("removal")
     @Override
     public void handleMouseEvent(View view, long time, int type, int button,
                                  int x, int y, int xAbs, int yAbs,
@@ -449,6 +451,7 @@ class GlassViewEventHandler extends View.EventHandler {
         });
     }
 
+    @SuppressWarnings("removal")
     @Override public void handleMenuEvent(final View view,
                                           final int x, final int y, final int xAbs, final int yAbs,
                                           final boolean isKeyboardTrigger)
@@ -500,6 +503,7 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
+    @SuppressWarnings("removal")
     @Override public void handleScrollEvent(final View view, final long time,
                                             final int x, final int y, final int xAbs, final int yAbs,
                                             final double deltaX, final double deltaY, final int modifiers,
@@ -624,6 +628,7 @@ class GlassViewEventHandler extends View.EventHandler {
         return composed;
     }
 
+    @SuppressWarnings("removal")
     @Override public void handleInputMethodEvent(final long time, final String text,
                                                  final int[] clauseBoundary,
                                                  final int[] attrBoundary, final byte[] attrValue,
@@ -913,6 +918,7 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
+    @SuppressWarnings("removal")
     @Override public void handleViewEvent(View view, long time, final int type) {
         if (PULSE_LOGGING_ENABLED) {
             PulseLogger.newInput("VIEW_EVENT: "+ViewEvent.getTypeString(type));
@@ -932,6 +938,7 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
+    @SuppressWarnings("removal")
     @Override public void handleScrollGestureEvent(
             View view, final long time, final int type,
             final int modifiers, final boolean isDirect, final boolean isInertia, final int touchCount,
@@ -1009,6 +1016,7 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
+    @SuppressWarnings("removal")
     @Override public void handleZoomGestureEvent(
             View view, final long time, final int type,
             final int modifiers, final boolean isDirect, final boolean isInertia,
@@ -1085,6 +1093,7 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
+    @SuppressWarnings("removal")
     @Override public void handleRotateGestureEvent(
             View view, final long time, final int type,
             final int modifiers, final boolean isDirect, final boolean isInertia,
@@ -1159,6 +1168,7 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
+    @SuppressWarnings("removal")
     @Override public void handleSwipeGestureEvent(
             View view, final long time, int type,
             final int modifiers, final boolean isDirect,
@@ -1235,6 +1245,7 @@ class GlassViewEventHandler extends View.EventHandler {
         }
     }
 
+    @SuppressWarnings("removal")
     @Override public void handleBeginTouchEvent(
             View view, final long time, final int modifiers,
             final boolean isDirect, final int touchEventCount)
@@ -1272,6 +1283,7 @@ class GlassViewEventHandler extends View.EventHandler {
         gestures.notifyBeginTouchEvent(time, modifiers, isDirect, touchEventCount);
     }
 
+    @SuppressWarnings("removal")
     @Override public void handleNextTouchEvent(
             View view, final long time, final int type, final long touchId,
             final int x, final int y, final int xAbs, final int yAbs)
@@ -1342,6 +1354,7 @@ class GlassViewEventHandler extends View.EventHandler {
         gestures.notifyNextTouchEvent(time, type, touchId, x, y, xAbs, yAbs);
     }
 
+    @SuppressWarnings("removal")
     @Override public void handleEndTouchEvent(View view, long time) {
         if (PULSE_LOGGING_ENABLED) {
             PulseLogger.newInput("END_TOUCH_EVENT");

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
@@ -63,6 +63,7 @@ import javafx.scene.input.ZoomEvent;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+@SuppressWarnings("removal")
 class GlassViewEventHandler extends View.EventHandler {
 
     static boolean zoomGestureEnabled;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassWindowEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassWindowEventHandler.java
@@ -155,6 +155,7 @@ class GlassWindowEventHandler extends Window.EventHandler implements PrivilegedA
         return null;
     }
 
+    @SuppressWarnings("removal")
     @Override
     public void handleLevelEvent(int level) {
         QuantumToolkit.runWithoutRenderLock(() -> {
@@ -166,6 +167,7 @@ class GlassWindowEventHandler extends Window.EventHandler implements PrivilegedA
         });
     }
 
+    @SuppressWarnings("removal")
     @Override
     public void handleWindowEvent(final Window window, final long time, final int type) {
         this.window = window;
@@ -177,6 +179,7 @@ class GlassWindowEventHandler extends Window.EventHandler implements PrivilegedA
         });
     }
 
+    @SuppressWarnings("removal")
     @Override
     public void handleScreenChangedEvent(Window window, long time, Screen oldScreen, Screen newScreen) {
         GlassScene scene = stage.getScene();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PerformanceLogger.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PerformanceLogger.java
@@ -73,6 +73,7 @@ import java.io.Writer;
  * Note: This file a copy for sun.misc.PerformanceLogger before it was moved to
  * sun.awt.util and JavaFX do not want to be dependent on awt if possible.
  */
+@SuppressWarnings("removal")
 public class PerformanceLogger {
 
     // Timing values of global interest

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PerformanceLogger.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PerformanceLogger.java
@@ -73,7 +73,6 @@ import java.io.Writer;
  * Note: This file a copy for sun.misc.PerformanceLogger before it was moved to
  * sun.awt.util and JavaFX do not want to be dependent on awt if possible.
  */
-@SuppressWarnings("removal")
 public class PerformanceLogger {
 
     // Timing values of global interest
@@ -88,6 +87,7 @@ public class PerformanceLogger {
     private static long baseTime;
 
     static {
+        @SuppressWarnings("removal")
         String perfLoggingProp =
             java.security.AccessController.doPrivileged(
                     new java.security.PrivilegedAction<String>() {
@@ -99,6 +99,7 @@ public class PerformanceLogger {
             perfLoggingOn = true;
 
             // Check if we should use nanoTime
+            @SuppressWarnings("removal")
             String perfNanoProp =
                 java.security.AccessController.doPrivileged(
                     new java.security.PrivilegedAction<String>() {
@@ -116,7 +117,8 @@ public class PerformanceLogger {
             }
             if (logFileName != null) {
                 if (logWriter == null) {
-                    java.security.AccessController.doPrivileged(
+                    @SuppressWarnings("removal")
+                    var dummy = java.security.AccessController.doPrivileged(
                     new java.security.PrivilegedAction<Void>() {
                         public Void run() {
                             try {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PerformanceTrackerHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PerformanceTrackerHelper.java
@@ -46,6 +46,7 @@ abstract class PerformanceTrackerHelper {
     }
 
     private static PerformanceTrackerHelper createInstance() {
+        @SuppressWarnings("removal")
         PerformanceTrackerHelper trackerImpl = AccessController.doPrivileged(
                 new PrivilegedAction<PerformanceTrackerHelper>() {
 
@@ -129,6 +130,7 @@ abstract class PerformanceTrackerHelper {
                 // Attempt to log launchTime, if not set already
                 if (PerformanceLogger.getStartTime() <= 0) {
                     // Standalone apps record launch time as sysprop
+                    @SuppressWarnings("removal")
                     String launchTimeString = AccessController.doPrivileged(
                             (PrivilegedAction<String>) () -> System.getProperty("launchTime"));
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PrismImageLoader2.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PrismImageLoader2.java
@@ -228,12 +228,14 @@ class PrismImageLoader2 implements com.sun.javafx.tk.ImageLoader {
         private static final ExecutorService BG_LOADING_EXECUTOR =
                 createExecutor();
 
+        @SuppressWarnings("removal")
         private final AccessControlContext acc;
 
         double width, height;
         boolean preserveRatio;
         boolean smooth;
 
+        @SuppressWarnings("removal")
         public AsyncImageLoader(
                 AsyncOperationListener<PrismImageLoader2> listener,
                 String url,
@@ -252,6 +254,7 @@ class PrismImageLoader2 implements com.sun.javafx.tk.ImageLoader {
             return new PrismImageLoader2(stream, width, height, preserveRatio, smooth);
         }
 
+        @SuppressWarnings("removal")
         @Override
         public PrismImageLoader2 call() throws IOException {
             try {
@@ -274,6 +277,7 @@ class PrismImageLoader2 implements com.sun.javafx.tk.ImageLoader {
         }
 
         private static ExecutorService createExecutor() {
+            @SuppressWarnings("removal")
             final ThreadGroup bgLoadingThreadGroup =
                     AccessController.doPrivileged(
                             (PrivilegedAction<ThreadGroup>) () -> new ThreadGroup(
@@ -282,6 +286,7 @@ class PrismImageLoader2 implements com.sun.javafx.tk.ImageLoader {
                                 "Background image loading thread pool")
                     );
 
+            @SuppressWarnings("removal")
             final ThreadFactory bgLoadingThreadFactory =
                     runnable -> AccessController.doPrivileged(
                             (PrivilegedAction<Thread>) () -> {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumClipboard.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumClipboard.java
@@ -85,6 +85,7 @@ final class QuantumClipboard implements TKClipboard {
      *      javafx.scene.input.Clipboard
      *          ... user code ...
      */
+    @SuppressWarnings("removal")
     private AccessControlContext accessContext = null;
 
     /**
@@ -126,13 +127,14 @@ final class QuantumClipboard implements TKClipboard {
     private QuantumClipboard() {
     }
 
-    @Override public void setSecurityContext(AccessControlContext acc) {
+    @Override public void setSecurityContext(@SuppressWarnings("removal") AccessControlContext acc) {
         if (accessContext != null) {
             throw new RuntimeException("Clipboard security context has been already set!");
         }
         accessContext = acc;
     }
 
+    @SuppressWarnings("removal")
     private AccessControlContext getAccessControlContext() {
         if (accessContext == null) {
             throw new RuntimeException("Clipboard security context has not been set!");
@@ -371,8 +373,10 @@ final class QuantumClipboard implements TKClipboard {
                 String url = parseIMG(htmlData);
                 if (url != null) {
                     try {
+                        @SuppressWarnings("removal")
                         SecurityManager sm = System.getSecurityManager();
                         if (sm != null) {
+                            @SuppressWarnings("removal")
                             AccessControlContext context = getAccessControlContext();
                             URL u = new URL(url);
                             String protocol = u.getProtocol();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumRenderer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumRenderer.java
@@ -55,6 +55,7 @@ import java.util.HashMap;
  * Quantum Renderer
  */
 final class QuantumRenderer extends ThreadPoolExecutor  {
+    @SuppressWarnings("removal")
     private static boolean usePurgatory = // TODO - deprecate
         AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("decora.purgatory"));
 
@@ -132,6 +133,7 @@ final class QuantumRenderer extends ThreadPoolExecutor  {
     private class QuantumThreadFactory implements ThreadFactory {
         final AtomicInteger threadNumber = new AtomicInteger(0);
 
+        @SuppressWarnings("removal")
         @Override public Thread newThread(Runnable r) {
             final PipelineRunnable pipeline = new PipelineRunnable(r);
             _renderer =
@@ -191,6 +193,7 @@ final class QuantumRenderer extends ThreadPoolExecutor  {
         }
     }
 
+    @SuppressWarnings("removal")
     protected void stopRenderer() {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             shutdown();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
@@ -247,7 +247,6 @@ public final class QuantumToolkit extends Toolkit {
 
     private final PerformanceTracker perfTracker = new PerformanceTrackerImpl();
 
-    @SuppressWarnings("removal")
     @Override public boolean init() {
         /*
          * Glass Mac, X11 need Application.setDeviceDetails to happen prior to Glass Application.Run
@@ -264,7 +263,8 @@ public final class QuantumToolkit extends Toolkit {
                 dispose();
             }
         };
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             Runtime.getRuntime().addShutdownHook(shutdownHook);
             return null;
         });

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
@@ -137,12 +137,15 @@ import java.util.Optional;
 
 public final class QuantumToolkit extends Toolkit {
 
+    @SuppressWarnings("removal")
     public static final boolean verbose =
             AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("quantum.verbose"));
 
+    @SuppressWarnings("removal")
     public static final boolean pulseDebug =
             AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("quantum.pulse"));
 
+    @SuppressWarnings("removal")
     private static final boolean multithreaded =
             AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
                 // If it is not specified, or it is true, then it should
@@ -156,12 +159,15 @@ public final class QuantumToolkit extends Toolkit {
                 return result;
             });
 
+    @SuppressWarnings("removal")
     private static boolean debug =
             AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("quantum.debug"));
 
+    @SuppressWarnings("removal")
     private static Integer pulseHZ =
             AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Integer.getInteger("javafx.animation.pulse"));
 
+    @SuppressWarnings("removal")
     static final boolean liveResize =
             AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
                 boolean isSWT = "swt".equals(System.getProperty("glass.platform"));
@@ -169,12 +175,14 @@ public final class QuantumToolkit extends Toolkit {
                 return "true".equals(System.getProperty("javafx.live.resize", result));
             });
 
+    @SuppressWarnings("removal")
     static final boolean drawInPaint =
             AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
                 boolean isSWT = "swt".equals(System.getProperty("glass.platform"));
                 String result = PlatformUtil.isMac() && isSWT ? "true" : "false";
                 return "true".equals(System.getProperty("javafx.draw.in.paint", result));});
 
+    @SuppressWarnings("removal")
     private static boolean singleThreaded =
             AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
                 Boolean result = Boolean.getBoolean("quantum.singlethreaded");
@@ -184,6 +192,7 @@ public final class QuantumToolkit extends Toolkit {
                 return result;
             });
 
+    @SuppressWarnings("removal")
     private static boolean noRenderJobs =
             AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
                 Boolean result = Boolean.getBoolean("quantum.norenderjobs");
@@ -238,6 +247,7 @@ public final class QuantumToolkit extends Toolkit {
 
     private final PerformanceTracker perfTracker = new PerformanceTrackerImpl();
 
+    @SuppressWarnings("removal")
     @Override public boolean init() {
         /*
          * Glass Mac, X11 need Application.setDeviceDetails to happen prior to Glass Application.Run
@@ -596,7 +606,7 @@ public final class QuantumToolkit extends Toolkit {
         }
     }
 
-    @Override public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl, AccessControlContext acc) {
+    @Override public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl, @SuppressWarnings("removal") AccessControlContext acc) {
         assertToolkitRunning();
         WindowStage stage = new WindowStage(peerWindow, securityDialog, stageStyle, modality, owner);
         stage.setSecurityContext(acc);
@@ -669,7 +679,7 @@ public final class QuantumToolkit extends Toolkit {
     @Override public TKStage createTKPopupStage(Window peerWindow,
                                                 StageStyle popupStyle,
                                                 TKStage owner,
-                                                AccessControlContext acc) {
+                                                @SuppressWarnings("removal") AccessControlContext acc) {
         assertToolkitRunning();
         boolean securityDialog = owner instanceof WindowStage ?
                 ((WindowStage)owner).isSecurityDialog() : false;
@@ -680,7 +690,7 @@ public final class QuantumToolkit extends Toolkit {
         return stage;
     }
 
-    @Override public TKStage createTKEmbeddedStage(HostInterface host, AccessControlContext acc) {
+    @Override public TKStage createTKEmbeddedStage(HostInterface host, @SuppressWarnings("removal") AccessControlContext acc) {
         assertToolkitRunning();
         EmbeddedStage stage = new EmbeddedStage(host);
         stage.setSecurityContext(acc);
@@ -838,6 +848,7 @@ public final class QuantumToolkit extends Toolkit {
         super.exit();
     }
 
+    @SuppressWarnings("removal")
     public void dispose() {
         if (toolkitRunning.compareAndSet(true, false)) {
             pulseTimer.stop();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/RotateGestureRecognizer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/RotateGestureRecognizer.java
@@ -44,7 +44,6 @@ import javafx.animation.Timeline;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 
-@SuppressWarnings("removal")
 class RotateGestureRecognizer implements GestureRecognizer {
     private ViewScene scene;
 
@@ -54,7 +53,8 @@ class RotateGestureRecognizer implements GestureRecognizer {
     private static double MAX_INITIAL_VELOCITY = 500;
     private static double ROTATION_INERTIA_MILLIS = 1500;
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             String s = System.getProperty("com.sun.javafx.gestures.rotate.threshold");
             if (s != null) {
                 ROTATATION_THRESHOLD = Double.valueOf(s);
@@ -318,6 +318,7 @@ class RotateGestureRecognizer implements GestureRecognizer {
         }
     }
 
+    @SuppressWarnings("removal")
     private void sendRotateStartedEvent() {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             if (scene.sceneListener != null) {
@@ -336,6 +337,7 @@ class RotateGestureRecognizer implements GestureRecognizer {
         }, scene.getAccessControlContext());
     }
 
+    @SuppressWarnings("removal")
     private void sendRotateEvent(boolean isInertia) {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             if (scene.sceneListener != null) {
@@ -353,6 +355,7 @@ class RotateGestureRecognizer implements GestureRecognizer {
         }, scene.getAccessControlContext());
     }
 
+    @SuppressWarnings("removal")
     private void sendRotateFinishedEvent() {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             if (scene.sceneListener != null) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/RotateGestureRecognizer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/RotateGestureRecognizer.java
@@ -44,6 +44,7 @@ import javafx.animation.Timeline;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 
+@SuppressWarnings("removal")
 class RotateGestureRecognizer implements GestureRecognizer {
     private ViewScene scene;
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ScrollGestureRecognizer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ScrollGestureRecognizer.java
@@ -43,6 +43,7 @@ import javafx.animation.Timeline;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 
+@SuppressWarnings("removal")
 class ScrollGestureRecognizer implements GestureRecognizer {
     // gesture will be activated if |scroll amount| > SCROLL_THRESHOLD
     private static double SCROLL_THRESHOLD = 10; //in pixels

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ScrollGestureRecognizer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ScrollGestureRecognizer.java
@@ -43,7 +43,6 @@ import javafx.animation.Timeline;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 
-@SuppressWarnings("removal")
 class ScrollGestureRecognizer implements GestureRecognizer {
     // gesture will be activated if |scroll amount| > SCROLL_THRESHOLD
     private static double SCROLL_THRESHOLD = 10; //in pixels
@@ -51,7 +50,8 @@ class ScrollGestureRecognizer implements GestureRecognizer {
     private static double MAX_INITIAL_VELOCITY = 1000;
     private static double SCROLL_INERTIA_MILLIS = 1500;
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             String s = System.getProperty("com.sun.javafx.gestures.scroll.threshold");
             if (s != null) {
                 SCROLL_THRESHOLD = Double.valueOf(s);
@@ -263,6 +263,7 @@ class ScrollGestureRecognizer implements GestureRecognizer {
         }
     }
 
+    @SuppressWarnings("removal")
     private void sendScrollStartedEvent(double xAbs, double yAbs, int touchCount) {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             if (scene.sceneListener != null) {
@@ -284,6 +285,7 @@ class ScrollGestureRecognizer implements GestureRecognizer {
         }, scene.getAccessControlContext());
     }
 
+    @SuppressWarnings("removal")
     private void sendScrollEvent(boolean isInertia, double xAbs, double yAbs, int touchCount) {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             if (scene.sceneListener != null) {
@@ -305,6 +307,7 @@ class ScrollGestureRecognizer implements GestureRecognizer {
         }, scene.getAccessControlContext());
     }
 
+    @SuppressWarnings("removal")
     private void sendScrollFinishedEvent(double xAbs, double yAbs, int touchCount) {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             if (scene.sceneListener != null) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/SwipeGestureRecognizer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/SwipeGestureRecognizer.java
@@ -148,6 +148,7 @@ class SwipeGestureRecognizer implements GestureRecognizer {
         }
     }
 
+    @SuppressWarnings("removal")
     private void handleSwipeType(final EventType<SwipeEvent> swipeType,
             final CenterComputer cc, final int touchCount, final int modifiers, final boolean isDirect)
     {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
@@ -259,7 +259,7 @@ class WindowStage extends GlassStage {
         return style;
     }
 
-    @Override public TKScene createTKScene(boolean depthBuffer, boolean msaa, AccessControlContext acc) {
+    @Override public TKScene createTKScene(boolean depthBuffer, boolean msaa, @SuppressWarnings("removal") AccessControlContext acc) {
         ViewScene scene = new ViewScene(depthBuffer, msaa);
         scene.setSecurityContext(acc);
         return scene;
@@ -630,6 +630,7 @@ class WindowStage extends GlassStage {
 
     private boolean hasPermission(Permission perm) {
         try {
+            @SuppressWarnings("removal")
             final SecurityManager sm = System.getSecurityManager();
             if (sm != null) {
                 sm.checkPermission(perm, getAccessControlContext());
@@ -762,6 +763,7 @@ class WindowStage extends GlassStage {
         }
     }
 
+    @SuppressWarnings("removal")
     void fullscreenChanged(final boolean fs) {
         if (!fs) {
             if (activeFSWindow.compareAndSet(this, null)) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ZoomGestureRecognizer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ZoomGestureRecognizer.java
@@ -43,7 +43,6 @@ import javafx.animation.Timeline;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 
-@SuppressWarnings("removal")
 class ZoomGestureRecognizer implements GestureRecognizer {
     // gesture will be activated if |zoomFactor - 1| > ZOOM_FACTOR_THRESHOLD
     private static double ZOOM_FACTOR_THRESHOLD = 0.1;
@@ -55,7 +54,8 @@ class ZoomGestureRecognizer implements GestureRecognizer {
     private static double MAX_ZOOM_OUT_FACTOR = 0.1;
 
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             String s = System.getProperty("com.sun.javafx.gestures.zoom.threshold");
             if (s != null) {
                 ZOOM_FACTOR_THRESHOLD = Double.valueOf(s);
@@ -291,6 +291,7 @@ class ZoomGestureRecognizer implements GestureRecognizer {
         }
     }
 
+    @SuppressWarnings("removal")
     private void sendZoomStartedEvent() {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             if (scene.sceneListener != null) {
@@ -309,6 +310,7 @@ class ZoomGestureRecognizer implements GestureRecognizer {
         }, scene.getAccessControlContext());
     }
 
+    @SuppressWarnings("removal")
     private void sendZoomEvent(boolean isInertia) {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             if (scene.sceneListener != null) {
@@ -326,6 +328,7 @@ class ZoomGestureRecognizer implements GestureRecognizer {
         }, scene.getAccessControlContext());
     }
 
+    @SuppressWarnings("removal")
     private void sendZoomFinishedEvent() {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             if (scene.sceneListener != null) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ZoomGestureRecognizer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/ZoomGestureRecognizer.java
@@ -43,6 +43,7 @@ import javafx.animation.Timeline;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 
+@SuppressWarnings("removal")
 class ZoomGestureRecognizer implements GestureRecognizer {
     // gesture will be activated if |zoomFactor - 1| > ZOOM_FACTOR_THRESHOLD
     private static double ZOOM_FACTOR_THRESHOLD = 0.1;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/util/ModuleHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/util/ModuleHelper.java
@@ -30,6 +30,7 @@ import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+@SuppressWarnings("removal")
 public class ModuleHelper {
     private static final Method getModuleMethod;
     private static final Method addReadsMethod;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/util/ModuleHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/util/ModuleHelper.java
@@ -30,7 +30,6 @@ import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-@SuppressWarnings("removal")
 public class ModuleHelper {
     private static final Method getModuleMethod;
     private static final Method addReadsMethod;
@@ -39,8 +38,10 @@ public class ModuleHelper {
     private static final boolean verbose;
 
     static {
-        verbose = AccessController.doPrivileged((PrivilegedAction<Boolean>) () ->
+        @SuppressWarnings("removal")
+        boolean tmp = AccessController.doPrivileged((PrivilegedAction<Boolean>) () ->
                 Boolean.getBoolean("javafx.verbose"));
+        verbose = tmp;
 
         if (verbose) {
             System.err.println("" + ModuleHelper.class.getName() + " : <clinit>");

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/util/Utils.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/util/Utils.java
@@ -669,6 +669,7 @@ public class Utils {
     }
 
     public static boolean hasFullScreenStage(final Screen screen) {
+        @SuppressWarnings("removal")
         final List<Window> allWindows = AccessController.doPrivileged(
                 (PrivilegedAction<List<Window>>) () -> Window.getWindows(),
                 null,
@@ -974,6 +975,7 @@ public class Utils {
         return new String(dst, 0, dstIndex);
     }
 
+    @SuppressWarnings("removal")
     public static synchronized void loadNativeSwingLibrary() {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             String libName = "prism_common";

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/DMarlinRenderingEngine.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/DMarlinRenderingEngine.java
@@ -74,6 +74,7 @@ public final class DMarlinRenderingEngine implements MarlinConst
         USE_THREAD_LOCAL = MarlinProperties.isUseThreadLocal();
 
         // Soft reference by default:
+        @SuppressWarnings("removal")
         final String refType = AccessController.doPrivileged(
             (PrivilegedAction<String>) () -> {
                 String value = System.getProperty("prism.marlin.useRef");

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/MarlinProperties.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/MarlinProperties.java
@@ -242,6 +242,7 @@ public final class MarlinProperties {
     }
 
     // system property utilities
+    @SuppressWarnings("removal")
     static String getString(final String key, final String def) {
         return AccessController.doPrivileged(
             (PrivilegedAction<String>) () -> {
@@ -250,6 +251,7 @@ public final class MarlinProperties {
             });
     }
 
+    @SuppressWarnings("removal")
     static boolean getBoolean(final String key, final String def) {
         return Boolean.valueOf(AccessController.doPrivileged(
             (PrivilegedAction<String>) () -> {
@@ -261,6 +263,7 @@ public final class MarlinProperties {
     static int getInteger(final String key, final int def,
                                  final int min, final int max)
     {
+        @SuppressWarnings("removal")
         final String property = AccessController.doPrivileged(
                     (PrivilegedAction<String>) () -> System.getProperty(key));
 
@@ -291,6 +294,7 @@ public final class MarlinProperties {
                                    final double min, final double max)
     {
         double value = def;
+        @SuppressWarnings("removal")
         final String property = AccessController.doPrivileged(
                     (PrivilegedAction<String>) () -> System.getProperty(key));
 

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/OffHeapArray.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/OffHeapArray.java
@@ -34,6 +34,7 @@ import sun.misc.Unsafe;
 /**
  *
  */
+@SuppressWarnings("removal")
 final class OffHeapArray  {
 
     // unsafe reference

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/OffHeapArray.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/OffHeapArray.java
@@ -34,7 +34,6 @@ import sun.misc.Unsafe;
 /**
  *
  */
-@SuppressWarnings("removal")
 final class OffHeapArray  {
 
     // unsafe reference
@@ -43,7 +42,8 @@ final class OffHeapArray  {
     static final int SIZE_INT;
 
     static {
-        UNSAFE = AccessController.doPrivileged(new PrivilegedAction<Unsafe>() {
+        @SuppressWarnings("removal")
+        Unsafe tmp = AccessController.doPrivileged(new PrivilegedAction<Unsafe>() {
             @Override
             public Unsafe run() {
                 Unsafe ref = null;
@@ -57,6 +57,7 @@ final class OffHeapArray  {
                 return ref;
             }
         });
+        UNSAFE = tmp;
 
         SIZE_INT = Unsafe.ARRAY_INT_INDEX_SCALE;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/RendererStats.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/RendererStats.java
@@ -353,6 +353,7 @@ public final class RendererStats implements MarlinConst {
         private final ConcurrentLinkedQueue<RendererStats> allStats
             = new ConcurrentLinkedQueue<RendererStats>();
 
+        @SuppressWarnings("removal")
         private RendererStatsHolder() {
             AccessController.doPrivileged(
                 (PrivilegedAction<Void>) () -> {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPipeline.java
@@ -35,6 +35,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.List;
 
+@SuppressWarnings("removal")
 public final class D3DPipeline extends GraphicsPipeline {
 
     private static final boolean d3dEnabled;

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPipeline.java
@@ -35,7 +35,6 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.List;
 
-@SuppressWarnings("removal")
 public final class D3DPipeline extends GraphicsPipeline {
 
     private static final boolean d3dEnabled;
@@ -47,7 +46,8 @@ public final class D3DPipeline extends GraphicsPipeline {
 
     static {
 
-        d3dEnabled = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
+        @SuppressWarnings("removal")
+        boolean tmp = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
             if (PrismSettings.verbose) {
                 System.out.println("Loading D3D native library ...");
             }
@@ -57,6 +57,7 @@ public final class D3DPipeline extends GraphicsPipeline {
             }
             return Boolean.valueOf(nInit(PrismSettings.class, true));
         });
+        d3dEnabled = tmp;
 
         if (PrismSettings.verbose) {
             System.out.println("Direct3D initialization " + (d3dEnabled ? "succeeded" : "failed"));

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResourceFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DResourceFactory.java
@@ -418,6 +418,7 @@ class D3DResourceFactory extends BaseShaderFactory {
             throw new IllegalArgumentException("Shader name must be non-null");
         }
         try {
+            @SuppressWarnings("removal")
             InputStream stream = AccessController.doPrivileged(
                     (PrivilegedAction<InputStream>) () -> D3DResourceFactory.class.
                            getResourceAsStream("hlsl/" + name + ".obj")

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Pipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Pipeline.java
@@ -36,7 +36,6 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.HashMap;
 
-@SuppressWarnings("removal")
 public class ES2Pipeline extends GraphicsPipeline {
 
     public static final GLFactory glFactory;
@@ -49,7 +48,8 @@ public class ES2Pipeline extends GraphicsPipeline {
     private static boolean isEglfb = false;
 
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             String libName = "prism_es2";
 
             String eglType = PlatformUtil.getEmbeddedType();

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Pipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Pipeline.java
@@ -36,6 +36,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.HashMap;
 
+@SuppressWarnings("removal")
 public class ES2Pipeline extends GraphicsPipeline {
 
     public static final GLFactory glFactory;

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLFactory.java
@@ -31,7 +31,6 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.HashMap;
 
-@SuppressWarnings("removal")
 abstract class GLFactory {
 
     private static native boolean
@@ -83,8 +82,10 @@ abstract class GLFactory {
         if (PrismSettings.verbose) {
             System.out.println("GLFactory using " + factoryClassName);
         }
-        platformFactory = factoryClassName == null ? null :
+        @SuppressWarnings("removal")
+        GLFactory tmp = factoryClassName == null ? null :
             AccessController.doPrivileged(new FactoryLoader(factoryClassName));
+        platformFactory = tmp;
     }
 
     private static class FactoryLoader implements PrivilegedAction<GLFactory> {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLFactory.java
@@ -31,6 +31,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.HashMap;
 
+@SuppressWarnings("removal")
 abstract class GLFactory {
 
     private static native boolean

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLPixelFormat.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLPixelFormat.java
@@ -29,7 +29,6 @@ import java.lang.annotation.Native;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-@SuppressWarnings("removal")
 class GLPixelFormat {
     final private Attributes attributes;
     final private long nativeScreen;
@@ -38,7 +37,8 @@ class GLPixelFormat {
     private static int defaultBufferSize;
 
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
            defaultDepthSize = Integer.getInteger("prism.glDepthSize", 24);
            defaultBufferSize = Integer.getInteger("prism.glBufferSize", 32);
             return null;

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLPixelFormat.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLPixelFormat.java
@@ -29,6 +29,7 @@ import java.lang.annotation.Native;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+@SuppressWarnings("removal")
 class GLPixelFormat {
     final private Attributes attributes;
     final private long nativeScreen;

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/MonocleGLDrawable.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/MonocleGLDrawable.java
@@ -32,6 +32,7 @@ import java.security.PrivilegedAction;
 
 class MonocleGLDrawable extends GLDrawable {
 
+    @SuppressWarnings("removal")
     private static final boolean transparentFramebuffer =
             AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.getBoolean("com.sun.javafx.transparentFramebuffer"));
 

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/BufferUtil.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/BufferUtil.java
@@ -57,6 +57,7 @@ public class BufferUtil {
     private BufferUtil() {
     }
 
+    @SuppressWarnings("removal")
     public static void nativeOrder(ByteBuffer buf) {
         if (!isCDCFP) {
             try {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/PrismSettings.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/PrismSettings.java
@@ -112,6 +112,7 @@ public final class PrismSettings {
     }
 
     static {
+        @SuppressWarnings("removal")
         final Properties systemProperties =
                 (Properties) AccessController.doPrivileged(
                         (PrivilegedAction) () -> System.getProperties());

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/ps/BaseShaderGraphics.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/ps/BaseShaderGraphics.java
@@ -508,6 +508,7 @@ public abstract class BaseShaderGraphics
 
     private static final float FRINGE_FACTOR;
     static {
+        @SuppressWarnings("removal")
         String v = (String) AccessController.doPrivileged((PrivilegedAction) () -> System.getProperty("prism.primshaderpad"));
         if (v == null) {
             FRINGE_FACTOR = -0.5f;

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/J2DFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/J2DFontFactory.java
@@ -147,7 +147,6 @@ final class J2DFontFactory implements FontFactory {
         });
     }
 
-    @SuppressWarnings("removal")
     public PGFont[] loadEmbeddedFont(String name, String path,
                                      float size,
                                      boolean register,
@@ -167,7 +166,8 @@ final class J2DFontFactory implements FontFactory {
         // REMIND: this needs to be upgraded to use JDK9 createFont
         // which can handle a collection.
         final FontResource fr = fonts[0].getFontResource();
-        AccessController.doPrivileged(new PrivilegedAction<Object>() {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged(new PrivilegedAction<Object>() {
             public Object run() {
                 try {
                     File file = new File(fr.getFileName());
@@ -191,14 +191,14 @@ final class J2DFontFactory implements FontFactory {
      * subject to change.
      * ALso this may be just a stop gap measure.
      */
-    @SuppressWarnings("removal")
     static java.awt.Font getCompositeFont(final java.awt.Font srcFont) {
         if (PlatformUtil.isMac()) {
             return srcFont;
         }
         synchronized (J2DFontFactory.class) {
             if (!compositeFontMethodsInitialized) {
-                AccessController.doPrivileged(
+                @SuppressWarnings("removal")
+                var dummy = AccessController.doPrivileged(
                         (PrivilegedAction<Void>) () -> {
                             compositeFontMethodsInitialized = true;
                             Class<?> fontMgrCls;

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/J2DFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/J2DFontFactory.java
@@ -123,6 +123,7 @@ final class J2DFontFactory implements FontFactory {
      * printing begins, so grabs a copy of the file holding an
      * embedded font to 2D on first use.
      */
+    @SuppressWarnings("removal")
     public static void registerFont(final FontResource fr) {
 
         AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
@@ -146,6 +147,7 @@ final class J2DFontFactory implements FontFactory {
         });
     }
 
+    @SuppressWarnings("removal")
     public PGFont[] loadEmbeddedFont(String name, String path,
                                      float size,
                                      boolean register,
@@ -189,6 +191,7 @@ final class J2DFontFactory implements FontFactory {
      * subject to change.
      * ALso this may be just a stop gap measure.
      */
+    @SuppressWarnings("removal")
     static java.awt.Font getCompositeFont(final java.awt.Font srcFont) {
         if (PlatformUtil.isMac()) {
             return srcFont;

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/print/J2DPrinterJob.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/print/J2DPrinterJob.java
@@ -89,11 +89,11 @@ import java.lang.reflect.Constructor;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
-@SuppressWarnings("removal")
 public class J2DPrinterJob implements PrinterJobImpl {
 
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             String libName = "prism_common";
 
             if (PrismSettings.verbose) {
@@ -117,6 +117,7 @@ public class J2DPrinterJob implements PrinterJobImpl {
     private volatile Object elo = null;
 
     private static Class onTopClass = null;
+    @SuppressWarnings("removal")
     PrintRequestAttribute getAlwaysOnTop(final long id) {
         return AccessController.doPrivileged(
             (PrivilegedAction<PrintRequestAttribute>) () -> {
@@ -792,6 +793,7 @@ public class J2DPrinterJob implements PrinterJobImpl {
      * to be made before we start the underlying native job.
      */
     private void checkPermissions() {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkPrintJobAccess();

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/print/J2DPrinterJob.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/print/J2DPrinterJob.java
@@ -89,6 +89,7 @@ import java.lang.reflect.Constructor;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
+@SuppressWarnings("removal")
 public class J2DPrinterJob implements PrinterJobImpl {
 
     static {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWPipeline.java
@@ -35,11 +35,11 @@ import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.HashMap;
 
-@SuppressWarnings("removal")
 public final class SWPipeline extends GraphicsPipeline {
 
     static {
-        AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Object>) () -> {
             NativeLibLoader.loadLibrary("prism_sw");
             return null;
         });

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWPipeline.java
@@ -35,6 +35,7 @@ import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.HashMap;
 
+@SuppressWarnings("removal")
 public final class SWPipeline extends GraphicsPipeline {
 
     static {

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/ImageData.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/ImageData.java
@@ -42,6 +42,7 @@ import com.sun.scenario.effect.impl.Renderer;
  * it intended to be used with using
  * {@link #validate(com.sun.scenario.effect.FilterContext)} method.
  */
+@SuppressWarnings("removal")
 public class ImageData {
 
     private static HashSet<ImageData> alldatas;

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/ImageData.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/ImageData.java
@@ -42,13 +42,13 @@ import com.sun.scenario.effect.impl.Renderer;
  * it intended to be used with using
  * {@link #validate(com.sun.scenario.effect.FilterContext)} method.
  */
-@SuppressWarnings("removal")
 public class ImageData {
 
     private static HashSet<ImageData> alldatas;
 
     static {
-        AccessController.doPrivileged((PrivilegedAction) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction) () -> {
             if (System.getProperty("decora.showleaks") != null) {
                 alldatas = new HashSet<ImageData>();
                 Runtime.getRuntime().addShutdownHook(new Thread() {

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/BufferUtil.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/BufferUtil.java
@@ -57,6 +57,7 @@ public class BufferUtil {
     private BufferUtil() {
     }
 
+    @SuppressWarnings("removal")
     public static void nativeOrder(ByteBuffer buf) {
         if (!isCDCFP) {
             try {

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/ImagePool.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/ImagePool.java
@@ -39,7 +39,6 @@ import com.sun.scenario.effect.Filterable;
  * a fairly expensive operation (in terms of footprint and performance),
  * especially for the GPU backends, so image reuse is critical.
  */
-@SuppressWarnings("removal")
 public class ImagePool {
 
     public static long numEffects;
@@ -49,7 +48,8 @@ public class ImagePool {
     static long pixelsAccessed;
 
     static {
-        AccessController.doPrivileged((PrivilegedAction) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction) () -> {
             if (System.getProperty("decora.showstats") != null) {
                 Runtime.getRuntime().addShutdownHook(new Thread() {
                     @Override public void run() {

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/ImagePool.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/ImagePool.java
@@ -39,6 +39,7 @@ import com.sun.scenario.effect.Filterable;
  * a fairly expensive operation (in terms of footprint and performance),
  * especially for the GPU backends, so image reuse is critical.
  */
+@SuppressWarnings("removal")
 public class ImagePool {
 
     public static long numEffects;

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/Renderer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/Renderer.java
@@ -92,6 +92,7 @@ public abstract class Renderer {
         Collections.synchronizedMap(new HashMap<String, EffectPeer>(5));
     private final ImagePool imagePool;
 
+    @SuppressWarnings("removal")
     protected static final boolean verbose = AccessController.doPrivileged(
             (PrivilegedAction<Boolean>) () -> Boolean.getBoolean("decora.verbose"));
 

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/RendererFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/RendererFactory.java
@@ -179,6 +179,7 @@ class RendererFactory {
         return r;
     }
 
+    @SuppressWarnings("removal")
     static Renderer createRenderer(final FilterContext fctx) {
         return AccessController.doPrivileged((PrivilegedAction<Renderer>) () -> {
             Renderer r = null;

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/state/LinearConvolveRenderState.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/state/LinearConvolveRenderState.java
@@ -71,6 +71,7 @@ public abstract class LinearConvolveRenderState implements RenderState {
          * The default value is set to 64 if platform is an embedded system and 128 otherwise.
          */
         final int defSize = PlatformUtil.isEmbedded() ? 64 : MAX_COMPILED_KERNEL_SIZE;
+        @SuppressWarnings("removal")
         int size = AccessController.doPrivileged(
                 (PrivilegedAction<Integer>) () -> Integer.getInteger(
                         "decora.maxLinearConvolveKernelSize", defSize));

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/sw/sse/SSERendererDelegate.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/sw/sse/SSERendererDelegate.java
@@ -32,6 +32,7 @@ import com.sun.scenario.effect.Effect.AccelType;
 import com.sun.scenario.effect.impl.Renderer;
 import com.sun.scenario.effect.impl.sw.RendererDelegate;
 
+@SuppressWarnings("removal")
 public class SSERendererDelegate implements RendererDelegate {
 
     public static native boolean isSupported();

--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/sw/sse/SSERendererDelegate.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/sw/sse/SSERendererDelegate.java
@@ -32,13 +32,13 @@ import com.sun.scenario.effect.Effect.AccelType;
 import com.sun.scenario.effect.impl.Renderer;
 import com.sun.scenario.effect.impl.sw.RendererDelegate;
 
-@SuppressWarnings("removal")
 public class SSERendererDelegate implements RendererDelegate {
 
     public static native boolean isSupported();
 
     static {
-        AccessController.doPrivileged((PrivilegedAction) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction) () -> {
             NativeLibLoader.loadLibrary("decora_sse");
             return null;
         });

--- a/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
@@ -153,12 +153,14 @@ public abstract class Animation {
 
     // Access control context, captured whenever we add this pulse receiver to
     // the PrimaryTimer (which is called when an animation is played or resumed)
+    @SuppressWarnings("removal")
     private AccessControlContext accessCtrlCtx = null;
 
     private long now() {
         return TickCalculation.fromNano(timer.nanos());
     }
 
+    @SuppressWarnings("removal")
     private void addPulseReceiver() {
         // Capture the Access Control Context to be used during the animation pulse
         accessCtrlCtx = AccessController.getContext();
@@ -190,6 +192,7 @@ public abstract class Animation {
     }
 
     // package private only for the sake of testing
+    @SuppressWarnings("removal")
     final PulseReceiver pulseReceiver = new PulseReceiver() {
         @Override public void timePulse(long now) {
             final long elapsedTime = now - startTime;

--- a/modules/javafx.graphics/src/main/java/javafx/animation/AnimationTimer.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/AnimationTimer.java
@@ -48,6 +48,7 @@ import java.security.PrivilegedAction;
 public abstract class AnimationTimer {
 
     private class AnimationTimerReceiver implements TimerReceiver {
+        @SuppressWarnings("removal")
         @Override public void handle(final long now) {
             if (accessCtrlCtx == null) {
                 throw new IllegalStateException("Error: AccessControlContext not captured");
@@ -65,6 +66,7 @@ public abstract class AnimationTimer {
     private boolean active;
 
     // Access control context, captured in start()
+    @SuppressWarnings("removal")
     private AccessControlContext accessCtrlCtx = null;
 
     /**
@@ -97,6 +99,7 @@ public abstract class AnimationTimer {
      *
      * The {@code AnimationTimer} can be stopped by calling {@link #stop()}.
      */
+    @SuppressWarnings("removal")
     public void start() {
         if (!active) {
             // Capture the Access Control Context to be used during the animation pulse

--- a/modules/javafx.graphics/src/main/java/javafx/application/Preloader.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Preloader.java
@@ -110,6 +110,7 @@ public abstract class Preloader extends Application {
     private static final String lineSeparator;
 
     static {
+        @SuppressWarnings("removal")
         String prop = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("line.separator"));
         lineSeparator = prop != null ? prop : "\n";
     }

--- a/modules/javafx.graphics/src/main/java/javafx/concurrent/Service.java
+++ b/modules/javafx.graphics/src/main/java/javafx/concurrent/Service.java
@@ -168,6 +168,7 @@ public abstract class Service<V> implements Worker<V>, EventTarget {
     };
 
     // Addition of doPrivileged added due to RT-19580
+    @SuppressWarnings("removal")
     private static final ThreadGroup THREAD_GROUP = AccessController.doPrivileged((PrivilegedAction<ThreadGroup>) () -> new ThreadGroup("javafx concurrent thread pool"));
     private static final Thread.UncaughtExceptionHandler UNCAUGHT_HANDLER = (thread, throwable) -> {
         // Ignore IllegalMonitorStateException, these are thrown from the ThreadPoolExecutor
@@ -179,6 +180,7 @@ public abstract class Service<V> implements Worker<V>, EventTarget {
     };
 
     // Addition of doPrivileged added due to RT-19580
+    @SuppressWarnings("removal")
     private static final ThreadFactory THREAD_FACTORY = run -> AccessController.doPrivileged((PrivilegedAction<Thread>) () -> {
         final Thread th = new Thread(THREAD_GROUP, run);
         th.setUncaughtExceptionHandler(UNCAUGHT_HANDLER);
@@ -717,6 +719,7 @@ public abstract class Service<V> implements Worker<V>, EventTarget {
      * @param task a non-null task to execute
      * @since JavaFX 2.1
      */
+    @SuppressWarnings("removal")
     protected void executeTask(final Task<V> task) {
         final AccessControlContext acc = AccessController.getContext();
         final Executor e = getExecutor() != null ? getExecutor() : EXECUTOR;

--- a/modules/javafx.graphics/src/main/java/javafx/concurrent/Task.java
+++ b/modules/javafx.graphics/src/main/java/javafx/concurrent/Task.java
@@ -1008,6 +1008,7 @@ public abstract class Task<V> extends FutureTask<V> implements Worker<V>, EventT
     @Override public boolean cancel(boolean mayInterruptIfRunning) {
         // Delegate to the super implementation to actually attempt to cancel this thing
         // Assert the modifyThread permission
+        @SuppressWarnings("removal")
         boolean flag = AccessController.doPrivileged(
             (PrivilegedAction<Boolean>) () -> super.cancel(mayInterruptIfRunning),
             null,

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/URLConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/URLConverter.java
@@ -180,6 +180,7 @@ public final class URLConverter extends StyleConverter<ParsedValue[], String> {
 
             System.err.println("WARNING: resolveRuntimeImport cannot resolve: " + resourcePath);
 
+            @SuppressWarnings("removal")
             final SecurityManager sm = System.getSecurityManager();
             if (sm == null) {
                 // If the SecurityManager is not null, then just look up the resource on the class-path.
@@ -193,6 +194,7 @@ public final class URLConverter extends StyleConverter<ParsedValue[], String> {
 
             // check whether the path is file from our runtime jar
             try {
+                @SuppressWarnings("removal")
                 final URL rtJarURL = AccessController.doPrivileged((PrivilegedExceptionAction<URL>) () -> {
                     // getProtectionDomain either throws a SecurityException or returns a non-null value
                     final ProtectionDomain protectionDomain = Application.class.getProtectionDomain();

--- a/modules/javafx.graphics/src/main/java/javafx/print/Printer.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/Printer.java
@@ -70,6 +70,7 @@ public final class Printer {
      * have permission to browse printers.
      */
     public static ObservableSet<Printer> getAllPrinters() {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkPrintJobAccess();
@@ -80,6 +81,7 @@ public final class Printer {
     private static ReadOnlyObjectWrapper<Printer> defaultPrinter;
 
     private static ReadOnlyObjectWrapper<Printer> defaultPrinterImpl() {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkPrintJobAccess();

--- a/modules/javafx.graphics/src/main/java/javafx/print/PrinterJob.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/PrinterJob.java
@@ -111,6 +111,7 @@ public final class PrinterJob {
      * to initiate a printer job.
      */
     public static final PrinterJob createPrinterJob() {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkPrintJobAccess();
@@ -134,6 +135,7 @@ public final class PrinterJob {
      * to initiate a printer job.
      */
     public static final PrinterJob createPrinterJob(Printer printer) {
+        @SuppressWarnings("removal")
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkPrintJobAccess();

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -9966,7 +9966,7 @@ public abstract class Node implements EventTarget, Styleable {
         if (accessible == null) {
             accessible = Application.GetApplication().createAccessible();
             accessible.setEventHandler(new Accessible.EventHandler() {
-                @SuppressWarnings({"removal","deprecation"})
+                @SuppressWarnings("removal")
                 @Override public AccessControlContext getAccessControlContext() {
                     Scene scene = getScene();
                     if (scene == null) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -9966,7 +9966,7 @@ public abstract class Node implements EventTarget, Styleable {
         if (accessible == null) {
             accessible = Application.GetApplication().createAccessible();
             accessible.setEventHandler(new Accessible.EventHandler() {
-                @SuppressWarnings("deprecation")
+                @SuppressWarnings({"removal","deprecation"})
                 @Override public AccessControlContext getAccessControlContext() {
                     Scene scene = getScene();
                     if (scene == null) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/PropertyHelper.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/PropertyHelper.java
@@ -33,6 +33,7 @@ class PropertyHelper {
     // this runs within a doPrivilege block so this function must be package-private.
     static boolean getBooleanProperty(final String propName) {
         try {
+            @SuppressWarnings("removal")
             boolean answer =
                 AccessController.doPrivileged((java.security.PrivilegedAction<Boolean>) () -> {
                         String propVal = System.getProperty(propName);

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -179,6 +179,7 @@ public class Scene implements EventTarget {
 
     private EnumSet<DirtyBits> dirtyBits = EnumSet.noneOf(DirtyBits.class);
 
+    @SuppressWarnings("removal")
     final AccessControlContext acc = AccessController.getContext();
 
     private Camera defaultCamera;
@@ -1386,6 +1387,7 @@ public class Scene implements EventTarget {
     private static List<Runnable> snapshotRunnableListB;
     private static List<Runnable> snapshotRunnableList;
 
+    @SuppressWarnings("removal")
     static void addSnapshotRunnable(final Runnable runnable) {
         Toolkit.getToolkit().checkFxUserThread();
 
@@ -6235,6 +6237,7 @@ public class Scene implements EventTarget {
      *                                                                         *
      **************************************************************************/
 
+    @SuppressWarnings("removal")
     private static final NodeOrientation defaultNodeOrientation =
         AccessController.doPrivileged(
                 (PrivilegedAction<Boolean>) () -> Boolean.getBoolean("javafx.scene.nodeOrientation.RTL")) ? NodeOrientation.RIGHT_TO_LEFT : NodeOrientation.INHERIT;
@@ -6438,6 +6441,7 @@ public class Scene implements EventTarget {
         if (accessible == null) {
             accessible = Application.GetApplication().createAccessible();
             accessible.setEventHandler(new Accessible.EventHandler() {
+                @SuppressWarnings("removal")
                 @Override public AccessControlContext getAccessControlContext() {
                     return getPeer().getAccessControlContext();
                 }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/Clipboard.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/Clipboard.java
@@ -187,6 +187,7 @@ public class Clipboard {
      * the system will invoke the provided callback to stream the image data over to the client.
      */
 
+    @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/scene/robot/Robot.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/robot/Robot.java
@@ -70,6 +70,7 @@ public final class Robot {
         Application.checkEventThread();
 
         // Ensure we have proper permission for creating a robot.
+        @SuppressWarnings("removal")
         final SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
             sm.checkPermission(CREATE_ROBOT_PERMISSION);

--- a/modules/javafx.graphics/src/main/java/javafx/scene/text/Font.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/text/Font.java
@@ -473,6 +473,7 @@ public final class Font {
             // Getting the path from a File fixes this.
             path = new java.io.File(path).getPath();
             try {
+                @SuppressWarnings("removal")
                 SecurityManager sm = System.getSecurityManager();
                 if (sm != null) {
                     FilePermission filePermission =

--- a/modules/javafx.graphics/src/main/java/javafx/stage/PopupWindow.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/PopupWindow.java
@@ -509,6 +509,7 @@ public abstract class PopupWindow extends Window {
             // Setup the peer
             StageStyle popupStyle;
             try {
+                @SuppressWarnings("removal")
                 final SecurityManager securityManager =
                         System.getSecurityManager();
                 if (securityManager != null) {

--- a/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
@@ -1141,6 +1141,7 @@ public class Stage extends Window {
 
             StageStyle stageStyle = getStyle();
             if (stageStyle == StageStyle.TRANSPARENT) {
+                @SuppressWarnings("removal")
                 final SecurityManager securityManager =
                         System.getSecurityManager();
                 if (securityManager != null) {

--- a/modules/javafx.graphics/src/main/java/javafx/stage/Window.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/Window.java
@@ -199,6 +199,7 @@ public class Window implements EventTarget {
                         return window.screenProperty();
                     }
 
+                    @SuppressWarnings("removal")
                     @Override
                     public AccessControlContext getAccessControlContext(Window window) {
                         return window.acc;
@@ -214,6 +215,7 @@ public class Window implements EventTarget {
      * @since 9
      */
     public static ObservableList<Window> getWindows() {
+        @SuppressWarnings("removal")
         final SecurityManager securityManager = System.getSecurityManager();
         if (securityManager != null) {
             securityManager.checkPermission(ACCESS_WINDOW_LIST_PERMISSION);
@@ -222,6 +224,7 @@ public class Window implements EventTarget {
         return unmodifiableWindows;
     }
 
+    @SuppressWarnings("removal")
     final AccessControlContext acc = AccessController.getContext();
 
     protected Window() {

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubScene.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubScene.java
@@ -135,6 +135,7 @@ public class StubScene implements TKScene {
         return camera;
     }
 
+    @SuppressWarnings("removal")
     @Override
     public AccessControlContext getAccessControlContext() {
         return null;

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubStage.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubStage.java
@@ -48,7 +48,7 @@ public class StubStage implements TKStage {
     }
 
     @Override
-    public TKScene createTKScene(boolean depthBuffer, boolean msaa, AccessControlContext acc) {
+    public TKScene createTKScene(boolean depthBuffer, boolean msaa, @SuppressWarnings("removal") AccessControlContext acc) {
         return new StubScene();
     }
 

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubToolkit.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubToolkit.java
@@ -120,18 +120,18 @@ public class StubToolkit extends Toolkit {
     }
 
     @Override
-    public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl, AccessControlContext acc) {
+    public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl, @SuppressWarnings("removal") AccessControlContext acc) {
 
         return new StubStage();
     }
 
     @Override
-    public TKStage createTKPopupStage(Window peerWindow, StageStyle popupStyle, TKStage owner, AccessControlContext acc) {
+    public TKStage createTKPopupStage(Window peerWindow, StageStyle popupStyle, TKStage owner, @SuppressWarnings("removal") AccessControlContext acc) {
         return new StubPopupStage();
     }
 
     @Override
-    public TKStage createTKEmbeddedStage(HostInterface host, AccessControlContext acc) {
+    public TKStage createTKEmbeddedStage(HostInterface host, @SuppressWarnings("removal") AccessControlContext acc) {
         return new StubStage();
     }
 
@@ -388,7 +388,7 @@ public class StubToolkit extends Toolkit {
         private double offsetY;
 
         @Override
-        public void setSecurityContext(AccessControlContext ctx) {
+        public void setSecurityContext(@SuppressWarnings("removal") AccessControlContext ctx) {
         }
 
         @Override public Set<DataFormat> getContentTypes() {

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/input/DragAndDropTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/input/DragAndDropTest.java
@@ -1624,7 +1624,7 @@ public class DragAndDropTest {
         private double offsetY;
 
         @Override
-        public void setSecurityContext(AccessControlContext ctx) {
+        public void setSecurityContext(@SuppressWarnings("removal") AccessControlContext ctx) {
         }
 
         @Override

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/locator/Locator.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/locator/Locator.java
@@ -167,6 +167,7 @@ public class Locator {
     }
 
     private static long getContentLengthLong(URLConnection connection) {
+        @SuppressWarnings("removal")
         Method method = AccessController.doPrivileged((PrivilegedAction<Method>) () -> {
             try {
                 return URLConnection.class.getMethod("getContentLengthLong");

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/HostUtils.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/HostUtils.java
@@ -31,7 +31,6 @@ import java.security.PrivilegedAction;
 /**
  * Common functions that involve the host platform
  */
-@SuppressWarnings("removal")
 public class HostUtils {
     private static String osName;
     private static String osArch;
@@ -39,7 +38,8 @@ public class HostUtils {
     private static boolean is64bit = false;
 
     static {
-        embedded = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
+        @SuppressWarnings("removal")
+        boolean tmp = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
             osName = System.getProperty("os.name").toLowerCase();
             osArch = System.getProperty("os.arch").toLowerCase();
 
@@ -49,6 +49,7 @@ public class HostUtils {
 
             return Boolean.getBoolean("com.sun.javafx.isEmbedded");
         });
+        embedded = tmp;
     }
 
     public static boolean is64Bit() {

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/HostUtils.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/HostUtils.java
@@ -31,6 +31,7 @@ import java.security.PrivilegedAction;
 /**
  * Common functions that involve the host platform
  */
+@SuppressWarnings("removal")
 public class HostUtils {
     private static String osName;
     private static String osArch;

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/NativeMediaManager.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/NativeMediaManager.java
@@ -96,6 +96,7 @@ public class NativeMediaManager {
     /**
      * Create a <code>NativeMediaManager</code>.
      */
+    @SuppressWarnings("removal")
     protected NativeMediaManager() {
         /*
          * Load native libraries. This must be done early as platforms may need

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/platform/PlatformManager.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/platform/PlatformManager.java
@@ -43,11 +43,11 @@ import java.lang.reflect.Method;
 /**
  * Core media platform management code.
  */
-@SuppressWarnings("removal")
 public final class PlatformManager {
     private static String enabledPlatforms;
     static {
-        AccessController.doPrivileged((PrivilegedAction) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction) () -> {
             getPlatformSettings();
             return null;
         });

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/platform/PlatformManager.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/platform/PlatformManager.java
@@ -43,6 +43,7 @@ import java.lang.reflect.Method;
 /**
  * Core media platform management code.
  */
+@SuppressWarnings("removal")
 public final class PlatformManager {
     private static String enabledPlatforms;
     static {

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/platform/osx/OSXPlatform.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/platform/osx/OSXPlatform.java
@@ -67,6 +67,7 @@ public final class OSXPlatform extends Platform {
         "https"
     };
 
+    @SuppressWarnings("removal")
     private static final class OSXPlatformInitializer {
         private static final OSXPlatform globalInstance;
         static {

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/platform/osx/OSXPlatform.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/platform/osx/OSXPlatform.java
@@ -67,7 +67,6 @@ public final class OSXPlatform extends Platform {
         "https"
     };
 
-    @SuppressWarnings("removal")
     private static final class OSXPlatformInitializer {
         private static final OSXPlatform globalInstance;
         static {
@@ -75,7 +74,8 @@ public final class OSXPlatform extends Platform {
             // Do this early so we can report the correct content types
             boolean isLoaded = false;
             try {
-                isLoaded = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
+                @SuppressWarnings("removal")
+                boolean tmp = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
                     boolean avf = false;
                     boolean qtk = false;
                     // attempt to load the AVFoundation based player first
@@ -91,6 +91,7 @@ public final class OSXPlatform extends Platform {
 
                     return avf || qtk;
                 });
+                isLoaded = tmp;
             } catch (Exception e) {
                 // Ignore
             }

--- a/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/Disposer.java
+++ b/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/Disposer.java
@@ -43,7 +43,6 @@ import java.util.Hashtable;
  *
  * @see DisposerRecord
  */
-@SuppressWarnings("removal")
 public class Disposer implements Runnable {
     private static final ReferenceQueue queue = new ReferenceQueue();
     private static final Hashtable records = new Hashtable();
@@ -53,7 +52,8 @@ public class Disposer implements Runnable {
         disposerInstance = new Disposer();
 
         ThreadGroup tg = Thread.currentThread().getThreadGroup();
-        java.security.AccessController.doPrivileged(
+        @SuppressWarnings("removal")
+        var dummy = java.security.AccessController.doPrivileged(
             new java.security.PrivilegedAction() {
                 public Object run() {
                     /* The thread must be a member of a thread group

--- a/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/Disposer.java
+++ b/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/Disposer.java
@@ -43,6 +43,7 @@ import java.util.Hashtable;
  *
  * @see DisposerRecord
  */
+@SuppressWarnings("removal")
 public class Disposer implements Runnable {
     private static final ReferenceQueue queue = new ReferenceQueue();
     private static final Hashtable records = new Hashtable();

--- a/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/FXDnD.java
+++ b/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/FXDnD.java
@@ -41,6 +41,7 @@ import com.sun.javafx.embed.swing.newimpl.FXDnDInteropN;
  * A utility class to connect DnD mechanism of Swing and FX.
  * It allows Swing content to use the FX machinery for performing DnD.
  */
+@SuppressWarnings("removal")
 final public class FXDnD {
     public static boolean fxAppThreadIsDispatchThread;
     private FXDnDInteropN fxdndiop;

--- a/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/FXDnD.java
+++ b/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/FXDnD.java
@@ -41,13 +41,13 @@ import com.sun.javafx.embed.swing.newimpl.FXDnDInteropN;
  * A utility class to connect DnD mechanism of Swing and FX.
  * It allows Swing content to use the FX machinery for performing DnD.
  */
-@SuppressWarnings("removal")
 final public class FXDnD {
     public static boolean fxAppThreadIsDispatchThread;
     private FXDnDInteropN fxdndiop;
 
     static {
-        AccessController.doPrivileged(new PrivilegedAction<Object>() {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged(new PrivilegedAction<Object>() {
             public Object run() {
                 fxAppThreadIsDispatchThread =
                         "true".equals(System.getProperty("javafx.embed.singleThread"));

--- a/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/SwingFXUtilsImpl.java
+++ b/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/SwingFXUtilsImpl.java
@@ -38,6 +38,7 @@ public class SwingFXUtilsImpl {
         swFXUtilIOP = new SwingFXUtilsImplInteropN();
     }
 
+    @SuppressWarnings("removal")
     private static EventQueue getEventQueue() {
         return AccessController.doPrivileged(
                 (PrivilegedAction<EventQueue>) () -> java.awt.Toolkit.getDefaultToolkit().getSystemEventQueue());

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
@@ -212,6 +212,7 @@ public class JFXPanel extends JComponent {
         if (fxInitialized) {
             return;
         }
+        @SuppressWarnings("removal")
         EventQueue eventQueue = AccessController.doPrivileged(
                                 (PrivilegedAction<EventQueue>) java.awt.Toolkit
                                 .getDefaultToolkit()::getSystemEventQueue);
@@ -295,6 +296,7 @@ public class JFXPanel extends JComponent {
         if (Toolkit.getToolkit().isFxUserThread()) {
             setSceneImpl(newScene);
         } else {
+            @SuppressWarnings("removal")
             EventQueue eventQueue = AccessController.doPrivileged(
                     (PrivilegedAction<EventQueue>) java.awt.Toolkit
                             .getDefaultToolkit()::getSystemEventQueue);
@@ -872,6 +874,7 @@ public class JFXPanel extends JComponent {
      * method is invoked, the chain of parent components is set up with
      * KeyboardAction event listeners.
      */
+    @SuppressWarnings("removal")
     @Override
     public void addNotify() {
         super.addNotify();
@@ -906,6 +909,7 @@ public class JFXPanel extends JComponent {
      * When this method is invoked, any KeyboardActions set up in the the
      * chain of parent components are removed.
      */
+    @SuppressWarnings("removal")
     @Override public void removeNotify() {
         SwingNodeHelper.runOnFxThread(() -> {
             if ((stage != null) && stage.isShowing()) {

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingNode.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingNode.java
@@ -116,6 +116,7 @@ import com.sun.javafx.embed.swing.newimpl.SwingNodeInteropN;
  * </pre>
  * @since JavaFX 8.0
  */
+@SuppressWarnings("removal")
 public class SwingNode extends Node {
     private static boolean isThreadMerged;
 

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingNode.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingNode.java
@@ -116,12 +116,12 @@ import com.sun.javafx.embed.swing.newimpl.SwingNodeInteropN;
  * </pre>
  * @since JavaFX 8.0
  */
-@SuppressWarnings("removal")
 public class SwingNode extends Node {
     private static boolean isThreadMerged;
 
     static {
-        AccessController.doPrivileged(new PrivilegedAction<Object>() {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged(new PrivilegedAction<Object>() {
             public Object run() {
                 isThreadMerged = Boolean.valueOf(
                         System.getProperty("javafx.embed.singleThread"));
@@ -555,6 +555,7 @@ public class SwingNode extends Node {
         locateLwFrame();
     };
 
+    @SuppressWarnings("removal")
     private final EventHandler<FocusUngrabEvent> ungrabHandler = event -> {
         if (!skipBackwardUnrgabNotification) {
             if (lwFrame != null) {
@@ -882,7 +883,8 @@ public class SwingNode extends Node {
                         frame, swingID, swingWhen, swingModifiers,
                         relX, relY, absX, absY,
                         event.getClickCount(), swingPopupTrigger, swingButton);
-            AccessController.doPrivileged(new PostEventAction(mouseEvent));
+            @SuppressWarnings("removal")
+            var dummy = AccessController.doPrivileged(new PostEventAction(mouseEvent));
         }
     }
 
@@ -923,7 +925,8 @@ public class SwingNode extends Node {
             int y = (int) Math.round(fxY);
             MouseWheelEvent mouseWheelEvent =
                 swNodeIOP.createMouseWheelEvent(source, swingModifiers, x, y, -wheelRotation);
-            AccessController.doPrivileged(new PostEventAction(mouseWheelEvent));
+            @SuppressWarnings("removal")
+            var dummy = AccessController.doPrivileged(new PostEventAction(mouseWheelEvent));
         }
     }
 
@@ -968,7 +971,8 @@ public class SwingNode extends Node {
             java.awt.event.KeyEvent keyEvent = swNodeIOP.createKeyEvent(frame,
                 swingID, swingWhen, swingModifiers, swingKeyCode,
                 swingChar);
-            AccessController.doPrivileged(new PostEventAction(keyEvent));
+            @SuppressWarnings("removal")
+            var dummy = AccessController.doPrivileged(new PostEventAction(keyEvent));
         }
     }
 }

--- a/modules/javafx.swt/src/main/java/javafx/embed/swt/FXCanvas.java
+++ b/modules/javafx.swt/src/main/java/javafx/embed/swt/FXCanvas.java
@@ -259,6 +259,7 @@ public class FXCanvas extends Canvas {
             }
         } else if (SWT.getPlatform().equals("win32")) {
             try {
+                @SuppressWarnings("removal")
                 String autoScale = AccessController.doPrivileged((PrivilegedAction<String>)() -> System.getProperty("swt.autoScale"));
                 if (autoScale == null || ! "false".equalsIgnoreCase(autoScale)) {
                     Class dpiUtilClass = Class.forName("org.eclipse.swt.internal.DPIUtil");
@@ -309,6 +310,7 @@ public class FXCanvas extends Canvas {
         return null;
     }
 
+    @SuppressWarnings("removal")
     private static void initFx() {
         // NOTE: no internal "com.sun.*" packages can be accessed until after
         // the JavaFX platform is initialized. The list of needed internal

--- a/modules/javafx.swt/src/main/java/javafx/embed/swt/SWTFXUtils.java
+++ b/modules/javafx.swt/src/main/java/javafx/embed/swt/SWTFXUtils.java
@@ -191,6 +191,7 @@ public class SWTFXUtils {
         return msbFirst;
     }
 
+    @SuppressWarnings("removal")
     private static int readValue(final String name) throws Exception {
         final Class<?> clazz = ImageData.class;
         return AccessController.doPrivileged(
@@ -202,6 +203,7 @@ public class SWTFXUtils {
     }
 
     private static Method blitDirect;
+    @SuppressWarnings("removal")
     private static void blit(int op,
             byte[] srcData, int srcDepth, int srcStride, int srcOrder,
             int srcX, int srcY, int srcWidth, int srcHeight,
@@ -245,6 +247,7 @@ public class SWTFXUtils {
     }
 
     private static Method blitPalette;
+    @SuppressWarnings("removal")
     private static void blit(int op,
         byte[] srcData, int srcDepth, int srcStride, int srcOrder,
         int srcX, int srcY, int srcWidth, int srcHeight,
@@ -288,6 +291,7 @@ public class SWTFXUtils {
     }
 
     private static Method getByteOrderMethod;
+    @SuppressWarnings("removal")
     private static int getByteOrder(ImageData image) throws Exception {
         final Class<?> clazz = ImageData.class;
         if (getByteOrderMethod != null) {

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/UIClientImpl.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/UIClientImpl.java
@@ -112,6 +112,7 @@ public final class UIClientImpl implements UIClient {
         return accessor.getEngine();
     }
 
+    @SuppressWarnings("removal")
     private AccessControlContext getAccessContext() {
         return accessor.getPage().getAccessControlContext();
     }
@@ -122,6 +123,7 @@ public final class UIClientImpl implements UIClient {
         if (w != null && w.getCreatePopupHandler() != null) {
             final PopupFeatures pf =
                     new PopupFeatures(menu, status, toolbar, resizable);
+            @SuppressWarnings("removal")
             WebEngine popup = AccessController.doPrivileged(
                     (PrivilegedAction<WebEngine>) () -> w.getCreatePopupHandler().call(pf), getAccessContext());
             return Accessor.getPageFor(popup);
@@ -129,6 +131,7 @@ public final class UIClientImpl implements UIClient {
         return null;
     }
 
+    @SuppressWarnings("removal")
     private void dispatchWebEvent(final EventHandler handler, final WebEvent ev) {
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             handler.handle(ev);
@@ -195,6 +198,7 @@ public final class UIClientImpl implements UIClient {
         }
     }
 
+    @SuppressWarnings("removal")
     @Override public boolean confirm(final String text) {
         final WebEngine w = getWebEngine();
         if (w != null && w.getConfirmHandler() != null) {
@@ -204,6 +208,7 @@ public final class UIClientImpl implements UIClient {
         return false;
     }
 
+    @SuppressWarnings("removal")
     @Override public String prompt(String text, String defaultValue) {
         final WebEngine w = getWebEngine();
         if (w != null && w.getPromptHandler() != null) {

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/WebPageClientImpl.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/WebPageClientImpl.java
@@ -49,17 +49,12 @@ import com.sun.webkit.graphics.WCPoint;
 import com.sun.webkit.graphics.WCRectangle;
 
 public final class WebPageClientImpl implements WebPageClient<WebView> {
-    private static final boolean backBufferSupported;
+    @SuppressWarnings("removal")
+    private static final boolean backBufferSupported = Boolean.valueOf(
+        AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty(
+            "com.sun.webkit.pagebackbuffer", "true")));
     private static WebConsoleListener consoleListener = null;
     private final Accessor accessor;
-
-    static {
-        @SuppressWarnings("removal")
-        boolean tmp = Boolean.valueOf(
-                AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty(
-                        "com.sun.webkit.pagebackbuffer", "true")));
-        backBufferSupported = tmp;
-    }
 
     static void setConsoleListener(WebConsoleListener consoleListener) {
         WebPageClientImpl.consoleListener = consoleListener;

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/WebPageClientImpl.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/WebPageClientImpl.java
@@ -48,16 +48,17 @@ import com.sun.webkit.graphics.WCPageBackBuffer;
 import com.sun.webkit.graphics.WCPoint;
 import com.sun.webkit.graphics.WCRectangle;
 
-@SuppressWarnings("removal")
 public final class WebPageClientImpl implements WebPageClient<WebView> {
     private static final boolean backBufferSupported;
     private static WebConsoleListener consoleListener = null;
     private final Accessor accessor;
 
     static {
-        backBufferSupported = Boolean.valueOf(
+        @SuppressWarnings("removal")
+        boolean tmp = Boolean.valueOf(
                 AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty(
                         "com.sun.webkit.pagebackbuffer", "true")));
+        backBufferSupported = tmp;
     }
 
     static void setConsoleListener(WebConsoleListener consoleListener) {

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/WebPageClientImpl.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/WebPageClientImpl.java
@@ -48,6 +48,7 @@ import com.sun.webkit.graphics.WCPageBackBuffer;
 import com.sun.webkit.graphics.WCPoint;
 import com.sun.webkit.graphics.WCRectangle;
 
+@SuppressWarnings("removal")
 public final class WebPageClientImpl implements WebPageClient<WebView> {
     private static final boolean backBufferSupported;
     private static WebConsoleListener consoleListener = null;

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCGraphicsPrismContext.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCGraphicsPrismContext.java
@@ -81,6 +81,7 @@ class WCGraphicsPrismContext extends WCGraphicsContext {
 
     private final static PlatformLogger log =
             PlatformLogger.getLogger(WCGraphicsPrismContext.class.getName());
+    @SuppressWarnings("removal")
     private final static boolean DEBUG_DRAW_CLIP_SHAPE = Boolean.valueOf(
             AccessController.doPrivileged((PrivilegedAction<String>) () ->
             System.getProperty("com.sun.webkit.debugDrawClipShape", "false")));

--- a/modules/javafx.web/src/main/java/com/sun/webkit/Disposer.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/Disposer.java
@@ -52,6 +52,7 @@ import java.util.concurrent.LinkedBlockingQueue;
  *
  * @see DisposerRecord
  */
+@SuppressWarnings("removal")
 public final class Disposer implements Runnable {
     private static final ReferenceQueue queue = new ReferenceQueue();
     private static final Disposer disposerInstance = new Disposer();

--- a/modules/javafx.web/src/main/java/com/sun/webkit/Disposer.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/Disposer.java
@@ -52,7 +52,6 @@ import java.util.concurrent.LinkedBlockingQueue;
  *
  * @see DisposerRecord
  */
-@SuppressWarnings("removal")
 public final class Disposer implements Runnable {
     private static final ReferenceQueue queue = new ReferenceQueue();
     private static final Disposer disposerInstance = new Disposer();
@@ -60,7 +59,8 @@ public final class Disposer implements Runnable {
             new HashSet<WeakDisposerRecord>();
 
     static {
-        java.security.AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = java.security.AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             /*
              * The thread must be a member of a thread group
              * which will not get GCed before VM exit.

--- a/modules/javafx.web/src/main/java/com/sun/webkit/MethodHelper.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/MethodHelper.java
@@ -36,6 +36,7 @@ import com.sun.javafx.reflect.ReflectUtil;
  * Utility class to wrap method invocation.
  */
 public class MethodHelper {
+    @SuppressWarnings("removal")
     private static final boolean logAccessErrors
             = AccessController.doPrivileged((PrivilegedAction<Boolean>) ()
                     -> Boolean.getBoolean("sun.reflect.debugModuleAccessChecks"));

--- a/modules/javafx.web/src/main/java/com/sun/webkit/Timer.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/Timer.java
@@ -42,6 +42,7 @@ public class Timer {
         SEPARATE_THREAD
     }
 
+    @SuppressWarnings("removal")
     public synchronized static Mode getMode() {
         if (mode == null) {
             mode = Boolean.valueOf(AccessController.doPrivileged(

--- a/modules/javafx.web/src/main/java/com/sun/webkit/Utilities.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/Utilities.java
@@ -100,6 +100,7 @@ public abstract class Utilities {
         "sun.misc"
     );
 
+    @SuppressWarnings("removal")
     private static Object fwkInvokeWithContext(final Method method,
                                                final Object instance,
                                                final Object[] args,

--- a/modules/javafx.web/src/main/java/com/sun/webkit/WebPage.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/WebPage.java
@@ -77,7 +77,6 @@ import org.w3c.dom.Element;
  * </ul>
  */
 
-@SuppressWarnings("removal")
 public final class WebPage {
     private final static PlatformLogger log = PlatformLogger.getLogger(WebPage.class.getName());
     private final static PlatformLogger paintLog = PlatformLogger.getLogger(WebPage.class.getName() + ".paint");
@@ -101,6 +100,7 @@ public final class WebPage {
     private final Set<Long> frames = new HashSet<Long>();
 
     // The access control context associated with this object
+    @SuppressWarnings("removal")
     private final AccessControlContext accessControlContext;
 
     // Maps load request identifiers to URLs
@@ -130,7 +130,8 @@ public final class WebPage {
     private int updateContentCycleID;
 
     static {
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        @SuppressWarnings("removal")
+        var dummy = AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             NativeLibLoader.loadLibrary("jfxwebkit");
             log.finer("jfxwebkit loaded");
 
@@ -192,7 +193,9 @@ public final class WebPage {
             this.scrollbarTheme = null;
         }
 
-        accessControlContext = AccessController.getContext();
+        @SuppressWarnings("removal")
+        AccessControlContext tmpAcc = AccessController.getContext();
+        accessControlContext = tmpAcc;
 
         hostWindow = new WCFrameView(this);
         pPage = twkCreatePage(editable);
@@ -226,6 +229,7 @@ public final class WebPage {
      * May be called on any thread.
      * @return the access control context associated with this object
      */
+    @SuppressWarnings("removal")
     public AccessControlContext getAccessControlContext() {
         return accessControlContext;
     }

--- a/modules/javafx.web/src/main/java/com/sun/webkit/WebPage.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/WebPage.java
@@ -77,6 +77,7 @@ import org.w3c.dom.Element;
  * </ul>
  */
 
+@SuppressWarnings("removal")
 public final class WebPage {
     private final static PlatformLogger log = PlatformLogger.getLogger(WebPage.class.getName());
     private final static PlatformLogger paintLog = PlatformLogger.getLogger(WebPage.class.getName() + ".paint");

--- a/modules/javafx.web/src/main/java/com/sun/webkit/dom/JSObject.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/dom/JSObject.java
@@ -84,6 +84,7 @@ class JSObject extends netscape.javascript.JSObject {
     private static native Object getMemberImpl(long peer, int peer_type,
                                                String name);
 
+    @SuppressWarnings("removal")
     @Override
     public void setMember(String name, Object value) throws JSException {
         Invoker.getInvoker().checkEventThread();
@@ -92,7 +93,7 @@ class JSObject extends netscape.javascript.JSObject {
     }
     private static native void setMemberImpl(long peer, int peer_type,
                                              String name, Object value,
-                                             AccessControlContext acc);
+                                             @SuppressWarnings("removal") AccessControlContext acc);
 
     @Override
     public void removeMember(String name) throws JSException {
@@ -110,6 +111,7 @@ class JSObject extends netscape.javascript.JSObject {
     private static native Object getSlotImpl(long peer, int peer_type,
                                              int index);
 
+    @SuppressWarnings("removal")
     @Override
     public void setSlot(int index, Object value) throws JSException {
         Invoker.getInvoker().checkEventThread();
@@ -118,8 +120,9 @@ class JSObject extends netscape.javascript.JSObject {
     }
     private static native void setSlotImpl(long peer, int peer_type,
                                            int index, Object value,
-                                           AccessControlContext acc);
+                                           @SuppressWarnings("removal") AccessControlContext acc);
 
+    @SuppressWarnings("removal")
     @Override
     public Object call(String methodName, Object... args) throws JSException {
         Invoker.getInvoker().checkEventThread();
@@ -128,7 +131,7 @@ class JSObject extends netscape.javascript.JSObject {
     }
     private static native Object callImpl(long peer, int peer_type,
                                           String methodName, Object[] args,
-                                          AccessControlContext acc);
+                                          @SuppressWarnings("removal") AccessControlContext acc);
 
     @Override
     public String toString() {

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/HTTP2Loader.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/HTTP2Loader.java
@@ -369,7 +369,6 @@ final class HTTP2Loader extends URLLoaderBase {
                   createNormalBodySubscriber() : createZIPEncodedBodySubscriber(contentEncoding);
     }
 
-    @SuppressWarnings("removal")
     private HTTP2Loader(WebPage webPage,
               ByteBufferPool byteBufferPool,
               boolean asynchronous,
@@ -412,11 +411,13 @@ final class HTTP2Loader extends URLLoaderBase {
         };
 
         // Run the HttpClient in the page's access control context
-        this.response = AccessController.doPrivileged((PrivilegedAction<CompletableFuture<Void>>) () -> {
+        @SuppressWarnings("removal")
+        CompletableFuture<Void> tmpResponse = AccessController.doPrivileged((PrivilegedAction<CompletableFuture<Void>>) () -> {
             return HTTP_CLIENT.sendAsync(request, bodyHandler)
                               .thenAccept($ -> {})
                               .exceptionally(ex -> didFail(ex.getCause()));
         }, webPage.getAccessControlContext());
+        this.response = tmpResponse;
 
         if (!asynchronous) {
             waitForRequestToComplete();

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/HTTP2Loader.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/HTTP2Loader.java
@@ -412,7 +412,7 @@ final class HTTP2Loader extends URLLoaderBase {
 
         // Run the HttpClient in the page's access control context
         @SuppressWarnings("removal")
-        CompletableFuture<Void> tmpResponse = AccessController.doPrivileged((PrivilegedAction<CompletableFuture<Void>>) () -> {
+        var tmpResponse = AccessController.doPrivileged((PrivilegedAction<CompletableFuture<Void>>) () -> {
             return HTTP_CLIENT.sendAsync(request, bodyHandler)
                               .thenAccept($ -> {})
                               .exceptionally(ex -> didFail(ex.getCause()));

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/HTTP2Loader.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/HTTP2Loader.java
@@ -102,6 +102,7 @@ final class HTTP2Loader extends URLLoaderBase {
 
     private final CompletableFuture<Void> response;
     // Use singleton instance of HttpClient to get the maximum benefits
+    @SuppressWarnings("removal")
     private final static HttpClient HTTP_CLIENT =
         AccessController.doPrivileged((PrivilegedAction<HttpClient>) () -> HttpClient.newBuilder()
                 .version(Version.HTTP_2)  // this is the default
@@ -114,6 +115,7 @@ final class HTTP2Loader extends URLLoaderBase {
     private static final int DEFAULT_BUFSIZE = 40 * 1024;
     private final static ByteBuffer BUFFER;
     static {
+       @SuppressWarnings("removal")
        int bufSize  = AccessController.doPrivileged(
                         (PrivilegedAction<Integer>) () ->
                             Integer.valueOf(System.getProperty("jdk.httpclient.bufsize", Integer.toString(DEFAULT_BUFSIZE))));
@@ -367,6 +369,7 @@ final class HTTP2Loader extends URLLoaderBase {
                   createNormalBodySubscriber() : createZIPEncodedBodySubscriber(contentEncoding);
     }
 
+    @SuppressWarnings("removal")
     private HTTP2Loader(WebPage webPage,
               ByteBufferPool byteBufferPool,
               boolean asynchronous,
@@ -584,7 +587,7 @@ final class HTTP2Loader extends URLLoaderBase {
                 throw th;
             } catch (MalformedURLException ex) {
                 errorCode = LoadListenerClient.MALFORMED_URL;
-            } catch (AccessControlException ex) {
+            } catch (@SuppressWarnings("removal") AccessControlException ex) {
                 errorCode = LoadListenerClient.PERMISSION_DENIED;
             } catch (UnknownHostException ex) {
                 errorCode = LoadListenerClient.UNKNOWN_HOST;

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/NetworkContext.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/NetworkContext.java
@@ -242,8 +242,8 @@ final class NetworkContext {
         private static final Permission modifyThreadGroupPerm = new RuntimePermission("modifyThreadGroup");
         private static final Permission modifyThreadPerm = new RuntimePermission("modifyThread");
 
-        @SuppressWarnings("removal")
         private URLLoaderThreadFactory() {
+            @SuppressWarnings("removal")
             SecurityManager sm = System.getSecurityManager();
             group = (sm != null) ? sm.getThreadGroup()
                     : Thread.currentThread().getThreadGroup();

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/NetworkContext.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/NetworkContext.java
@@ -42,7 +42,6 @@ import com.sun.javafx.logging.PlatformLogger.Level;
 import com.sun.webkit.WebPage;
 import java.security.Permission;
 
-@SuppressWarnings("removal")
 final class NetworkContext {
 
     private static final PlatformLogger logger =
@@ -93,12 +92,14 @@ final class NetworkContext {
                 new URLLoaderThreadFactory());
         threadPool.allowCoreThreadTimeOut(true);
 
-        useHTTP2Loader = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
+        @SuppressWarnings("removal")
+        boolean tmp = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
             // Use HTTP2 by default on JDK 12 or later
             final var version = Runtime.Version.parse(System.getProperty("java.version"));
             final String defaultUseHTTP2 = version.feature() >= 12 ? "true" : "false";
             return Boolean.valueOf(System.getProperty("com.sun.webkit.useHTTP2Loader", defaultUseHTTP2));
         });
+        useHTTP2Loader = tmp;
     }
 
     /**
@@ -217,6 +218,7 @@ final class NetworkContext {
         // Our implementation employs HttpURLConnection for all
         // HTTP exchanges, so return the value of the "http.maxConnections"
         // system property.
+        @SuppressWarnings("removal")
         int propValue = AccessController.doPrivileged(
                 (PrivilegedAction<Integer>) () -> Integer.getInteger("http.maxConnections", -1));
 
@@ -240,12 +242,14 @@ final class NetworkContext {
         private static final Permission modifyThreadGroupPerm = new RuntimePermission("modifyThreadGroup");
         private static final Permission modifyThreadPerm = new RuntimePermission("modifyThread");
 
+        @SuppressWarnings("removal")
         private URLLoaderThreadFactory() {
             SecurityManager sm = System.getSecurityManager();
             group = (sm != null) ? sm.getThreadGroup()
                     : Thread.currentThread().getThreadGroup();
         }
 
+        @SuppressWarnings("removal")
         @Override
         public Thread newThread(Runnable r) {
             // Assert the modifyThread and modifyThreadGroup permissions

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/NetworkContext.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/NetworkContext.java
@@ -42,6 +42,7 @@ import com.sun.javafx.logging.PlatformLogger.Level;
 import com.sun.webkit.WebPage;
 import java.security.Permission;
 
+@SuppressWarnings("removal")
 final class NetworkContext {
 
     private static final PlatformLogger logger =

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/PublicSuffixes.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/PublicSuffixes.java
@@ -72,6 +72,7 @@ final class PublicSuffixes {
     /**
      * The public suffix list file.
      */
+    @SuppressWarnings("removal")
     private static final File pslFile = AccessController.doPrivileged((PrivilegedAction<File>)
         () -> new File(System.getProperty("java.home"), "lib/security/public_suffix_list.dat"));
 
@@ -79,6 +80,7 @@ final class PublicSuffixes {
     /*
      * Determines whether the public suffix list file is available.
      */
+    @SuppressWarnings("removal")
     private static final boolean pslFileExists = AccessController.doPrivileged(
         (PrivilegedAction<Boolean>) () -> {
             if (!pslFile.exists()) {
@@ -195,6 +197,7 @@ final class PublicSuffixes {
         }
 
         private static InputStream getPubSuffixStream() {
+            @SuppressWarnings("removal")
             InputStream is = AccessController.doPrivileged(
                 (PrivilegedAction<InputStream>) () -> {
                     try {

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/SocketStreamHandle.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/SocketStreamHandle.java
@@ -101,6 +101,7 @@ final class SocketStreamHandle {
         return ssh;
     }
 
+    @SuppressWarnings("removal")
     private void run() {
         if (webPage == null) {
             logger.finest("{0} is not associated with any web "
@@ -197,6 +198,7 @@ final class SocketStreamHandle {
     }
 
     private void connect() throws IOException {
+        @SuppressWarnings("removal")
         SecurityManager securityManager = System.getSecurityManager();
         if (securityManager != null) {
             securityManager.checkConnect(host, port);
@@ -207,6 +209,7 @@ final class SocketStreamHandle {
         boolean success = false;
         IOException lastException = null;
         boolean triedDirectConnection = false;
+        @SuppressWarnings("removal")
         ProxySelector proxySelector = AccessController.doPrivileged(
                 (PrivilegedAction<ProxySelector>) () -> ProxySelector.getDefault());
         if (proxySelector != null) {
@@ -419,6 +422,7 @@ final class SocketStreamHandle {
         private final AtomicInteger index = new AtomicInteger(1);
 
         private CustomThreadFactory() {
+            @SuppressWarnings("removal")
             SecurityManager sm = System.getSecurityManager();
             group = (sm != null) ? sm.getThreadGroup()
                     : Thread.currentThread().getThreadGroup();

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/URLLoader.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/URLLoader.java
@@ -122,6 +122,7 @@ final class URLLoader extends URLLoaderBase implements Runnable {
     /**
      * {@inheritDoc}
      */
+    @SuppressWarnings("removal")
     @Override
     public void run() {
         // Run the loader in the page's access control context
@@ -185,7 +186,7 @@ final class URLLoader extends URLLoaderBase implements Runnable {
         } catch (MalformedURLException ex) {
             error = ex;
             errorCode = LoadListenerClient.MALFORMED_URL;
-        } catch (AccessControlException ex) {
+        } catch (@SuppressWarnings("removal") AccessControlException ex) {
             error = ex;
             errorCode = LoadListenerClient.PERMISSION_DENIED;
         } catch (UnknownHostException ex) {

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/URLs.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/URLs.java
@@ -80,7 +80,6 @@ public final class URLs {
      * @throws MalformedURLException if no protocol is specified, or an
      *         unknown protocol is found.
      */
-    @SuppressWarnings("removal")
     public static URL newURL(final URL context, final String spec)
         throws MalformedURLException
     {
@@ -100,13 +99,15 @@ public final class URLs {
             try {
                 // We should be able to specify one of our stream handlers for the URL
                 // when running as an applet or a web start app.
-                return AccessController.doPrivileged((PrivilegedAction<URL>) () -> {
+                @SuppressWarnings("removal")
+                URL result = AccessController.doPrivileged((PrivilegedAction<URL>) () -> {
                     try {
                         return new URL(context, spec, handler);
                     } catch (MalformedURLException muex) {
                         throw new RuntimeException(muex);
                     }
                 }, null, streamHandlerPermission);
+                return result;
 
             } catch (RuntimeException re) {
                 if (re.getCause() instanceof MalformedURLException) {

--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/URLs.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/URLs.java
@@ -80,6 +80,7 @@ public final class URLs {
      * @throws MalformedURLException if no protocol is specified, or an
      *         unknown protocol is found.
      */
+    @SuppressWarnings("removal")
     public static URL newURL(final URL context, final String spec)
         throws MalformedURLException
     {

--- a/modules/javafx.web/src/main/java/javafx/scene/web/HTMLEditorSkin.java
+++ b/modules/javafx.web/src/main/java/javafx/scene/web/HTMLEditorSkin.java
@@ -830,6 +830,7 @@ public class HTMLEditorSkin extends SkinBase<HTMLEditor> {
         button.getStyleClass().add(styleClass);
         toolbar.getItems().add(button);
 
+        @SuppressWarnings("removal")
         Image icon = AccessController.doPrivileged((PrivilegedAction<Image>) () -> new Image(HTMLEditorSkin.class.getResource(iconName).toString()));
 //        button.setGraphic(new ImageView(icon));
         ((StyleableProperty)button.graphicProperty()).applyStyle(null, new ImageView(icon));
@@ -854,6 +855,7 @@ public class HTMLEditorSkin extends SkinBase<HTMLEditor> {
             toggleButton.setToggleGroup(toggleGroup);
         }
 
+        @SuppressWarnings("removal")
         Image icon = AccessController.doPrivileged((PrivilegedAction<Image>) () -> new Image(HTMLEditorSkin.class.getResource(iconName).toString()));
         ((StyleableProperty)toggleButton.graphicProperty()).applyStyle(null, new ImageView(icon));
 //        toggleButton.setGraphic(new ImageView(icon));

--- a/modules/javafx.web/src/main/java/javafx/scene/web/WebEngine.java
+++ b/modules/javafx.web/src/main/java/javafx/scene/web/WebEngine.java
@@ -1565,6 +1565,7 @@ final public class WebEngine {
         }
 
 
+        @SuppressWarnings("removal")
         @Override
         public boolean sendMessageToFrontend(final String message) {
             boolean result = false;

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/UserDataDirectoryTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/UserDataDirectoryTest.java
@@ -400,6 +400,7 @@ public class UserDataDirectoryTest extends TestBase {
         }
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testSecurityError() {
         String url = new File("src/test/resources/test/html/ipsum.html")
@@ -417,6 +418,7 @@ public class UserDataDirectoryTest extends TestBase {
         assertHasNoLocalStorage(webEngine);
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testSecurityErrorWithPassiveHandler() {
         String url = new File("src/test/resources/test/html/ipsum.html")
@@ -438,6 +440,7 @@ public class UserDataDirectoryTest extends TestBase {
         assertOccurred(USER_DATA_DIRECTORY_SECURITY_ERROR, handler);
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testSecurityErrorWithRecoveringHandler() {
         String url = new File("src/test/resources/test/html/ipsum.html")
@@ -718,6 +721,7 @@ public class UserDataDirectoryTest extends TestBase {
         }
     }
 
+    @SuppressWarnings("removal")
     private static final class CustomSecurityManager extends SecurityManager {
         private final String path;
 

--- a/tests/system/src/test/java/test/com/sun/javafx/css/StylesheetWithSecurityManagerTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/css/StylesheetWithSecurityManagerTest.java
@@ -86,6 +86,7 @@ public class StylesheetWithSecurityManagerTest {
         }
     };
 
+    @SuppressWarnings("removal")
     @Test
     public void testRT_38395() throws Exception {
 
@@ -112,6 +113,7 @@ public class StylesheetWithSecurityManagerTest {
         assertEquals(expected.getBlue(), base.getBlue(), 1E-6);
     }
 
+    @SuppressWarnings("removal")
     @Test
     public void testRT_38395_import_local() throws Exception {
         System.setSecurityManager(new TestSecurityManager());
@@ -140,6 +142,7 @@ public class StylesheetWithSecurityManagerTest {
     //
     // The code in URLConverter that this attempts to test only checks to see whether or not there is a SecurityManager.
     //
+    @SuppressWarnings("removal")
     static class TestSecurityManager extends SecurityManager {
         @Override
         public void checkPermission(Permission perm) {

--- a/tests/system/src/test/java/test/robot/helloworld/CustomSecurityManagerTest.java
+++ b/tests/system/src/test/java/test/robot/helloworld/CustomSecurityManagerTest.java
@@ -62,6 +62,7 @@ public class CustomSecurityManagerTest extends VisualTestBase {
     private static final int WIDTH = 400;
     private static final int HEIGHT = 300;
 
+    @SuppressWarnings("removal")
     static class MySecurityManager extends SecurityManager {
         private final boolean permissive;
 
@@ -91,11 +92,13 @@ public class CustomSecurityManagerTest extends VisualTestBase {
         }
     }
 
+    @SuppressWarnings("removal")
     @After
     public void cleanup() {
         System.setSecurityManager(null);
     }
 
+    @SuppressWarnings("removal")
     private void doTestOnTopCommon(SecurityManager sm, boolean expectedOnTop) {
         // Skip on Linux due to 8145152
         assumeTrue(!PlatformUtil.isLinux());
@@ -139,6 +142,7 @@ public class CustomSecurityManagerTest extends VisualTestBase {
         });
     }
 
+    @SuppressWarnings("removal")
     private void doTestFullScreenCommon(SecurityManager sm,
                                         boolean initFullScreen,
                                         boolean expectedFullScreen)
@@ -205,6 +209,7 @@ public class CustomSecurityManagerTest extends VisualTestBase {
         });
     }
 
+    @SuppressWarnings("removal")
     private void doTestRobotCommon(SecurityManager sm, boolean expectedCreateRobot) {
         final AtomicReference<Robot> robot = new AtomicReference<>();
         System.setSecurityManager(sm);


### PR DESCRIPTION
This PR adds the necessary `@SuppressWarnings("removal")` annotations for the recently-integrated security manager deprecation, [JEP 411](https://openjdk.java.net/jeps/411). See openjdk/jdk#4073.

There are four commits:

1. 678b026 : A patch generated by @wangweij to add annotations to the runtime (`modules/*/src/main/java`) using the same automated tooling that he used as part of the implementation of JEP 411.
2. 9698e87 : Same as above for the tests.
3. 1c42cf8 : Manually removes a pair of unused imports, one of which (a static import) was causing a removal warning.
4. 4f87d18 : Manually reduced the scope of the annotation where it was added to an entire class, or to a large method where only a small part of the method uses a deprecated method. This was done using similar techniques to the following fixes that Weijun did in openjdk/jdk#4172.
 
The first two commits represent the bulk of the changes. Other than scanning to ensure that there are no obvious errors, and testing, they probably don't need the same level of scrutiny as the manual changes do.

I tested this on all three platforms by doing a build / test with `JDK_HOME` set to a local JDK 17 ea build that includes the fix for JEP 411. I ran the build with `gradle -PLINT=removal` and verified that there were removal warnings for the security manager APIs without this fix and none with this fix.

NOTE: The following files under `modules/javafx.web/src/android` and `modules/javafx.web/src/ios` were not processed by the automated tool. As I have no way to compile them, I chose not to manually fix them either, but doing so would be trivial as a follow-up fix if desired.

```
modules/javafx.web/src/android/java/com/sun/webkit/Timer.java
modules/javafx.web/src/android/java/com/sun/webkit/WebPage.java
modules/javafx.web/src/android/java/javafx/scene/web/WebEngine.java
modules/javafx.web/src/ios/java/javafx/scene/web/ExportedJavaObject.java
modules/javafx.web/src/ios/java/javafx/scene/web/HTMLEditorSkin.java
modules/javafx.web/src/ios/java/javafx/scene/web/JS2JavaBridge.java
modules/javafx.web/src/ios/java/javafx/scene/web/WebEngine.java
```


/reviewers 2
/contributor add weijun
/contributor add kcr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8264139](https://bugs.openjdk.java.net/browse/JDK-8264139): Suppress removal warnings for Security Manager methods


### Reviewers
 * [Weijun Wang](https://openjdk.java.net/census#weijun) (@wangweij - no project role) 🔄 Re-review required (review applies to 4f87d1873429f11f35c988cddafdf6d834366104)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Contributors
 * Weijun Wang `<weijun@openjdk.org>`
 * Kevin Rushforth `<kcr@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/528/head:pull/528` \
`$ git checkout pull/528`

Update a local copy of the PR: \
`$ git checkout pull/528` \
`$ git pull https://git.openjdk.java.net/jfx pull/528/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 528`

View PR using the GUI difftool: \
`$ git pr show -t 528`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/528.diff">https://git.openjdk.java.net/jfx/pull/528.diff</a>

</details>
