### PR TITLE
8269374: Menu inoperable after setting stage to second monitor

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinView.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinView.java
@@ -24,7 +24,6 @@
  */
 package com.sun.glass.ui.win;
 
-import com.sun.glass.events.ViewEvent;
 import com.sun.glass.ui.Application;
 import com.sun.glass.ui.Pixels;
 import com.sun.glass.ui.View;
@@ -96,10 +95,10 @@ final class WinView extends View {
     protected void notifyResize(int width, int height) {
         super.notifyResize(width, height);
 
-        // After resizing, do a move notification to force a view relocation.
+        // After resizing, do a move notification to force the view relocation.
         // When moving to a screen with different DPI settings, its location needs
         // to be recalculated.
-        notifyView(ViewEvent.MOVE);
+        updateLocation();
     }
 }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinView.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinView.java
@@ -24,6 +24,7 @@
  */
 package com.sun.glass.ui.win;
 
+import com.sun.glass.events.ViewEvent;
 import com.sun.glass.ui.Application;
 import com.sun.glass.ui.Pixels;
 import com.sun.glass.ui.View;
@@ -91,5 +92,14 @@ final class WinView extends View {
     @Override native protected boolean _enterFullscreen(long ptr, boolean animate, boolean keepRatio, boolean hideCursor);
     @Override native protected void _exitFullscreen(long ptr, boolean animate);
 
+    @Override
+    protected void notifyResize(int width, int height) {
+        super.notifyResize(width, height);
+
+        // After resizing, do a move notification to force a view relocation.
+        // When moving to a screen with different DPI settings, its location needs
+        // to be recalculated.
+        notifyView(ViewEvent.MOVE);
+    }
 }
 


### PR DESCRIPTION
On Windows, with two monitors with different DPI settings, if a JavaFX application changes screens (either by dragging or programmatically) there is a resize event to adjust the view to its new platform scale.

Note that there is already a [call](https://github.com/openjdk/jfx/blob/master/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinWindow.java#L206) to `View::updateLocation` in WinWindow, right after `notifyMoveToAnotherScreen` and `notifyScaleChanged `. But this is done too soon, before the resize event. There are other MOVE events processed too (in a long complex chain of recursive calls to `WinWindow::setBounds`).

As a consequence, as commented in the issue [JDK-8269374](https://bugs.openjdk.java.net/browse/JDK-8269374), the view x/y coordinates are wrongly set using the _old_ X,Y values (from the previous screen) with the _new_ platform scale (from the new screen).

This PR adds an extra call to View::updateLocation` in WinWindow, forcing the view relocation on Windows after every resize event to fix the issue. With the correct location of the scene, the Menus are now perfectly aligned, and the mouse events are correctly processed. It doesn't have any side effect on other platforms.

There's a very small penalty, as this new relocation will be called whenever there is a resize event on Windows, but it simplifies the overhead of detecting when the change of screens is effectively done (including the chain of move/resize) events.

No tests are provided, since these would require a setup of two monitors with different DPI settings. However, the test case in the JBS issue can be used to validate the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269374](https://bugs.openjdk.java.net/browse/JDK-8269374): Menu inoperable after setting stage to second monitor


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/572/head:pull/572` \
`$ git checkout pull/572`

Update a local copy of the PR: \
`$ git checkout pull/572` \
`$ git pull https://git.openjdk.java.net/jfx pull/572/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 572`

View PR using the GUI difftool: \
`$ git pr show -t 572`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/572.diff">https://git.openjdk.java.net/jfx/pull/572.diff</a>

</details>
