### PR TITLE
8271484: Tree-/TableCell: NPE when accessing edit event from startEdit

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
@@ -327,17 +327,17 @@ public class TableCell<S,T> extends IndexedCell<T> {
         // by calling super.startEdit().
         super.startEdit();
 
+        editingCellAtStartEdit = new TablePosition<>(table, getIndex(), column);
         if (column != null) {
             CellEditEvent<S,?> editEvent = new CellEditEvent<>(
                 table,
-                table.getEditingCell(),
+                editingCellAtStartEdit,
                 TableColumn.editStartEvent(),
                 null
             );
 
             Event.fireEvent(column, editEvent);
         }
-        editingCellAtStartEdit = new TablePosition<>(table, getIndex(), column);
     }
 
     /** {@inheritDoc} */

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
@@ -344,17 +344,17 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
         // by calling super.startEdit().
         super.startEdit();
 
+        editingCellAtStartEdit = new TreeTablePosition<>(table, getIndex(), column);
         if (column != null) {
             CellEditEvent editEvent = new CellEditEvent(
                 table,
-                table.getEditingCell(),
+                editingCellAtStartEdit,
                 TreeTableColumn.<S,T>editStartEvent(),
                 null
             );
 
             Event.fireEvent(column, editEvent);
         }
-        editingCellAtStartEdit = new TreeTablePosition<>(table, getIndex(), column);
     }
 
     /** {@inheritDoc} */

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
@@ -550,6 +550,31 @@ public class TableCellTest {
         assertEquals("startEdit must not fire while editing", 0, events.size());
     }
 
+    @Test
+    public void testEditStartEventAfterStartOnCell() {
+        setupForEditing();
+        int editingIndex = 1;
+        cell.updateIndex(editingIndex);
+        List<CellEditEvent<?, ?>> events = new ArrayList<>();
+        editingColumn.setOnEditStart(events::add);
+        cell.startEdit();
+        assertEquals(editingColumn, events.get(0).getTableColumn());
+        TablePosition<?, ?> editingCell = events.get(0).getTablePosition();
+        assertEquals(editingIndex, editingCell.getRow());
+    }
+
+    @Test
+    public void testEditStartEventAfterStartOnTable() {
+        setupForEditing();
+        int editingIndex = 1;
+        cell.updateIndex(editingIndex);
+        List<CellEditEvent<?, ?>> events = new ArrayList<>();
+        editingColumn.setOnEditStart(events::add);
+        table.edit(editingIndex, editingColumn);
+        assertEquals(editingColumn, events.get(0).getTableColumn());
+        TablePosition<?, ?> editingCell = events.get(0).getTablePosition();
+        assertEquals(editingIndex, editingCell.getRow());
+    }
 
     /**
      * Test that cell.cancelEdit can switch table editing off

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
@@ -876,6 +876,32 @@ public class TreeTableCellTest {
         assertEquals("treeItem must be gc'ed", null, itemRef.get());
     }
 
+    @Test
+    public void testEditStartEventAfterStartOnCell() {
+        setupForEditing();
+        int editingIndex = 1;
+        cell.updateIndex(editingIndex);
+        List<CellEditEvent<?, ?>> events = new ArrayList<>();
+        editingColumn.setOnEditStart(events::add);
+        cell.startEdit();
+        assertEquals(editingColumn, events.get(0).getTableColumn());
+        TreeTablePosition<?, ?> editingCell = events.get(0).getTreeTablePosition();
+        assertEquals(editingIndex, editingCell.getRow());
+    }
+
+    @Test
+    public void testEditStartEventAfterStartOnTable() {
+        setupForEditing();
+        int editingIndex = 1;
+        cell.updateIndex(editingIndex);
+        List<CellEditEvent<?, ?>> events = new ArrayList<>();
+        editingColumn.setOnEditStart(events::add);
+        tree.edit(editingIndex, editingColumn);
+        assertEquals(editingColumn, events.get(0).getTableColumn());
+        TreeTablePosition<?, ?> editingCell = events.get(0).getTreeTablePosition();
+        assertEquals(editingIndex, editingCell.getRow());
+    }
+
 
     /**
      * Test that cell.cancelEdit can switch table editing off


### PR DESCRIPTION
The NPE was an indirect effect: 

- the bug on part of the cell was an incorrect (== missing) edit location in cellEditEvent - that's fixed in this PR
- a related bug is on part of the implementation of CellEditEvent (assuming that TablePosition != null, [JDK-8269871](https://bugs.openjdk.java.net/browse/JDK-8269871) which is not addressed in this PR

Fix is to use the cell's state at startEdit for creating the editing location, added tests starting the edit on the cell that failed/passed before/after the fix, also added sanity tests with starting edit on the control that passed before/after.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271484](https://bugs.openjdk.java.net/browse/JDK-8271484): Tree-/TableCell: NPE when accessing edit event from startEdit


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/592/head:pull/592` \
`$ git checkout pull/592`

Update a local copy of the PR: \
`$ git checkout pull/592` \
`$ git pull https://git.openjdk.java.net/jfx pull/592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 592`

View PR using the GUI difftool: \
`$ git pr show -t 592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/592.diff">https://git.openjdk.java.net/jfx/pull/592.diff</a>

</details>
