### PR TITLE
8269638: Property methods, setters, and getters in printing API should be final

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/print/JobSettings.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/JobSettings.java
@@ -439,25 +439,21 @@ public final class JobSettings {
                     throw new
                         RuntimeException("Jobname property cannot be bound");
                 }
+
+                @Override
+                public String toString() {
+                    return get();
+                }
             };
         }
         return jobName;
     }
 
-    /**
-     * Get the name of a job.
-     * @return a string representing the name of a job
-     */
-    public String getJobName() {
+    public final String getJobName() {
         return jobNameProperty().get();
     }
 
-
-    /**
-     * Set the name of a job.
-     * @param name string representing the name of a job
-     */
-    public void setJobName(String name) {
+    public final void setJobName(String name) {
         jobNameProperty().set(name);
     }
     ///////////////////////  END JOBNAME /////////////////////
@@ -544,12 +540,11 @@ public final class JobSettings {
         return outputFile;
     }
 
-    public String getOutputFile() {
+    public final String getOutputFile() {
         return outputFileProperty().get();
     }
 
-
-    public void setOutputFile(String filePath) {
+    public final void setOutputFile(String filePath) {
         outputFileProperty().set(filePath);
     }
     ///////////////////////  END OUTPUTFILE /////////////////////
@@ -599,23 +594,20 @@ public final class JobSettings {
                     throw new
                         RuntimeException("Copies property cannot be bound");
                 }
+
+                @Override
+                public String toString() {
+                     return "" + get();
+                }
             };
         }
         return copies;
     }
 
-    /**
-     * Get the number of copies to print.
-     * @return number of copies to print
-     */
-    public int getCopies() {
+    public final int getCopies() {
          return copiesProperty().get();
     }
 
-    /**
-     * Set the number of copies to print.
-     * @param nCopies number of copies to print
-     */
     public final void setCopies(int nCopies) {
         copiesProperty().set(nCopies);
     }
@@ -694,17 +686,31 @@ public final class JobSettings {
                     throw new RuntimeException
                         ("PageRanges property cannot be bound");
                 }
+
+                @Override
+                public String toString() {
+                      PageRange[] ranges = (PageRange[])get();
+                      if (ranges == null || ranges.length == 0) {
+                          return "null";
+                      }
+                      String s = "";
+                      int len = ranges.length;
+                      for (int r=0; r<len; r++) {
+                          s += ranges[r];
+                          if ((r+1) < len) {
+                              s += ", ";
+                          } else {
+                              s += ".";
+                          }
+                      }
+                      return s;
+                }
             };
         }
         return pageRanges;
     }
 
-    /**
-     * The range of pages to print. null always means all pages.
-     * See {@link pageRangesProperty} for more details.
-     * @return null or an array as specified above
-     */
-    public PageRange[] getPageRanges() {
+    public final PageRange[] getPageRanges() {
         return (PageRange[])(pageRangesProperty().get());
     }
 
@@ -717,7 +723,7 @@ public final class JobSettings {
      * See {@link pageRangesProperty} for more details.
      * @param pages null or a varargs array as specified above
      */
-    public void setPageRanges(PageRange... pages) {
+    public final void setPageRanges(PageRange... pages) {
         pageRangesProperty().set((PageRange[])pages);
     }
 
@@ -769,28 +775,21 @@ public final class JobSettings {
                     throw new RuntimeException
                         ("PrintSides property cannot be bound");
                 }
+
+                @Override
+                public String toString() {
+                     return  get().toString();
+                }
             };
         }
         return sides;
     }
 
