### PR TITLE
8187229: Tree/TableCell: cancel event must return correct editing location

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
@@ -299,6 +299,9 @@ public class TableCell<S,T> extends IndexedCell<T> {
      *                                                                         *
      **************************************************************************/
 
+    // editing location at start of edit - fix for JDK-8187229
+    private TablePosition<S, T> editingCellAtStartEdit;
+
     /** {@inheritDoc} */
     @Override public void startEdit() {
         final TableView<S> table = getTableView();
@@ -333,6 +336,7 @@ public class TableCell<S,T> extends IndexedCell<T> {
 
             Event.fireEvent(column, editEvent);
         }
+        editingCellAtStartEdit = new TablePosition<>(table, getIndex(), column);
     }
 
     /** {@inheritDoc} */
@@ -384,7 +388,6 @@ public class TableCell<S,T> extends IndexedCell<T> {
 
         // reset the editing index on the TableView
         if (table != null) {
-            TablePosition<S,?> editingCell = table.getEditingCell();
             if (updateEditingIndex) table.edit(-1, null);
 
             // request focus back onto the table, only if the current focus
@@ -395,7 +398,7 @@ public class TableCell<S,T> extends IndexedCell<T> {
 
             CellEditEvent<S,?> editEvent = new CellEditEvent<>(
                 table,
-                editingCell,
+                editingCellAtStartEdit,
                 TableColumn.editCancelEvent(),
                 null
             );
@@ -703,9 +706,6 @@ public class TableCell<S,T> extends IndexedCell<T> {
         }
         super.layoutChildren();
     }
-
-
-
 
     /***************************************************************************
      *                                                                         *

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TablePosition.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TablePosition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,7 +70,7 @@ public class TablePosition<S,T> extends TablePositionBase<TableColumn<S,T>> {
         super(row, tableColumn);
         this.controlRef = new WeakReference<>(tableView);
 
-        List<S> items = tableView.getItems();
+        List<S> items = tableView != null ? tableView.getItems() : null;
         this.itemRef = new WeakReference<>(
                 items != null && row >= 0 && row < items.size() ? items.get(row) : null);
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
@@ -300,6 +300,9 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
      *                                                                         *
      **************************************************************************/
 
+    // editing location at start of edit - fix for JDK-8187229
+    private TreeTablePosition<S, T> editingCellAtStartEdit = null;
+
     /** {@inheritDoc} */
     @Override public void startEdit() {
         if (isEditing()) return;
@@ -336,6 +339,7 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
 
             Event.fireEvent(column, editEvent);
         }
+        editingCellAtStartEdit = new TreeTablePosition<>(table, getIndex(), column);
     }
 
     /** {@inheritDoc} */
@@ -390,9 +394,6 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
 
         // reset the editing index on the TableView
         if (table != null) {
-            @SuppressWarnings("unchecked")
-            TreeTablePosition<S,T> editingCell = (TreeTablePosition<S,T>) table.getEditingCell();
-
             if (updateEditingIndex) table.edit(-1, null);
 
             // request focus back onto the table, only if the current focus
@@ -403,7 +404,7 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
 
             CellEditEvent<S,T> editEvent = new CellEditEvent<S,T>(
                 table,
-                editingCell,
+                editingCellAtStartEdit,
                 TreeTableColumn.<S,T>editCancelEvent(),
                 null
             );

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTablePosition.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTablePosition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,8 @@ public class TreeTablePosition<S,T> extends TablePositionBase<TreeTableColumn<S,
     TreeTablePosition(@NamedArg("treeTableView") TreeTableView<S> treeTableView, @NamedArg("row") int row, @NamedArg("tableColumn") TreeTableColumn<S,T> tableColumn, boolean doLookup) {
         super(row, tableColumn);
         this.controlRef = new WeakReference<>(treeTableView);
-        this.treeItemRef = new WeakReference<>(doLookup ? treeTableView.getTreeItem(row) : null);
+        this.treeItemRef = new WeakReference<>(doLookup ?
+                (treeTableView != null ? treeTableView.getTreeItem(row) : null) : null);
 
         nonFixedColumnIndex = treeTableView == null || tableColumn == null ? -1 : treeTableView.getVisibleLeafIndex(tableColumn);
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
@@ -415,11 +415,9 @@ public class TableCellTest {
         assertFalse(cell.isEditing());
     }
 
-//------------ testing editCancel event: location on event - JDK-8187229
-
     /**
      * Basic config of table-/cell to allow testing of editEvents:
-     * table has editingColumn and cell is configured with table and column.
+     * table is editable, has editingColumn and cell is configured with table and column.
      */
     private void setupForEditing() {
         table.setEditable(true);
@@ -431,10 +429,6 @@ public class TableCellTest {
         cell.updateTableColumn(editingColumn);
     }
 
-
-    /**
-     * Passes before fix of JDK-8187229, must pass after.
-     */
     @Test
     public void testEditCancelEventAfterCancelOnCell() {
         setupForEditing();
@@ -449,9 +443,6 @@ public class TableCellTest {
         assertEquals("editing location of cancel event", editingPosition, events.get(0).getTablePosition());
     }
 
-    /**
-     * Fails before fix of JDK-8187229.
-     */
     @Test
     public void testEditCancelEventAfterCancelOnTable() {
         setupForEditing();
@@ -466,9 +457,6 @@ public class TableCellTest {
         assertEquals("editing location of cancel event", editingPosition, events.get(0).getTablePosition());
     }
 
-    /**
-     * Passes before fix of JDK-8187229, must pass after.
-     */
     @Test
     public void testEditCancelEventAfterCellReuse() {
         setupForEditing();
@@ -483,9 +471,6 @@ public class TableCellTest {
         assertEquals("editing location of cancel event", editingPosition, events.get(0).getTablePosition());
     }
 
-    /**
-     * Fails before fix of JDK-8187229.
-     */
     @Test
     public void testEditCancelEventAfterModifyItems() {
         setupForEditing();
@@ -522,9 +507,7 @@ public class TableCellTest {
     }
 
     /**
-     * Sanity test: fix must not introduce a memory leak.
-     * Note: not an issue for Tree/TableCell because we store the Tree/TablePosition which
-     * takes care of wrapping everything into weakRefs.
+     * Test that removing the editing item does not cause a memory leak.
      */
     @Test
     public void testEditCancelMemoryLeakAfterRemoveEditingItem() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
@@ -25,33 +25,44 @@
 
 package test.javafx.scene.control;
 
-import javafx.scene.control.TableRow;
-import javafx.scene.control.TreeTableRow;
-import javafx.scene.control.skin.TableCellSkin;
-import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
-import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
-import javafx.scene.control.TableCell;
-import javafx.scene.control.TableCellShim;
-import javafx.scene.control.TableColumn;
-import javafx.scene.control.TableView;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.assertStyleClassContains;
+import com.sun.javafx.tk.Toolkit;
+
 import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
+import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.*;
+import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory.*;
+
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableCellShim;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableColumn.CellEditEvent;
+import javafx.scene.control.TablePosition;
+import javafx.scene.control.TableRow;
+import javafx.scene.control.TableView;
+import javafx.scene.control.skin.TableCellSkin;
+import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
+import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
 
 /**
  */
 public class TableCellTest {
     private TableCell<String,String> cell;
     private TableView<String> table;
+    private TableColumn<String, String> editingColumn;
     private TableRow<String> row;
     private ObservableList<String> model;
+    private StageLoader stageLoader;
 
     @Before public void setup() {
         Thread.currentThread().setUncaughtExceptionHandler((thread, throwable) -> {
@@ -65,12 +76,14 @@ public class TableCellTest {
         cell = new TableCell<String,String>();
         model = FXCollections.observableArrayList("Four", "Five", "Fear"); // "Flop", "Food", "Fizz"
         table = new TableView<String>(model);
+        editingColumn = new TableColumn<>("TEST");
 
         row = new TableRow<>();
     }
 
     @After
     public void cleanup() {
+        if (stageLoader != null) stageLoader.dispose();
         Thread.currentThread().setUncaughtExceptionHandler(null);
     }
 
@@ -400,6 +413,137 @@ public class TableCellTest {
         cell.startEdit();
 
         assertFalse(cell.isEditing());
+    }
+
+//------------ testing editCancel event: location on event - JDK-8187229
+
+    /**
+     * Basic config of table-/cell to allow testing of editEvents:
+     * table has editingColumn and cell is configured with table and column.
+     */
+    private void setupForEditing() {
+        table.setEditable(true);
+        table.getColumns().add(editingColumn);
+        // FIXME: default cell (of tableColumn) needs not-null value for firing cancel
+        editingColumn.setCellValueFactory(cc -> new SimpleObjectProperty<>(""));
+
+        cell.updateTableView(table);
+        cell.updateTableColumn(editingColumn);
+    }
+
+
+    /**
+     * Passes before fix of JDK-8187229, must pass after.
+     */
+    @Test
+    public void testEditCancelEventAfterCancelOnCell() {
+        setupForEditing();
+        int editingIndex = 1;
+        cell.updateIndex(editingIndex);
+        table.edit(editingIndex, editingColumn);
+        TablePosition<?, ?> editingPosition = table.getEditingCell();
+        List<CellEditEvent<?, ?>> events = new ArrayList<>();
+        editingColumn.setOnEditCancel(events::add);
+        cell.cancelEdit();
+        assertEquals("column must have received editCancel", 1, events.size());
+        assertEquals("editing location of cancel event", editingPosition, events.get(0).getTablePosition());
+    }
+
+    /**
+     * Fails before fix of JDK-8187229.
+     */
+    @Test
+    public void testEditCancelEventAfterCancelOnTable() {
+        setupForEditing();
+        int editingIndex = 1;
+        cell.updateIndex(editingIndex);
+        table.edit(editingIndex, editingColumn);
+        TablePosition<?, ?> editingPosition = table.getEditingCell();
+        List<CellEditEvent<?, ?>> events = new ArrayList<>();
+        editingColumn.setOnEditCancel(events::add);
+        table.edit(-1, null);
+        assertEquals("column must have received editCancel", 1, events.size());
+        assertEquals("editing location of cancel event", editingPosition, events.get(0).getTablePosition());
+    }
+
+    /**
+     * Passes before fix of JDK-8187229, must pass after.
+     */
+    @Test
+    public void testEditCancelEventAfterCellReuse() {
+        setupForEditing();
+        int editingIndex = 1;
+        cell.updateIndex(editingIndex);
+        table.edit(editingIndex, editingColumn);
+        TablePosition<?, ?> editingPosition = table.getEditingCell();
+        List<CellEditEvent<?, ?>> events = new ArrayList<>();
+        editingColumn.setOnEditCancel(events::add);
+        cell.updateIndex(0);
+        assertEquals("column must have received editCancel", 1, events.size());
+        assertEquals("editing location of cancel event", editingPosition, events.get(0).getTablePosition());
+    }
+
+    /**
+     * Fails before fix of JDK-8187229.
+     */
+    @Test
+    public void testEditCancelEventAfterModifyItems() {
+        setupForEditing();
+        stageLoader = new StageLoader(table);
+        int editingIndex = 1;
+        table.edit(editingIndex, editingColumn);
+        TablePosition<?, ?> editingPosition = table.getEditingCell();
+        List<CellEditEvent<?, ?>> events = new ArrayList<>();
+        editingColumn.setOnEditCancel(events::add);
+        table.getItems().add(0, "added");
+        Toolkit.getToolkit().firePulse();
+        assertEquals("column must have received editCancel", 1, events.size());
+        assertEquals("editing location of cancel event", editingPosition, events.get(0).getTablePosition());
+    }
+
+    /**
+     * Test that removing the editing item implicitly cancels an ongoing
+     * edit and fires a correct cancel event.
+     */
+    @Test
+    public void testEditCancelEventAfterRemoveEditingItem() {
+        setupForEditing();
+        stageLoader = new StageLoader(table);
+        int editingIndex = 1;
+        table.edit(editingIndex, editingColumn);
+        TablePosition<?, ?> editingPosition = table.getEditingCell();
+        List<CellEditEvent<?, ?>> events = new ArrayList<>();
+        editingColumn.setOnEditCancel(events::add);
+        table.getItems().remove(editingIndex);
+        Toolkit.getToolkit().firePulse();
+        assertNull("sanity: editing terminated on items modification", table.getEditingCell());
+        assertEquals("column must have received editCancel", 1, events.size());
+        assertEquals("editing location of cancel event", editingPosition, events.get(0).getTablePosition());
+    }
+
+    /**
+     * Sanity test: fix must not introduce a memory leak.
+     * Note: not an issue for Tree/TableCell because we store the Tree/TablePosition which
+     * takes care of wrapping everything into weakRefs.
+     */
+    @Test
+    public void testEditCancelMemoryLeakAfterRemoveEditingItem() {
+        TableView<MenuItem> table = new TableView<>(FXCollections.observableArrayList(
+                new MenuItem("some"), new MenuItem("other")));
+        TableColumn<MenuItem, String> editingColumn = new TableColumn<>("Text");
+        editingColumn.setCellValueFactory(cc -> new SimpleObjectProperty<>(""));
+        table.setEditable(true);
+        table.getColumns().add(editingColumn);
+        stageLoader = new StageLoader(table);
+        int editingIndex = 1;
+        MenuItem editingItem = table.getItems().get(editingIndex);
+        WeakReference<MenuItem> itemRef = new WeakReference<>(editingItem);
+        table.edit(editingIndex, editingColumn);
+        table.getItems().remove(editingIndex);
+        editingItem = null;
+        Toolkit.getToolkit().firePulse();
+        attemptGC(itemRef);
+        assertEquals("item must be gc'ed", null, itemRef.get());
     }
 
     /**

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TablePositionBaseTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TablePositionBaseTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.control;
+
+import org.junit.Test;
+
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TablePosition;
+import javafx.scene.control.TreeTableColumn;
+import javafx.scene.control.TreeTablePosition;
+
+/**
+ * Test Tree/TablePosition.
+ */
+public class TablePositionBaseTest {
+
+//---------- TableView
+
+    /**
+     * JDK-8269136: must not throw on null Table.
+     */
+    @Test
+    public void testNullTable() {
+        new TablePosition<>(null, 2, new TableColumn<>());
+    }
+
+//------------- TreeTableView
+
+    /**
+     * JDK-8269136: must not throw on null TreeTable.
+     */
+    @Test
+    public void testNullTreeTable() {
+        new TreeTablePosition<>(null, 2, new TreeTableColumn<>());
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
@@ -28,19 +28,28 @@ package test.javafx.scene.control;
 import javafx.scene.control.skin.TreeTableCellSkin;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeTableCell;
 import javafx.scene.control.TreeTableCellShim;
 import javafx.scene.control.TreeTableColumn;
+import javafx.scene.control.TreeTableColumn.CellEditEvent;
+import javafx.scene.control.TreeTablePosition;
 import javafx.scene.control.TreeTableRow;
 import javafx.scene.control.TreeTableView;
-import javafx.util.Callback;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import com.sun.javafx.tk.Toolkit;
+
+import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory.*;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.*;
 import static org.junit.Assert.*;
 
@@ -58,6 +67,9 @@ public class TreeTableCellTest {
     private TreeItem<String> apples;
     private TreeItem<String> oranges;
     private TreeItem<String> pears;
+    private StageLoader stageLoader;
+
+    private TreeTableColumn<String, String> editingColumn;
 
     @Before public void setup() {
         Thread.currentThread().setUncaughtExceptionHandler((thread, throwable) -> {
@@ -78,12 +90,14 @@ public class TreeTableCellTest {
 
         tree = new TreeTableView<String>(root);
         root.setExpanded(true);
+        editingColumn = new TreeTableColumn<>("TEST");
 
         row = new TreeTableRow<>();
     }
 
     @After
     public void cleanup() {
+        if (stageLoader != null) stageLoader.dispose();
         Thread.currentThread().setUncaughtExceptionHandler(null);
     }
 
@@ -707,6 +721,145 @@ public class TreeTableCellTest {
 
         assertFalse(cell.isEditing());
     }
+
+//------------ testing editCancel event: location on event - JDK-8187229
+
+    /**
+     * Basic config of treeTable-/cell to allow testing of editEvents:
+     * table has editingColumn and cell is configured with table and column.
+     */
+    private void setupForEditing() {
+        tree.setEditable(true);
+        tree.getColumns().add(editingColumn);
+        // FIXME: default cell (of tableColumn) needs not-null value for firing cancel
+        editingColumn.setCellValueFactory(cc -> new SimpleObjectProperty<>(""));
+
+        cell.updateTreeTableView(tree);
+        cell.updateTreeTableColumn(editingColumn);
+    }
+
+    /**
+     * Sanity test: passes before fix of JDK-8187229, must pass after.
+     */
+    @Test
+    public void testEditCancelEventAfterCancelOnCell() {
+        setupForEditing();
+        int editingIndex = 1;
+        cell.updateIndex(editingIndex);
+        tree.edit(editingIndex, editingColumn);
+        TreeTablePosition<?,?> editingPosition = tree.getEditingCell();
+        List<CellEditEvent<?, ?>> events = new ArrayList<>();
+        editingColumn.setOnEditCancel(events::add);
+        cell.cancelEdit();
+        assertEquals("column must have received editCancel", 1, events.size());
+        assertEquals("editing location of cancel event", editingPosition, events.get(0).getTreeTablePosition());
+    }
+
+    @Test
+    public void testEditCancelEventAfterCancelOnTreeTable() {
+        setupForEditing();
+        int editingIndex = 1;
+        cell.updateIndex(editingIndex);
+        tree.edit(editingIndex, editingColumn);
+        TreeTablePosition<?, ?> editingPosition = tree.getEditingCell();
+        List<CellEditEvent<?, ?>> events = new ArrayList<>();
+        editingColumn.setOnEditCancel(events::add);
+        tree.edit(-1, null);
+        assertEquals("column must have received editCancel", 1, events.size());
+        assertEquals("editing location of cancel event", editingPosition, events.get(0).getTreeTablePosition());
+    }
+
+    /**
+     * Sanity test: passes before fix of JDK-8187229, must pass after.
+     */
+    @Test
+    public void testEditCancelEventAfterCellReuse() {
+        setupForEditing();
+        int editingIndex = 1;
+        cell.updateIndex(editingIndex);
+        tree.edit(editingIndex, editingColumn);
+        TreeTablePosition<?, ?> editingPosition = tree.getEditingCell();
+        List<CellEditEvent<?, ?>> events = new ArrayList<>();
+        editingColumn.setOnEditCancel(events::add);
+        cell.updateIndex(0);
+        assertEquals("column must have received editCancel", 1, events.size());
+        assertEquals("editing location of cancel event", editingPosition, events.get(0).getTreeTablePosition());
+    }
+
+    @Test
+    public void testEditCancelEventAfterCollapse() {
+        setupForEditing();
+        stageLoader = new StageLoader(tree);
+        int editingIndex = 1;
+        tree.edit(editingIndex, editingColumn);
+        TreeTablePosition<?, ?> editingPosition = tree.getEditingCell();
+        List<CellEditEvent<?, ?>> events = new ArrayList<>();
+        editingColumn.setOnEditCancel(events::add);
+        root.setExpanded(false);
+        Toolkit.getToolkit().firePulse();
+        assertEquals("column must have received editCancel", 1, events.size());
+        assertEquals("editing location of cancel event", editingPosition, events.get(0).getTreeTablePosition());
+    }
+
+    @Test
+    public void testEditCancelEventAfterModifyItems() {
+        setupForEditing();
+        stageLoader = new StageLoader(tree);
+        int editingIndex = 2;
+        tree.edit(editingIndex, editingColumn);
+        TreeTablePosition<?, ?> editingPosition = tree.getEditingCell();
+        List<CellEditEvent<?, ?>> events = new ArrayList<>();
+        editingColumn.setOnEditCancel(events::add);
+        root.getChildren().add(0, new TreeItem<>("added"));
+        Toolkit.getToolkit().firePulse();
+        assertNull("sanity: editing terminated on items modification", tree.getEditingCell());
+        assertEquals("column must have received editCancel", 1, events.size());
+        assertEquals("editing location of cancel event", editingPosition, events.get(0).getTreeTablePosition());
+    }
+
+    /**
+     * Test that removing the editing item implicitly cancels an ongoing
+     * edit and fires a correct cancel event.
+     */
+    @Test
+    public void testEditCancelEventAfterRemoveEditingItem() {
+        setupForEditing();
+        stageLoader = new StageLoader(tree);
+        int editingIndex = 1;
+        tree.edit(editingIndex, editingColumn);
+        TreeTablePosition<?, ?> editingPosition = tree.getEditingCell();
+        List<CellEditEvent<?, ?>> events = new ArrayList<>();
+        editingColumn.setOnEditCancel(events::add);
+        root.getChildren().remove(editingIndex - 1);
+        Toolkit.getToolkit().firePulse();
+        assertNull("sanity: editing terminated on items modification", tree.getEditingCell());
+        assertEquals("column must have received editCancel", 1, events.size());
+        assertEquals("editing location of cancel event", editingPosition, events.get(0).getTreeTablePosition());
+    }
+
+    /**
+     * Sanity test: fix must not introduce a memory leak.
+     * Note: not an issue for Tree/TableCell because we store the Tree/TablePosition which
+     * takes care of wrapping everything into weakRefs.
+     */
+    @Test
+    public void testEditCancelMemoryLeakAfterRemoveEditingItem() {
+        setupForEditing();
+        stageLoader = new StageLoader(tree);
+        // the item to test for being gc'ed
+        TreeItem<String> editingItem = new TreeItem<>("added");
+        WeakReference<TreeItem<?>> itemRef = new WeakReference<>(editingItem);
+        root.getChildren().add(0, editingItem);
+        Toolkit.getToolkit().firePulse();
+        int editingIndex = tree.getRow(editingItem);
+        tree.edit(editingIndex, editingColumn);
+        root.getChildren().remove(editingItem);
+        Toolkit.getToolkit().firePulse();
+        editingItem = null;
+        attemptGC(itemRef);
+        assertEquals("treeItem must be gc'ed", null, itemRef.get());
+    }
+
 
     /**
      * Test that cell.cancelEdit can switch table editing off

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
@@ -722,11 +722,9 @@ public class TreeTableCellTest {
         assertFalse(cell.isEditing());
     }
 
-//------------ testing editCancel event: location on event - JDK-8187229
-
     /**
      * Basic config of treeTable-/cell to allow testing of editEvents:
-     * table has editingColumn and cell is configured with table and column.
+     * table is editable, has editingColumn and cell is configured with table and column.
      */
     private void setupForEditing() {
         tree.setEditable(true);
@@ -738,9 +736,6 @@ public class TreeTableCellTest {
         cell.updateTreeTableColumn(editingColumn);
     }
 
-    /**
-     * Sanity test: passes before fix of JDK-8187229, must pass after.
-     */
     @Test
     public void testEditCancelEventAfterCancelOnCell() {
         setupForEditing();
@@ -769,9 +764,6 @@ public class TreeTableCellTest {
         assertEquals("editing location of cancel event", editingPosition, events.get(0).getTreeTablePosition());
     }
 
-    /**
-     * Sanity test: passes before fix of JDK-8187229, must pass after.
-     */
     @Test
     public void testEditCancelEventAfterCellReuse() {
         setupForEditing();
@@ -838,9 +830,7 @@ public class TreeTableCellTest {
     }
 
     /**
-     * Sanity test: fix must not introduce a memory leak.
-     * Note: not an issue for Tree/TableCell because we store the Tree/TablePosition which
-     * takes care of wrapping everything into weakRefs.
+     * Test that removing the editing item does not cause a memory leak.
      */
     @Test
     public void testEditCancelMemoryLeakAfterRemoveEditingItem() {


### PR DESCRIPTION
the bug is an incorrect edit location (for Tree/Table: Tree/TablePosition) in edit cancel events - expected is the location at the time the cell edit was started, actual was the location of at the time the edit was cancelled. See the report for details.

The fix is analogue to those for ListCell/TreeCell, that is storing the edit location in startEdit and use that in cancelEdit.

Added tests that failed before and passed after and tests that (accidentally :) passed before and still pass after.

Related issues:

- also fixes [JDK-8269136](https://bugs.openjdk.java.net/browse/JDK-8269136) (Tree/TablePosition: must not throw NPE on instantiating with null table), in hind-sight it seemed too small to warrant its own PR. 
- does not fix the implementation of CellEditEvent (todo: file follow-up issue) which must not throw with null Tree/TablePosition.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8187229](https://bugs.openjdk.java.net/browse/JDK-8187229): Tree/TableCell: cancel event must return correct editing location
 * [JDK-8269136](https://bugs.openjdk.java.net/browse/JDK-8269136): Tree/TablePosition: must not throw NPE on instantiating with null table


### Reviewers
 * [Marius Hanl](https://openjdk.java.net/census#mhanl) (@Maran23 - Author)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/561/head:pull/561` \
`$ git checkout pull/561`

Update a local copy of the PR: \
`$ git checkout pull/561` \
`$ git pull https://git.openjdk.java.net/jfx pull/561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 561`

View PR using the GUI difftool: \
`$ git pr show -t 561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/561.diff">https://git.openjdk.java.net/jfx/pull/561.diff</a>

</details>
