### PR TITLE
8269967: JavaFX should fail fast on macOS below minimum version

### DIFF
--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -59,6 +59,10 @@ def isAarch64 = TARGET_ARCH == "aarch64" || TARGET_ARCH == "arm64";
 def macOSMinVersion = isAarch64 ? "11.0" : "10.10";
 defineProperty("MACOSX_MIN_VERSION", macOSMinVersion);
 
+def macOSMinVersionArr = macOSMinVersion.split("\\.")
+def macOSMinVersionMajor = macOSMinVersionArr[0]
+def macOSMinVersionMinor = macOSMinVersionArr[1]
+
 // Create $buildDir/mac_tools.properties file and load props from it
 setupTools("mac_tools",
     { propFile ->
@@ -178,7 +182,9 @@ MAC.glass.javahInclude = [
     "com/sun/glass/ui/mac/*"]
 MAC.glass.nativeSource = file("${project("graphics").projectDir}/src/main/native-glass/mac")
 MAC.glass.compiler = compiler
-MAC.glass.ccFlags = [ccFlags].flatten()
+MAC.glass.ccFlags = [ccFlags,
+    "-DMACOS_MIN_VERSION_MAJOR=$macOSMinVersionMajor",
+    "-DMACOS_MIN_VERSION_MINOR=$macOSMinVersionMinor"].flatten()
 MAC.glass.linker = linker
 MAC.glass.linkFlags = [linkFlags].flatten()
 MAC.glass.lib = "glass"

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -793,34 +793,6 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacApplication__1initIDs
 {
     LOG("Java_com_sun_glass_ui_mac_MacApplication__1initIDs");
 
-    disableSyncRendering = jDisableSyncRendering ? YES : NO;
-
-    jApplicationClass = (*env)->NewGlobalRef(env, jClass);
-
-    javaIDs.Application.createPixels = (*env)->GetStaticMethodID(
-            env, jClass, "createPixels", "(II[IFF)Lcom/sun/glass/ui/Pixels;");
-    if ((*env)->ExceptionCheck(env)) return;
-
-    javaIDs.Application.getScaleFactor = (*env)->GetStaticMethodID(
-            env, jClass, "getScaleFactor", "(IIII)F");
-    if ((*env)->ExceptionCheck(env)) return;
-
-    javaIDs.Application.reportException = (*env)->GetStaticMethodID(
-            env, jClass, "reportException", "(Ljava/lang/Throwable;)V");
-    if ((*env)->ExceptionCheck(env)) return;
-
-    javaIDs.Application.enterNestedEventLoop = (*env)->GetStaticMethodID(
-            env, jClass, "enterNestedEventLoop", "()Ljava/lang/Object;");
-    if ((*env)->ExceptionCheck(env)) return;
-
-    javaIDs.Application.leaveNestedEventLoop = (*env)->GetStaticMethodID(
-            env, jClass, "leaveNestedEventLoop", "(Ljava/lang/Object;)V");
-    if ((*env)->ExceptionCheck(env)) return;
-
-    javaIDs.MacApplication.notifyApplicationDidTerminate = (*env)->GetMethodID(
-            env, jClass, "notifyApplicationDidTerminate", "()V");
-    if ((*env)->ExceptionCheck(env)) return;
-
     // Check minimum OS version
     NSOperatingSystemVersion osVer;
     osVer = [[NSProcessInfo processInfo] operatingSystemVersion];
@@ -848,6 +820,34 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacApplication__1initIDs
         }
         return;
     }
+
+    disableSyncRendering = jDisableSyncRendering ? YES : NO;
+
+    jApplicationClass = (*env)->NewGlobalRef(env, jClass);
+
+    javaIDs.Application.createPixels = (*env)->GetStaticMethodID(
+            env, jClass, "createPixels", "(II[IFF)Lcom/sun/glass/ui/Pixels;");
+    if ((*env)->ExceptionCheck(env)) return;
+
+    javaIDs.Application.getScaleFactor = (*env)->GetStaticMethodID(
+            env, jClass, "getScaleFactor", "(IIII)F");
+    if ((*env)->ExceptionCheck(env)) return;
+
+    javaIDs.Application.reportException = (*env)->GetStaticMethodID(
+            env, jClass, "reportException", "(Ljava/lang/Throwable;)V");
+    if ((*env)->ExceptionCheck(env)) return;
+
+    javaIDs.Application.enterNestedEventLoop = (*env)->GetStaticMethodID(
+            env, jClass, "enterNestedEventLoop", "()Ljava/lang/Object;");
+    if ((*env)->ExceptionCheck(env)) return;
+
+    javaIDs.Application.leaveNestedEventLoop = (*env)->GetStaticMethodID(
+            env, jClass, "leaveNestedEventLoop", "(Ljava/lang/Object;)V");
+    if ((*env)->ExceptionCheck(env)) return;
+
+    javaIDs.MacApplication.notifyApplicationDidTerminate = (*env)->GetMethodID(
+            env, jClass, "notifyApplicationDidTerminate", "()V");
+    if ((*env)->ExceptionCheck(env)) return;
 
     if (jRunnableRun == NULL)
     {

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -827,11 +827,6 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacApplication__1initIDs
     NSInteger osVerMajor = osVer.majorVersion;
     NSInteger osVerMinor = osVer.minorVersion;
 
-    // KCR: begin debug
-    NSLog(@"macOSMinVersion = %d . %d", MACOS_MIN_VERSION_MAJOR, MACOS_MIN_VERSION_MINOR);
-    NSLog(@"    osVer (raw)      = %d . %d", (int)osVerMajor, (int)osVerMinor);
-    // KCR: end debug
-
     // Map 10.16 to 11.0, since macOS will return 10.16 by default (for compatibility)
     if (osVerMajor == 10 && osVerMinor >= 16) {
         // FIXME: if we ever need to know which minor version of macOS 11.x we
@@ -840,10 +835,6 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacApplication__1initIDs
         osVerMajor = 11;
         osVerMinor = 0;
     }
-
-    // KCR: begin debug
-    NSLog(@"    osVer (adjusted) = %d . %d", (int)osVerMajor, (int)osVerMinor);
-    // KCR: end debug
 
     if (osVerMajor < MACOS_MIN_VERSION_MAJOR ||
             (osVerMajor == MACOS_MIN_VERSION_MAJOR &&

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -821,6 +821,43 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacApplication__1initIDs
             env, jClass, "notifyApplicationDidTerminate", "()V");
     if ((*env)->ExceptionCheck(env)) return;
 
+    // Check minimum OS version
+    NSOperatingSystemVersion osVer;
+    osVer = [[NSProcessInfo processInfo] operatingSystemVersion];
+    NSInteger osVerMajor = osVer.majorVersion;
+    NSInteger osVerMinor = osVer.minorVersion;
+
+    // KCR: begin debug
+    NSLog(@"macOSMinVersion = %d . %d", MACOS_MIN_VERSION_MAJOR, MACOS_MIN_VERSION_MINOR);
+    NSLog(@"    osVer (raw)      = %d . %d", (int)osVerMajor, (int)osVerMinor);
+    // KCR: end debug
+
+    // Map 10.16 to 11.0, since macOS will return 10.16 by default (for compatibility)
+    if (osVerMajor == 10 && osVerMinor >= 16) {
+        // FIXME: if we ever need to know which minor version of macOS 11.x we
+        // are running on, we will need to look it up using a similar technique
+        // to what the JDK does.
+        osVerMajor = 11;
+        osVerMinor = 0;
+    }
+
+    // KCR: begin debug
+    NSLog(@"    osVer (adjusted) = %d . %d", (int)osVerMajor, (int)osVerMinor);
+    // KCR: end debug
+
+    if (osVerMajor < MACOS_MIN_VERSION_MAJOR ||
+            (osVerMajor == MACOS_MIN_VERSION_MAJOR &&
+             osVerMinor < MACOS_MIN_VERSION_MINOR))
+    {
+        NSLog(@"ERROR: macOS version is %d.%d, which is below the minimum of %d.%d",
+              (int)osVerMajor, (int)osVerMinor, MACOS_MIN_VERSION_MAJOR, MACOS_MIN_VERSION_MINOR);
+        jclass exceptionClass = (*env)->FindClass(env, "java/lang/RuntimeException");
+        if (exceptionClass != 0) {
+            (*env)->ThrowNew(env, exceptionClass, "Unsupported macOS version");
+        }
+        return;
+    }
+
     if (jRunnableRun == NULL)
     {
         jclass jcls = (*env)->FindClass(env, "java/lang/Runnable");


### PR DESCRIPTION
This PR implements a version check in the JavaFX runtime initialization code on macOS to ensure that the platform is running a version of macOS that is at or above the minimum version. If the platform is below the specified minimum, the JavaFX initialization code throws an exception.

The minimum version is passed from the `mac.gradle` file to the Mac glass code as a pair of build time constants, which are compared at runtime to the platform version.

Notes to reviewers:

* In case anyone is interested, the first commit has some debug logging which will print the minimum version and the detected platform version. I removed them with the second commit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269967](https://bugs.openjdk.java.net/browse/JDK-8269967): JavaFX should fail fast on macOS below minimum version


### Reviewers
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/567/head:pull/567` \
`$ git checkout pull/567`

Update a local copy of the PR: \
`$ git checkout pull/567` \
`$ git pull https://git.openjdk.java.net/jfx pull/567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 567`

View PR using the GUI difftool: \
`$ git pr show -t 567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/567.diff">https://git.openjdk.java.net/jfx/pull/567.diff</a>

</details>
