### PR TITLE
8266743: crash on macOS 10.11 due to ignored check on 10.12

### DIFF
--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -56,7 +56,7 @@ def defaultSdkPath = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOS
 // Set the minimum API version that we require (developers do not need to override this)
 // Note that this is not necessarily the same as the preferred SDK version
 def isAarch64 = TARGET_ARCH == "aarch64" || TARGET_ARCH == "arm64";
-def macOSMinVersion = isAarch64 ? "11.0" : "10.12";
+def macOSMinVersion = isAarch64 ? "11.0" : "10.10";
 defineProperty("MACOSX_MIN_VERSION", macOSMinVersion);
 
 // Create $buildDir/mac_tools.properties file and load props from it


### PR DESCRIPTION
This fix restores the minimum macOS version needed to run JavaFX on x64 platforms to 10.10.

The fix for [JDK-8265031](https://bugs.openjdk.java.net/browse/JDK-8265031) bumped the minimum version for macOS on aarch64 to 11.0 and on x64 to 10.12. The change on aarch64 was necessary, since that is the minimum version that will run on Apple Silicon. The change on x64 was not necessary, but was done to match JDK 17. In connection with the fix for [JDK-8263169](https://bugs.openjdk.java.net/browse/JDK-8263169), this causes a crash on older macOS systems running 10.10 or 10.11. The long term solution is to detect and throw an exception at startup if the version of macOS is below the minimum, but for JavaFX 17 it was felt that restoring the minimum of macOS 10.10 for x64 platforms was safer.

See the discussion in JBS for more information.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8266743](https://bugs.openjdk.java.net/browse/JDK-8266743): crash on macOS 10.11 due to ignored check on 10.12


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/565/head:pull/565` \
`$ git checkout pull/565`

Update a local copy of the PR: \
`$ git checkout pull/565` \
`$ git pull https://git.openjdk.java.net/jfx pull/565/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 565`

View PR using the GUI difftool: \
`$ git pr show -t 565`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/565.diff">https://git.openjdk.java.net/jfx/pull/565.diff</a>

</details>
