### PR TITLE
8270314: TreeTableCell: inconsistent naming for tableRow and tableColumn property methods

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableCellBehaviorBase.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableCellBehaviorBase.java
@@ -66,7 +66,7 @@ public abstract class TableCellBehaviorBase<S, T, TC extends TableColumnBase<S, 
     protected abstract TableSelectionModel<S> getSelectionModel();
     protected abstract TableFocusModel<S,TC> getFocusModel();
     protected abstract TablePositionBase getFocusedCell();
-    protected abstract boolean isTableRowSelected(); // tableCell.getTreeTableRow().isSelected()
+    protected abstract boolean isTableRowSelected(); // tableCell.getTableRow().isSelected()
 
     /**
      * Returns the position of the given table column in the visible leaf columns

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TreeTableCellBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TreeTableCellBehavior.java
@@ -88,7 +88,7 @@ public class TreeTableCellBehavior<S,T> extends TableCellBehaviorBase<TreeItem<S
 
     /** @{@inheritDoc} */
     @Override protected boolean isTableRowSelected() {
-        return getNode().getTreeTableRow().isSelected();
+        return getNode().getTableRow().isSelected();
     }
 
     /** @{@inheritDoc} */
@@ -111,7 +111,7 @@ public class TreeTableCellBehavior<S,T> extends TableCellBehaviorBase<TreeItem<S
     }
 
     @Override protected boolean handleDisclosureNode(double x, double y) {
-        final TreeItem<S> treeItem = getNode().getTreeTableRow().getTreeItem();
+        final TreeItem<S> treeItem = getNode().getTableRow().getTreeItem();
 
         final TreeTableView<S> treeTableView = getNode().getTreeTableView();
         final TreeTableColumn<S,T> column = getTableColumn();
@@ -119,7 +119,7 @@ public class TreeTableCellBehavior<S,T> extends TableCellBehaviorBase<TreeItem<S
                 treeTableView.getVisibleLeafColumn(0) : treeTableView.getTreeColumn();
 
         if (column == treeColumn) {
-            final Node disclosureNode = getNode().getTreeTableRow().getDisclosureNode();
+            final Node disclosureNode = getNode().getTableRow().getDisclosureNode();
           // fix JDK-8253597: check disclosure node for visibility along with existence
           if (disclosureNode != null && disclosureNode.isVisible()) {
                 double startX = 0;
@@ -142,7 +142,7 @@ public class TreeTableCellBehavior<S,T> extends TableCellBehaviorBase<TreeItem<S
     @Override
     protected void handleClicks(MouseButton button, int clickCount, boolean isAlreadySelected) {
         // handle editing, which only occurs with the primary mouse button
-        TreeItem<S> treeItem = getNode().getTreeTableRow().getTreeItem();
+        TreeItem<S> treeItem = getNode().getTableRow().getTreeItem();
         if (button == MouseButton.PRIMARY) {
             if (clickCount == 1 && isAlreadySelected) {
                 edit(getNode());

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
@@ -712,39 +712,42 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
      **************************************************************************/
 
     /**
-     * Updates the TreeTableView associated with this TreeTableCell. This is typically
-     * only done once when the TreeTableCell is first added to the TreeTableView.
-     *
+     * Updates the {@code TreeTableView} associated with this {@code TreeTableCell}.
+     * This is typically only done once when the {@code TreeTableCell} is first
+     * added to the {@code TreeTableView}.
+     * <p>
      * Note: This function is intended to be used by experts, primarily
      *       by those implementing new Skins. It is not common
      *       for developers or designers to access this function directly.
-     * @param tv the TreeTableView associated with this TreeTableCell
+     * @param tv the {@code TreeTableView} associated with this {@code TreeTableCell}
      */
     public final void updateTreeTableView(TreeTableView<S> tv) {
         setTreeTableView(tv);
     }
 
     /**
-     * Updates the TreeTableRow associated with this TreeTableCell.
-     *
+     * Updates the {@code TreeTableRow} associated with this {@code TreeTableCell}.
+     * <p>
      * Note: This function is intended to be used by experts, primarily
      *       by those implementing new Skins. It is not common
      *       for developers or designers to access this function directly.
-     * @param treeTableRow the TreeTableRow associated with this TreeTableCell
+     * @param row the {@code TreeTableRow} associated with this {@code TreeTableCell}
+     * @since 17
      */
-    public final void updateTreeTableRow(TreeTableRow<S> treeTableRow) {
-        this.setTableRow(treeTableRow);
+    public final void updateTableRow(TreeTableRow<S> row) {
+        this.setTableRow(row);
     }
 
     /**
-     * Updates the TreeTableColumn associated with this TreeTableCell.
-     *
+     * Updates the {@code TreeTableColumn} associated with this {@code TreeTableCell}.
+     * <p>
      * Note: This function is intended to be used by experts, primarily
      *       by those implementing new Skins. It is not common
      *       for developers or designers to access this function directly.
-     * @param col the TreeTableColumn associated with this TreeTableCell
+     * @param column the {@code TreeTableColumn} associated with this {@code TreeTableCell}
+     * @since 17
      */
-    public final void updateTreeTableColumn(TreeTableColumn<S,T> col) {
+    public final void updateTableColumn(TreeTableColumn<S,T> column) {
         // remove style class of existing tree table column, if it is non-null
         TreeTableColumn<S,T> oldCol = getTableColumn();
         if (oldCol != null) {
@@ -764,20 +767,39 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
             }
         }
 
-        setTableColumn(col);
+        setTableColumn(column);
 
-        if (col != null) {
-            getStyleClass().addAll(col.getStyleClass());
-            col.getStyleClass().addListener(weakColumnStyleClassListener);
+        if (column != null) {
+            getStyleClass().addAll(column.getStyleClass());
+            column.getStyleClass().addListener(weakColumnStyleClassListener);
 
-            col.idProperty().addListener(weakColumnIdListener);
-            col.styleProperty().addListener(weakColumnStyleListener);
+            column.idProperty().addListener(weakColumnIdListener);
+            column.styleProperty().addListener(weakColumnStyleListener);
 
-            possiblySetId(col.getId());
-            possiblySetStyle(col.getStyle());
+            possiblySetId(column.getId());
+            possiblySetStyle(column.getStyle());
         }
     }
 
+    // The following methods were misnamed and are deprecated in favor of the
+    // correctly named methods.
+    /**
+     * @deprecated Use {@link updateTableRow} instead.
+     * @param row the {@code TreeTableRow}
+     */
+    @Deprecated(since = "17")
+    public final void updateTreeTableRow(TreeTableRow<S> row) {
+        updateTableRow(row);
+    }
+
+    /**
+     * @deprecated Use {@link updateTableColumn} instead.
+     * @param column the {@code TreeTableColumn}
+     */
+    @Deprecated(since = "17")
+    public final void updateTreeTableColumn(TreeTableColumn<S,T> column) {
+        updateTableColumn(column);
+    }
 
 
     /***************************************************************************

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
@@ -289,6 +289,11 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
     private ReadOnlyObjectWrapper<TreeTableRow<S>> tableRow =
             new ReadOnlyObjectWrapper<TreeTableRow<S>>(this, "tableRow");
     private void setTableRow(TreeTableRow<S> value) { tableRow.set(value); }
+    /**
+     * Gets the value of the property {@code tableRow}.
+     * @return the value of the property {@code tableRow}
+     * @since 17
+     */
     public final TreeTableRow<S> getTableRow() { return tableRow.get(); }
     public final ReadOnlyObjectProperty<TreeTableRow<S>> tableRowProperty() {
         return tableRow.getReadOnlyProperty();

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
@@ -200,7 +200,7 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
 
     // --- TableColumn
     /**
-     * The {code TreeTableColumn} instance that backs this {@code TreeTableCell}.
+     * The {@code TreeTableColumn} instance that backs this {@code TreeTableCell}.
      */
     private ReadOnlyObjectWrapper<TreeTableColumn<S,T>> tableColumn =
             new ReadOnlyObjectWrapper<TreeTableColumn<S,T>>(this, "tableColumn") {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
@@ -200,22 +200,22 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
 
     // --- TableColumn
     /**
-     * The TreeTableColumn instance that backs this TreeTableCell.
+     * The {code TreeTableColumn} instance that backs this {@code TreeTableCell}.
      */
-    private ReadOnlyObjectWrapper<TreeTableColumn<S,T>> treeTableColumn =
-            new ReadOnlyObjectWrapper<TreeTableColumn<S,T>>(this, "treeTableColumn") {
+    private ReadOnlyObjectWrapper<TreeTableColumn<S,T>> tableColumn =
+            new ReadOnlyObjectWrapper<TreeTableColumn<S,T>>(this, "tableColumn") {
         @Override protected void invalidated() {
             updateColumnIndex();
         }
     };
-    public final ReadOnlyObjectProperty<TreeTableColumn<S,T>> tableColumnProperty() { return treeTableColumn.getReadOnlyProperty(); }
-    private void setTableColumn(TreeTableColumn<S,T> value) { treeTableColumn.set(value); }
-    public final TreeTableColumn<S,T> getTableColumn() { return treeTableColumn.get(); }
+    public final ReadOnlyObjectProperty<TreeTableColumn<S,T>> tableColumnProperty() { return tableColumn.getReadOnlyProperty(); }
+    private void setTableColumn(TreeTableColumn<S,T> value) { tableColumn.set(value); }
+    public final TreeTableColumn<S,T> getTableColumn() { return tableColumn.get(); }
 
 
     // --- TableView
     /**
-     * The TreeTableView associated with this TreeTableCell.
+     * The {@code TreeTableView} associated with this {@code TreeTableCell}.
      */
     private ReadOnlyObjectWrapper<TreeTableView<S>> treeTableView;
     private void setTreeTableView(TreeTableView<S> value) {
@@ -284,14 +284,24 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
 
     // --- TableRow
     /**
-     * The TreeTableRow that this TreeTableCell currently finds itself placed within.
+     * The {@code TreeTableRow} that this {@code TreeTableCell} currently finds itself placed within.
      */
-    private ReadOnlyObjectWrapper<TreeTableRow<S>> treeTableRow =
-            new ReadOnlyObjectWrapper<TreeTableRow<S>>(this, "treeTableRow");
-    private void setTreeTableRow(TreeTableRow<S> value) { treeTableRow.set(value); }
-    public final TreeTableRow<S> getTreeTableRow() { return treeTableRow.get(); }
-    public final ReadOnlyObjectProperty<TreeTableRow<S>> tableRowProperty() { return treeTableRow;  }
+    private ReadOnlyObjectWrapper<TreeTableRow<S>> tableRow =
+            new ReadOnlyObjectWrapper<TreeTableRow<S>>(this, "tableRow");
+    private void setTableRow(TreeTableRow<S> value) { tableRow.set(value); }
+    public final TreeTableRow<S> getTableRow() { return tableRow.get(); }
+    public final ReadOnlyObjectProperty<TreeTableRow<S>> tableRowProperty() {
+        return tableRow.getReadOnlyProperty();
+    }
 
+    // The following method was misnamed and is deprecated in favor of the
+    // correctly named method.
+    /**
+     * @deprecated Use {@link getTableRow} instead.
+     * @return the {@code TreeTableRow}
+     */
+    @Deprecated(since = "17")
+    public final TreeTableRow<S> getTreeTableRow() { return getTableRow(); }
 
 
     /***************************************************************************
@@ -309,7 +319,7 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
 
         final TreeTableView<S> table = getTreeTableView();
         final TreeTableColumn<S,T> column = getTableColumn();
-        final TreeTableRow<S> row = getTreeTableRow();
+        final TreeTableRow<S> row = getTableRow();
         if (!isEditable() ||
                 (table != null && !table.isEditable()) ||
                 (column != null && !column.isEditable()) ||
@@ -427,7 +437,7 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
         // out, as it is valid for an empty TableCell to be selected, as long
         // as the parent TableRow is not empty (see RT-15529).
         /*if (selected && isEmpty()) return;*/
-        if (getTreeTableRow() == null || getTreeTableRow().isEmpty()) return;
+        if (getTableRow() == null || getTableRow().isEmpty()) return;
         setSelected(selected);
     }
 
@@ -620,7 +630,7 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
         final boolean isEmpty = isEmpty();
         final T oldValue = getItem();
 
-        final TreeTableRow<S> tableRow = getTreeTableRow();
+        final TreeTableRow<S> tableRow = getTableRow();
         final S rowItem = tableRow == null ? null : tableRow.getItem();
 
         final boolean indexExceedsItemCount = index >= itemCount;
@@ -723,7 +733,7 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
      * @param treeTableRow the TreeTableRow associated with this TreeTableCell
      */
     public final void updateTreeTableRow(TreeTableRow<S> treeTableRow) {
-        this.setTreeTableRow(treeTableRow);
+        this.setTableRow(treeTableRow);
     }
 
     /**
@@ -810,7 +820,7 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
         switch (attribute) {
             case ROW_INDEX: return getIndex();
             case COLUMN_INDEX: return columnIndex;
-            case SELECTED: return isInCellSelectionMode() ? isSelected() : getTreeTableRow().isSelected();
+            case SELECTED: return isInCellSelectionMode() ? isSelected() : getTableRow().isSelected();
             default: return super.queryAccessibleAttribute(attribute, parameters);
         }
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
@@ -725,9 +725,9 @@ public class TableColumnHeader extends Region {
             treeTableRow.updateIndex(row);
             treeTableRow.updateTreeItem(ttv.getTreeItem(row));
 
-            cell.updateTreeTableColumn(tc);
+            cell.updateTableColumn(tc);
             cell.updateTreeTableView(ttv);
-            cell.updateTreeTableRow(treeTableRow);
+            cell.updateTableRow(treeTableRow);
             cell.updateIndex(row);
 
             if ((cell.getText() != null && !cell.getText().isEmpty()) || cell.getGraphic() != null) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableCellSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableCellSkin.java
@@ -128,7 +128,7 @@ public class TreeTableCellSkin<S,T> extends TableCellSkinBase<TreeItem<S>, T, Tr
             return leftPadding;
         }
 
-        TreeTableRow<S> treeTableRow = cell.getTreeTableRow();
+        TreeTableRow<S> treeTableRow = cell.getTableRow();
         if (treeTableRow == null) return leftPadding;
 
         TreeItem<S> treeItem = treeTableRow.getTreeItem();

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableRowSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableRowSkin.java
@@ -265,7 +265,7 @@ public class TreeTableRowSkin<T> extends TableRowSkinBase<TreeItem<T>, TreeTable
         TreeTableColumn tableColumn = (TreeTableColumn<T,?>) tcb;
         TreeTableCell cell = (TreeTableCell) tableColumn.getCellFactory().call(tableColumn);
 
-        cell.updateTreeTableColumn(tableColumn);
+        cell.updateTableColumn(tableColumn);
         cell.updateTreeTableView(tableColumn.getTreeTableView());
 
         return cell;
@@ -321,7 +321,7 @@ public class TreeTableRowSkin<T> extends TableRowSkinBase<TreeItem<T>, TreeTable
 
     /** {@inheritDoc} */
     @Override protected void updateCell(TreeTableCell<T, ?> cell, TreeTableRow<T> row) {
-        cell.updateTreeTableRow(row);
+        cell.updateTableRow(row);
     }
 
     /** {@inheritDoc} */

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellTest.java
@@ -92,7 +92,7 @@ public class CellTest {
         } else if (cell instanceof TreeTableCell) {
             TreeTableRow tableRow = new TreeTableRow();
             CellShim.updateItem(tableRow, "TableRow", false);
-            ((TreeTableCell)cell).updateTreeTableRow(tableRow);
+            ((TreeTableCell)cell).updateTableRow(tableRow);
             TreeTableCellShim.set_lockItemOnEdit((TreeTableCell)cell, true);
         }
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellEditingTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellEditingTest.java
@@ -176,7 +176,7 @@ public class TreeTableCellEditingTest {
         editingColumn.setCellValueFactory(param -> null);
         table.getColumns().add(editingColumn);
         cell.updateTreeTableView(table);
-        cell.updateTreeTableColumn(editingColumn);
+        cell.updateTableColumn(editingColumn);
         // make sure that focus change doesn't interfere with tests
         // (editing cell loosing focus will be canceled from focusListener in Cell)
         // Note: not really needed for Tree/TableCell because the cell is never focused

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
@@ -151,7 +151,7 @@ public class TreeTableCellTest {
 
     @Test public void treeItemIsNullWhenIndexIsOutOfRange() {
         cell.updateIndex(50);
-        cell.updateTreeTableRow(row);
+        cell.updateTableRow(row);
         cell.updateTreeTableView(tree);
         assertNull(cell.getTableRow().getTreeItem());
     }
@@ -506,7 +506,7 @@ public class TreeTableCellTest {
 
     @Test public void checkTableRowProperty() {
         cell.updateTreeTableView(tree);
-        cell.updateTreeTableRow(row);
+        cell.updateTableRow(row);
         assertSame(row, cell.getTableRow());
         assertSame(row, cell.tableRowProperty().get());
         assertFalse(cell.tableRowProperty() instanceof ObjectProperty);
@@ -515,7 +515,7 @@ public class TreeTableCellTest {
     @Test public void checkTableColumnProperty() {
         TreeTableColumn<String, String> column = new TreeTableColumn<>();
         cell.updateTreeTableView(tree);
-        cell.updateTreeTableColumn(column);
+        cell.updateTableColumn(column);
         assertSame(column, cell.getTableColumn());
         assertSame(column, cell.tableColumnProperty().get());
         assertFalse(cell.tableColumnProperty() instanceof ObjectProperty);
@@ -533,7 +533,7 @@ public class TreeTableCellTest {
         TreeTableColumn col = new TreeTableColumn("TEST");
         col.setCellValueFactory(param -> null);
         tree.getColumns().add(col);
-        cell.updateTreeTableColumn(col);
+        cell.updateTableColumn(col);
         cell.updateTreeTableView(tree);
 
         // set index to 0, which results in the cell value factory returning
@@ -688,8 +688,8 @@ public class TreeTableCellTest {
         treeTableColumn.setEditable(true);
         tree.getColumns().add(treeTableColumn);
 
-        cell.updateTreeTableColumn(treeTableColumn);
-        cell.updateTreeTableRow(row);
+        cell.updateTableColumn(treeTableColumn);
+        cell.updateTableRow(row);
         cell.updateTreeTableView(tree);
 
         cell.updateIndex(0);
@@ -713,8 +713,8 @@ public class TreeTableCellTest {
         treeTableColumn.setEditable(true);
         tree.getColumns().add(treeTableColumn);
 
-        cell.updateTreeTableColumn(treeTableColumn);
-        cell.updateTreeTableRow(row);
+        cell.updateTableColumn(treeTableColumn);
+        cell.updateTableRow(row);
         cell.updateTreeTableView(tree);
 
         cell.updateIndex(0);
@@ -738,8 +738,8 @@ public class TreeTableCellTest {
         treeTableColumn.setEditable(false);
         tree.getColumns().add(treeTableColumn);
 
-        cell.updateTreeTableColumn(treeTableColumn);
-        cell.updateTreeTableRow(row);
+        cell.updateTableColumn(treeTableColumn);
+        cell.updateTableRow(row);
         cell.updateTreeTableView(tree);
 
         cell.updateIndex(0);
@@ -759,7 +759,7 @@ public class TreeTableCellTest {
         editingColumn.setCellValueFactory(cc -> new SimpleObjectProperty<>(""));
 
         cell.updateTreeTableView(tree);
-        cell.updateTreeTableColumn(editingColumn);
+        cell.updateTableColumn(editingColumn);
     }
 
     @Test
@@ -893,7 +893,7 @@ public class TreeTableCellTest {
         editingColumn.setCellValueFactory(param -> null);
         tree.getColumns().add(editingColumn);
         cell.updateTreeTableView(tree);
-        cell.updateTreeTableColumn(editingColumn);
+        cell.updateTableColumn(editingColumn);
         // test editing: first round
         // switch cell off editing by table api
         int editingIndex = 1;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
@@ -29,6 +29,7 @@ import javafx.scene.control.skin.TreeTableCellSkin;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.ObjectProperty;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeTableCell;
 import javafx.scene.control.TreeTableCellShim;
@@ -125,10 +126,10 @@ public class TreeTableCellTest {
         cell.updateIndex(0);
         cell.updateTreeTableView(tree);
         assertSame(ROOT, cell.getItem());
-        assertSame(root, cell.getTreeTableRow().getTreeItem());
+        assertSame(root, cell.getTableRow().getTreeItem());
         cell.updateIndex(1);
         assertSame(APPLES, cell.getItem());
-        assertSame(apples, cell.getTreeTableRow().getTreeItem());
+        assertSame(apples, cell.getTableRow().getTreeItem());
     }
 
     @Ignore // TODO file bug!
@@ -136,10 +137,10 @@ public class TreeTableCellTest {
         cell.updateTreeTableView(tree);
         cell.updateIndex(0);
         assertSame(ROOT, cell.getItem());
-        assertSame(root, cell.getTreeTableRow().getTreeItem());
+        assertSame(root, cell.getTableRow().getTreeItem());
         cell.updateIndex(1);
         assertSame(APPLES, cell.getItem());
-        assertSame(apples, cell.getTreeTableRow().getTreeItem());
+        assertSame(apples, cell.getTableRow().getTreeItem());
     }
 
     @Test public void itemIsNullWhenIndexIsOutOfRange() {
@@ -152,7 +153,7 @@ public class TreeTableCellTest {
         cell.updateIndex(50);
         cell.updateTreeTableRow(row);
         cell.updateTreeTableView(tree);
-        assertNull(cell.getTreeTableRow().getTreeItem());
+        assertNull(cell.getTableRow().getTreeItem());
     }
 
     @Test public void itemIsNullWhenIndexIsOutOfRange2() {
@@ -178,7 +179,7 @@ public class TreeTableCellTest {
         cell.updateTreeTableView(tree);
         assertSame(ORANGES, cell.getItem());
         root.getChildren().remove(oranges);
-        assertNull(cell.getTreeTableRow().getTreeItem());
+        assertNull(cell.getTableRow().getTreeItem());
         assertNull(cell.getItem());
     }
 
@@ -188,7 +189,7 @@ public class TreeTableCellTest {
         cell.updateIndex(1);
         cell.updateTreeTableView(tree);
         assertSame(APPLES, cell.getItem());
-        assertSame(apples, cell.getTreeTableRow().getTreeItem());
+        assertSame(apples, cell.getTableRow().getTreeItem());
 
         // then update the root children list so that the 1st item (including root),
         // is no longer 'Apples', but 'Lime'
@@ -201,7 +202,7 @@ public class TreeTableCellTest {
         cell.updateIndex(2);
         cell.updateTreeTableView(tree);
         assertSame(ORANGES, cell.getItem());
-        assertSame(oranges, cell.getTreeTableRow().getTreeItem());
+        assertSame(oranges, cell.getTableRow().getTreeItem());
         String previous = APPLES;
         root.getChildren().add(0, new TreeItem<>("Lime"));
         assertEquals(previous, cell.getItem());
@@ -493,6 +494,31 @@ public class TreeTableCellTest {
 
     @Test public void treeTableViewPropertyNameIs_treeTableView() {
         assertEquals("treeTableView", cell.treeTableViewProperty().getName());
+    }
+
+    @Test public void checkTableRowPropertyName() {
+        assertEquals("tableRow", cell.tableRowProperty().getName());
+    }
+
+    @Test public void checkTableColumnPropertyName() {
+        assertEquals("tableColumn", cell.tableColumnProperty().getName());
+    }
+
+    @Test public void checkTableRowProperty() {
+        cell.updateTreeTableView(tree);
+        cell.updateTreeTableRow(row);
+        assertSame(row, cell.getTableRow());
+        assertSame(row, cell.tableRowProperty().get());
+        assertFalse(cell.tableRowProperty() instanceof ObjectProperty);
+    }
+
+    @Test public void checkTableColumnProperty() {
+        TreeTableColumn<String, String> column = new TreeTableColumn<>();
+        cell.updateTreeTableView(tree);
+        cell.updateTreeTableColumn(column);
+        assertSame(column, cell.getTableColumn());
+        assertSame(column, cell.tableColumnProperty().get());
+        assertFalse(cell.tableColumnProperty() instanceof ObjectProperty);
     }
 
     private int rt_29923_count = 0;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/CheckBoxTreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/CheckBoxTreeTableCellTest.java
@@ -69,7 +69,7 @@ public class CheckBoxTreeTableCellTest {
 
     private void setTableViewAndTableColumn(TreeTableCell cell) {
         cell.updateTreeTableView(tableView);
-        cell.updateTreeTableColumn(tableColumn);
+        cell.updateTableColumn(tableColumn);
     }
 
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/ChoiceBoxTreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/ChoiceBoxTreeTableCellTest.java
@@ -294,7 +294,7 @@ public class ChoiceBoxTreeTableCellTest {
         tableView.setEditable(true);
         ChoiceBoxTreeTableCell<Object,Object> cell = new ChoiceBoxTreeTableCell<>();
         cell.updateTreeTableView(tableView);
-        cell.updateTreeTableColumn(tc);
+        cell.updateTableColumn(tc);
 
         tableView.edit(0, tc);
         assertFalse(cell.isEditing());
@@ -308,7 +308,7 @@ public class ChoiceBoxTreeTableCellTest {
         ChoiceBoxTreeTableCell<Object,Object> cell = new ChoiceBoxTreeTableCell<>();
         cell.setEditable(true);
         cell.updateTreeTableView(tableView);
-        cell.updateTreeTableColumn(tc);
+        cell.updateTableColumn(tc);
 
         tableView.edit(0, tc);
         assertFalse(cell.isEditing());
@@ -353,7 +353,7 @@ public class ChoiceBoxTreeTableCellTest {
         ChoiceBoxTreeTableCell<Object,Object> cell = new ChoiceBoxTreeTableCell<>();
         cell.updateTreeTableView(tableView);
         cell.updateIndex(0);
-        cell.updateTreeTableColumn(tc);
+        cell.updateTableColumn(tc);
 
         tableView.edit(0, tc);
         assertTrue(cell.isEditing());
@@ -368,7 +368,7 @@ public class ChoiceBoxTreeTableCellTest {
         ChoiceBoxTreeTableCell<Object,Object> cell = new ChoiceBoxTreeTableCell<>();
         cell.updateTreeTableView(tableView);
         cell.updateIndex(0);
-        cell.updateTreeTableColumn(tc);
+        cell.updateTableColumn(tc);
         cell.setEditable(true);
 
         tableView.edit(0, tc);
@@ -385,7 +385,7 @@ public class ChoiceBoxTreeTableCellTest {
         ChoiceBoxTreeTableCell<Object,Object> cell = new ChoiceBoxTreeTableCell<>();
         cell.updateTreeTableView(tableView);
         cell.updateIndex(0);
-        cell.updateTreeTableColumn(tc);
+        cell.updateTableColumn(tc);
         cell.setEditable(true);
 
         tableView.edit(0, tc);
@@ -405,7 +405,7 @@ public class ChoiceBoxTreeTableCellTest {
         ChoiceBoxTreeTableCell<Object,Object> cell = new ChoiceBoxTreeTableCell<>();
         cell.updateTreeTableView(tableView);
         cell.updateIndex(0);
-        cell.updateTreeTableColumn(tc);
+        cell.updateTableColumn(tc);
         cell.setEditable(true);
 
         tableView.edit(0, tc);
@@ -425,7 +425,7 @@ public class ChoiceBoxTreeTableCellTest {
         ChoiceBoxTreeTableCell<Object,Object> cell = new ChoiceBoxTreeTableCell<>();
         cell.updateTreeTableView(tableView);
         cell.updateIndex(0);
-        cell.updateTreeTableColumn(tc);
+        cell.updateTableColumn(tc);
         cell.setEditable(true);
 
         tableView.edit(0, tc);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/ComboBoxTreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/ComboBoxTreeTableCellTest.java
@@ -317,7 +317,7 @@ public class ComboBoxTreeTableCellTest {
         tableView.setEditable(true);
         ComboBoxTreeTableCell<Object,Object> cell = new ComboBoxTreeTableCell<>();
         cell.updateTreeTableView(tableView);
-        cell.updateTreeTableColumn(tc);
+        cell.updateTableColumn(tc);
 
         tableView.edit(0, tc);
         assertFalse(cell.isEditing());
@@ -331,7 +331,7 @@ public class ComboBoxTreeTableCellTest {
         ComboBoxTreeTableCell<Object,Object> cell = new ComboBoxTreeTableCell<>();
         cell.setEditable(true);
         cell.updateTreeTableView(tableView);
-        cell.updateTreeTableColumn(tc);
+        cell.updateTableColumn(tc);
 
         tableView.edit(0, tc);
         assertFalse(cell.isEditing());
@@ -376,7 +376,7 @@ public class ComboBoxTreeTableCellTest {
         ComboBoxTreeTableCell<Object,Object> cell = new ComboBoxTreeTableCell<>();
         cell.updateTreeTableView(tableView);
         cell.updateIndex(0);
-        cell.updateTreeTableColumn(tc);
+        cell.updateTableColumn(tc);
 
         tableView.edit(0, tc);
         assertTrue(cell.isEditing());
@@ -391,7 +391,7 @@ public class ComboBoxTreeTableCellTest {
         ComboBoxTreeTableCell<Object,Object> cell = new ComboBoxTreeTableCell<>();
         cell.updateTreeTableView(tableView);
         cell.updateIndex(0);
-        cell.updateTreeTableColumn(tc);
+        cell.updateTableColumn(tc);
         cell.setEditable(true);
 
         tableView.edit(0, tc);
@@ -408,7 +408,7 @@ public class ComboBoxTreeTableCellTest {
         ComboBoxTreeTableCell<Object,Object> cell = new ComboBoxTreeTableCell<>();
         cell.updateTreeTableView(tableView);
         cell.updateIndex(0);
-        cell.updateTreeTableColumn(tc);
+        cell.updateTableColumn(tc);
         cell.setEditable(true);
 
         tableView.edit(0, tc);
@@ -428,7 +428,7 @@ public class ComboBoxTreeTableCellTest {
         ComboBoxTreeTableCell<Object,Object> cell = new ComboBoxTreeTableCell<>();
         cell.updateTreeTableView(tableView);
         cell.updateIndex(0);
-        cell.updateTreeTableColumn(tc);
+        cell.updateTableColumn(tc);
         cell.setEditable(true);
 
         tableView.edit(0, tc);
@@ -448,7 +448,7 @@ public class ComboBoxTreeTableCellTest {
         ComboBoxTreeTableCell<Object,Object> cell = new ComboBoxTreeTableCell<>();
         cell.updateTreeTableView(tableView);
         cell.updateIndex(0);
-        cell.updateTreeTableColumn(tc);
+        cell.updateTableColumn(tc);
         cell.setEditable(true);
 
         tableView.edit(0, tc);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/ProgressBarTreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/ProgressBarTreeTableCellTest.java
@@ -65,7 +65,7 @@ public class ProgressBarTreeTableCellTest {
 
     private void setTableViewAndTreeTableColumn(TreeTableCell cell) {
         cell.updateTreeTableView(tableView);
-        cell.updateTreeTableColumn(tableColumn);
+        cell.updateTableColumn(tableColumn);
     }
 
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TextFieldTreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TextFieldTreeTableCellTest.java
@@ -250,7 +250,7 @@ public class TextFieldTreeTableCellTest {
         tableView.setEditable(true);
         TextFieldTreeTableCell<Object,Object> cell = new TextFieldTreeTableCell<>();
         cell.updateTreeTableView(tableView);
-        cell.updateTreeTableColumn(tc);
+        cell.updateTableColumn(tc);
 
         tableView.edit(0, tc);
         assertFalse(cell.isEditing());
@@ -265,7 +265,7 @@ public class TextFieldTreeTableCellTest {
     //        TextFieldTreeTableCell<Object,Object> cell = new TextFieldTreeTableCell<>();
     //        cell.updateTreeTableView(tableView);
     //        cell.updateIndex(0);
-    //        cell.updateTreeTableColumn(tc);
+    //        cell.updateTableColumn(tc);
     //        cell.setEditable(true);
     //
     //        tableView.edit(0, tc);
@@ -289,7 +289,7 @@ public class TextFieldTreeTableCellTest {
         TreeTableView tableView = new TreeTableView(new TreeItem("TEST"));
         tableView.getColumns().add(tableColumn);
         TextFieldTreeTableCell<Object,Object> cell = new TextFieldTreeTableCell<>();
-        cell.updateTreeTableColumn(tableColumn);
+        cell.updateTableColumn(tableColumn);
         cell.updateTreeTableView(tableView);
         cell.updateItem("TEST", false);
 
@@ -314,7 +314,7 @@ public class TextFieldTreeTableCellTest {
         TextFieldTreeTableCell<Object,Object> cell = new TextFieldTreeTableCell<>();
         cell.updateTreeTableView(tableView);
         cell.updateIndex(0);
-        cell.updateTreeTableColumn(tc);
+        cell.updateTableColumn(tc);
 
         tableView.edit(0, tc);
         assertTrue(cell.isEditing());
@@ -329,7 +329,7 @@ public class TextFieldTreeTableCellTest {
         TextFieldTreeTableCell<Object,Object> cell = new TextFieldTreeTableCell<>();
         cell.updateTreeTableView(tableView);
         cell.updateIndex(0);
-        cell.updateTreeTableColumn(tc);
+        cell.updateTableColumn(tc);
         cell.setEditable(true);
 
         tableView.edit(0, tc);
@@ -346,7 +346,7 @@ public class TextFieldTreeTableCellTest {
         TextFieldTreeTableCell<Object,Object> cell = new TextFieldTreeTableCell<>();
         cell.updateTreeTableView(tableView);
         cell.updateIndex(0);
-        cell.updateTreeTableColumn(tc);
+        cell.updateTableColumn(tc);
         cell.setEditable(true);
 
         tableView.edit(0, tc);
@@ -366,7 +366,7 @@ public class TextFieldTreeTableCellTest {
         TextFieldTreeTableCell<Object,Object> cell = new TextFieldTreeTableCell<>();
         cell.updateTreeTableView(tableView);
         cell.updateIndex(0);
-        cell.updateTreeTableColumn(tc);
+        cell.updateTableColumn(tc);
         cell.setEditable(true);
 
         tableView.edit(0, tc);


### PR DESCRIPTION
In the `TreeTableCell` class there is a mismatch between name of the following property method vs the getter:

```
    public final ReadOnlyObjectProperty<TreeTableRow<S>> tableRowProperty()
    public final TreeTableRow<S> getTreeTableRow()
```

The get method has "Tree" in the name while the property method does not.

By contrast, the corresponding methods for column are self-consistent, and are named without "Tree" in the name:

```
    public final ReadOnlyObjectProperty<TreeTableColumn<S,​T>> tableColumnProperty()
    public final TreeTableColumn<S,​T> getTableColumn()
```

The solution is to effectively change `getTreeTableRow()` to `getTableRow()`. In order to preserve source and binary compatibility, the method is copied rather than renamed. The existing `getTreeTableRow()` method is deprecated (not for removal).

Additionally, the docs for each property is on a private property field that *does* have tree in the name, which results in no docs being generated for either the `tableRow` or `tableColumn` property.

Finally, there is a problem with the implementation of the `tableRowProperty()` method in that it returns the writable property by mistake rather than the read-only property that is specified by the method's return type.

In summary, the following changes are made to `TreeTableCell`:

1. Deprecate the `getTreeTableRow` method.
2. Add a `getTableRow` method.
3. Rename the (private) property object fields from `treeTableRow` and `treeTableColumn` to `tableRow` and `tableColumn`, including the name of the bean, so that they match the public property method names. This will allow API docs to be generated.
4. Change the implementation of the tableRowProperty() method to return a read-only property.

In addition to changing the existing implementation and tests to call the new `getTableRow` method instead of the now-deprecated `getTreeTableRow` method, I added unit tests to validate changes 3 and 4.

NOTE: this is targeted to `jfx17`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270314](https://bugs.openjdk.java.net/browse/JDK-8270314): TreeTableCell: inconsistent naming for tableRow and tableColumn property methods


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Jeanette Winzenburg](https://openjdk.java.net/census#fastegal) (@kleopatra - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/575/head:pull/575` \
`$ git checkout pull/575`

Update a local copy of the PR: \
`$ git checkout pull/575` \
`$ git pull https://git.openjdk.java.net/jfx pull/575/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 575`

View PR using the GUI difftool: \
`$ git pr show -t 575`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/575.diff">https://git.openjdk.java.net/jfx/pull/575.diff</a>

</details>
