### PR TITLE
8267472: JavaFX modules to include version information

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3903,6 +3903,7 @@ allprojects {
         project.compileJava {
             options.compilerArgs.addAll([
                 '-implicit:none',
+                '--module-version', "$RELEASE_VERSION_SHORT",
                 '--module-source-path', project.moduleSourcePath
                 ])
         }
@@ -3925,6 +3926,7 @@ allprojects {
         project.compileShimsJava {
             options.compilerArgs.addAll([
                 '-implicit:none',
+                '--module-version', "$RELEASE_VERSION_SHORT",
                 '--module-source-path', project.moduleSourcePathShim
                 ])
         }

--- a/build.gradle
+++ b/build.gradle
@@ -5281,6 +5281,7 @@ compileTargets { t ->
                         args("create")
                         args("--class-path")
                         args(srcClassesDir)
+                        args("--module-version", "$RELEASE_VERSION_SHORT")
                         // Not all modules have a "lib" dir
                         if (file(srcLibDir).isDirectory()) {
                             args("--libs")

--- a/build.gradle
+++ b/build.gradle
@@ -2205,6 +2205,7 @@ project(":graphics") {
         options.compilerArgs.addAll([
             '-h', "$buildDir/gensrc/headers/",  // Note: this creates the native headers
             '-implicit:none',
+            '--module-version', "$RELEASE_VERSION_SHORT",
             '--module-source-path', defaultModuleSourcePath
             ] )
     }
@@ -3600,6 +3601,7 @@ project(":web") {
             source = project.sourceSets.main.java.srcDirs
             options.compilerArgs.addAll([
                 '-implicit:none',
+                '--module-version', "$RELEASE_VERSION_SHORT",
                 '--module-source-path', defaultModuleSourcePath
                 ])
         }


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8267472

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8267472](https://bugs.openjdk.java.net/browse/JDK-8267472): JavaFX modules to include version information


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/608/head:pull/608` \
`$ git checkout pull/608`

Update a local copy of the PR: \
`$ git checkout pull/608` \
`$ git pull https://git.openjdk.java.net/jfx pull/608/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 608`

View PR using the GUI difftool: \
`$ git pr show -t 608`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/608.diff">https://git.openjdk.java.net/jfx/pull/608.diff</a>

</details>
