### PR TITLE
8264137: Suppress deprecation and removal warnings of internal methods

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/util/converter/DateStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/DateStringConverter.java
@@ -127,6 +127,7 @@ public class DateStringConverter extends DateTimeStringConverter {
     // --------------------------------------------------------- Private Methods
 
     /** {@inheritDoc} */
+    @SuppressWarnings("removal")
     @Override protected DateFormat getDateFormat() {
         DateFormat df = null;
 

--- a/modules/javafx.base/src/main/java/javafx/util/converter/TimeStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/TimeStringConverter.java
@@ -128,6 +128,7 @@ public class TimeStringConverter extends DateTimeStringConverter {
     // --------------------------------------------------------- Private Methods
 
     /** {@inheritDoc} */
+    @SuppressWarnings("removal")
     @Override protected DateFormat getDateFormat() {
         DateFormat df = null;
 

--- a/modules/javafx.base/src/shims/java/javafx/util/converter/DateTimeStringConverterShim.java
+++ b/modules/javafx.base/src/shims/java/javafx/util/converter/DateTimeStringConverterShim.java
@@ -30,26 +30,32 @@ import java.util.Locale;
 
 public class DateTimeStringConverterShim {
 
+    @SuppressWarnings("removal")
     public static int getTimeStyle(DateTimeStringConverter tsc) {
         return tsc.timeStyle;
     }
 
+    @SuppressWarnings("removal")
     public static String getPattern(DateTimeStringConverter tsc) {
         return tsc.pattern;
     }
 
+    @SuppressWarnings("removal")
     public static int getDateStyle(DateTimeStringConverter tsc) {
         return tsc.dateStyle;
     }
 
+    @SuppressWarnings("removal")
     public static DateFormat getDateFormat(DateTimeStringConverter tsc) {
         return tsc.getDateFormat();
     }
 
+    @SuppressWarnings("removal")
     public static DateFormat getDateFormatVar(DateTimeStringConverter tsc) {
         return tsc.dateFormat;
     }
 
+    @SuppressWarnings("removal")
     public static Locale getLocale(DateTimeStringConverter tsc) {
         return tsc.locale;
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ColorPickerSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ColorPickerSkin.java
@@ -584,10 +584,10 @@ public class ColorPickerSkin extends ComboBoxPopupControl<Color> {
             final double height = getHeight();
             final double right = snappedRightInset();
             final double bottom = snappedBottomInset();
-            colorRect.setX(snapPosition(colorRectX.get()));
-            colorRect.setY(snapPosition(colorRectY.get()));
-            colorRect.setWidth(snapSize(colorRectWidth.get()));
-            colorRect.setHeight(snapSize(colorRectHeight.get()));
+            colorRect.setX(snapPositionX(colorRectX.get()));
+            colorRect.setY(snapPositionY(colorRectY.get()));
+            colorRect.setWidth(snapSizeX(colorRectWidth.get()));
+            colorRect.setHeight(snapSizeY(colorRectHeight.get()));
             if (getChildren().size() == 2) {
                 final ImageView icon = (ImageView) getChildren().get(1);
                 Pos childAlignment = StackPane.getAlignment(icon);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/PaginationSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/PaginationSkin.java
@@ -838,7 +838,7 @@ public class PaginationSkin extends SkinBase<Pagination> {
             leftArrowButton.prefHeightProperty().bind(leftArrowButton.minHeightProperty());
             leftArrowButton.getStyleClass().add("left-arrow-button");
             leftArrowButton.setFocusTraversable(false);
-            HBox.setMargin(leftArrowButton, new Insets(0, snapSize(arrowButtonGap.get()), 0, 0));
+            HBox.setMargin(leftArrowButton, new Insets(0, snapSizeX(arrowButtonGap.get()), 0, 0));
             leftArrow = new StackPane();
             leftArrow.setMaxSize(USE_PREF_SIZE, USE_PREF_SIZE);
             leftArrowButton.setGraphic(leftArrow);
@@ -851,7 +851,7 @@ public class PaginationSkin extends SkinBase<Pagination> {
             rightArrowButton.prefHeightProperty().bind(rightArrowButton.minHeightProperty());
             rightArrowButton.getStyleClass().add("right-arrow-button");
             rightArrowButton.setFocusTraversable(false);
-            HBox.setMargin(rightArrowButton, new Insets(0, 0, 0, snapSize(arrowButtonGap.get())));
+            HBox.setMargin(rightArrowButton, new Insets(0, 0, 0, snapSizeX(arrowButtonGap.get())));
             rightArrow = new StackPane();
             rightArrow.setMaxSize(USE_PREF_SIZE, USE_PREF_SIZE);
             rightArrowButton.setGraphic(rightArrow);
@@ -874,8 +874,8 @@ public class PaginationSkin extends SkinBase<Pagination> {
                     HBox.setMargin(rightArrowButton, null);
 
                 } else {
-                    HBox.setMargin(leftArrowButton, new Insets(0, snapSize(newValue.doubleValue()), 0, 0));
-                    HBox.setMargin(rightArrowButton, new Insets(0, 0, 0, snapSize(newValue.doubleValue())));
+                    HBox.setMargin(leftArrowButton, new Insets(0, snapSizeX(newValue.doubleValue()), 0, 0));
+                    HBox.setMargin(rightArrowButton, new Insets(0, 0, 0, snapSizeX(newValue.doubleValue())));
                 }
             });
         }
@@ -970,18 +970,18 @@ public class PaginationSkin extends SkinBase<Pagination> {
         private void layoutPageIndicators() {
             final double left = snappedLeftInset();
             final double right = snappedRightInset();
-            final double width = snapSize(getWidth()) - (left + right);
+            final double width = snapSizeX(getWidth()) - (left + right);
             final double controlBoxleft = controlBox.snappedLeftInset();
             final double controlBoxRight = controlBox.snappedRightInset();
-            final double leftArrowWidth = snapSize(Utils.boundedSize(leftArrowButton.prefWidth(-1), leftArrowButton.minWidth(-1), leftArrowButton.maxWidth(-1)));
-            final double rightArrowWidth = snapSize(Utils.boundedSize(rightArrowButton.prefWidth(-1), rightArrowButton.minWidth(-1), rightArrowButton.maxWidth(-1)));
-            final double spacing = snapSize(controlBox.getSpacing());
+            final double leftArrowWidth = snapSizeX(Utils.boundedSize(leftArrowButton.prefWidth(-1), leftArrowButton.minWidth(-1), leftArrowButton.maxWidth(-1)));
+            final double rightArrowWidth = snapSizeX(Utils.boundedSize(rightArrowButton.prefWidth(-1), rightArrowButton.minWidth(-1), rightArrowButton.maxWidth(-1)));
+            final double spacing = snapSizeX(controlBox.getSpacing());
             double w = width - (controlBoxleft + leftArrowWidth + 2* arrowButtonGap.get() + spacing + rightArrowWidth + controlBoxRight);
 
             if (isPageInformationVisible() &&
                     (Side.LEFT.equals(getPageInformationAlignment()) ||
                     Side.RIGHT.equals(getPageInformationAlignment()))) {
-                w -= snapSize(pageInformation.prefWidth(-1));
+                w -= snapSizeX(pageInformation.prefWidth(-1));
             }
 
             double x = 0;
@@ -991,7 +991,7 @@ public class PaginationSkin extends SkinBase<Pagination> {
                 double iw = minButtonSize;
                 if (index != -1) {
                     IndicatorButton ib = (IndicatorButton)indicatorButtons.getToggles().get(index);
-                    iw = snapSize(Utils.boundedSize(ib.prefWidth(-1), ib.minWidth(-1), ib.maxWidth(-1)));
+                    iw = snapSizeX(Utils.boundedSize(ib.prefWidth(-1), ib.minWidth(-1), ib.maxWidth(-1)));
                 }
 
                 x += (iw + spacing);
@@ -1159,13 +1159,13 @@ public class PaginationSkin extends SkinBase<Pagination> {
         @Override protected double computeMinWidth(double height) {
             double left = snappedLeftInset();
             double right = snappedRightInset();
-            double leftArrowWidth = snapSize(Utils.boundedSize(leftArrowButton.prefWidth(-1), leftArrowButton.minWidth(-1), leftArrowButton.maxWidth(-1)));
-            double rightArrowWidth = snapSize(Utils.boundedSize(rightArrowButton.prefWidth(-1), rightArrowButton.minWidth(-1), rightArrowButton.maxWidth(-1)));
-            double spacing = snapSize(controlBox.getSpacing());
+            double leftArrowWidth = snapSizeX(Utils.boundedSize(leftArrowButton.prefWidth(-1), leftArrowButton.minWidth(-1), leftArrowButton.maxWidth(-1)));
+            double rightArrowWidth = snapSizeX(Utils.boundedSize(rightArrowButton.prefWidth(-1), rightArrowButton.minWidth(-1), rightArrowButton.maxWidth(-1)));
+            double spacing = snapSizeX(controlBox.getSpacing());
             double pageInformationWidth = 0;
             Side side = getPageInformationAlignment();
             if (Side.LEFT.equals(side) || Side.RIGHT.equals(side)) {
-                pageInformationWidth = snapSize(pageInformation.prefWidth(-1));
+                pageInformationWidth = snapSizeX(pageInformation.prefWidth(-1));
             }
             double arrowGap = arrowButtonGap.get();
 
@@ -1180,11 +1180,11 @@ public class PaginationSkin extends SkinBase<Pagination> {
         @Override protected double computePrefWidth(double height) {
             final double left = snappedLeftInset();
             final double right = snappedRightInset();
-            final double controlBoxWidth = snapSize(controlBox.prefWidth(height));
+            final double controlBoxWidth = snapSizeX(controlBox.prefWidth(height));
             double pageInformationWidth = 0;
             Side side = getPageInformationAlignment();
             if (Side.LEFT.equals(side) || Side.RIGHT.equals(side)) {
-                pageInformationWidth = snapSize(pageInformation.prefWidth(-1));
+                pageInformationWidth = snapSizeX(pageInformation.prefWidth(-1));
             }
 
             return left + controlBoxWidth + right + pageInformationWidth;
@@ -1193,11 +1193,11 @@ public class PaginationSkin extends SkinBase<Pagination> {
         @Override protected double computePrefHeight(double width) {
             final double top = snappedTopInset();
             final double bottom = snappedBottomInset();
-            final double boxHeight = snapSize(controlBox.prefHeight(width));
+            final double boxHeight = snapSizeY(controlBox.prefHeight(width));
             double pageInformationHeight = 0;
             Side side = getPageInformationAlignment();
             if (Side.TOP.equals(side) || Side.BOTTOM.equals(side)) {
-                pageInformationHeight = snapSize(pageInformation.prefHeight(-1));
+                pageInformationHeight = snapSizeY(pageInformation.prefHeight(-1));
             }
 
             return top + boxHeight + pageInformationHeight + bottom;
@@ -1208,12 +1208,12 @@ public class PaginationSkin extends SkinBase<Pagination> {
             final double bottom = snappedBottomInset();
             final double left = snappedLeftInset();
             final double right = snappedRightInset();
-            final double width = snapSize(getWidth()) - (left + right);
-            final double height = snapSize(getHeight()) - (top + bottom);
-            final double controlBoxWidth = snapSize(controlBox.prefWidth(-1));
-            final double controlBoxHeight = snapSize(controlBox.prefHeight(-1));
-            final double pageInformationWidth = snapSize(pageInformation.prefWidth(-1));
-            final double pageInformationHeight = snapSize(pageInformation.prefHeight(-1));
+            final double width = snapSizeX(getWidth()) - (left + right);
+            final double height = snapSizeY(getHeight()) - (top + bottom);
+            final double controlBoxWidth = snapSizeX(controlBox.prefWidth(-1));
+            final double controlBoxHeight = snapSizeY(controlBox.prefHeight(-1));
+            final double pageInformationWidth = snapSizeX(pageInformation.prefWidth(-1));
+            final double pageInformationHeight = snapSizeY(pageInformation.prefHeight(-1));
 
             leftArrowButton.setDisable(false);
             rightArrowButton.setDisable(false);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ProgressIndicatorSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ProgressIndicatorSkin.java
@@ -593,15 +593,15 @@ public class ProgressIndicatorSkin extends SkinBase<ProgressIndicator> {
             final double radiusW = areaW / 2;
             final double radiusH = areaH / 2;
             final double radius = Math.floor(Math.min(radiusW, radiusH));
-            final double centerX = snapPosition(left + radiusW);
-            final double centerY = snapPosition(top + radius);
+            final double centerX = snapPositionX(left + radiusW);
+            final double centerY = snapPositionY(top + radius);
 
             // find radius that fits inside radius - insetsPadding
             final double iLeft = indicator.snappedLeftInset();
             final double iRight = indicator.snappedRightInset();
             final double iTop = indicator.snappedTopInset();
             final double iBottom = indicator.snappedBottomInset();
-            final double progressRadius = snapSize(Math.min(
+            final double progressRadius = snapSizeX(Math.min(
                     Math.min(radius - iLeft, radius - iRight),
                     Math.min(radius - iTop, radius - iBottom)));
 
@@ -619,7 +619,7 @@ public class ProgressIndicatorSkin extends SkinBase<ProgressIndicator> {
             final double pRight = progress.snappedRightInset();
             final double pTop = progress.snappedTopInset();
             final double pBottom = progress.snappedBottomInset();
-            final double indicatorRadius = snapSize(Math.min(
+            final double indicatorRadius = snapSizeX(Math.min(
                     Math.min(progressRadius - pLeft, progressRadius - pRight),
                     Math.min(progressRadius - pTop, progressRadius - pBottom)));
 
@@ -636,8 +636,8 @@ public class ProgressIndicatorSkin extends SkinBase<ProgressIndicator> {
             double textHeight = text.getLayoutBounds().getHeight();
             if (control.getWidth() >= textWidth && control.getHeight() >= textHeight) {
                 if (!text.isVisible()) text.setVisible(true);
-                text.setLayoutY(snapPosition(centerY + radius + textGap));
-                text.setLayoutX(snapPosition(centerX - (textWidth/2)));
+                text.setLayoutY(snapPositionY(centerY + radius + textGap));
+                text.setLayoutX(snapPositionX(centerX - (textWidth/2)));
             } else {
                 if (text.isVisible()) text.setVisible(false);
             }
@@ -650,12 +650,12 @@ public class ProgressIndicatorSkin extends SkinBase<ProgressIndicator> {
             final double iRight = indicator.snappedRightInset();
             final double iTop = indicator.snappedTopInset();
             final double iBottom = indicator.snappedBottomInset();
-            final double indicatorMax = snapSize(Math.max(Math.max(iLeft, iRight), Math.max(iTop, iBottom)));
+            final double indicatorMax = snapSizeX(Math.max(Math.max(iLeft, iRight), Math.max(iTop, iBottom)));
             final double pLeft = progress.snappedLeftInset();
             final double pRight = progress.snappedRightInset();
             final double pTop = progress.snappedTopInset();
             final double pBottom = progress.snappedBottomInset();
-            final double progressMax = snapSize(Math.max(Math.max(pLeft, pRight), Math.max(pTop, pBottom)));
+            final double progressMax = snapSizeX(Math.max(Math.max(pLeft, pRight), Math.max(pTop, pBottom)));
             final double tLeft = tick.snappedLeftInset();
             final double tRight = tick.snappedRightInset();
             final double indicatorWidth = indicatorMax + progressMax + tLeft + tRight + progressMax + indicatorMax;
@@ -669,12 +669,12 @@ public class ProgressIndicatorSkin extends SkinBase<ProgressIndicator> {
             final double iRight = indicator.snappedRightInset();
             final double iTop = indicator.snappedTopInset();
             final double iBottom = indicator.snappedBottomInset();
-            final double indicatorMax = snapSize(Math.max(Math.max(iLeft, iRight), Math.max(iTop, iBottom)));
+            final double indicatorMax = snapSizeY(Math.max(Math.max(iLeft, iRight), Math.max(iTop, iBottom)));
             final double pLeft = progress.snappedLeftInset();
             final double pRight = progress.snappedRightInset();
             final double pTop = progress.snappedTopInset();
             final double pBottom = progress.snappedBottomInset();
-            final double progressMax = snapSize(Math.max(Math.max(pLeft, pRight), Math.max(pTop, pBottom)));
+            final double progressMax = snapSizeY(Math.max(Math.max(pLeft, pRight), Math.max(pTop, pBottom)));
             final double tTop = tick.snappedTopInset();
             final double tBottom = tick.snappedBottomInset();
             final double indicatorHeight = indicatorMax + progressMax + tTop + tBottom + progressMax + indicatorMax;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ScrollPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ScrollPaneSkin.java
@@ -684,7 +684,7 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
                     computeScrollNodeSize(getWidth(),getHeight());
                 }
                 if (scrollNode != null && scrollNode.isResizable()) {
-                    scrollNode.resize(snapSize(nodeWidth), snapSize(nodeHeight));
+                    scrollNode.resize(snapSizeX(nodeWidth), snapSizeY(nodeHeight));
                     if (vsbvis != determineVerticalSBVisible() || hsbvis != determineHorizontalSBVisible()) {
                         getSkinnable().requestLayout();
                     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
@@ -851,7 +851,7 @@ public class TabPaneSkin extends SkinBase<TabPane> {
                             width += tabHeaderSkin.prefWidth(height);
                         }
                     }
-                    return snapSize(width) + snappedLeftInset() + snappedRightInset();
+                    return snapSizeX(width) + snappedLeftInset() + snappedRightInset();
                 }
 
                 @Override protected double computePrefHeight(double width) {
@@ -860,7 +860,7 @@ public class TabPaneSkin extends SkinBase<TabPane> {
                         TabHeaderSkin tabHeaderSkin = (TabHeaderSkin)child;
                         height = Math.max(height, tabHeaderSkin.prefHeight(width));
                     }
-                    return snapSize(height) + snappedTopInset() + snappedBottomInset();
+                    return snapSizeY(height) + snappedTopInset() + snappedBottomInset();
                 }
 
                 @Override protected void layoutChildren() {
@@ -876,17 +876,17 @@ public class TabPaneSkin extends SkinBase<TabPane> {
                     }
 
                     Side tabPosition = getSkinnable().getSide();
-                    double tabBackgroundHeight = snapSize(prefHeight(-1));
+                    double tabBackgroundHeight = snapSizeY(prefHeight(-1));
                     double tabX = (tabPosition.equals(Side.LEFT) || tabPosition.equals(Side.BOTTOM)) ?
-                        snapSize(getWidth()) - getScrollOffset() : getScrollOffset();
+                        snapSizeX(getWidth()) - getScrollOffset() : getScrollOffset();
 
                     updateHeaderClip();
                     for (Node node : getChildren()) {
                         TabHeaderSkin tabHeader = (TabHeaderSkin)node;
 
                         // size and position the header relative to the other headers
-                        double tabHeaderPrefWidth = snapSize(tabHeader.prefWidth(-1) * tabHeader.animationTransition.get());
-                        double tabHeaderPrefHeight = snapSize(tabHeader.prefHeight(-1));
+                        double tabHeaderPrefWidth = snapSizeX(tabHeader.prefWidth(-1) * tabHeader.animationTransition.get());
+                        double tabHeaderPrefHeight = snapSizeY(tabHeader.prefHeight(-1));
                         tabHeader.resize(tabHeaderPrefWidth, tabHeaderPrefHeight);
 
                         // This ensures that the tabs are located in the correct position
@@ -963,13 +963,13 @@ public class TabPaneSkin extends SkinBase<TabPane> {
             double maxWidth = 0;
             double shadowRadius = 0;
             double clipOffset = firstTabIndent();
-            double controlButtonPrefWidth = snapSize(controlButtons.prefWidth(-1));
+            double controlButtonPrefWidth = snapSizeX(controlButtons.prefWidth(-1));
 
             measureClosingTabs = true;
-            double headersPrefWidth = snapSize(headersRegion.prefWidth(-1));
+            double headersPrefWidth = snapSizeX(headersRegion.prefWidth(-1));
             measureClosingTabs = false;
 
-            double headersPrefHeight = snapSize(headersRegion.prefHeight(-1));
+            double headersPrefHeight = snapSizeY(headersRegion.prefHeight(-1));
 
             // Add the spacer if isShowTabsMenu is true.
             if (controlButtonPrefWidth > 0) {
@@ -981,7 +981,7 @@ public class TabPaneSkin extends SkinBase<TabPane> {
                 shadowRadius = shadow.getRadius();
             }
 
-            maxWidth = snapSize(getWidth()) - controlButtonPrefWidth - clipOffset;
+            maxWidth = snapSizeX(getWidth()) - controlButtonPrefWidth - clipOffset;
             if (tabPosition.equals(Side.LEFT) || tabPosition.equals(Side.BOTTOM)) {
                 if (headersPrefWidth < maxWidth) {
                     clipWidth = headersPrefWidth + shadowRadius;
@@ -1036,16 +1036,16 @@ public class TabPaneSkin extends SkinBase<TabPane> {
         }
 
         private boolean tabsFit() {
-            double headerPrefWidth = snapSize(headersRegion.prefWidth(-1));
-            double controlTabWidth = snapSize(controlButtons.prefWidth(-1));
+            double headerPrefWidth = snapSizeX(headersRegion.prefWidth(-1));
+            double controlTabWidth = snapSizeX(controlButtons.prefWidth(-1));
             double visibleWidth = headerPrefWidth + controlTabWidth + firstTabIndent() + SPACER;
             return visibleWidth < getWidth();
         }
 
         private void ensureSelectedTabIsVisible() {
             // work out the visible width of the tab header
-            double tabPaneWidth = snapSize(isHorizontal() ? getSkinnable().getWidth() : getSkinnable().getHeight());
-            double controlTabWidth = snapSize(controlButtons.getWidth());
+            double tabPaneWidth = snapSizeX(isHorizontal() ? getSkinnable().getWidth() : getSkinnable().getHeight());
+            double controlTabWidth = snapSizeX(controlButtons.getWidth());
             double visibleWidth = tabPaneWidth - controlTabWidth - firstTabIndent() - SPACER;
 
             // and get where the selected tab is in the header area
@@ -1055,7 +1055,7 @@ public class TabPaneSkin extends SkinBase<TabPane> {
             for (Node node : headersRegion.getChildren()) {
                 TabHeaderSkin tabHeader = (TabHeaderSkin)node;
 
-                double tabHeaderPrefWidth = snapSize(tabHeader.prefWidth(-1));
+                double tabHeaderPrefWidth = snapSizeX(tabHeader.prefWidth(-1));
 
                 if (selectedTab != null && selectedTab.equals(tabHeader.getTab())) {
                     selectedTabOffset = offset;
@@ -1091,15 +1091,15 @@ public class TabPaneSkin extends SkinBase<TabPane> {
 
         private void setScrollOffset(double newScrollOffset) {
             // work out the visible width of the tab header
-            double tabPaneWidth = snapSize(isHorizontal() ? getSkinnable().getWidth() : getSkinnable().getHeight());
-            double controlTabWidth = snapSize(controlButtons.getWidth());
+            double tabPaneWidth = snapSizeX(isHorizontal() ? getSkinnable().getWidth() : getSkinnable().getHeight());
+            double controlTabWidth = snapSizeX(controlButtons.getWidth());
             double visibleWidth = tabPaneWidth - controlTabWidth - firstTabIndent() - SPACER;
 
             // measure the width of all tabs
             double offset = 0.0;
             for (Node node : headersRegion.getChildren()) {
                 TabHeaderSkin tabHeader = (TabHeaderSkin)node;
-                double tabHeaderPrefWidth = snapSize(tabHeader.prefWidth(-1));
+                double tabHeaderPrefWidth = snapSizeX(tabHeader.prefWidth(-1));
                 offset += tabHeaderPrefWidth;
             }
 
@@ -1142,7 +1142,7 @@ public class TabPaneSkin extends SkinBase<TabPane> {
             double padding = isHorizontal() ?
                 snappedLeftInset() + snappedRightInset() :
                 snappedTopInset() + snappedBottomInset();
-            return snapSize(headersRegion.prefWidth(height)) + controlButtons.prefWidth(height) +
+            return snapSizeX(headersRegion.prefWidth(height)) + controlButtons.prefWidth(height) +
                     firstTabIndent() + SPACER + padding;
         }
 
@@ -1150,7 +1150,7 @@ public class TabPaneSkin extends SkinBase<TabPane> {
             double padding = isHorizontal() ?
                 snappedTopInset() + snappedBottomInset() :
                 snappedLeftInset() + snappedRightInset();
-            return snapSize(headersRegion.prefHeight(-1)) + padding;
+            return snapSizeY(headersRegion.prefHeight(-1)) + padding;
         }
 
         @Override public double getBaselineOffset() {
@@ -1165,13 +1165,13 @@ public class TabPaneSkin extends SkinBase<TabPane> {
             final double rightInset = snappedRightInset();
             final double topInset = snappedTopInset();
             final double bottomInset = snappedBottomInset();
-            double w = snapSize(getWidth()) - (isHorizontal() ?
+            double w = snapSizeX(getWidth()) - (isHorizontal() ?
                     leftInset + rightInset : topInset + bottomInset);
-            double h = snapSize(getHeight()) - (isHorizontal() ?
+            double h = snapSizeY(getHeight()) - (isHorizontal() ?
                     topInset + bottomInset : leftInset + rightInset);
-            double tabBackgroundHeight = snapSize(prefHeight(-1));
-            double headersPrefWidth = snapSize(headersRegion.prefWidth(-1));
-            double headersPrefHeight = snapSize(headersRegion.prefHeight(-1));
+            double tabBackgroundHeight = snapSizeY(prefHeight(-1));
+            double headersPrefWidth = snapSizeX(headersRegion.prefWidth(-1));
+            double headersPrefHeight = snapSizeY(headersRegion.prefHeight(-1));
 
             controlButtons.showTabsMenu(! tabsFit());
 
@@ -1179,7 +1179,7 @@ public class TabPaneSkin extends SkinBase<TabPane> {
             headersRegion.requestLayout();
 
             // RESIZE CONTROL BUTTONS
-            double btnWidth = snapSize(controlButtons.prefWidth(-1));
+            double btnWidth = snapSizeX(controlButtons.prefWidth(-1));
             final double btnHeight = controlButtons.prefHeight(btnWidth);
             controlButtons.resize(btnWidth, btnHeight);
 
@@ -1189,7 +1189,7 @@ public class TabPaneSkin extends SkinBase<TabPane> {
             if (isFloatingStyleClass()) {
                 headerBackground.setVisible(false);
             } else {
-                headerBackground.resize(snapSize(getWidth()), snapSize(getHeight()));
+                headerBackground.resize(snapSizeX(getWidth()), snapSizeY(getHeight()));
                 headerBackground.setVisible(true);
             }
 
@@ -1203,26 +1203,26 @@ public class TabPaneSkin extends SkinBase<TabPane> {
                 startX = leftInset;
                 startY = tabBackgroundHeight - headersPrefHeight - bottomInset;
                 controlStartX = w - btnWidth + leftInset;
-                controlStartY = snapSize(getHeight()) - btnHeight - bottomInset;
+                controlStartY = snapSizeY(getHeight()) - btnHeight - bottomInset;
             } else if (tabPosition.equals(Side.RIGHT)) {
                 startX = topInset;
                 startY = tabBackgroundHeight - headersPrefHeight - leftInset;
                 controlStartX = w - btnWidth + topInset;
-                controlStartY = snapSize(getHeight()) - btnHeight - leftInset;
+                controlStartY = snapSizeY(getHeight()) - btnHeight - leftInset;
             } else if (tabPosition.equals(Side.BOTTOM)) {
-                startX = snapSize(getWidth()) - headersPrefWidth - leftInset;
+                startX = snapSizeX(getWidth()) - headersPrefWidth - leftInset;
                 startY = tabBackgroundHeight - headersPrefHeight - topInset;
                 controlStartX = rightInset;
-                controlStartY = snapSize(getHeight()) - btnHeight - topInset;
+                controlStartY = snapSizeY(getHeight()) - btnHeight - topInset;
             } else if (tabPosition.equals(Side.LEFT)) {
-                startX = snapSize(getWidth()) - headersPrefWidth - topInset;
+                startX = snapSizeX(getWidth()) - headersPrefWidth - topInset;
                 startY = tabBackgroundHeight - headersPrefHeight - rightInset;
                 controlStartX = leftInset;
-                controlStartY = snapSize(getHeight()) - btnHeight - rightInset;
+                controlStartY = snapSizeY(getHeight()) - btnHeight - rightInset;
             }
             if (headerBackground.isVisible()) {
                 positionInArea(headerBackground, 0, 0,
-                        snapSize(getWidth()), snapSize(getHeight()), /*baseline ignored*/0, HPos.CENTER, VPos.CENTER);
+                        snapSizeX(getWidth()), snapSizeY(getHeight()), /*baseline ignored*/0, HPos.CENTER, VPos.CENTER);
             }
             positionInArea(headersRegion, startX, startY, w, h, /*baseline ignored*/0, HPos.LEFT, VPos.CENTER);
             positionInArea(controlButtons, controlStartX, controlStartY, btnWidth, btnHeight,
@@ -1341,14 +1341,14 @@ public class TabPaneSkin extends SkinBase<TabPane> {
                     final double w = getWidth() - (paddingLeft + paddingRight);
                     final double h = getHeight() - (paddingTop + paddingBottom);
 
-                    final double prefLabelWidth = snapSize(label.prefWidth(-1));
-                    final double prefLabelHeight = snapSize(label.prefHeight(-1));
+                    final double prefLabelWidth = snapSizeX(label.prefWidth(-1));
+                    final double prefLabelHeight = snapSizeY(label.prefHeight(-1));
 
-                    final double closeBtnWidth = showCloseButton() ? snapSize(closeBtn.prefWidth(-1)) : 0;
-                    final double closeBtnHeight = showCloseButton() ? snapSize(closeBtn.prefHeight(-1)) : 0;
-                    final double minWidth = snapSize(skinnable.getTabMinWidth());
-                    final double maxWidth = snapSize(skinnable.getTabMaxWidth());
-                    final double maxHeight = snapSize(skinnable.getTabMaxHeight());
+                    final double closeBtnWidth = showCloseButton() ? snapSizeX(closeBtn.prefWidth(-1)) : 0;
+                    final double closeBtnHeight = showCloseButton() ? snapSizeY(closeBtn.prefHeight(-1)) : 0;
+                    final double minWidth = snapSizeX(skinnable.getTabMinWidth());
+                    final double maxWidth = snapSizeX(skinnable.getTabMaxWidth());
+                    final double maxHeight = snapSizeY(skinnable.getTabMaxHeight());
 
                     double labelAreaWidth = prefLabelWidth;
                     double labelWidth = prefLabelWidth;
@@ -1583,15 +1583,15 @@ public class TabPaneSkin extends SkinBase<TabPane> {
 //            if (animating) {
 //                return prefWidth.getValue();
 //            }
-            double minWidth = snapSize(getSkinnable().getTabMinWidth());
-            double maxWidth = snapSize(getSkinnable().getTabMaxWidth());
+            double minWidth = snapSizeX(getSkinnable().getTabMinWidth());
+            double maxWidth = snapSizeX(getSkinnable().getTabMaxWidth());
             double paddingRight = snappedRightInset();
             double paddingLeft = snappedLeftInset();
-            double tmpPrefWidth = snapSize(label.prefWidth(-1));
+            double tmpPrefWidth = snapSizeX(label.prefWidth(-1));
 
             // only include the close button width if it is relevant
             if (showCloseButton()) {
-                tmpPrefWidth += snapSize(closeBtn.prefWidth(-1));
+                tmpPrefWidth += snapSizeX(closeBtn.prefWidth(-1));
             }
 
             if (tmpPrefWidth > maxWidth) {
@@ -1605,11 +1605,11 @@ public class TabPaneSkin extends SkinBase<TabPane> {
         }
 
         @Override protected double computePrefHeight(double width) {
-            double minHeight = snapSize(getSkinnable().getTabMinHeight());
-            double maxHeight = snapSize(getSkinnable().getTabMaxHeight());
+            double minHeight = snapSizeY(getSkinnable().getTabMinHeight());
+            double maxHeight = snapSizeY(getSkinnable().getTabMaxHeight());
             double paddingTop = snappedTopInset();
             double paddingBottom = snappedBottomInset();
-            double tmpPrefHeight = snapSize(label.prefHeight(width));
+            double tmpPrefHeight = snapSizeY(label.prefHeight(width));
 
             if (tmpPrefHeight > maxHeight) {
                 tmpPrefHeight = maxHeight;
@@ -1621,8 +1621,8 @@ public class TabPaneSkin extends SkinBase<TabPane> {
         }
 
         @Override protected void layoutChildren() {
-            double w = (snapSize(getWidth()) - snappedRightInset() - snappedLeftInset()) * animationTransition.getValue();
-            inner.resize(w, snapSize(getHeight()) - snappedTopInset() - snappedBottomInset());
+            double w = (snapSizeX(getWidth()) - snappedRightInset() - snappedLeftInset()) * animationTransition.getValue();
+            inner.resize(w, snapSizeY(getHeight()) - snappedTopInset() - snappedBottomInset());
             inner.relocate(snappedLeftInset(), snappedTopInset());
         }
 
@@ -1761,7 +1761,7 @@ public class TabPaneSkin extends SkinBase<TabPane> {
             inner = new StackPane() {
                 @Override protected double computePrefWidth(double height) {
                     double pw;
-                    double maxArrowWidth = ! isShowTabsMenu() ? 0 : snapSize(downArrow.prefWidth(getHeight())) + snapSize(downArrowBtn.prefWidth(getHeight()));
+                    double maxArrowWidth = ! isShowTabsMenu() ? 0 : snapSizeX(downArrow.prefWidth(getHeight())) + snapSizeX(downArrowBtn.prefWidth(getHeight()));
                     pw = 0.0F;
                     if (isShowTabsMenu()) {
                         pw += maxArrowWidth;
@@ -1775,7 +1775,7 @@ public class TabPaneSkin extends SkinBase<TabPane> {
                 @Override protected double computePrefHeight(double width) {
                     double height = 0.0F;
                     if (isShowTabsMenu()) {
-                        height = Math.max(height, snapSize(downArrowBtn.prefHeight(width)));
+                        height = Math.max(height, snapSizeY(downArrowBtn.prefHeight(width)));
                     }
                     if (height > 0) {
                         height += snappedTopInset() + snappedBottomInset();
@@ -1787,8 +1787,8 @@ public class TabPaneSkin extends SkinBase<TabPane> {
                     if (isShowTabsMenu()) {
                         double x = 0;
                         double y = snappedTopInset();
-                        double w = snapSize(getWidth()) - x + snappedLeftInset();
-                        double h = snapSize(getHeight()) - y + snappedBottomInset();
+                        double w = snapSizeX(getWidth()) - x + snappedLeftInset();
+                        double h = snapSizeY(getHeight()) - y + snappedBottomInset();
                         positionArrow(downArrowBtn, downArrow, x, y, w, h);
                     }
                 }
@@ -1798,8 +1798,8 @@ public class TabPaneSkin extends SkinBase<TabPane> {
                     positionInArea(btn, x, y, width, height, /*baseline ignored*/0,
                             HPos.CENTER, VPos.CENTER);
                     // center arrow region within arrow button
-                    double arrowWidth = snapSize(arrow.prefWidth(-1));
-                    double arrowHeight = snapSize(arrow.prefHeight(-1));
+                    double arrowWidth = snapSizeX(arrow.prefWidth(-1));
+                    double arrowHeight = snapSizeY(arrow.prefHeight(-1));
                     arrow.resize(arrowWidth, arrowHeight);
                     positionInArea(arrow, btn.snappedLeftInset(), btn.snappedTopInset(),
                             width - btn.snappedLeftInset() - btn.snappedRightInset(),
@@ -1858,7 +1858,7 @@ public class TabPaneSkin extends SkinBase<TabPane> {
         }
 
         @Override protected double computePrefWidth(double height) {
-            double pw = snapSize(inner.prefWidth(height));
+            double pw = snapSizeX(inner.prefWidth(height));
             if (pw > 0) {
                 pw += snappedLeftInset() + snappedRightInset();
             }
@@ -1866,15 +1866,15 @@ public class TabPaneSkin extends SkinBase<TabPane> {
         }
 
         @Override protected double computePrefHeight(double width) {
-            return Math.max(getSkinnable().getTabMinHeight(), snapSize(inner.prefHeight(width))) +
+            return Math.max(getSkinnable().getTabMinHeight(), snapSizeY(inner.prefHeight(width))) +
                     snappedTopInset() + snappedBottomInset();
         }
 
         @Override protected void layoutChildren() {
             double x = snappedLeftInset();
             double y = snappedTopInset();
-            double w = snapSize(getWidth()) - x + snappedRightInset();
-            double h = snapSize(getHeight()) - y + snappedBottomInset();
+            double w = snapSizeX(getWidth()) - x + snappedRightInset();
+            double h = snapSizeY(getHeight()) - y + snappedBottomInset();
 
             if (showControlButtons) {
                 showControlButtons();

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TitledPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TitledPaneSkin.java
@@ -494,7 +494,7 @@ public class TitledPaneSkin extends LabeledSkinBase<TitledPane>  {
             double labelPrefWidth = labelPrefWidth(height);
 
             if (arrowRegion != null) {
-                arrowWidth = snapSize(arrowRegion.prefWidth(height));
+                arrowWidth = snapSizeX(arrowRegion.prefWidth(height));
             }
 
             return left + arrowWidth + labelPrefWidth + right;
@@ -507,7 +507,7 @@ public class TitledPaneSkin extends LabeledSkinBase<TitledPane>  {
             double labelPrefHeight = labelPrefHeight(width);
 
             if (arrowRegion != null) {
-                arrowHeight = snapSize(arrowRegion.prefHeight(width));
+                arrowHeight = snapSizeY(arrowRegion.prefHeight(width));
             }
 
             return top + Math.max(arrowHeight, labelPrefHeight) + bottom;
@@ -520,10 +520,10 @@ public class TitledPaneSkin extends LabeledSkinBase<TitledPane>  {
             final double right = snappedRightInset();
             double width = getWidth() - (left + right);
             double height = getHeight() - (top + bottom);
-            double arrowWidth = snapSize(arrowRegion.prefWidth(-1));
-            double arrowHeight = snapSize(arrowRegion.prefHeight(-1));
-            double labelWidth = snapSize(Math.min(width - arrowWidth / 2.0, labelPrefWidth(-1)));
-            double labelHeight = snapSize(labelPrefHeight(-1));
+            double arrowWidth = snapSizeX(arrowRegion.prefWidth(-1));
+            double arrowHeight = snapSizeY(arrowRegion.prefHeight(-1));
+            double labelWidth = snapSizeX(Math.min(width - arrowWidth / 2.0, labelPrefWidth(-1)));
+            double labelHeight = snapSizeY(labelPrefHeight(-1));
 
             double x = left + arrowWidth + Utils.computeXOffset(width - arrowWidth, labelWidth, hpos);
             if (HPos.CENTER == hpos) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ToolBarSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ToolBarSkin.java
@@ -792,10 +792,10 @@ public class ToolBarSkin extends SkinBase<ToolBar> {
         }
 
         @Override protected void layoutChildren() {
-            double w = snapSize(downArrow.prefWidth(-1));
-            double h = snapSize(downArrow.prefHeight(-1));
-            double x = (snapSize(getWidth()) - w)/2;
-            double y = (snapSize(getHeight()) - h)/2;
+            double w = snapSizeX(downArrow.prefWidth(-1));
+            double h = snapSizeY(downArrow.prefHeight(-1));
+            double x = (snapSizeX(getWidth()) - w)/2;
+            double y = (snapSizeY(getHeight()) - h)/2;
 
             // TODO need to provide support for when the toolbar is on the right
             // or bottom

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYChartTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/XYChartTest.java
@@ -88,8 +88,8 @@ public class XYChartTest extends ChartTestBase {
         // set tick label font via css and test if ticklabelfont, measure and tick textnode follow.
         ParsedValue pv = new CssParserShim().parseExpr("-fx-tick-label-font","0.916667em System");
         Object val = pv.convert(null);
-        CssMetaData prop = ((StyleableProperty)yaxis.tickLabelFontProperty()).getCssMetaData();
-        prop.set(yaxis, val, null);
+        StyleableProperty prop = (StyleableProperty)yaxis.tickLabelFontProperty();
+        prop.applyStyle(null, val);
         // confirm tickLabelFont, measure and tick's textnode all are in sync with -fx-tick-label-font
         assertEquals(11, Double.valueOf(yaxis.getTickLabelFont().getSize()).intValue());
         assertEquals(11, Double.valueOf(AxisShim.get_measure(yaxis).getFont().getSize()).intValue());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/LabeledTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/LabeledTest.java
@@ -764,8 +764,8 @@ public class LabeledTest {
 
     @Test public void canSpecifyLabelPaddingFromCSS() {
         Insets insets = new Insets(5, 4, 3, 2);
-        CssMetaData styleable = ((StyleableProperty)labeled.labelPaddingProperty()).getCssMetaData();
-        styleable.set(labeled, insets, null);
+        StyleableProperty prop = ((StyleableProperty)labeled.labelPaddingProperty());
+        prop.applyStyle(null, insets);
         assertEquals(insets, labeled.getLabelPadding());
         assertEquals(insets, labeled.labelPaddingProperty().get());
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeItemTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeItemTest.java
@@ -196,11 +196,13 @@ public class TreeItemTest {
         assertEquals(child1, root.getChildren().get(0));
     }
 
+    @SuppressWarnings("deprecation")
     @Test public void ensureRootNodeHas0Level() {
         final TreeItem root = new TreeItem("Node");
         assertEquals(0, TreeView.getNodeLevel(root));
     }
 
+    @SuppressWarnings("deprecation")
     @Test public void ensureChildOfRootNodeHas1Level() {
         final TreeItem root = new TreeItem("Node");
         final TreeItem child1 = new TreeItem("child1");
@@ -208,6 +210,7 @@ public class TreeItemTest {
         assertEquals(1, TreeView.getNodeLevel(child1));
     }
 
+    @SuppressWarnings("deprecation")
     @Test public void ensureGrandchildOfRootNodeHas2Level() {
         final TreeItem root = new TreeItem("Node");
         final TreeItem child1 = new TreeItem("child1");
@@ -217,6 +220,7 @@ public class TreeItemTest {
         assertEquals(2, TreeView.getNodeLevel(grandchild1));
     }
 
+    @SuppressWarnings("deprecation")
     @Test public void detachNodeFromParent_observeThatLevelDecreases() {
         final TreeItem root = new TreeItem("Node");
         final TreeItem child1 = new TreeItem("child1");

--- a/modules/javafx.fxml/src/test/java/test/com/oracle/javafx/fxml/test/TestLoadPerformance.java
+++ b/modules/javafx.fxml/src/test/java/test/com/oracle/javafx/fxml/test/TestLoadPerformance.java
@@ -101,6 +101,7 @@ public class TestLoadPerformance extends Application {
         System.exit(0);
     }
 
+    @SuppressWarnings("deprecation")
     protected void loadSAX(URL location) throws Exception {
         long t0 = System.currentTimeMillis();
 

--- a/modules/javafx.graphics/src/shims/java/javafx/scene/input/GestureEventShim.java
+++ b/modules/javafx.graphics/src/shims/java/javafx/scene/input/GestureEventShim.java
@@ -42,6 +42,7 @@ public class GestureEventShim {
                pickResult);
     }
 
+    @SuppressWarnings("deprecation")
     public static GestureEvent getGestureEvent(
             Object source, EventTarget target,
             final EventType<? extends GestureEvent> eventType) {

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/StylesheetTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/StylesheetTest.java
@@ -615,6 +615,7 @@ public class StylesheetTest {
        }
    }
 
+    @SuppressWarnings("deprecation")
     @Test
     public void testRT_37301() {
         try {

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/Scenegraph_eventHandlers_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/Scenegraph_eventHandlers_Test.java
@@ -339,7 +339,7 @@ public final class Scenegraph_eventHandlers_Test {
     private static final Group TEST_ROOT_NODE =
             new Group(TEST_L_NODE, TEST_R_NODE);
     private static final Scene TEST_SCENE = new Scene(TEST_ROOT_NODE);
-    private static final Event TEST_EVENT = new Event(new EventType<Event>());
+    private static final Event TEST_EVENT = new Event(new EventType<Event>("Test Event"));
 
     private static final EventHandler<Event> EVENT_CONSUMING_HANDLER =
             event -> event.consume();

--- a/tests/system/src/test/java/test/robot/com/sun/glass/ui/monocle/input/devices/TestTouchDevices.java
+++ b/tests/system/src/test/java/test/robot/com/sun/glass/ui/monocle/input/devices/TestTouchDevices.java
@@ -43,7 +43,7 @@ public class TestTouchDevices {
             }
             try {
                 devices.add((TestTouchDevice)
-                                    Class.forName(selectedDeviceClass).newInstance());
+                                    Class.forName(selectedDeviceClass).getDeclaredConstructor().newInstance());
             } catch (Exception e) {
                 e.printStackTrace();
             }

--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/JFXPanelTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/JFXPanelTest.java
@@ -92,8 +92,8 @@ public class JFXPanelTest {
             }
             while (!stop) {
                 robot.mouseMove(300, 10);
-                robot.mousePress(InputEvent.BUTTON1_MASK);
-                robot.mouseRelease(InputEvent.BUTTON1_MASK);
+                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             }
         }).start();
         beginLatch.countDown();

--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/NonFocusableJFXPanelTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/NonFocusableJFXPanelTest.java
@@ -71,8 +71,8 @@ public class NonFocusableJFXPanelTest {
         robot.mouseMove(pt.x + WIDTH/2, pt.y + HEIGHT/2);
         robot.waitForIdle();
         for (int i = 0; i < 5; i++) {
-            robot.mousePress(InputEvent.BUTTON1_MASK);
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
         }
         Assert.assertFalse("Extra MouseEvent generated", clickCount > 5);
     }


### PR DESCRIPTION
This PR suppresses -PLINT="removal" warnings and fixes -PLINT="deprecation" warnings. I have created separate commits for each type of warnings for the ease of review.

`gradle --info -PLINT="deprecation,removal"` -- results in warnings during build without this PR and results in no warnings with this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8264137](https://bugs.openjdk.java.net/browse/JDK-8264137): Suppress deprecation and removal warnings of internal methods
 * [JDK-8252820](https://bugs.openjdk.java.net/browse/JDK-8252820): Skins: cleanup use of deprecated snapSize/snapPosition


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Marius Hanl](https://openjdk.java.net/census#mhanl) (@Maran23 - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/538/head:pull/538` \
`$ git checkout pull/538`

Update a local copy of the PR: \
`$ git checkout pull/538` \
`$ git pull https://git.openjdk.java.net/jfx pull/538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 538`

View PR using the GUI difftool: \
`$ git pr show -t 538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/538.diff">https://git.openjdk.java.net/jfx/pull/538.diff</a>

</details>
