### PR TITLE
8244419: TextAreaSkin: throws UnsupportedOperation on dispose

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextAreaSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextAreaSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package javafx.scene.control.skin;
 
-import com.sun.javafx.scene.control.behavior.BehaviorBase;
 import com.sun.javafx.scene.control.behavior.TextAreaBehavior;
 import com.sun.javafx.scene.control.skin.Utils;
 import javafx.animation.KeyFrame;
@@ -36,7 +35,6 @@ import javafx.beans.binding.DoubleBinding;
 import javafx.beans.binding.IntegerBinding;
 import javafx.beans.value.ObservableBooleanValue;
 import javafx.beans.value.ObservableIntegerValue;
-import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -49,8 +47,6 @@ import javafx.geometry.VerticalDirection;
 import javafx.scene.AccessibleAttribute;
 import javafx.scene.Group;
 import javafx.scene.Node;
-import javafx.scene.control.Accordion;
-import javafx.scene.control.Button;
 import javafx.scene.control.Control;
 import javafx.scene.control.IndexRange;
 import javafx.scene.control.ScrollPane;
@@ -58,7 +54,6 @@ import javafx.scene.control.TextArea;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.input.ScrollEvent;
 import javafx.scene.layout.Region;
-import javafx.scene.shape.MoveTo;
 import javafx.scene.shape.Path;
 import javafx.scene.shape.PathElement;
 import javafx.scene.text.Text;
@@ -69,7 +64,6 @@ import java.util.List;
 
 import static com.sun.javafx.PlatformUtil.isMac;
 import static com.sun.javafx.PlatformUtil.isWindows;
-
 /**
  * Default skin implementation for the {@link TextArea} control.
  *
@@ -144,6 +138,8 @@ public class TextAreaSkin extends TextInputControlSkin<TextArea> {
     private double pressX, pressY; // For dragging handles on embedded
     private boolean handlePressed;
 
+    private EventHandler<ScrollEvent> scrollEventFilter;
+
     /**
      * Remembers horizontal position when traversing up / down.
      */
