### PR TITLE
8268642: Expand the javafx.beans.property.Property documentation

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/beans/property/BooleanPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/BooleanPropertyBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,13 +159,13 @@ public abstract class BooleanPropertyBase extends BooleanProperty {
      * Note:
      */
     @Override
-    public void bind(final ObservableValue<? extends Boolean> rawObservable) {
-        if (rawObservable == null) {
+    public void bind(final ObservableValue<? extends Boolean> source) {
+        if (source == null) {
             throw new NullPointerException("Cannot bind to null");
         }
 
-        final ObservableBooleanValue newObservable = (rawObservable instanceof ObservableBooleanValue) ? (ObservableBooleanValue) rawObservable
-                : new ValueWrapper(rawObservable);
+        final ObservableBooleanValue newObservable = (source instanceof ObservableBooleanValue) ? (ObservableBooleanValue) source
+                : new ValueWrapper(source);
 
         if (!newObservable.equals(observable)) {
             unbind();

--- a/modules/javafx.base/src/main/java/javafx/beans/property/BooleanPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/BooleanPropertyBase.java
@@ -27,6 +27,7 @@ package javafx.beans.property;
 
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
+import javafx.beans.WeakListener;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableBooleanValue;
@@ -34,7 +35,7 @@ import javafx.beans.value.ObservableValue;
 
 import com.sun.javafx.binding.ExpressionHelper;
 import java.lang.ref.WeakReference;
-import javafx.beans.WeakListener;
+import java.util.Objects;
 
 /**
  * The class {@code BooleanPropertyBase} is the base class for a property
@@ -160,12 +161,10 @@ public abstract class BooleanPropertyBase extends BooleanProperty {
      */
     @Override
     public void bind(final ObservableValue<? extends Boolean> source) {
-        if (source == null) {
-            throw new NullPointerException("Cannot bind to null");
-        }
+        Objects.requireNonNull(source, "Cannot bind to null");
 
-        final ObservableBooleanValue newObservable = (source instanceof ObservableBooleanValue) ? (ObservableBooleanValue) source
-                : new ValueWrapper(source);
+        final ObservableBooleanValue newObservable = (source instanceof ObservableBooleanValue) ?
+                (ObservableBooleanValue) source : new ValueWrapper(source);
 
         if (!newObservable.equals(observable)) {
             unbind();

--- a/modules/javafx.base/src/main/java/javafx/beans/property/DoublePropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/DoublePropertyBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,17 +161,17 @@ public abstract class DoublePropertyBase extends DoubleProperty {
      * {@inheritDoc}
      */
     @Override
-    public void bind(final ObservableValue<? extends Number> rawObservable) {
-        if (rawObservable == null) {
+    public void bind(final ObservableValue<? extends Number> source) {
+        if (source == null) {
             throw new NullPointerException("Cannot bind to null");
         }
 
         ObservableDoubleValue newObservable;
-        if (rawObservable instanceof ObservableDoubleValue) {
-            newObservable = (ObservableDoubleValue)rawObservable;
-        } else if (rawObservable instanceof ObservableNumberValue) {
-            final ObservableNumberValue numberValue = (ObservableNumberValue)rawObservable;
-            newObservable = new ValueWrapper(rawObservable) {
+        if (source instanceof ObservableDoubleValue) {
+            newObservable = (ObservableDoubleValue)source;
+        } else if (source instanceof ObservableNumberValue) {
+            final ObservableNumberValue numberValue = (ObservableNumberValue)source;
+            newObservable = new ValueWrapper(source) {
 
                 @Override
                 protected double computeValue() {
@@ -179,11 +179,11 @@ public abstract class DoublePropertyBase extends DoubleProperty {
                 }
             };
         } else {
-            newObservable = new ValueWrapper(rawObservable) {
+            newObservable = new ValueWrapper(source) {
 
                 @Override
                 protected double computeValue() {
-                    final Number value = rawObservable.getValue();
+                    final Number value = source.getValue();
                     return (value == null)? 0.0 : value.doubleValue();
                 }
             };

--- a/modules/javafx.base/src/main/java/javafx/beans/property/DoublePropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/DoublePropertyBase.java
@@ -27,15 +27,16 @@ package javafx.beans.property;
 
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
+import javafx.beans.WeakListener;
 import javafx.beans.binding.DoubleBinding;
 import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableDoubleValue;
+import javafx.beans.value.ObservableNumberValue;
 import javafx.beans.value.ObservableValue;
 
 import com.sun.javafx.binding.ExpressionHelper;
 import java.lang.ref.WeakReference;
-import javafx.beans.WeakListener;
-import javafx.beans.value.ObservableDoubleValue;
-import javafx.beans.value.ObservableNumberValue;
+import java.util.Objects;
 
 /**
  * The class {@code DoublePropertyBase} is the base class for a property
@@ -162,9 +163,7 @@ public abstract class DoublePropertyBase extends DoubleProperty {
      */
     @Override
     public void bind(final ObservableValue<? extends Number> source) {
-        if (source == null) {
-            throw new NullPointerException("Cannot bind to null");
-        }
+        Objects.requireNonNull(source, "Cannot bind to null");
 
         ObservableDoubleValue newObservable;
         if (source instanceof ObservableDoubleValue) {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/FloatPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/FloatPropertyBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,17 +161,17 @@ public abstract class FloatPropertyBase extends FloatProperty {
      * {@inheritDoc}
      */
     @Override
-    public void bind(final ObservableValue<? extends Number> rawObservable) {
-        if (rawObservable == null) {
+    public void bind(final ObservableValue<? extends Number> source) {
+        if (source == null) {
             throw new NullPointerException("Cannot bind to null");
         }
 
         ObservableFloatValue newObservable;
-        if (rawObservable instanceof ObservableFloatValue) {
-            newObservable = (ObservableFloatValue)rawObservable;
-        } else if (rawObservable instanceof ObservableNumberValue) {
-            final ObservableNumberValue numberValue = (ObservableNumberValue)rawObservable;
-            newObservable = new ValueWrapper(rawObservable) {
+        if (source instanceof ObservableFloatValue) {
+            newObservable = (ObservableFloatValue)source;
+        } else if (source instanceof ObservableNumberValue) {
+            final ObservableNumberValue numberValue = (ObservableNumberValue)source;
+            newObservable = new ValueWrapper(source) {
 
                 @Override
                 protected float computeValue() {
@@ -179,11 +179,11 @@ public abstract class FloatPropertyBase extends FloatProperty {
                 }
             };
         } else {
-            newObservable = new ValueWrapper(rawObservable) {
+            newObservable = new ValueWrapper(source) {
 
                 @Override
                 protected float computeValue() {
-                    final Number value = rawObservable.getValue();
+                    final Number value = source.getValue();
                     return (value == null)? 0.0f : value.floatValue();
                 }
             };

--- a/modules/javafx.base/src/main/java/javafx/beans/property/FloatPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/FloatPropertyBase.java
@@ -27,15 +27,16 @@ package javafx.beans.property;
 
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
+import javafx.beans.WeakListener;
 import javafx.beans.binding.FloatBinding;
 import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableFloatValue;
+import javafx.beans.value.ObservableNumberValue;
 import javafx.beans.value.ObservableValue;
 
 import com.sun.javafx.binding.ExpressionHelper;
 import java.lang.ref.WeakReference;
-import javafx.beans.WeakListener;
-import javafx.beans.value.ObservableFloatValue;
-import javafx.beans.value.ObservableNumberValue;
+import java.util.Objects;
 
 /**
  * The class {@code FloatPropertyBase} is the base class for a property wrapping
@@ -162,9 +163,7 @@ public abstract class FloatPropertyBase extends FloatProperty {
      */
     @Override
     public void bind(final ObservableValue<? extends Number> source) {
-        if (source == null) {
-            throw new NullPointerException("Cannot bind to null");
-        }
+        Objects.requireNonNull(source, "Cannot bind to null");
 
         ObservableFloatValue newObservable;
         if (source instanceof ObservableFloatValue) {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/IntegerPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/IntegerPropertyBase.java
@@ -27,15 +27,16 @@ package javafx.beans.property;
 
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
+import javafx.beans.WeakListener;
 import javafx.beans.binding.IntegerBinding;
 import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableIntegerValue;
+import javafx.beans.value.ObservableNumberValue;
 import javafx.beans.value.ObservableValue;
 
 import com.sun.javafx.binding.ExpressionHelper;
 import java.lang.ref.WeakReference;
-import javafx.beans.WeakListener;
-import javafx.beans.value.ObservableIntegerValue;
-import javafx.beans.value.ObservableNumberValue;
+import java.util.Objects;
 
 /**
  * The class {@code IntegerPropertyBase} is the base class for a property
@@ -162,9 +163,7 @@ public abstract class IntegerPropertyBase extends IntegerProperty {
      */
     @Override
     public void bind(final ObservableValue<? extends Number> source) {
-        if (source == null) {
-            throw new NullPointerException("Cannot bind to null");
-        }
+        Objects.requireNonNull(source, "Cannot bind to null");
 
         ObservableIntegerValue newObservable;
         if (source instanceof ObservableIntegerValue) {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/IntegerPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/IntegerPropertyBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,17 +161,17 @@ public abstract class IntegerPropertyBase extends IntegerProperty {
      * {@inheritDoc}
      */
     @Override
-    public void bind(final ObservableValue<? extends Number> rawObservable) {
-        if (rawObservable == null) {
+    public void bind(final ObservableValue<? extends Number> source) {
+        if (source == null) {
             throw new NullPointerException("Cannot bind to null");
         }
 
         ObservableIntegerValue newObservable;
-        if (rawObservable instanceof ObservableIntegerValue) {
-            newObservable = (ObservableIntegerValue)rawObservable;
-        } else if (rawObservable instanceof ObservableNumberValue) {
-            final ObservableNumberValue numberValue = (ObservableNumberValue)rawObservable;
-            newObservable = new ValueWrapper(rawObservable) {
+        if (source instanceof ObservableIntegerValue) {
+            newObservable = (ObservableIntegerValue)source;
+        } else if (source instanceof ObservableNumberValue) {
+            final ObservableNumberValue numberValue = (ObservableNumberValue)source;
+            newObservable = new ValueWrapper(source) {
 
                 @Override
                 protected int computeValue() {
@@ -179,11 +179,11 @@ public abstract class IntegerPropertyBase extends IntegerProperty {
                 }
             };
         } else {
-            newObservable = new ValueWrapper(rawObservable) {
+            newObservable = new ValueWrapper(source) {
 
                 @Override
                 protected int computeValue() {
-                    final Number value = rawObservable.getValue();
+                    final Number value = source.getValue();
                     return (value == null)? 0 : value.intValue();
                 }
             };

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ListPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ListPropertyBase.java
@@ -27,6 +27,7 @@ package javafx.beans.property;
 
 import com.sun.javafx.binding.ListExpressionHelper;
 import java.lang.ref.WeakReference;
+import java.util.Objects;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.WeakListener;
@@ -266,9 +267,7 @@ public abstract class ListPropertyBase<E> extends ListProperty<E> {
 
     @Override
     public void bind(final ObservableValue<? extends ObservableList<E>> source) {
-        if (source == null) {
-            throw new NullPointerException("Cannot bind to null");
-        }
+        Objects.requireNonNull(source, "Cannot bind to null");
 
         if (source != observable) {
             unbind();

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ListPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ListPropertyBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -265,14 +265,14 @@ public abstract class ListPropertyBase<E> extends ListProperty<E> {
     }
 
     @Override
-    public void bind(final ObservableValue<? extends ObservableList<E>> newObservable) {
-        if (newObservable == null) {
+    public void bind(final ObservableValue<? extends ObservableList<E>> source) {
+        if (source == null) {
             throw new NullPointerException("Cannot bind to null");
         }
 
-        if (newObservable != observable) {
+        if (source != observable) {
             unbind();
-            observable = newObservable;
+            observable = source;
             if (listener == null) {
                 listener = new Listener<>(this);
             }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/LongPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/LongPropertyBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,17 +161,17 @@ public abstract class LongPropertyBase extends LongProperty {
      * {@inheritDoc}
      */
     @Override
-    public void bind(final ObservableValue<? extends Number> rawObservable) {
-        if (rawObservable == null) {
+    public void bind(final ObservableValue<? extends Number> source) {
+        if (source == null) {
             throw new NullPointerException("Cannot bind to null");
         }
 
         ObservableLongValue newObservable;
-        if (rawObservable instanceof ObservableLongValue) {
-            newObservable = (ObservableLongValue)rawObservable;
-        } else if (rawObservable instanceof ObservableNumberValue) {
-            final ObservableNumberValue numberValue = (ObservableNumberValue)rawObservable;
-            newObservable = new ValueWrapper(rawObservable) {
+        if (source instanceof ObservableLongValue) {
+            newObservable = (ObservableLongValue)source;
+        } else if (source instanceof ObservableNumberValue) {
+            final ObservableNumberValue numberValue = (ObservableNumberValue)source;
+            newObservable = new ValueWrapper(source) {
 
                 @Override
                 protected long computeValue() {
@@ -179,11 +179,11 @@ public abstract class LongPropertyBase extends LongProperty {
                 }
             };
         } else {
-            newObservable = new ValueWrapper(rawObservable) {
+            newObservable = new ValueWrapper(source) {
 
                 @Override
                 protected long computeValue() {
-                    final Number value = rawObservable.getValue();
+                    final Number value = source.getValue();
                     return (value == null)? 0L : value.longValue();
                 }
             };

--- a/modules/javafx.base/src/main/java/javafx/beans/property/LongPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/LongPropertyBase.java
@@ -27,15 +27,16 @@ package javafx.beans.property;
 
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
+import javafx.beans.WeakListener;
 import javafx.beans.binding.LongBinding;
 import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableLongValue;
+import javafx.beans.value.ObservableNumberValue;
 import javafx.beans.value.ObservableValue;
 
 import com.sun.javafx.binding.ExpressionHelper;
 import java.lang.ref.WeakReference;
-import javafx.beans.WeakListener;
-import javafx.beans.value.ObservableLongValue;
-import javafx.beans.value.ObservableNumberValue;
+import java.util.Objects;
 
 /**
  * The class {@code LongPropertyBase} is the base class for a property wrapping
@@ -162,9 +163,7 @@ public abstract class LongPropertyBase extends LongProperty {
      */
     @Override
     public void bind(final ObservableValue<? extends Number> source) {
-        if (source == null) {
-            throw new NullPointerException("Cannot bind to null");
-        }
+        Objects.requireNonNull(source, "Cannot bind to null");
 
         ObservableLongValue newObservable;
         if (source instanceof ObservableLongValue) {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/MapPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/MapPropertyBase.java
@@ -27,6 +27,7 @@ package javafx.beans.property;
 
 import com.sun.javafx.binding.MapExpressionHelper;
 import java.lang.ref.WeakReference;
+import java.util.Objects;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.WeakListener;
@@ -268,9 +269,8 @@ public abstract class MapPropertyBase<K, V> extends MapProperty<K, V> {
 
     @Override
     public void bind(final ObservableValue<? extends ObservableMap<K, V>> source) {
-        if (source == null) {
-            throw new NullPointerException("Cannot bind to null");
-        }
+        Objects.requireNonNull(source, "Cannot bind to null");
+
         if (source != observable) {
             unbind();
             observable = source;

--- a/modules/javafx.base/src/main/java/javafx/beans/property/MapPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/MapPropertyBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -267,13 +267,13 @@ public abstract class MapPropertyBase<K, V> extends MapProperty<K, V> {
     }
 
     @Override
-    public void bind(final ObservableValue<? extends ObservableMap<K, V>> newObservable) {
-        if (newObservable == null) {
+    public void bind(final ObservableValue<? extends ObservableMap<K, V>> source) {
+        if (source == null) {
             throw new NullPointerException("Cannot bind to null");
         }
-        if (newObservable != observable) {
+        if (source != observable) {
             unbind();
-            observable = newObservable;
+            observable = source;
             if (listener == null) {
                 listener = new Listener<>(this);
             }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ObjectPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ObjectPropertyBase.java
@@ -27,12 +27,13 @@ package javafx.beans.property;
 
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
+import javafx.beans.WeakListener;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 
 import com.sun.javafx.binding.ExpressionHelper;
 import java.lang.ref.WeakReference;
-import javafx.beans.WeakListener;
+import java.util.Objects;
 
 /**
  * The class {@code ObjectPropertyBase} is the base class for a property
@@ -161,9 +162,7 @@ public abstract class ObjectPropertyBase<T> extends ObjectProperty<T> {
      */
     @Override
     public void bind(final ObservableValue<? extends T> source) {
-        if (source == null) {
-            throw new NullPointerException("Cannot bind to null");
-        }
+        Objects.requireNonNull(source, "Cannot bind to null");
 
         if (!source.equals(this.observable)) {
             unbind();

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ObjectPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ObjectPropertyBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -160,14 +160,14 @@ public abstract class ObjectPropertyBase<T> extends ObjectProperty<T> {
      * {@inheritDoc}
      */
     @Override
-    public void bind(final ObservableValue<? extends T> newObservable) {
-        if (newObservable == null) {
+    public void bind(final ObservableValue<? extends T> source) {
+        if (source == null) {
             throw new NullPointerException("Cannot bind to null");
         }
 
-        if (!newObservable.equals(this.observable)) {
+        if (!source.equals(this.observable)) {
             unbind();
-            observable = newObservable;
+            observable = source;
             if (listener == null) {
                 listener = new Listener(this);
             }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/Property.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/Property.java
@@ -44,9 +44,9 @@ public interface Property<T> extends ReadOnlyProperty<T>, WritableValue<T> {
      * and an {@link ObservableValue} (the <i>binding source</i>).
      * <p>
      * After establishing the binding, the value of the bound property is synchronized with the value
-     * of the binding source. If the value of the binding source changes, the change is immediately
-     * reflected in the value of the bound property. Furthermore, the bound property becomes effectively
-     * read-only: any call to {@link #setValue(Object)} will fail with an exception.
+     * of the binding source: any change to the value of the binding source will immediately result in
+     * the value of the bound property being changed accordingly. Furthermore, the bound property becomes
+     * effectively read-only: any call to {@link #setValue(Object)} will fail with an exception.
      * <p>
      * The bound property <i>strongly</i> references the binding source; this means that, as long as
      * the bound property is alive, the binding source will not be garbage-collected. As a consequence,
@@ -113,6 +113,8 @@ public interface Property<T> extends ReadOnlyProperty<T>, WritableValue<T> {
      * @param other the other property
      * @throws NullPointerException if {@code other} is {@code null}
      * @throws IllegalArgumentException if {@code other} is {@code this}
+     *
+     * @see #bind(ObservableValue)
      */
     void bindBidirectional(Property<T> other);
 

--- a/modules/javafx.base/src/main/java/javafx/beans/property/SetPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/SetPropertyBase.java
@@ -27,6 +27,7 @@ package javafx.beans.property;
 
 import com.sun.javafx.binding.SetExpressionHelper;
 import java.lang.ref.WeakReference;
+import java.util.Objects;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.WeakListener;
@@ -268,9 +269,7 @@ public abstract class SetPropertyBase<E> extends SetProperty<E> {
 
     @Override
     public void bind(final ObservableValue<? extends ObservableSet<E>> source) {
-        if (source == null) {
-            throw new NullPointerException("Cannot bind to null");
-        }
+        Objects.requireNonNull(source, "Cannot bind to null");
 
         if (source != this.observable) {
             unbind();

--- a/modules/javafx.base/src/main/java/javafx/beans/property/SetPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/SetPropertyBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -267,14 +267,14 @@ public abstract class SetPropertyBase<E> extends SetProperty<E> {
     }
 
     @Override
-    public void bind(final ObservableValue<? extends ObservableSet<E>> newObservable) {
-        if (newObservable == null) {
+    public void bind(final ObservableValue<? extends ObservableSet<E>> source) {
+        if (source == null) {
             throw new NullPointerException("Cannot bind to null");
         }
 
-        if (newObservable != this.observable) {
+        if (source != this.observable) {
             unbind();
-            observable = newObservable;
+            observable = source;
             if (listener == null) {
                 listener = new Listener<>(this);
             }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/StringPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/StringPropertyBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,13 +158,13 @@ public abstract class StringPropertyBase extends StringProperty {
      * {@inheritDoc}
      */
     @Override
-    public void bind(ObservableValue<? extends String> newObservable) {
-        if (newObservable == null) {
+    public void bind(ObservableValue<? extends String> source) {
+        if (source == null) {
             throw new NullPointerException("Cannot bind to null");
         }
-        if (!newObservable.equals(observable)) {
+        if (!source.equals(observable)) {
             unbind();
-            observable = newObservable;
+            observable = source;
             if (listener == null) {
                 listener = new Listener(this);
             }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/StringPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/StringPropertyBase.java
@@ -27,12 +27,13 @@ package javafx.beans.property;
 
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
+import javafx.beans.WeakListener;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 
 import com.sun.javafx.binding.ExpressionHelper;
 import java.lang.ref.WeakReference;
-import javafx.beans.WeakListener;
+import java.util.Objects;
 
 /**
  * The class {@code StringPropertyBase} is the base class for a property
@@ -159,9 +160,8 @@ public abstract class StringPropertyBase extends StringProperty {
      */
     @Override
     public void bind(ObservableValue<? extends String> source) {
-        if (source == null) {
-            throw new NullPointerException("Cannot bind to null");
-        }
+        Objects.requireNonNull(source, "Cannot bind to null");
+
         if (!source.equals(observable)) {
             unbind();
             observable = source;

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanBooleanProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanBooleanProperty.java
@@ -155,15 +155,15 @@ public final class JavaBeanBooleanProperty extends BooleanProperty implements Ja
      * {@inheritDoc}
      */
     @Override
-    public void bind(ObservableValue<? extends Boolean> observable) {
-        if (observable == null) {
+    public void bind(ObservableValue<? extends Boolean> source) {
+        if (source == null) {
             throw new NullPointerException("Cannot bind to null");
         }
 
-        if (!observable.equals(this.observable)) {
+        if (!source.equals(this.observable)) {
             unbind();
-            set(observable.getValue());
-            this.observable = observable;
+            set(source.getValue());
+            this.observable = source;
             this.observable.addListener(listener);
         }
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanDoubleProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanDoubleProperty.java
@@ -156,15 +156,15 @@ public final class JavaBeanDoubleProperty extends DoubleProperty implements Java
      * {@inheritDoc}
      */
     @Override
-    public void bind(ObservableValue<? extends Number> observable) {
-        if (observable == null) {
+    public void bind(ObservableValue<? extends Number> source) {
+        if (source == null) {
             throw new NullPointerException("Cannot bind to null");
         }
 
-        if (!observable.equals(this.observable)) {
+        if (!source.equals(this.observable)) {
             unbind();
-            set(observable.getValue().doubleValue());
-            this.observable = observable;
+            set(source.getValue().doubleValue());
+            this.observable = source;
             this.observable.addListener(listener);
         }
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanFloatProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanFloatProperty.java
@@ -155,15 +155,15 @@ public final class JavaBeanFloatProperty extends FloatProperty implements JavaBe
      * {@inheritDoc}
      */
     @Override
-    public void bind(ObservableValue<? extends Number> observable) {
-        if (observable == null) {
+    public void bind(ObservableValue<? extends Number> source) {
+        if (source == null) {
             throw new NullPointerException("Cannot bind to null");
         }
 
-        if (!observable.equals(this.observable)) {
+        if (!source.equals(this.observable)) {
             unbind();
-            set(observable.getValue().floatValue());
-            this.observable = observable;
+            set(source.getValue().floatValue());
+            this.observable = source;
             this.observable.addListener(listener);
         }
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanIntegerProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanIntegerProperty.java
@@ -155,15 +155,15 @@ public final class JavaBeanIntegerProperty extends IntegerProperty implements Ja
      * {@inheritDoc}
      */
     @Override
-    public void bind(ObservableValue<? extends Number> observable) {
-        if (observable == null) {
+    public void bind(ObservableValue<? extends Number> source) {
+        if (source == null) {
             throw new NullPointerException("Cannot bind to null");
         }
 
-        if (!observable.equals(this.observable)) {
+        if (!source.equals(this.observable)) {
             unbind();
-            set(observable.getValue().intValue());
-            this.observable = observable;
+            set(source.getValue().intValue());
+            this.observable = source;
             this.observable.addListener(listener);
         }
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanLongProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanLongProperty.java
@@ -155,15 +155,15 @@ public final class JavaBeanLongProperty extends LongProperty implements JavaBean
      * {@inheritDoc}
      */
     @Override
-    public void bind(ObservableValue<? extends Number> observable) {
-        if (observable == null) {
+    public void bind(ObservableValue<? extends Number> source) {
+        if (source == null) {
             throw new NullPointerException("Cannot bind to null");
         }
 
-        if (!observable.equals(this.observable)) {
+        if (!source.equals(this.observable)) {
             unbind();
-            set(observable.getValue().longValue());
-            this.observable = observable;
+            set(source.getValue().longValue());
+            this.observable = source;
             this.observable.addListener(listener);
         }
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanObjectProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanObjectProperty.java
@@ -159,15 +159,15 @@ public final class JavaBeanObjectProperty<T> extends ObjectProperty<T> implement
      * {@inheritDoc}
      */
     @Override
-    public void bind(ObservableValue<? extends T> observable) {
-        if (observable == null) {
+    public void bind(ObservableValue<? extends T> source) {
+        if (source == null) {
             throw new NullPointerException("Cannot bind to null");
         }
 
-        if (!observable.equals(this.observable)) {
+        if (!source.equals(this.observable)) {
             unbind();
-            set(observable.getValue());
-            this.observable = observable;
+            set(source.getValue());
+            this.observable = source;
             this.observable.addListener(listener);
         }
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanStringProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanStringProperty.java
@@ -154,15 +154,15 @@ public final class JavaBeanStringProperty extends StringProperty implements Java
      * {@inheritDoc}
      */
     @Override
-    public void bind(ObservableValue<? extends String> observable) {
-        if (observable == null) {
+    public void bind(ObservableValue<? extends String> source) {
+        if (source == null) {
             throw new NullPointerException("Cannot bind to null");
         }
 
-        if (!observable.equals(this.observable)) {
+        if (!source.equals(this.observable)) {
             unbind();
-            set(observable.getValue());
-            this.observable = observable;
+            set(source.getValue());
+            this.observable = source;
             this.observable.addListener(listener);
         }
     }


### PR DESCRIPTION
* Expand the `Property.bind` and `Property.bindBidirectional` documentation
* Change the name of the formal parameter of `Property.bind` to "source" (currently, it is inconsistently named "observable", "rawObservable" or "newObservable")

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ The change requires a CSR request to be approved.

### Issue
 * [JDK-8268642](https://bugs.openjdk.java.net/browse/JDK-8268642): Expand the javafx.beans.property.Property documentation


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/533/head:pull/533` \
`$ git checkout pull/533`

Update a local copy of the PR: \
`$ git checkout pull/533` \
`$ git pull https://git.openjdk.java.net/jfx pull/533/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 533`

View PR using the GUI difftool: \
`$ git pr show -t 533`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/533.diff">https://git.openjdk.java.net/jfx/pull/533.diff</a>

</details>
