### PR TITLE
8269593: Different fontname on macos

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
@@ -647,6 +647,16 @@ public abstract class PrismFontFactory implements FontFactory {
         }
     }
 
+    /**
+     * Retrieve the <code></code>FontResource</code> that corresponds to the provided name.
+     * It is guaranteed that invoking <code>FontResource.getFullName()</code> on
+     * the resulting FontResource returns the <code>name</code> parameter, unless
+     * a <code>null</code> value is returned.
+     * @param name the unique identifier for the requested font.
+     * @param file the file holding this font. This can be null, in which case the available fonts are checked.
+     * @param wantComp use composite font
+     * @return the requested <code>FontResource</code>, or <code>null</code> in case no matching font is found.
+     */
     public synchronized FontResource getFontResource(String name, String file,
                                                      boolean wantComp) {
         FontResource fr = null;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFile.java
@@ -607,7 +607,9 @@ public abstract class PrismFontFile implements FontResource, FontConstants {
              * any file read implementation which doesn't have random access.
              */
             initNames();
-
+            if (name != null) {
+                fullName = name;
+            }
             if (familyName == null || fullName == null) {
                 String fontName = name != null ? name : "";
                 if (fullName == null) {

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/font/PrismFontFactoryTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/font/PrismFontFactoryTest.java
@@ -78,7 +78,7 @@ public class PrismFontFactoryTest {
     }
 
     @Test
-    public void testFontFactoryWithHelveticaTTC() {
+    public void testFontFactoryWithSystemFontRegular() {
         // System Font Regular is only on Mac
         assumeTrue(PrismFontFactory.isMacOSX);
         PrismFontFactory factory = PrismFontFactory.getFontFactory();

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/font/PrismFontFactoryTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/font/PrismFontFactoryTest.java
@@ -30,11 +30,13 @@
 
 package test.com.sun.javafx.font;
 
+import com.sun.javafx.font.FontResource;
 import com.sun.javafx.font.PrismFontFactory;
 import org.junit.After;
 import org.junit.AfterClass;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -74,5 +76,15 @@ public class PrismFontFactoryTest {
         expResult = PrismFontFactory.getFontFactory();
         assertEquals("Creates different instance of FontFactory", expResult, result);
     }
+
+    @Test
+    public void testFontFactoryWithHelveticaTTC() {
+        // System Font Regular is only on Mac
+        assumeTrue(PrismFontFactory.isMacOSX);
+        PrismFontFactory factory = PrismFontFactory.getFontFactory();
+        FontResource font = factory.getFontResource("System Font Regular", null, false);
+        assertEquals("System Font Regular", font.getFullName());
+    }
+
 
 }


### PR DESCRIPTION
Make sure the returned fullName of a created font matches the requested name. Since the name is used as a key/identifier in some cases, some internal code relies on this.
Added a test to check the case of "System Font Regular" on MacOS, which fails before and succeeds after the patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8269593](https://bugs.openjdk.org/browse/JDK-8269593): Different fontname on macos


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/553/head:pull/553` \
`$ git checkout pull/553`

Update a local copy of the PR: \
`$ git checkout pull/553` \
`$ git pull https://git.openjdk.org/jfx.git pull/553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 553`

View PR using the GUI difftool: \
`$ git pr show -t 553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/553.diff">https://git.openjdk.org/jfx/pull/553.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/553#issuecomment-870631655)