### PR TITLE
8089398: [ChoiceBox, ComboBox] throws NPE on setting value on null selectionModel

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ChoiceBox.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ChoiceBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -151,9 +151,12 @@ public class ChoiceBox<T> extends Control {
         // selection model to indicate that this is the selected item
         valueProperty().addListener((ov, t, t1) -> {
             if (getItems() == null) return;
+            SingleSelectionModel<T> sm = getSelectionModel();
+            if (sm == null) return;
+
             int index = getItems().indexOf(t1);
             if (index > -1) {
-                getSelectionModel().select(index);
+                sm.select(index);
             }
         });
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBox.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -240,8 +240,9 @@ public class ComboBox<T> extends ComboBoxBase<T> {
         // selection model to indicate that this is the selected item
         valueProperty().addListener((ov, t, t1) -> {
             if (getItems() == null) return;
-
             SelectionModel<T> sm = getSelectionModel();
+            if (sm == null) return;
+
             int index = getItems().indexOf(t1);
 
             if (index == -1) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBox.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBox.java
@@ -279,7 +279,10 @@ public class ComboBox<T> extends ComboBoxBase<T> {
             if (!isEditable()) {
                 // check if value is in items list
                 if (getItems() != null && !getItems().contains(getValue())) {
-                    getSelectionModel().clearSelection();
+                    SingleSelectionModel<T> selectionModel = getSelectionModel();
+                    if (selectionModel != null) {
+                        selectionModel.clearSelection();
+                    }
                 }
             }
         });

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
@@ -564,8 +564,11 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
 
         _listView.getSelectionModel().selectedIndexProperty().addListener(o -> {
             if (listSelectionLock) return;
+            SingleSelectionModel<T> selectionModel = comboBox.getSelectionModel();
+            if (selectionModel == null) return;
+
             int index = listView.getSelectionModel().getSelectedIndex();
-            comboBox.getSelectionModel().select(index);
+            selectionModel.select(index);
             updateDisplayNode();
             comboBox.notifyAccessibleAttributeChanged(AccessibleAttribute.TEXT);
         });

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
@@ -573,9 +573,12 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
             comboBox.notifyAccessibleAttributeChanged(AccessibleAttribute.TEXT);
         });
 
-        comboBox.getSelectionModel().selectedItemProperty().addListener(o -> {
-            listViewSelectionDirty = true;
-        });
+        SingleSelectionModel<T> selectionModel = comboBox.getSelectionModel();
+        if (selectionModel != null) {
+            selectionModel.selectedItemProperty().addListener(o -> {
+                listViewSelectionDirty = true;
+            });
+        }
 
         _listView.addEventFilter(MouseEvent.MOUSE_RELEASED, t -> {
             // RT-18672: Without checking if the user is clicking in the

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,6 +53,7 @@ import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.SelectionModel;
+import javafx.scene.control.SingleSelectionModel;
 import javafx.scene.control.TextField;
 import javafx.scene.input.*;
 import javafx.util.Callback;
@@ -396,6 +397,11 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
     }
 
     private void updateValue() {
+        SingleSelectionModel<T> comboBoxSM = comboBox.getSelectionModel();
+        if (comboBoxSM == null) {
+            return;
+        }
+
         T newValue = comboBox.getValue();
 
         SelectionModel<T> listViewSM = listView.getSelectionModel();
@@ -413,7 +419,7 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
                 listViewSM.clearSelection();
                 listSelectionLock = false;
             } else {
-                int index = comboBox.getSelectionModel().getSelectedIndex();
+                int index = comboBoxSM.getSelectedIndex();
                 if (index >= 0 && index < comboBoxItems.size()) {
                     T itemsObj = comboBoxItems.get(index);
                     if ((itemsObj != null && itemsObj.equals(newValue)) || (itemsObj == null && newValue == null)) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
@@ -322,9 +322,13 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
         if (listViewSelectionDirty) {
             try {
                 listSelectionLock = true;
-                T item = comboBox.getSelectionModel().getSelectedItem();
-                listView.getSelectionModel().clearSelection();
-                listView.getSelectionModel().select(item);
+                SingleSelectionModel<T> selectionModel = comboBox.getSelectionModel();
+
+                if (selectionModel != null) {
+                    T item = selectionModel.getSelectedItem();
+                    listView.getSelectionModel().clearSelection();
+                    listView.getSelectionModel().select(item);
+                }
             } finally {
                 listSelectionLock = false;
                 listViewSelectionDirty = false;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxTest.java
@@ -26,10 +26,10 @@
 package test.javafx.scene.control;
 
 import javafx.scene.control.Separator;
+import org.junit.After;
 import test.com.sun.javafx.pgstub.StubToolkit;
 import com.sun.javafx.tk.Toolkit;
 
-import static org.junit.Assert.fail;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.assertPseudoClassDoesNotExist;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.assertPseudoClassExists;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.assertStyleClassContains;
@@ -69,9 +69,6 @@ public class ChoiceBoxTest {
     private Stage stage;
 
     @Before public void setup() {
-        //This step is not needed (Just to make sure StubToolkit is loaded into VM)
-        tk = (StubToolkit)Toolkit.getToolkit();
-
         Thread.currentThread().setUncaughtExceptionHandler((thread, throwable) -> {
             if (throwable instanceof RuntimeException) {
                 throw (RuntimeException) throwable;
@@ -79,6 +76,13 @@ public class ChoiceBoxTest {
                 Thread.currentThread().getThreadGroup().uncaughtException(thread, throwable);
             }
         });
+
+        //This step is not needed (Just to make sure StubToolkit is loaded into VM)
+        tk = (StubToolkit)Toolkit.getToolkit();
+    }
+
+    @After public void cleanUp() {
+        Thread.currentThread().setUncaughtExceptionHandler(null);
     }
 
     protected void startApp(Parent root) {
@@ -168,11 +172,7 @@ public class ChoiceBoxTest {
         box.setItems(items);
         box.setSelectionModel(null);
 
-        try {
-            box.setValue(items.get(1));
-        } catch (Exception e) {
-            fail("ChoiceBox.setValue() should not throw an exception.");
-        }
+        box.setValue(items.get(1));
 
         String text = ChoiceBoxSkinNodesShim.getChoiceBoxSelectedText((ChoiceBoxSkin<?>) box.getSkin());
         assertEquals(items.get(1), text);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxTest.java
@@ -62,9 +62,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-
 public class ChoiceBoxTest {
     private final ChoiceBox<String> box = new ChoiceBox<String>();
     private Toolkit tk;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,12 +56,13 @@ import javafx.scene.control.SelectionModelShim;
 import javafx.scene.control.SingleSelectionModel;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
-import javafx.event.Event;
-import javafx.event.EventHandler;
 
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 
 public class ChoiceBoxTest {
     private final ChoiceBox<String> box = new ChoiceBox<String>();
@@ -152,6 +153,26 @@ public class ChoiceBoxTest {
     @Test public void selectionModelCanBeNull() {
         box.setSelectionModel(null);
         assertNull(box.getSelectionModel());
+    }
+
+    @Test public void testNullSelectionModelDoesNotThrowNPEOnValueChange() {
+        PrintStream defaultErrorStream = System.err;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(out, true));
+
+        ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
+
+        box.setSkin(new ChoiceBoxSkin<>(box));
+        box.setItems(items);
+        box.setSelectionModel(null);
+
+        box.setValue(items.get(1));
+
+        String text = ChoiceBoxSkinNodesShim.getChoiceBoxSelectedText((ChoiceBoxSkin<?>) box.getSkin());
+        assertEquals(items.get(1), text);
+
+        System.setErr(defaultErrorStream);
+        assertEquals("No NPE should be thrown", "", out.toString());
     }
 
     @Test public void selectionModelCanBeBound() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -46,6 +46,8 @@ import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -283,6 +285,32 @@ public class ComboBoxTest {
     @Test public void selectionModelCanBeNull() {
         comboBox.setSelectionModel(null);
         assertNull(comboBox.getSelectionModel());
+    }
+
+    @Test public void testNullSelectionModelDoesNotThrowNPEOnValueChange() {
+        PrintStream defaultErrorStream = System.err;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(out, true));
+
+        ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
+
+        ListCell<String> buttonCell = new ListCell<>() {
+            @Override
+            protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+                setText(item);
+            }
+        };
+        comboBox.setButtonCell(buttonCell);
+        comboBox.setItems(items);
+        comboBox.setSelectionModel(null);
+
+        comboBox.setValue(items.get(1));
+
+        assertEquals(items.get(1), comboBox.getButtonCell().getText());
+
+        System.setErr(defaultErrorStream);
+        assertEquals("No NPE should be thrown", "", out.toString());
     }
 
     @Test public void selectionModelCanBeBound() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -288,10 +288,6 @@ public class ComboBoxTest {
     }
 
     @Test public void testNullSelectionModelDoesNotThrowNPEOnValueChange() {
-        PrintStream defaultErrorStream = System.err;
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        System.setErr(new PrintStream(out, true));
-
         ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
 
         ListCell<String> buttonCell = new ListCell<>() {
@@ -305,12 +301,13 @@ public class ComboBoxTest {
         comboBox.setItems(items);
         comboBox.setSelectionModel(null);
 
-        comboBox.setValue(items.get(1));
+        try {
+            comboBox.setValue(items.get(1));
+        } catch (Exception e) {
+            fail("ComboBox.setValue() should not throw an exception.");
+        }
 
         assertEquals(items.get(1), comboBox.getButtonCell().getText());
-
-        System.setErr(defaultErrorStream);
-        assertEquals("No NPE should be thrown", "", out.toString());
     }
 
     @Test public void selectionModelCanBeBound() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -304,6 +304,38 @@ public class ComboBoxTest {
         assertEquals(items.get(1), comboBox.getButtonCell().getText());
     }
 
+    @Test public void testNullSelectionModelDoesNotThrowNPEInSkinOnLayout() {
+        ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
+
+        ListCell<String> buttonCell = new ListCell<>() {
+            @Override
+            protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+                setText(item);
+            }
+        };
+        comboBox.setButtonCell(buttonCell);
+        comboBox.setItems(items);
+
+        comboBox.setValue(items.get(1));
+        comboBox.setSelectionModel(null);
+
+        comboBox.layout();
+
+        assertEquals(items.get(1), comboBox.getButtonCell().getText());
+    }
+
+    @Test public void testNullSelectionModelDoesNotThrowNPEOnEditableChange() {
+        ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
+
+        comboBox.setEditable(true);
+        comboBox.setItems(items);
+        comboBox.setSelectionModel(null);
+        comboBox.setEditable(false);
+
+        assertNull(comboBox.getValue());
+    }
+
     @Test public void testNullSelectionModelDoesNotThrowNPEOnValueChange() {
         ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -354,6 +354,14 @@ public class ComboBoxTest {
         listView.getSelectionModel().select(1);
     }
 
+    @Test public void testNullSelectionModelDoesNotThrowNPEOnSkinCreation() {
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setSelectionModel(null);
+
+        // Should not throw an NPE.
+        comboBox.setSkin(new ComboBoxListViewSkin<>(comboBox));
+    }
+
     @Test public void selectionModelCanBeBound() {
         SingleSelectionModel<String> sm = ComboBoxShim.<String>get_ComboBoxSelectionModel(comboBox);
         ObjectProperty<SingleSelectionModel<String>> other = new SimpleObjectProperty<SingleSelectionModel<String>>(sm);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -46,8 +46,6 @@ import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -349,9 +349,9 @@ public class ComboBoxTest {
         comboBox.setSelectionModel(null);
         ListView<String> listView = (ListView<String>) ((ComboBoxListViewSkin<String>) comboBox.getSkin())
                 .getPopupContent();
-        listView.getSelectionModel().select(1);
 
-        assertNull(comboBox.getValue());
+        // Should not throw an NPE.
+        listView.getSelectionModel().select(1);
     }
 
     @Test public void selectionModelCanBeBound() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -285,7 +285,7 @@ public class ComboBoxTest {
         assertNull(comboBox.getSelectionModel());
     }
 
-    @Test public void testNullSelectionModelDoesNotThrowNPEOnValueChange() {
+    @Test public void testNullSelectionModelDoesNotThrowNPEInSkinOnValueChange() {
         ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
 
         ListCell<String> buttonCell = new ListCell<>() {
@@ -299,13 +299,30 @@ public class ComboBoxTest {
         comboBox.setItems(items);
         comboBox.setSelectionModel(null);
 
-        try {
-            comboBox.setValue(items.get(1));
-        } catch (Exception e) {
-            fail("ComboBox.setValue() should not throw an exception.");
-        }
+        comboBox.setValue(items.get(1));
 
         assertEquals(items.get(1), comboBox.getButtonCell().getText());
+    }
+
+    @Test public void testNullSelectionModelDoesNotThrowNPEOnValueChange() {
+        ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
+
+        ListCell<String> buttonCell = new ListCell<>() {
+            @Override
+            protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+                setText(item);
+            }
+        };
+
+        ComboBox<String> comboBox = new ComboBox<>();
+        comboBox.setButtonCell(buttonCell);
+        comboBox.setItems(items);
+        comboBox.setSelectionModel(null);
+
+        comboBox.setValue(items.get(1));
+
+        assertEquals(items.get(1), comboBox.getValue());
     }
 
     @Test public void selectionModelCanBeBound() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -299,30 +299,23 @@ public class ComboBoxTest {
         comboBox.setItems(items);
         comboBox.setSelectionModel(null);
 
+        // Should not throw an NPE.
         comboBox.setValue(items.get(1));
 
+        assertEquals(items.get(1), comboBox.getValue());
         assertEquals(items.get(1), comboBox.getButtonCell().getText());
     }
 
     @Test public void testNullSelectionModelDoesNotThrowNPEInSkinOnLayout() {
         ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
 
-        ListCell<String> buttonCell = new ListCell<>() {
-            @Override
-            protected void updateItem(String item, boolean empty) {
-                super.updateItem(item, empty);
-                setText(item);
-            }
-        };
-        comboBox.setButtonCell(buttonCell);
         comboBox.setItems(items);
 
         comboBox.setValue(items.get(1));
         comboBox.setSelectionModel(null);
 
+        // Should not throw an NPE.
         comboBox.layout();
-
-        assertEquals(items.get(1), comboBox.getButtonCell().getText());
     }
 
     @Test public void testNullSelectionModelDoesNotThrowNPEOnEditableChange() {
@@ -331,9 +324,9 @@ public class ComboBoxTest {
         comboBox.setEditable(true);
         comboBox.setItems(items);
         comboBox.setSelectionModel(null);
-        comboBox.setEditable(false);
 
-        assertNull(comboBox.getValue());
+        // Should not throw an NPE.
+        comboBox.setEditable(false);
     }
 
     @Test public void testNullSelectionModelDoesNotThrowNPEOnValueChange() {
@@ -343,9 +336,22 @@ public class ComboBoxTest {
         comboBox.setItems(items);
         comboBox.setSelectionModel(null);
 
+        // Should not throw an NPE.
         comboBox.setValue(items.get(1));
 
         assertEquals(items.get(1), comboBox.getValue());
+    }
+
+    @Test public void testNullSelectionModelDoesNotThrowNPEOnListViewSelect() {
+        ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
+
+        comboBox.setItems(items);
+        comboBox.setSelectionModel(null);
+        ListView<String> listView = (ListView<String>) ((ComboBoxListViewSkin<String>) comboBox.getSkin())
+                .getPopupContent();
+        listView.getSelectionModel().select(1);
+
+        assertNull(comboBox.getValue());
     }
 
     @Test public void selectionModelCanBeBound() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboBoxTest.java
@@ -307,16 +307,7 @@ public class ComboBoxTest {
     @Test public void testNullSelectionModelDoesNotThrowNPEOnValueChange() {
         ObservableList<String> items = FXCollections.observableArrayList("ITEM1", "ITEM2");
 
-        ListCell<String> buttonCell = new ListCell<>() {
-            @Override
-            protected void updateItem(String item, boolean empty) {
-                super.updateItem(item, empty);
-                setText(item);
-            }
-        };
-
         ComboBox<String> comboBox = new ComboBox<>();
-        comboBox.setButtonCell(buttonCell);
         comboBox.setItems(items);
         comboBox.setSelectionModel(null);
 


### PR DESCRIPTION
This PR fixes multiple NPEs in Choice-and ComboBox, when the selection model is null.

ChoiceBox: 
- Null check in **valueProperty()** listener

ComboBox:
- Null check in **editableProperty()** listener
- Null check in **valueProperty()** listener
- Null check in **ComboBoxListViewSkin#updateValue()**
- Null check in **ComboBoxListViewSkin#layoutChildren()**
- 2x Null check in **ComboBoxListViewSkin#createListView()**

~~The tests checks, that no NPE is printed to the console.
Some checks, that the set value is still displayed (either in the ComboBox button cell or the ChoiceBox display label)~~

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8089398](https://bugs.openjdk.java.net/browse/JDK-8089398): [ChoiceBox, ComboBox] throws NPE on setting value on null selectionModel


### Reviewers
 * [Jeanette Winzenburg](https://openjdk.java.net/census#fastegal) (@kleopatra - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/557/head:pull/557` \
`$ git checkout pull/557`

Update a local copy of the PR: \
`$ git checkout pull/557` \
`$ git pull https://git.openjdk.java.net/jfx pull/557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 557`

View PR using the GUI difftool: \
`$ git pr show -t 557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/557.diff">https://git.openjdk.java.net/jfx/pull/557.diff</a>

</details>
