### PR TITLE
8169098: [TestBug] Manual test case for JDK-8089915

### DIFF
--- a/tests/manual/web/InputTypeAcceptAttributeTest.java
+++ b/tests/manual/web/InputTypeAcceptAttributeTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.geometry.Insets;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
+import javafx.stage.Stage;
+import javafx.scene.layout.VBox;
+import javafx.scene.layout.HBox;
+
+import java.io.File;
+
+
+public class InputTypeAcceptAttributeTest extends Application {
+
+    private String fileNames[] = {"TEXT.txt", "PNG.png", "PDF.pdf", "JPG.jpg"};
+    private File file = null;
+
+    @Override
+    public void start(Stage primaryStage) throws Exception {
+        for (int i = 0; i < fileNames.length; ++i) {
+            file = new File(fileNames[i]);
+            file.createNewFile();
+        }
+
+        String currentDirPath = file.getCanonicalPath();
+        currentDirPath = currentDirPath.substring(0, currentDirPath.lastIndexOf(file.separator));
+        VBox instructions =  new VBox(
+            new Label(" This test creates four files (TEXT.txt, PNG.png, PDF.pdf, JPG.jpg) at below mentioned path:"),
+            new Label("  " + currentDirPath),
+            new Label(" There are five different scenarios, follow below steps for each scenario."),
+            new Label(""),
+            new Label(" STEPS:"),
+            new Label("  1. Click Choose File, it will display file chooser dialog."),
+            new Label("  2. Navigate to above mentioned path."),
+            new Label(" Expected behaviour: File Chooser dialog should show only the files of specified type."),
+            new Label(" On Mac, the behaviour is little different than windows/linux. " +
+                        "It shows all files, but user can select files of specified type only."));
+
+        Button passButton = new Button("Pass");
+        Button failButton = new Button("Fail");
+        passButton.setOnAction(e -> {
+                cleanup();
+		Platform.exit();
+	});
+        failButton.setOnAction(e -> {
+            cleanup();
+            Platform.exit();
+            throw new AssertionError("Displayed wrong type file.");
+        });
+
+        WebView webView = new WebView();
+        WebEngine webEngine = webView.getEngine();
+        webEngine.loadContent("<html>\n" +
+                " <body>\n" +
+                " 1. <input type = file /> should show all files. If not press Fail. <br/>" +
+                " 2. <input type = file accept = image/* /> should show only (PNG.png, JPG.jpg) files. If not press Fail. <br/>" +
+                " 3. <input type = file accept = text/* /> should show only TEXT.txt file. If not press Fail. <br/>" +
+                " 4. <input type = file accept = image/png /> should show only PNG.png file. If not press Fail. <br/>" +
+                " 5. <input type = file accept = image/jpg /> should show only JPG.jpg file. If not press Fail. <br/>" +
+                " </body>\n" +
+                "</html>");
+
+    HBox buttons = new HBox(20, passButton, failButton);
+    buttons.setPadding(new Insets(10));
+    VBox rootNode = new VBox(20, new HBox(instructions), webView, buttons);
+    rootNode.setPadding(new Insets(10));
+        Scene scene = new Scene(rootNode, 1000, 450);
+        primaryStage.setScene(scene);
+        primaryStage.show();
+    }
+
+    private void cleanup() {
+	file = null;
+	for (int i = 0; i < fileNames.length; ++i) {
+            file = new File(fileNames[i]);
+	    file.delete();
+	}
+
+    }
+
+    public static void main(String[] args) {
+        launch(args);
+    }
+}

--- a/tests/manual/web/InputTypeAcceptAttributeTest.java
+++ b/tests/manual/web/InputTypeAcceptAttributeTest.java
@@ -38,7 +38,6 @@ import javafx.scene.layout.HBox;
 
 import java.io.File;
 
-
 public class InputTypeAcceptAttributeTest extends Application {
 
     private String fileNames[] = {"TEXT.txt", "PNG.png", "PDF.pdf", "JPG.jpg"};
@@ -66,11 +65,12 @@ public class InputTypeAcceptAttributeTest extends Application {
                         "It shows all files, but user can select files of specified type only."));
 
         Button passButton = new Button("Pass");
-        Button failButton = new Button("Fail");
         passButton.setOnAction(e -> {
-                cleanup();
-		Platform.exit();
-	});
+            cleanup();
+            Platform.exit();
+        });
+
+        Button failButton = new Button("Fail");
         failButton.setOnAction(e -> {
             cleanup();
             Platform.exit();
@@ -89,22 +89,21 @@ public class InputTypeAcceptAttributeTest extends Application {
                 " </body>\n" +
                 "</html>");
 
-    HBox buttons = new HBox(20, passButton, failButton);
-    buttons.setPadding(new Insets(10));
-    VBox rootNode = new VBox(20, new HBox(instructions), webView, buttons);
-    rootNode.setPadding(new Insets(10));
+        HBox buttons = new HBox(20, passButton, failButton);
+        buttons.setPadding(new Insets(10));
+        VBox rootNode = new VBox(20, new HBox(instructions), webView, buttons);
+        rootNode.setPadding(new Insets(10));
         Scene scene = new Scene(rootNode, 1000, 450);
         primaryStage.setScene(scene);
         primaryStage.show();
     }
 
     private void cleanup() {
-	file = null;
-	for (int i = 0; i < fileNames.length; ++i) {
+        file = null;
+        for (int i = 0; i < fileNames.length; ++i) {
             file = new File(fileNames[i]);
-	    file.delete();
-	}
-
+            file.delete();
+        }
     }
 
     public static void main(String[] args) {

--- a/tests/manual/web/InputTypeAcceptAttributeTest.java
+++ b/tests/manual/web/InputTypeAcceptAttributeTest.java
@@ -23,18 +23,17 @@
  * questions.
  */
 
-
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.geometry.Insets;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
+import javafx.scene.layout.VBox;
+import javafx.scene.layout.HBox;
 import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
-import javafx.scene.layout.VBox;
-import javafx.scene.layout.HBox;
 
 import java.io.File;
 

--- a/tests/manual/web/InputTypeAcceptAttributeTest.java
+++ b/tests/manual/web/InputTypeAcceptAttributeTest.java
@@ -26,11 +26,11 @@
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.geometry.Insets;
-import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.layout.VBox;
 import javafx.scene.layout.HBox;
+import javafx.scene.Scene;
 import javafx.scene.web.WebEngine;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;


### PR DESCRIPTION
Adding a new manual test case for accept attribute of input tag.
This test is to verify the fix for [JDK-8089915](https://bugs.openjdk.java.net/browse/JDK-8089915) .
We have tested the test cases on all three platforms and its working as expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8169098](https://bugs.openjdk.java.net/browse/JDK-8169098): [TestBug] Manual test case for JDK-8089915


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/607/head:pull/607` \
`$ git checkout pull/607`

Update a local copy of the PR: \
`$ git checkout pull/607` \
`$ git pull https://git.openjdk.java.net/jfx pull/607/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 607`

View PR using the GUI difftool: \
`$ git pr show -t 607`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/607.diff">https://git.openjdk.java.net/jfx/pull/607.diff</a>

</details>
