### PR TITLE
8266743: Crash on macOS 10.11 due to ignored @available 10.12 check

### DIFF
--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -56,7 +56,7 @@ def defaultSdkPath = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOS
 // Set the minimum API version that we require (developers do not need to override this)
 // Note that this is not necessarily the same as the preferred SDK version
 def isAarch64 = TARGET_ARCH == "aarch64" || TARGET_ARCH == "arm64";
-def macOSMinVersion = isAarch64 ? "11.0" : "10.12";
+def macOSMinVersion = isAarch64 ? "11.0" : "10.10";
 defineProperty("MACOSX_MIN_VERSION", macOSMinVersion);
 
 // Create $buildDir/mac_tools.properties file and load props from it

--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -59,6 +59,10 @@ def isAarch64 = TARGET_ARCH == "aarch64" || TARGET_ARCH == "arm64";
 def macOSMinVersion = isAarch64 ? "11.0" : "10.10";
 defineProperty("MACOSX_MIN_VERSION", macOSMinVersion);
 
+def macOSMinVersionArr = macOSMinVersion.split("\\.")
+def macOSMinVersionMajor = macOSMinVersionArr[0]
+def macOSMinVersionMinor = macOSMinVersionArr[1]
+
 // Create $buildDir/mac_tools.properties file and load props from it
 setupTools("mac_tools",
     { propFile ->
@@ -178,7 +182,9 @@ MAC.glass.javahInclude = [
     "com/sun/glass/ui/mac/*"]
 MAC.glass.nativeSource = file("${project("graphics").projectDir}/src/main/native-glass/mac")
 MAC.glass.compiler = compiler
-MAC.glass.ccFlags = [ccFlags].flatten()
+MAC.glass.ccFlags = [ccFlags,
+    "-DMACOS_MIN_VERSION_MAJOR=$macOSMinVersionMajor",
+    "-DMACOS_MIN_VERSION_MINOR=$macOSMinVersionMinor"].flatten()
 MAC.glass.linker = linker
 MAC.glass.linkFlags = [linkFlags].flatten()
 MAC.glass.lib = "glass"

--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -59,10 +59,6 @@ def isAarch64 = TARGET_ARCH == "aarch64" || TARGET_ARCH == "arm64";
 def macOSMinVersion = isAarch64 ? "11.0" : "10.10";
 defineProperty("MACOSX_MIN_VERSION", macOSMinVersion);
 
-def macOSMinVersionArr = macOSMinVersion.split("\\.")
-def macOSMinVersionMajor = macOSMinVersionArr[0]
-def macOSMinVersionMinor = macOSMinVersionArr[1]
-
 // Create $buildDir/mac_tools.properties file and load props from it
 setupTools("mac_tools",
     { propFile ->
@@ -182,9 +178,7 @@ MAC.glass.javahInclude = [
     "com/sun/glass/ui/mac/*"]
 MAC.glass.nativeSource = file("${project("graphics").projectDir}/src/main/native-glass/mac")
 MAC.glass.compiler = compiler
-MAC.glass.ccFlags = [ccFlags,
-    "-DMACOS_MIN_VERSION_MAJOR=$macOSMinVersionMajor",
-    "-DMACOS_MIN_VERSION_MINOR=$macOSMinVersionMinor"].flatten()
+MAC.glass.ccFlags = [ccFlags].flatten()
 MAC.glass.linker = linker
 MAC.glass.linkFlags = [linkFlags].flatten()
 MAC.glass.lib = "glass"

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -821,43 +821,6 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacApplication__1initIDs
             env, jClass, "notifyApplicationDidTerminate", "()V");
     if ((*env)->ExceptionCheck(env)) return;
 
-    // Check minimum OS version
-    NSOperatingSystemVersion osVer;
-    osVer = [[NSProcessInfo processInfo] operatingSystemVersion];
-    NSInteger osVerMajor = osVer.majorVersion;
-    NSInteger osVerMinor = osVer.minorVersion;
-
-    // KCR: begin debug
-    NSLog(@"macOSMinVersion = %d . %d", MACOS_MIN_VERSION_MAJOR, MACOS_MIN_VERSION_MINOR);
-    NSLog(@"    osVer (raw)      = %d . %d", (int)osVerMajor, (int)osVerMinor);
-    // KCR: end debug
-
-    // Map 10.16 to 11.0, since macOS will return 10.16 by default (for compatibility)
-    if (osVerMajor == 10 && osVerMinor >= 16) {
-        // FIXME: if we ever need to know which minor version of macOS 11.x we
-        // are running on, we will need to look it up using a similar technique
-        // to what the JDK does.
-        osVerMajor = 11;
-        osVerMinor = 0;
-    }
-
-    // KCR: begin debug
-    NSLog(@"    osVer (adjusted) = %d . %d", (int)osVerMajor, (int)osVerMinor);
-    // KCR: end debug
-
-    if (osVerMajor < MACOS_MIN_VERSION_MAJOR ||
-            (osVerMajor == MACOS_MIN_VERSION_MAJOR &&
-             osVerMinor < MACOS_MIN_VERSION_MINOR))
-    {
-        NSLog(@"ERROR: macOS version is %d.%d, which is below the minimum of %d.%d",
-              (int)osVerMajor, (int)osVerMinor, MACOS_MIN_VERSION_MAJOR, MACOS_MIN_VERSION_MINOR);
-        jclass exceptionClass = (*env)->FindClass(env, "java/lang/RuntimeException");
-        if (exceptionClass != 0) {
-            (*env)->ThrowNew(env, exceptionClass, "Unsupported macOS version");
-        }
-        return;
-    }
-
     if (jRunnableRun == NULL)
     {
         jclass jcls = (*env)->FindClass(env, "java/lang/Runnable");

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -821,6 +821,43 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacApplication__1initIDs
             env, jClass, "notifyApplicationDidTerminate", "()V");
     if ((*env)->ExceptionCheck(env)) return;
 
+    // Check minimum OS version
+    NSOperatingSystemVersion osVer;
+    osVer = [[NSProcessInfo processInfo] operatingSystemVersion];
+    NSInteger osVerMajor = osVer.majorVersion;
+    NSInteger osVerMinor = osVer.minorVersion;
+
+    // KCR: begin debug
+    NSLog(@"macOSMinVersion = %d . %d", MACOS_MIN_VERSION_MAJOR, MACOS_MIN_VERSION_MINOR);
+    NSLog(@"    osVer (raw)      = %d . %d", (int)osVerMajor, (int)osVerMinor);
+    // KCR: end debug
+
+    // Map 10.16 to 11.0, since macOS will return 10.16 by default (for compatibility)
+    if (osVerMajor == 10 && osVerMinor >= 16) {
+        // FIXME: if we ever need to know which minor version of macOS 11.x we
+        // are running on, we will need to look it up using a similar technique
+        // to what the JDK does.
+        osVerMajor = 11;
+        osVerMinor = 0;
+    }
+
+    // KCR: begin debug
+    NSLog(@"    osVer (adjusted) = %d . %d", (int)osVerMajor, (int)osVerMinor);
+    // KCR: end debug
+
+    if (osVerMajor < MACOS_MIN_VERSION_MAJOR ||
+            (osVerMajor == MACOS_MIN_VERSION_MAJOR &&
+             osVerMinor < MACOS_MIN_VERSION_MINOR))
+    {
+        NSLog(@"ERROR: macOS version is %d.%d, which is below the minimum of %d.%d",
+              (int)osVerMajor, (int)osVerMinor, MACOS_MIN_VERSION_MAJOR, MACOS_MIN_VERSION_MINOR);
+        jclass exceptionClass = (*env)->FindClass(env, "java/lang/RuntimeException");
+        if (exceptionClass != 0) {
+            (*env)->ThrowNew(env, exceptionClass, "Unsupported macOS version");
+        }
+        return;
+    }
+
     if (jRunnableRun == NULL)
     {
         jclass jcls = (*env)->FindClass(env, "java/lang/Runnable");


### PR DESCRIPTION
This fix restores the minimum macOS version needed to run JavaFX on x64 platforms to 10.10.

The fix for [JDK-8265031](https://bugs.openjdk.java.net/browse/JDK-8265031) bumped the minimum version for macOS on aarch64 to 11.0 and on x64 to 10.12. The change on aarch64 was necessary, since that is the minimum version that will run on Apple Silicon. The change on x64 was not necessary, but was done to match JDK 17. In connection with the fix for [JDK-8263169](https://bugs.openjdk.java.net/browse/JDK-8263169), this causes a crash on older macOS systems running 10.10 or 10.11. The long term solution is to detect and throw an exception at startup if the version of macOS is below the minimum, but for JavaFX 17 it was felt that restoring the minimum of macOS 10.10 for x64 platforms was safer.

See the discussion in JBS for more information.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8266743](https://bugs.openjdk.java.net/browse/JDK-8266743): Crash on macOS 10.11 due to ignored @available 10.12 check


### Reviewers
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/566/head:pull/566` \
`$ git checkout pull/566`

Update a local copy of the PR: \
`$ git checkout pull/566` \
`$ git pull https://git.openjdk.java.net/jfx pull/566/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 566`

View PR using the GUI difftool: \
`$ git pr show -t 566`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/566.diff">https://git.openjdk.java.net/jfx/pull/566.diff</a>

</details>
