### PR TITLE
8269639: [macos] Calling stage.setY(0) twice causes wrong popups location

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
@@ -350,6 +350,14 @@ extern NSSize maxScreenDimensions;
     jint newH = (h > 0) ? h : (ch > 0) ? (jint)sizeForClient.height : (jint)size.height;
 
     [self _setWindowFrameWithRect:NSMakeRect(newX, newY, newW, newH) withDisplay:JNI_TRUE withAnimate:JNI_FALSE];
+
+    NSRect flipFrame = [self _flipFrame];
+    if (newX != flipFrame.origin.x || newY != flipFrame.origin.y) {
+        // If the new location does not match the position of the window,
+        // send back the actual position to notify the WindowStage,
+        // as it is possible that the windowDidMove event is not triggered.
+        [self _sendJavaWindowMoveEventForFrame:flipFrame];
+    }
 }
 
 - (void)_restorePreZoomedRect

--- a/tests/system/src/test/java/test/javafx/stage/StageAtTopPositionTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/StageAtTopPositionTest.java
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package test.javafx.stage;
 
 import com.sun.javafx.PlatformUtil;
@@ -42,6 +43,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 public class StageAtTopPositionTest {
@@ -69,24 +71,18 @@ public class StageAtTopPositionTest {
             stage.setX(300);
             stage.setY(400);
             stage.addEventHandler(WindowEvent.WINDOW_SHOWN, e ->
-                                    Platform.runLater(startupLatch::countDown));
+                                  Platform.runLater(startupLatch::countDown));
             stage.show();
         }
     }
 
     @BeforeClass
-    public static void initFX() {
+    public static void initFX() throws Exception {
         startupLatch = new CountDownLatch(1);
         new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        try {
-            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
-                fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            fail("Unexpected exception: " + ex);
-        }
+        assertTrue("Timeout waiting for FX runtime to start",
+                   startupLatch.await(15, TimeUnit.SECONDS));
     }
-
 
     @Test
     public void testMoveToTopPosition() throws Exception {

--- a/tests/system/src/test/java/test/javafx/stage/StageAtTopPositionTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/StageAtTopPositionTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.javafx.stage;
+
+import com.sun.javafx.PlatformUtil;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.beans.value.ChangeListener;
+import javafx.scene.Scene;
+import javafx.scene.layout.VBox;
+import javafx.stage.Screen;
+import javafx.stage.Stage;
+import javafx.stage.WindowEvent;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+public class StageAtTopPositionTest {
+    static CountDownLatch startupLatch;
+    static Stage stage;
+
+    public static void main(String[] args) throws Exception {
+        initFX();
+        try {
+            StageAtTopPositionTest test = new StageAtTopPositionTest();
+            test.testMoveToTopPosition();
+        } catch (Throwable e) {
+            e.printStackTrace();
+        } finally {
+            teardown();
+        }
+    }
+
+    public static class TestApp extends Application {
+
+        @Override
+        public void start(Stage primaryStage) throws Exception {
+            primaryStage.setScene(new Scene(new VBox()));
+            stage = primaryStage;
+            stage.setX(300);
+            stage.setY(400);
+            stage.addEventHandler(WindowEvent.WINDOW_SHOWN, e ->
+                                    Platform.runLater(startupLatch::countDown));
+            stage.show();
+        }
+    }
+
+    @BeforeClass
+    public static void initFX() {
+        startupLatch = new CountDownLatch(1);
+        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
+        try {
+            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
+                fail("Timeout waiting for FX runtime to start");
+            }
+        } catch (InterruptedException ex) {
+            fail("Unexpected exception: " + ex);
+        }
+    }
+
+
+    @Test
+    public void testMoveToTopPosition() throws Exception {
+        // Only on Mac
+        assumeTrue(PlatformUtil.isMac());
+
+        Thread.sleep(200);
+        Assert.assertTrue(stage.isShowing());
+        Assert.assertFalse(stage.isFullScreen());
+
+        final double minY = Screen.getPrimary().getVisualBounds().getMinY(); // Mac's system menubar height
+
+        CountDownLatch latch = new CountDownLatch(2);
+        ChangeListener<Number> listenerY = (observable, oldValue, newValue) -> {
+            if (Math.abs((Double) newValue - minY) < 0.1) {
+                latch.countDown();
+            };
+        };
+        stage.yProperty().addListener(listenerY);
+
+        // move once to y=0, gets moved to yMin
+        Platform.runLater(() -> stage.setY(0));
+        Thread.sleep(200);
+        Assert.assertEquals("Window was moved once", minY, stage.getY(), 0.1);
+
+        // move again to y=0, remains at yMin
+        Platform.runLater(() -> stage.setY(0));
+        latch.await(5, TimeUnit.SECONDS);
+        stage.xProperty().removeListener(listenerY);
+
+        Assert.assertEquals("Window was moved twice", minY, stage.getY(), 0.1);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        Platform.runLater(stage::hide);
+        Platform.exit();
+    }
+}


### PR DESCRIPTION
As described in the issue, when the stage is moved to the screen top position, it is moved below the system menu bar. However, doing it twice doesn't trigger a native callback to the Java layer, and the stage yPosition doesn't get updated with the actual position of the application. This has several side effects, like the wrong popup control position.

This PR adds a callback in case set position doesn’t match actual position. 

It is only going to be called when the final position of the stage doesn't match the one that was set, which could happen in rare occasions, mainly due to constrains applied by the native layer, so it doesn't add any overhead.

A system test for MacOS is included.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269639](https://bugs.openjdk.java.net/browse/JDK-8269639): [macos] Calling stage.setY(0) twice causes wrong popups location


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/580/head:pull/580` \
`$ git checkout pull/580`

Update a local copy of the PR: \
`$ git checkout pull/580` \
`$ git pull https://git.openjdk.java.net/jfx pull/580/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 580`

View PR using the GUI difftool: \
`$ git pr show -t 580`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/580.diff">https://git.openjdk.java.net/jfx/pull/580.diff</a>

</details>
