### PR TITLE
8269244: [IDE] Dependency verification of *-sources.jar fails when doing gradle sync

### DIFF
--- a/gradle/README.txt
+++ b/gradle/README.txt
@@ -32,7 +32,16 @@ Recreate the dependency verification file as follows:
    builds to pick up the internal tools and development kits in the
    'javafx' component group.
 
-6. Commit the final version of the file to the repository.
+6. Add the following entry inside the <configuration> section:
+
+   <trusted-artifacts>
+      <trust file=".*-sources[.]jar" regex="true"/>
+   </trusted-artifacts>
+
+   This configures Gradle to trust automatically all sources.
+   See also: https://docs.gradle.org/current/userguide/dependency_verification.html#sec:skipping-javadocs
+
+7. Commit the final version of the file to the repository.
 
 These commands will cause Gradle to compute the requested checksums
 directly from the newly downloaded artifacts and add them to the file.

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -3,6 +3,9 @@
    <configuration>
       <verify-metadata>true</verify-metadata>
       <verify-signatures>false</verify-signatures>
+      <trusted-artifacts>
+         <trust file=".*-sources[.]jar" regex="true"/>
+      </trusted-artifacts>
    </configuration>
    <components>
       <component group="" name="ffmpeg-3.3.3" version="">


### PR DESCRIPTION
This PR fixes the issue identified and discussed in PR https://github.com/openjdk/jfx/pull/506 which will make the gradle sync in IntelliJ fail because of the failing dependency verification for source files.

Gradle provides a way to skip the verification of source files, documented here:
https://docs.gradle.org/current/userguide/dependency_verification.html#sec:skipping-javadocs

Also the **README.txt** file is adjusted to include the instructions neccessary when updating the **verification-metadata.xml** file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269244](https://bugs.openjdk.java.net/browse/JDK-8269244): [IDE] Dependency verification of *-sources.jar fails when doing gradle sync


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Nir Lisker](https://openjdk.java.net/census#nlisker) (@nlisker - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/549/head:pull/549` \
`$ git checkout pull/549`

Update a local copy of the PR: \
`$ git checkout pull/549` \
`$ git pull https://git.openjdk.java.net/jfx pull/549/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 549`

View PR using the GUI difftool: \
`$ git pr show -t 549`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/549.diff">https://git.openjdk.java.net/jfx/pull/549.diff</a>

</details>
