### PR TITLE
8258499: JavaFX: Move src.zip out of the lib directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4754,7 +4754,7 @@ compileTargets { t ->
     // and the standalone sdk should be independent of one another, but seems
     // better than the alternatives.
     def zipSourceFilesTask = project.task("zipSourceFilesStandalone$t.capital", type: Zip, dependsOn: buildModulesTask) {
-        destinationDirectory = file("${standaloneLibDir}")
+        destinationDirectory = file("${standaloneSdkDir}")
         archiveFileName = standaloneSrcZipName
         includeEmptyDirs = false
         from modulesSrcDir


### PR DESCRIPTION
The JavaFX SDK bundle provides a set of modular jars in the `lib` directory. It provides a `src.zip` file for use by IDEs in that same `lib` directory. If a developer adds the `lib` directory to their application's module path in the IDE, it will try to load `src.zip` as if it were a jar file, and will fail. This is a pain point for developers using the SDK. 

The proposed solution is to move the `src.zip` file from the lib directory to the top directory of the SDK.

With this fix, the layout of the SDK will be:

```
<sdk>/
    bin/                      (Windows)
        <native libraries>    (Windows)

    legal/
        ...

    lib/
        *.jar
        <native libraries>    (macOS and Linux)

    src.zip
```

NOTES:
1. The JavaFX Eclipse plugin will need a minor change, which is tracked by eclipse-efx/efxclipse-eclipse#85.
2. This still needs to be tested on IntelliJ

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8258499](https://bugs.openjdk.java.net/browse/JDK-8258499): JavaFX: Move src.zip out of the lib directory


### Reviewers
 * [Marius Hanl](https://openjdk.java.net/census#mhanl) (@Maran23 - Author)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/558/head:pull/558` \
`$ git checkout pull/558`

Update a local copy of the PR: \
`$ git checkout pull/558` \
`$ git pull https://git.openjdk.java.net/jfx pull/558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 558`

View PR using the GUI difftool: \
`$ git pr show -t 558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/558.diff">https://git.openjdk.java.net/jfx/pull/558.diff</a>

</details>
