### PR TITLE
8270838: Remove deprecated protected access members from DateTimeStringConverter

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/util/converter/DateTimeStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/DateTimeStringConverter.java
@@ -44,37 +44,15 @@ public class DateTimeStringConverter extends StringConverter<Date> {
 
     // ------------------------------------------------------ Private properties
 
-    /**
-     * @deprecated This field was exposed erroneously and will be removed in a future version.
-     */
-    @Deprecated(forRemoval = true, since = "17")
-    protected final Locale locale;
+    final Locale locale;
 
-    /**
-     * @deprecated This field was exposed erroneously and will be removed in a future version.
-     */
-    @Deprecated(forRemoval = true, since = "17")
-    protected final String pattern;
+    final String pattern;
 
-    /**
-     * @deprecated This field was exposed erroneously and will be removed in a future version.
-     */
-    @Deprecated(forRemoval = true, since = "17")
-    protected final DateFormat dateFormat;
+    final DateFormat dateFormat;
 
-    /**
-     * @deprecated This field was exposed erroneously and will be removed in a future version.
-     * @since JavaFX 8u40
-     */
-    @Deprecated(forRemoval = true, since = "17")
-    protected final int dateStyle;
+    final int dateStyle;
 
-    /**
-     * @deprecated This field was exposed erroneously and will be removed in a future version.
-     * @since JavaFX 8u40
-     */
-    @Deprecated(forRemoval = true, since = "17")
-    protected final int timeStyle;
+    final int timeStyle;
 
 
     // ------------------------------------------------------------ Constructors
@@ -218,11 +196,8 @@ public class DateTimeStringConverter extends StringConverter<Date> {
      *
      * @return a {@code DateFormat} instance for formatting and parsing in this
      * {@link StringConverter}
-     *
-     * @deprecated This method exposes internal implementation details and will be removed in a future version.
      */
-    @Deprecated(forRemoval = true, since = "17")
-    protected DateFormat getDateFormat() {
+    DateFormat getDateFormat() {
         DateFormat df = null;
 
         if (dateFormat != null) {


### PR DESCRIPTION
`protected` members were changed to package visibility.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270838](https://bugs.openjdk.java.net/browse/JDK-8270838): Remove deprecated protected access members from DateTimeStringConverter


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/578/head:pull/578` \
`$ git checkout pull/578`

Update a local copy of the PR: \
`$ git checkout pull/578` \
`$ git pull https://git.openjdk.java.net/jfx pull/578/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 578`

View PR using the GUI difftool: \
`$ git pr show -t 578`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/578.diff">https://git.openjdk.java.net/jfx/pull/578.diff</a>

</details>
