### PR TITLE
8242531: [macos] JavaFX OSXPlatform tries to load nonexistent libjfxmedia_qtkit

### DIFF
--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/platform/osx/OSXPlatform.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/platform/osx/OSXPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,11 +37,8 @@ import java.security.PrivilegedAction;
 import java.util.Arrays;
 
 /**
- * Mac OS X Platform implementation. This class implements both the QTKit based
- * platform and the AVFoundation based platforms.
- *
- * NOTE: The QTKit based platform is deprecated and will be removed in a future
- * release.
+ * Mac OS X Platform implementation. This class implements the AVFoundation
+ * based platform.
  */
 public final class OSXPlatform extends Platform {
     /**
@@ -77,19 +74,12 @@ public final class OSXPlatform extends Platform {
                 @SuppressWarnings("removal")
                 boolean tmp = AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
                     boolean avf = false;
-                    boolean qtk = false;
-                    // attempt to load the AVFoundation based player first
-                    // AVFoundation will have precedence
                     try {
                         NativeLibLoader.loadLibrary("jfxmedia_avf");
                         avf = true;
                     } catch (UnsatisfiedLinkError ule) {}
-                    try {
-                        NativeLibLoader.loadLibrary("jfxmedia_qtkit");
-                        qtk = true;
-                    } catch (UnsatisfiedLinkError ule) {}
 
-                    return avf || qtk;
+                    return avf;
                 });
                 isLoaded = tmp;
             } catch (Exception e) {


### PR DESCRIPTION
Removed code which loads nonexistent libjfxmedia_qtkit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242531](https://bugs.openjdk.java.net/browse/JDK-8242531): [macos] JavaFX OSXPlatform tries to load nonexistent libjfxmedia_qtkit


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/597/head:pull/597` \
`$ git checkout pull/597`

Update a local copy of the PR: \
`$ git checkout pull/597` \
`$ git pull https://git.openjdk.java.net/jfx pull/597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 597`

View PR using the GUI difftool: \
`$ git pr show -t 597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/597.diff">https://git.openjdk.java.net/jfx/pull/597.diff</a>

</details>
