### PR TITLE
8269424: Some SuppressWarnings annotations can be more localized

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassScene.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassScene.java
@@ -242,8 +242,8 @@ abstract class GlassScene implements TKScene {
 
     @Override
     public TKClipboard createDragboard(boolean isDragSource) {
-        @SuppressWarnings("removal")
         ClipboardAssistance assistant = new ClipboardAssistance(Clipboard.DND) {
+            @SuppressWarnings("removal")
             @Override
             public void actionPerformed(final int performedAction) {
                 super.actionPerformed(performedAction);

--- a/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
@@ -192,8 +192,8 @@ public abstract class Animation {
     }
 
     // package private only for the sake of testing
-    @SuppressWarnings("removal")
     final PulseReceiver pulseReceiver = new PulseReceiver() {
+        @SuppressWarnings("removal")
         @Override public void timePulse(long now) {
             final long elapsedTime = now - startTime;
             if (elapsedTime < 0) {


### PR DESCRIPTION
This is a follow-on fix to [JDK-8264139](https://bugs.openjdk.java.net/browse/JDK-8264139), which added `@SuppressWarning` annotations to usages of deprecated security manager methods. @wangweij noticed that there was one pattern where the automated tool added the warning at a higher level than was needed. This fix moves the annotation down to be more localized in the two places that were affected.

/contributor add weijun

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269424](https://bugs.openjdk.java.net/browse/JDK-8269424): Some SuppressWarnings annotations can be more localized


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - Committer)

### Contributors
 * Weijun Wang `<weijun@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/546/head:pull/546` \
`$ git checkout pull/546`

Update a local copy of the PR: \
`$ git checkout pull/546` \
`$ git pull https://git.openjdk.java.net/jfx pull/546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 546`

View PR using the GUI difftool: \
`$ git pr show -t 546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/546.diff">https://git.openjdk.java.net/jfx/pull/546.diff</a>

</details>
