### PR TITLE
8240506: TextFieldSkin/Behavior: misbehavior on switching skin

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextFieldBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextFieldBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,12 +26,10 @@
 package com.sun.javafx.scene.control.behavior;
 
 
-import com.sun.javafx.PlatformUtil;
 import com.sun.javafx.geom.transform.Affine3D;
 import com.sun.javafx.scene.NodeHelper;
 import com.sun.javafx.scene.control.Properties;
 import com.sun.javafx.scene.control.skin.Utils;
-import com.sun.javafx.stage.WindowHelper;
 
 import static com.sun.javafx.PlatformUtil.*;
 
@@ -39,7 +37,6 @@ import javafx.beans.value.ChangeListener;
 import javafx.beans.value.WeakChangeListener;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
-import javafx.geometry.Bounds;
 import javafx.geometry.Point2D;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Node;
@@ -59,8 +56,14 @@ import javafx.stage.Window;
 public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
     private TextFieldSkin skin;
     private TwoLevelFocusBehavior tlFocus;
+
+    // listeners to focus-related state
+    private ChangeListener<Boolean> focusListener;
     private ChangeListener<Scene> sceneListener;
+    private WeakChangeListener<Scene> weakSceneListener;
     private ChangeListener<Node> focusOwnerListener;
+    private WeakChangeListener<Node> weakFocusOwnerListener;
+
 
     public TextFieldBehavior(final TextField textField) {
         super(textField);
@@ -69,12 +72,11 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
             contextMenu.getStyleClass().add("text-input-context-menu");
         }
 
-        handleFocusChange();
-
-        // Register for change events
-        textField.focusedProperty().addListener((observable, oldValue, newValue) -> {
+        focusListener = (observable, oldValue, newValue) -> {
             handleFocusChange();
-        });
+        };
+        textField.focusedProperty().addListener(focusListener);
+        handleFocusChange();
 
         focusOwnerListener = (observable, oldValue, newValue) -> {
             // RT-23699: The selection is now only affected when the TextField
@@ -88,9 +90,8 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
                 textField.selectRange(0, 0);
             }
         };
+        weakFocusOwnerListener = new WeakChangeListener<Node>(focusOwnerListener);
 
-        final WeakChangeListener<Node> weakFocusOwnerListener =
-                                new WeakChangeListener<Node>(focusOwnerListener);
         sceneListener = (observable, oldValue, newValue) -> {
             if (oldValue != null) {
                 oldValue.focusOwnerProperty().removeListener(weakFocusOwnerListener);
@@ -99,8 +100,9 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
                 newValue.focusOwnerProperty().addListener(weakFocusOwnerListener);
             }
         };
-        textField.sceneProperty().addListener(new WeakChangeListener<Scene>(sceneListener));
+        weakSceneListener = new WeakChangeListener<Scene>(sceneListener);
 
+        textField.sceneProperty().addListener(weakSceneListener);
         if (textField.getScene() != null) {
             textField.getScene().focusOwnerProperty().addListener(weakFocusOwnerListener);
         }
