### PR TITLE
8271557: Undecorated interactive stage style

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package com.sun.glass.ui;
 import com.sun.glass.events.KeyEvent;
 import com.sun.glass.ui.CommonDialogs.ExtensionFilter;
 import com.sun.glass.ui.CommonDialogs.FileChooserResult;
+import javafx.stage.WindowRegionClassifier;
 
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -567,7 +568,7 @@ public abstract class Application {
      * allowed to be of exactly one visual kind, and exactly one functional
      * type.
      */
-    public abstract Window createWindow(Window owner, Screen screen, int styleMask);
+    public abstract Window createWindow(Window owner, Screen screen, WindowRegionClassifier classifier, int styleMask);
 
     /**
      * Create a window.
@@ -579,8 +580,8 @@ public abstract class Application {
      * allowed to be of exactly one visual kind, and exactly one functional
      * type.
      */
-    public final Window createWindow(Screen screen, int styleMask) {
-        return createWindow(null, screen, styleMask);
+    public final Window createWindow(Screen screen, WindowRegionClassifier classifier, int styleMask) {
+        return createWindow(null, screen, classifier, styleMask);
     }
 
     public abstract Window createWindow(long parent);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/MoveResizeHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/MoveResizeHelper.java
@@ -1,0 +1,174 @@
+package com.sun.glass.ui;
+
+import com.sun.glass.events.MouseEvent;
+import javafx.scene.Node;
+import javafx.stage.WindowRegion;
+import javafx.stage.WindowRegionClassifier;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MoveResizeHelper {
+
+    private static final Map<WindowRegion, Cursor> RESIZE_CURSORS = new HashMap<>();
+
+    static {
+        Application application = Application.GetApplication();
+        RESIZE_CURSORS.put(WindowRegion.TOP_LEFT, application.createCursor(Cursor.CURSOR_RESIZE_NORTHWEST));
+        RESIZE_CURSORS.put(WindowRegion.TOP_RIGHT, application.createCursor(Cursor.CURSOR_RESIZE_NORTHEAST));
+        RESIZE_CURSORS.put(WindowRegion.BOTTOM_LEFT, application.createCursor(Cursor.CURSOR_RESIZE_SOUTHWEST));
+        RESIZE_CURSORS.put(WindowRegion.BOTTOM_RIGHT, application.createCursor(Cursor.CURSOR_RESIZE_SOUTHEAST));
+        RESIZE_CURSORS.put(WindowRegion.LEFT, application.createCursor(Cursor.CURSOR_RESIZE_LEFTRIGHT));
+        RESIZE_CURSORS.put(WindowRegion.RIGHT, application.createCursor(Cursor.CURSOR_RESIZE_LEFTRIGHT));
+        RESIZE_CURSORS.put(WindowRegion.TOP, application.createCursor(Cursor.CURSOR_RESIZE_UPDOWN));
+        RESIZE_CURSORS.put(WindowRegion.BOTTOM, application.createCursor(Cursor.CURSOR_RESIZE_UPDOWN));
+    }
+
+    private final View view;
+    private final Window window;
+    private final WindowRegionClassifier regionClassifier;
+    private int mouseDownX, mouseDownY;
+    private int mouseDownWindowX, mouseDownWindowY;
+    private int mouseDownWindowWidth, mouseDownWindowHeight;
+    private WindowRegion currentWindowRegion;
+    private Cursor lastCursor;
+
+    public MoveResizeHelper(View view, Window window) {
+        this.view = view;
+        this.window = window;
+        this.regionClassifier = window.regionClassifier;
+    }
+
+    public final boolean handleMouseEvent(int type, int button, int x, int y, int xAbs, int yAbs) {
+        int wx = (int)(x / window.getPlatformScaleX());
+        int wy = (int)(y / window.getPlatformScaleY());
+
+        if (type != MouseEvent.DRAG) {
+            var eventHandler = view.getEventHandler();
+            Node pickedNode = eventHandler != null ? eventHandler.pickNode(wx, wy) : null;
+            currentWindowRegion = regionClassifier.classify(wx, wy, pickedNode);
+            updateCursor(currentWindowRegion);
+
+            if (currentWindowRegion == WindowRegion.CLIENT) {
+                return false;
+            }
+        }
+
+        switch (type) {
+            case MouseEvent.DRAG:
+                handleMouseDrag(button, xAbs, yAbs, currentWindowRegion);
+                break;
+            case MouseEvent.DOWN:
+                handleMouseDown(xAbs, yAbs);
+                break;
+        }
+
+        return false;
+    }
+
+    protected boolean shouldStartMoveDrag(int button, WindowRegion region) {
+        return button == MouseEvent.BUTTON_LEFT && region == WindowRegion.TITLE;
+    }
+
+    protected boolean shouldStartResizeDrag(int button, WindowRegion region) {
+        return button == MouseEvent.BUTTON_LEFT && RESIZE_CURSORS.get(region) != null;
+    }
+
+    private void handleMouseDrag(int button, int xAbs, int yAbs, WindowRegion region) {
+        if (shouldStartMoveDrag(button, region)) {
+            handleMoveWindow(xAbs, yAbs);
+        } else if (shouldStartResizeDrag(button, region)) {
+            handleResizeWindow(xAbs, yAbs, region);
+        }
+    }
+
+    private void handleMouseDown(int xAbs, int yAbs) {
+        mouseDownX = xAbs;
+        mouseDownY = yAbs;
+        mouseDownWindowX = window.getX();
+        mouseDownWindowY = window.getY();
+        mouseDownWindowWidth = window.getWidth();
+        mouseDownWindowHeight = window.getHeight();
+    }
+
+    private void handleMoveWindow(int xAbs, int yAbs) {
+        window.setPosition(mouseDownWindowX + xAbs - mouseDownX, mouseDownWindowY + yAbs - mouseDownY);
+    }
+
+    private void handleResizeWindow(int xAbs, int yAbs, WindowRegion region) {
+        int dx = xAbs - mouseDownX;
+        int dy = yAbs - mouseDownY;
+
+        switch (region) {
+            case LEFT:
+                adjustWindowPosition(dx, 0);
+                adjustWindowSize(-dx, 0);
+                break;
+            case RIGHT:
+                adjustWindowSize(dx, 0);
+                break;
+            case TOP:
+                adjustWindowPosition(0, dy);
+                adjustWindowSize(0, -dy);
+                break;
+            case BOTTOM:
+                adjustWindowSize(0, dy);
+                break;
+            case TOP_LEFT:
+                adjustWindowPosition(dx, dy);
+                adjustWindowSize(-dx, -dy);
+                break;
+            case TOP_RIGHT:
+                adjustWindowPosition(0, dy);
+                adjustWindowSize(dx, -dy);
+                break;
+            case BOTTOM_LEFT:
+                adjustWindowPosition(dx, 0);
+                adjustWindowSize(-dx, dy);
+                break;
+            case BOTTOM_RIGHT:
+                adjustWindowSize(dx, dy);
+                break;
+        }
+    }
+
+    private void adjustWindowPosition(int dx, int dy) {
+        int unclampedWidth = mouseDownWindowWidth - dx;
+        int unclampedHeight = mouseDownWindowHeight - dy;
+        int clampedWidth = dx != 0 ? clampWidth(unclampedWidth) : unclampedWidth;
+        int clampedHeight = dy != 0 ? clampHeight(unclampedHeight) : unclampedHeight;
+        int cx = unclampedWidth - clampedWidth;
+        int cy = unclampedHeight - clampedHeight;
+        window.setPosition(mouseDownWindowX + dx + cx, mouseDownWindowY + dy + cy);
+    }
+
+    private void adjustWindowSize(int dx, int dy) {
+        int width = dx != 0 ? clampWidth(mouseDownWindowWidth + dx) : mouseDownWindowWidth;
+        int height = dy != 0 ? clampHeight(mouseDownWindowHeight + dy) : mouseDownWindowHeight;
+        window.setSize(width, height);
+    }
+
+    private int clampWidth(int width) {
+        return Math.max(window.getMinimumWidth(), Math.min(window.getMaximumWidth(), width));
+    }
+
+    private int clampHeight(int height) {
+        return Math.max(window.getMinimumHeight(), Math.min(window.getMaximumHeight(), height));
+    }
+
+    private void updateCursor(WindowRegion region) {
+        Cursor newCursor = RESIZE_CURSORS.get(region);
+
+        if (lastCursor == null && newCursor != null) {
+            lastCursor = window.getCursor();
+        } else if (lastCursor != null && newCursor == null) {
+            window.setCursor(lastCursor);
+            lastCursor = null;
+        }
+
+        if (newCursor != null) {
+            window.setCursor(newCursor);
+        }
+    }
+
+}

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/MoveResizeHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/MoveResizeHelper.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package com.sun.glass.ui;
 
 import com.sun.glass.events.MouseEvent;

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/View.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/View.java
@@ -929,15 +929,6 @@ public abstract class View {
             return;
         }
 
-        // gznote: optimize - only call for undecorated Windows!
-        if (this.window != null) {
-            // handled by window (programmatical move/resize)
-            if (this.window.handleMouseEvent(type, button, x, y, xAbs, yAbs)) {
-                // The evnet has been processed by Glass
-                return;
-            }
-        }
-
         long now = System.nanoTime();
         if (type == MouseEvent.DOWN) {
             View lastClickedView = View.lastClickedView == null ? null : View.lastClickedView.get();

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,7 @@ import com.sun.javafx.util.Logging;
 import com.sun.glass.utils.NativeLibLoader;
 import com.sun.prism.impl.PrismSettings;
 import com.sun.javafx.logging.PlatformLogger;
+import javafx.stage.WindowRegionClassifier;
 
 import java.io.File;
 import java.lang.reflect.Method;
@@ -378,7 +379,7 @@ final class GtkApplication extends Application implements
     }
 
     @Override
-    public Window createWindow(Window owner, Screen screen, int styleMask) {
+    public Window createWindow(Window owner, Screen screen, WindowRegionClassifier classifier, int styleMask) {
         return new GtkWindow(owner, screen, styleMask);
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
@@ -380,7 +380,7 @@ final class GtkApplication extends Application implements
 
     @Override
     public Window createWindow(Window owner, Screen screen, WindowRegionClassifier classifier, int styleMask) {
-        return new GtkWindow(owner, screen, styleMask);
+        return new GtkWindow(owner, screen, classifier, styleMask);
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,11 +30,12 @@ import com.sun.glass.ui.Pixels;
 import com.sun.glass.ui.Screen;
 import com.sun.glass.ui.View;
 import com.sun.glass.ui.Window;
+import javafx.stage.WindowRegionClassifier;
 
 class GtkWindow extends Window {
 
-    public GtkWindow(Window owner, Screen screen, int styleMask) {
-        super(owner, screen, styleMask);
+    public GtkWindow(Window owner, Screen screen, WindowRegionClassifier regionClassifier, int styleMask) {
+        super(owner, screen, regionClassifier, styleMask);
     }
 
     protected GtkWindow(long parent) {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package com.sun.glass.ui.ios;
 import com.sun.glass.ui.*;
 import com.sun.glass.ui.CommonDialogs.ExtensionFilter;
 import com.sun.glass.ui.CommonDialogs.FileChooserResult;
+import javafx.stage.WindowRegionClassifier;
 
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -75,8 +76,8 @@ public final class IosApplication extends Application {
      * @inheritDoc
      */
     @Override
-    public Window createWindow(Window owner, Screen screen, int styleMask) {
-        return new IosWindow(owner, screen, styleMask);
+    public Window createWindow(Window owner, Screen screen, WindowRegionClassifier classifier, int styleMask) {
+        return new IosWindow(owner, screen, classifier, styleMask);
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,13 +30,14 @@ import com.sun.glass.ui.Pixels;
 import com.sun.glass.ui.Screen;
 import com.sun.glass.ui.View;
 import com.sun.glass.ui.Window;
+import javafx.stage.WindowRegionClassifier;
 
 /**
  * iOS platform Window implementation class.
  */
 final class IosWindow extends Window {
-    protected IosWindow(Window owner, Screen screen, int styleMask) {
-        super(owner, screen, styleMask);
+    protected IosWindow(Window owner, Screen screen, WindowRegionClassifier regionClassifier, int styleMask) {
+        super(owner, screen, regionClassifier, styleMask);
     }
     protected IosWindow(long parent) {
         super(parent);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import com.sun.glass.ui.*;
 import com.sun.glass.ui.CommonDialogs.ExtensionFilter;
 import com.sun.glass.ui.CommonDialogs.FileChooserResult;
 import com.sun.javafx.util.Logging;
+import javafx.stage.WindowRegionClassifier;
 
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -243,8 +244,8 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
 
     // FACTORY METHODS
 
-    @Override public Window createWindow(Window owner, Screen screen, int styleMask) {
-        return new MacWindow(owner, screen, styleMask);
+    @Override public Window createWindow(Window owner, Screen screen, WindowRegionClassifier classifier, int styleMask) {
+        return new MacWindow(owner, screen, classifier, styleMask);
     }
 
     final static long BROWSER_PARENT_ID = -1L;

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,9 +31,9 @@ import com.sun.glass.ui.Pixels;
 import com.sun.glass.ui.Screen;
 import com.sun.glass.ui.View;
 import com.sun.glass.ui.Window;
-import com.sun.glass.ui.Window.State;
-import java.nio.ByteBuffer;
+import javafx.stage.WindowRegionClassifier;
 
+import java.nio.ByteBuffer;
 import java.util.Map;
 
 /**
@@ -46,8 +46,8 @@ final class MacWindow extends Window {
         _initIDs();
     }
 
-    protected MacWindow(Window owner, Screen screen, int styleMask) {
-        super(owner, screen, styleMask);
+    protected MacWindow(Window owner, Screen screen, WindowRegionClassifier regionClassifier, int styleMask) {
+        super(owner, screen, regionClassifier, styleMask);
     }
     protected MacWindow(long parent) {
         super(parent);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleApplication.java
@@ -153,7 +153,7 @@ public final class MonocleApplication extends Application {
 
     @Override
     public Window createWindow(Window owner, Screen screen, WindowRegionClassifier classifier, int styleMask) {
-        return new MonocleWindow(owner, screen, styleMask);
+        return new MonocleWindow(owner, screen, classifier, styleMask);
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import com.sun.glass.ui.Timer;
 import com.sun.glass.ui.View;
 import com.sun.glass.ui.Window;
 import javafx.collections.SetChangeListener;
+import javafx.stage.WindowRegionClassifier;
 
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -151,7 +152,7 @@ public final class MonocleApplication extends Application {
     }
 
     @Override
-    public Window createWindow(Window owner, Screen screen, int styleMask) {
+    public Window createWindow(Window owner, Screen screen, WindowRegionClassifier classifier, int styleMask) {
         return new MonocleWindow(owner, screen, styleMask);
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,7 @@ import com.sun.glass.ui.Pixels;
 import com.sun.glass.ui.Screen;
 import com.sun.glass.ui.View;
 import com.sun.glass.ui.Window;
+import javafx.stage.WindowRegionClassifier;
 
 
 final class MonocleWindow extends Window {
@@ -51,8 +52,8 @@ final class MonocleWindow extends Window {
     private int maxW = -1;
     private int maxH = -1;
 
-    MonocleWindow(Window owner, Screen screen, int styleMask) {
-        super(owner, screen, styleMask);
+    MonocleWindow(Window owner, Screen screen, WindowRegionClassifier regionClassifier, int styleMask) {
+        super(owner, screen, regionClassifier, styleMask);
     }
 
     MonocleWindow(long parent) {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,14 +30,13 @@ import com.sun.glass.ui.CommonDialogs.FileChooserResult;
 import com.sun.javafx.application.PlatformImpl;
 import com.sun.prism.impl.PrismSettings;
 import com.sun.javafx.tk.Toolkit;
+import javafx.stage.WindowRegionClassifier;
 
 import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.Iterator;
-import java.util.Locale;
 import java.util.ResourceBundle;
 
 final class WinApplication extends Application implements InvokeLaterDispatcher.InvokeLaterSubmitter {
@@ -225,8 +224,8 @@ final class WinApplication extends Application implements InvokeLaterDispatcher.
 
     // FACTORY METHODS
 
-    @Override public Window createWindow(Window owner, Screen screen, int styleMask) {
-        return new WinWindow(owner, screen, styleMask);
+    @Override public Window createWindow(Window owner, Screen screen, WindowRegionClassifier classifier, int styleMask) {
+        return new WinWindow(owner, screen, classifier, styleMask);
     }
 
     @Override public Window createWindow(long parent) {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinView.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinView.java
@@ -98,10 +98,10 @@ final class WinView extends View {
         updateLocation();
     }
 
-    /*@Override
+    @Override
     protected MoveResizeHelper getMoveResizeHelper() {
         // We don't use a move-resize helper on Windows, but handle the WM_NCHITTEST message instead.
         return null;
-    }*/
+    }
 }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinView.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,12 +24,9 @@
  */
 package com.sun.glass.ui.win;
 
-import com.sun.glass.ui.Application;
+import com.sun.glass.ui.MoveResizeHelper;
 import com.sun.glass.ui.Pixels;
 import com.sun.glass.ui.View;
-import com.sun.glass.ui.Window;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import java.util.Map;
 
@@ -100,5 +97,11 @@ final class WinView extends View {
         // to be recalculated.
         updateLocation();
     }
+
+    /*@Override
+    protected MoveResizeHelper getMoveResizeHelper() {
+        // We don't use a move-resize helper on Windows, but handle the WM_NCHITTEST message instead.
+        return null;
+    }*/
 }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,8 @@ import com.sun.glass.ui.Pixels;
 import com.sun.glass.ui.Screen;
 import com.sun.glass.ui.View;
 import com.sun.glass.ui.Window;
+import javafx.scene.Node;
+import javafx.stage.WindowRegionClassifier;
 
 /**
  * MS Windows platform implementation class for Window.
@@ -50,8 +52,8 @@ class WinWindow extends Window {
         _initIDs();
     }
 
-    protected WinWindow(Window owner, Screen screen, int styleMask) {
-        super(owner, screen, styleMask);
+    protected WinWindow(Window owner, Screen screen, WindowRegionClassifier regionClassifier, int styleMask) {
+        super(owner, screen, regionClassifier, styleMask);
     }
 
     protected WinWindow(long parent) {
@@ -249,6 +251,31 @@ class WinWindow extends Window {
             return _setBackground2(ptr, r, g, b);
         }
         return true;
+    }
+
+    protected int classifyWindowRegion(int x, int y) {
+        /*if (regionClassifier != null) {
+            double wx = (x - this.x) / platformScaleX;
+            double wy = (y - this.y) / platformScaleY;
+
+            var eventHandler = view.getEventHandler();
+            Node pickedNode = eventHandler != null ? eventHandler.pickNode(wx, wy) : null;
+
+            switch (regionClassifier.classify(wx, wy, pickedNode)) {
+                case NONE: return 0; // HTNOWHERE
+                case TITLE: return 2; // HTCAPTION
+                case TOP: return 12; // HTTOP
+                case TOP_RIGHT: return 14; // HTTOPRIGHT
+                case RIGHT: return 11; // HTRIGHT
+                case BOTTOM_RIGHT: return 17; // HTBOTTOMRIGHT
+                case BOTTOM: return 15; // HTBOTTOM
+                case BOTTOM_LEFT: return 16; // HTBOTTOMLEFT
+                case LEFT: return 10; // HTLEFT
+                case TOP_LEFT: return 13; // HTTOPLEFT
+            }
+        }*/
+
+        return 1; // HTCLIENT
     }
 
     native private long _getInsets(long ptr);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinWindow.java
@@ -254,7 +254,7 @@ class WinWindow extends Window {
     }
 
     protected int classifyWindowRegion(int x, int y) {
-        /*if (regionClassifier != null) {
+        if (regionClassifier != null) {
             double wx = (x - this.x) / platformScaleX;
             double wy = (y - this.y) / platformScaleY;
 
@@ -273,7 +273,7 @@ class WinWindow extends Window {
                 case LEFT: return 10; // HTLEFT
                 case TOP_LEFT: return 13; // HTTOPLEFT
             }
-        }*/
+        }
 
         return 1; // HTCLIENT
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/DummyToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/DummyToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/DummyToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/DummyToolkit.java
@@ -43,7 +43,6 @@ import javafx.scene.shape.StrokeLineJoin;
 import javafx.scene.shape.StrokeType;
 import javafx.stage.FileChooser.ExtensionFilter;
 import javafx.stage.Modality;
-import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.Window;
 import java.io.File;
@@ -67,6 +66,8 @@ import com.sun.scenario.DelayedRunnable;
 import com.sun.scenario.animation.AbstractPrimaryTimer;
 import com.sun.scenario.effect.FilterContext;
 import com.sun.scenario.effect.Filterable;
+import javafx.stage.WindowRegionClassifier;
+
 import java.util.Optional;
 
 /**
@@ -103,7 +104,7 @@ final public class DummyToolkit extends Toolkit {
     }
 
     @Override
-    public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl, @SuppressWarnings("removal") AccessControlContext acc) {
+    public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, WindowRegionClassifier classifier, TKStage owner, boolean rtl, @SuppressWarnings("removal") AccessControlContext acc) {
         throw new UnsupportedOperationException("Not supported yet.");
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKSceneListener.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKSceneListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKSceneListener.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKSceneListener.java
@@ -28,6 +28,7 @@ package com.sun.javafx.tk;
 import com.sun.glass.ui.Accessible;
 import javafx.collections.ObservableList;
 import javafx.event.EventType;
+import javafx.scene.Node;
 import javafx.scene.input.*;
 
 /**
@@ -120,4 +121,6 @@ public interface TKSceneListener {
     public void touchEventEnd();
 
     public Accessible getSceneAccessible();
+
+    public Node pickNode(double x, double y);
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -28,7 +28,6 @@ package com.sun.javafx.tk;
 import javafx.application.ConditionalFeature;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.geometry.Dimension2D;
-import javafx.scene.Scene;
 import javafx.scene.effect.BlurType;
 import javafx.scene.image.Image;
 import javafx.scene.image.PixelFormat;
@@ -51,11 +50,10 @@ import javafx.scene.shape.StrokeLineJoin;
 import javafx.scene.shape.StrokeType;
 import javafx.stage.FileChooser.ExtensionFilter;
 import javafx.stage.Modality;
-import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.Window;
+import javafx.stage.WindowRegionClassifier;
 import java.io.File;
-import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.security.AccessControlContext;
@@ -63,7 +61,6 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -82,7 +79,6 @@ import com.sun.javafx.perf.PerformanceTracker;
 import com.sun.javafx.runtime.VersionInfo;
 import com.sun.javafx.runtime.async.AsyncOperation;
 import com.sun.javafx.runtime.async.AsyncOperationListener;
-import com.sun.javafx.scene.SceneHelper;
 import com.sun.javafx.scene.text.TextLayoutFactory;
 import com.sun.javafx.sg.prism.NGCamera;
 import com.sun.javafx.sg.prism.NGLightBase;
@@ -370,7 +366,7 @@ public abstract class Toolkit {
 
     public abstract boolean isNestedLoopRunning();
 
-    public abstract TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl, @SuppressWarnings("removal") AccessControlContext acc);
+    public abstract TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, WindowRegionClassifier classifier, TKStage owner, boolean rtl, @SuppressWarnings("removal") AccessControlContext acc);
 
     public abstract TKStage createTKPopupStage(Window peerWindow, StageStyle popupStyle, TKStage owner, @SuppressWarnings("removal") AccessControlContext acc);
     public abstract TKStage createTKEmbeddedStage(HostInterface host, @SuppressWarnings("removal") AccessControlContext acc);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassAppletWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassAppletWindow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassAppletWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassAppletWindow.java
@@ -53,7 +53,7 @@ class GlassAppletWindow implements AppletWindow {
             if (serverName != null) {
                 throw new RuntimeException("GlassAppletWindow constructor used incorrectly.");
             }
-            glassWindow = Application.GetApplication().createWindow(null, Window.NORMAL);
+            glassWindow = Application.GetApplication().createWindow(null, null, Window.NORMAL);
         } else {
             this.serverName = serverName;
             glassWindow = Application.GetApplication().createWindow(nativeParent);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,7 @@ import javafx.collections.ObservableList;
 
 import javafx.event.EventType;
 import javafx.geometry.Point2D;
+import javafx.scene.Node;
 import javafx.scene.input.InputMethodEvent;
 import javafx.scene.input.InputMethodHighlight;
 import javafx.scene.input.InputMethodTextRun;
@@ -1390,5 +1391,17 @@ class GlassViewEventHandler extends View.EventHandler {
             return scene.sceneListener.getSceneAccessible();
         }
         return null;
+    }
+
+    @Override
+    public Node pickNode(double x, double y) {
+        return QuantumToolkit.runWithoutRenderLock(() -> {
+            return AccessController.doPrivileged((PrivilegedAction<Node>) () -> {
+                if (scene.sceneListener != null) {
+                    return scene.sceneListener.pickNode(x, y);
+                }
+                return null;
+            });
+        });
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +55,7 @@ import javafx.stage.FileChooser;
 import javafx.stage.Modality;
 import javafx.stage.StageStyle;
 import javafx.stage.Window;
+import javafx.stage.WindowRegionClassifier;
 import java.io.File;
 import java.io.InputStream;
 import java.nio.Buffer;
@@ -607,9 +608,9 @@ public final class QuantumToolkit extends Toolkit {
         }
     }
 
-    @Override public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl, @SuppressWarnings("removal") AccessControlContext acc) {
+    @Override public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, WindowRegionClassifier classifier, TKStage owner, boolean rtl, @SuppressWarnings("removal") AccessControlContext acc) {
         assertToolkitRunning();
-        WindowStage stage = new WindowStage(peerWindow, securityDialog, stageStyle, modality, owner);
+        WindowStage stage = new WindowStage(peerWindow, securityDialog, stageStyle, modality, classifier, owner);
         stage.setSecurityContext(acc);
         if (primary) {
             stage.setIsPrimary();
@@ -684,7 +685,7 @@ public final class QuantumToolkit extends Toolkit {
         assertToolkitRunning();
         boolean securityDialog = owner instanceof WindowStage ?
                 ((WindowStage)owner).isSecurityDialog() : false;
-        WindowStage stage = new WindowStage(peerWindow, securityDialog, popupStyle, null, owner);
+        WindowStage stage = new WindowStage(peerWindow, securityDialog, popupStyle, null, null, owner);
         stage.setSecurityContext(acc);
         stage.setIsPopup();
         stage.init(systemMenu);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,7 @@ import javafx.scene.input.KeyCombination;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
+import javafx.stage.WindowRegionClassifier;
 
 import com.sun.glass.events.WindowEvent;
 import com.sun.glass.ui.*;
@@ -64,6 +65,7 @@ class WindowStage extends GlassStage {
     private StageStyle style;
     private GlassStage owner = null;
     private Modality modality = Modality.NONE;
+    private final WindowRegionClassifier regionClassifier;
     private final boolean securityDialog;
 
     private OverlayWarning warning = null;
@@ -102,10 +104,11 @@ class WindowStage extends GlassStage {
                                  ".QuantumMessagesBundle", LOCALE);
 
 
-    public WindowStage(javafx.stage.Window peerWindow, boolean securityDialog, final StageStyle stageStyle, Modality modality, TKStage owner) {
+    public WindowStage(javafx.stage.Window peerWindow, boolean securityDialog, final StageStyle stageStyle, Modality modality, WindowRegionClassifier classifier, TKStage owner) {
         this.style = stageStyle;
         this.owner = (GlassStage)owner;
         this.modality = modality;
+        this.regionClassifier = classifier;
         this.securityDialog = securityDialog;
 
         if (peerWindow instanceof javafx.stage.Stage) {
@@ -188,6 +191,9 @@ class WindowStage extends GlassStage {
                         case UTILITY:
                             windowMask |=  Window.TITLED | Window.UTILITY | Window.CLOSABLE;
                             break;
+                        case UNDECORATED_INTERACTIVE:
+                            windowMask |= Window.INTERACTIVE;
+                            // fall through
                         default:
                             windowMask |=
                                     (transparent ? Window.TRANSPARENT : Window.UNTITLED) | Window.CLOSABLE;
@@ -198,7 +204,7 @@ class WindowStage extends GlassStage {
                     windowMask |= Window.MODAL;
                 }
                 platformWindow =
-                        app.createWindow(ownerWindow, Screen.getMainScreen(), windowMask);
+                        app.createWindow(ownerWindow, Screen.getMainScreen(), regionClassifier, windowMask);
                 platformWindow.setResizable(resizable);
                 platformWindow.setFocusable(focusable);
                 if (securityDialog) {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DSwapChain.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DSwapChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,12 +66,15 @@ class D3DSwapChain
         int sh = texBackBuffer.getContentHeight();
         int dw = this.getContentWidth();
         int dh = this.getContentHeight();
+        int dx = (dw - sw) / 2;
+        int dy = (dh - sh) / 2;
+
         if (isMSAA()) {
             context.flushVertexBuffer();
-            g.blit(texBackBuffer, null, 0, 0, sw, sh, 0, 0, dw, dh);
+            g.blit(texBackBuffer, null, 0, 0, sw, sh, dx, dy, dx + sw, dy + sh);
         } else {
             g.setCompositeMode(CompositeMode.SRC);
-            g.drawTexture(texBackBuffer, 0, 0, dw, dh, 0, 0, sw, sh);
+            g.drawTexture(texBackBuffer, dx, dy, dx + sw, dy + sh, 0, 0, sw, sh);
         }
         context.flushVertexBuffer();
         texBackBuffer.unlock();

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DSwapChain.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DSwapChain.java
@@ -62,6 +62,12 @@ class D3DSwapChain
         if (g == null) {
             return false;
         }
+
+        // The size of the swap chain surface may be different than the size of the back buffer.
+        // This happens for a maximized window with the UNDECORATED_INTERACTIVE stage style:
+        // In this case, the window extends slightly beyond the edges of the screen, while the
+        // back buffer only contains the pixels that are actually visible. We need to center
+        // the back buffer texture on the swap chain surface to line it up with the screen edges.
         int sw = texBackBuffer.getContentWidth();
         int sh = texBackBuffer.getContentHeight();
         int dw = this.getContentWidth();

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -2884,6 +2884,21 @@ public class Scene implements EventTarget {
         public Accessible getSceneAccessible() {
             return getAccessible();
         }
+
+        private final PickRay pickRay = new PickRay();
+
+        @Override
+        public Node pickNode(double x, double y) {
+            Node root = Scene.this.getRoot();
+            if (root != null) {
+                pickRay.set(x, y, 1, 0, Double.POSITIVE_INFINITY);
+                var pickResultChooser = new PickResultChooser();
+                root.pickNode(pickRay, pickResultChooser);
+                return pickResultChooser.getIntersectedNode();
+            }
+
+            return null;
+        }
     }
 
     private class ScenePeerPaintListener implements TKScenePaintListener {

--- a/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -530,6 +530,39 @@ public class Stage extends Window {
      */
     public final Modality getModality() {
         return modality;
+    }
+
+    private WindowRegionClassifier regionClassifier;
+
+    /**
+     * Specifies the {@code WindowRegionClassifier} for this stage.
+     * Stages that use the {@link StageStyle#UNDECORATED_INTERACTIVE} style should also provide a
+     * window region classifier that returns the {@link WindowRegion} for a given coordinate.
+     * <p>
+     * The JavaFX windowing subsystem may use this information to enable platform-specific window
+     * interactions or animations when the user interacts with each of the various window regions.
+     * For example, clicking and dragging the {@link WindowRegion#TITLE} region may move the window,
+     * while double-clicking may maximize the window or restore it from its maximized state.
+     *
+     * @param classifier the window region classifier
+     * @since 18
+     */
+    public final void initRegionClassifier(WindowRegionClassifier classifier) {
+        if (hasBeenVisible) {
+            throw new IllegalStateException("Cannot set classifier once stage has been set visible");
+        }
+
+        this.regionClassifier = classifier;
+    }
+
+    /**
+     * Retrieves the {@code WindowRegionClassifier} for this stage.
+     *
+     * @return the window region classifier
+     * @since 18
+     */
+    public final WindowRegionClassifier getRegionClassifier() {
+        return regionClassifier;
     }
 
     private Window owner = null;
@@ -1153,7 +1186,7 @@ public class Stage extends Window {
                 }
             }
             setPeer(toolkit.createTKStage(this, isSecurityDialog(),
-                    stageStyle, isPrimary(), getModality(), tkStage, rtl, acc));
+                    stageStyle, isPrimary(), getModality(), getRegionClassifier(), tkStage, rtl, acc));
             getPeer().setMinimumSize((int) Math.ceil(getMinWidth()),
                     (int) Math.ceil(getMinHeight()));
             getPeer().setMaximumSize((int) Math.floor(getMaxWidth()),

--- a/modules/javafx.graphics/src/main/java/javafx/stage/StageStyle.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/StageStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,15 @@ public enum StageStyle {
      * Defines a {@code Stage} style with a solid white background and no decorations.
      */
     UNDECORATED,
+
+    /**
+     * Defines a {@code Stage} style that is similar to {@code StageStyle.UNDECORATED}, but enables
+     * platform-specific window interactions. A stage that is initialized with this style must also
+     * provide a region classifier using {@link Stage#initRegionClassifier(WindowRegionClassifier)}.
+     *
+     * @since 18
+     */
+    UNDECORATED_INTERACTIVE,
 
     /**
      * Defines a {@code Stage} style with a transparent background and no decorations.

--- a/modules/javafx.graphics/src/main/java/javafx/stage/WindowRegion.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/WindowRegion.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package javafx.stage;
+
+/**
+ * Defines the regions of a window.
+ *
+ * @since 18
+ */
+public enum WindowRegion {
+    /**
+     * The region is not a part of the window.
+     */
+    NONE,
+
+    /**
+     * The client area, which includes everything that is not part of one of the other named regions.
+     */
+    CLIENT,
+
+    /**
+     * The title bar of the window, which may afford a click-and-drag interaction.
+     */
+    TITLE,
+
+    /**
+     * The top border of the window, which may afford a click-and-resize interaction.
+     */
+    TOP,
+
+    /**
+     * The top-right corner of the window, which may afford a click-and-resize interaction.
+     */
+    TOP_RIGHT,
+
+    /**
+     * The right border of the window, which may afford a click-and-resize interaction.
+     */
+    RIGHT,
+
+    /**
+     * The bottom-right corner of the window, which may afford a click-and-resize interaction.
+     */
+    BOTTOM_RIGHT,
+
+    /**
+     * The bottom border of the window, which may afford a click-and-resize interaction.
+     */
+    BOTTOM,
+
+    /**
+     * The bottom-left corner of the window, which may afford a click-and-resize interaction.
+     */
+    BOTTOM_LEFT,
+
+    /**
+     * The left border of the window, which may afford a click-and-resize interaction.
+     */
+    LEFT,
+
+    /**
+     * The top-left corner of the window, which may afford a click-and-resize interaction.
+     */
+    TOP_LEFT
+}

--- a/modules/javafx.graphics/src/main/java/javafx/stage/WindowRegionClassifier.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/WindowRegionClassifier.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package javafx.stage;
+
+import javafx.scene.Node;
+
+/**
+ * Classifier that is used by windows with the {@link StageStyle#UNDECORATED_INTERACTIVE} style
+ * to determine which region of a window was interacted with.
+ *
+ * @since 18
+ */
+@FunctionalInterface
+public interface WindowRegionClassifier {
+
+    /**
+     * Determines which window region corresponds to the specified coordinates.
+     *
+     * @param x x-coordinate, relative to the left window border
+     * @param y y-coordinate, relative to the top window border
+     * @param node the top-most node at the position indicated by {@code x} and {@code y},
+     *             or {@code null} if there is no node at this position
+     * @return the window region
+     */
+    WindowRegion classify(double x, double y, Node node);
+
+}

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@
 
 class GlassWindow : public BaseWnd, public ViewContainer {
 public:
-    GlassWindow(jobject jrefThis, bool isTransparent, bool isDecorated, bool isUnified, bool isChild, HWND parentOrOwner);
+    GlassWindow(jobject jrefThis, bool isTransparent, bool isDecorated, bool isUnified, bool isInteractive, bool isChild, HWND parentOrOwner);
     virtual ~GlassWindow();
 
     static GlassWindow* FromHandle(HWND hWnd) {
@@ -60,6 +60,7 @@ public:
     inline bool IsTransparent() { return m_isTransparent; }
     inline bool IsResizable() { return m_isResizable; }
     inline bool IsDecorated() { return m_isDecorated; }
+    inline bool IsInteractive() { return m_isInteractive; }
     inline virtual bool IsGlassWindow() { return true; }
 
     bool SetResizable(bool resizable);
@@ -146,6 +147,7 @@ private:
     const bool m_isTransparent;
     const bool m_isDecorated;
     const bool m_isUnified;
+    const bool m_isInteractive;
     const HWND m_parent; // != NULL for child windows only
 
     bool m_isResizable;
@@ -181,12 +183,13 @@ private:
     void HandleDestroyEvent();
     // if pRect == NULL => get position/size by GetWindowRect
     void HandleWindowPosChangingEvent(WINDOWPOS *pWinPos);
-    void HandleMoveEvent(RECT *pRect);
+    void HandleMoveEvent();
     // if pRect == NULL => get position/size by GetWindowRect
-    void HandleSizeEvent(int type, RECT *pRect);
+    void HandleSizeEvent(int type);
     void HandleDPIEvent(WPARAM wParam, LPARAM lParam);
     bool HandleCommand(WORD cmdID);
     void HandleFocusDisabledEvent();
+    LRESULT HandleNCHitTestEvent(SHORT, SHORT);
 };
 
 

--- a/modules/javafx.graphics/src/main/native-glass/win/Utils.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/Utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/native-glass/win/Utils.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/Utils.cpp
@@ -114,9 +114,6 @@ RECT utils::GetScreenSpaceClipRect(HWND hwnd)
     monitorInfo.cbSize = sizeof(MONITORINFO);
     LONG_PTR userData = ::GetWindowLongPtr(hwnd, GWLP_USERDATA);
 
-    // Due to historical reasons, a maximized window with the undecorated-interactive style
-    // will extend slightly beyond the edges of the screen's work area. The pixels that fall
-    // outside of the work area are clipped, which we need to take into account here.
     if (userData != NULL
             && ((WndUserData*)userData)->interactive
             && SUCCEEDED(::GetWindowPlacement(hwnd, &placement))

--- a/modules/javafx.graphics/src/main/native-glass/win/Utils.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/Utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,6 +84,19 @@ JNIEnv* GetEnv();
 jboolean CheckAndClearException(JNIEnv *env);
 
 jint GetModifiers();
+
+struct WndUserData {
+    bool interactive = false;
+};
+
+namespace utils {
+    RECT GetScreenSpaceClipRect(HWND);
+    RECT GetScreenSpaceWindowRect(HWND);
+    BOOL GetClipRect(HWND, LPRECT);
+    BOOL ScreenToClip(HWND, LPPOINT);
+    BOOL ClipToScreen(HWND, LPPOINT);
+    BOOL ClientToClip(HWND, LPPOINT);
+}
 
 class JString {
 public:
@@ -443,6 +456,7 @@ typedef struct _tagJavaIDs {
         jmethodID notifyFocusUngrab;
         jmethodID notifyDestroy;
         jmethodID notifyDelegatePtr;
+        jmethodID classifyWindowRegion;
     } Window;
     struct {
         jmethodID notifyResize;

--- a/modules/javafx.graphics/src/main/native-glass/win/Utils.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/Utils.h
@@ -89,6 +89,11 @@ struct WndUserData {
     bool interactive = false;
 };
 
+// A maximized window will extend slightly beyond the edges of the screen, such that
+// its borders are clipped. However, with the undecorated-interactive style, we extended
+// the client area to include the (now invisible) borders.
+// We define the part of the client area that is visible on the screen as the "clip area"
+// and use this area instead of the client area when we are dealing with a maximized window.
 namespace utils {
     RECT GetScreenSpaceClipRect(HWND);
     RECT GetScreenSpaceWindowRect(HWND);

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubToolkit.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubToolkit.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubToolkit.java
@@ -61,6 +61,7 @@ import javafx.stage.FileChooser.ExtensionFilter;
 import javafx.stage.Modality;
 import javafx.stage.StageStyle;
 import javafx.stage.Window;
+import javafx.stage.WindowRegionClassifier;
 import javafx.util.Pair;
 
 import java.io.File;
@@ -120,7 +121,7 @@ public class StubToolkit extends Toolkit {
     }
 
     @Override
-    public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl, @SuppressWarnings("removal") AccessControlContext acc) {
+    public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, WindowRegionClassifier classifier, TKStage owner, boolean rtl, @SuppressWarnings("removal") AccessControlContext acc) {
 
         return new StubStage();
     }


### PR DESCRIPTION
This PR introduces `StageStyle.UNDECORATED_INTERACTIVE`. This style is similiar to `StageStyle.UNDECORATED`, but adds platform-specific interactions to the window.

For all platforms, this includes move and resize behaviors.
On Windows, it also includes Aero behaviors (snap to screen edges, dock at top to maximize, etc.).

Additionally, on Windows this style adds window animations and a drop shadow (both of which `StageStyle.UNDECORATED` lacks).

This new style can be used to create custom window decorations without losing window interactions.

![ezgif-2-013a29cf85a4](https://user-images.githubusercontent.com/43553916/127551600-9754a5c3-8906-41a4-b4b6-d2a0e6b28b93.gif)

Applications that use this stage style need to provide an implementation of `WindowRegionClassifier` to let the JavaFX windowing subsystem know which parts of the window should afford window interactions:

```java
stage.initStyle(StageStyle.UNDECORATED_INTERACTIVE);

stage.initRegionClassifier(new WindowRegionClassifier() {
    @Override
    public WindowRegion classify(double x, double y, Node nodeAtPosition) {

        // Regions can be identified by the node under the current cursor position...
        if (nodeAtPosition == titleBar) {
            return WindowRegion.TITLE;
        }
        
        // ...or by window coordinates
        if (x < 10) {
            return WindowRegion.LEFT;
        }
        
        if (x > primaryStage.getWidth() - 10) {
            return WindowRegion.RIGHT;
        }

        return WindowRegion.CLIENT;

    }
});
```

If a window region is not returned from the classifier, no interaction will be available for this region.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Patch contains a binary file (apps/samples/3DViewer/src/test/resources/com/javafx/importers/dae/test-data-maya/duke.png)

### Issue
 * [JDK-8271557](https://bugs.openjdk.org/browse/JDK-8271557): Undecorated interactive stage style (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/594/head:pull/594` \
`$ git checkout pull/594`

Update a local copy of the PR: \
`$ git checkout pull/594` \
`$ git pull https://git.openjdk.org/jfx.git pull/594/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 594`

View PR using the GUI difftool: \
`$ git pr show -t 594`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/594.diff">https://git.openjdk.org/jfx/pull/594.diff</a>

</details>