@@ -201,11 +197,12 @@ public class TextAreaSkin extends TextInputControlSkin<TextArea> {
         scrollPane.setContent(contentView);
         getChildren().add(scrollPane);
 
-        getSkinnable().addEventFilter(ScrollEvent.ANY, event -> {
+        scrollEventFilter = event -> {
             if (event.isDirect() && handlePressed) {
                 event.consume();
             }
-        });
+        };
+        getSkinnable().addEventFilter(ScrollEvent.ANY, scrollEventFilter);
 
         // Add selection
         selectionHighlightGroup.setManaged(false);
@@ -255,23 +252,23 @@ public class TextAreaSkin extends TextInputControlSkin<TextArea> {
             addParagraphNode(i, paragraph.toString());
         }
 
-        control.selectionProperty().addListener((observable, oldValue, newValue) -> {
+        registerChangeListener(control.selectionProperty(), e -> {
             // TODO Why do we need two calls here?
             control.requestLayout();
             contentView.requestLayout();
         });
 
-        control.wrapTextProperty().addListener((observable, oldValue, newValue) -> {
+        registerChangeListener(control.wrapTextProperty(), e -> {
             invalidateMetrics();
-            scrollPane.setFitToWidth(newValue);
+            scrollPane.setFitToWidth(control.isWrapText());
         });
 
-        control.prefColumnCountProperty().addListener((observable, oldValue, newValue) -> {
+        registerChangeListener(control.prefColumnCountProperty(), e -> {
             invalidateMetrics();
             updatePrefViewportWidth();
         });
 
-        control.prefRowCountProperty().addListener((observable, oldValue, newValue) -> {
+        registerChangeListener(control.prefRowCountProperty(), e -> {
             invalidateMetrics();
             updatePrefViewportHeight();
         });
@@ -303,24 +300,26 @@ public class TextAreaSkin extends TextInputControlSkin<TextArea> {
             }
         });
 
-        control.scrollTopProperty().addListener((observable, oldValue, newValue) -> {
-            double vValue = (newValue.doubleValue() < getScrollTopMax())
-                               ? (newValue.doubleValue() / getScrollTopMax()) : 1.0;
+        registerChangeListener(control.scrollTopProperty(), e -> {
+            double newValue = control.getScrollTop();
+            double vValue = (newValue < getScrollTopMax())
+                               ? (newValue / getScrollTopMax()) : 1.0;
             scrollPane.setVvalue(vValue);
         });
 
-        control.scrollLeftProperty().addListener((observable, oldValue, newValue) -> {
-            double hValue = (newValue.doubleValue() < getScrollLeftMax())
-                               ? (newValue.doubleValue() / getScrollLeftMax()) : 1.0;
+        registerChangeListener(control.scrollLeftProperty(), e -> {
+            double newValue = control.getScrollLeft();
+            double hValue = (newValue < getScrollLeftMax())
+                               ? (newValue / getScrollLeftMax()) : 1.0;
             scrollPane.setHvalue(hValue);
         });
 
         if (USE_MULTIPLE_NODES) {
-            control.getParagraphs().addListener((ListChangeListener.Change<? extends CharSequence> change) -> {
+            registerListChangeListener(control.getParagraphs(), change -> {
                 while (change.next()) {
                     int from = change.getFrom();
                     int to = change.getTo();
-                    List<? extends CharSequence> removed = change.getRemoved();
+                    List<? extends CharSequence> removed = (List<? extends CharSequence>) change.getRemoved();
                     if (from < to) {
 
                         if (removed.isEmpty()) {
@@ -343,7 +342,7 @@ public class TextAreaSkin extends TextInputControlSkin<TextArea> {
                 }
             });
         } else {
-            control.textProperty().addListener(observable -> {
+            registerInvalidationListener(control.textProperty(), e -> {
                 invalidateMetrics();
                 ((Text)paragraphNodes.getChildren().get(0)).setText(control.textProperty().getValueSafe());
                 contentView.requestLayout();
@@ -364,7 +363,7 @@ public class TextAreaSkin extends TextInputControlSkin<TextArea> {
             createPromptNode();
         }
 
-        usePromptText.addListener(observable -> {
+        registerInvalidationListener(usePromptText, e -> {
             createPromptNode();
             control.requestLayout();
         });
@@ -832,14 +831,14 @@ public class TextAreaSkin extends TextInputControlSkin<TextArea> {
 
     /** {@inheritDoc} */
     @Override public void dispose() {
+        if (getSkinnable() == null) return;
+        getSkinnable().removeEventFilter(ScrollEvent.ANY, scrollEventFilter);
+        getChildren().remove(scrollPane);
         super.dispose();
 
         if (behavior != null) {
             behavior.dispose();
         }
-
-        // TODO Unregister listeners on text editor, paragraph list
-        throw new UnsupportedOperationException();
     }
 
     /** {@inheritDoc} */
@@ -1168,7 +1167,8 @@ public class TextAreaSkin extends TextInputControlSkin<TextArea> {
         return p;
     }
 
-    private Text getTextNode() {
+    // package for testing only!
+    Text getTextNode() {
         if (USE_MULTIPLE_NODES) {
             throw new IllegalArgumentException("Multiple node traversal is not yet implemented.");
         }
@@ -1185,7 +1185,20 @@ public class TextAreaSkin extends TextInputControlSkin<TextArea> {
         textNode.caretBiasProperty().set(isForwardBias());
     }
 
+    // for testing
+    void setHandlePressed(boolean pressed) {
+        handlePressed = pressed;
+    }
 
+    // for testing
+    ScrollPane getScrollPane() {
+        return scrollPane;
+    }
+
+    // for testing
+    Text getPromptNode() {
+        return promptNode;
+    }
 
     /* ************************************************************************
      *

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/TextInputSkinShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/TextInputSkinShim.java
@@ -25,6 +25,8 @@
 
 package javafx.scene.control.skin;
 
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TextInputControl;
 import javafx.scene.text.Text;
@@ -33,6 +35,8 @@ import javafx.scene.text.Text;
  * Utility methods to access package-private api in TextInput-related skins.
  */
 public class TextInputSkinShim {
+
+//------------ TextField
 
     /**
      * Returns the promptNode from the textField's skin. The skin must be of type
@@ -60,6 +64,34 @@ public class TextInputSkinShim {
         TextFieldSkin skin = (TextFieldSkin) textField.getSkin();
         return skin.getTextTranslateX();
     }
+
+//----------- TextArea
+
+    /**
+     * Returns the promptNode from the textField's skin. The skin must be of type
+     * TextFieldSkin.
+     */
+    public static Text getPromptNode(TextArea textArea) {
+        TextAreaSkin skin = (TextAreaSkin) textArea.getSkin();
+        return skin.getPromptNode();
+    }
+
+    public static Text getTextNode(TextArea textArea) {
+        TextAreaSkin skin = (TextAreaSkin) textArea.getSkin();
+        return skin.getTextNode();
+    }
+
+    public static ScrollPane getScrollPane(TextArea textArea) {
+        TextAreaSkin skin = (TextAreaSkin) textArea.getSkin();
+        return skin.getScrollPane();
+    }
+
+    public static void setHandlePressed(TextArea textArea, boolean pressed) {
+        TextAreaSkin skin = (TextAreaSkin) textArea.getSkin();
+        skin.setHandlePressed(pressed);
+    }
+
+//---------- TextInputControl
 
     /**
      * Returns a boolean indicating whether or not the control's caret is blinking.

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorCleanupTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorCleanupTest.java
@@ -48,6 +48,7 @@ import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Control;
 import javafx.scene.control.ListView;
+import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
@@ -67,6 +68,17 @@ public class BehaviorCleanupTest {
     private Stage stage;
     private Pane root;
 
+//---------- TextAera
+
+    @Test
+    public void testTextAreaFocusListener() {
+        TextArea control = new TextArea("some text");
+        showControl(control, true);
+        assertTrue("caret must be blinking if focused", isCaretBlinking(control));
+        Button button = new Button("dummy");
+        showControl(button, true);
+        assertFalse("caret must not be blinking if not focused", isCaretBlinking(control));
+    }
 
 //---------- TextField
 

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorMemoryLeakTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorMemoryLeakTest.java
@@ -43,7 +43,6 @@ import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactor
 import javafx.scene.control.Control;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.TableView;
-import javafx.scene.control.TextArea;
 import javafx.scene.control.TreeTableView;
 
 /**
@@ -82,7 +81,6 @@ public class BehaviorMemoryLeakTest {
         List<Class<? extends Control>> leakingClasses = List.of(
                 PasswordField.class,
                 TableView.class,
-                TextArea.class,
                 TreeTableView.class
          );
         // remove the known issues to make the test pass

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinDisposeContractTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinDisposeContractTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,6 @@ import static javafx.scene.control.ControlShim.*;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory.*;
 
 import javafx.scene.control.Control;
-import javafx.scene.control.TextArea;
 
 /**
  * Test for https://bugs.openjdk.java.net/browse/JDK-8244112:
@@ -76,8 +75,6 @@ public class SkinDisposeContractTest {
     @Parameterized.Parameters //(name = "{index}: {0} ")
     public static Collection<Object[]> data() {
         List<Class<Control>> controlClasses = getControlClasses();
-        // @Ignore("8244419")
-        controlClasses.remove(TextArea.class);
         return asArrays(controlClasses);
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinMemoryLeakTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinMemoryLeakTest.java
@@ -54,11 +54,8 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.control.Spinner;
 import javafx.scene.control.SplitMenuButton;
 import javafx.scene.control.SplitPane;
-import javafx.scene.control.TabPane;
 import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
-import javafx.scene.control.TextArea;
-import javafx.scene.control.TextField;
 import javafx.scene.control.TreeTableRow;
 import javafx.scene.control.TreeTableView;
 
@@ -115,8 +112,6 @@ public class SkinMemoryLeakTest {
                 SplitPane.class,
                 TableRow.class,
                 TableView.class,
-                // @Ignore("8244419")
-                TextArea.class,
                 TreeTableRow.class,
                 TreeTableView.class
         );


### PR DESCRIPTION
The issue was a glaring contract violation of TextAreaSkin which throws a UnsupportedOperationException. The fix was to remove the throwing and cleanup on dispose which implies

in TextAreaBehavior:
- remove the listener to focusProperty in dispose

in TextAreaSkin:
- register all listeners to control properties via skin api
- remove installed event filter in dispose
- remove direct children (here only the scrollPane)

Added tests to guard the listener re-wiring (must pass before and after), and tests to expose side-effects on replacing the skin (fail before, pass after)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244419](https://bugs.openjdk.java.net/browse/JDK-8244419): TextAreaSkin: throws UnsupportedOperation on dispose


### Reviewers
 * [Marius Hanl](https://openjdk.java.net/census#mhanl) (@Maran23 - Author)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/604/head:pull/604` \
`$ git checkout pull/604`

Update a local copy of the PR: \
`$ git checkout pull/604` \
`$ git pull https://git.openjdk.java.net/jfx pull/604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 604`

View PR using the GUI difftool: \
`$ git pr show -t 604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/604.diff">https://git.openjdk.java.net/jfx/pull/604.diff</a>

</details>
