### PR TITLE
8267554: Support loading stylesheets from data-URIs

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/StyleManager.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/StyleManager.java
@@ -52,6 +52,7 @@ import javafx.stage.Window;
 import com.sun.javafx.logging.PlatformLogger;
 import com.sun.javafx.logging.PlatformLogger.Level;
 
+import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.FilePermission;
 import java.io.IOException;
@@ -65,6 +66,9 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.IllegalCharsetNameException;
+import java.nio.charset.UnsupportedCharsetException;
 import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.DigestInputStream;
@@ -1087,7 +1091,6 @@ final public class StyleManager {
                 // check if url has extension, if not then just url as is and always parse as css text
                 if (!(fname.endsWith(".css") || fname.endsWith(".bss"))) {
                     url = getURL(fname);
-                    parse = true;
                 } else {
                     final String name = fname.substring(0, fname.length() - 4);
 
@@ -1100,27 +1103,90 @@ final public class StyleManager {
                     }
 
                     if ((url != null) && !parse) {
-
                         try {
                             // RT-36332: if loadBinary throws an IOException, make sure to try .css
                             stylesheet = Stylesheet.loadBinary(url);
-                        } catch (IOException ioe) {
-                            stylesheet = null;
+                        } catch (IOException ignored) {
                         }
 
-                        if (stylesheet == null && (parse = !parse)) {
+                        if (stylesheet == null) {
                             // If we failed to load the .bss file,
                             // fall back to the .css file.
-                            // Note that 'parse' is toggled in the test.
                             url = getURL(fname);
                         }
                     }
                 }
 
-                // either we failed to load the .bss file, or parse
-                // was set to true.
-                if ((url != null) && parse) {
-                    stylesheet = new CssParser().parse(url);
+                if (stylesheet == null) {
+                    DataURI dataUri = null;
+
+                    if (url != null) {
+                        stylesheet = new CssParser().parse(url);
+                    } else {
+                        dataUri = DataURI.tryParse(fname);
+                    }
+
+                    if (dataUri != null) {
+                        String mimeType = dataUri.getMimeType();
+                        parse = true;
+
+                        if (mimeType != null) {
+                            boolean isText =
+                                "text".equalsIgnoreCase(dataUri.getMimeType())
+                                    && ("css".equalsIgnoreCase(dataUri.getMimeSubtype())
+                                        || "plain".equalsIgnoreCase(dataUri.getMimeSubtype()));
+
+                            boolean isBinary =
+                                "application".equalsIgnoreCase(dataUri.getMimeType())
+                                    && "octet-stream".equalsIgnoreCase(dataUri.getMimeSubtype());
+
+                            if (!isText && !isBinary) {
+                                String message = String.format("Unexpected MIME type \"%s/%s\" in stylesheet URI \"%s\"",
+                                    dataUri.getMimeType(), dataUri.getMimeSubtype(), dataUri);
+
+                                if (errors != null) {
+                                    errors.add(new CssParser.ParseError(message));
+                                }
+
+                                if (getLogger().isLoggable(Level.WARNING)) {
+                                    getLogger().warning(message);
+                                }
+
+                                return null;
+                            }
+
+                            parse = isText;
+                        }
+
+                        if (parse) {
+                            String charsetName = dataUri.getParameters().get("charset");
+                            Charset charset;
+
+                            try {
+                                charset = charsetName != null ? Charset.forName(charsetName) : Charset.defaultCharset();
+                            } catch (IllegalCharsetNameException | UnsupportedCharsetException ex) {
+                                String message = String.format(
+                                    "Unsupported charset \"%s\" in stylesheet URI \"%s\"", charsetName, dataUri);
+
+                                if (errors != null) {
+                                    errors.add(new CssParser.ParseError(message));
+                                }
+
+                                if (getLogger().isLoggable(Level.WARNING)) {
+                                    getLogger().warning(message);
+                                }
+
+                                return null;
+                            }
+
+                            var stylesheetText = new String(dataUri.getData(), charset);
+                            stylesheet = new CssParser().parse(stylesheetText);
+                        } else {
+                            try (InputStream stream = new ByteArrayInputStream(dataUri.getData())) {
+                                stylesheet = Stylesheet.loadBinary(stream);
+                            }
+                        }
+                    }
                 }
 
                 if (stylesheet == null) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/StyleManager.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/StyleManager.java
@@ -1226,15 +1226,15 @@ final public class StyleManager {
                     getLogger().info("Could not find stylesheet: " + fname);//, fnfe);
                 }
             } catch (IOException ioe) {
-                    if (errors != null) {
-                        CssParser.ParseError error =
-                            new CssParser.ParseError(
-                                "Could not load stylesheet: " + fname
-                            );
-                        errors.add(error);
-                    }
+                // For data URIs, use the pretty-printed version for logging
+                var dataUri = DataURI.tryParse(fname);
+                String stylesheetName = dataUri != null ? dataUri.toString() : fname;
+
+                if (errors != null) {
+                    errors.add(new CssParser.ParseError("Could not load stylesheet: " + stylesheetName));
+                }
                 if (getLogger().isLoggable(Level.INFO)) {
-                    getLogger().info("Could not load stylesheet: " + fname);//, ioe);
+                    getLogger().info("Could not load stylesheet: " + stylesheetName);
                 }
             }
             return null;

--- a/modules/javafx.graphics/src/main/java/javafx/application/Application.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Application.java
@@ -25,12 +25,14 @@
 
 package javafx.application;
 
+import java.io.File;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.List;
 import java.util.Map;
 
 import javafx.application.Preloader.PreloaderNotification;
+import javafx.css.Stylesheet;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 
@@ -513,6 +515,18 @@ public abstract class Application {
      * on the command line with {@code -Djavafx.userAgentStylesheetUrl=[URL]}
      * Setting it on the command line overrides anything set using this method
      * in code.
+     * <p>
+     * The URL is a hierarchical URI of the form [scheme:][//authority][path]. If the URL
+     * does not have a [scheme:] component, the URL is considered to be the [path] component only.
+     * Any leading '/' character of the [path] is ignored and the [path] is treated as a path relative to
+     * the root of the application's classpath.
+     * </p>
+     * The RFC 2397 "data" scheme for URLs is supported in addition to the protocol handlers that
+     * are registered for the application.
+     * If a URL uses the "data" scheme and the MIME type is either empty, "text/plain", or "text/css",
+     * the payload will be interpreted as a CSS file.
+     * If the MIME type is "application/octet-stream", the payload will be interpreted as a binary
+     * CSS file (see {@link Stylesheet#convertToBinary(File, File)}).
      * <p>
      * NOTE: This method must be called on the JavaFX Application Thread.
      * </p>

--- a/modules/javafx.graphics/src/main/java/javafx/application/Application.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Application.java
@@ -520,7 +520,7 @@ public abstract class Application {
      * does not have a [scheme:] component, the URL is considered to be the [path] component only.
      * Any leading '/' character of the [path] is ignored and the [path] is treated as a path relative to
      * the root of the application's classpath.
-     * </p>
+     * <p>
      * The RFC 2397 "data" scheme for URLs is supported in addition to the protocol handlers that
      * are registered for the application.
      * If a URL uses the "data" scheme and the MIME type is either empty, "text/plain", or "text/css",
@@ -529,8 +529,6 @@ public abstract class Application {
      * CSS file (see {@link Stylesheet#convertToBinary(File, File)}).
      * <p>
      * NOTE: This method must be called on the JavaFX Application Thread.
-     * </p>
-     *
      *
      * @param url The URL to the stylesheet as a String.
      * @since JavaFX 8.0

--- a/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
@@ -278,25 +279,46 @@ public class Stylesheet {
      * css version or if an I/O error occurs while reading from the stream
      */
     public static Stylesheet loadBinary(URL url) throws IOException {
+        if (url == null) {
+            return null;
+        }
 
-        if (url == null) return null;
+        try (InputStream stream = url.openStream()) {
+            return loadBinary(stream, url.toExternalForm());
+        } catch (FileNotFoundException ex) {
+            return null;
+        }
+    }
 
+    /**
+     * Loads a binary stylesheet from a stream.
+     *
+     * @param stream the input stream
+     * @return the loaded {@code Stylesheet}
+     * @throws IOException if the binary stream corresponds to a more recent binary
+     * css version or if an I/O error occurs while reading from the stream
+     */
+    public static Stylesheet loadBinary(InputStream stream) throws IOException {
+        return loadBinary(stream, null);
+    }
+
+    private static Stylesheet loadBinary(InputStream stream, String uri) throws IOException {
         Stylesheet stylesheet = null;
 
         try (DataInputStream dataInputStream =
-                     new DataInputStream(new BufferedInputStream(url.openStream(), 40 * 1024))) {
+                     new DataInputStream(new BufferedInputStream(stream, 40 * 1024))) {
 
             // read file version
             final int bssVersion = dataInputStream.readShort();
             if (bssVersion > Stylesheet.BINARY_CSS_VERSION) {
-                throw new IOException(url.toString() + " wrong binary CSS version: "
+                throw new IOException("Wrong binary CSS version: "
                         + bssVersion + ". Expected version less than or equal to" +
                         Stylesheet.BINARY_CSS_VERSION);
             }
             // read strings
             final String[] strings = StringStore.readBinary(dataInputStream);
             // read binary data
-            stylesheet = new Stylesheet(url.toExternalForm());
+            stylesheet = new Stylesheet(uri);
 
             try {
 
@@ -305,7 +327,7 @@ public class Stylesheet {
 
             } catch (Exception e) {
 
-                stylesheet = new Stylesheet(url.toExternalForm());
+                stylesheet = new Stylesheet(uri);
 
                 dataInputStream.reset();
 
@@ -317,9 +339,6 @@ public class Stylesheet {
                 }
             }
 
-        } catch (FileNotFoundException fnfe) {
-            // This comes from url.openStream() and is expected.
-            // It just means that the .bss file doesn't exist.
         }
 
         // return stylesheet

--- a/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
@@ -297,6 +297,8 @@ public class Stylesheet {
      * @return the loaded {@code Stylesheet}
      * @throws IOException if the binary stream corresponds to a more recent binary
      * css version or if an I/O error occurs while reading from the stream
+     *
+     * @since 17
      */
     public static Stylesheet loadBinary(InputStream stream) throws IOException {
         return loadBinary(stream, null);

--- a/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Stylesheet.java
@@ -313,9 +313,10 @@ public class Stylesheet {
             // read file version
             final int bssVersion = dataInputStream.readShort();
             if (bssVersion > Stylesheet.BINARY_CSS_VERSION) {
-                throw new IOException("Wrong binary CSS version: "
-                        + bssVersion + ". Expected version less than or equal to" +
-                        Stylesheet.BINARY_CSS_VERSION);
+                throw new IOException(
+                    String.format("Wrong binary CSS version %s, expected version less than or equal to %s",
+                        uri != null ? bssVersion + " in stylesheet \"" + uri + "\"" : bssVersion,
+                        Stylesheet.BINARY_CSS_VERSION));
             }
             // read strings
             final String[] strings = StringStore.readBinary(dataInputStream);

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -1622,7 +1622,7 @@ public class Scene implements EventTarget {
      * does not have a [scheme:] component, the URL is considered to be the [path] component only.
      * Any leading '/' character of the [path] is ignored and the [path] is treated as a path relative to
      * the root of the application's classpath.
-     * </p>
+     * <p>
      * The RFC 2397 "data" scheme for URLs is supported in addition to the protocol handlers that
      * are registered for the application.
      * If a URL uses the "data" scheme and the MIME type is either empty, "text/plain", or "text/css",
@@ -1703,7 +1703,7 @@ public class Scene implements EventTarget {
      * does not have a [scheme:] component, the URL is considered to be the [path] component only.
      * Any leading '/' character of the [path] is ignored and the [path] is treated as a path relative to
      * the root of the application's classpath.
-     * </p>
+     * <p>
      * The RFC 2397 "data" scheme for URLs is supported in addition to the protocol handlers that
      * are registered for the application.
      * If a URL uses the "data" scheme and the MIME type is either empty, "text/plain", or "text/css",
@@ -1713,7 +1713,7 @@ public class Scene implements EventTarget {
      * <p>
      * For additional information about using CSS with the scene graph,
      * see the <a href="doc-files/cssref.html">CSS Reference Guide</a>.
-     * </p>
+     *
      * @param url the URL of the user-agent stylesheet
      * @since  JavaFX 8u20
      */

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -1699,13 +1699,22 @@ public class Scene implements EventTarget {
      * the platform-default user-agent stylesheet. If the URL does not resolve to a valid location,
      * the platform-default user-agent stylesheet will be used.
      * <p>
-     * For additional information about using CSS with the scene graph,
-     * see the <a href="doc-files/cssref.html">CSS Reference Guide</a>.
-     * </p>
-     * @param url The URL is a hierarchical URI of the form [scheme:][//authority][path]. If the URL
+     * The URL is a hierarchical URI of the form [scheme:][//authority][path]. If the URL
      * does not have a [scheme:] component, the URL is considered to be the [path] component only.
      * Any leading '/' character of the [path] is ignored and the [path] is treated as a path relative to
      * the root of the application's classpath.
+     * </p>
+     * The RFC 2397 "data" scheme for URLs is supported in addition to the protocol handlers that
+     * are registered for the application.
+     * If a URL uses the "data" scheme and the MIME type is either empty, "text/plain", or "text/css",
+     * the payload will be interpreted as a CSS file.
+     * If the MIME type is "application/octet-stream", the payload will be interpreted as a binary
+     * CSS file (see {@link Stylesheet#convertToBinary(File, File)}).
+     * <p>
+     * For additional information about using CSS with the scene graph,
+     * see the <a href="doc-files/cssref.html">CSS Reference Guide</a>.
+     * </p>
+     * @param url the URL of the user-agent stylesheet
      * @since  JavaFX 8u20
      */
     public final void setUserAgentStylesheet(String url) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -68,6 +68,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
 import javafx.css.CssMetaData;
 import javafx.css.StyleableObjectProperty;
+import javafx.css.Stylesheet;
 import javafx.event.*;
 import javafx.geometry.*;
 import javafx.scene.image.WritableImage;
@@ -83,6 +84,7 @@ import javafx.util.Duration;
 import com.sun.javafx.logging.PlatformLogger;
 import com.sun.javafx.logging.PlatformLogger.Level;
 
+import java.io.File;
 import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -1621,6 +1623,12 @@ public class Scene implements EventTarget {
      * Any leading '/' character of the [path] is ignored and the [path] is treated as a path relative to
      * the root of the application's classpath.
      * </p>
+     * The RFC 2397 "data" scheme for URLs is supported in addition to the protocol handlers that
+     * are registered for the application.
+     * If a URL uses the "data" scheme and the MIME type is either empty, "text/plain", or "text/css",
+     * the payload will be interpreted as a CSS file.
+     * If the MIME type is "application/octet-stream", the payload will be interpreted as a binary
+     * CSS file (see {@link Stylesheet#convertToBinary(File, File)}).
      * <pre><code>
      *
      * package com.example.javafx.app;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/SubScene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/SubScene.java
@@ -33,11 +33,13 @@ import javafx.application.ConditionalFeature;
 import javafx.application.Platform;
 import javafx.beans.NamedArg;
 import javafx.beans.property.*;
+import javafx.css.Stylesheet;
 import javafx.geometry.NodeOrientation;
 import javafx.geometry.Point3D;
 import javafx.scene.input.PickResult;
 import javafx.scene.paint.Paint;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -681,13 +683,22 @@ public class SubScene extends Node {
      * the platform-default user-agent stylesheet. If the URL does not resolve to a valid location,
      * the platform-default user-agent stylesheet will be used.
      * <p>
-     * For additional information about using CSS with the scene graph,
-     * see the <a href="doc-files/cssref.html">CSS Reference Guide</a>.
-     * </p>
-     * @param url The URL is a hierarchical URI of the form [scheme:][//authority][path]. If the URL
+     * The URL is a hierarchical URI of the form [scheme:][//authority][path]. If the URL
      * does not have a [scheme:] component, the URL is considered to be the [path] component only.
      * Any leading '/' character of the [path] is ignored and the [path] is treated as a path relative to
      * the root of the application's classpath.
+     * </p>
+     * The RFC 2397 "data" scheme for URLs is supported in addition to the protocol handlers that
+     * are registered for the application.
+     * If a URL uses the "data" scheme and the MIME type is either empty, "text/plain", or "text/css",
+     * the payload will be interpreted as a CSS file.
+     * If the MIME type is "application/octet-stream", the payload will be interpreted as a binary
+     * CSS file (see {@link Stylesheet#convertToBinary(File, File)}).
+     * <p>
+     * For additional information about using CSS with the scene graph,
+     * see the <a href="doc-files/cssref.html">CSS Reference Guide</a>.
+     * </p>
+     * @param url the URL of the user-agent stylesheet
      * @since  JavaFX 8u20
      */
     public final void setUserAgentStylesheet(String url) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/SubScene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/SubScene.java
@@ -687,7 +687,7 @@ public class SubScene extends Node {
      * does not have a [scheme:] component, the URL is considered to be the [path] component only.
      * Any leading '/' character of the [path] is ignored and the [path] is treated as a path relative to
      * the root of the application's classpath.
-     * </p>
+     * <p>
      * The RFC 2397 "data" scheme for URLs is supported in addition to the protocol handlers that
      * are registered for the application.
      * If a URL uses the "data" scheme and the MIME type is either empty, "text/plain", or "text/css",
@@ -697,7 +697,7 @@ public class SubScene extends Node {
      * <p>
      * For additional information about using CSS with the scene graph,
      * see the <a href="doc-files/cssref.html">CSS Reference Guide</a>.
-     * </p>
+     *
      * @param url the URL of the user-agent stylesheet
      * @since  JavaFX 8u20
      */

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/StyleManagerTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/StyleManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import com.sun.javafx.css.CascadingStyle;
 import com.sun.javafx.css.StyleManager;
 import com.sun.javafx.css.StyleManagerShim;
 import com.sun.javafx.css.StyleMap;
+import javafx.application.Application;
 import javafx.css.CssParser;
 import javafx.css.StyleOrigin;
 import javafx.css.StyleableProperty;
@@ -38,6 +39,7 @@ import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.SubScene;
 import javafx.scene.layout.Pane;
+import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.Paint;
 import javafx.scene.shape.Rectangle;
@@ -1119,5 +1121,54 @@ public class StyleManagerTest {
         // "3c1a430e67c1c22a0e28d49901c4a612" // Generated using command 'md5sum checksum.css'
 
         assertTrue(Arrays.equals(expectedChecksum, checksum));
+    }
+
+    @Test
+    public void testSetSceneUserAgentStylesheetFromDataURI() {
+        var rect = new Rectangle();
+        var root = new StackPane(rect);
+        rect.getStyleClass().add("rect");
+
+        // Stylesheet content: .rect { -fx-fill: blue; }
+        Scene scene = new Scene(root);
+        scene.setUserAgentStylesheet("data:base64,LnJlY3QgeyAtZngtZmlsbDogYmx1ZTsgfQ==");
+        scene.getRoot().applyCss();
+
+        assertEquals(Color.BLUE, rect.getFill());
+    }
+
+    @Test
+    public void testSetSubSceneUserAgentStylesheetFromDataURI() {
+        var rect = new Rectangle();
+        var root = new StackPane(rect);
+        rect.getStyleClass().add("rect");
+
+        // Stylesheet content: .rect { -fx-fill: blue; }
+        var subScene = new SubScene(root, 100, 100);
+        subScene.setUserAgentStylesheet("data:base64,LnJlY3QgeyAtZngtZmlsbDogYmx1ZTsgfQ==");
+
+        Scene scene = new Scene(new StackPane(subScene));
+        scene.getRoot().applyCss();
+
+        assertEquals(Color.BLUE, rect.getFill());
+    }
+
+    @Test
+    public void testSetApplicationUserAgentStylesheetFromDataURI() {
+        var rect = new Rectangle();
+        var root = new StackPane(rect);
+        rect.getStyleClass().add("rect");
+        String uaStylesheet = Application.getUserAgentStylesheet();
+
+        try {
+            // Stylesheet content: .rect { -fx-fill: blue; }
+            Application.setUserAgentStylesheet("data:base64,LnJlY3QgeyAtZngtZmlsbDogYmx1ZTsgfQ==");
+            Scene scene = new Scene(root);
+            scene.getRoot().applyCss();
+
+            assertEquals(Color.BLUE, rect.getFill());
+        } finally {
+            Application.setUserAgentStylesheet(uaStylesheet);
+        }
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/StyleManagerTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/StyleManagerTest.java
@@ -1158,7 +1158,6 @@ public class StyleManagerTest {
         var rect = new Rectangle();
         var root = new StackPane(rect);
         rect.getStyleClass().add("rect");
-        String uaStylesheet = Application.getUserAgentStylesheet();
 
         try {
             // Stylesheet content: .rect { -fx-fill: blue; }
@@ -1168,7 +1167,7 @@ public class StyleManagerTest {
 
             assertEquals(Color.BLUE, rect.getFill());
         } finally {
-            Application.setUserAgentStylesheet(uaStylesheet);
+            Application.setUserAgentStylesheet("data:,");
         }
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/StylesheetTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/StylesheetTest.java
@@ -650,26 +650,17 @@ public class StylesheetTest {
     }
 
     private byte[] convertCssTextToBinary(String cssText) throws IOException {
-        File inputFile = null, outputFile = null;
-        byte[] stylesheetData;
-
-        try {
-            inputFile = File.createTempFile("convertCssTextToBinary", ".css");
-            outputFile = File.createTempFile("convertCssTextToBinary", ".bss");
-            Files.writeString(inputFile.toPath(), cssText);
-            Stylesheet.convertToBinary(inputFile, outputFile);
-            stylesheetData = Files.readAllBytes(outputFile.toPath());
-        } finally {
-            if (inputFile != null) {
-                inputFile.delete();
-            }
-
-            if (outputFile != null) {
-                outputFile.delete();
-            }
-        }
-
-        return stylesheetData;
+        var stylesheet = new CssParser().parse(cssText);
+        var stream = new ByteArrayOutputStream();
+        var stringStore = new StringStore();
+        StylesheetShim.writeBinary(stylesheet, new DataOutputStream(stream), stringStore);
+        var stylesheetData = stream.toByteArray();
+        stream = new ByteArrayOutputStream();
+        var dataStream = new DataOutputStream(stream);
+        dataStream.writeShort(StylesheetShim.BINARY_CSS_VERSION);
+        stringStore.writeBinary(dataStream);
+        dataStream.write(stylesheetData);
+        return stream.toByteArray();
     }
 
     @Test


### PR DESCRIPTION
This PR extends data URI support to allow stylesheets to be loaded from data URIs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267554](https://bugs.openjdk.java.net/browse/JDK-8267554): Support loading stylesheets from data-URIs


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/536/head:pull/536` \
`$ git checkout pull/536`

Update a local copy of the PR: \
`$ git checkout pull/536` \
`$ git pull https://git.openjdk.java.net/jfx pull/536/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 536`

View PR using the GUI difftool: \
`$ git pr show -t 536`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/536.diff">https://git.openjdk.java.net/jfx/pull/536.diff</a>

</details>
