### PR TITLE
8270839: Remove deprecated implementation methods from Scene

### DIFF
--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyEventFirer.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyEventFirer.java
@@ -25,6 +25,8 @@
 
 package test.com.sun.javafx.scene.control.infrastructure;
 
+import com.sun.javafx.scene.SceneHelper;
+
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -63,7 +65,7 @@ public class KeyEventFirer {
      * Any one of those can be null, but not both. A null/not null scene decides
      * about the delivering path of events. If null, events are delivered
      * via <code>EventUtils.fire(target, keyEvent)</code>, otherwise via
-     * <code>scene.processKeyEvent(keyEvent)</code>.
+     * <code>SceneHelper.processKeyEvent(scene, keyEvent)</code>.
      * <p>
      * Note that in the latter case, the target doesn't matter - the scene
      * delivers keyEvents to its focusOwner. Calling code is responsible to
@@ -111,14 +113,14 @@ public class KeyEventFirer {
      * Dispatches the given events. The process depends on the state of
      * this firer. If the scene is null, the events are delivered via
      * Event.fireEvent(target,..), otherwise they are delivered via
-     * scene.processKeyEvent.
+     * SceneHelper.processKeyEvent.
      *
      * @param events the events to dispatch.
      */
     private void fireEvents(KeyEvent... events) {
         for (KeyEvent evt : events) {
             if (scene != null) {
-                scene.processKeyEvent(evt);
+                SceneHelper.processKeyEvent(scene, evt);
             } else {
                 Event.fireEvent(target, evt);
             }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -842,12 +842,7 @@ public class Scene implements EventTarget {
         PerformanceTracker.logEvent("Scene.initPeer finished");
     }
 
-    // FIXME: make this method package-scope in the next release
-    /**
-     * @deprecated This method was exposed erroneously and will be removed in a future version.
-     */
-    @Deprecated(forRemoval = true, since = "17")
-    public void disposePeer() {
+    void disposePeer() {
         if (peer == null) {
             // This is fine, the window is either not shown yet and there is no
             // need in disposing scene peer, or is hidden and disposePeer()
@@ -2140,13 +2135,7 @@ public class Scene implements EventTarget {
         traverse(node, Direction.NEXT);
     }
 
-    // FIXME: make this method package-scope in the next release
-    /**
-     * @deprecated This method was exposed erroneously and will be removed in a future version.
-     * @param e undocumented method parameter
-     */
-    @Deprecated(forRemoval = true, since = "17")
-    public void processKeyEvent(KeyEvent e) {
+    void processKeyEvent(KeyEvent e) {
         if (dndGesture != null) {
             if (!dndGesture.processKey(e)) {
                 dndGesture = null;
@@ -2232,13 +2221,7 @@ public class Scene implements EventTarget {
         }
     }
 
-    // FIXME: make this method package-scope in the next release
-    /**
-     * @deprecated This method was exposed erroneously and will be removed in a future version.
-     * @param enable undocumented method parameter
-     */
-    @Deprecated(forRemoval = true, since = "17")
-    public void enableInputMethodEvents(boolean enable) {
+    void enableInputMethodEvents(boolean enable) {
        if (peer != null) {
            peer.enableInputMethodEvents(enable);
        }

--- a/tests/system/src/test/addExports
+++ b/tests/system/src/test/addExports
@@ -19,6 +19,7 @@
 --add-exports javafx.graphics/com.sun.javafx.image.impl=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.image=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.sg.prism=ALL-UNNAMED
+--add-exports javafx.graphics/com.sun.javafx.scene=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.prism.impl=ALL-UNNAMED
 #


### PR DESCRIPTION
This removes following implementation methods in Scene by making them package-scope. They were previously deprecated for removal by [JDK-8270246](https://bugs.openjdk.java.net/browse/JDK-8270246):

```
    public void disposePeer()
    public void enableInputMethodEvents(boolean enable)
    public void processKeyEvent(KeyEvent e) 
```

One of the test harness classes was calling `Scene::processKeyEvent` directly, so I changed it to call it via `SceneHelper`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8270839](https://bugs.openjdk.java.net/browse/JDK-8270839): Remove deprecated implementation methods from Scene


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/579/head:pull/579` \
`$ git checkout pull/579`

Update a local copy of the PR: \
`$ git checkout pull/579` \
`$ git pull https://git.openjdk.java.net/jfx pull/579/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 579`

View PR using the GUI difftool: \
`$ git pr show -t 579`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/579.diff">https://git.openjdk.java.net/jfx/pull/579.diff</a>

</details>
