### PR TITLE
8270246: Deprecate for removal implementation methods in Scene

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -842,6 +842,11 @@ public class Scene implements EventTarget {
         PerformanceTracker.logEvent("Scene.initPeer finished");
     }
 
+    // FIXME: make this method package-scope in the next release
+    /**
+     * @deprecated This method was exposed erroneously and will be removed in a future version.
+     */
+    @Deprecated(forRemoval = true, since = "17")
     public void disposePeer() {
         if (peer == null) {
             // This is fine, the window is either not shown yet and there is no
@@ -2135,6 +2140,12 @@ public class Scene implements EventTarget {
         traverse(node, Direction.NEXT);
     }
 
+    // FIXME: make this method package-scope in the next release
+    /**
+     * @deprecated This method was exposed erroneously and will be removed in a future version.
+     * @param e undocumented method parameter
+     */
+    @Deprecated(forRemoval = true, since = "17")
     public void processKeyEvent(KeyEvent e) {
         if (dndGesture != null) {
             if (!dndGesture.processKey(e)) {
@@ -2221,6 +2232,12 @@ public class Scene implements EventTarget {
         }
     }
 
+    // FIXME: make this method package-scope in the next release
+    /**
+     * @deprecated This method was exposed erroneously and will be removed in a future version.
+     * @param enable undocumented method parameter
+     */
+    @Deprecated(forRemoval = true, since = "17")
     public void enableInputMethodEvents(boolean enable) {
        if (peer != null) {
            peer.enableInputMethodEvents(enable);


### PR DESCRIPTION
The following methods in Scene were former `impl_*` method that were intended to be encapsulated as part of [JDK-8157295](https://bugs.openjdk.java.net/browse/JDK-8157295) in JDK 9, but were mistakenly left as public:

```
    public void disposePeer()
    public void enableInputMethodEvents(boolean enable)
    public void processKeyEvent(KeyEvent e)
```

In the fix for [JDK-8157295](https://bugs.openjdk.java.net/browse/JDK-8157295), the `impl_` prefix was removed, and the necessary accessors were added, but the `public` modifier was not removed. See the diffs for these three methods in Scene.java: [`disposePeer`](https://github.com/openjdk/jfx/commit/d864a620dfc7631585872547b42dcf93e9d570e6#diff-72cb5f9e4cc8a3804417166fdef390361e82d5890603f4e5158c9fc70c22e9daL833), [`enableInputMethodEvents`](https://github.com/openjdk/jfx/commit/d864a620dfc7631585872547b42dcf93e9d570e6#diff-72cb5f9e4cc8a3804417166fdef390361e82d5890603f4e5158c9fc70c22e9daL2221), [`processKeyEvent`](https://github.com/openjdk/jfx/commit/d864a620dfc7631585872547b42dcf93e9d570e6#diff-72cb5f9e4cc8a3804417166fdef390361e82d5890603f4e5158c9fc70c22e9daL2129)

We will deprecate these methods for removal with the intention to remove them from the public API in a future version of JavaFX. This will need a CSR.

NOTE: this is targeted to `jfx17`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270246](https://bugs.openjdk.java.net/browse/JDK-8270246): Deprecate for removal implementation methods in Scene


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/573/head:pull/573` \
`$ git checkout pull/573`

Update a local copy of the PR: \
`$ git checkout pull/573` \
`$ git pull https://git.openjdk.java.net/jfx pull/573/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 573`

View PR using the GUI difftool: \
`$ git pr show -t 573`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/573.diff">https://git.openjdk.java.net/jfx/pull/573.diff</a>

</details>