-    /**
-     * If a printer supports it, then a job may be printed on
-     * both sides of the media (paper), ie duplex printing.
-     * This method returns the selected setting.
-     * @return the duplex (side) setting.
-     */
-    public PrintSides getPrintSides() {
+    public final PrintSides getPrintSides() {
         return printSidesProperty().get();
     }
 
-    /**
-     * Set the <code>PrintSides</code> property which controls
-     * duplex printing.
-     * A null value is ignored.
-     * @param sides new setting for number of sides.
-     */
-    public void setPrintSides(PrintSides sides) {
+    public final void setPrintSides(PrintSides sides) {
         if (sides == getPrintSides()) {
             return;
         }
@@ -805,6 +804,19 @@ public final class JobSettings {
 
     /**
      * Property representing an instance of <code>Collation</code>.
+     * Collation determines how sheets are sorted when
+     * multiple copies of a document are printed.
+     * As such it is only relevant if 2 or more copies of
+     * a document with 2 more sheets are printed.
+     * A sheet is the physical media, so documents with 2 pages
+     * that are printed N-up, or double-sided may still have only
+     * one sheet.
+     * A collated print job produces documents with sheets
+     * of a document sorted in sequence.
+     * An uncollated job collects together the multiple copies
+     * of the same sheet.
+     * Uncollated (<code>false</code>) is the typical default value.
+     *
      * @return an instance of <code>Collation</code>
      */
     public final ObjectProperty<Collation> collationProperty() {
@@ -845,37 +857,21 @@ public final class JobSettings {
                     throw new RuntimeException
                         ("Collation property cannot be bound");
                 }
+
+                @Override
+                public String toString() {
+                     return get().toString();
+                }
             };
         }
         return collation;
     }
 
-    /**
-     * Collation determines how sheets are sorted when
-     * multiple copies of a document are printed.
-     * As such it is only relevant if 2 or more copies of
-     * a document with 2 more sheets are printed.
-     * A sheet is the physical media, so documents with 2 pages
-     * that are printed N-up, or double-sided may still have only
-     * one sheet.
-     * A collated print job produces documents with sheets
-     * of a document sorted in sequence.
-     * An uncollated job collects together the multiple copies
-     * of the same sheet.
-     * Uncollated (<code>false</code>) is the typical default value.
-     *
-     * @return the collation
-     */
-    public Collation getCollation() {
+    public final Collation getCollation() {
         return collationProperty().get();
     }
 
-    /**
-     * Set the <code>Collation</code> property.
-     * A null value is ignored.
-     * @param collation new setting for collation
-     */
-    public void setCollation(Collation collation) {
+    public final void setCollation(Collation collation) {
         if (collation == getCollation()) {
             return;
         }
@@ -890,6 +886,7 @@ public final class JobSettings {
 
     /**
      * Property representing an instance of <code>PrintColor</code>.
+     * If a null value is set it is ignored.
      * @return an instance of <code>PrintColor</code>
      */
     public final ObjectProperty<PrintColor> printColorProperty() {
@@ -930,22 +927,21 @@ public final class JobSettings {
                     throw new RuntimeException
                         ("PrintColor property cannot be bound");
                 }
+
+                @Override
+                public String toString() {
+                     return get().toString();
+                }
             };
         }
         return color;
     }
 
-    public PrintColor getPrintColor() {
+    public final PrintColor getPrintColor() {
         return printColorProperty().get();
     }
 
-    /**
-     * Set the <code>PrintColor</code> property.
-     * A null value is ignored.
-     *
-     * @param color new setting for print color.
-     */
-    public void setPrintColor(PrintColor color) {
+    public final void setPrintColor(PrintColor color) {
         if (color == getPrintColor()) {
             return;
         }
@@ -960,6 +956,16 @@ public final class JobSettings {
 
     /**
      * Property representing an instance of <code>PrintQuality</code>.
+     * <p>
+     * Note that quality and resolution are overlapping concepts.
+     * Therefore a printer may support setting one, or the other but
+     * not both. Applications setting these programmatically should
+     * query both properties and select appropriately from the supported
+     * values. If a printer supports non-standard values, code likely
+     * cannot distinguish the printer's interpretation of these values
+     * and it is safest to stick to selecting a standard value that
+     * matches the requirement.
+     * <p>
      * @return an instance of <code>PrintQuality</code>
      */
     public final ObjectProperty<PrintQuality> printQualityProperty() {
@@ -1000,30 +1006,21 @@ public final class JobSettings {
                     throw new RuntimeException
                         ("PrintQuality property cannot be bound");
                 }
+
+                @Override
+                public String toString() {
+                     return  get().toString();
+                }
             };
         }
         return quality;
     }
 
-    public PrintQuality getPrintQuality() {
+    public final PrintQuality getPrintQuality() {
         return  printQualityProperty().get();
     }
 
-    /**
-     * Set the <code>PrintQuality</code> property.
-     * A null value is ignored.
-     * <p>
-     * Note that quality and resolution overlapping concepts.
-     * Therefore a printer may support setting one, or the other but
-     * not both. Applications setting these programmatically should
-     * query both properties and select appropriately from the supported
-     * values. If a printer supports non-standard values, code likely
-     * cannot distinguish the printer's interpretation of these values
-     * and is safest to stick to selecting from the standard value that
-     * matches the requirement.
-     * @param quality new setting for print quality.
-     */
-    public void setPrintQuality(PrintQuality quality) {
+    public final void setPrintQuality(PrintQuality quality) {
         if (quality == getPrintQuality()) {
             return;
         }
@@ -1039,6 +1036,17 @@ public final class JobSettings {
 
     /**
      * Property representing an instance of <code>PrintResolution</code>.
+     * A null value is ignored.
+     * <p>
+     * Note that quality and resolution are overlapping concepts.
+     * Therefore a printer may support setting one, or the other but
+     * not both. Applications setting these programmatically should
+     * query both properties and select appropriately from the supported
+     * values. If a printer supports non-standard values, code likely
+     * cannot distinguish the printer's interpretation of these values
+     * and it is safest to stick to selecting a standard value that
+     * matches the requirement.
+     * <p>
      * @return an instance of <code>PrintResolution</code>
      */
     public final ObjectProperty<PrintResolution> printResolutionProperty() {
@@ -1081,34 +1089,21 @@ public final class JobSettings {
                     throw new RuntimeException
                         ("PrintResolution property cannot be bound");
                 }
+
+                @Override
+                public String toString() {
+                     return  get().toString();
+                }
             };
         }
         return resolution;
     }
 
-    /**
-     *
-     * @return the print resolution
-     */
-    public PrintResolution getPrintResolution() {
+    public final PrintResolution getPrintResolution() {
         return printResolutionProperty().get();
     }
 
-    /**
-     * Set the <code>PrintResolution</code> property.
-     * A null value is ignored.
-     * <p>
-     * Note that quality and resolution overlapping concepts.
-     * Therefore a printer may support setting one, or the other but
-     * not both. Applications setting these programmatically should
-     * query both properties and select appropriately from the supported
-     * values. If a printer supports non-standard values, code likely
-     * cannot distinguish the printer's interpretation of these values
-     * and is safest to stick to selecting from the standard value that
-     * matches the requirement.
-     * @param resolution new setting for print resolution.
-     */
-    public void setPrintResolution(PrintResolution resolution) {
+    public final void setPrintResolution(PrintResolution resolution) {
         if (resolution == null || resolution == getPrintResolution()) {
             return;
         }
@@ -1124,6 +1119,7 @@ public final class JobSettings {
 
     /**
      * Property representing an instance of <code>PaperSource</code>.
+     * A null value is ignored.
      * @return an instance of <code>PaperSource</code>
      */
     public final ObjectProperty<PaperSource> paperSourceProperty() {
@@ -1164,17 +1160,22 @@ public final class JobSettings {
                     throw new RuntimeException
                         ("PaperSource property cannot be bound");
                 }
+
+                @Override
+                public String toString() {
+                     return  get().toString();
+                }
             };
         }
         return paperSource;
     }
 
 
-    public PaperSource getPaperSource() {
+    public final PaperSource getPaperSource() {
         return paperSourceProperty().get();
     }
 
-    public void setPaperSource(PaperSource value) {
+    public final void setPaperSource(PaperSource value) {
         paperSourceProperty().set(value);
     }
 
@@ -1196,6 +1197,7 @@ public final class JobSettings {
 
     /**
      * Property representing an instance of <code>PageLayout</code>.
+     * Setting a null value is ignored.
      * @return an instance of <code>PageLayout</code>
      */
     public final ObjectProperty<PageLayout> pageLayoutProperty() {
@@ -1228,24 +1230,21 @@ public final class JobSettings {
                     throw new RuntimeException
                         ("PageLayout property cannot be bound");
                 }
+
+                @Override
+                public String toString() {
+                     return  get().toString();
+                }
             };
         }
         return layout;
     }
 
-    /**
-     * Get the current page layout for this job.
-     * @return page layout to use for the job.
-     */
-    public PageLayout getPageLayout() {
+    public final PageLayout getPageLayout() {
         return pageLayoutProperty().get();
     }
 
-    /**
-     * Set the PageLayout to use.
-     * @param pageLayout The page layout to use.
-     */
-    public void setPageLayout(PageLayout pageLayout) {
+    public final void setPageLayout(PageLayout pageLayout) {
         pageLayoutProperty().set(pageLayout);
     }
 
@@ -1259,7 +1258,8 @@ public final class JobSettings {
             " Copies = " + getCopies() + nl +
             " Sides = " + getPrintSides() + nl +
             " JobName = " + getJobName() + nl +
-            " Page ranges = " + getPageRanges() + nl +
+            " Output file = " + getOutputFile() + nl +
+            " Page ranges = " + pageRangesProperty().toString() + nl +
             " Print color = " + getPrintColor() + nl +
             " Print quality = " + getPrintQuality() + nl +
             " Print resolution = " + getPrintResolution() + nl +

--- a/modules/javafx.graphics/src/main/java/javafx/print/JobSettings.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/JobSettings.java
@@ -965,7 +965,6 @@ public final class JobSettings {
      * cannot distinguish the printer's interpretation of these values
      * and it is safest to stick to selecting a standard value that
      * matches the requirement.
-     * <p>
      * @return an instance of <code>PrintQuality</code>
      */
     public final ObjectProperty<PrintQuality> printQualityProperty() {
@@ -1046,7 +1045,6 @@ public final class JobSettings {
      * cannot distinguish the printer's interpretation of these values
      * and it is safest to stick to selecting a standard value that
      * matches the requirement.
-     * <p>
      * @return an instance of <code>PrintResolution</code>
      */
     public final ObjectProperty<PrintResolution> printResolutionProperty() {

--- a/modules/javafx.graphics/src/main/java/javafx/print/PageRange.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/PageRange.java
@@ -87,18 +87,14 @@ public final class PageRange {
 
     /**
      * <code>IntegerProperty</code> representing the starting
-     * page number of the range. See {@link getStartPage getStartPage()}
-     * for more information.
+     * page number of the range.
      * @return the starting page number of the range
      */
-    public ReadOnlyIntegerProperty startPageProperty() {
+    public final ReadOnlyIntegerProperty startPageProperty() {
         return startPageImplProperty().getReadOnlyProperty();
     }
 
-    /**
-     * @return the starting page of the range.
-     */
-    public int getStartPage() {
+    public final int getStartPage() {
         return startPageProperty().get();
     }
 
@@ -123,18 +119,19 @@ public final class PageRange {
 
     /**
      * <code>IntegerProperty</code> representing the ending
-     * page number of the range. See {@link #getEndPage getEndPage()}
-     * for more information.
+     * page number of the range.
      * @return the ending page number of the range
      */
-    public ReadOnlyIntegerProperty endPageProperty() {
+    public final ReadOnlyIntegerProperty endPageProperty() {
         return endPageImplProperty().getReadOnlyProperty();
     }
 
-    /**
-     * @return the ending page of the range.
-     */
-    public int getEndPage() {
+    public final int getEndPage() {
         return endPageProperty().get();
+    }
+
+    @Override
+    public String toString() {
+       return "Pages " + getStartPage() + " to " + getEndPage();
     }
 }

--- a/modules/javafx.graphics/src/main/java/javafx/print/PrinterJob.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/PrinterJob.java
@@ -220,11 +220,7 @@ public final class PrinterJob {
         return printer;
     }
 
-    /**
-     * Gets the printer currently associated with this job.
-     * @return printer for the job.
-     */
-    public synchronized Printer getPrinter() {
+    public synchronized final Printer getPrinter() {
         return printerProperty().get();
     }
 
@@ -489,15 +485,11 @@ public final class PrinterJob {
      * <code>JobStatus</code>
      * @return the current <code>JobStatus</code>
      */
-    public ReadOnlyObjectProperty<JobStatus> jobStatusProperty() {
+    public final ReadOnlyObjectProperty<JobStatus> jobStatusProperty() {
         return jobStatus.getReadOnlyProperty();
     }
 
-    /**
-     * Obtain the current status of the job.
-     * @return the current <code>JobStatus</code>
-     */
-    public JobStatus getJobStatus() {
+    public final JobStatus getJobStatus() {
         return jobStatus.get();
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/print/PrinterJob.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/PrinterJob.java
@@ -223,7 +223,7 @@ public final class PrinterJob {
      * <p>
      * Setting a null value for printer will install the default printer.
      * Setting the current printer has no effect.
-     * @return the <code>Printer</code> for this job
+     * @return the {@code Printer} for this job
      */
     public final ObjectProperty<Printer> printerProperty() {
         /* The PrinterJob constructor always creates this property,

--- a/modules/javafx.graphics/src/main/java/javafx/print/PrinterJob.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/PrinterJob.java
@@ -209,8 +209,20 @@ public final class PrinterJob {
     }
 
     /**
-     * Property representing the
-     * <code>Printer</code> for this job.
+     * Property representing the {@code Printer} for this job.
+     * When setting a printer which does not support the current job settings,
+     * (for example if DUPLEX printing is requested but the new printer
+     * does not support this), then the values are reset to the default
+     * for the new printer, or in some cases a similar value. For example
+     * this might mean REVERSE_LANDSCAPE is updated to LANDSCAPE, however
+     * this implementation optimisation is allowed, but not required.
+     * <p>
+     * The above applies whether the printer is changed by directly calling
+     * this method, or as a side-effect of user interaction with a print
+     * dialog.
+     * <p>
+     * Setting a null value for printer will install the default printer.
+     * Setting the current printer has no effect.
      * @return the <code>Printer</code> for this job
      */
     public final ObjectProperty<Printer> printerProperty() {
@@ -224,24 +236,7 @@ public final class PrinterJob {
         return printerProperty().get();
     }
 
-    /**
-     * Change the printer for this job.
-     * If the new printer does not support the current job settings,
-     * (for example if DUPLEX printing is requested but the new printer
-     * does not support this), then the values are reset to the default
-     * for the new printer, or in some cases a similar value. For example
-     * this might mean REVERSE_LANDSCAPE is updated to LANDSCAPE, however
-     * this implementation optimisation is allowed, but not required.
-     * <p>
-     * The above applies whether the printer is changed by directly calling
-     * this method, or as a side-effect of user interaction with a print
-     * dialog.
-     * <p>
-     * Setting a null value for printer will install the default printer.
-     * Setting the current printer has no effect.
-     * @param printer to be used for this print job.
-     */
-    public synchronized void setPrinter(Printer printer) {
+    public synchronized final void setPrinter(Printer printer) {
          printerProperty().set(printer);
     }
 

--- a/tests/manual/printing/JobSettingsInfo.java
+++ b/tests/manual/printing/JobSettingsInfo.java
@@ -42,7 +42,7 @@ import javafx.application.Application;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Scene;
 import javafx.scene.control.TextArea;
-import javafx.scene.layout.*;
+import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 import javafx.stage.Screen;
 import javafx.stage.Stage;

--- a/tests/manual/printing/JobSettingsInfo.java
+++ b/tests/manual/printing/JobSettingsInfo.java
@@ -23,23 +23,26 @@
  * questions.
  */
 
-import java.io.File;
+import javafx.print.Printer;
+import javafx.print.PrinterJob;
+import javafx.print.JobSettings;
+import javafx.print.Collation;
+import javafx.print.PageLayout;
+import javafx.print.PageOrientation;
+import javafx.print.PageRange;
+import javafx.print.Paper;
+import javafx.print.PaperSource;
+import javafx.print.PrintColor;
+import javafx.print.PrintQuality;
+import javafx.print.PrintResolution;
+import javafx.print.PrintSides;
 
-import javafx.application.Platform;
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
-import javafx.print.*;
 
 import javafx.application.Application;
 import javafx.geometry.Rectangle2D;
-import javafx.scene.Group;
-import javafx.scene.Node;
 import javafx.scene.Scene;
-import javafx.scene.control.Button;
-import javafx.scene.control.Label;
 import javafx.scene.control.TextArea;
 import javafx.scene.layout.*;
-import javafx.scene.paint.Color;
 import javafx.scene.text.Text;
 import javafx.stage.Screen;
 import javafx.stage.Stage;

--- a/tests/manual/printing/JobSettingsInfo.java
+++ b/tests/manual/printing/JobSettingsInfo.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.File;
+
+import javafx.application.Platform;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.print.*;
+
+import javafx.application.Application;
+import javafx.geometry.Rectangle2D;
+import javafx.scene.Group;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
+import javafx.scene.layout.*;
+import javafx.scene.paint.Color;
+import javafx.scene.text.Text;
+import javafx.stage.Screen;
+import javafx.stage.Stage;
+
+public class JobSettingsInfo extends Application {
+
+    private final int WIDTH = 1000;
+    private final int HEIGHT = 800;
+
+    private volatile boolean passed = false;
+    private Scene scene;
+    private VBox root;
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+
+    public void start(Stage stage) {
+        stage.setWidth(WIDTH);
+        stage.setHeight(HEIGHT);
+        stage.setTitle("Printing to file test");
+        Rectangle2D bds = Screen.getPrimary().getVisualBounds();
+        stage.setX((bds.getWidth() - WIDTH) / 2);
+        stage.setY((bds.getHeight() - HEIGHT) / 2);
+        stage.setScene(createScene());
+        stage.show();
+    }
+
+    static final String instructions =
+        "This displays the JobSettings info as JobSettings.toString() and \n" +
+        "again as individual properties. There's no more validation as to \n" +
+        "the exact values than is necessary since it is just toString()\n " +
+        "being tested. Just exit the test after reading what is displayed";
+
+    static final String noprinter =
+            "There are no printers installed. This test cannot be run\n";
+
+    private TextArea createTextArea(String msg, int hgt) {
+        TextArea t = new TextArea(msg);
+        t.setWrapText(false);
+        t.setEditable(false);
+        t.prefRowCountProperty().set(hgt);
+        return t;
+    }
+
+    private Scene createScene() {
+
+        root = new VBox();
+        scene = new Scene(root);
+
+        String msg = instructions;
+        if (Printer.getDefaultPrinter() == null) {
+            msg = noprinter;
+        }
+        TextArea info = createTextArea(msg,6);
+        root.getChildren().add(info);
+
+        String infoText = runTest();
+        TextArea jobInfo = createTextArea(infoText,40);
+        root.getChildren().add(jobInfo);
+
+        return scene;
+    }
+
+    public String runTest() {
+        String text = "";
+        PrinterJob job = PrinterJob.createPrinterJob();
+        JobSettings settings = job.getJobSettings();
+        Printer printer = job.getPrinter();
+        PageLayout pl = printer.createPageLayout(Paper.A4, PageOrientation.LANDSCAPE,
+                Printer.MarginType.EQUAL);
+        settings.pageLayoutProperty().set(pl);
+        String fileName = "printtofiletest.prn";
+        settings.outputFileProperty().set(fileName);
+        settings.jobNameProperty().set("Test Job Name");
+        settings.setPageRanges(new PageRange(1,2), new PageRange(5,10));
+        settings.copiesProperty().set(2);
+        settings.paperSourceProperty().set(PaperSource.MANUAL);
+        settings.collationProperty().set(Collation.COLLATED);
+        settings.printColorProperty().set(PrintColor.COLOR);
+        settings.printSidesProperty().set(PrintSides.DUPLEX);
+        settings.printQualityProperty().set(PrintQuality.DRAFT);
+
+        text += "Printer=" + printer + "\n";
+        text += "\n";
+        text += "Settings:\n";
+        text += settings;
+        text += "\n\n";
+        text += "Individually printed settings\n";
+        text += "Collation : " + settings.collationProperty() + "\n";
+        text += "Copies : " + settings.copiesProperty() + "\n";
+        text += "Sides : " + settings.printSidesProperty() + "\n";
+        text += "Job name : " + settings.jobNameProperty() + "\n";
+        text += "Output file : " + settings.outputFileProperty() + "\n";
+        text += "Page Ranges : " + settings.pageRangesProperty() + "\n";
+        text += "Color : " + settings.printColorProperty() + "\n";
+        text += "Quality : " + settings.printQualityProperty() + "\n";
+        text += "Resolution : " + settings.printResolutionProperty() + "\n";
+        text += "Source : " + settings.paperSourceProperty() + "\n";
+        text += "Page layout : " + settings.pageLayoutProperty() + "\n";
+
+        return text;
+    }
+}


### PR DESCRIPTION
- Make various setters and getters and properties final as needed
- Move documentation to the property so the setters and getters inherit it, with an exception for the special case of JobSettings.setPageRanges()
- Override toString() on the properties in JobSettings so it doesn't delegate to the JobSettings class.
- Add a manual test program just so you can see what toString() does. No pass or fail, just informative.

This will need a CSR but I won't create that until the review is done.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269638](https://bugs.openjdk.java.net/browse/JDK-8269638): Property methods, setters, and getters in printing API should be final


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.java.net/census#psadhukhan) (@prsadhuk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/574/head:pull/574` \
`$ git checkout pull/574`

Update a local copy of the PR: \
`$ git checkout pull/574` \
`$ git pull https://git.openjdk.java.net/jfx pull/574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 574`

View PR using the GUI difftool: \
`$ git pr show -t 574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/574.diff">https://git.openjdk.java.net/jfx/pull/574.diff</a>

</details>
