### PR TITLE
8223717: javafx printing: Support Specifying Print to File in the API

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/print/J2DPrinterJob.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/print/J2DPrinterJob.java
@@ -69,10 +69,8 @@ import java.awt.print.PageFormat;
 import java.awt.print.Pageable;
 import java.awt.print.Printable;
 import java.awt.print.PrinterException;
-import java.net.MalformedURLException;
+import java.io.File;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Set;
 import com.sun.glass.ui.Application;
@@ -347,10 +345,7 @@ public class J2DPrinterJob implements PrinterJobImpl {
         Destination dest =
             (Destination)printReqAttrSet.get(Destination.class);
         if (dest != null) {
-            try {
-                settings.setOutputFile(dest.getURI().toURL().toString());
-            } catch (MalformedURLException e) {
-            }
+            settings.setOutputFile(dest.getURI().getPath());
         } else {
             settings.setOutputFile("");
         }
@@ -631,16 +626,10 @@ public class J2DPrinterJob implements PrinterJobImpl {
         printReqAttrSet.remove(Destination.class);
         String file = settings.getOutputFile();
         if (file != null && !file.isEmpty()) {
-            try {
-                 URL url = new URL(file);
-                 if (!"file".equals(url.getProtocol())) {
-                     return;
-                 }
-                 URI uri = url.toURI();
-                 Destination d = new Destination(uri);
-                 printReqAttrSet.add(d);
-            } catch (MalformedURLException | URISyntaxException e) {
-            }
+             // check SE, check access ?
+             URI uri = (new File(file)).toURI();
+             Destination d = new Destination(uri);
+             printReqAttrSet.add(d);
         }
     }
 
@@ -836,11 +825,8 @@ public class J2DPrinterJob implements PrinterJobImpl {
         if (security != null) {
             security.checkPrintJobAccess();
             String file = settings.getOutputFile();
-            if (!file.isEmpty()) {
-                try {
-                     security.checkWrite((new URL(file)).getPath());
-                } catch (MalformedURLException e) {
-                }
+            if (file != null && !file.isEmpty()) {
+                security.checkWrite(file);
             }
         }
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/print/J2DPrinterJob.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/print/J2DPrinterJob.java
@@ -346,7 +346,6 @@ public class J2DPrinterJob implements PrinterJobImpl {
     private void updateOutputFile() {
         Destination dest =
             (Destination)printReqAttrSet.get(Destination.class);
-System.out.println("DEST="+dest);
         if (dest != null) {
             try {
                 settings.setOutputFile(dest.getURI().toURL().toString());

--- a/modules/javafx.graphics/src/main/java/javafx/print/JobSettings.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/JobSettings.java
@@ -464,32 +464,43 @@ public final class JobSettings {
 
     ///////////////////////  START OUTPUTFILE /////////////////////
 
-    private static final String DEFAULT_OUTPUTFILE = "";
     private SimpleStringProperty outputFile;
 
     /**
-     * A {@code StringProperty} representing the {@code java.net.URL}
-     * encoded name of a filesystem file, to which the platform printer
+     * A {@code StringProperty} representing the 
+     * name of a filesystem file, to which the platform printer
      * driver should spool the rendered print data.
      * <p>
-     * Applications can use this to request print-to-file behavior where
-     * the native print system is capable of spooling the output to a
-     * filesystem file, rather than the printer device.
+     * Applications can use this to programmatically request print-to-file
+     * behavior where the native print system is capable of spooling the
+     * output to a filesystem file, rather than the printer device.
      * <p>
      * This is often useful where the printer driver generates a format
      * such as Postscript or PDF, and the application intends to distribute
      * the result instead of printing it, or for some other reason the
      * application does not want physical media (paper) emitted by the printer.
      * <p>
-     * If the application does not have permission to write to the specified
-     * file, a {@code SecurityException} may be thrown when printing.
+     * The default value is an empty string, which is interpreted as unset,
+     * equivalent to null, which means output is sent to the printer.
+     * So in order to reset to print to the printer, clear the value of
+     * this property by setting it to null or an empty string.
+     * <p>
+     * Additionally if the application displays a printer dialog which allows
+     * the user to specify a file destination including altering an application
+     * specified file destination, the value of this property will reflect that
+     * user-specified choice, including clearing it to re-set to print to
+     * the printer, if the user does so.
+     * <p>
      * If the print system does not support print-to-file, then this
      * setting will be ignored.
      * <p>
-     * If the URL specifies a non-existent path, or does not specify
-     * a writable file it may be ignored, or a SecurityException may be thrown.
-     * The default value is an empty string, which is interpreted as unset,
-     * which means output is sent to the printer.
+     * If the specified name specifies a non-existent path, or does not specify
+     * a user writable file, when printing the results are platform-dependent, including
+     * replacement with a default output file location, printing to the printer instead,
+     * or a platform printing error.
+     * If a {@code SecurityManager} is installed and it denies access to the
+     * specified file a {@code SecurityException} may be thrown.
+     * @defaultValue an empty String
      *
      * @return the name of a printer spool file
      * @since 17
@@ -497,8 +508,7 @@ public final class JobSettings {
     public final StringProperty outputFileProperty() {
         if (outputFile == null) {
             outputFile =
-                new SimpleStringProperty(JobSettings.this, "outputFile",
-                                         DEFAULT_OUTPUTFILE) {
+                new SimpleStringProperty(JobSettings.this, "outputFile", "") {
 
                 @Override
                 public void set(String value) {
@@ -506,7 +516,7 @@ public final class JobSettings {
                         return;
                     }
                     if (value == null) {
-                        value = DEFAULT_OUTPUTFILE;
+                        value = "";
                     }
                     super.set(value);
                 }
@@ -533,23 +543,13 @@ public final class JobSettings {
         return outputFile;
     }
 
-    /**
-     * Get the output file path name.
-     * @return the output file as a string encoded {@code java.net.URL}
-     * @since 17
-     */
     public String getOutputFile() {
         return outputFileProperty().get();
     }
 
 
-    /**
-     * Set the output file.
-     * @param urlString the output file as a string encoded {@code java.net.URL}
-     * @since 17
-     */
-    public void setOutputFile(String urlString) {
-        outputFileProperty().set(urlString);
+    public void setOutputFile(String filePath) {
+        outputFileProperty().set(filePath);
     }
     ///////////////////////  END OUTPUTFILE /////////////////////
 

--- a/modules/javafx.graphics/src/main/java/javafx/print/JobSettings.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/JobSettings.java
@@ -492,7 +492,7 @@ public final class JobSettings {
      * which means output is sent to the printer.
      *
      * @return the name of a printer spool file
-     * @since 13
+     * @since 17
      */
     public final StringProperty outputFileProperty() {
         if (outputFile == null) {
@@ -536,7 +536,7 @@ public final class JobSettings {
     /**
      * Get the output file path name.
      * @return the output file as a string encoded {@code java.net.URL}
-     * @since 13
+     * @since 17
      */
     public String getOutputFile() {
         return outputFileProperty().get();
@@ -546,7 +546,7 @@ public final class JobSettings {
     /**
      * Set the output file.
      * @param urlString the output file as a string encoded {@code java.net.URL}
-     * @since 13
+     * @since 17
      */
     public void setOutputFile(String urlString) {
         outputFileProperty().set(urlString);

--- a/modules/javafx.graphics/src/main/java/javafx/print/JobSettings.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/JobSettings.java
@@ -467,7 +467,7 @@ public final class JobSettings {
     private SimpleStringProperty outputFile;
 
     /**
-     * A {@code StringProperty} representing the 
+     * A {@code StringProperty} representing the
      * name of a filesystem file, to which the platform printer
      * driver should spool the rendered print data.
      * <p>
@@ -500,7 +500,8 @@ public final class JobSettings {
      * or a platform printing error.
      * If a {@code SecurityManager} is installed and it denies access to the
      * specified file a {@code SecurityException} may be thrown.
-     * @defaultValue an empty String
+     *
+     * @defaultValue an empty string
      *
      * @return the name of a printer spool file
      * @since 17

--- a/modules/javafx.graphics/src/main/java/javafx/print/JobSettings.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/JobSettings.java
@@ -486,18 +486,18 @@ public final class JobSettings {
      * this property by setting it to null or an empty string.
      * <p>
      * Additionally if the application displays a printer dialog which allows
-     * the user to specify a file destination including altering an application
+     * the user to specify a file destination, including altering an application
      * specified file destination, the value of this property will reflect that
-     * user-specified choice, including clearing it to re-set to print to
+     * user-specified choice, including clearing it to reset to print to
      * the printer, if the user does so.
      * <p>
      * If the print system does not support print-to-file, then this
      * setting will be ignored.
      * <p>
      * If the specified name specifies a non-existent path, or does not specify
-     * a user writable file, when printing the results are platform-dependent, including
-     * replacement with a default output file location, printing to the printer instead,
-     * or a platform printing error.
+     * a user writable file, when printing the results are platform-dependent.
+     * Possible behaviours might include replacement with a default output file location,
+     * printing to the printer instead, or a platform printing error.
      * If a {@code SecurityManager} is installed and it denies access to the
      * specified file a {@code SecurityException} may be thrown.
      *

--- a/modules/javafx.graphics/src/main/java/javafx/print/JobSettings.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/JobSettings.java
@@ -472,8 +472,8 @@ public final class JobSettings {
      * encoded name of a filesystem file, to which the platform printer
      * driver should spool the rendered print data.
      * <p>
-     * Applications can use this to request print-to-file behaviour where
-     * the native print system is capabale of spooling the output to a
+     * Applications can use this to request print-to-file behavior where
+     * the native print system is capable of spooling the output to a
      * filesystem file, rather than the printer device.
      * <p>
      * This is often useful where the printer driver generates a format
@@ -484,8 +484,8 @@ public final class JobSettings {
      * If the application does not have permission to write to the specified
      * file, a {@code SecurityException} may be thrown when printing.
      * If the print system does not support print-to-file, then this
-     * <p>
      * setting will be ignored.
+     * <p>
      * If the URL specifies a non-existent path, or does not specify
      * a writable file it may be ignored, or a SecurityException may be thrown.
      * The default value is an empty string, which is interpreted as unset,

--- a/modules/javafx.graphics/src/main/java/javafx/print/JobSettings.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/JobSettings.java
@@ -462,6 +462,97 @@ public final class JobSettings {
     }
     ///////////////////////  END JOBNAME /////////////////////
 
+    ///////////////////////  START OUTPUTFILE /////////////////////
+
+    private static final String DEFAULT_OUTPUTFILE = "";
+    private SimpleStringProperty outputFile;
+
+    /**
+     * A {@code StringProperty} representing the {@code java.net.URL}
+     * encoded name of a filesystem file, to which the platform printer
+     * driver should spool the rendered print data.
+     * <p>
+     * Applications can use this to request print-to-file behaviour where
+     * the native print system is capabale of spooling the output to a
+     * filesystem file, rather than the printer device.
+     * <p>
+     * This is often useful where the printer driver generates a format
+     * such as Postscript or PDF, and the application intends to distribute
+     * the result instead of printing it, or for some other reason the
+     * application does not want physical media (paper) emitted by the printer.
+     * <p>
+     * If the application does not have permission to write to the specified
+     * file, a {@code SecurityException} may be thrown when printing.
+     * If the print system does not support print-to-file, then this
+     * <p>
+     * setting will be ignored.
+     * If the URL specifies a non-existent path, or does not specify
+     * a writable file it may be ignored, or a SecurityException may be thrown.
+     * The default value is an empty string, which is interpreted as unset,
+     * which means output is sent to the printer.
+     *
+     * @return the name of a printer spool file
+     * @since 13
+     */
+    public final StringProperty outputFileProperty() {
+        if (outputFile == null) {
+            outputFile =
+                new SimpleStringProperty(JobSettings.this, "outputFile",
+                                         DEFAULT_OUTPUTFILE) {
+
+                @Override
+                public void set(String value) {
+                    if (!isJobNew()) {
+                        return;
+                    }
+                    if (value == null) {
+                        value = DEFAULT_OUTPUTFILE;
+                    }
+                    super.set(value);
+                }
+
+                @Override
+                public void bind(ObservableValue<? extends String>
+                                 rawObservable) {
+                    throw new
+                        RuntimeException("OutputFile property cannot be bound");
+                }
+
+                @Override
+                public void bindBidirectional(Property<String> other) {
+                    throw new
+                        RuntimeException("OutputFile property cannot be bound");
+                }
+
+                @Override
+                public String toString() {
+                     return get();
+                }
+            };
+        }
+        return outputFile;
+    }
+
+    /**
+     * Get the output file path name.
+     * @return the output file as a string encoded {@code java.net.URL}
+     * @since 13
+     */
+    public String getOutputFile() {
+        return outputFileProperty().get();
+    }
+
+
+    /**
+     * Set the output file.
+     * @param urlString the output file as a string encoded {@code java.net.URL}
+     * @since 13
+     */
+    public void setOutputFile(String urlString) {
+        outputFileProperty().set(urlString);
+    }
+    ///////////////////////  END OUTPUTFILE /////////////////////
+
     //////////////////////// START COPIES ////////////////////////
 
     private IntegerProperty copies;

--- a/tests/manual/printing/PrintToFileTest.java
+++ b/tests/manual/printing/PrintToFileTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+import java.net.URL;
+import java.net.MalformedURLException;
+
+import javafx.application.Platform;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.print.*;
+
+import javafx.application.Application;
+import javafx.geometry.Rectangle2D;
+import javafx.scene.Group;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
+import javafx.scene.layout.*;
+import javafx.scene.paint.Color;
+import javafx.scene.text.Text;
+import javafx.stage.Screen;
+import javafx.stage.Stage;
+
+public class PrintToFileTest extends Application {
+
+    private final int WIDTH = 400;
+    private final int HEIGHT = 400;
+
+    private volatile boolean passed = false;
+    private volatile boolean failed = false;
+    private Scene scene;
+    private VBox root;
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+
+    public void start(Stage stage) {
+        stage.setWidth(WIDTH);
+        stage.setHeight(HEIGHT);
+        stage.setTitle("Printing to file test");
+        Rectangle2D bds = Screen.getPrimary().getVisualBounds();
+        stage.setX((bds.getWidth() - WIDTH) / 2);
+        stage.setY((bds.getHeight() - HEIGHT) / 2);
+        stage.setScene(createScene());
+        stage.show();
+    }
+
+    static final String instructions =
+        "This tests that programmatically specifying print to file works.\n" +
+        "Select the Print button to run the test\n";
+
+    static final String noprinter =
+            "There are no printers installed. This test cannot be run\n";
+
+    private TextArea createInfo(String msg) {
+        TextArea t = new TextArea(msg);
+        t.setWrapText(true);
+        t.setEditable(false);
+        return t;
+    }
+
+    private Scene createScene() {
+
+        root = new VBox();
+        scene = new Scene(root);
+
+        String msg = instructions;
+        if (Printer.getDefaultPrinter() == null) {
+            msg = noprinter;
+        }
+        TextArea info = createInfo(msg);
+        root.getChildren().add(info);
+
+        Button print = new Button("Print");
+        print.setLayoutX(80);
+        print.setLayoutY(200);
+        print.setOnAction(e -> runTest());
+        root.getChildren().add(print);
+
+        return scene;
+    }
+
+    public void runTest() {
+        new Thread(() -> {
+            passed = false;
+            failed = false;
+            System.out.println("START OF PRINT JOB");
+            PrinterJob job = PrinterJob.createPrinterJob();
+            JobSettings settings = job.getJobSettings();
+            File f = new File("printtofiletest.prn");
+            f.delete();
+            try {
+                URL url = f.toURL();
+                String urlStr = url.toString();
+                settings.outputFileProperty().set(urlStr);
+            } catch (MalformedURLException e) {
+                System.out.println(e);
+                failed = true; 
+            }
+ 
+            Platform.runLater(() -> {
+                Text t = new Text("file="+settings.getOutputFile());
+                root.getChildren().add(t);
+            });
+            Text printNode = new Text("\n\nTEST\nabc\ndef");
+            job.printPage(printNode);
+            job.endJob();
+            if (f.exists()) {
+                System.out.println("created file");
+                passed = true;
+                f.delete();
+            } else {
+                failed = true;
+            }
+            System.out.println("END OF PRINT JOB");
+        }).start();
+        new Thread(() -> {
+            while (!passed && !failed) {
+                try {
+                    Thread.sleep(500);
+                } catch (InterruptedException e) {
+                }
+            }
+            Platform.runLater(() -> displayMessage());
+            
+        }).start();
+    }
+
+    private void displayMessage() {
+        Text t = new Text();
+        if (passed) {
+            t.setText("TEST PASSED!");
+        } else {
+            t.setText("TEST FAILED!");
+        }
+        root.getChildren().add(t);
+    }
+}

--- a/tests/manual/printing/PrintToFileTest.java
+++ b/tests/manual/printing/PrintToFileTest.java
@@ -121,9 +121,9 @@ public class PrintToFileTest extends Application {
                 settings.outputFileProperty().set(urlStr);
             } catch (MalformedURLException e) {
                 System.out.println(e);
-                failed = true; 
+                failed = true;
             }
- 
+
             Platform.runLater(() -> {
                 Text t = new Text("file="+settings.getOutputFile());
                 root.getChildren().add(t);
@@ -148,7 +148,7 @@ public class PrintToFileTest extends Application {
                 }
             }
             Platform.runLater(() -> displayMessage());
-            
+
         }).start();
     }
 

--- a/tests/manual/printing/PrintToFileTest.java
+++ b/tests/manual/printing/PrintToFileTest.java
@@ -145,7 +145,7 @@ public class PrintToFileTest extends Application {
                 }
             }
             Platform.runLater(() -> displayMessage());
-            
+ 
         }).start();
     }
 

--- a/tests/manual/printing/PrintToFileTest.java
+++ b/tests/manual/printing/PrintToFileTest.java
@@ -24,8 +24,6 @@
  */
 
 import java.io.File;
-import java.net.URL;
-import java.net.MalformedURLException;
 
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
@@ -113,17 +111,12 @@ public class PrintToFileTest extends Application {
             System.out.println("START OF PRINT JOB");
             PrinterJob job = PrinterJob.createPrinterJob();
             JobSettings settings = job.getJobSettings();
-            File f = new File("printtofiletest.prn");
+            String fileName = "printtofiletest.prn";
+            settings.outputFileProperty().set(fileName);
+            String destFileName =  settings.outputFileProperty().get();
+            System.out.println("dest="+ destFileName);
+            File f = new File(destFileName);
             f.delete();
-            try {
-                URL url = f.toURL();
-                String urlStr = url.toString();
-                settings.outputFileProperty().set(urlStr);
-            } catch (MalformedURLException e) {
-                System.out.println(e);
-                failed = true;
-            }
-
             Platform.runLater(() -> {
                 Text t = new Text("file="+settings.getOutputFile());
                 root.getChildren().add(t);
@@ -131,10 +124,14 @@ public class PrintToFileTest extends Application {
             Text printNode = new Text("\n\nTEST\nabc\ndef");
             job.printPage(printNode);
             job.endJob();
+            try {
+                 // wait for printer spooler to create the file.
+                 Thread.sleep(3000);
+            } catch (InterruptedException e) {
+            }
             if (f.exists()) {
-                System.out.println("created file");
+                System.out.println("created file " + f);
                 passed = true;
-                f.delete();
             } else {
                 failed = true;
             }
@@ -148,7 +145,7 @@ public class PrintToFileTest extends Application {
                 }
             }
             Platform.runLater(() -> displayMessage());
-
+            
         }).start();
     }
 

--- a/tests/manual/printing/PrintToFileTest.java
+++ b/tests/manual/printing/PrintToFileTest.java
@@ -145,7 +145,7 @@ public class PrintToFileTest extends Application {
                 }
             }
             Platform.runLater(() -> displayMessage());
- 
+
         }).start();
     }
 


### PR DESCRIPTION
This enhancement adds the String property outputFileProperty() to the JobSettings class.
The value should be a string that references a local file encoded as a URL.
If this is non-null and set to a location that the user has permission to write to,
then the printer output will be spooled there instead of the printer, so long as the platform printing system supports this.
The user can of course also set a print-to-file destination in the platform printer dialogs which may over-ride what the application set. But now the application can also see what it was set to, and cancel or alter it if necessary.

A simple manual test is provided, manual mainly because the few real printing functional tests are all manual as they are only useful if run with a printer configured.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8223717](https://bugs.openjdk.java.net/browse/JDK-8223717): javafx printing: Support Specifying Print to File in the API


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/543/head:pull/543` \
`$ git checkout pull/543`

Update a local copy of the PR: \
`$ git checkout pull/543` \
`$ git pull https://git.openjdk.java.net/jfx pull/543/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 543`

View PR using the GUI difftool: \
`$ git pr show -t 543`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/543.diff">https://git.openjdk.java.net/jfx/pull/543.diff</a>

</details>
