### PR TITLE
8165214: ListView.EditEvent.getIndex() does not return the correct index

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -352,6 +352,8 @@ public class ListCell<T> extends IndexedCell<T> {
      * Editing API                                                             *
      *                                                                         *
      **************************************************************************/
+    // index at time of startEdit - fix for JDK-8165214
+    int indexAtStartEdit;
 
     /** {@inheritDoc} */
     @Override public void startEdit() {
@@ -374,6 +376,8 @@ public class ListCell<T> extends IndexedCell<T> {
             list.edit(getIndex());
             list.requestFocus();
         }
+
+        indexAtStartEdit = getIndex();
     }
 
     /** {@inheritDoc} */
@@ -418,13 +422,11 @@ public class ListCell<T> extends IndexedCell<T> {
     @Override public void cancelEdit() {
         if (! isEditing()) return;
 
-         // Inform the ListView of the edit being cancelled.
-        ListView<T> list = getListView();
-
         super.cancelEdit();
 
+        // Inform the ListView of the edit being cancelled.
+        ListView<T> list = getListView();
         if (list != null) {
-            int editingIndex = list.getEditingIndex();
 
             // reset the editing index on the ListView
             if (updateEditingIndex) list.edit(-1);
@@ -438,7 +440,7 @@ public class ListCell<T> extends IndexedCell<T> {
             list.fireEvent(new ListView.EditEvent<T>(list,
                     ListView.<T>editCancelEvent(),
                     null,
-                    editingIndex));
+                    indexAtStartEdit));
         }
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -353,7 +353,7 @@ public class ListCell<T> extends IndexedCell<T> {
      *                                                                         *
      **************************************************************************/
     // index at time of startEdit - fix for JDK-8165214
-    int indexAtStartEdit;
+    private int indexAtStartEdit;
 
     /** {@inheritDoc} */
     @Override public void startEdit() {


### PR DESCRIPTION
Issue was that the cancel event carried the listView's editingIndex at the time of firing the event - that's wrong nearly always (because the list's editing state/index might have changed between start and cancel, f.i. due to calling list.edit(someDifferentIndex)). 

Fixed by keeping the index at startEdit and using that in cancelEdit (similar approach as in TreeCell fix [TreeCell fix JDK-8265210](https://bugs.openjdk.java.net/browse/JDK-8265210). 

Added tests that are failing (and one that was accidentally passing) before, all passing after.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8165214](https://bugs.openjdk.java.net/browse/JDK-8165214): ListView.EditEvent.getIndex() does not return the correct index


### Reviewers
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/539/head:pull/539` \
`$ git checkout pull/539`

Update a local copy of the PR: \
`$ git checkout pull/539` \
`$ git pull https://git.openjdk.java.net/jfx pull/539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 539`

View PR using the GUI difftool: \
`$ git pr show -t 539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/539.diff">https://git.openjdk.java.net/jfx/pull/539.diff</a>

</details>
