### PR TITLE
8266224: GitHub actions: use gcc 10.3 on Linux

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           set -x
           sudo apt-get update
-          sudo apt-get install libgl1-mesa-dev libx11-dev libxxf86vm-dev libxt-dev pkg-config libgtk2.0-dev libgtk-3-dev libxtst-dev gcc-10=10.2.0-5ubuntu1~20.04 g++-10=10.2.0-5ubuntu1~20.04
+          sudo apt-get install libgl1-mesa-dev libx11-dev libxxf86vm-dev libxt-dev pkg-config libgtk2.0-dev libgtk-3-dev libxtst-dev gcc-10=10.3.0-1ubuntu1~20.04 g++-10=10.3.0-1ubuntu1~20.04
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
           mkdir -p "${HOME}/build-tools"
           wget -O "${HOME}/build-tools/${ANT_FILENAME}" "${ANT_URL}"


### PR DESCRIPTION
install latest version of gcc/g++ (older specific versions are not available anymore)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266224](https://bugs.openjdk.java.net/browse/JDK-8266224): GitHub actions: use gcc 10.3 on Linux


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/555/head:pull/555` \
`$ git checkout pull/555`

Update a local copy of the PR: \
`$ git checkout pull/555` \
`$ git pull https://git.openjdk.java.net/jfx pull/555/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 555`

View PR using the GUI difftool: \
`$ git pr show -t 555`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/555.diff">https://git.openjdk.java.net/jfx/pull/555.diff</a>

</details>
