### PR TITLE
8188027: List/TableCell: must not fire event in startEdit if already editing

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -357,6 +357,7 @@ public class ListCell<T> extends IndexedCell<T> {
 
     /** {@inheritDoc} */
     @Override public void startEdit() {
+        if (isEditing()) return;
         final ListView<T> list = getListView();
         if (!isEditable() || (list != null && ! list.isEditable())) {
             return;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
@@ -304,6 +304,7 @@ public class TableCell<S,T> extends IndexedCell<T> {
 
     /** {@inheritDoc} */
     @Override public void startEdit() {
+        if (isEditing()) return;
         final TableView<S> table = getTableView();
         final TableColumn<S,T> column = getTableColumn();
         final TableRow<S> row = getTableRow();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -672,6 +672,17 @@ public class ListCellTest {
         assertTrue(called[0]);
     }
 
+    @Test public void editCellDoesNotFireEventWhileAlreadyEditing() {
+        list.setEditable(true);
+        cell.updateListView(list);
+        cell.updateIndex(2);
+        cell.startEdit();
+        List<EditEvent<?>> events = new ArrayList<>();
+        list.setOnEditStart(events::add);
+        cell.startEdit();
+        assertEquals("startEdit must not fire event while editing", 0, events.size());
+    }
+
     // commitEdit()
     @Test public void commitWhenListIsNullIsOK() {
         cell.updateIndex(1);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
@@ -529,6 +529,28 @@ public class TableCellTest {
         assertEquals("item must be gc'ed", null, itemRef.get());
     }
 
+    @Test
+    public void testEditStartFiresEvent() {
+        setupForEditing();
+        cell.updateIndex(1);
+        List<CellEditEvent<?, ?>> events = new ArrayList<>();
+        editingColumn.setOnEditStart(events::add);
+        cell.startEdit();
+        assertEquals("startEdit must fire", 1, events.size());
+    }
+    
+    @Test
+    public void testEditStartDoesNotFireEventWhileEditing() {
+        setupForEditing();
+        cell.updateIndex(1);
+        cell.startEdit();
+        List<CellEditEvent<?, ?>> events = new ArrayList<>();
+        editingColumn.setOnEditStart(events::add);
+        cell.startEdit();
+        assertEquals("startEdit must not fire while editing", 0, events.size());
+    }
+
+
     /**
      * Test that cell.cancelEdit can switch table editing off
      * even if a subclass violates its contract.

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
@@ -538,7 +538,7 @@ public class TableCellTest {
         cell.startEdit();
         assertEquals("startEdit must fire", 1, events.size());
     }
-    
+
     @Test
     public void testEditStartDoesNotFireEventWhileEditing() {
         setupForEditing();


### PR DESCRIPTION
issue was a missing check in startEdit if already editing (as Tree- and TreeTableCell do)

fix was to add the check and backout if true, added tests to List/TableCell that fail/pass before/after the fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8188027](https://bugs.openjdk.java.net/browse/JDK-8188027): List/TableCell: must not fire event in startEdit if already editing


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/571/head:pull/571` \
`$ git checkout pull/571`

Update a local copy of the PR: \
`$ git checkout pull/571` \
`$ git pull https://git.openjdk.java.net/jfx pull/571/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 571`

View PR using the GUI difftool: \
`$ git pr show -t 571`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/571.diff">https://git.openjdk.java.net/jfx/pull/571.diff</a>

</details>
