### PR TITLE
8255015: Inconsistent illumination of 3D shape by PointLight

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGSubScene.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGSubScene.java
@@ -206,6 +206,10 @@ public class NGSubScene extends NGNode {
                                               msaa);
             }
             Graphics rttGraphics = rtt.createGraphics();
+            // The pixel scale factors must be set to the rttGraphics, otherwise the position
+            // of the lights will not be scaled correctly on retina displays
+            // See https://bugs.openjdk.java.net/browse/JDK-8255015
+            rttGraphics.setPixelScaleFactors(g.getPixelScaleFactorX(), g.getPixelScaleFactorY());
             rttGraphics.scale((float) scaleX, (float) scaleY);
             rttGraphics.setLights(lights);
 


### PR DESCRIPTION
The inconsistent illumination happens on Macs with retina displays only if the 3D shape is placed in a SubScene. The light sources are located with wrong coordinates in sub scenes and this causes a different illumination. The wrong coordinates for the light sources come from the fact that the retina pixel scale factors are not used in a SubScene.

With this pull request, the retina pixel scale factors will be also used in SubScenes and this should resolve the bug
[https://bugs.openjdk.java.net/browse/JDK-8255015](url)