### PR TITLE
8270479: WebKit 612.1 build fails with Visual Studio 2017

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.cpp
@@ -2695,9 +2695,9 @@ static bool isSiblingSubsequent(const Node& siblingA, const Node& siblingB)
     return false;
 }
 
+#if PLATFORM(JAVA)
 // VS 2017 has buggy support for compile-time inline constants, so they
 // are defined here as runtime constants
-#if PLATFORM(JAVA)
 const PartialOrdering PartialOrdering::less(Type::Less);
 const PartialOrdering PartialOrdering::equivalent(Type::Equivalent);
 const PartialOrdering PartialOrdering::greater(Type::Greater);

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.cpp
@@ -2695,6 +2695,15 @@ static bool isSiblingSubsequent(const Node& siblingA, const Node& siblingB)
     return false;
 }
 
+// VS 2017 has buggy support for compile-time inline constants, so they
+// are defined here as runtime constants
+#if PLATFORM(JAVA)
+const PartialOrdering PartialOrdering::less(Type::Less);
+const PartialOrdering PartialOrdering::equivalent(Type::Equivalent);
+const PartialOrdering PartialOrdering::greater(Type::Greater);
+const PartialOrdering PartialOrdering::unordered(Type::Unordered);
+#endif
+
 template<TreeType treeType> PartialOrdering treeOrder(const Node& a, const Node& b)
 {
     if (&a == &b)

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.h
@@ -941,9 +941,10 @@ inline void Node::addInclusiveAncestorState(AncestorState state)
     }
 }
 
+#if PLATFORM(JAVA)
 // VS 2017 has buggy support for compile-time inline constants, so the
 // definitions are moved to Node.cpp
-#if !PLATFORM(JAVA)
+#else
 inline constexpr PartialOrdering PartialOrdering::less(Type::Less);
 inline constexpr PartialOrdering PartialOrdering::equivalent(Type::Equivalent);
 inline constexpr PartialOrdering PartialOrdering::greater(Type::Greater);

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.h
@@ -941,10 +941,14 @@ inline void Node::addInclusiveAncestorState(AncestorState state)
     }
 }
 
+// VS 2017 has buggy support for compile-time inline constants, so the
+// definitions are moved to Node.cpp
+#if !PLATFORM(JAVA)
 inline constexpr PartialOrdering PartialOrdering::less(Type::Less);
 inline constexpr PartialOrdering PartialOrdering::equivalent(Type::Equivalent);
 inline constexpr PartialOrdering PartialOrdering::greater(Type::Greater);
 inline constexpr PartialOrdering PartialOrdering::unordered(Type::Unordered);
+#endif
 
 constexpr bool is_eq(PartialOrdering ordering)
 {

--- a/modules/javafx.web/src/main/native/Source/WebCore/inspector/InspectorOverlay.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/inspector/InspectorOverlay.cpp
@@ -1195,8 +1195,15 @@ void InspectorOverlay::drawLayoutLabel(GraphicsContext& context, String label, F
     FontCascade font(WTFMove(fontDescription), 0, 0);
     font.update(nullptr);
 
+#if PLATFORM(JAVA)
+    // VS2017 complains if these are not defined as float constants (which they
+    // really should be anyway)
+    constexpr auto padding = 4.0f;
+    constexpr auto arrowSize = 4.0f;
+#else
     constexpr auto padding = 4;
     constexpr auto arrowSize = 4;
+#endif
     float textHeight = font.fontMetrics().floatHeight();
     float textDescent = font.fontMetrics().floatDescent();
 


### PR DESCRIPTION
This fix allows the latest WebKit 612.1 to compile with Visual Studio 2017. For the jfx mainline, our current toolchain for Windows is VS2019 16.9.3, but we would like to continue to allow developers to build with VS 2017.

The JavaFX 11 code line still uses VS2017 (15.9.24), so we must fix this in the `jfx11u` code line in any case. Fixing it mainline first and then backporting it will allow the native WebKit code to remain in sync between mainline and jfx11u as well as keeping JavaFX buildable on VS2017 for a while longer.

As noted in the JBS bug report, eventually we will need to upgrade all code lines to a minimum of VS2019 for building WebKit, but this fix allows us to delay that for a while longer.

## Notes to Reviewers

There were two problems that needed to be fixed:

*  `WebCore/inspector/InspectorOverlay.cpp` fails to compile with an error that "conversion from 'const int' to 'float' requires a narrowing conversion". The fix is to initialize the two `constexpr` variables with float constants instead of integer constants.
* `jfxwebkit.dll` fails to link with 4 duplicate symbols due to VS2017's incomplete (or buggy) support for inline constant variables. The fix is to move the definition of those 4 constant variables from `Node.h` to `Node.cpp` and define them as runtime constants. 

I qualified both changes with `#if PLATFORM(JAVA)` so our local modifications are clearly identified. I could have further qualified the second of these two changes (there's no point in doing it for the first) with `&& OS(WINDOWS)` but chose to be consistent on all OS platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270479](https://bugs.openjdk.java.net/browse/JDK-8270479): WebKit 612.1 build fails with Visual Studio 2017


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Joeri Sykora](https://openjdk.java.net/census#sykora) (@tiainen - Author)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/576/head:pull/576` \
`$ git checkout pull/576`

Update a local copy of the PR: \
`$ git checkout pull/576` \
`$ git pull https://git.openjdk.java.net/jfx pull/576/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 576`

View PR using the GUI difftool: \
`$ git pr show -t 576`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/576.diff">https://git.openjdk.java.net/jfx/pull/576.diff</a>

</details>
