### PR TITLE
8269968: [REDO] Bump minimum version of macOS for x64 to 10.12

### DIFF
--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -56,7 +56,7 @@ def defaultSdkPath = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOS
 // Set the minimum API version that we require (developers do not need to override this)
 // Note that this is not necessarily the same as the preferred SDK version
 def isAarch64 = TARGET_ARCH == "aarch64" || TARGET_ARCH == "arm64";
-def macOSMinVersion = isAarch64 ? "11.0" : "10.10";
+def macOSMinVersion = isAarch64 ? "11.0" : "10.12";
 defineProperty("MACOSX_MIN_VERSION", macOSMinVersion);
 
 def macOSMinVersionArr = macOSMinVersion.split("\\.")


### PR DESCRIPTION
The fix for [JDK-8266743](https://bugs.openjdk.java.net/browse/JDK-8266743) (crash on macOS 10.11) -- was to partially revert [JDK-8265031](https://bugs.openjdk.java.net/browse/JDK-8265031), and lower the minimum macOS version for x64 back to 10.10 in JavaFX 17. We should bump it back to 10.12 in JavaFX 18.

This will be done in connection with [JDK-8269967](https://bugs.openjdk.java.net/browse/JDK-8269967), PR #567, which will provide a fail-fast when attempting to run on an older version of macOS than the minimum. I will not integrate this PR until after that one is integrated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269968](https://bugs.openjdk.java.net/browse/JDK-8269968): [REDO] Bump minimum version of macOS for x64 to 10.12


### Reviewers
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/570/head:pull/570` \
`$ git checkout pull/570`

Update a local copy of the PR: \
`$ git checkout pull/570` \
`$ git pull https://git.openjdk.java.net/jfx pull/570/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 570`

View PR using the GUI difftool: \
`$ git pr show -t 570`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/570.diff">https://git.openjdk.java.net/jfx/pull/570.diff</a>

</details>
