### PR TITLE
8269597: Change JavaFX release version to 18

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -39,7 +39,7 @@
 jfx.release.suffix=-ea
 
 # UPDATE THE FOLLOWING VALUES FOR A NEW RELEASE
-jfx.release.major.version=17
+jfx.release.major.version=18
 jfx.release.minor.version=0
 jfx.release.security.version=0
 jfx.release.patch.version=0
@@ -56,8 +56,8 @@ jfx.release.patch.version=0
 
 javadoc.bottom=<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2021, Oracle and/or its affiliates. All rights reserved.</small>
 
-javadoc.title=JavaFX 17
-javadoc.header=JavaFX&nbsp;17
+javadoc.title=JavaFX 18
+javadoc.header=JavaFX&nbsp;18
 
 ##############################################################################
 #

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
@@ -89,7 +89,7 @@ public class VersionInfoTest {
         String version = VersionInfo.getVersion();
         // Need to update major version number when we develop the next
         // major release.
-        assertTrue(version.startsWith("17"));
+        assertTrue(version.startsWith("18"));
         String runtimeVersion = VersionInfo.getRuntimeVersion();
         assertTrue(runtimeVersion.startsWith(version));
     }


### PR DESCRIPTION
Bump the version number of JavaFX to 18. I will integrate this immediately after forking the `jfx17` stabilization branch, which is scheduled for Thursday, July 8, 2021 at 16:00 UTC.

~~Leaving it as `Draft` for now. I'll make it `rfr` next week.~~

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269597](https://bugs.openjdk.java.net/browse/JDK-8269597): Change JavaFX release version to 18


### Reviewers
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - Committer)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/554/head:pull/554` \
`$ git checkout pull/554`

Update a local copy of the PR: \
`$ git checkout pull/554` \
`$ git pull https://git.openjdk.java.net/jfx pull/554/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 554`

View PR using the GUI difftool: \
`$ git pr show -t 554`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/554.diff">https://git.openjdk.java.net/jfx/pull/554.diff</a>

</details>
