### PR TITLE
8090158: Wrong implementation of adjustValue in scrollBars

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ScrollBar.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ScrollBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -325,8 +325,6 @@ public class ScrollBar extends Control {
             }
 
             boolean incrementing = position > ((getValue() - getMin())/(getMax() - getMin()));
-            if (incrementing && newValue > posValue) newValue = posValue;
-            if (! incrementing && newValue < posValue) newValue = posValue;
             setValue(Utils.clamp(getMin(), newValue, getMax()));
         }
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ScrollBar.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ScrollBar.java
@@ -324,7 +324,6 @@ public class ScrollBar extends Control {
                 newValue = getValue() - getBlockIncrement();
             }
 
-            boolean incrementing = position > ((getValue() - getMin())/(getMax() - getMin()));
             setValue(Utils.clamp(getMin(), newValue, getMax()));
         }
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ScrollBarTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ScrollBarTest.java
@@ -415,6 +415,34 @@ public class ScrollBarTest {
         assertEquals(scrollBar.getValue(), 50.0, 0.0);
     }
 
+    /**
+     * @test
+     * @bug 8090158
+     * Adjusting the scrollbar value close to the max value should use the block increment and reach the max value.
+     */
+    @Test
+    public void incrementCloseToMax() {
+        scrollBar.setMin(0.0);
+        scrollBar.setMax(100.0);
+        scrollBar.setValue(90.0);
+        scrollBar.adjustValue(0.95); //This should block increment to the max value
+        assertEquals(scrollBar.getValue(), 100.0, 0.0);
+    }
+
+    /**
+     * @test
+     * @bug 8090158
+     * Adjusting the scrollbar value close to the min value should use the block increment and reach the min value.
+     */
+    @Test
+    public void incrementCloseToMin() {
+        scrollBar.setMin(0.0);
+        scrollBar.setMax(100.0);
+        scrollBar.setValue(10.0);
+        scrollBar.adjustValue(0.05); //This should block increment to the max value
+        assertEquals(scrollBar.getValue(), 0.0, 0.0);
+    }
+
     @Test public void incrementWhenValueIsNegativeAndSeeIfValueIsClampedToMin() {
         scrollBar.setValue(-30.0);
         scrollBar.increment();


### PR DESCRIPTION
JBS bug: [JDK-8090158](https://bugs.openjdk.java.net/browse/JDK-8090158)

The javadoc of the ScrollBar#adjustValue specifically says that it will adjust the value based on the block increment value. Therefore, there is no reason to stop at the given value when reaching an end. 
