### PR TITLE
8252238: TableView: Editable (pseudo-editable) cells should respect the row editability

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -303,9 +303,11 @@ public class TableCell<S,T> extends IndexedCell<T> {
     @Override public void startEdit() {
         final TableView<S> table = getTableView();
         final TableColumn<S,T> column = getTableColumn();
-        if (! isEditable() ||
-                (table != null && ! table.isEditable()) ||
-                (column != null && ! getTableColumn().isEditable())) {
+        final TableRow<S> row = getTableRow();
+        if (!isEditable() ||
+                (table != null && !table.isEditable()) ||
+                (column != null && !column.isEditable()) ||
+                (row != null) && !row.isEditable()) {
             return;
         }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
@@ -307,7 +307,7 @@ public class TableCell<S,T> extends IndexedCell<T> {
         if (!isEditable() ||
                 (table != null && !table.isEditable()) ||
                 (column != null && !column.isEditable()) ||
-                (row != null) && !row.isEditable()) {
+                (row != null && !row.isEditable())) {
             return;
         }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -306,9 +306,11 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
 
         final TreeTableView<S> table = getTreeTableView();
         final TreeTableColumn<S,T> column = getTableColumn();
-        if (! isEditable() ||
-                (table != null && ! table.isEditable()) ||
-                (column != null && ! getTableColumn().isEditable())) {
+        final TreeTableRow<S> row = getTreeTableRow();
+        if (!isEditable() ||
+                (table != null && !table.isEditable()) ||
+                (column != null && !column.isEditable()) ||
+                (row != null && !row.isEditable())) {
             return;
         }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
@@ -26,6 +26,7 @@
 package test.javafx.scene.control;
 
 import javafx.scene.control.TableRow;
+import javafx.scene.control.TreeTableRow;
 import javafx.scene.control.skin.TableCellSkin;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
@@ -49,6 +50,7 @@ import static org.junit.Assert.assertEquals;
 public class TableCellTest {
     private TableCell<String,String> cell;
     private TableView<String> table;
+    private TableRow<String> row;
     private ObservableList<String> model;
 
     @Before public void setup() {
@@ -63,6 +65,8 @@ public class TableCellTest {
         cell = new TableCell<String,String>();
         model = FXCollections.observableArrayList("Four", "Five", "Fear"); // "Flop", "Food", "Fizz"
         table = new TableView<String>(model);
+
+        row = new TableRow<>();
     }
 
     @After
@@ -323,21 +327,76 @@ public class TableCellTest {
         cell.setSkin(new TableCellSkin(cell));
     }
 
+    /**
+     * Table: Editable<br>
+     * Row: Not editable<br>
+     * Column: Editable<br>
+     * Expected: Cell can not be edited because the row is not editable.
+     */
     @Test
     public void testCellInUneditableRowIsNotEditable() {
         table.setEditable(true);
-        TableRow row = new TableRow();
         row.setEditable(false);
 
-        TableColumn<String, String> treeTableColumn = new TableColumn<>();
-        table.getColumns().add(treeTableColumn);
+        TableColumn<String, String> tableColumn = new TableColumn<>();
+        tableColumn.setEditable(true);
+        table.getColumns().add(tableColumn);
 
-        cell.updateTableColumn(treeTableColumn);
+        cell.updateTableColumn(tableColumn);
         cell.updateTableRow(row);
         cell.updateTableView(table);
 
         cell.updateIndex(0);
+        cell.startEdit();
 
+        assertFalse(cell.isEditing());
+    }
+
+    /**
+     * Table: Not editable<br>
+     * Row: Editable<br>
+     * Column: Editable<br>
+     * Expected: Cell can not be edited because the table is not editable.
+     */
+    @Test
+    public void testCellInUneditableTableIsNotEditable() {
+        table.setEditable(false);
+        row.setEditable(true);
+
+        TableColumn<String, String> tableColumn = new TableColumn<>();
+        tableColumn.setEditable(true);
+        table.getColumns().add(tableColumn);
+
+        cell.updateTableColumn(tableColumn);
+        cell.updateTableRow(row);
+        cell.updateTableView(table);
+
+        cell.updateIndex(0);
+        cell.startEdit();
+
+        assertFalse(cell.isEditing());
+    }
+
+    /**
+     * Table: Editable<br>
+     * Row: Editable<br>
+     * Column: Not editable<br>
+     * Expected: Cell can not be edited because the column is not editable.
+     */
+    @Test
+    public void testCellInUneditableColumnIsNotEditable() {
+        table.setEditable(true);
+        row.setEditable(true);
+
+        TableColumn<String, String> tableColumn = new TableColumn<>();
+        tableColumn.setEditable(false);
+        table.getColumns().add(tableColumn);
+
+        cell.updateTableColumn(tableColumn);
+        cell.updateTableRow(row);
+        cell.updateTableView(table);
+
+        cell.updateIndex(0);
         cell.startEdit();
 
         assertFalse(cell.isEditing());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package test.javafx.scene.control;
 
+import javafx.scene.control.TableRow;
 import javafx.scene.control.skin.TableCellSkin;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
@@ -320,6 +321,26 @@ public class TableCellTest {
     @Test public void test_jdk_8151524() {
         TableCell cell = new TableCell();
         cell.setSkin(new TableCellSkin(cell));
+    }
+
+    @Test
+    public void testCellInUneditableRowIsNotEditable() {
+        table.setEditable(true);
+        TableRow row = new TableRow();
+        row.setEditable(false);
+
+        TableColumn<String, String> treeTableColumn = new TableColumn<>();
+        table.getColumns().add(treeTableColumn);
+
+        cell.updateTableColumn(treeTableColumn);
+        cell.updateTableRow(row);
+        cell.updateTableView(table);
+
+        cell.updateIndex(0);
+
+        cell.startEdit();
+
+        assertFalse(cell.isEditing());
     }
 
     /**

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
@@ -633,12 +633,19 @@ public class TreeTableCellTest {
         cell.setSkin(new TreeTableCellSkin(cell));
     }
 
+    /**
+     * Table: Editable<br>
+     * Row: Not editable<br>
+     * Column: Editable<br>
+     * Expected: Cell can not be edited because the row is not editable.
+     */
     @Test
     public void testCellInUneditableRowIsNotEditable() {
         tree.setEditable(true);
         row.setEditable(false);
 
-        TreeTableColumn treeTableColumn = new TreeTableColumn();
+        TreeTableColumn<String, String> treeTableColumn = new TreeTableColumn<>();
+        treeTableColumn.setEditable(true);
         tree.getColumns().add(treeTableColumn);
 
         cell.updateTreeTableColumn(treeTableColumn);
@@ -646,7 +653,56 @@ public class TreeTableCellTest {
         cell.updateTreeTableView(tree);
 
         cell.updateIndex(0);
+        cell.startEdit();
 
+        assertFalse(cell.isEditing());
+    }
+
+    /**
+     * Table: Not editable<br>
+     * Row: Editable<br>
+     * Column: Editable<br>
+     * Expected: Cell can not be edited because the table is not editable.
+     */
+    @Test
+    public void testCellInUneditableTableIsNotEditable() {
+        tree.setEditable(false);
+        row.setEditable(true);
+
+        TreeTableColumn<String, String> treeTableColumn = new TreeTableColumn<>();
+        treeTableColumn.setEditable(true);
+        tree.getColumns().add(treeTableColumn);
+
+        cell.updateTreeTableColumn(treeTableColumn);
+        cell.updateTreeTableRow(row);
+        cell.updateTreeTableView(tree);
+
+        cell.updateIndex(0);
+        cell.startEdit();
+
+        assertFalse(cell.isEditing());
+    }
+
+    /**
+     * Table: Editable<br>
+     * Row: Editable<br>
+     * Column: Not editable<br>
+     * Expected: Cell can not be edited because the column is not editable.
+     */
+    @Test
+    public void testCellInUneditableColumnIsNotEditable() {
+        tree.setEditable(true);
+        row.setEditable(true);
+
+        TreeTableColumn<String, String> treeTableColumn = new TreeTableColumn<>();
+        treeTableColumn.setEditable(false);
+        tree.getColumns().add(treeTableColumn);
+
+        cell.updateTreeTableColumn(treeTableColumn);
+        cell.updateTreeTableRow(row);
+        cell.updateTreeTableView(tree);
+
+        cell.updateIndex(0);
         cell.startEdit();
 
         assertFalse(cell.isEditing());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -631,6 +631,25 @@ public class TreeTableCellTest {
     @Test public void test_jdk_8151524() {
         TreeTableCell cell = new TreeTableCell();
         cell.setSkin(new TreeTableCellSkin(cell));
+    }
+
+    @Test
+    public void testCellInUneditableRowIsNotEditable() {
+        tree.setEditable(true);
+        row.setEditable(false);
+
+        TreeTableColumn treeTableColumn = new TreeTableColumn();
+        tree.getColumns().add(treeTableColumn);
+
+        cell.updateTreeTableColumn(treeTableColumn);
+        cell.updateTreeTableRow(row);
+        cell.updateTreeTableView(tree);
+
+        cell.updateIndex(0);
+
+        cell.startEdit();
+
+        assertFalse(cell.isEditing());
     }
 
     /**


### PR DESCRIPTION
This PR enables Tree- and TableCells to also check the row editability when an edit should happen. With this a Tree- or TableCell is not editable, when the row where the cell is in is not.

While this PR fixes the problem described in the ticket, it does not fix the example.
This is due the example uses the **CheckBoxTableCell**, which is a ready-to-use subclass of **TableCell**. 

While looking into this, I found out that multiple sub implementations still have this issue, but the fix is not always the same, e.g. CheckBoxTableCell should disable the CheckBox (in **updateItem**), while the ChoiceBoxTableCell should check the row editability in the **startEdit** method (like this PR does).

I created a follow-up issues for fixing all the sub Tree- and TableCell implementation which do not count the row editability in:
[JDK-8268295](https://bugs.openjdk.java.net/browse/JDK-8268295)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8252238](https://bugs.openjdk.java.net/browse/JDK-8252238): TableView: Editable (pseudo-editable) cells should respect the row editability


### Reviewers
 * [Jeanette Winzenburg](https://openjdk.java.net/census#fastegal) (@kleopatra - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/529/head:pull/529` \
`$ git checkout pull/529`

Update a local copy of the PR: \
`$ git checkout pull/529` \
`$ git pull https://git.openjdk.java.net/jfx pull/529/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 529`

View PR using the GUI difftool: \
`$ git pr show -t 529`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/529.diff">https://git.openjdk.java.net/jfx/pull/529.diff</a>

</details>
