### PR TITLE
8268683: JavaFX MediaPlayer onEndOfMedia behaviour different from Javadoc

### DIFF
--- a/modules/javafx.media/src/main/java/javafx/scene/media/MediaPlayer.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/MediaPlayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,10 +112,11 @@ import javafx.event.EventHandler;
  * duration of media playback is then the product of the cycle duration and the
  * number of times the cycle is played. If the stop time of the cycle is reached
  * and the cycle is to be played again, the event handler registered with the
- * {@link #onRepeatProperty onRepeat} property is invoked. If the stop time is reached and
- * the cycle is <i>not</i> to be repeated, then the event handler registered
- * with the {@link #onEndOfMediaProperty onEndOfMedia} property is invoked. A zero-relative index of
- * which cycle is presently being played is maintained by {@link #currentCountProperty currentCount}.
+ * {@link #onRepeatProperty onRepeat} property is invoked. If the stop time is
+ * reached, then the event handler registered with the {@link #onEndOfMediaProperty onEndOfMedia}
+ * property is invoked regardless if the cycle is to be repeated or not.
+ * A zero-relative index of which cycle is presently being played is maintained
+ * by {@link #currentCountProperty currentCount}.
  * </p>
  *
  * <p>The operation of a <code>MediaPlayer</code> is inherently asynchronous.

--- a/modules/javafx.media/src/main/java/javafx/scene/media/MediaPlayer.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/MediaPlayer.java
@@ -114,7 +114,7 @@ import javafx.event.EventHandler;
  * and the cycle is to be played again, the event handler registered with the
  * {@link #onRepeatProperty onRepeat} property is invoked. If the stop time is
  * reached, then the event handler registered with the {@link #onEndOfMediaProperty onEndOfMedia}
- * property is invoked regardless if the cycle is to be repeated or not.
+ * property is invoked regardless of whether the cycle is to be repeated or not.
  * A zero-relative index of which cycle is presently being played is maintained
  * by {@link #currentCountProperty currentCount}.
  * </p>


### PR DESCRIPTION
Fixed javadoc to indicate that onEndOfMedia is invoked each time when end of cycle is reached regardless if it is repeating or not.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268683](https://bugs.openjdk.java.net/browse/JDK-8268683): JavaFX MediaPlayer onEndOfMedia behaviour different from Javadoc


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/552/head:pull/552` \
`$ git checkout pull/552`

Update a local copy of the PR: \
`$ git checkout pull/552` \
`$ git pull https://git.openjdk.java.net/jfx pull/552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 552`

View PR using the GUI difftool: \
`$ git pr show -t 552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/552.diff">https://git.openjdk.java.net/jfx/pull/552.diff</a>

</details>
