### PR TITLE
8269026: PasswordField doesn't render bullet character on Android

### DIFF
--- a/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextFieldSkinAndroid.java
+++ b/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextFieldSkinAndroid.java
@@ -79,7 +79,7 @@ public class TextFieldSkinAndroid extends TextFieldSkin {
         if (getSkinnable() instanceof PasswordField) {
             return String.valueOf(BULLET).repeat(txt.length());
         } else {
-            return txt;
+            return super.maskText(txt);
         }
     }
 

--- a/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextFieldSkinAndroid.java
+++ b/modules/javafx.controls/src/android/java/javafx/scene/control/skin/TextFieldSkinAndroid.java
@@ -28,6 +28,7 @@ package javafx.scene.control.skin;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.WeakChangeListener;
 import javafx.event.EventHandler;
+import javafx.scene.control.PasswordField;
 import javafx.scene.control.TextField;
 import javafx.scene.input.MouseEvent;
 
@@ -38,6 +39,8 @@ public class TextFieldSkinAndroid extends TextFieldSkin {
      * Private fields
      *
      **************************************************************************/
+
+    private static final char BULLET = '\u2022';
 
     private final EventHandler<MouseEvent> mouseEventListener = e -> {
         if (getSkinnable().isEditable() && getSkinnable().isFocused()) {
@@ -70,6 +73,15 @@ public class TextFieldSkinAndroid extends TextFieldSkin {
      * Public API                                                              *
      *                                                                         *
      **************************************************************************/
+
+    /** {@inheritDoc} */
+    @Override protected String maskText(String txt) {
+        if (getSkinnable() instanceof PasswordField) {
+            return String.valueOf(BULLET).repeat(txt.length());
+        } else {
+            return txt;
+        }
+    }
 
     /** {@inheritDoc} */
     @Override public void dispose() {


### PR DESCRIPTION
This PR modifies the PasswordField's bullet character used on Android, as the current unicode code is not supported for most fonts, including Roboto.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269026](https://bugs.openjdk.java.net/browse/JDK-8269026): PasswordField doesn't render bullet character on Android


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/537/head:pull/537` \
`$ git checkout pull/537`

Update a local copy of the PR: \
`$ git checkout pull/537` \
`$ git pull https://git.openjdk.java.net/jfx pull/537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 537`

View PR using the GUI difftool: \
`$ git pr show -t 537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/537.diff">https://git.openjdk.java.net/jfx/pull/537.diff</a>

</details>
