### PR TITLE
8268718: [macos] Video stops, but audio continues to play when stopTime is reached

### DIFF
--- a/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFMediaPlayer.mm
+++ b/modules/javafx.media/src/main/native/jfxmedia/platform/osx/avf/AVFMediaPlayer.mm
@@ -333,6 +333,9 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink,
 - (void) setCurrentTime:(double)time
 {
     [self.player seekToTime:CMTimeMakeWithSeconds(time, 1)];
+    if (previousPlayerState == kPlayerState_FINISHED) {
+        [self play];
+    }
 }
 
 - (BOOL) mute {
@@ -402,6 +405,8 @@ static CVReturn displayLinkCallback(CVDisplayLinkRef displayLink,
 }
 
 - (void) finish {
+    [self.player pause];
+    [self setPlayerState:kPlayerState_FINISHED];
 }
 
 - (void) dispose {


### PR DESCRIPTION
Not sure why, but our finish() handle was not implemented on OSXPlatform. This handle should pause media stream when called. Also, seek should restart playback when we finish playing video. With proposed fix OSXPlatform will behave same as GSTPlatform. Stop playback when stopTime is reached and resume playback if seek is performed after EndOfMedia or stopTime is reached.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268718](https://bugs.openjdk.java.net/browse/JDK-8268718): [macos] Video stops, but audio continues to play when stopTime is reached


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/559/head:pull/559` \
`$ git checkout pull/559`

Update a local copy of the PR: \
`$ git checkout pull/559` \
`$ git pull https://git.openjdk.java.net/jfx pull/559/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 559`

View PR using the GUI difftool: \
`$ git pr show -t 559`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/559.diff">https://git.openjdk.java.net/jfx/pull/559.diff</a>

</details>
