### PR TITLE
8268219: hlsprogressbuffer should provide PTS after GStreamer update

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gstreamer/libs/gst/base/gstbaseparse.c
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gstreamer/libs/gst/base/gstbaseparse.c
@@ -1336,11 +1336,7 @@ gst_base_parse_sink_event_default (GstBaseParse * parse, GstEvent * event)
         /* not considered BYTE seekable if it is talking to us in TIME,
          * whatever else it might claim */
         parse->priv->upstream_seekable = FALSE;
-#ifndef GSTREAMER_LITE
         next_dts = GST_CLOCK_TIME_NONE;
-#else // GSTREAMER_LITE
-        next_dts = in_segment->start;
-#endif // GSTREAMER_LITE
         gst_event_copy_segment (event, &out_segment);
       }
 


### PR DESCRIPTION
- Reverted JDK-8268152 fix in gstbaseparse.c, since it is no longer needed.
 - Our hlsprogressbuffer outputs buffers in time format, but without any PTS. After GStreamer update mpregparser no longer tries to figure out timestamps if stream in time format and it will assume that upstream provides timestamps. Fixed by providing starting timestamp at the beginning or after seek. In this case mpegparser able to figure out timestamps and will provide them for each buffer downstream.
 - Segment start was also incorrect it should be seek position, otherwise after seek playback waits for seek time. For example if we seek to 2 min, mediaplayer hangs for 2 min and only after that resumes playback. I think it worked before, since mpegparser handled PTS before.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268219](https://bugs.openjdk.java.net/browse/JDK-8268219): hlsprogressbuffer should provide PTS after GStreamer update


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/532/head:pull/532` \
`$ git checkout pull/532`

Update a local copy of the PR: \
`$ git checkout pull/532` \
`$ git pull https://git.openjdk.java.net/jfx pull/532/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 532`

View PR using the GUI difftool: \
`$ git pr show -t 532`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/532.diff">https://git.openjdk.java.net/jfx/pull/532.diff</a>

</details>
