### PR TITLE
8234921: Add DirectionalLight to the selection of 3D light types

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/DirectionalLightHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/DirectionalLightHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/DirectionalLightHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/DirectionalLightHelper.java
@@ -32,7 +32,7 @@ import javafx.scene.DirectionalLight;
 import javafx.scene.Node;
 
 /**
- * Used to access internal methods of SpotLight.
+ * Used to access internal methods of DirectionalLight.
  */
 public class DirectionalLightHelper extends LightBaseHelper {
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/DirectionalLightHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/DirectionalLightHelper.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.scene;
+
+import com.sun.javafx.sg.prism.NGNode;
+import com.sun.javafx.util.Utils;
+
+import javafx.scene.DirectionalLight;
+import javafx.scene.Node;
+
+/**
+ * Used to access internal methods of SpotLight.
+ */
+public class DirectionalLightHelper extends LightBaseHelper {
+
+    private static final DirectionalLightHelper theInstance;
+    private static DirectionalLightAccessor directionalLightAccessor;
+
+    static {
+        theInstance = new DirectionalLightHelper();
+        Utils.forceInit(DirectionalLight.class);
+    }
+
+    private static DirectionalLightHelper getInstance() {
+        return theInstance;
+    }
+
+    public static void initHelper(DirectionalLight directionalLight) {
+        setHelper(directionalLight, getInstance());
+    }
+
+    @Override
+    protected NGNode createPeerImpl(Node node) {
+        return directionalLightAccessor.doCreatePeer(node);
+    }
+
+    @Override
+    protected void updatePeerImpl(Node node) {
+        super.updatePeerImpl(node);
+        directionalLightAccessor.doUpdatePeer(node);
+    }
+
+    public static void setDirectionalLightAccessor(final DirectionalLightAccessor newAccessor) {
+        if (directionalLightAccessor != null) {
+            throw new IllegalStateException("Accessor already exists");
+        }
+
+        directionalLightAccessor = newAccessor;
+    }
+
+    public interface DirectionalLightAccessor {
+        NGNode doCreatePeer(Node node);
+        void doUpdatePeer(Node node);
+    }
+}

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGDirectionalLight.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGDirectionalLight.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.sg.prism;
+
+import com.sun.javafx.geom.Vec3d;
+
+import javafx.geometry.Point3D;
+
+/**
+ * The peer of the {@code DirectionalLight} class. Holds the default values of {@code DirectionalLight}'s
+ * properties and updates the visuals via {@link NGNode#visualsChanged} when one of the current
+ * values changes. The peer receives its changes by {@link javafx.scene.DirectionalLight#doUpdatePeer} calls.
+ */
+public class NGDirectionalLight extends NGLightBase {
+
+    /** Direction default value */
+    private static final Point3D DEFAULT_DIRECTION = new Point3D(0, 0, 1);
+
+    public NGDirectionalLight() {
+    }
+
+    public static Point3D getDefaultDirection() {
+        return DEFAULT_DIRECTION;
+    }
+
+    private Point3D direction = DEFAULT_DIRECTION;
+    private final Vec3d effectiveDir = new Vec3d();
+
+    public Point3D getDirection() {
+        var dir = new Vec3d(direction.getX(), direction.getY(), direction.getZ());
+        getWorldTransform().deltaTransform(dir, effectiveDir);
+        return new Point3D(effectiveDir.x, effectiveDir.y, effectiveDir.z);
+    }
+
+    public void setDirection(Point3D direction) {
+        if (!this.direction.equals(direction)) {
+            this.direction = direction;
+            visualsChanged();
+        }
+    }
+}

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGShape3D.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGShape3D.java
@@ -200,20 +200,16 @@ public abstract class NGShape3D extends NGNode {
                             light.getFalloff());
                 } else if (lightBase instanceof NGDirectionalLight) {
                     var light = (NGDirectionalLight) lightBase;
-                    Point3D direction = light.getDirection();
                     meshView.setLight(lightIndex++,
-                            0,
-                            0,
-                            0,
+                            0, 0, 0,                 // position is irrelevant
                             rL, gL, bL, 1.0f,
-                            1, 0, 0, 0,
-                            Float.POSITIVE_INFINITY,
-                            (float) direction.getX(),
-                            (float) direction.getY(),
-                            (float) direction.getZ(),
-                            NGPointLight.getSimulatedInnerAngle(),
-                            NGPointLight.getSimulatedOuterAngle(),
-                            NGPointLight.getSimulatedFalloff());
+                            1, 0, 0,                 // attenuation is irrelevant
+                            0,
+                            Float.POSITIVE_INFINITY, // range is irrelevant
+                            (float) light.getDirection().getX(),
+                            (float) light.getDirection().getY(),
+                            (float) light.getDirection().getZ(),
+                            0, 0, 0);                // spotlight factors are irrelevant
                 } else if (lightBase instanceof NGAmbientLight) {
                     // Accumulate ambient lights
                     ambientRed   += rL;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGShape3D.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGShape3D.java
@@ -25,17 +25,20 @@
 
 package com.sun.javafx.sg.prism;
 
-import javafx.application.ConditionalFeature;
-import javafx.application.Platform;
-import javafx.scene.shape.CullFace;
-import javafx.scene.shape.DrawMode;
 import com.sun.javafx.geom.Vec3d;
+import com.sun.javafx.geom.Vec3f;
 import com.sun.javafx.geom.transform.Affine3D;
 import com.sun.javafx.util.Utils;
 import com.sun.prism.Graphics;
 import com.sun.prism.Material;
 import com.sun.prism.MeshView;
 import com.sun.prism.ResourceFactory;
+
+import javafx.application.ConditionalFeature;
+import javafx.application.Platform;
+import javafx.geometry.Point3D;
+import javafx.scene.shape.CullFace;
+import javafx.scene.shape.DrawMode;
 
 /**
  * TODO: 3D - Need documentation
@@ -130,6 +133,7 @@ public abstract class NGShape3D extends NGNode {
                     NGPointLight.getDefaultCa(),
                     NGPointLight.getDefaultLa(),
                     NGPointLight.getDefaultQa(),
+                    1,
                     NGPointLight.getDefaultMaxRange(),
                     (float) NGPointLight.getSimulatedDirection().getX(),
                     (float) NGPointLight.getSimulatedDirection().getY(),
@@ -186,6 +190,7 @@ public abstract class NGShape3D extends NGNode {
                             light.getCa(),
                             light.getLa(),
                             light.getQa(),
+                            1,
                             light.getMaxRange(),
                             (float) light.getDirection().getX(),
                             (float) light.getDirection().getY(),
@@ -193,6 +198,22 @@ public abstract class NGShape3D extends NGNode {
                             light.getInnerAngle(),
                             light.getOuterAngle(),
                             light.getFalloff());
+                } else if (lightBase instanceof NGDirectionalLight) {
+                    var light = (NGDirectionalLight) lightBase;
+                    Point3D direction = light.getDirection();
+                    meshView.setLight(lightIndex++,
+                            0,
+                            0,
+                            0,
+                            rL, gL, bL, 1.0f,
+                            1, 0, 0, 0,
+                            Float.POSITIVE_INFINITY,
+                            (float) direction.getX(),
+                            (float) direction.getY(),
+                            (float) direction.getZ(),
+                            NGPointLight.getSimulatedInnerAngle(),
+                            NGPointLight.getSimulatedOuterAngle(),
+                            NGPointLight.getSimulatedFalloff());
                 } else if (lightBase instanceof NGAmbientLight) {
                     // Accumulate ambient lights
                     ambientRed   += rL;
@@ -211,8 +232,8 @@ public abstract class NGShape3D extends NGNode {
             meshView.setLight(lightIndex++,
                     0, 0, 0,    // x y z
                     0, 0, 0, 0, // r g b w
-                    1, 0, 0, 0, // ca la qa maxRange
-                    0, 0, 0,    // dirX Y Z
+                    1, 0, 0, 1, 0, // ca la qa isAttenuated maxRange
+                    0, 0, 1,    // dirX Y Z
                     0, 0, 0);   // inner outer falloff
         }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/MeshView.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/MeshView.java
@@ -47,7 +47,7 @@ public interface MeshView extends GraphicsResource {
     public void setAmbientLight(float r, float g, float b);
 
     public void setLight(int index, float x, float y, float z, float r, float g, float b, float w,
-            float ca, float la, float qa, float maxRange, float dirX, float dirY, float dirZ,
+            float ca, float la, float qa, float isAttenuated, float maxRange, float dirX, float dirY, float dirZ,
             float innerAngle, float outerAngle, float falloff);
 
     public void render(Graphics g);

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
@@ -475,7 +475,8 @@ class D3DContext extends BaseShaderContext {
             float r, float g, float b);
     private static native void nSetLight(long pContext, long nativeMeshView,
             int index, float x, float y, float z, float r, float g, float b, float w, float ca, float la, float qa,
-            float maxRange, float dirX, float dirY, float dirZ, float innerAngle, float outerAngle, float falloff);
+            float isAttenuated, float maxRange, float dirX, float dirY, float dirZ, float innerAngle, float outerAngle,
+            float falloff);
     private static native void nRenderMeshView(long pContext, long nativeMeshView);
     private static native int nDrawIndexedQuads(long pContext,
             float coords[], byte colors[], int numVertices);
@@ -611,9 +612,9 @@ class D3DContext extends BaseShaderContext {
     }
 
     void setLight(long nativeMeshView, int index, float x, float y, float z, float r, float g, float b, float w,
-            float ca, float la, float qa, float maxRange, float dirX, float dirY, float dirZ,
+            float ca, float la, float qa, float isAttenuated, float maxRange, float dirX, float dirY, float dirZ,
             float innerAngle, float outerAngle, float falloff) {
-        nSetLight(pContext, nativeMeshView, index, x, y, z, r, g, b, w,  ca, la, qa, maxRange,
+        nSetLight(pContext, nativeMeshView, index, x, y, z, r, g, b, w,  ca, la, qa, isAttenuated, maxRange,
                 dirX, dirY, dirZ, innerAngle, outerAngle, falloff);
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DMeshView.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DMeshView.java
@@ -83,11 +83,11 @@ class D3DMeshView extends BaseMeshView {
 
     @Override
     public void setLight(int index, float x, float y, float z, float r, float g, float b, float w,
-            float ca, float la, float qa, float maxRange, float dirX, float dirY, float dirZ,
+            float ca, float la, float qa, float isAttenuated, float maxRange, float dirX, float dirY, float dirZ,
             float innerAngle, float outerAngle, float falloff) {
         // NOTE: We only support up to 3 point lights at the present
         if (index >= 0 && index <= 2) {
-            context.setLight(nativeHandle, index, x, y, z, r, g, b, w, ca, la, qa, maxRange,
+            context.setLight(nativeHandle, index, x, y, z, r, g, b, w, ca, la, qa, isAttenuated, maxRange,
                     dirX, dirY, dirZ, innerAngle, outerAngle, falloff);
         }
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Context.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Context.java
@@ -450,10 +450,10 @@ class ES2Context extends BaseShaderContext {
     }
 
     void setLight(long nativeHandle, int index, float x, float y, float z, float r, float g, float b, float w,
-            float ca, float la, float qa, float maxRange, float dirX, float dirY, float dirZ,
+            float ca, float la, float qa, float isAttenuated, float maxRange, float dirX, float dirY, float dirZ,
             float innerAngle, float outerAngle, float falloff) {
-        glContext.setLight(nativeHandle, index, x, y, z, r, g, b, w, ca, la, qa, maxRange, dirX, dirY, dirZ,
-                innerAngle, outerAngle, falloff);
+        glContext.setLight(nativeHandle, index, x, y, z, r, g, b, w, ca, la, qa, isAttenuated,
+                maxRange, dirX, dirY, dirZ, innerAngle, outerAngle, falloff);
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Light.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Light.java
@@ -65,7 +65,7 @@ class ES2Light {
     }
 
     boolean isDirectionalLight() {
-     // testing if w is 0 or 1 using <0.5 since equality check for floating points might not work well
+        // testing if w is 0 or 1 using <0.5 since equality check for floating points might not work well
         return isAttenuated < 0.5;
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Light.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Light.java
@@ -65,6 +65,7 @@ class ES2Light {
     }
 
     boolean isDirectionalLight() {
+     // testing if w is 0 or 1 using <0.5 since equality check for floating points might not work well
         return isAttenuated < 0.5;
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Light.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Light.java
@@ -32,12 +32,14 @@ class ES2Light {
 
     float x, y, z = 0;
     float r, g, b, w = 1;
-    float ca, la, qa, maxRange;
+    float ca, la, qa, isAttenuated;
+    float maxRange;
     float dirX, dirY, dirZ;
     float innerAngle, outerAngle, falloff;
 
     ES2Light(float x, float y, float z, float r, float g, float b, float w, float ca, float la, float qa,
-            float maxRange, float dirX, float dirY, float dirZ, float innerAngle, float outerAngle, float falloff) {
+            float isAttenuated, float maxRange, float dirX, float dirY, float dirZ,
+            float innerAngle, float outerAngle, float falloff) {
         this.x = x;
         this.y = y;
         this.z = z;
@@ -48,6 +50,7 @@ class ES2Light {
         this.ca = ca;
         this.la = la;
         this.qa = qa;
+        this.isAttenuated = isAttenuated;
         this.maxRange = maxRange;
         this.dirX = dirX;
         this.dirY = dirY;
@@ -58,6 +61,10 @@ class ES2Light {
     }
 
     boolean isPointLight() {
-        return falloff == 0 && outerAngle == 180;
+        return falloff == 0 && outerAngle == 180 && isAttenuated > 0.5;
+    }
+
+    boolean isDirectionalLight() {
+        return isAttenuated < 0.5;
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2MeshView.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2MeshView.java
@@ -106,10 +106,10 @@ class ES2MeshView extends BaseMeshView {
             float innerAngle, float outerAngle, float falloff) {
         // NOTE: We only support up to 3 point lights at the present
         if (index >= 0 && index <= 2) {
-            lights[index] = new ES2Light(x, y, z, r, g, b, w, ca, la, qa, maxRange, dirX, dirY, dirZ, innerAngle,
-                        outerAngle, falloff);
-            context.setLight(nativeHandle, index, x, y, z, r, g, b, w, ca, la, qa, maxRange, dirX, dirY, dirZ,
-                    innerAngle, outerAngle, falloff);
+            lights[index] = new ES2Light(x, y, z, r, g, b, w, ca, la, qa, isAttenuated,
+                    maxRange, dirX, dirY, dirZ, innerAngle, outerAngle, falloff);
+            context.setLight(nativeHandle, index, x, y, z, r, g, b, w, ca, la, qa, isAttenuated,
+                    maxRange, dirX, dirY, dirZ, innerAngle, outerAngle, falloff);
         }
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2MeshView.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2MeshView.java
@@ -102,7 +102,7 @@ class ES2MeshView extends BaseMeshView {
 
     @Override
     public void setLight(int index, float x, float y, float z, float r, float g, float b, float w,
-            float ca, float la, float qa, float maxRange, float dirX, float dirY, float dirZ,
+            float ca, float la, float qa, float isAttenuated, float maxRange, float dirX, float dirY, float dirZ,
             float innerAngle, float outerAngle, float falloff) {
         // NOTE: We only support up to 3 point lights at the present
         if (index >= 0 && index <= 2) {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2PhongShader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2PhongShader.java
@@ -214,19 +214,22 @@ class ES2PhongShader {
     private static void setLightConstants(int i, ES2Shader shader, ES2Light light) {
         shader.setConstant("lights[" + i + "].pos", light.x, light.y, light.z, light.w);
         shader.setConstant("lights[" + i + "].color", light.r, light.g, light.b);
-        shader.setConstant("lights[" + i + "].attn", light.ca, light.la, light.qa);
+        shader.setConstant("lights[" + i + "].attn", light.ca, light.la, light.qa, light.isAttenuated);
         shader.setConstant("lights[" + i + "].range", light.maxRange);
         if (light.isPointLight()) {
             shader.setConstant("lights[" + i + "].dir", 0f, 0f, 1f);
-            shader.setConstant("lights[" + i + "].cosOuter", -1f); // cos(180)
-            shader.setConstant("lights[" + i + "].denom", 2f);     // cos(0) - cos(180)
-            shader.setConstant("lights[" + i + "].falloff", 0f);
         } else {
             float dirX = light.dirX;
             float dirY = light.dirY;
             float dirZ = light.dirZ;
             float length = (float) Math.sqrt(dirX * dirX + dirY * dirY + dirZ * dirZ);
             shader.setConstant("lights[" + i + "].dir", dirX / length, dirY / length, dirZ / length);
+        }
+        if (light.isPointLight() || light.isDirectionalLight()) {
+            shader.setConstant("lights[" + i + "].cosOuter", -1f); // cos(180)
+            shader.setConstant("lights[" + i + "].denom", 2f);     // cos(0) - cos(180)
+            shader.setConstant("lights[" + i + "].falloff", 0f);
+        } else {
             // preparing for: I = pow((cosAngle - cosOuter) / (cosInner - cosOuter), falloff);
             float cosOuter = (float) Math.cos(Math.toRadians(light.outerAngle));
             float cosInner = (float) Math.cos(Math.toRadians(light.innerAngle));

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLContext.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLContext.java
@@ -253,7 +253,8 @@ abstract class GLContext {
             float r, float g, float b);
     private static native void nSetLight(long nativeCtxInfo, long nativeMeshViewInfo,
             int index, float x, float y, float z, float r, float g, float b, float w, float ca, float la, float qa,
-            float maxRange, float dirX, float dirY, float dirZ, float innerAngle, float outerAngle, float falloff);
+            float isAttenuated, float maxRange, float dirX, float dirY, float dirZ,
+            float innerAngle, float outerAngle, float falloff);
     private static native void nRenderMeshView(long nativeCtxInfo, long nativeMeshViewInfo);
     private static native void nBlit(long nativeCtxInfo, int srcFBO, int dstFBO,
             int srcX0, int srcY0, int srcX1, int srcY1,
@@ -810,10 +811,10 @@ abstract class GLContext {
     }
 
     void setLight(long nativeMeshViewInfo, int index, float x, float y, float z, float r, float g, float b, float w,
-            float ca, float la, float qa, float maxRange, float dirX, float dirY, float dirZ,
+            float ca, float la, float qa, float isAttenuated, float maxRange, float dirX, float dirY, float dirZ,
             float innerAngle, float outerAngle, float falloff) {
-        nSetLight(nativeCtxInfo, nativeMeshViewInfo, index, x, y, z, r, g, b, w, ca, la, qa, maxRange,
-                dirX, dirY, dirZ, innerAngle, outerAngle, falloff);
+        nSetLight(nativeCtxInfo, nativeMeshViewInfo, index, x, y, z, r, g, b, w, ca, la, qa, isAttenuated,
+                maxRange, dirX, dirY, dirZ, innerAngle, outerAngle, falloff);
     }
 
     void renderMeshView(long nativeMeshViewInfo) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/DirectionalLight.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/DirectionalLight.java
@@ -73,14 +73,13 @@ public class DirectionalLight extends LightBase {
     }
 
     /**
-     * Creates a new instance of {@code SpotLight} class with a default {@code Color.WHITE} light source.
+     * Creates a new {@code DirectionalLight} with a default {@code Color.WHITE} color.
      */
     public DirectionalLight() {
-        super();
     }
 
     /**
-     * Creates a new instance of {@code SpotLight} class using the specified color.
+     * Creates a new {@code DirectionalLight} with the specified color.
      *
      * @param color the color of the light source
      */
@@ -90,8 +89,8 @@ public class DirectionalLight extends LightBase {
 
 
     /**
-     * The direction vector of the spotlight. It can be rotated by setting a rotation transform on the
-     * {@code SpotLight}. The vector need not be normalized.
+     * The direction vector of the directional light. It can be rotated by setting a rotation transform on the
+     * {@code DirectionalLight}. The vector need not be normalized.
      *
      * @defaultValue {@code Point3D(0, 0, 1)}
      */

--- a/modules/javafx.graphics/src/main/java/javafx/scene/DirectionalLight.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/DirectionalLight.java
@@ -40,9 +40,9 @@ import javafx.scene.paint.PhongMaterial;
 /**
  * A light that illuminates an object from a specific direction.
  * The direction is defined by the {@link #directionProperty() direction} vector property of the light. The direction
- * can be rotated by setting a rotation transform on the {@code SpotLight}. For example, if the direction vector is
- * {@code (1, 1, 1)} and the light is not rotated, it will point in the {@code (1, 1, 1)} direction, and if the light is
- * rotated 90 degrees on the y axis, it will point in the {@code (1, 1, -1)} direction.
+ * can be rotated by setting a rotation transform on the {@code DirectionalLight}. For example, if the direction vector
+ * is {@code (1, 1, 1)} and the light is not rotated, it will point in the {@code (1, 1, 1)} direction, and if the light
+ * is rotated 90 degrees on the y axis, it will point in the {@code (1, 1, -1)} direction.
  * <p>
  * {@code DirectionalLight}s can represent strong light sources that are far enough from the objects they illuminate
  * that their light rays appear to be parallel. Because these light sources are considered to be infinitely far, they

--- a/modules/javafx.graphics/src/main/java/javafx/scene/DirectionalLight.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/DirectionalLight.java
@@ -49,7 +49,7 @@ import javafx.scene.paint.PhongMaterial;
  * cannot be attenuated. A decrease in intensity can be achieved by using a darker color. The sun is a common light
  * source that can be simulated with this light type.
  *
- * @since 17
+ * @since 18
  * @see PhongMaterial
  */
 public class DirectionalLight extends LightBase {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/DirectionalLight.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/DirectionalLight.java
@@ -38,14 +38,16 @@ import javafx.scene.paint.Color;
 import javafx.scene.paint.PhongMaterial;
 
 /**
- * A light that radiates light in parallel in a specific direction.
+ * A light that illuminates an object from a specific direction.
  * The direction is defined by the {@link #directionProperty() direction} vector property of the light. The direction
  * can be rotated by setting a rotation transform on the {@code SpotLight}. For example, if the direction vector is
  * {@code (1, 1, 1)} and the light is not rotated, it will point in the {@code (1, 1, 1)} direction, and if the light is
  * rotated 90 degrees on the y axis, it will point in the {@code (1, 1, -1)} direction.
  * <p>
- * {@code DirectionalLight}s can represent light sources that are far enough for their light rays to appear to come in parallel
- * such as the sun.
+ * {@code DirectionalLight}s can represent strong light sources that are far enough from the objects they illuminate
+ * that their light rays appear to be parallel. Because these light sources are considered to be infinitely far, they
+ * cannot be attenuated. A decrease in intensity can be achieved by using a darker color. The sun is a common light
+ * source that can be simulated with this light type.
  *
  * @since 17
  * @see PhongMaterial

--- a/modules/javafx.graphics/src/main/java/javafx/scene/DirectionalLight.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/DirectionalLight.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package javafx.scene;
+
+import com.sun.javafx.scene.DirectionalLightHelper;
+import com.sun.javafx.scene.DirtyBits;
+import com.sun.javafx.scene.NodeHelper;
+import com.sun.javafx.sg.prism.NGDirectionalLight;
+import com.sun.javafx.sg.prism.NGNode;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.geometry.Point3D;
+import javafx.scene.paint.Color;
+import javafx.scene.paint.PhongMaterial;
+
+/**
+ * A light that radiates light in parallel in a specific direction.
+ * The direction is defined by the {@link #directionProperty() direction} vector property of the light. The direction
+ * can be rotated by setting a rotation transform on the {@code SpotLight}. For example, if the direction vector is
+ * {@code (1, 1, 1)} and the light is not rotated, it will point in the {@code (1, 1, 1)} direction, and if the light is
+ * rotated 90 degrees on the y axis, it will point in the {@code (1, 1, -1)} direction.
+ * <p>
+ * {@code DirectionalLight}s can represent light sources that are far enough for their light rays to appear to come in parallel
+ * such as the sun.
+ *
+ * @since 17
+ * @see PhongMaterial
+ */
+public class DirectionalLight extends LightBase {
+    static {
+        DirectionalLightHelper.setDirectionalLightAccessor(new DirectionalLightHelper.DirectionalLightAccessor() {
+            @Override
+            public NGNode doCreatePeer(Node node) {
+                return ((DirectionalLight) node).doCreatePeer();
+            }
+
+            @Override
+            public void doUpdatePeer(Node node) {
+                ((DirectionalLight) node).doUpdatePeer();
+            }
+        });
+    }
+
+    {
+        // To initialize the class helper at the beginning of each constructor of this class
+        DirectionalLightHelper.initHelper(this);
+    }
+
+    /**
+     * Creates a new instance of {@code SpotLight} class with a default {@code Color.WHITE} light source.
+     */
+    public DirectionalLight() {
+        super();
+    }
+
+    /**
+     * Creates a new instance of {@code SpotLight} class using the specified color.
+     *
+     * @param color the color of the light source
+     */
+    public DirectionalLight(Color color) {
+        super(color);
+    }
+
+
+    /**
+     * The direction vector of the spotlight. It can be rotated by setting a rotation transform on the
+     * {@code SpotLight}. The vector need not be normalized.
+     *
+     * @defaultValue {@code Point3D(0, 0, 1)}
+     */
+    private ObjectProperty<Point3D> direction;
+
+    public final void setDirection(Point3D value) {
+        directionProperty().set(value);
+    }
+
+    private static final Point3D DEFAULT_DIRECTION = NGDirectionalLight.getDefaultDirection();
+
+    public final Point3D getDirection() {
+        return direction == null ? DEFAULT_DIRECTION : direction.get();
+    }
+
+    public final ObjectProperty<Point3D> directionProperty() {
+        if (direction == null) {
+            direction = new SimpleObjectProperty<>(this, "direction", DEFAULT_DIRECTION) {
+                @Override
+                protected void invalidated() {
+                    NodeHelper.markDirty(DirectionalLight.this, DirtyBits.NODE_LIGHT);
+                }
+            };
+        }
+        return direction;
+    }
+
+
+    /*
+     * Note: This method MUST only be called via its accessor method.
+     */
+    private NGNode doCreatePeer() {
+        return new NGDirectionalLight();
+    }
+
+    private void doUpdatePeer() {
+        if (isDirty(DirtyBits.NODE_LIGHT)) {
+            NGDirectionalLight peer = getPeer();
+            peer.setDirection(getDirection());
+        }
+    }
+}

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.cc
@@ -512,18 +512,19 @@ JNIEXPORT void JNICALL Java_com_sun_prism_d3d_D3DContext_nSetAmbientLight
 /*
  * Class:     com_sun_prism_d3d_D3DContext
  * Method:    nSetLight
- * Signature: (JJIFFFFFFFFFFFFFFFFF)V
+ * Signature: (JJIFFFFFFFFFFFFFFFFFF)V
  */
 JNIEXPORT void JNICALL Java_com_sun_prism_d3d_D3DContext_nSetLight
   (JNIEnv *env, jclass, jlong ctx, jlong nativeMeshView, jint index,
         jfloat x, jfloat y, jfloat z, jfloat r, jfloat g, jfloat b, jfloat w,
-        jfloat ca, jfloat la, jfloat qa, jfloat range,
+        jfloat ca, jfloat la, jfloat qa, jfloat isAttenuated, jfloat range,
         jfloat dirX, jfloat dirY, jfloat dirZ, jfloat innerAngle, jfloat outerAngle, jfloat falloff)
 {
     TraceLn(NWT_TRACE_INFO, "D3DContext_nSetLight");
     D3DMeshView *meshView = (D3DMeshView *) jlong_to_ptr(nativeMeshView);
     RETURN_IF_NULL(meshView);
-    meshView->setLight(index, x, y, z, r, g, b, w, ca, la, qa, range, dirX, dirY, dirZ, innerAngle, outerAngle, falloff);
+    meshView->setLight(index, x, y, z, r, g, b, w, ca, la, qa, isAttenuated, range, dirX, dirY, dirZ,
+            innerAngle, outerAngle, falloff);
 }
 
 /*

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DLight.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DLight.cc
@@ -47,7 +47,11 @@ D3DLight::D3DLight() :
     {}
 
 bool D3DLight::isPointLight() {
-    return falloff == 0 && outerAngle == 180;
+    return falloff == 0 && outerAngle == 180 && attenuation[3] > 0.5;
+}
+
+bool D3DLight::isDirectionalLight() {
+    return attenuation[3] < 0.5;
 }
 
 void D3DLight::setColor(float r, float g, float b) {

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DLight.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DLight.cc
@@ -51,6 +51,7 @@ bool D3DLight::isPointLight() {
 }
 
 bool D3DLight::isDirectionalLight() {
+    // testing if w is 0 or 1 using <0.5 since equality check for floating points might not work well
     return attenuation[3] < 0.5;
 }
 

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DLight.h
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DLight.h
@@ -35,13 +35,14 @@ public:
     D3DLight();
     virtual ~D3DLight();
     bool isPointLight();
+    bool isDirectionalLight();
     void setColor(float r, float g, float b);
     void setPosition(float x, float y, float z);
 
     float position[3];
     float color[3];
     float w;
-    float attenuation[3]; // ca, la, qa
+    float attenuation[4]; // ca, la, qa, isAttenuated
     float maxRange;
     float direction[3];
     float innerAngle;

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DMeshView.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DMeshView.cc
@@ -74,7 +74,7 @@ void D3DMeshView::setAmbientLight(float r, float g, float b) {
 }
 
 void D3DMeshView::setLight(int index, float x, float y, float z, float r, float g, float b, float w,
-        float ca, float la, float qa, float maxRange,
+        float ca, float la, float qa, float isAttenuated, float maxRange,
         float dirX, float dirY, float dirZ, float innerAngle, float outerAngle, float falloff) {
     // NOTE: We only support up to 3 point lights at the present
     if (index >= 0 && index <= MAX_NUM_LIGHTS - 1) {
@@ -89,6 +89,7 @@ void D3DMeshView::setLight(int index, float x, float y, float z, float r, float 
         light.attenuation[0] = ca;
         light.attenuation[1] = la;
         light.attenuation[2] = qa;
+        light.attenuation[3] = isAttenuated;
         light.maxRange = maxRange;
         light.direction[0] = dirX;
         light.direction[1] = dirY;
@@ -193,7 +194,7 @@ void D3DMeshView::render() {
     }
 
     float lightsColor[MAX_NUM_LIGHTS * 4];        // 3 lights x (3 color + 1 padding)
-    float lightsAttenuation[MAX_NUM_LIGHTS * 4];  // 3 lights x (3 attenuation factors + 1 padding)
+    float lightsAttenuation[MAX_NUM_LIGHTS * 4];  // 3 lights x (3 attenuation factors + 1 isAttenuated)
     float lightsRange[MAX_NUM_LIGHTS * 4];        // 3 lights x (1 maxRange + 3 padding)
     float spotLightsFactors[MAX_NUM_LIGHTS * 4];  // 3 lights x (2 angles + 1 falloff + 1 padding)
     for (int i = 0, c = 0, a = 0, r = 0, s = 0; i < MAX_NUM_LIGHTS; i++) {
@@ -206,14 +207,14 @@ void D3DMeshView::render() {
         lightsAttenuation[a++] = lights[i].attenuation[0];
         lightsAttenuation[a++] = lights[i].attenuation[1];
         lightsAttenuation[a++] = lights[i].attenuation[2];
-        lightsAttenuation[a++] = 0;
+        lightsAttenuation[a++] = lights[i].attenuation[3];
 
         lightsRange[r++] = lights[i].maxRange;
         lightsRange[r++] = 0;
         lightsRange[r++] = 0;
         lightsRange[r++] = 0;
 
-        if (lights[i].isPointLight()) {
+        if (lights[i].isPointLight() || lights[i].isDirectionalLight()) {
             spotLightsFactors[s++] = -1; // cos(180)
             spotLightsFactors[s++] = 2;  // cos(0) - cos(180)
             spotLightsFactors[s++] = 0;

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DMeshView.h
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DMeshView.h
@@ -43,7 +43,7 @@ public:
     void setAmbientLight(float r, float g, float b);
     void setLight(int index, float x, float y, float z,
         float r, float g, float b, float w,
-        float ca, float la, float qa, float maxRange,
+        float ca, float la, float qa, float isAttenuated, float maxRange,
         float dirX, float dirY, float dirZ,
         float innerAngle, float outerAngle, float falloff);
     void computeNumLights();

--- a/modules/javafx.graphics/src/main/native-prism-d3d/hlsl/psConstants.h
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/hlsl/psConstants.h
@@ -30,7 +30,7 @@ static const int numMaxLights = 5;
 float4 gDiffuseColor : register(c0);
 float4 gSpecularColor : register(c1); // specular power is in the alpha
 float4 gLightColor[numMaxLights] : register(c4);
-float4 gLightAttenuation[numMaxLights] : register(c9);
+float4 gLightAttenuation[numMaxLights] : register(c9);  // {constant, linear, quadratic, on == 1 / off == 0}
 float4 gLightRange[numMaxLights] : register(c14);       // {max range, reserved min range, _, _}
 float4 gSpotLightFactors[numMaxLights] : register(c19); // {cos(outer), cos(inner) - cos(outer), falloff, _}
 

--- a/modules/javafx.graphics/src/main/native-prism-d3d/hlsl/psMath.h
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/hlsl/psMath.h
@@ -103,6 +103,11 @@ float computeSpotlightFactor3(float3 l, float3 lightDir, float cosOuter, float d
 }
 
 void computeLight(float i, float3 n, float3 refl, float specPower, float3 L, float3 lightDir, in out float3 d, in out float3 s) {
+    if (gLightAttenuation[i].w < 0.5) {
+        d += saturate(dot(n, -lightDir)) * gLightColor[i].xyz;
+        s += pow(saturate(dot(-refl, -lightDir)), specPower) * gLightColor[i].xyz;
+        return;
+    }
     float dist = length(L);
     if (dist > gLightRange[i].x) {
         return;

--- a/modules/javafx.graphics/src/main/native-prism-d3d/hlsl/psMath.h
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/hlsl/psMath.h
@@ -103,6 +103,7 @@ float computeSpotlightFactor3(float3 l, float3 lightDir, float cosOuter, float d
 }
 
 void computeLight(float i, float3 n, float3 refl, float specPower, float3 L, float3 lightDir, in out float3 d, in out float3 s) {
+    // testing if w is 0 or 1 using <0.5 since equality check for floating points might not work well
     if (gLightAttenuation[i].w < 0.5) {
         d += saturate(dot(n, -lightDir)) * gLightColor[i].xyz;
         s += pow(saturate(dot(-refl, -lightDir)), specPower) * gLightColor[i].xyz;

--- a/modules/javafx.graphics/src/main/native-prism-es2/GLContext.c
+++ b/modules/javafx.graphics/src/main/native-prism-es2/GLContext.c
@@ -2125,6 +2125,7 @@ JNIEXPORT jlong JNICALL Java_com_sun_prism_es2_GLContext_nCreateES2MeshView
     meshViewInfo->lightAttenuation[0] = 1;
     meshViewInfo->lightAttenuation[1] = 0;
     meshViewInfo->lightAttenuation[2] = 0;
+    meshViewInfo->lightAttenuation[3] = 1;
     meshViewInfo->lightMaxRange = 0;
     meshViewInfo->lightDir[0] = 1;
     meshViewInfo->lightDir[1] = 0;
@@ -2271,12 +2272,12 @@ JNIEXPORT void JNICALL Java_com_sun_prism_es2_GLContext_nSetAmbientLight
 /*
  * Class:     com_sun_prism_es2_GLContext
  * Method:    nSetLight
- * Signature: (JJIFFFFFFFFFFFFFFFFF)V
+ * Signature: (JJIFFFFFFFFFFFFFFFFFF)V
  */
 JNIEXPORT void JNICALL Java_com_sun_prism_es2_GLContext_nSetLight
   (JNIEnv *env, jclass class, jlong nativeCtxInfo, jlong nativeMeshViewInfo,
         jint index, jfloat x, jfloat y, jfloat z, jfloat r, jfloat g, jfloat b, jfloat w,
-        jfloat ca, jfloat la, jfloat qa, jfloat maxRange, jfloat dirX, jfloat dirY, jfloat dirZ,
+        jfloat ca, jfloat la, jfloat qa, jfloat isAttenuated, jfloat maxRange, jfloat dirX, jfloat dirY, jfloat dirZ,
         jfloat innerAngle, jfloat outerAngle, jfloat falloff)
 {
     ContextInfo *ctxInfo = (ContextInfo *) jlong_to_ptr(nativeCtxInfo);
@@ -2296,6 +2297,7 @@ JNIEXPORT void JNICALL Java_com_sun_prism_es2_GLContext_nSetLight
     meshViewInfo->lightAttenuation[0] = ca;
     meshViewInfo->lightAttenuation[1] = la;
     meshViewInfo->lightAttenuation[2] = qa;
+    meshViewInfo->lightAttenuation[3] = isAttenuated;
     meshViewInfo->lightMaxRange = maxRange;
     meshViewInfo->lightDir[0] = dirX;
     meshViewInfo->lightDir[1] = dirY;

--- a/modules/javafx.graphics/src/main/native-prism-es2/PrismES2Defs.h
+++ b/modules/javafx.graphics/src/main/native-prism-es2/PrismES2Defs.h
@@ -380,7 +380,7 @@ struct MeshViewInfoRec {
     GLfloat lightColor[3];
     GLfloat lightPosition[3];
     GLfloat lightWeight;
-    GLfloat lightAttenuation[3];
+    GLfloat lightAttenuation[4];
     GLfloat lightMaxRange;
     GLfloat lightDir[3];
     GLfloat lightInnerAngle;

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main.vert
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main.vert
@@ -35,7 +35,7 @@ attribute vec4 tangent;
 struct Light {
     vec4 pos;
     vec3 color;
-    vec3 attn;
+    vec4 attn;
     vec3 dir;
     float range;
     float cosOuter;

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main1Light.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main1Light.frag
@@ -119,6 +119,7 @@ float computeSpotlightFactor3(vec3 l, vec3 lightDir, float cosOuter, float denom
 void computeLight(int i, vec3 n, vec3 refl, float specPower, inout vec3 d, inout vec3 s) {
     Light light = lights[i];
     vec3 lightDir = lightTangentSpaceDirections[i].xyz;
+    // testing if w is 0 or 1 using <0.5 since equality check for floating points might not work well
     if (light.attn.w < 0.5) {
         d += clamp(dot(n, -lightDir), 0.0, 1.0) * light.color.rgb;
         s += pow(clamp(dot(-refl, -lightDir), 0.0, 1.0), specPower) * light.color.rgb;

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main1Light.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main1Light.frag
@@ -58,7 +58,7 @@ vec4 apply_selfIllum();
 struct Light {
     vec4 pos;
     vec3 color;
-    vec3 attn;
+    vec4 attn;
     vec3 dir;
     float range;
     float cosOuter;
@@ -118,6 +118,13 @@ float computeSpotlightFactor3(vec3 l, vec3 lightDir, float cosOuter, float denom
 
 void computeLight(int i, vec3 n, vec3 refl, float specPower, inout vec3 d, inout vec3 s) {
     Light light = lights[i];
+    vec3 lightDir = lightTangentSpaceDirections[i].xyz;
+    if (light.attn.w < 0.5) {
+        d += clamp(dot(n, -lightDir), 0.0, 1.0) * light.color.rgb;
+        s += pow(clamp(dot(-refl, -lightDir), 0.0, 1.0), specPower) * light.color.rgb;
+        return;
+    }
+
     vec3 pos = lightTangentSpacePositions[i].xyz;
     float dist = length(pos);
     if (dist > light.range) {
@@ -125,7 +132,6 @@ void computeLight(int i, vec3 n, vec3 refl, float specPower, inout vec3 d, inout
     }
     vec3 l = normalize(pos);
 
-    vec3 lightDir = lightTangentSpaceDirections[i].xyz;
     float spotlightFactor = computeSpotlightFactor(l, lightDir, light.cosOuter, light.denom, light.falloff);
 
     float invAttnFactor = light.attn.x + light.attn.y * dist + light.attn.z * dist * dist;

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main2Lights.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main2Lights.frag
@@ -119,6 +119,7 @@ float computeSpotlightFactor3(vec3 l, vec3 lightDir, float cosOuter, float denom
 void computeLight(int i, vec3 n, vec3 refl, float specPower, inout vec3 d, inout vec3 s) {
     Light light = lights[i];
     vec3 lightDir = lightTangentSpaceDirections[i].xyz;
+    // testing if w is 0 or 1 using <0.5 since equality check for floating points might not work well
     if (light.attn.w < 0.5) {
         d += clamp(dot(n, -lightDir), 0.0, 1.0) * light.color.rgb;
         s += pow(clamp(dot(-refl, -lightDir), 0.0, 1.0), specPower) * light.color.rgb;

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main2Lights.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main2Lights.frag
@@ -58,7 +58,7 @@ vec4 apply_selfIllum();
 struct Light {
     vec4 pos;
     vec3 color;
-    vec3 attn;
+    vec4 attn;
     vec3 dir;
     float range;
     float cosOuter;
@@ -118,6 +118,13 @@ float computeSpotlightFactor3(vec3 l, vec3 lightDir, float cosOuter, float denom
 
 void computeLight(int i, vec3 n, vec3 refl, float specPower, inout vec3 d, inout vec3 s) {
     Light light = lights[i];
+    vec3 lightDir = lightTangentSpaceDirections[i].xyz;
+    if (light.attn.w < 0.5) {
+        d += clamp(dot(n, -lightDir), 0.0, 1.0) * light.color.rgb;
+        s += pow(clamp(dot(-refl, -lightDir), 0.0, 1.0), specPower) * light.color.rgb;
+        return;
+    }
+
     vec3 pos = lightTangentSpacePositions[i].xyz;
     float dist = length(pos);
     if (dist > light.range) {
@@ -125,7 +132,6 @@ void computeLight(int i, vec3 n, vec3 refl, float specPower, inout vec3 d, inout
     }
     vec3 l = normalize(pos);
 
-    vec3 lightDir = lightTangentSpaceDirections[i].xyz;
     float spotlightFactor = computeSpotlightFactor(l, lightDir, light.cosOuter, light.denom, light.falloff);
 
     float invAttnFactor = light.attn.x + light.attn.y * dist + light.attn.z * dist * dist;

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main3Lights.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main3Lights.frag
@@ -119,6 +119,7 @@ float computeSpotlightFactor3(vec3 l, vec3 lightDir, float cosOuter, float denom
 void computeLight(int i, vec3 n, vec3 refl, float specPower, inout vec3 d, inout vec3 s) {
     Light light = lights[i];
     vec3 lightDir = lightTangentSpaceDirections[i].xyz;
+    // testing if w is 0 or 1 using <0.5 since equality check for floating points might not work well
     if (light.attn.w < 0.5) {
         d += clamp(dot(n, -lightDir), 0.0, 1.0) * light.color.rgb;
         s += pow(clamp(dot(-refl, -lightDir), 0.0, 1.0), specPower) * light.color.rgb;

--- a/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main3Lights.frag
+++ b/modules/javafx.graphics/src/main/resources/com/sun/prism/es2/glsl/main3Lights.frag
@@ -58,7 +58,7 @@ vec4 apply_selfIllum();
 struct Light {
     vec4 pos;
     vec3 color;
-    vec3 attn;
+    vec4 attn;
     vec3 dir;
     float range;
     float cosOuter;
@@ -118,6 +118,13 @@ float computeSpotlightFactor3(vec3 l, vec3 lightDir, float cosOuter, float denom
 
 void computeLight(int i, vec3 n, vec3 refl, float specPower, inout vec3 d, inout vec3 s) {
     Light light = lights[i];
+    vec3 lightDir = lightTangentSpaceDirections[i].xyz;
+    if (light.attn.w < 0.5) {
+        d += clamp(dot(n, -lightDir), 0.0, 1.0) * light.color.rgb;
+        s += pow(clamp(dot(-refl, -lightDir), 0.0, 1.0), specPower) * light.color.rgb;
+        return;
+    }
+
     vec3 pos = lightTangentSpacePositions[i].xyz;
     float dist = length(pos);
     if (dist > light.range) {
@@ -125,7 +132,6 @@ void computeLight(int i, vec3 n, vec3 refl, float specPower, inout vec3 d, inout
     }
     vec3 l = normalize(pos);
 
-    vec3 lightDir = lightTangentSpaceDirections[i].xyz;
     float spotlightFactor = computeSpotlightFactor(l, lightDir, light.cosOuter, light.denom, light.falloff);
 
     float invAttnFactor = light.attn.x + light.attn.y * dist + light.attn.z * dist * dist;

--- a/tests/performance/3DLighting/attenuation/AttenLightingSample.java
+++ b/tests/performance/3DLighting/attenuation/AttenLightingSample.java
@@ -25,9 +25,15 @@
 
 package attenuation;
 
+import java.util.List;
+
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.collections.ObservableList;
 import javafx.geometry.Point3D;
+import javafx.scene.DirectionalLight;
+import javafx.scene.Node;
 import javafx.scene.PointLight;
 import javafx.scene.SpotLight;
 import javafx.scene.control.Label;
@@ -36,6 +42,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.scene.transform.Rotate;
+import javafx.scene.transform.Transform;
 import javafx.util.converter.NumberStringConverter;
 
 /**
@@ -60,27 +67,41 @@ public class AttenLightingSample extends LightingSample {
         var ia = createSliderControl("inner", light.innerAngleProperty(), 0, 180, light.getInnerAngle());
         var oa = createSliderControl("outer", light.outerAngleProperty(), 0, 180, light.getOuterAngle());
         var fo = createSliderControl("falloff", light.falloffProperty(), -5, 5, light.getFalloff());
+        vbox.getChildren().addAll(ia, oa, fo);
 
+        List<Node> directionControls = createDirectionControls(light.getTransforms(), light.directionProperty());
+        vbox.getChildren().addAll(directionControls);
+        return vbox;
+    }
+
+    @Override
+    protected VBox addDirectionalLightControls(DirectionalLight light) {
+        var vbox = super.addLightControls(light);
+        List<Node> directionControls = createDirectionControls(light.getTransforms(), light.directionProperty());
+        vbox.getChildren().addAll(directionControls);
+        return vbox;
+    }
+
+    private List<Node> createDirectionControls(ObservableList<Transform> transforms, ObjectProperty<Point3D> directionProperty) {
         var transX = new Rotate(0, Rotate.X_AXIS);
         var transY = new Rotate(0, Rotate.Y_AXIS);
         var transZ = new Rotate(0, Rotate.Z_AXIS);
-        light.getTransforms().addAll(transX, transY, transZ);
+        transforms.addAll(transX, transY, transZ);
         var rotX = createSliderControl("rot x", transX.angleProperty(), -180, 180, 0);
         var rotY = createSliderControl("rot y", transY.angleProperty(), -180, 180, 0);
         var rotZ = createSliderControl("rot z", transZ.angleProperty(), -180, 180, 0);
 
-        var sliderX = createSlider(-5, 5, light.getDirection().getX());
-        var sliderY = createSlider(-5, 5, light.getDirection().getY());
-        var sliderZ = createSlider(-5, 5, light.getDirection().getZ());
-        light.directionProperty().bind(Bindings.createObjectBinding(() ->
+        var sliderX = createSlider(-5, 5, directionProperty.get().getX());
+        var sliderY = createSlider(-5, 5, directionProperty.get().getY());
+        var sliderZ = createSlider(-5, 5, directionProperty.get().getZ());
+        directionProperty.bind(Bindings.createObjectBinding(() ->
             new Point3D(sliderX.getValue(), sliderY.getValue(), sliderZ.getValue()),
             sliderX.valueProperty(), sliderY.valueProperty(), sliderZ.valueProperty()));
         var dirX = createSliderControl("dir x", sliderX);
         var dirY = createSliderControl("dir y", sliderY);
         var dirZ = createSliderControl("dir z", sliderZ);
 
-        vbox.getChildren().addAll(ia, oa, fo, rotX, rotY, rotZ, dirX, dirY, dirZ);
-        return vbox;
+        return List.of(rotX, rotY, rotZ, dirX, dirY, dirZ);
     }
 
     private HBox createSliderControl(String name, DoubleProperty property, double min, double max, double start) {

--- a/tests/performance/3DLighting/attenuation/Environment.java
+++ b/tests/performance/3DLighting/attenuation/Environment.java
@@ -28,6 +28,7 @@ package attenuation;
 import java.util.ArrayList;
 import java.util.List;
 
+import javafx.geometry.Point3D;
 import javafx.scene.AmbientLight;
 import javafx.scene.DirectionalLight;
 import javafx.scene.Group;

--- a/tests/performance/3DLighting/attenuation/Environment.java
+++ b/tests/performance/3DLighting/attenuation/Environment.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javafx.scene.AmbientLight;
+import javafx.scene.DirectionalLight;
 import javafx.scene.Group;
 import javafx.scene.LightBase;
 import javafx.scene.Node;
@@ -47,13 +48,17 @@ class Environment extends CameraScene3D {
     private final static double LIGHT_Z_DIST = 50;
     private final static double LIGHT_X_DIST = 50;
 
+    private final DirectionalLight directionalLight1 = new DirectionalLight(Color.RED);
+    private final DirectionalLight directionalLight2 = new DirectionalLight(Color.BLUE);
+    private final DirectionalLight directionalLight3 = new DirectionalLight(Color.MAGENTA);
     private final PointLight pointLight1 = new PointLight(Color.RED);
     private final PointLight pointLight2 = new PointLight(Color.BLUE);
     private final PointLight pointLight3 = new PointLight(Color.MAGENTA);
     private final SpotLight spotLight1 = new SpotLight(Color.RED);
     private final SpotLight spotLight2 = new SpotLight(Color.BLUE);
     private final SpotLight spotLight3 = new SpotLight(Color.MAGENTA);
-    final LightBase[] lights = {pointLight1, pointLight2, pointLight3, spotLight1, spotLight2, spotLight3};
+    final LightBase[] lights = {directionalLight1, directionalLight2, directionalLight3,
+            pointLight1, pointLight2, pointLight3, spotLight1, spotLight2, spotLight3};
 
     private Node currentShape;
 
@@ -78,6 +83,9 @@ class Environment extends CameraScene3D {
         pointLight2.setTranslateX(-LIGHT_X_DIST);
         spotLight2.setTranslateX(-LIGHT_X_DIST);
 
+        directionalLight1.setUserData("RED");
+        directionalLight2.setUserData("BLUE");
+        directionalLight3.setUserData("MAGENTA");
         pointLight1.setUserData("RED");
         pointLight2.setUserData("BLUE");
         pointLight3.setUserData("MAGENTA");

--- a/tests/performance/3DLighting/attenuation/Environment.java
+++ b/tests/performance/3DLighting/attenuation/Environment.java
@@ -83,6 +83,9 @@ class Environment extends CameraScene3D {
         pointLight2.setTranslateX(-LIGHT_X_DIST);
         spotLight2.setTranslateX(-LIGHT_X_DIST);
 
+        directionalLight1.setDirection(new Point3D(-LIGHT_X_DIST, 0, LIGHT_Z_DIST));
+        directionalLight2.setDirection(new Point3D(LIGHT_X_DIST, 0, LIGHT_Z_DIST));
+
         directionalLight1.setUserData("RED");
         directionalLight2.setUserData("BLUE");
         directionalLight3.setUserData("MAGENTA");

--- a/tests/performance/3DLighting/attenuation/LightingSample.java
+++ b/tests/performance/3DLighting/attenuation/LightingSample.java
@@ -29,6 +29,7 @@ import javafx.animation.Animation;
 import javafx.animation.TranslateTransition;
 import javafx.application.Application;
 import javafx.beans.binding.When;
+import javafx.scene.DirectionalLight;
 import javafx.scene.Group;
 import javafx.scene.LightBase;
 import javafx.scene.Node;
@@ -84,8 +85,12 @@ public class LightingSample extends Application {
                 vBox = addSpotLightControls((SpotLight) light);
             } else if (light instanceof PointLight) {
                 vBox = addPointLightControls((PointLight) light);
+            } else if (light instanceof DirectionalLight) {
+                vBox = addDirectionalLightControls((DirectionalLight) light);
             }
-            controls.getChildren().add(new TitledPane(light.getUserData() + " " + light.getClass().getSimpleName(), vBox));
+            var titlePane = new TitledPane(light.getUserData() + " " + light.getClass().getSimpleName(), vBox);
+            titlePane.setExpanded(false);
+            controls.getChildren().add(titlePane);
         }
 
         var hBox = new HBox(new ScrollPane(controls), environment);
@@ -152,6 +157,10 @@ public class LightingSample extends Application {
     }
 
     protected VBox addSpotLightControls(SpotLight light) {
+        return addLightControls(light);
+    }
+
+    protected VBox addDirectionalLightControls(DirectionalLight light) {
         return addLightControls(light);
     }
 

--- a/tests/system/src/test/java/test/javafx/scene/lighting3D/DirectionalLightTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/lighting3D/DirectionalLightTest.java
@@ -46,7 +46,7 @@ import test.util.Util;
 
 public class DirectionalLightTest extends LightingTest {
 
-    private static final Point3D[] DIRECTIONS = { new Point3D(0, 0, 1), new Point3D(0, 1, 1), new Point3D(0, 0, -1) }; 
+    private static final Point3D[] DIRECTIONS = { new Point3D(0, 0, 1), new Point3D(0, 1, 1), new Point3D(0, 0, -1) };
 
     private static final DirectionalLight LIGHT = new DirectionalLight(Color.BLUE);
 

--- a/tests/system/src/test/java/test/javafx/scene/lighting3D/DirectionalLightTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/lighting3D/DirectionalLightTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.lighting3D;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javafx.application.Application;
+import javafx.application.ConditionalFeature;
+import javafx.application.Platform;
+import javafx.geometry.Point3D;
+import javafx.scene.DirectionalLight;
+import javafx.scene.paint.Color;
+import test.util.Util;
+
+public class DirectionalLightTest extends LightingTest {
+
+    private static final Point3D[] DIRECTIONS = { new Point3D(0, 0, 1), new Point3D(0, 1, 1), new Point3D(0, 0, -1) }; 
+
+    private static final DirectionalLight LIGHT = new DirectionalLight(Color.BLUE);
+
+    public static void main(String[] args) throws Exception {
+        initFX();
+    }
+
+    @BeforeClass
+    public static void initFX() throws Exception {
+        startupLatch = new CountDownLatch(1);
+        LightingTest.light = LIGHT;
+        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
+        assertTrue("Timeout waiting for FX runtime to start", startupLatch.await(15, TimeUnit.SECONDS));
+    }
+
+    @Before
+    public void setupEach() {
+        assumeTrue(Platform.isSupported(ConditionalFeature.SCENE3D));
+    }
+
+    @Test
+    public void testSpotlightAttenuation() {
+        Util.runAndWait(() -> {
+            for (Point3D direction : DIRECTIONS) {
+                LIGHT.setDirection(direction);
+                double sampledBlue = snapshot().getPixelReader().getColor(0, 0).getBlue();
+                assertEquals(FAIL_MESSAGE, dotProduct(direction), sampledBlue, DELTA);
+            }
+        });
+    }
+
+    private double dotProduct(Point3D direction) {
+        double value = -direction.normalize().dotProduct(0, 0, -1); // the normal of the front of the box is (0, 0, -1)
+        return value < 0 ? 0 : value;
+    }
+}

--- a/tests/system/src/test/java/test/javafx/scene/lighting3D/DirectionalLightTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/lighting3D/DirectionalLightTest.java
@@ -68,7 +68,7 @@ public class DirectionalLightTest extends LightingTest {
     }
 
     @Test
-    public void testSpotlightAttenuation() {
+    public void testDirectionalLight() {
         Util.runAndWait(() -> {
             for (Point3D direction : DIRECTIONS) {
                 LIGHT.setDirection(direction);


### PR DESCRIPTION
Adds a directional light as a subclass of `LightBase`. I think that this is the correct hierarchy for it.

I tried to simulate a directional light by putting a point light far away, but I got artifacts when the distance was large. Instead, I added an on/off attenuation flag as the 4th component of the attenuation 4-vector. When it is 0, a simpler computation is used in the pixel/fragment shader that calculates the illumination based on the light direction only (making the position variables meaningless). When it is 1, the point/spot light computation is used. It's possible that the vertex shader can also be simplified in this case since it does not need to transform the position vectors, but I left this optimization avenue for another time.

I noticed a drop of ~1 fps in the stress test of 5000 meshes.

I added a system test that verifies the correct color result from a few directions. I also updated the lighting sample application to include 3 directional lights and tested them on all the models visually. The lights seem to behave the way I would expect.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8234921](https://bugs.openjdk.java.net/browse/JDK-8234921): Add DirectionalLight to the selection of 3D light types
 * [JDK-8269514](https://bugs.openjdk.java.net/browse/JDK-8269514): Add DirectionalLight to the selection of 3D light types (**CSR**)


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/548/head:pull/548` \
`$ git checkout pull/548`

Update a local copy of the PR: \
`$ git checkout pull/548` \
`$ git pull https://git.openjdk.java.net/jfx pull/548/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 548`

View PR using the GUI difftool: \
`$ git pr show -t 548`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/548.diff">https://git.openjdk.java.net/jfx/pull/548.diff</a>

</details>