@@ -112,6 +114,11 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
     }
 
     @Override public void dispose() {
+        getNode().focusedProperty().removeListener(focusListener);
+        getNode().sceneProperty().removeListener(weakSceneListener);
+        if (getNode().getScene() != null) {
+            getNode().getScene().focusOwnerProperty().removeListener(weakFocusOwnerListener);
+        }
         if (tlFocus != null) tlFocus.dispose();
         super.dispose();
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,12 @@
 
 package javafx.scene.control.skin;
 
-import com.sun.javafx.scene.control.behavior.BehaviorBase;
-import com.sun.javafx.scene.control.behavior.TextAreaBehavior;
+import java.util.List;
+
+import com.sun.javafx.scene.control.behavior.PasswordFieldBehavior;
+import com.sun.javafx.scene.control.behavior.TextFieldBehavior;
 import com.sun.javafx.scene.control.behavior.TextInputControlBehavior;
+
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.binding.DoubleBinding;
 import javafx.beans.binding.ObjectBinding;
@@ -44,8 +47,6 @@ import javafx.geometry.Rectangle2D;
 import javafx.scene.AccessibleAttribute;
 import javafx.scene.Group;
 import javafx.scene.Node;
-import javafx.scene.control.Accordion;
-import javafx.scene.control.Button;
 import javafx.scene.control.Control;
 import javafx.scene.control.IndexRange;
 import javafx.scene.control.PasswordField;
@@ -57,11 +58,8 @@ import javafx.scene.paint.Paint;
 import javafx.scene.shape.Path;
 import javafx.scene.shape.PathElement;
 import javafx.scene.shape.Rectangle;
-import javafx.scene.text.Text;
 import javafx.scene.text.HitInfo;
-import java.util.List;
-import com.sun.javafx.scene.control.behavior.TextFieldBehavior;
-import com.sun.javafx.scene.control.behavior.PasswordFieldBehavior;
+import javafx.scene.text.Text;
 
 /**
  * Default skin implementation for the {@link TextField} control.
@@ -154,7 +152,7 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
         this.behavior.setTextFieldSkin(this);
 //        control.setInputMap(behavior.getInputMap());
 
-        control.caretPositionProperty().addListener((observable, oldValue, newValue) -> {
+        registerChangeListener(control.caretPositionProperty(), e -> {
             if (control.getWidth() > 0) {
                 updateTextNodeCaretPos(control.getCaretPosition());
                 if (!isForwardBias()) {
@@ -219,9 +217,7 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
         });
         // updated by listener on caretPosition to ensure order
         updateTextNodeCaretPos(control.getCaretPosition());
-        control.selectionProperty().addListener(observable -> {
-            updateSelection();
-        });
+        registerInvalidationListener(control.selectionProperty(), e -> updateSelection());
 
         // Add selection
         selectionHighlightPath.setManaged(false);
@@ -229,9 +225,8 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
         selectionHighlightPath.layoutXProperty().bind(textTranslateX);
         selectionHighlightPath.visibleProperty().bind(control.anchorProperty().isNotEqualTo(control.caretPositionProperty()).and(control.focusedProperty()));
         selectionHighlightPath.fillProperty().bind(highlightFillProperty());
-        textNode.selectionShapeProperty().addListener(observable -> {
-            updateSelection();
-        });
+
+        registerInvalidationListener(textNode.selectionShapeProperty(), e -> updateSelection());
 
         // Add caret
         caretPath.setManaged(false);
@@ -262,7 +257,7 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
 
         // Be sure to get the control to request layout when the font changes,
         // since this will affect the pref height and pref width.
-        control.fontProperty().addListener(observable -> {
+        registerInvalidationListener(control.fontProperty(), e -> {
             // I do both so that any cached values for prefWidth/height are cleared.
             // The problem is that the skin is unmanaged and so calling request layout
             // doesn't walk up the tree all the way. I think....
@@ -273,7 +268,7 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
         registerChangeListener(control.prefColumnCountProperty(), e -> getSkinnable().requestLayout());
         if (control.isFocused()) setCaretAnimating(true);
 
-        control.alignmentProperty().addListener(observable -> {
+        registerInvalidationListener(control.alignmentProperty(), e -> {
             if (control.getWidth() > 0) {
                 updateTextPos();
                 updateCaretOff();
@@ -298,7 +293,7 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
             updateTextPos();
         });
 
-        control.textProperty().addListener(observable -> {
+        registerInvalidationListener(control.textProperty(), e -> {
             if (!behavior.isEditing()) {
                 // Text changed, but not by user action
                 updateTextPos();
@@ -309,7 +304,7 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
             createPromptNode();
         }
 
-        usePromptText.addListener(observable -> {
+        registerInvalidationListener(usePromptText, e -> {
             createPromptNode();
             control.requestLayout();
         });
@@ -391,6 +386,8 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
 
     /** {@inheritDoc} */
     @Override public void dispose() {
+        if (getSkinnable() == null) return;
+        getChildren().removeAll(textGroup, handleGroup);
         super.dispose();
 
         if (behavior != null) {
@@ -921,4 +918,20 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
 
         updateCaretOff();
     }
+
+    // for testing only!
+    Text getTextNode() {
+        return textNode;
+    }
+
+    // for testing only!
+    Text getPromptNode() {
+        return promptNode;
+    }
+
+    // for testing only!
+    double getTextTranslateX() {
+        return textTranslateX.get();
+    }
+
 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextInputControlSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextInputControlSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,24 @@
 
 package javafx.scene.control.skin;
 
+import java.lang.ref.WeakReference;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import com.sun.javafx.PlatformUtil;
 import com.sun.javafx.scene.control.Properties;
+import com.sun.javafx.scene.control.behavior.TextInputControlBehavior;
 import com.sun.javafx.scene.control.skin.FXVK;
 import com.sun.javafx.scene.input.ExtendedInputMethodRequests;
+import com.sun.javafx.tk.FontMetrics;
+import com.sun.javafx.tk.Toolkit;
+
+import static com.sun.javafx.PlatformUtil.*;
+
+import javafx.animation.Animation.Status;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
 import javafx.application.ConditionalFeature;
@@ -45,6 +60,9 @@ import javafx.css.Styleable;
 import javafx.css.StyleableBooleanProperty;
 import javafx.css.StyleableObjectProperty;
 import javafx.css.StyleableProperty;
+import javafx.css.converter.BooleanConverter;
+import javafx.css.converter.PaintConverter;
+import javafx.event.EventHandler;
 import javafx.geometry.NodeOrientation;
 import javafx.geometry.Point2D;
 import javafx.geometry.Rectangle2D;
@@ -69,22 +87,8 @@ import javafx.scene.shape.Path;
 import javafx.scene.shape.PathElement;
 import javafx.scene.shape.Shape;
 import javafx.scene.shape.VLineTo;
-import javafx.scene.text.HitInfo;
 import javafx.stage.Window;
 import javafx.util.Duration;
-import java.lang.ref.WeakReference;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import com.sun.javafx.PlatformUtil;
-import javafx.css.converter.BooleanConverter;
-import javafx.css.converter.PaintConverter;
-import com.sun.javafx.scene.control.behavior.TextInputControlBehavior;
-import com.sun.javafx.tk.FontMetrics;
-import com.sun.javafx.tk.Toolkit;
-import static com.sun.javafx.PlatformUtil.isWindows;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 /**
  * Abstract base class for text input skins.
@@ -164,6 +168,7 @@ public abstract class TextInputControlSkin<T extends TextInputControl> extends S
     // Holds concrete attributes for the composition runs
     private List<Shape> imattrs = new java.util.ArrayList<Shape>();
 
+    private EventHandler<InputMethodEvent> inputMethodTextChangedHandler;
 
 
     /**************************************************************************
@@ -280,7 +285,7 @@ public abstract class TextInputControlSkin<T extends TextInputControl> extends S
                     }
                 }
             }
-            control.focusedProperty().addListener(observable -> {
+            registerInvalidationListener(control.focusedProperty(), observable -> {
                 if (FXVK.useFXVK()) {
                     Scene scene = getSkinnable().getScene();
                     if (control.isEditable() && control.isFocused()) {
@@ -296,10 +301,10 @@ public abstract class TextInputControlSkin<T extends TextInputControl> extends S
             });
         }
 
+        // FIXME: JDK-8268877 - incorrectly wired handler on replacing skin
         if (control.getOnInputMethodTextChanged() == null) {
-            control.setOnInputMethodTextChanged(event -> {
-                handleInputMethodEvent(event);
-            });
+            inputMethodTextChangedHandler = this::handleInputMethodEvent;
+            control.setOnInputMethodTextChanged(inputMethodTextChangedHandler);
         }
 
         control.setInputMethodRequests(new ExtendedInputMethodRequests() {
@@ -359,6 +364,18 @@ public abstract class TextInputControlSkin<T extends TextInputControl> extends S
         });
     }
 
+    @Override
+    public void dispose() {
+        if (getSkinnable() == null) return;
+        // the inputMethodEvent handler installed by this skin must be removed prevent a memory leak
+        // while a handler installed by the control must not be removed
+        if (getSkinnable().getOnInputMethodTextChanged() == inputMethodTextChangedHandler) {
+            getSkinnable().setOnInputMethodTextChanged(null);
+        }
+        // cleanup to guard against potential NPE
+        getSkinnable().setInputMethodRequests(null);
+        super.dispose();
+    }
 
 
     /**************************************************************************
@@ -764,6 +781,11 @@ public abstract class TextInputControlSkin<T extends TextInputControl> extends S
 
     ObservableBooleanValue caretVisibleProperty() {
         return caretVisible;
+    }
+
+    // for testing only!
+    boolean isCaretBlinking() {
+        return caretBlinking.caretTimeline.getStatus() == Status.RUNNING;
     }
 
     boolean isRTL() {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextInputControlSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextInputControlSkin.java
@@ -367,7 +367,7 @@ public abstract class TextInputControlSkin<T extends TextInputControl> extends S
     @Override
     public void dispose() {
         if (getSkinnable() == null) return;
-        // the inputMethodEvent handler installed by this skin must be removed prevent a memory leak
+        // the inputMethodEvent handler installed by this skin must be removed to prevent a memory leak
         // while a handler installed by the control must not be removed
         if (getSkinnable().getOnInputMethodTextChanged() == inputMethodTextChangedHandler) {
             getSkinnable().setOnInputMethodTextChanged(null);

--- a/modules/javafx.controls/src/shims/java/com/sun/javafx/scene/control/behavior/TextBehaviorShim.java
+++ b/modules/javafx.controls/src/shims/java/com/sun/javafx/scene/control/behavior/TextBehaviorShim.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.scene.control.behavior;
+
+import java.text.Bidi;
+
+/**
+ * Utility class to access package-private api of text related behaviors.
+ */
+public class TextBehaviorShim {
+
+    /**
+     * Returns the value of the bidi field.
+     */
+    public static Bidi getRawBidi(TextInputControlBehavior<?> behavior) {
+        return behavior.getRawBidi();
+    }
+
+    public static boolean isRTLText(TextInputControlBehavior<?> behavior) {
+        return behavior.isRTLText();
+    }
+
+    private TextBehaviorShim() {};
+}

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/TextInputSkinShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/TextInputSkinShim.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package javafx.scene.control.skin;
+
+import javafx.scene.control.TextField;
+import javafx.scene.control.TextInputControl;
+import javafx.scene.text.Text;
+
+/**
+ * Utility methods to access package-private api in TextInput-related skins.
+ */
+public class TextInputSkinShim {
+
+    /**
+     * Returns the promptNode from the textField's skin. The skin must be of type
+     * TextFieldSkin.
+     */
+    public static Text getPromptNode(TextField textField) {
+        TextFieldSkin skin = (TextFieldSkin) textField.getSkin();
+        return skin.getPromptNode();
+    }
+
+    /**
+     * Returns the textNode from the textField's skin. The skin must be of type
+     * TextFieldSkin.
+     */
+    public static Text getTextNode(TextField textField) {
+        TextFieldSkin skin = (TextFieldSkin) textField.getSkin();
+        return skin.getTextNode();
+    }
+
+    /**
+     * Returns the textTranslateX from the textField's skin. The skin must be of type
+     * TextFieldSkin.
+     */
+    public static double getTextTranslateX(TextField textField) {
+        TextFieldSkin skin = (TextFieldSkin) textField.getSkin();
+        return skin.getTextTranslateX();
+    }
+
+    /**
+     * Returns a boolean indicating whether or not the control's caret is blinking.
+     * The control's skin must be of type TextInputControlSkin.
+     */
+    public static boolean isCaretBlinking(TextInputControl control) {
+        TextInputControlSkin<?> skin = (TextInputControlSkin<?>) control.getSkin();
+        return skin.isCaretBlinking();
+    }
+
+    private TextInputSkinShim() {}
+}

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorCleanupTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorCleanupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,14 +33,28 @@ import org.junit.Test;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
 import com.sun.javafx.scene.control.behavior.ListCellBehavior;
+import com.sun.javafx.scene.control.behavior.TextFieldBehavior;
+import com.sun.javafx.scene.control.inputmap.InputMap;
+import com.sun.javafx.scene.control.inputmap.KeyBinding;
+import com.sun.javafx.scene.control.inputmap.InputMap.KeyMapping;
 
+import static com.sun.javafx.scene.control.behavior.TextBehaviorShim.*;
 import static javafx.collections.FXCollections.*;
+import static javafx.scene.control.skin.TextInputSkinShim.*;
 import static org.junit.Assert.*;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory.*;
 
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Control;
 import javafx.scene.control.ListView;
+import javafx.scene.control.TextField;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
+import javafx.scene.input.KeyCode;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
 
 /**
  * Test for misbehavior of individual implementations that turned
@@ -48,6 +62,181 @@ import javafx.scene.control.TreeView;
  *
  */
 public class BehaviorCleanupTest {
+
+    private Scene scene;
+    private Stage stage;
+    private Pane root;
+
+
+//---------- TextField
+
+    @Test
+    public void testFocusListener() {
+        TextField control = new TextField("some text");
+        showControl(control, true);
+        assertTrue(isCaretBlinking(control));
+        Button button = new Button("dummy");
+        showControl(button, true);
+        assertFalse("caret must be blinking on focus gained", isCaretBlinking(control));
+    }
+
+    @Test
+    public void testFocusOwnerListenerRegisteredInitially() {
+        TextField control = new TextField("some text");
+        showControl(control, true);
+        assertEquals("all text selected", control.getText(), control.getSelectedText());
+        Button button = new Button("dummy");
+        showControl(button, true);
+        assertEquals("selection cleared", 0, control.getSelectedText().length());
+    }
+
+    /**
+     * Tests that focusOwnerListener is re-wired as expected on changing scene
+     * (here: by removing/adding the textField)
+     *
+     * Note: this tests both sceneListener and focusOwnerListener are properly updated.
+     */
+    @Test
+    public void testFocusOwnerListenerOnSceneChanged() {
+        // setup: two focusable nodes, textField focused
+        String firstWord = "some";
+        String secondWord = "text";
+        String text = firstWord + " " + secondWord;
+        TextField control = new TextField(text);
+        showControl(control, true);
+        Button button = new Button("dummy");
+        showControl(button, false);
+        control.selectNextWord();
+        assertEquals("sanity: ", secondWord, control.getSelectedText());
+        // detach textfield from scene
+        root.getChildren().remove(control);
+        assertEquals("selection unchanged after remove", secondWord, control.getSelectedText());
+        // change scene's focusOwner to another node
+        Button secondButton = new Button("another dummy");
+        showControl(secondButton, true);
+        assertEquals("selection unchanged after focusOwner change in old scene",
+                secondWord, control.getSelectedText());
+        // re-add textField
+        root.getChildren().add(control);
+        control.requestFocus();
+        assertEquals("selection changed on becoming scene's focusOwner",
+                text, control.getSelectedText());
+    }
+
+    /**
+     * Guard against regression of JDK-8116975: activate another stage must not affect
+     * selection of textField.
+     */
+    @Test
+    public void testFocusOwnerListenerSecondStage() {
+        String firstWord = "some";
+        String secondWord = "text";
+        String text = firstWord + " " + secondWord;
+        TextField control = new TextField(text);
+        showControl(control, true);
+        Button button = new Button("dummy");
+        showControl(button, false);
+        control.selectNextWord();
+        assertEquals("sanity: ", secondWord, control.getSelectedText());
+
+        // build and activate second stage
+        VBox secondRoot = new VBox(10, new Button("secondButton"));
+        Scene secondScene = new Scene(secondRoot);
+        Stage secondStage = new Stage();
+        secondStage.setScene(secondScene);
+        secondStage.show();
+        secondStage.requestFocus();
+
+        try {
+            assertTrue("sanity: ", secondStage.isFocused());
+            assertEquals("selection unchanged", secondWord, control.getSelectedText());
+            // back to first
+            stage.requestFocus();
+            assertTrue("sanity: ", stage.isFocused());
+            assertTrue("sanity: ", control.isFocused());
+            assertEquals("selection unchanged", secondWord, control.getSelectedText());
+        } finally {
+            // cleanup
+            secondStage.hide();
+        }
+
+    }
+
+//---------- TextInputControl
+
+    @Test
+    public void testChildMapsCleared() {
+        TextField control = new TextField("some text");
+        TextFieldBehavior behavior = (TextFieldBehavior) createBehavior(control);
+        InputMap<?> inputMap = behavior.getInputMap();
+        assertFalse("sanity: inputMap has child maps", inputMap.getChildInputMaps().isEmpty());
+        behavior.dispose();
+        assertEquals("default child maps be cleared", 0, inputMap.getChildInputMaps().size());
+    }
+
+    @Test
+    public void testDefaultMappingsCleared() {
+        TextField control = new TextField("some text");
+        TextFieldBehavior behavior = (TextFieldBehavior) createBehavior(control);
+        InputMap<?> inputMap = behavior.getInputMap();
+        assertFalse("sanity: inputMap has mappings", inputMap.getMappings().isEmpty());
+        behavior.dispose();
+        assertEquals("default mappings must be cleared", 0, inputMap.getMappings().size());
+    }
+
+    /**
+     * Sanity test: mappings to key pad keys.
+     */
+    @Test
+    public void testKeyPadMapping() {
+        TextField control = new TextField("some text");
+        TextFieldBehavior behavior = (TextFieldBehavior) createBehavior(control);
+        InputMap<?> inputMap = behavior.getInputMap();
+        // FIXME: test for all?
+        // Here we take one of the expected only - assumption being that
+        // if the one is properly registered, it's siblings are handled as well
+        KeyCode expectedCode = KeyCode.KP_LEFT;
+        KeyMapping expectedMapping = new KeyMapping(expectedCode, null);
+        assertTrue(inputMap.getMappings().contains(expectedMapping));
+    }
+
+    /**
+     * Sanity test: child mappings to key pad keys.
+     */
+    @Test
+    public void testKeyPadMappingChildInputMap() {
+        TextField control = new TextField("some text");
+        TextFieldBehavior behavior = (TextFieldBehavior) createBehavior(control);
+        InputMap<?> inputMap = behavior.getInputMap();
+        // FIXME: test for all?
+        // Here we take one of the expected only - assumption being that
+        // if the one is properly registered, its siblings are handled as well
+        KeyCode expectedCode = KeyCode.KP_LEFT;
+        // test os specific child mappings
+        InputMap<?> childInputMapMac = inputMap.getChildInputMaps().get(0);
+        KeyMapping expectedMac = new KeyMapping(new KeyBinding(expectedCode).shortcut(), null);
+        assertTrue(childInputMapMac.getMappings().contains(expectedMac));
+
+        InputMap<?> childInputMapNotMac = inputMap.getChildInputMaps().get(1);
+        KeyMapping expectedNotMac = new KeyMapping(new KeyBinding(expectedCode).ctrl(), null);
+        assertTrue(childInputMapNotMac.getMappings().contains(expectedNotMac));
+    }
+
+    /**
+     * Sanity test: listener to textProperty still effective after fix
+     * (accidentally added twice)
+     */
+    @Test
+    public void testTextPropertyListener() {
+        TextField control = new TextField("some text");
+        TextFieldBehavior behavior = (TextFieldBehavior) createBehavior(control);
+        assertNull("sanity: initial bidi", getRawBidi(behavior));
+        // validate bidi field
+        isRTLText(behavior);
+        assertNotNull(getRawBidi(behavior));
+        control.setText("dummy");
+        assertNull("listener working (bidi is reset)", getRawBidi(behavior));
+    }
 
 //----------- TreeView
 
@@ -188,8 +377,46 @@ public class BehaviorCleanupTest {
 
   //------------------ setup/cleanup
 
+    /**
+     * Ensures the control is shown and focused in an active scenegraph.
+     *
+     * @param control the control to show
+     */
+    protected void showControl(Control control) {
+        showControl(control, true);
+    }
+
+    /**
+     * Ensures the control is shown in an active scenegraph. Requests
+     * focus on the control if focused == true.
+     *
+     * @param control the control to show
+     * @param focused if true, requests focus on the added control
+     */
+    protected void showControl(Control control, boolean focused) {
+        if (root == null) {
+            root = new VBox();
+            scene = new Scene(root);
+            stage = new Stage();
+            stage.setScene(scene);
+        }
+        if (!root.getChildren().contains(control)) {
+            root.getChildren().add(control);
+        }
+        stage.show();
+        if (focused) {
+            stage.requestFocus();
+            control.requestFocus();
+            assertTrue(control.isFocused());
+            assertSame(control, scene.getFocusOwner());
+        }
+    }
+
     @After
     public void cleanup() {
+        if (stage != null) {
+            stage.hide();
+        }
         Thread.currentThread().setUncaughtExceptionHandler(null);
     }
 

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorCleanupTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorCleanupTest.java
@@ -74,10 +74,10 @@ public class BehaviorCleanupTest {
     public void testFocusListener() {
         TextField control = new TextField("some text");
         showControl(control, true);
-        assertTrue(isCaretBlinking(control));
+        assertTrue("caret must be blinking if focused", isCaretBlinking(control));
         Button button = new Button("dummy");
         showControl(button, true);
-        assertFalse("caret must be blinking on focus gained", isCaretBlinking(control));
+        assertFalse("caret must not be blinking if not focused", isCaretBlinking(control));
     }
 
     @Test
@@ -159,7 +159,6 @@ public class BehaviorCleanupTest {
             // cleanup
             secondStage.hide();
         }
-
     }
 
 //---------- TextInputControl
@@ -171,7 +170,7 @@ public class BehaviorCleanupTest {
         InputMap<?> inputMap = behavior.getInputMap();
         assertFalse("sanity: inputMap has child maps", inputMap.getChildInputMaps().isEmpty());
         behavior.dispose();
-        assertEquals("default child maps be cleared", 0, inputMap.getChildInputMaps().size());
+        assertEquals("default child maps must be cleared", 0, inputMap.getChildInputMaps().size());
     }
 
     @Test

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorMemoryLeakTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorMemoryLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,6 @@ import javafx.scene.control.Control;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TextArea;
-import javafx.scene.control.TextField;
 import javafx.scene.control.TreeTableView;
 
 /**
@@ -84,7 +83,6 @@ public class BehaviorMemoryLeakTest {
                 PasswordField.class,
                 TableView.class,
                 TextArea.class,
-                TextField.class,
                 TreeTableView.class
          );
         // remove the known issues to make the test pass

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinMemoryLeakTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinMemoryLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,8 +117,6 @@ public class SkinMemoryLeakTest {
                 TableView.class,
                 // @Ignore("8244419")
                 TextArea.class,
-                // @Ignore("8240506")
-                TextField.class,
                 TreeTableRow.class,
                 TreeTableView.class
         );


### PR DESCRIPTION
The issue is about memory leaks and side-effects (like NPEs) when switching skins. 

Details (copied from issue for convenience):

memory leak in TextInputControlBehavior:
- listener accidentally added twice (removed once)
- keyPad mappings not properly installed/disposed

memory leak TextFieldBehavior:
- listeners to scene/focusOwner property not removed,

memory leak in TextInputControlSkin:
- event handlers related to inputMethods not removed

issues in TextFieldSkin:
- memory leak due to behavior leaking
- memory leaks due to manually added change/invalidation listeners that are not removed
- memory leaks due to not removing children with strong references to skin
- side-effects (f.i. NPEs) due to listeners/bindings that are still active after dispose

Fix was to properly install/remove those listeners/handlers. Added tests that failed/passed before/after the fix, respectively, also added tests passing before that must pass after the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8240506](https://bugs.openjdk.java.net/browse/JDK-8240506): TextFieldSkin/Behavior: misbehavior on switching skin


### Reviewers
 * [Marius Hanl](https://openjdk.java.net/census#mhanl) (@Maran23 - Author)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/534/head:pull/534` \
`$ git checkout pull/534`

Update a local copy of the PR: \
`$ git checkout pull/534` \
`$ git pull https://git.openjdk.java.net/jfx pull/534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 534`

View PR using the GUI difftool: \
`$ git pr show -t 534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/534.diff">https://git.openjdk.java.net/jfx/pull/534.diff</a>

</details>
