### PR TITLE
8246104: Some complex text doesn't render correctly on macOS

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/MacFontFinder.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/MacFontFinder.java
@@ -25,11 +25,16 @@
 
 package com.sun.javafx.font;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.stream.Stream;
 
 import com.sun.glass.utils.NativeLibLoader;
 
@@ -72,6 +77,13 @@ class MacFontFinder {
         if (locale == null) {
             locale = Locale.ENGLISH;
         }
+        try {
+            Stream<Path> stream = Files.list(Paths.get("/System/Library/Fonts"));
+            stream.forEach(f -> PrismFontFactory.getFontFactory().registerEmbeddedFont(f.toString()));
+        } catch (IOException e) {
+            System.err.println("Error registering system fonts: "+e.getMessage()+".\nSome fonts might now be available.");
+        }
+
         String[] fontData = getFontData();
         if (fontData == null) return false;
 


### PR DESCRIPTION
[Mac only] register system fonts.
Fix for JDK-8246104

The list of available fonts returned by CTFontCollectionCreateFromAvailableFonts does not contain internal fonts (at least not by default, although this is not documented). By registering font(s) (files), those fonts become available in the returned list.
The CT Glyph processing might assign internal fonts to a glyph, and since we lookup the requested font in this list, we fail if the list doesn't contain the font.
This PR registers all fonts in the system library so that they become available. This is not creating additional Java objects or overhead, as it almost directly invokes `CTFontManagerRegisterFontsForURL` via `CTFontFile.registerFont(String fontfile)`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8246104](https://bugs.openjdk.org/browse/JDK-8246104): Some complex text doesn't render correctly on macOS


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/547/head:pull/547` \
`$ git checkout pull/547`

Update a local copy of the PR: \
`$ git checkout pull/547` \
`$ git pull https://git.openjdk.org/jfx.git pull/547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 547`

View PR using the GUI difftool: \
`$ git pr show -t 547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/547.diff">https://git.openjdk.org/jfx/pull/547.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/547#issuecomment-869020626)