### PR TITLE
8271485: Javadoc "Method Summary" table is misaligned if overridden JDK method has {@inheritDoc} tag

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4078,6 +4078,10 @@ task javadoc(type: Javadoc, dependsOn: createMSPfile) {
     options.addBooleanOption("javafx").setValue(true);
     options.addBooleanOption("use").setValue(true);
 
+    // Suppress generating overridden methods with no additional documentation
+    // The leading '-' is necessary, since this option starts with '--' and gradle adds '-' when passing an option to javadoc
+    options.addBooleanOption("-override-methods=summary").setValue(true);
+
     options.setOptionFiles([
         new File(rootProject.buildDir,MODULESOURCEPATH)
         ]);


### PR DESCRIPTION
As noted in the JBS bug report, the javadoc-generated HTML table for a class is messed up if any method is overridden from a core JDK class and has the `{@inheritDoc}` tag. For example, the following taken from the [Background](https://github.com/openjdk/jfx/blob/jfx17/modules/javafx.graphics/src/main/java/javafx/scene/layout/Background.java#L622) class provokes this bug:

```
    /**
     * {@inheritDoc}
     */
    @Override public boolean equals(Object o) {
```

The proposed fix is to stop generating javadocs for overridden methods with no spec change. This matches how the JDK docs have been generated since JDK 10. See [JDK-8157000](https://bugs.openjdk.java.net/browse/JDK-8157000). This is done by running `javadoc` with the `--override-methods=summary` option.

There is no useful information generated for such overridden methods regardless of whether or not they use the `{@inheritDoc}` tag, so this fix also addresses the problem of having methods with no description.

See the attached "before" and "after" images.

Before:

![javadoc-before](https://user-images.githubusercontent.com/34689748/127527754-ae5c529a-8c49-47a2-b595-5e423f5c9c49.png)

After:

![javadoc-after](https://user-images.githubusercontent.com/34689748/127527789-c97c4689-154f-4ed0-a4a1-5dfdfde0d9d2.png)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271485](https://bugs.openjdk.java.net/browse/JDK-8271485): Javadoc "Method Summary" table is misaligned if overridden JDK method has {@inheritDoc} tag


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/593/head:pull/593` \
`$ git checkout pull/593`

Update a local copy of the PR: \
`$ git checkout pull/593` \
`$ git pull https://git.openjdk.java.net/jfx pull/593/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 593`

View PR using the GUI difftool: \
`$ git pr show -t 593`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/593.diff">https://git.openjdk.java.net/jfx/pull/593.diff</a>

</details>
