### PR TITLE
8194924: Checking for selection size before update

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
@@ -2468,7 +2468,9 @@ public class TableView<S> extends Control {
                 change = ControlUtils.buildClearAndSelectChange(selectedCellsSeq, previousSelection, row);
             } else {
                 final int changeIndex = isCellSelectionEnabled ? 0 : Math.max(0, selectedCellsSeq.indexOf(newTablePosition));
-                final int changeSize = isCellSelectionEnabled ? getSelectedCells().size() : 1;
+                // It is possible that during selection it was cleared - for example called clearSelection() on change
+                // So we should check if selectedCellsSeq is not empty
+                final int changeSize = isCellSelectionEnabled ? getSelectedCells().size() : Math.min(1, selectedCellsSeq.size());
                 change = new NonIterableChange.GenericAddRemoveChange<>(
                         changeIndex, changeIndex + changeSize, previousSelection, selectedCellsSeq);
 //                selectedCellsSeq._beginChange();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -5540,4 +5540,13 @@ public class TableViewTest {
 
         sl.dispose();
     }
+
+    // see JDK-8194924
+    @Test
+    public void test_noExceptionIsFiredIfClearSelectionOnChangeEvent(){
+        table.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue)
+                -> table.getSelectionModel().clearSelection());
+        table.getSelectionModel().select(0);
+        assertNull(table.getSelectionModel().getSelectedItem());
+    }
 }


### PR DESCRIPTION
It is possible situation when `clearSelection()` is invoked during `onChange()` notify. In such case `selectedCellsSeq` is clearing and possible `IndexOutOfBoundsException` on `GenericAddRemoveChange` creation. 
So we should check it to create correct `GenericAddRemoveChange`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8194924](https://bugs.openjdk.java.net/browse/JDK-8194924)

### Issue
 * [JDK-8194924](https://bugs.openjdk.java.net/browse/JDK-8194924): TableView.getSelectionModel().clearSelection() results in IndexOutOfBoundsException ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/542/head:pull/542` \
`$ git checkout pull/542`

Update a local copy of the PR: \
`$ git checkout pull/542` \
`$ git pull https://git.openjdk.java.net/jfx pull/542/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 542`

View PR using the GUI difftool: \
`$ git pr show -t 542`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/542.diff">https://git.openjdk.java.net/jfx/pull/542.diff</a>

</details>
