### PR TITLE
8250590: Classes and methods in the javafx.css package are missing documentation

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/util/StringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/StringConverter.java
@@ -43,7 +43,7 @@ public abstract class StringConverter<T> {
     * Converts the object provided into its string form.
     * Format of the returned string is defined by the specific converter.
     * @param object the object of type {@code T} to convert
-    * @return a string representation of the object passed in.
+    * @return a string representation of the object passed in
     */
     public abstract String toString(T object);
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/PseudoClassImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/PseudoClassImpl.java
@@ -32,23 +32,38 @@ import javafx.css.PseudoClass;
  */
 final class PseudoClassImpl extends PseudoClass {
 
-
+    /**
+     * Constructs a {@code PseudoClassImpl} object.
+     * @param pseudoClassName name of the pseudo-class
+     * @param index index of this PseudoClass in pseudoClasses list
+     * @return a {@code PseudoClassImpl} object
+     */
     PseudoClassImpl(String pseudoClassName, int index) {
         this.pseudoClassName = pseudoClassName;
         this.index = index;
     }
 
-    /** @return the pseudo-class state */
+    /**
+     * Gets the pseudo class name.
+     * @return the pseudo class name
+     */
     @Override
     public String getPseudoClassName() {
         return pseudoClassName;
     }
 
-    /** @return the pseudo-class state */
+    /**
+     * Gets the pseudo class name.
+     * @return the pseudo class name
+     */
     @Override public String toString() {
         return pseudoClassName;
     }
 
+    /**
+     * Returns the index of this {@code PseudoClass} in the styleClasses list.
+     * @return index
+     */
     public int getIndex() {
        return index;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/css/CssMetaData.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CssMetaData.java
@@ -113,7 +113,7 @@ import javafx.scene.Node;
 public abstract class CssMetaData<S extends Styleable, V> {
 
     /**
-     * Set the value of the corresponding property on the given Node.
+     * Sets the value of the corresponding property on the given Node.
      * @param styleable The Styleable on which the property value is being set
      * @param value The value to which the property is set
      * @param origin the origin
@@ -160,7 +160,9 @@ public abstract class CssMetaData<S extends Styleable, V> {
     public abstract StyleableProperty<V> getStyleableProperty(S styleable);
 
     private final String property;
+
     /**
+     * Gets the CSS property name.
      * @return the CSS property name
      */
     public final String getProperty() {
@@ -168,8 +170,10 @@ public abstract class CssMetaData<S extends Styleable, V> {
     }
 
     private final StyleConverter<?,V> converter;
+
     /**
-     * @return The CSS converter that handles conversion from a CSS value to a Java Object
+     * Gets the CSS converter that handles conversion from a CSS value to a Java Object.
+     * @return the CSS converter
      */
     public final StyleConverter<?,V> getConverter() {
         return converter;

--- a/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
@@ -107,7 +107,7 @@ import java.util.Map;
 import java.util.Stack;
 
 /**
- * A parser for CSS document string.
+ * A parser for a CSS document string.
  * @since 9
  */
 final public class CssParser {
@@ -4746,7 +4746,7 @@ final public class CssParser {
 
         /**
          * Constructs a {@code ParseError} object with the message.
-         * @param message message
+         * @param message the message
          */
         public ParseError(String message) {
             this.message = message;

--- a/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
@@ -113,7 +113,7 @@ import java.util.Stack;
 final public class CssParser {
 
     /**
-     * Constructs a {@code CssParser}
+     * Constructs a {@code CssParser}.
      */
     public CssParser() {
         properties = new HashMap<String,String>();
@@ -4721,8 +4721,8 @@ final public class CssParser {
     }
 
     /**
-     * List of errors that may have occurred during css processing.
-     * @return An {@code ObservableList} of {@code ParseError}
+     * List of errors that may have occurred during CSS processing.
+     * @return an {@code ObservableList} of {@code ParseError}
      */
     public static ObservableList<ParseError> errorsProperty() {
         return StyleManager.errorsProperty();
@@ -4737,14 +4737,15 @@ final public class CssParser {
     public static class ParseError {
 
         /**
-         * @return The error message from the CSS code.
+         * Returns the error message.
+         * @return the error message
          */
         public final String getMessage() {
             return message;
         }
 
         /**
-         * Constructs a {@code ParseError} object with given message.
+         * Constructs a {@code ParseError} object with the message.
          * @param message message
          */
         public ParseError(String message) {
@@ -4832,7 +4833,7 @@ final public class CssParser {
 
             /**
              * Constructs a {@code PropertySetError} object.
-             * @param styleableProperty css meta data
+             * @param styleableProperty CSS meta data
              * @param styleable styleable node
              * @param message parse error message
              */

--- a/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
@@ -107,10 +107,14 @@ import java.util.Map;
 import java.util.Stack;
 
 /**
+ * A parser for CSS document string.
  * @since 9
  */
 final public class CssParser {
 
+    /**
+     * Constructs a {@code CssParser}
+     */
     public CssParser() {
         properties = new HashMap<String,String>();
     }
@@ -180,10 +184,10 @@ final public class CssParser {
     }
 
     /**
-     * Creates a stylesheet from a CSS document string.
+     * Creates a {@code Stylesheet} from a CSS document string.
      *
      * @param stylesheetText the CSS document to parse
-     * @return the Stylesheet
+     * @return the {@code Stylesheet}
      */
     public Stylesheet parse(final String stylesheetText) {
         final Stylesheet stylesheet = new Stylesheet();
@@ -199,8 +203,8 @@ final public class CssParser {
     }
 
     /**
-     * Creates a stylesheet from a CSS document string using docbase as the base
-     * URL for resolving references within stylesheet.
+     * Creates a {@code Stylesheet} from a CSS document string using docbase as the base
+     * URL for resolving references within {@code Stylesheet}.
      *
      * @param docbase the doc base for resolving URL references
      * @param stylesheetText the CSS document to parse
@@ -256,7 +260,8 @@ final public class CssParser {
 
     }
 
-    /** Parse an in-line style from a Node.
+    /**
+     * Parse an in-line style from a {@code Node}.
      * @param node the styleable node
      * @return the style sheet
      */
@@ -4715,6 +4720,10 @@ final public class CssParser {
         return term;
     }
 
+    /**
+     * List of errors that may have occurred during css processing.
+     * @return An {@code ObservableList} of {@code ParseError}
+     */
     public static ObservableList<ParseError> errorsProperty() {
         return StyleManager.errorsProperty();
     }
@@ -4722,16 +4731,22 @@ final public class CssParser {
 
 
     /**
-     * Encapsulate information about the source and nature of errors encountered
-     * while parsing CSS or applying styles to Nodes.
+     * A class that encapsulates information about the source and nature
+     *  of errors encountered while parsing CSS or applying styles to Nodes.
      */
     public static class ParseError {
 
-        /** @return The error message from the CSS code. */
+        /**
+         * @return The error message from the CSS code.
+         */
         public final String getMessage() {
             return message;
         }
 
+        /**
+         * Constructs a {@code ParseError} object with given message.
+         * @param message message
+         */
         public ParseError(String message) {
             this.message = message;
         }
@@ -4815,6 +4830,12 @@ final public class CssParser {
             private final CssMetaData styleableProperty;
             private final Styleable styleable;
 
+            /**
+             * Constructs a {@code PropertySetError} object.
+             * @param styleableProperty css meta data
+             * @param styleable styleable node
+             * @param message parse error message
+             */
             public PropertySetError(CssMetaData styleableProperty,
                     Styleable styleable, String message) {
                 super(message);

--- a/modules/javafx.graphics/src/main/java/javafx/css/Declaration.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Declaration.java
@@ -33,7 +33,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 
 /**
- * This class serves as a container of CSS property and its value.
+ * This class serves as a container of a CSS property and its value.
  * @since 9
  */
 final public class Declaration {
@@ -88,7 +88,7 @@ final public class Declaration {
 
     /**
      * Gets the importance of this {@code Declaration}.
-     * @return important
+     * @return the important flag
      */
     public final boolean isImportant() {
         return important;
@@ -105,13 +105,14 @@ final public class Declaration {
         return null;
     }
     /**
-     * Indicates whether some other object is "equal to" this one.
+     * Indicates whether some other {@code Object} is "equal to" this one.
      * <p>
-     * One declaration is equal to another regardless of the {@code Rule} to which
+     * One {@code Declaration} is equal to another regardless of the {@code Rule} to which
      * the {@code Declaration} belongs. Only the property, value and importance are
      * considered.
-     * </p>
-     * @return true if this object is the same as the obj argument; false otherwise.
+     *
+     * @param obj an {@code Object} to compare
+     * @return {@code true} if this object is the same as the {@code obj} argument; {@code false} otherwise.
      */
     @Override public boolean equals(Object obj) {
         if (this == obj) {

--- a/modules/javafx.graphics/src/main/java/javafx/css/Declaration.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Declaration.java
@@ -33,6 +33,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 
 /**
+ * This class serves as a container of CSS-property and it's value.
  * @since 9
  */
 final public class Declaration {
@@ -42,6 +43,12 @@ final public class Declaration {
     // The Rule to which this Declaration belongs.
     Rule rule;
 
+    /**
+     * Constructs a {@code Declaration} object
+     * @param propertyName Name of the CSS property
+     * @param parsedValue Value of the CSS property
+     * @param important Importance of the Declaration
+     */
     Declaration(final String propertyName, final ParsedValue parsedValue,
                 final boolean important) {
         this.property = propertyName;
@@ -55,26 +62,41 @@ final public class Declaration {
         }
     }
 
-    /** @return ParsedValue contains the parsed declaration. */
+    /**
+     * Get the parsed value
+     * @return ParsedValue
+     */
     public ParsedValue getParsedValue() {
         return parsedValue;
     }
 
-    /** @return The CSS property name */
+    /**
+     * Get the CSS property name
+     * @return css-property
+     */
     public String getProperty() {
         return property;
     }
 
-    /** @return The Rule to which this Declaration belongs. */
+    /**
+     * Get the {@code Rule} to which this {@code Declaration} belongs.
+     * @return rule
+     */
     public Rule getRule() {
         return rule;
     }
 
+    /**
+     * Get the importance of this {@code Declaration}.
+     * @return important
+     */
     public final boolean isImportant() {
         return important;
     }
 
-    /** Helper */
+    /**
+     * Get the {@code StyleOrigin} of this {@code Declaration}
+     */
     private StyleOrigin getOrigin() {
         Rule rule = getRule();
         if (rule != null)  {
@@ -83,8 +105,8 @@ final public class Declaration {
         return null;
     }
     /**
-     * One declaration is the equal to another regardless of the Rule to which
-     * the Declaration belongs. Only the property, value and importance are
+     * One declaration is equal to another regardless of the {@code Rule} to which
+     * the {@code Declaration} belongs. Only the property, value and importance are
      * considered.
      */
     @Override public boolean equals(Object obj) {
@@ -113,6 +135,9 @@ final public class Declaration {
         return true;
     }
 
+    /**
+     * Returns the hash code of this {@code Declaration}
+     */
     @Override public int hashCode() {
         int hash = 5;
         hash = 89 * hash + (this.property != null ? this.property.hashCode() : 0);
@@ -121,6 +146,9 @@ final public class Declaration {
         return hash;
     }
 
+    /**
+     * Returns a String version of this {@code Declaration}
+     */
     @Override public String toString() {
         StringBuilder sbuf = new StringBuilder(property);
         sbuf.append(": ");

--- a/modules/javafx.graphics/src/main/java/javafx/css/Declaration.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Declaration.java
@@ -112,7 +112,7 @@ final public class Declaration {
      * considered.
      *
      * @param obj an {@code Object} to compare
-     * @return {@code true} if this object is the same as the {@code obj} argument; {@code false} otherwise.
+     * @return {@code true} if this object is the same as the {@code obj} argument; {@code false} otherwise
      */
     @Override public boolean equals(Object obj) {
         if (this == obj) {
@@ -140,9 +140,6 @@ final public class Declaration {
         return true;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override public int hashCode() {
         int hash = 5;
         hash = 89 * hash + (this.property != null ? this.property.hashCode() : 0);
@@ -151,9 +148,6 @@ final public class Declaration {
         return hash;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override public String toString() {
         StringBuilder sbuf = new StringBuilder(property);
         sbuf.append(": ");

--- a/modules/javafx.graphics/src/main/java/javafx/css/Declaration.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Declaration.java
@@ -33,7 +33,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 
 /**
- * This class serves as a container of CSS-property and it's value.
+ * This class serves as a container of CSS property and its value.
  * @since 9
  */
 final public class Declaration {
@@ -44,10 +44,10 @@ final public class Declaration {
     Rule rule;
 
     /**
-     * Constructs a {@code Declaration} object
-     * @param propertyName Name of the CSS property
-     * @param parsedValue Value of the CSS property
-     * @param important Importance of the Declaration
+     * Constructs a {@code Declaration} object.
+     * @param propertyName name of the CSS property
+     * @param parsedValue value of the CSS property
+     * @param important importance of the Declaration
      */
     Declaration(final String propertyName, final ParsedValue parsedValue,
                 final boolean important) {
@@ -63,31 +63,31 @@ final public class Declaration {
     }
 
     /**
-     * Get the parsed value
-     * @return ParsedValue
+     * Gets the parsed value.
+     * @return the parsed value
      */
     public ParsedValue getParsedValue() {
         return parsedValue;
     }
 
     /**
-     * Get the CSS property name
-     * @return css-property
+     * Gets the CSS property name.
+     * @return the CSS property
      */
     public String getProperty() {
         return property;
     }
 
     /**
-     * Get the {@code Rule} to which this {@code Declaration} belongs.
-     * @return rule
+     * Gets the {@code Rule} to which this {@code Declaration} belongs.
+     * @return the {@code Rule}
      */
     public Rule getRule() {
         return rule;
     }
 
     /**
-     * Get the importance of this {@code Declaration}.
+     * Gets the importance of this {@code Declaration}.
      * @return important
      */
     public final boolean isImportant() {
@@ -95,7 +95,7 @@ final public class Declaration {
     }
 
     /**
-     * Get the {@code StyleOrigin} of this {@code Declaration}
+     * Gets the {@code StyleOrigin} of this {@code Declaration}.
      */
     private StyleOrigin getOrigin() {
         Rule rule = getRule();
@@ -105,9 +105,13 @@ final public class Declaration {
         return null;
     }
     /**
+     * Indicates whether some other object is "equal to" this one.
+     * <p>
      * One declaration is equal to another regardless of the {@code Rule} to which
      * the {@code Declaration} belongs. Only the property, value and importance are
      * considered.
+     * </p>
+     * @return true if this object is the same as the obj argument; false otherwise.
      */
     @Override public boolean equals(Object obj) {
         if (this == obj) {
@@ -136,7 +140,7 @@ final public class Declaration {
     }
 
     /**
-     * Returns the hash code of this {@code Declaration}
+     * {@inheritDoc}
      */
     @Override public int hashCode() {
         int hash = 5;
@@ -147,7 +151,7 @@ final public class Declaration {
     }
 
     /**
-     * Returns a String version of this {@code Declaration}
+     * {@inheritDoc}
      */
     @Override public String toString() {
         StringBuilder sbuf = new StringBuilder(property);

--- a/modules/javafx.graphics/src/main/java/javafx/css/Match.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Match.java
@@ -66,8 +66,8 @@ public final class Match implements Comparable<Match> {
     }
 
     /**
-     * Gets the Selector.
-     * @return the selector.
+     * Gets the {@code Selector}.
+     * @return the {@code Selector}
      */
     public Selector getSelector() {
         return selector;
@@ -75,7 +75,7 @@ public final class Match implements Comparable<Match> {
 
     /**
      * Gets the pseudo class state.
-     * @return the pseudo class state.
+     * @return the pseudo class state
      */
     public PseudoClassState getPseudoClasses() {
         return pseudoClasses;

--- a/modules/javafx.graphics/src/main/java/javafx/css/Match.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Match.java
@@ -65,14 +65,26 @@ public final class Match implements Comparable<Match> {
         specificity = (idCount << 8) | (styleClassCount << 4) | nPseudoClasses;
     }
 
+    /**
+     * Gets the Selector.
+     * @return the selector.
+     */
     public Selector getSelector() {
         return selector;
     }
 
+    /**
+     * Gets the pseudo class state.
+     * @return the pseudo class state.
+     */
     public PseudoClassState getPseudoClasses() {
         return pseudoClasses;
     }
 
+    /**
+     * Gets the specificity.
+     * @return the specificity.
+     */
     public int getSpecificity() {
         return specificity;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/css/Match.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Match.java
@@ -83,12 +83,22 @@ public final class Match implements Comparable<Match> {
 
     /**
      * Gets the specificity.
-     * @return the specificity.
+     * @return the specificity
      */
     public int getSpecificity() {
         return specificity;
     }
 
+    /**
+     * Compares this object with the given {@code Match} object.
+     * <p>
+     * Comparison is based on the specificity of the objects.
+     * Specificity is calculated based on the id count, the style class count and
+     * the pseudoclass count.
+     * @param o the {@code Match} object to be compared
+     * @return the difference between the specificity of this object and
+     * the specificity of the given {@code Match} object
+     */
     @Override public int compareTo(Match o) {
         return specificity - o.specificity;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/css/ParsedValue.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/ParsedValue.java
@@ -47,8 +47,9 @@ public class ParsedValue<V, T> {
     final protected V value;
 
     /**
-     * @return The CSS property value as created by the parser, which may be null
+     * Gets the CSS property value as created by the parser, which may be null
      * or otherwise incomprehensible.
+     * @return the CSS property value
      */
     public final V getValue() { return value; }
 

--- a/modules/javafx.graphics/src/main/java/javafx/css/PseudoClass.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/PseudoClass.java
@@ -84,9 +84,9 @@ public abstract class PseudoClass {
      * Gets the {@code PseudoClass} instance for a given pseudo class name.
      * <p>
      * Note: There is only one {@code PseudoClass} instance for a given pseudo class name.
-     * </p>
+     *
      * @param pseudoClass the name of the pseudo class
-     * @return the {@code PseudoClass} instance for a given pseudo class name.
+     * @return the {@code PseudoClass} instance for a given pseudo class name
      * It will not return null.
      * @throws IllegalArgumentException if pseudoClass parameter is null or an empty String
      */
@@ -96,7 +96,7 @@ public abstract class PseudoClass {
 
     /**
      * Gets the name of the {@code PseudoClass}.
-     * @return the name of the {@code PseudoClass}.
+     * @return the name of the {@code PseudoClass}
      */
     abstract public String getPseudoClassName();
 

--- a/modules/javafx.graphics/src/main/java/javafx/css/PseudoClass.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/PseudoClass.java
@@ -86,9 +86,9 @@ public abstract class PseudoClass {
      * Note: There is only one {@code PseudoClass} instance for a given pseudo class name.
      *
      * @param pseudoClass the name of the pseudo class
-     * @return the {@code PseudoClass} instance for a given pseudo class name
-     * It will not return null.
-     * @throws IllegalArgumentException if pseudoClass parameter is null or an empty String
+     * @return the {@code PseudoClass} instance for a given pseudo class name;
+     * It will not return {@code null}
+     * @throws IllegalArgumentException if pseudoClass parameter is {@code null} or an empty {@code String}
      */
     public static PseudoClass getPseudoClass(String pseudoClass) {
         return PseudoClassState.getPseudoClass(pseudoClass);

--- a/modules/javafx.graphics/src/main/java/javafx/css/PseudoClass.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/PseudoClass.java
@@ -81,18 +81,21 @@ public abstract class PseudoClass {
     }
 
     /**
-     * There is only one PseudoClass instance for a given pseudoClass.
-     * @param pseudoClass the pseudo-class
-     * @return The PseudoClass for the given pseudoClass. Will not return null.
+     * Gets the {@code PseudoClass} instance for a given pseudo class name.
+     * Note : There is only one PseudoClass instance for a given pseudo class name.
+     * @param pseudoClass the name of the pseudo-class
+     * @return the {@code PseudoClass} instance for a given pseudo class name.
+     * It will not return null.
      * @throws IllegalArgumentException if pseudoClass parameter is null or an empty String
      */
     public static PseudoClass getPseudoClass(String pseudoClass) {
-
         return PseudoClassState.getPseudoClass(pseudoClass);
-
     }
 
-    /** @return the pseudo-class state */
+    /**
+     * Gets the name of the {@code PseudoClass}.
+     * @return the name of the {@code PseudoClass}.
+     */
     abstract public String getPseudoClassName();
 
 }

--- a/modules/javafx.graphics/src/main/java/javafx/css/PseudoClass.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/PseudoClass.java
@@ -82,8 +82,10 @@ public abstract class PseudoClass {
 
     /**
      * Gets the {@code PseudoClass} instance for a given pseudo class name.
-     * Note : There is only one PseudoClass instance for a given pseudo class name.
-     * @param pseudoClass the name of the pseudo-class
+     * <p>
+     * Note: There is only one {@code PseudoClass} instance for a given pseudo class name.
+     * </p>
+     * @param pseudoClass the name of the pseudo class
      * @return the {@code PseudoClass} instance for a given pseudo class name.
      * It will not return null.
      * @throws IllegalArgumentException if pseudoClass parameter is null or an empty String

--- a/modules/javafx.graphics/src/main/java/javafx/css/Rule.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Rule.java
@@ -138,7 +138,7 @@ final public class Rule {
     private Stylesheet stylesheet;
 
     /**
-     * The {@code Stylesheet} this {@code Selector} belongs to.
+     * Gets the {@code Stylesheet} this {@code Rule} belongs to.
      * @return the stylesheet
      */
     public Stylesheet getStylesheet() {

--- a/modules/javafx.graphics/src/main/java/javafx/css/Rule.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Rule.java
@@ -40,8 +40,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-/*
- * A selector is a collection of selectors and declarations.
+/**
+ * A Rule is a collection of CSS {@code Selector}s and {@code Declaration}s.
  *
  * @since 9
  */
@@ -135,8 +135,12 @@ final public class Rule {
         return observables.getSelectors();
     }
 
-    /** The stylesheet this selector belongs to */
     private Stylesheet stylesheet;
+
+    /**
+     * The {@code Stylesheet} this {@code Selector} belongs to.
+     * @return the stylesheet
+     */
     public Stylesheet getStylesheet() {
         return stylesheet;
     }
@@ -156,6 +160,10 @@ final public class Rule {
         }
     }
 
+    /**
+     * Get the {@code StyleOrigin} of this {@code Stylesheet}.
+     * @return the origin of the stylesheet
+     */
     public StyleOrigin getOrigin() {
         return stylesheet != null ? stylesheet.getOrigin() : null;
     }
@@ -211,8 +219,9 @@ final public class Rule {
         return mask;
     }
 
-    /** Converts this object to a string.
-     * @return the converted string
+    /**
+     * Converts this object to a {@code String}.
+     * @return the converted {@code String}
      */
     @Override public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
@@ -58,31 +58,64 @@ abstract public class Selector {
     }
 
     private Rule rule;
+    /**
+     * Sets {@code Rule} of this Selector
+     * @param rule Rule of this Selector
+     */
     void setRule(Rule rule) {
         this.rule = rule;
     }
+
+    /**
+     * Gets {@code Rule} of this Selector
+     * @return rule
+     */
     public Rule getRule() {
         return rule;
     }
 
     private int ordinal = -1;
+    /**
+     * Sets ordinal of this Selector
+     * @param ordinal ordinal of this Selector
+     */
     public void setOrdinal(int ordinal) {
         this.ordinal = ordinal;
     }
+
+    /**
+     * Gets ordinal
+     * @return ordinal
+     */
     public int getOrdinal() {
         return ordinal;
     }
 
+    /**
+     * Creates a {@code Match}
+     * @return match
+     */
     public abstract Match createMatch();
 
-    // same as the matches method expect return true/false rather than a match
+    /**
+     * Same as the matches method expect return true/false rather than a match.
+     * @param styleable styleable to match.
+     * @return {@code true} if this {@code Selector} applies to the given {@code Styleable}.
+     */
     public abstract boolean applies(Styleable styleable);
 
-    // same as applies, but will return pseudoclass state that it finds along the way
-    public abstract boolean applies(Styleable styleable, Set<PseudoClass>[] triggerStates, int bit);
+    /**
+     * Same as applies, but will return pseudoclass state that it finds along the way.
+     * @param styleable styleable to match.
+     * @param triggerStates a set of {@code PseudoClass} states
+     * @param depth depth of the {@code Node} heirarchy to look for
+     * @return {@code true} if this {@code Selector} and a set of {@code PseudoClass}
+     * applies to the given {@code Styleable}.
+     */
+    public abstract boolean applies(Styleable styleable, Set<PseudoClass>[] triggerStates, int depth);
 
     /**
-     * Determines whether the current state of the node and its parents
+     * Determines whether the current state of the {@code Node} and its parents
      * matches the pseudo-classes defined (if any) for this selector.
      * @param styleable the styleable
      * @param state the state
@@ -94,6 +127,12 @@ abstract public class Selector {
     private static final int TYPE_SIMPLE = 1;
     private static final int TYPE_COMPOUND = 2;
 
+    /**
+     * Writes {@code Selector} data in binary form to given {@code DataOutputStream}
+     * @param os {@code DataOutputStream} to write {@code Selector} data to
+     * @param stringStore unsused
+     * @throws IOException if writing to {@code DataOutputStream} fails
+     */
     protected void writeBinary(DataOutputStream os, StyleConverter.StringStore stringStore)
         throws IOException {
         if (this instanceof SimpleSelector) {
@@ -103,6 +142,13 @@ abstract public class Selector {
         }
     }
 
+    /**
+     * Reads binary {@code Selector} data from a given {@code DataInputStream}.
+     * @param bssVersion bss version identifier
+     * @param is {@code DataInputStream} to read {@code Selector} data from
+     * @param strings string array containing selector details
+     * @throws IOException if reading from {@code DataInputStream} fails
+     */
     static Selector readBinary(int bssVersion, DataInputStream is, String[] strings)
         throws IOException {
         final int type = is.readByte();
@@ -112,6 +158,11 @@ abstract public class Selector {
             return CompoundSelector.readBinary(bssVersion, is,strings);
     }
 
+    /**
+     * Creates a {@code Selector} object
+     * @param cssSelector css selector string
+     * @return a Selector
+     */
     public static Selector createSelector(final String cssSelector) {
         if (cssSelector == null || cssSelector.length() == 0) {
             return null; // actually return a default no-match selector

--- a/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
@@ -99,7 +99,6 @@ abstract public class Selector {
 
     /**
      * Gets whether this {@code Selector} applies to the given {@code Styleable}.
-     * It is the same as the {@link createMatch} method except it returns a boolean rather than a {@code Match}.
      * @param styleable the {@code Styleable} to match
      * @return {@code true} if this {@code Selector} applies to the given {@code Styleable}
      */

--- a/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Set;
 
 /**
- * Used by CSSRule to determine whether or not the selector applies to a
+ * Used by {@code CSSRule} to determine whether or not the {@code Selector} applies to a
  * given object.
  *
  * @since 9
@@ -59,15 +59,15 @@ abstract public class Selector {
 
     private Rule rule;
     /**
-     * Sets {@code Rule} of this Selector
-     * @param rule Rule of this Selector
+     * Sets the {@code Rule} of this Selector.
+     * @param rule the {@code Rule} of this Selector
      */
     void setRule(Rule rule) {
         this.rule = rule;
     }
 
     /**
-     * Gets {@code Rule} of this Selector
+     * Gets the {@code Rule} of this Selector.
      * @return rule
      */
     public Rule getRule() {
@@ -76,23 +76,23 @@ abstract public class Selector {
 
     private int ordinal = -1;
     /**
-     * Sets ordinal of this Selector
-     * @param ordinal ordinal of this Selector
+     * Sets the ordinal of this Selector.
+     * @param ordinal the ordinal of this Selector
      */
     public void setOrdinal(int ordinal) {
         this.ordinal = ordinal;
     }
 
     /**
-     * Gets ordinal
-     * @return ordinal
+     * Gets the ordinal of this Selector.
+     * @return the ordinal of this Selector
      */
     public int getOrdinal() {
         return ordinal;
     }
 
     /**
-     * Creates a {@code Match}
+     * Creates a {@code Match}.
      * @return match
      */
     public abstract Match createMatch();
@@ -128,7 +128,7 @@ abstract public class Selector {
     private static final int TYPE_COMPOUND = 2;
 
     /**
-     * Writes {@code Selector} data in binary form to given {@code DataOutputStream}
+     * Writes {@code Selector} data in binary form to given {@code DataOutputStream}.
      * @param os {@code DataOutputStream} to write {@code Selector} data to
      * @param stringStore unsused
      * @throws IOException if writing to {@code DataOutputStream} fails
@@ -159,7 +159,7 @@ abstract public class Selector {
     }
 
     /**
-     * Creates a {@code Selector} object
+     * Creates a {@code Selector} object.
      * @param cssSelector css selector string
      * @return a Selector
      */

--- a/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
@@ -99,7 +99,7 @@ abstract public class Selector {
 
     /**
      * Gets whether this {@code Selector} applies to the given {@code Styleable}.
-     * It is same as the {@link createMatch} method except it returns true/false rather than a {@code Match}.
+     * It is the same as the {@link createMatch} method except it returns a boolean rather than a {@code Match}.
      * @param styleable the {@code Styleable} to match
      * @return {@code true} if this {@code Selector} applies to the given {@code Styleable}
      */
@@ -107,7 +107,7 @@ abstract public class Selector {
 
     /**
      * Gets whether this {@code Selector} applies to the given {@code Styleable}.
-     * It is same as {@link applies} method except it also returns
+     * It is the same as the {@link applies(Styleable)} method except it also returns
      * {@code PseudoClass} state that it finds along the way.
      * @param styleable the {@code Styleable} to match
      * @param triggerStates a set of {@code PseudoClass} states

--- a/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
@@ -98,19 +98,22 @@ abstract public class Selector {
     public abstract Match createMatch();
 
     /**
-     * Same as the matches method expect return true/false rather than a match.
-     * @param styleable styleable to match.
-     * @return {@code true} if this {@code Selector} applies to the given {@code Styleable}.
+     * Gets whether this {@code Selector} applies to the given {@code Styleable}.
+     * It is same as the {@link createMatch} method except it returns true/false rather than a {@code Match}.
+     * @param styleable the {@code Styleable} to match
+     * @return {@code true} if this {@code Selector} applies to the given {@code Styleable}
      */
     public abstract boolean applies(Styleable styleable);
 
     /**
-     * Same as applies, but will return pseudoclass state that it finds along the way.
-     * @param styleable styleable to match.
+     * Gets whether this {@code Selector} applies to the given {@code Styleable}.
+     * It is same as {@link applies} method except it also returns
+     * {@code PseudoClass} state that it finds along the way.
+     * @param styleable the {@code Styleable} to match
      * @param triggerStates a set of {@code PseudoClass} states
      * @param depth depth of the {@code Node} heirarchy to look for
      * @return {@code true} if this {@code Selector} and a set of {@code PseudoClass}
-     * applies to the given {@code Styleable}.
+     * applies to the given {@code Styleable}
      */
     public abstract boolean applies(Styleable styleable, Set<PseudoClass>[] triggerStates, int depth);
 
@@ -130,7 +133,7 @@ abstract public class Selector {
     /**
      * Writes {@code Selector} data in binary form to given {@code DataOutputStream}.
      * @param os {@code DataOutputStream} to write {@code Selector} data to
-     * @param stringStore unsused
+     * @param stringStore unused
      * @throws IOException if writing to {@code DataOutputStream} fails
      */
     protected void writeBinary(DataOutputStream os, StyleConverter.StringStore stringStore)
@@ -160,8 +163,8 @@ abstract public class Selector {
 
     /**
      * Creates a {@code Selector} object.
-     * @param cssSelector css selector string
-     * @return a Selector
+     * @param cssSelector CSS selector string
+     * @return a {@code Selector}
      */
     public static Selector createSelector(final String cssSelector) {
         if (cssSelector == null || cssSelector.length() == 0) {

--- a/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
@@ -70,8 +70,8 @@ final public class SimpleSelector extends Selector {
     }
 
     /**
-     * Gets Immutable List of style-classes of the selector.
-     * @return Immutable List&lt;String&gt; of style-classes of the selector
+     * Gets an immutable list of style-classes of the {@code Selector}.
+     * @return an immutable list of style-classes of the {@code Selector}
      */
     public List<String> getStyleClasses() {
 
@@ -86,14 +86,16 @@ final public class SimpleSelector extends Selector {
     }
 
     /**
-     * Gets the {@code Set} of {@code StyleClass} of the selector.
-     * @return set of style class
+     * Gets the {@code Set} of {@code StyleClass}es of the {@code Selector}.
+     * @return the {@code Set} of {@code StyleClass}es
      */
     public Set<StyleClass> getStyleClassSet() {
         return styleClassSet;
     }
 
-    /** styleClasses converted to a set of bit masks */
+    /**
+     * styleClasses converted to a set of bit masks
+     */
     final private StyleClassSet styleClassSet;
 
     final private String id;
@@ -114,7 +116,8 @@ final public class SimpleSelector extends Selector {
     }
 
     /**
-     * @return Immutable List&lt;String&gt; of pseudo-classes of the selector
+     * Gets an immutable list of {@code String}s of pseudo classes of the {@code Selector}
+     * @return an immutable list of {@code String}s
      */
     List<String> getPseudoclasses() {
 
@@ -148,8 +151,9 @@ final public class SimpleSelector extends Selector {
 
     // Used in Match. If nodeOrientation is ltr or rtl,
     // then count it as a pseudoclass
-    /** Gets {@code NodeOrientation} of this Selector.
-     * @return nodeOrientation
+    /**
+     * Gets the {@code NodeOrientation} of this {@code Selector}.
+     * @return the {@code NodeOrientation}
      */
     public NodeOrientation getNodeOrientation() {
         return nodeOrientation;

--- a/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
@@ -68,6 +68,7 @@ final public class SimpleSelector extends Selector {
     }
 
     /**
+     * Gets Immutable List of style-classes of the selector.
      * @return Immutable List&lt;String&gt; of style-classes of the selector
      */
     public List<String> getStyleClasses() {
@@ -82,6 +83,10 @@ final public class SimpleSelector extends Selector {
         return Collections.unmodifiableList(names);
     }
 
+    /**
+     * Gets {@code Set} of {@code StyleClass} of the selector.
+     * @return styleClassSet
+     */
     public Set<StyleClass> getStyleClassSet() {
         return styleClassSet;
     }
@@ -90,7 +95,8 @@ final public class SimpleSelector extends Selector {
     final private StyleClassSet styleClassSet;
 
     final private String id;
-    /*
+    /**
+     * Gets the value of the selector id
      * @return The value of the selector id, which may be an empty string.
      */
     public String getId() {
@@ -139,6 +145,9 @@ final public class SimpleSelector extends Selector {
 
     // Used in Match. If nodeOrientation is ltr or rtl,
     // then count it as a pseudoclass
+    /** Gets {@code NodeOrientation} of this Selector.
+     * @return nodeOrientation
+     */
     public NodeOrientation getNodeOrientation() {
         return nodeOrientation;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
@@ -60,8 +60,10 @@ final public class SimpleSelector extends Selector {
      * then name would be "Rectangle".
      */
     final private String name;
+
     /**
-     * @return The name of the java class to which this selector is applied, or *.
+     * Gets the name of the java class to which this selector is applied, or *.
+     * @return the name of the java class
      */
     public String getName() {
         return name;
@@ -84,8 +86,8 @@ final public class SimpleSelector extends Selector {
     }
 
     /**
-     * Gets {@code Set} of {@code StyleClass} of the selector.
-     * @return styleClassSet
+     * Gets the {@code Set} of {@code StyleClass} of the selector.
+     * @return set of style class
      */
     public Set<StyleClass> getStyleClassSet() {
         return styleClassSet;
@@ -95,9 +97,10 @@ final public class SimpleSelector extends Selector {
     final private StyleClassSet styleClassSet;
 
     final private String id;
+
     /**
-     * Gets the value of the selector id
-     * @return The value of the selector id, which may be an empty string.
+     * Gets the value of the selector id.
+     * @return the value of the selector id, which may be an empty string
      */
     public String getId() {
         return id;

--- a/modules/javafx.graphics/src/main/java/javafx/css/Size.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Size.java
@@ -39,9 +39,9 @@ final public class Size {
     final private SizeUnits units;
 
     /**
-     * Constructs a {@code Size} object
-     * @param value value of the Size
-     * @param units unit of the Size
+     * Constructs a {@code Size} object.
+     * @param value value of the size
+     * @param units unit of the size
      */
     public Size(double value, SizeUnits units) {
         this.value = value;
@@ -49,7 +49,7 @@ final public class Size {
     }
 
     /**
-     * Return the value
+     * Returns the value.
      * @return the value
      */
     public double getValue() {
@@ -57,7 +57,7 @@ final public class Size {
     }
 
     /**
-     * Return the units
+     * Return the units.
      * @return the units
      */
     public SizeUnits getUnits() {
@@ -65,20 +65,22 @@ final public class Size {
     }
 
     /**
-     * Return whether or not this Size is an absolute value or a relative value.
+     * Returns whether or not this {@code Size} is an absolute value or a relative value.
      * @return true if it is absolute, otherwise false
      */
     public boolean isAbsolute() {
         return units.isAbsolute();
     }
 
-    /** Convert this size into Points units, a Point is 1/72 of a inch */
+    /**
+     * Converts this size into Points units, a Point is 1/72 of a inch
+     */
     double points(Font font) {
         return points(1.0, font);
     }
 
     /**
-      * Convert this size into points
+      * Converts this size into points.
       *
       * @param multiplier   The multiplier for PERCENTAGE sizes
       * @param font         The font for EM sizes
@@ -88,7 +90,7 @@ final public class Size {
     }
 
     /**
-      * Convert this size into pixels
+      * Converts this size into pixels.
       *
       * @param multiplier   The multiplier for PERCENTAGE sizes
       * @param font         The font for EM sizes

--- a/modules/javafx.graphics/src/main/java/javafx/css/Size.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Size.java
@@ -37,6 +37,12 @@ final public class Size {
 
     final private double value;
     final private SizeUnits units;
+
+    /**
+     * Constructs a {@code Size} object
+     * @param value value of the Size
+     * @param units unit of the Size
+     */
     public Size(double value, SizeUnits units) {
         this.value = value;
         this.units = (units != null) ? units : SizeUnits.PX;

--- a/modules/javafx.graphics/src/main/java/javafx/css/SizeUnits.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/SizeUnits.java
@@ -35,7 +35,7 @@ import javafx.scene.text.Font;
 public enum SizeUnits {
 
     /**
-     * Percentage
+     * Represents a size as a percentage.
      */
     PERCENT(false) {
 
@@ -55,7 +55,7 @@ public enum SizeUnits {
     },
 
     /**
-     * Inches
+     * Represents a size in inches.
      */
     IN(true) {
 
@@ -75,7 +75,7 @@ public enum SizeUnits {
     },
 
     /**
-     * Centimeters
+     * Represents a size in centimeters.
      */
     CM(true) {
 
@@ -95,7 +95,7 @@ public enum SizeUnits {
     },
 
     /**
-     * Millimeters
+     * Represents a size in millimeters.
      */
     MM(true) {
 
@@ -115,7 +115,8 @@ public enum SizeUnits {
     },
 
     /**
-     * EM (Unit relative to the font-size of the element)
+     * Represents a size in EM unit.
+     * Note: It is a unit relative to the font-size of the element.
      */
     EM(false) {
 
@@ -135,7 +136,8 @@ public enum SizeUnits {
     },
 
     /**
-     * EX
+     * Represents a size in EX unit.
+     * Note: In the absence of font metrics, one {@code EX} is taken to be half an {@code EM} unit.
      */
     EX(false) {
 
@@ -157,7 +159,7 @@ public enum SizeUnits {
     },
 
     /**
-     * Points
+     * Represents a size in points.
      */
     PT(true) {
         @Override
@@ -176,7 +178,7 @@ public enum SizeUnits {
     },
 
     /**
-     * Picas
+     * Represents a size in picas.
      */
     PC(true) {
         @Override
@@ -195,7 +197,7 @@ public enum SizeUnits {
     },
 
     /**
-     * Pixels
+     * Represents a size in pixels.
      */
     PX(true) {
         @Override
@@ -214,7 +216,7 @@ public enum SizeUnits {
     },
 
     /**
-     * Degrees
+     * Represents an angle in degrees.
      */
     DEG(true) {
         @Override
@@ -233,7 +235,8 @@ public enum SizeUnits {
     },
 
     /**
-     * Gradians (400 Gradians = 360 Degrees)
+     * Represents an angle in gradians.
+     * Note: 400 Gradians = 360 Degrees.
      */
     GRAD(true) {
 
@@ -255,7 +258,7 @@ public enum SizeUnits {
     },
 
     /**
-     * Radians
+     * Represents an angle in radians.
      */
     RAD(true) {
 
@@ -277,7 +280,8 @@ public enum SizeUnits {
     },
 
     /**
-     * Turns (1 Turn = 360 Degrees)
+     * Represents an angle in turns.
+     * Note: 1 Turn = 360 Degrees.
      */
     TURN(true) {
 
@@ -298,7 +302,7 @@ public enum SizeUnits {
     },
 
     /**
-     * Seconds
+     * Represents time in seconds.
      */
     S(true) {
 
@@ -318,7 +322,7 @@ public enum SizeUnits {
     },
 
     /**
-     * Milliseconds
+     * Represents time in milliseconds.
      */
     MS(true) {
 
@@ -338,7 +342,7 @@ public enum SizeUnits {
     };
 
     /**
-     * Calculates points for a particular {@code SizeUnits}
+     * Calculates points for a particular {@code SizeUnits}.
      * @param value value
      * @param multiplier multiplier
      * @param font font
@@ -347,7 +351,7 @@ public enum SizeUnits {
     public abstract double points(double value, double multiplier, Font font);
 
     /**
-     * Calculates pixels for a particular {@code SizeUnits}
+     * Calculates pixels for a particular {@code SizeUnits}.
      * @param value value
      * @param multiplier multiplier
      * @param font font
@@ -362,7 +366,7 @@ public enum SizeUnits {
     private final boolean absolute;
 
     /**
-     * Gets wehther this {@code SizeUnits} value is absolute
+     * Gets wehther this {@code SizeUnits} value is absolute.
      * @return whether value is absoulute
      */
     public boolean isAbsolute() {

--- a/modules/javafx.graphics/src/main/java/javafx/css/SizeUnits.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/SizeUnits.java
@@ -34,6 +34,9 @@ import javafx.scene.text.Font;
  */
 public enum SizeUnits {
 
+    /**
+     * Percentage
+     */
     PERCENT(false) {
 
         @Override
@@ -50,6 +53,10 @@ public enum SizeUnits {
         }
 
     },
+
+    /**
+     * Inches
+     */
     IN(true) {
 
         @Override
@@ -66,6 +73,10 @@ public enum SizeUnits {
         }
 
     },
+
+    /**
+     * Centimeters
+     */
     CM(true) {
 
         @Override
@@ -82,6 +93,10 @@ public enum SizeUnits {
         }
 
     },
+
+    /**
+     * Millimeters
+     */
     MM(true) {
 
         @Override
@@ -98,6 +113,10 @@ public enum SizeUnits {
         }
 
     },
+
+    /**
+     * EM (Unit relative to the font-size of the element)
+     */
     EM(false) {
 
         @Override
@@ -114,6 +133,10 @@ public enum SizeUnits {
         }
 
     },
+
+    /**
+     * EX
+     */
     EX(false) {
 
         @Override
@@ -132,6 +155,10 @@ public enum SizeUnits {
         }
 
     },
+
+    /**
+     * Points
+     */
     PT(true) {
         @Override
         public String toString() { return "pt"; }
@@ -147,6 +174,10 @@ public enum SizeUnits {
         }
 
     },
+
+    /**
+     * Picas
+     */
     PC(true) {
         @Override
         public String toString() { return "pc"; }
@@ -162,6 +193,10 @@ public enum SizeUnits {
         }
 
     },
+
+    /**
+     * Pixels
+     */
     PX(true) {
         @Override
         public String toString() { return "px"; }
@@ -178,6 +213,9 @@ public enum SizeUnits {
 
     },
 
+    /**
+     * Degrees
+     */
     DEG(true) {
         @Override
         public String toString() { return "deg"; }
@@ -194,6 +232,9 @@ public enum SizeUnits {
 
     },
 
+    /**
+     * Gradians (400 Gradians = 360 Degrees)
+     */
     GRAD(true) {
 
         @Override
@@ -213,6 +254,9 @@ public enum SizeUnits {
 
     },
 
+    /**
+     * Radians
+     */
     RAD(true) {
 
         @Override
@@ -232,6 +276,9 @@ public enum SizeUnits {
 
     },
 
+    /**
+     * Turns (1 Turn = 360 Degrees)
+     */
     TURN(true) {
 
         @Override
@@ -250,7 +297,9 @@ public enum SizeUnits {
 
     },
 
-
+    /**
+     * Seconds
+     */
     S(true) {
 
         @Override
@@ -268,6 +317,9 @@ public enum SizeUnits {
 
     },
 
+    /**
+     * Milliseconds
+     */
     MS(true) {
 
         @Override
@@ -285,7 +337,22 @@ public enum SizeUnits {
 
     };
 
+    /**
+     * Calculates points for a particular {@code SizeUnits}
+     * @param value value
+     * @param multiplier multiplier
+     * @param font font
+     * @return points for a particular {@code SizeUnits}
+     */
     public abstract double points(double value, double multiplier, Font font);
+
+    /**
+     * Calculates pixels for a particular {@code SizeUnits}
+     * @param value value
+     * @param multiplier multiplier
+     * @param font font
+     * @return pixels for a particular {@code SizeUnits}
+     */
     public abstract double pixels(double value, double multiplier, Font font);
 
     private SizeUnits(boolean absolute) {
@@ -293,6 +360,11 @@ public enum SizeUnits {
     }
 
     private final boolean absolute;
+
+    /**
+     * Gets wehther this {@code SizeUnits} value is absolute
+     * @return whether value is absoulute
+     */
     public boolean isAbsolute() {
         return absolute;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/css/Style.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Style.java
@@ -52,6 +52,11 @@ final public class Style {
         return declaration;
     }
 
+    /**
+     * Constructs a {@code Style} object.
+     * @param selector selector for this {@code Style}
+     * @param declaration declaration for this {@code Style}
+     */
     public Style(Selector selector, Declaration declaration) {
         this.selector = selector;
         this.declaration = declaration;

--- a/modules/javafx.graphics/src/main/java/javafx/css/StyleClass.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/StyleClass.java
@@ -25,26 +25,41 @@
 package javafx.css;
 
 /**
- *
+ * A class that contains StyleClass information
  * @since 9
  */
 public final class StyleClass {
 
+    /**
+     * Constructs a {@code StyleClass} object
+     * @param styleClassName name of the style class
+     * @param index style class index
+     */
     public StyleClass(String styleClassName, int index) {
         this.styleClassName = styleClassName;
         this.index = index;
     }
 
-    /** @return the style-class */
+    /**
+     * Returns the name of StyleClass.
+     * @return the style-class
+     */
     public String getStyleClassName() {
         return styleClassName;
     }
 
-    /** @return the style-class */
+    /**
+     * Returns the name of StyleClass.
+     * @return the style-class
+     */
     @Override public String toString() {
         return styleClassName;
     }
 
+    /**
+     * Returns the index of this StyleClass in styleClasses list.
+     * @return index
+     */
     public int getIndex() {
        return index;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/css/StyleClass.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/StyleClass.java
@@ -25,13 +25,13 @@
 package javafx.css;
 
 /**
- * A class that contains StyleClass information
+ * A class that contains {@code StyleClass} information.
  * @since 9
  */
 public final class StyleClass {
 
     /**
-     * Constructs a {@code StyleClass} object
+     * Constructs a {@code StyleClass} object.
      * @param styleClassName name of the style class
      * @param index style class index
      */
@@ -41,23 +41,23 @@ public final class StyleClass {
     }
 
     /**
-     * Returns the name of StyleClass.
-     * @return the style-class
+     * Returns the name of {@code StyleClass}.
+     * @return the name of {@code StyleClass}
      */
     public String getStyleClassName() {
         return styleClassName;
     }
 
     /**
-     * Returns the name of StyleClass.
-     * @return the style-class
+     * Returns the name of {@code StyleClass}.
+     * @return the name of {@code StyleClass}
      */
     @Override public String toString() {
         return styleClassName;
     }
 
     /**
-     * Returns the index of this StyleClass in styleClasses list.
+     * Returns the index of this {@code StyleClass} in the styleClasses list.
      * @return index
      */
     public int getIndex() {

--- a/modules/javafx.graphics/src/main/java/javafx/css/StyleConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/StyleConverter.java
@@ -531,7 +531,7 @@ public class StyleConverter<F, T> {
 
 
     /**
-     * The StringStore class
+     * The StringStore class.
      * @since 9
      */
     public static class StringStore {
@@ -564,7 +564,7 @@ public class StyleConverter<F, T> {
         }
 
         /**
-         * Writes the StringStore strings to a given {@code DataOutputStream}.
+         * Writes the {@code StringStore} strings to a given {@code DataOutputStream}.
          * @param os {@code DataOutputStream} where the StringStore strings need to be written
          * @throws IOException if writing to {@code DataOutputStream} fails
          */

--- a/modules/javafx.graphics/src/main/java/javafx/css/StyleConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/StyleConverter.java
@@ -536,6 +536,10 @@ public class StyleConverter<F, T> {
      */
     public static class StringStore {
         private final Map<String,Integer> stringMap = new HashMap<String,Integer>();
+
+        /**
+         * List of strings of this {@code StringStore}
+         */
         public final List<String> strings = new ArrayList<String>();
 
         /**
@@ -544,6 +548,11 @@ public class StyleConverter<F, T> {
         public StringStore() {
         }
 
+        /**
+         * Adds given string to the {@code StringStore}.
+         * @param s string to be added to the {@code StringStore}
+         * @return index at which the given string gets added
+         */
         public int addString(String s) {
             Integer index = stringMap.get(s);
             if (index == null) {
@@ -554,6 +563,11 @@ public class StyleConverter<F, T> {
             return index;
         }
 
+        /**
+         * Writes the StringStore strings to a given {@code DataOutputStream}.
+         * @param os {@code DataOutputStream} where the StringStore strings need to be written
+         * @throws IOException if writing to {@code DataOutputStream} fails
+         */
         public void writeBinary(DataOutputStream os) throws IOException {
             os.writeShort(strings.size());
             if (stringMap.containsKey(null)) {
@@ -570,6 +584,12 @@ public class StyleConverter<F, T> {
         }
 
         // TODO: this isn't parallel with writeBinary
+        /**
+         * Read the StringStore strings from a given {@code DataInputStream}.
+         * @param is {@code DataInputStream} from where StringStore strings need to be read from
+         * @return a String array constructed by reading {@code DataInputStream}
+         * @throws IOException if reading from {@code DataInputStream} fails
+         */
         public static String[] readBinary(DataInputStream is) throws IOException {
             int nStrings = is.readShort();
             int nullIndex = is.readShort();

--- a/modules/javafx.graphics/src/main/java/javafx/css/StyleConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/StyleConverter.java
@@ -538,7 +538,7 @@ public class StyleConverter<F, T> {
         private final Map<String,Integer> stringMap = new HashMap<String,Integer>();
 
         /**
-         * List of strings of this {@code StringStore}
+         * List of strings of this {@code StringStore}.
          */
         public final List<String> strings = new ArrayList<String>();
 
@@ -587,7 +587,7 @@ public class StyleConverter<F, T> {
         /**
          * Read the StringStore strings from a given {@code DataInputStream}.
          * @param is {@code DataInputStream} from where StringStore strings need to be read from
-         * @return a String array constructed by reading {@code DataInputStream}
+         * @return a {@code String} array constructed by reading {@code DataInputStream}
          * @throws IOException if reading from {@code DataInputStream} fails
          */
         public static String[] readBinary(DataInputStream is) throws IOException {

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/BooleanConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/BooleanConverter.java
@@ -30,7 +30,7 @@ import javafx.css.StyleConverter;
 import javafx.scene.text.Font;
 
 /**
- * Converter to convert a {@code String} to a {@code Boolean}
+ * Converter to convert a {@code String} to a {@code Boolean}.
  * @since 9
  */
 public final class BooleanConverter extends StyleConverter<String, Boolean> {
@@ -42,7 +42,7 @@ public final class BooleanConverter extends StyleConverter<String, Boolean> {
 
     /**
      * Get the {@code BooleanConverter} instance.
-     * @return the {@code BooleanConverter} instance.
+     * @return the {@code BooleanConverter} instance
      */
     public static StyleConverter<String, Boolean> getInstance() {
         return Holder.INSTANCE;

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/BooleanConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/BooleanConverter.java
@@ -30,6 +30,7 @@ import javafx.css.StyleConverter;
 import javafx.scene.text.Font;
 
 /**
+ * Converter to convert a {@code String} to a {@code Boolean}
  * @since 9
  */
 public final class BooleanConverter extends StyleConverter<String, Boolean> {
@@ -39,6 +40,10 @@ public final class BooleanConverter extends StyleConverter<String, Boolean> {
         static final BooleanConverter INSTANCE = new BooleanConverter();
     }
 
+    /**
+     * Get the {@code BooleanConverter} instance.
+     * @return the {@code BooleanConverter} instance.
+     */
     public static StyleConverter<String, Boolean> getInstance() {
         return Holder.INSTANCE;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/ColorConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/ColorConverter.java
@@ -31,7 +31,7 @@ import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 
 /**
- * Converter to convert a {@code String} to a {@code Color}
+ * Converter to convert a {@code String} to a {@code Color}.
  * @since 9
  */
 public final class ColorConverter extends StyleConverter<String, Color> {
@@ -42,8 +42,8 @@ public final class ColorConverter extends StyleConverter<String, Color> {
 
     // lazy, thread-safe instatiation
     /**
-     * Get the {@code ColorConverter} instance.
-     * @return the {@code ColorConverter} instance.
+     * Gets the {@code ColorConverter} instance.
+     * @return the {@code ColorConverter} instance
      */
     public static StyleConverter<String, Color> getInstance() {
         return Holder.COLOR_INSTANCE;

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/ColorConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/ColorConverter.java
@@ -31,6 +31,7 @@ import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 
 /**
+ * Converter to convert a {@code String} to a {@code Color}
  * @since 9
  */
 public final class ColorConverter extends StyleConverter<String, Color> {
@@ -40,6 +41,10 @@ public final class ColorConverter extends StyleConverter<String, Color> {
     }
 
     // lazy, thread-safe instatiation
+    /**
+     * Get the {@code ColorConverter} instance.
+     * @return the {@code ColorConverter} instance.
+     */
     public static StyleConverter<String, Color> getInstance() {
         return Holder.COLOR_INSTANCE;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/CursorConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/CursorConverter.java
@@ -31,6 +31,7 @@ import javafx.scene.Cursor;
 import javafx.scene.text.Font;
 
 /**
+ * Converter to convert a {@code String} to a {@code Cursor}
  * @since 9
  */
 public final class CursorConverter extends StyleConverter<String, Cursor> {
@@ -40,6 +41,10 @@ public final class CursorConverter extends StyleConverter<String, Cursor> {
         static final CursorConverter INSTANCE = new CursorConverter();
     }
 
+    /**
+     * Get the {@code CursorConverter} instance.
+     * @return the {@code CursorConverter} instance.
+     */
     public static StyleConverter<String, Cursor> getInstance() {
         return Holder.INSTANCE;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/CursorConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/CursorConverter.java
@@ -31,7 +31,7 @@ import javafx.scene.Cursor;
 import javafx.scene.text.Font;
 
 /**
- * Converter to convert a {@code String} to a {@code Cursor}
+ * Converter to convert a {@code String} to a {@code Cursor}.
  * @since 9
  */
 public final class CursorConverter extends StyleConverter<String, Cursor> {
@@ -42,8 +42,8 @@ public final class CursorConverter extends StyleConverter<String, Cursor> {
     }
 
     /**
-     * Get the {@code CursorConverter} instance.
-     * @return the {@code CursorConverter} instance.
+     * Gets the {@code CursorConverter} instance.
+     * @return the {@code CursorConverter} instance
      */
     public static StyleConverter<String, Cursor> getInstance() {
         return Holder.INSTANCE;

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/DeriveColorConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/DeriveColorConverter.java
@@ -33,6 +33,8 @@ import javafx.scene.text.Font;
 
 /**
  * Converter to convert a combination of color and brightness values to a derived {@code Color}.
+ *
+ * @since 9
  */
 public final class DeriveColorConverter extends StyleConverter<ParsedValue[], Color> {
 

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/DeriveColorConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/DeriveColorConverter.java
@@ -32,7 +32,7 @@ import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 
 /**
- * Derive a Color from a Color and a brightness value
+ * Converter to convert a combination of color and brightness values to a derived {@code Color}
  */
 public final class DeriveColorConverter extends StyleConverter<ParsedValue[], Color> {
 
@@ -41,6 +41,10 @@ public final class DeriveColorConverter extends StyleConverter<ParsedValue[], Co
         static final DeriveColorConverter INSTANCE = new DeriveColorConverter();
     }
 
+    /**
+     * Get the {@code DeriveColorConverter} instance.
+     * @return the {@code DeriveColorConverter} instance.
+     */
     public static DeriveColorConverter getInstance() {
         return Holder.INSTANCE;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/DeriveColorConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/DeriveColorConverter.java
@@ -32,7 +32,7 @@ import javafx.scene.paint.Color;
 import javafx.scene.text.Font;
 
 /**
- * Converter to convert a combination of color and brightness values to a derived {@code Color}
+ * Converter to convert a combination of color and brightness values to a derived {@code Color}.
  */
 public final class DeriveColorConverter extends StyleConverter<ParsedValue[], Color> {
 
@@ -42,8 +42,8 @@ public final class DeriveColorConverter extends StyleConverter<ParsedValue[], Co
     }
 
     /**
-     * Get the {@code DeriveColorConverter} instance.
-     * @return the {@code DeriveColorConverter} instance.
+     * Gets the {@code DeriveColorConverter} instance.
+     * @return the {@code DeriveColorConverter} instance
      */
     public static DeriveColorConverter getInstance() {
         return Holder.INSTANCE;

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/DeriveSizeConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/DeriveSizeConverter.java
@@ -32,7 +32,7 @@ import javafx.css.ParsedValue;
 import javafx.scene.text.Font;
 
 /**
- * A type that combines two Size values.  The primary purpose of
+ * Converter to combine two {@code Size} values.  The primary purpose of
  * this type is to handle "convert(size1, size2)" expressions in CSS.
  */
 public final class DeriveSizeConverter extends StyleConverter<ParsedValue<Size, Size>[], Size> {
@@ -42,6 +42,10 @@ public final class DeriveSizeConverter extends StyleConverter<ParsedValue<Size, 
         static final DeriveSizeConverter INSTANCE = new DeriveSizeConverter();
     }
 
+    /**
+     * Get the {@code DeriveSizeConverter} instance.
+     * @return the {@code DeriveSizeConverter} instance.
+     */
     public static DeriveSizeConverter getInstance() {
         return Holder.INSTANCE;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/DeriveSizeConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/DeriveSizeConverter.java
@@ -43,8 +43,8 @@ public final class DeriveSizeConverter extends StyleConverter<ParsedValue<Size, 
     }
 
     /**
-     * Get the {@code DeriveSizeConverter} instance.
-     * @return the {@code DeriveSizeConverter} instance.
+     * Gets the {@code DeriveSizeConverter} instance.
+     * @return the {@code DeriveSizeConverter} instance
      */
     public static DeriveSizeConverter getInstance() {
         return Holder.INSTANCE;

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/DeriveSizeConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/DeriveSizeConverter.java
@@ -34,6 +34,8 @@ import javafx.scene.text.Font;
 /**
  * Converter to combine two {@code Size} values.  The primary purpose of
  * this type is to handle "convert(size1, size2)" expressions in CSS.
+ *
+ * @since 9
  */
 public final class DeriveSizeConverter extends StyleConverter<ParsedValue<Size, Size>[], Size> {
 

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/DurationConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/DurationConverter.java
@@ -32,7 +32,7 @@ import javafx.scene.text.Font;
 import javafx.util.Duration;
 
 /**
- * Convert a Size to Duration
+ * Converter to Convert a {@code Size} to {@code Duration}
  *
  * @since 9
  */
@@ -43,6 +43,10 @@ public final class DurationConverter extends StyleConverter<ParsedValue<?, Size>
         static final DurationConverter INSTANCE = new DurationConverter();
     }
 
+    /**
+     * Get the {@code DurationConverter} instance.
+     * @return the {@code DurationConverter} instance.
+     */
     public static StyleConverter<ParsedValue<?, Size>, Duration> getInstance() {
         return Holder.INSTANCE;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/DurationConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/DurationConverter.java
@@ -32,7 +32,7 @@ import javafx.scene.text.Font;
 import javafx.util.Duration;
 
 /**
- * Converter to Convert a {@code Size} to {@code Duration}
+ * Converter to Convert a {@code Size} to {@code Duration}.
  *
  * @since 9
  */
@@ -44,8 +44,8 @@ public final class DurationConverter extends StyleConverter<ParsedValue<?, Size>
     }
 
     /**
-     * Get the {@code DurationConverter} instance.
-     * @return the {@code DurationConverter} instance.
+     * Gets the {@code DurationConverter} instance.
+     * @return the {@code DurationConverter} instance
      */
     public static StyleConverter<ParsedValue<?, Size>, Duration> getInstance() {
         return Holder.INSTANCE;

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/EffectConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/EffectConverter.java
@@ -38,7 +38,7 @@ import javafx.scene.text.Font;
 import java.util.Map;
 
 /**
- * Converter to convert representation of an {@code Effect} to an {@code Effect}.
+ * Converter to convert a string representation of an {@code Effect} to an {@code Effect}.
  * @since 9
  */
 public class EffectConverter extends StyleConverter<ParsedValue[], Effect> {
@@ -79,7 +79,7 @@ public class EffectConverter extends StyleConverter<ParsedValue[], Effect> {
     }
 
     /**
-     * Converter to convert DropShadow {@code Effect}.
+     * Converter to convert a {@code DropShadow} effect.
      * @since 9
      */
     public static final class DropShadowConverter extends EffectConverter {

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/EffectConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/EffectConverter.java
@@ -38,6 +38,7 @@ import javafx.scene.text.Font;
 import java.util.Map;
 
 /**
+ * Converter to convert representation of an {@code Effect} to an {@code Effect}
  * @since 9
  */
 public class EffectConverter extends StyleConverter<ParsedValue[], Effect> {
@@ -52,6 +53,10 @@ public class EffectConverter extends StyleConverter<ParsedValue[], Effect> {
                 new InnerShadowConverter();
     }
 
+    /**
+     * Get the {@code EffectConverter} instance.
+     * @return the {@code EffectConverter} instance.
+     */
     public static StyleConverter<ParsedValue[], Effect> getInstance() {
         return Holder.EFFECT_CONVERTER;
     }
@@ -61,6 +66,9 @@ public class EffectConverter extends StyleConverter<ParsedValue[], Effect> {
         throw new IllegalArgumentException("Parsed value is not an Effect");
     }
 
+    /**
+     * Constructs an EffectConverter.
+     */
     protected EffectConverter() {
         super();
     }
@@ -70,8 +78,16 @@ public class EffectConverter extends StyleConverter<ParsedValue[], Effect> {
         return "EffectConverter";
     }
 
+    /**
+     * Converter to convert DropShadow {@code Effect}
+     * @since 9
+     */
     public static final class DropShadowConverter extends EffectConverter {
 
+        /**
+         * Get the {@code DropShadowConverter} instance.
+         * @return the {@code DropShadowConverter} instance.
+         */
         public static DropShadowConverter getInstance() {
             return Holder.DROP_SHADOW_INSTANCE;
         }
@@ -141,8 +157,16 @@ public class EffectConverter extends StyleConverter<ParsedValue[], Effect> {
         }
     }
 
+    /**
+     * Converter to convert InnerShadow {@code Effect}
+     * @since 9
+     */
     public static final class InnerShadowConverter extends EffectConverter {
 
+        /**
+         * Get the {@code InnerShadowConverter} instance.
+         * @return the {@code InnerShadowConverter} instance.
+         */
         public static InnerShadowConverter getInstance() {
             return Holder.INNER_SHADOW_INSTANCE;
         }
@@ -214,6 +238,9 @@ public class EffectConverter extends StyleConverter<ParsedValue[], Effect> {
 
     private static Map<ParsedValue<ParsedValue[], Effect>, Effect> cache;
 
+    /**
+     * Clears the InnerShadowConverter cache.
+     */
     public static void clearCache() { if (cache != null) cache.clear(); }
 
 }

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/EffectConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/EffectConverter.java
@@ -158,7 +158,7 @@ public class EffectConverter extends StyleConverter<ParsedValue[], Effect> {
     }
 
     /**
-     * Converter to convert InnerShadow {@code Effect}.
+     * Converter to convert an {@code InnerShadow} effect.
      * @since 9
      */
     public static final class InnerShadowConverter extends EffectConverter {

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/EffectConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/EffectConverter.java
@@ -38,7 +38,7 @@ import javafx.scene.text.Font;
 import java.util.Map;
 
 /**
- * Converter to convert representation of an {@code Effect} to an {@code Effect}
+ * Converter to convert representation of an {@code Effect} to an {@code Effect}.
  * @since 9
  */
 public class EffectConverter extends StyleConverter<ParsedValue[], Effect> {
@@ -54,8 +54,8 @@ public class EffectConverter extends StyleConverter<ParsedValue[], Effect> {
     }
 
     /**
-     * Get the {@code EffectConverter} instance.
-     * @return the {@code EffectConverter} instance.
+     * Gets the {@code EffectConverter} instance.
+     * @return the {@code EffectConverter} instance
      */
     public static StyleConverter<ParsedValue[], Effect> getInstance() {
         return Holder.EFFECT_CONVERTER;
@@ -79,14 +79,14 @@ public class EffectConverter extends StyleConverter<ParsedValue[], Effect> {
     }
 
     /**
-     * Converter to convert DropShadow {@code Effect}
+     * Converter to convert DropShadow {@code Effect}.
      * @since 9
      */
     public static final class DropShadowConverter extends EffectConverter {
 
         /**
-         * Get the {@code DropShadowConverter} instance.
-         * @return the {@code DropShadowConverter} instance.
+         * Gets the {@code DropShadowConverter} instance.
+         * @return the {@code DropShadowConverter} instance
          */
         public static DropShadowConverter getInstance() {
             return Holder.DROP_SHADOW_INSTANCE;
@@ -158,14 +158,14 @@ public class EffectConverter extends StyleConverter<ParsedValue[], Effect> {
     }
 
     /**
-     * Converter to convert InnerShadow {@code Effect}
+     * Converter to convert InnerShadow {@code Effect}.
      * @since 9
      */
     public static final class InnerShadowConverter extends EffectConverter {
 
         /**
-         * Get the {@code InnerShadowConverter} instance.
-         * @return the {@code InnerShadowConverter} instance.
+         * Gets the {@code InnerShadowConverter} instance.
+         * @return the {@code InnerShadowConverter} instance
          */
         public static InnerShadowConverter getInstance() {
             return Holder.INNER_SHADOW_INSTANCE;

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/EnumConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/EnumConverter.java
@@ -40,6 +40,7 @@ import java.util.Locale;
 import java.util.Map;
 
 /**
+ * Converter to convert a String representation of an {@code Enum} to an {@code Enum}.
  * @since 9
  */
 public final class EnumConverter<E extends Enum<E>> extends StyleConverter<String, E> {
@@ -47,6 +48,10 @@ public final class EnumConverter<E extends Enum<E>> extends StyleConverter<Strin
     // package for unit testing
     final Class<E> enumClass;
 
+    /**
+     * Creates an {@code EnumConvertor} object
+     * @param enumClass enum Class
+     */
     public EnumConverter(Class<E> enumClass) {
         this.enumClass = enumClass;
     }
@@ -79,6 +84,13 @@ public final class EnumConverter<E extends Enum<E>> extends StyleConverter<Strin
     }
 
 
+    /**
+     * Reads binary {@code StyleConverter} data from a given {@code DataInputStream}.
+     * @param is {@code DataInputStream} to read {@code StyleConverter} data from
+     * @param strings string array containing StyleConverter details
+     * @return A {@code StyleConverter} from read binary data
+     * @throws IOException if reading from {@code DataInputStream} fails
+     */
     public static StyleConverter<?,?> readBinary(DataInputStream is, String[] strings)
             throws IOException {
 
@@ -106,6 +118,11 @@ public final class EnumConverter<E extends Enum<E>> extends StyleConverter<Strin
 
     private static Map<String,StyleConverter<?,?>> converters;
 
+    /**
+     * Gets an {@code EnumConverter} instance for a given enum name.
+     * @param ename enum name
+     * @return an {@code EnumConverter} instance for a given enum name.
+     */
     // package for unit testing
     static public StyleConverter<?,?> getInstance(final String ename) {
 

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/EnumConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/EnumConverter.java
@@ -49,8 +49,8 @@ public final class EnumConverter<E extends Enum<E>> extends StyleConverter<Strin
     final Class<E> enumClass;
 
     /**
-     * Creates an {@code EnumConvertor} object
-     * @param enumClass enum Class
+     * Creates an {@code EnumConvertor} object.
+     * @param enumClass enum class
      */
     public EnumConverter(Class<E> enumClass) {
         this.enumClass = enumClass;
@@ -88,7 +88,7 @@ public final class EnumConverter<E extends Enum<E>> extends StyleConverter<Strin
      * Reads binary {@code StyleConverter} data from a given {@code DataInputStream}.
      * @param is {@code DataInputStream} to read {@code StyleConverter} data from
      * @param strings string array containing StyleConverter details
-     * @return A {@code StyleConverter} from read binary data
+     * @return a {@code StyleConverter} from read binary data
      * @throws IOException if reading from {@code DataInputStream} fails
      */
     public static StyleConverter<?,?> readBinary(DataInputStream is, String[] strings)

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/EnumConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/EnumConverter.java
@@ -40,7 +40,7 @@ import java.util.Locale;
 import java.util.Map;
 
 /**
- * Converter to convert a String representation of an {@code Enum} to an {@code Enum}.
+ * Converter to convert a string representation of an {@code Enum} to an {@code Enum}.
  * @since 9
  */
 public final class EnumConverter<E extends Enum<E>> extends StyleConverter<String, E> {
@@ -123,7 +123,6 @@ public final class EnumConverter<E extends Enum<E>> extends StyleConverter<Strin
      * @param ename enum name
      * @return an {@code EnumConverter} instance for a given enum name.
      */
-    // package for unit testing
     static public StyleConverter<?,?> getInstance(final String ename) {
 
         StyleConverter<?,?> converter = null;

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/FontConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/FontConverter.java
@@ -40,6 +40,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 /**
+ * Converter to convert a parsed representation of a {@code Font} to a {@code Font}.
  * @since 9
  */
 public final class FontConverter extends StyleConverter<ParsedValue[], Font> {
@@ -49,6 +50,10 @@ public final class FontConverter extends StyleConverter<ParsedValue[], Font> {
         static final FontConverter INSTANCE = new FontConverter();
     }
 
+    /**
+     * Get the {@code FontConverter} instance.
+     * @return the {@code FontConverter} instance.
+     */
     public static StyleConverter<ParsedValue[], Font> getInstance() {
         return Holder.INSTANCE;
     }
@@ -110,6 +115,9 @@ public final class FontConverter extends StyleConverter<ParsedValue[], Font> {
         return "FontConverter";
     }
 
+    /**
+     * Converter to convert a {@code String} value to a {@code FontPosture} object.
+     */
     public static final class FontStyleConverter extends StyleConverter<String, FontPosture> {
 
         // lazy, thread-safe instatiation
@@ -117,6 +125,10 @@ public final class FontConverter extends StyleConverter<ParsedValue[], Font> {
             static final FontStyleConverter INSTANCE = new FontStyleConverter();
         }
 
+        /**
+         * Get the {@code FontStyleConverter} instance.
+         * @return the {@code FontStyleConverter} instance.
+         */
         public static FontStyleConverter getInstance() {
             return Holder.INSTANCE;
         }
@@ -156,6 +168,9 @@ public final class FontConverter extends StyleConverter<ParsedValue[], Font> {
         }
     }
 
+    /**
+     * Converter to convert a {@code String} value to a {@code FontWeight} object.
+     */
     public static final class FontWeightConverter extends StyleConverter<String, FontWeight> {
 
         // lazy, thread-safe instatiation
@@ -163,6 +178,10 @@ public final class FontConverter extends StyleConverter<ParsedValue[], Font> {
             static final FontWeightConverter INSTANCE = new FontWeightConverter();
         }
 
+        /**
+         * Get the {@code FontWeightConverter} instance.
+         * @return the {@code FontWeightConverter} instance.
+         */
         public static FontWeightConverter getInstance() {
             return Holder.INSTANCE;
         }
@@ -203,6 +222,9 @@ public final class FontConverter extends StyleConverter<ParsedValue[], Font> {
         }
     }
 
+    /**
+     * Converter to convert a parsed font size value to a {@code Number} object.
+     */
     public static final class FontSizeConverter extends StyleConverter<ParsedValue<?, Size>, Number> {
 
         // lazy, thread-safe instatiation
@@ -210,6 +232,10 @@ public final class FontConverter extends StyleConverter<ParsedValue[], Font> {
             static final FontSizeConverter INSTANCE = new FontSizeConverter();
         }
 
+        /**
+         * Get the {@code FontSizeConverter} instance.
+         * @return the {@code FontSizeConverter} instance.
+         */
         public static FontSizeConverter getInstance() {
             return Holder.INSTANCE;
         }

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/FontConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/FontConverter.java
@@ -51,8 +51,8 @@ public final class FontConverter extends StyleConverter<ParsedValue[], Font> {
     }
 
     /**
-     * Get the {@code FontConverter} instance.
-     * @return the {@code FontConverter} instance.
+     * Gets the {@code FontConverter} instance.
+     * @return the {@code FontConverter} instance
      */
     public static StyleConverter<ParsedValue[], Font> getInstance() {
         return Holder.INSTANCE;
@@ -117,6 +117,8 @@ public final class FontConverter extends StyleConverter<ParsedValue[], Font> {
 
     /**
      * Converter to convert a {@code String} value to a {@code FontPosture} object.
+     *
+     * @since 9
      */
     public static final class FontStyleConverter extends StyleConverter<String, FontPosture> {
 
@@ -126,8 +128,8 @@ public final class FontConverter extends StyleConverter<ParsedValue[], Font> {
         }
 
         /**
-         * Get the {@code FontStyleConverter} instance.
-         * @return the {@code FontStyleConverter} instance.
+         * Gets the {@code FontStyleConverter} instance.
+         * @return the {@code FontStyleConverter} instance
          */
         public static FontStyleConverter getInstance() {
             return Holder.INSTANCE;
@@ -170,6 +172,8 @@ public final class FontConverter extends StyleConverter<ParsedValue[], Font> {
 
     /**
      * Converter to convert a {@code String} value to a {@code FontWeight} object.
+     *
+     * @since 9
      */
     public static final class FontWeightConverter extends StyleConverter<String, FontWeight> {
 
@@ -179,8 +183,8 @@ public final class FontConverter extends StyleConverter<ParsedValue[], Font> {
         }
 
         /**
-         * Get the {@code FontWeightConverter} instance.
-         * @return the {@code FontWeightConverter} instance.
+         * Gets the {@code FontWeightConverter} instance.
+         * @return the {@code FontWeightConverter} instance
          */
         public static FontWeightConverter getInstance() {
             return Holder.INSTANCE;
@@ -224,6 +228,8 @@ public final class FontConverter extends StyleConverter<ParsedValue[], Font> {
 
     /**
      * Converter to convert a parsed font size value to a {@code Number} object.
+     *
+     * @since 9
      */
     public static final class FontSizeConverter extends StyleConverter<ParsedValue<?, Size>, Number> {
 
@@ -233,8 +239,8 @@ public final class FontConverter extends StyleConverter<ParsedValue[], Font> {
         }
 
         /**
-         * Get the {@code FontSizeConverter} instance.
-         * @return the {@code FontSizeConverter} instance.
+         * Gets the {@code FontSizeConverter} instance.
+         * @return the {@code FontSizeConverter} instance
          */
         public static FontSizeConverter getInstance() {
             return Holder.INSTANCE;

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/InsetsConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/InsetsConverter.java
@@ -50,8 +50,8 @@ public final class InsetsConverter extends StyleConverter<ParsedValue[], Insets>
     }
 
     /**
-     * Get the {@code InsetsConverter} instance.
-     * @return the {@code InsetsConverter} instance.
+     * Gets the {@code InsetsConverter} instance.
+     * @return the {@code InsetsConverter} instance
      */
     public static StyleConverter<ParsedValue[], Insets> getInstance() {
         return Holder.INSTANCE;
@@ -79,12 +79,13 @@ public final class InsetsConverter extends StyleConverter<ParsedValue[], Insets>
     /**
      * Converter to convert an array of parsed values, each of which is an array
      * of 1 to 4 size components, to an array of {@code Insets} objects.
+     * @since 9
      */
     public static final class SequenceConverter extends StyleConverter<ParsedValue<ParsedValue[], Insets>[], Insets[]> {
 
         /**
-         * Get the {@code SequenceConverter} instance.
-         * @return the {@code SequenceConverter} instance.
+         * Gets the {@code SequenceConverter} instance.
+         * @return the {@code SequenceConverter} instance
          */
         public static SequenceConverter getInstance() {
             return Holder.SEQUENCE_INSTANCE;

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/InsetsConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/InsetsConverter.java
@@ -32,7 +32,7 @@ import javafx.geometry.Insets;
 import javafx.scene.text.Font;
 
 /**
- * Converts a parsed value array of 1 to 4 size components to an Insets.
+ * Converter to convert a parsed value array of 1 to 4 size components to an {@code Insets}.
  * The size values are interpreted as
  * top, right, bottom, left.
  * If only top is given, that value is used on all sides.
@@ -49,6 +49,10 @@ public final class InsetsConverter extends StyleConverter<ParsedValue[], Insets>
         static final SequenceConverter SEQUENCE_INSTANCE = new SequenceConverter();
     }
 
+    /**
+     * Get the {@code InsetsConverter} instance.
+     * @return the {@code InsetsConverter} instance.
+     */
     public static StyleConverter<ParsedValue[], Insets> getInstance() {
         return Holder.INSTANCE;
     }
@@ -73,11 +77,15 @@ public final class InsetsConverter extends StyleConverter<ParsedValue[], Insets>
     }
 
     /**
-     * Converts an array of parsed values, each of which is an array
-     * of 1 to 4 size components, to an array of Insets objects.
+     * Converter to convert an array of parsed values, each of which is an array
+     * of 1 to 4 size components, to an array of {@code Insets} objects.
      */
     public static final class SequenceConverter extends StyleConverter<ParsedValue<ParsedValue[], Insets>[], Insets[]> {
 
+        /**
+         * Get the {@code SequenceConverter} instance.
+         * @return the {@code SequenceConverter} instance.
+         */
         public static SequenceConverter getInstance() {
             return Holder.SEQUENCE_INSTANCE;
         }

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/LadderConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/LadderConverter.java
@@ -31,6 +31,10 @@ import javafx.scene.paint.Color;
 import javafx.scene.paint.Stop;
 import javafx.scene.text.Font;
 
+/**
+ * Converter to convert a parsed representation of color ladder values to a {@code Color}.
+ * @since 9
+ */
 public final class LadderConverter extends StyleConverter<ParsedValue[], Color> {
 
     // lazy, thread-safe instatiation
@@ -38,6 +42,10 @@ public final class LadderConverter extends StyleConverter<ParsedValue[], Color> 
         static final LadderConverter INSTANCE = new LadderConverter();
     }
 
+    /**
+     * Get the {@code LadderConverter} instance.
+     * @return the {@code LadderConverter} instance.
+     */
     public static LadderConverter getInstance() {
         return Holder.INSTANCE;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/LadderConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/LadderConverter.java
@@ -43,8 +43,8 @@ public final class LadderConverter extends StyleConverter<ParsedValue[], Color> 
     }
 
     /**
-     * Get the {@code LadderConverter} instance.
-     * @return the {@code LadderConverter} instance.
+     * Gets the {@code LadderConverter} instance.
+     * @return the {@code LadderConverter} instance
      */
     public static LadderConverter getInstance() {
         return Holder.INSTANCE;

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/PaintConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/PaintConverter.java
@@ -57,8 +57,8 @@ public final class PaintConverter extends StyleConverter<ParsedValue<?, Paint>, 
     }
 
     /**
-     * Get the {@code PaintConverter} instance.
-     * @return the {@code PaintConverter} instance.
+     * Gets the {@code PaintConverter} instance.
+     * @return the {@code PaintConverter} instance
      */
     public static StyleConverter<ParsedValue<?, Paint>, Paint> getInstance() {
         return Holder.INSTANCE;
@@ -84,12 +84,13 @@ public final class PaintConverter extends StyleConverter<ParsedValue<?, Paint>, 
 
     /**
      * Converter to convert a sequence of parsed values to an array of {@code Paint} objects.
+     * @since 9
      */
     public static final class SequenceConverter extends StyleConverter<ParsedValue<?, Paint>[], Paint[]> {
 
         /**
-         * Get the {@code SequenceConverter} instance.
-         * @return the {@code SequenceConverter} instance.
+         * Gets the {@code SequenceConverter} instance.
+         * @return the {@code SequenceConverter} instance
          */
         public static SequenceConverter getInstance() {
             return Holder.SEQUENCE_INSTANCE;
@@ -117,12 +118,13 @@ public final class PaintConverter extends StyleConverter<ParsedValue<?, Paint>, 
 
     /**
      * Converter to convert linear gradient parsed values to a {@code Paint} object.
+     * @since 9
      */
     public static final class LinearGradientConverter extends StyleConverter<ParsedValue[], Paint> {
 
         /**
-         * Get the {@code LinearGradientConverter} instance.
-         * @return the {@code LinearGradientConverter} instance.
+         * Gets the {@code LinearGradientConverter} instance.
+         * @return the {@code LinearGradientConverter} instance
          */
         public static LinearGradientConverter getInstance() {
             return Holder.LINEAR_GRADIENT_INSTANCE;
@@ -164,12 +166,13 @@ public final class PaintConverter extends StyleConverter<ParsedValue<?, Paint>, 
 
     /**
      * Converter to convert image pattern parsed values to a {@code Paint} object.
+     * @since 9
      */
     public static final class ImagePatternConverter extends StyleConverter<ParsedValue[], Paint> {
 
         /**
-         * Get the {@code ImagePatternConverter} instance.
-         * @return the {@code ImagePatternConverter} instance.
+         * Gets the {@code ImagePatternConverter} instance.
+         * @return the {@code ImagePatternConverter} instance
          */
         public static ImagePatternConverter getInstance() {
             return Holder.IMAGE_PATTERN_INSTANCE;
@@ -217,12 +220,13 @@ public final class PaintConverter extends StyleConverter<ParsedValue<?, Paint>, 
 
     /**
      * Converter to convert repeating image pattern parsed values to a {@code Paint} object.
+     * @since 9
      */
     public static final class RepeatingImagePatternConverter extends StyleConverter<ParsedValue[], Paint> {
 
         /**
-         * Get the {@code RepeatingImagePatternConverter} instance.
-         * @return the {@code RepeatingImagePatternConverter} instance.
+         * Gets the {@code RepeatingImagePatternConverter} instance.
+         * @return the {@code RepeatingImagePatternConverter} instance
          */
         public static RepeatingImagePatternConverter getInstance() {
             return Holder.REPEATING_IMAGE_PATTERN_INSTANCE;
@@ -258,12 +262,13 @@ public final class PaintConverter extends StyleConverter<ParsedValue<?, Paint>, 
 
     /**
      * Converter to convert radial gradient parsed values to a {@code Paint} object.
+     * @since 9
      */
     public static final class RadialGradientConverter extends StyleConverter<ParsedValue[], Paint> {
 
         /**
-         * Get the {@code RadialGradientConverter} instance.
-         * @return the {@code RadialGradientConverter} instance.
+         * Gets the {@code RadialGradientConverter} instance.
+         * @return the {@code RadialGradientConverter} instance
          */
         public static RadialGradientConverter getInstance() {
             return Holder.RADIAL_GRADIENT_INSTANCE;

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/PaintConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/PaintConverter.java
@@ -41,6 +41,7 @@ import javafx.scene.text.Font;
 
 
 /**
+ * Converter to convert a parsed representation of a {@code Paint} to a {@code Paint}.
  * @since 9
  */
 public final class PaintConverter extends StyleConverter<ParsedValue<?, Paint>, Paint> {
@@ -55,6 +56,10 @@ public final class PaintConverter extends StyleConverter<ParsedValue<?, Paint>, 
         static final RadialGradientConverter RADIAL_GRADIENT_INSTANCE = new RadialGradientConverter();
     }
 
+    /**
+     * Get the {@code PaintConverter} instance.
+     * @return the {@code PaintConverter} instance.
+     */
     public static StyleConverter<ParsedValue<?, Paint>, Paint> getInstance() {
         return Holder.INSTANCE;
     }
@@ -78,10 +83,14 @@ public final class PaintConverter extends StyleConverter<ParsedValue<?, Paint>, 
     }
 
     /**
-     * Converts an array of parsed values to an array of Paint objects.
+     * Converter to convert a sequence of parsed values to an array of {@code Paint} objects.
      */
     public static final class SequenceConverter extends StyleConverter<ParsedValue<?, Paint>[], Paint[]> {
 
+        /**
+         * Get the {@code SequenceConverter} instance.
+         * @return the {@code SequenceConverter} instance.
+         */
         public static SequenceConverter getInstance() {
             return Holder.SEQUENCE_INSTANCE;
         }
@@ -106,8 +115,15 @@ public final class PaintConverter extends StyleConverter<ParsedValue<?, Paint>, 
         }
     }
 
+    /**
+     * Converter to convert linear gradient parsed values to a {@code Paint} object.
+     */
     public static final class LinearGradientConverter extends StyleConverter<ParsedValue[], Paint> {
 
+        /**
+         * Get the {@code LinearGradientConverter} instance.
+         * @return the {@code LinearGradientConverter} instance.
+         */
         public static LinearGradientConverter getInstance() {
             return Holder.LINEAR_GRADIENT_INSTANCE;
         }
@@ -146,8 +162,15 @@ public final class PaintConverter extends StyleConverter<ParsedValue<?, Paint>, 
         }
     }
 
+    /**
+     * Converter to convert image pattern parsed values to a {@code Paint} object.
+     */
     public static final class ImagePatternConverter extends StyleConverter<ParsedValue[], Paint> {
 
+        /**
+         * Get the {@code ImagePatternConverter} instance.
+         * @return the {@code ImagePatternConverter} instance.
+         */
         public static ImagePatternConverter getInstance() {
             return Holder.IMAGE_PATTERN_INSTANCE;
         }
@@ -192,8 +215,15 @@ public final class PaintConverter extends StyleConverter<ParsedValue<?, Paint>, 
         }
     }
 
+    /**
+     * Converter to convert repeating image pattern parsed values to a {@code Paint} object.
+     */
     public static final class RepeatingImagePatternConverter extends StyleConverter<ParsedValue[], Paint> {
 
+        /**
+         * Get the {@code RepeatingImagePatternConverter} instance.
+         * @return the {@code RepeatingImagePatternConverter} instance.
+         */
         public static RepeatingImagePatternConverter getInstance() {
             return Holder.REPEATING_IMAGE_PATTERN_INSTANCE;
         }
@@ -226,8 +256,15 @@ public final class PaintConverter extends StyleConverter<ParsedValue<?, Paint>, 
         }
     }
 
+    /**
+     * Converter to convert radial gradient parsed values to a {@code Paint} object.
+     */
     public static final class RadialGradientConverter extends StyleConverter<ParsedValue[], Paint> {
 
+        /**
+         * Get the {@code RadialGradientConverter} instance.
+         * @return the {@code RadialGradientConverter} instance.
+         */
         public static RadialGradientConverter getInstance() {
             return Holder.RADIAL_GRADIENT_INSTANCE;
         }

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/ShapeConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/ShapeConverter.java
@@ -34,13 +34,17 @@ import javafx.scene.text.Font;
 import java.util.Map;
 
 /**
- * Converts an SVG shape string into a Shape object.
+ * Converter to convert a SVG shape string into a {@code Shape} object.
  *
  * @since 9
  */
 public class ShapeConverter extends StyleConverter<String, Shape> {
     private static final ShapeConverter INSTANCE = new ShapeConverter();
 
+    /**
+     * Get the {@code ShapeConverter} instance.
+     * @return the {@code ShapeConverter} instance.
+     */
     public static StyleConverter<String, Shape> getInstance() { return INSTANCE; }
 
     private ShapeConverter() {
@@ -63,6 +67,9 @@ public class ShapeConverter extends StyleConverter<String, Shape> {
 
     private static Map<ParsedValue<String, Shape>, Shape> cache;
 
+    /**
+     * Clears the ShapeConverter cache.
+     */
     public static void clearCache() { if (cache != null) cache.clear(); }
 
 }

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/ShapeConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/ShapeConverter.java
@@ -42,8 +42,8 @@ public class ShapeConverter extends StyleConverter<String, Shape> {
     private static final ShapeConverter INSTANCE = new ShapeConverter();
 
     /**
-     * Get the {@code ShapeConverter} instance.
-     * @return the {@code ShapeConverter} instance.
+     * Gets the {@code ShapeConverter} instance.
+     * @return the {@code ShapeConverter} instance
      */
     public static StyleConverter<String, Shape> getInstance() { return INSTANCE; }
 
@@ -68,7 +68,7 @@ public class ShapeConverter extends StyleConverter<String, Shape> {
     private static Map<ParsedValue<String, Shape>, Shape> cache;
 
     /**
-     * Clears the ShapeConverter cache.
+     * Clears the {@code ShapeConverter} cache.
      */
     public static void clearCache() { if (cache != null) cache.clear(); }
 

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/SizeConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/SizeConverter.java
@@ -31,7 +31,7 @@ import javafx.css.StyleConverter;
 import javafx.scene.text.Font;
 
 /**
- * Convert a Size to Number
+ * Converter to convert a {@code Size} to a {@code Number}
  *
  * @since 9
  */
@@ -43,6 +43,10 @@ public final class SizeConverter extends StyleConverter<ParsedValue<?, Size>, Nu
         static final SequenceConverter SEQUENCE_INSTANCE = new SequenceConverter();
     }
 
+    /**
+     * Get the {@code SizeConverter} instance.
+     * @return the {@code SizeConverter} instance.
+     */
     public static StyleConverter<ParsedValue<?, Size>, Number> getInstance() {
         return Holder.INSTANCE;
     }
@@ -62,11 +66,15 @@ public final class SizeConverter extends StyleConverter<ParsedValue<?, Size>, Nu
         return "SizeConverter";
     }
 
-    /*
-     * Convert [<size>]+ to an array of Number[].
+    /**
+     * Converter to convert a sequence of sizes to an array of {@code Number}.
      */
     public static final class SequenceConverter extends StyleConverter<ParsedValue[], Number[]> {
 
+        /**
+         * Get the {@code SequenceConverter} instance.
+         * @return the {@code SequenceConverter} instance.
+         */
         public static SequenceConverter getInstance() {
             return Holder.SEQUENCE_INSTANCE;
         }

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/SizeConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/SizeConverter.java
@@ -31,7 +31,7 @@ import javafx.css.StyleConverter;
 import javafx.scene.text.Font;
 
 /**
- * Converter to convert a {@code Size} to a {@code Number}
+ * Converter to convert a {@code Size} to a {@code Number}.
  *
  * @since 9
  */
@@ -44,8 +44,8 @@ public final class SizeConverter extends StyleConverter<ParsedValue<?, Size>, Nu
     }
 
     /**
-     * Get the {@code SizeConverter} instance.
-     * @return the {@code SizeConverter} instance.
+     * Gets the {@code SizeConverter} instance.
+     * @return the {@code SizeConverter} instance
      */
     public static StyleConverter<ParsedValue<?, Size>, Number> getInstance() {
         return Holder.INSTANCE;
@@ -68,12 +68,13 @@ public final class SizeConverter extends StyleConverter<ParsedValue<?, Size>, Nu
 
     /**
      * Converter to convert a sequence of sizes to an array of {@code Number}.
+     * @since 9
      */
     public static final class SequenceConverter extends StyleConverter<ParsedValue[], Number[]> {
 
         /**
-         * Get the {@code SequenceConverter} instance.
-         * @return the {@code SequenceConverter} instance.
+         * Gets the {@code SequenceConverter} instance.
+         * @return the {@code SequenceConverter} instance
          */
         public static SequenceConverter getInstance() {
             return Holder.SEQUENCE_INSTANCE;

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/StopConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/StopConverter.java
@@ -34,6 +34,8 @@ import javafx.scene.text.Font;
 
 /**
  * Converter to convert a {@code Stop} from a {@code Size} and a {@code Color}.
+ *
+ * @since 9
  */
 public final class StopConverter extends StyleConverter<ParsedValue[], Stop> {
 

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/StopConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/StopConverter.java
@@ -33,7 +33,7 @@ import javafx.scene.paint.Stop;
 import javafx.scene.text.Font;
 
 /**
- * convert a Stop from a Size and a Color
+ * Converter to convert a {@code Stop} from a {@code Size} and a {@code Color}
  */
 public final class StopConverter extends StyleConverter<ParsedValue[], Stop> {
 
@@ -42,6 +42,10 @@ public final class StopConverter extends StyleConverter<ParsedValue[], Stop> {
         static final StopConverter INSTANCE = new StopConverter();
     }
 
+    /**
+     * Get the {@code StopConverter} instance.
+     * @return the {@code StopConverter} instance.
+     */
     public static StopConverter getInstance() {
         return Holder.INSTANCE;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/StopConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/StopConverter.java
@@ -33,7 +33,7 @@ import javafx.scene.paint.Stop;
 import javafx.scene.text.Font;
 
 /**
- * Converter to convert a {@code Stop} from a {@code Size} and a {@code Color}
+ * Converter to convert a {@code Stop} from a {@code Size} and a {@code Color}.
  */
 public final class StopConverter extends StyleConverter<ParsedValue[], Stop> {
 
@@ -43,8 +43,8 @@ public final class StopConverter extends StyleConverter<ParsedValue[], Stop> {
     }
 
     /**
-     * Get the {@code StopConverter} instance.
-     * @return the {@code StopConverter} instance.
+     * Gets the {@code StopConverter} instance.
+     * @return the {@code StopConverter} instance
      */
     public static StopConverter getInstance() {
         return Holder.INSTANCE;

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/StringConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/StringConverter.java
@@ -31,8 +31,7 @@ import javafx.css.StyleConverter;
 import javafx.scene.text.Font;
 
 /**
- * String type converts embedded unicode characters
- *
+ * Converter for quoted strings which may have embedded unicode characters.
  * @since 9
  */
 public final class StringConverter extends StyleConverter<String, String> {
@@ -43,6 +42,10 @@ public final class StringConverter extends StyleConverter<String, String> {
         static final SequenceConverter SEQUENCE_INSTANCE = new SequenceConverter();
     }
 
+    /**
+     * Get the {@code StringConverter} instance.
+     * @return the {@code StringConverter} instance.
+     */
     public static StyleConverter<String, String> getInstance() {
         return Holder.INSTANCE;
     }
@@ -65,9 +68,14 @@ public final class StringConverter extends StyleConverter<String, String> {
         return "StringConverter";
     }
 
+    /**
+     * Converter to convert a sequence of {@code String}s to a String[].
+     */
     public static final class SequenceConverter extends StyleConverter<ParsedValue<String, String>[], String[]> {
-
-
+        /**
+         * Get the {@code SequenceConverter} instance.
+         * @return the {@code SequenceConverter} instance.
+         */
         public static SequenceConverter getInstance() {
             return Holder.SEQUENCE_INSTANCE;
         }

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/StringConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/StringConverter.java
@@ -44,7 +44,7 @@ public final class StringConverter extends StyleConverter<String, String> {
 
     /**
      * Get the {@code StringConverter} instance.
-     * @return the {@code StringConverter} instance.
+     * @return the {@code StringConverter} instance
      */
     public static StyleConverter<String, String> getInstance() {
         return Holder.INSTANCE;
@@ -69,14 +69,14 @@ public final class StringConverter extends StyleConverter<String, String> {
     }
 
     /**
-     * Converter to convert a sequence of {@code String}s to a String[].
+     * Converter to convert a sequence of {@code String}s to an array of {@code String}s.
      *
      * @since 9
      */
     public static final class SequenceConverter extends StyleConverter<ParsedValue<String, String>[], String[]> {
         /**
          * Get the {@code SequenceConverter} instance.
-         * @return the {@code SequenceConverter} instance.
+         * @return the {@code SequenceConverter} instance
          */
         public static SequenceConverter getInstance() {
             return Holder.SEQUENCE_INSTANCE;

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/StringConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/StringConverter.java
@@ -70,6 +70,8 @@ public final class StringConverter extends StyleConverter<String, String> {
 
     /**
      * Converter to convert a sequence of {@code String}s to a String[].
+     *
+     * @since 9
      */
     public static final class SequenceConverter extends StyleConverter<ParsedValue<String, String>[], String[]> {
         /**

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/URLConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/URLConverter.java
@@ -251,7 +251,7 @@ public final class URLConverter extends StyleConverter<ParsedValue[], String> {
     }
 
     /**
-     * Converter to convert a sequence of URLs to a String[].
+     * Converter to convert a sequence of URLs to an array of {@code String}s.
      * @since 9
      */
     public static final class SequenceConverter extends StyleConverter<ParsedValue<ParsedValue[], String>[], String[]> {

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/URLConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/URLConverter.java
@@ -58,8 +58,8 @@ public final class URLConverter extends StyleConverter<ParsedValue[], String> {
     }
 
     /**
-     * Get the {@code URLConverter} instance.
-     * @return the {@code URLConverter} instance.
+     * Gets the {@code URLConverter} instance.
+     * @return the {@code URLConverter} instance
      */
     public static StyleConverter<ParsedValue[], String> getInstance() {
         return Holder.INSTANCE;
@@ -252,12 +252,13 @@ public final class URLConverter extends StyleConverter<ParsedValue[], String> {
 
     /**
      * Converter to convert a sequence of URLs to a String[].
+     * @since 9
      */
     public static final class SequenceConverter extends StyleConverter<ParsedValue<ParsedValue[], String>[], String[]> {
 
         /**
-         * Get the {@code SequenceConverter} instance.
-         * @return the {@code SequenceConverter} instance.
+         * Gets the {@code SequenceConverter} instance.
+         * @return the {@code SequenceConverter} instance
          */
         public static SequenceConverter getInstance() {
             return Holder.SEQUENCE_INSTANCE;

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/URLConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/URLConverter.java
@@ -43,7 +43,7 @@ import java.security.PrivilegedExceptionAction;
 import java.security.ProtectionDomain;
 
 /**
- * Converts a parsed value representing  URL to a URL string that is
+ * Converter to convert a parsed value representing URL to a URL string that is
  * resolved relative to the location of the stylesheet.
  * The input value is in the form: {@code url("<path>")}.
  *
@@ -57,6 +57,10 @@ public final class URLConverter extends StyleConverter<ParsedValue[], String> {
         static final SequenceConverter SEQUENCE_INSTANCE = new SequenceConverter();
     }
 
+    /**
+     * Get the {@code URLConverter} instance.
+     * @return the {@code URLConverter} instance.
+     */
     public static StyleConverter<ParsedValue[], String> getInstance() {
         return Holder.INSTANCE;
     }
@@ -246,8 +250,15 @@ public final class URLConverter extends StyleConverter<ParsedValue[], String> {
         return "URLType";
     }
 
+    /**
+     * Converter to convert a sequence of URLs to a String[].
+     */
     public static final class SequenceConverter extends StyleConverter<ParsedValue<ParsedValue[], String>[], String[]> {
 
+        /**
+         * Get the {@code SequenceConverter} instance.
+         * @return the {@code SequenceConverter} instance.
+         */
         public static SequenceConverter getInstance() {
             return Holder.SEQUENCE_INSTANCE;
         }


### PR DESCRIPTION
This PR corrects/adds missing documentation for classes in javafx.css package.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8250590](https://bugs.openjdk.java.net/browse/JDK-8250590): Classes and methods in the javafx.css package are missing documentation


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/589/head:pull/589` \
`$ git checkout pull/589`

Update a local copy of the PR: \
`$ git checkout pull/589` \
`$ git pull https://git.openjdk.java.net/jfx pull/589/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 589`

View PR using the GUI difftool: \
`$ git pr show -t 589`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/589.diff">https://git.openjdk.java.net/jfx/pull/589.diff</a>

</details>
