### PR TITLE
8272779: Package docs for javafx.embed.swing are misleading

### DIFF
--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/package.html
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/package.html
@@ -2,7 +2,7 @@
 
 <!--
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@
 </head>
 
 <body>
-<p>Provides the set of classes to use JavaFX inside Swing applications.</p>
 <p>Defines APIs for the JavaFX / Swing interop support included with the
    JavaFX UI toolkit, including {@link javafx.embed.swing.SwingNode} (for
    embedding Swing inside a JavaFX application) and
@@ -48,12 +47,12 @@
    to the attached JavaFX scene.
    The {@link javafx.embed.swing.SwingNode} class is used to embed
    a Swing content into a JavaFX application.
-   The content to be displayed is specified with the SwingNode.setContent method
-   that accepts an instance of Swing {@code JComponent}. The hierarchy of components
+   The content to be displayed is specified with the {@code SwingNode.setContent} method
+   that accepts an instance of a Swing {@code JComponent}. The hierarchy of components
    contained in the {@code JComponent} instance should not contain any heavyweight
    components, otherwise {@code SwingNode} may fail to paint it. The content gets
    repainted automatically. All the input and focus events are forwarded to the
-   {@code JComponent} instance transparently to the developer.</p>
+   {@code JComponent} instance.</p>
 
 </body>
 

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/package.html
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/package.html
@@ -37,11 +37,24 @@
 
 <body>
 <p>Provides the set of classes to use JavaFX inside Swing applications.</p>
-<p>The {@link javafx.embed.swing.JFXPanel JFXPanel} class is the base class
-that provides JavaFX and Swing interoperability. This class defines a
+<p>Defines APIs for the JavaFX / Swing interop support included with the
+   JavaFX UI toolkit, including {@link javafx.embed.swing.SwingNode} (for
+   embedding Swing inside a JavaFX application) and
+   {@link javafx.embed.swing.JFXPanel} (for embedding JavaFX inside a Swing
+   application). </p>
+<p>The {@link javafx.embed.swing.JFXPanel JFXPanel} class defines a
 lightweight Swing component, which accepts and renders an instance of
 {@link javafx.scene.Scene Scene} and forwards all input events from Swing
-to the attached JavaFX scene.</p>
+to the attached JavaFX scene.
+The {@link javafx.embed.swing.SwingNode} class is used to embed
+   a Swing content into a JavaFX application.
+ * The content to be displayed is specified with the {@link #setContent} method
+ * that accepts an instance of Swing {@code JComponent}. The hierarchy of components
+ * contained in the {@code JComponent} instance should not contain any heavyweight
+ * components, otherwise {@code SwingNode} may fail to paint it. The content gets
+ * repainted automatically. All the input and focus events are forwarded to the
+ * {@code JComponent} instance transparently to the developer.</p>
+
 </body>
 
 </html>

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/package.html
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/package.html
@@ -48,7 +48,7 @@
    to the attached JavaFX scene.
    The {@link javafx.embed.swing.SwingNode} class is used to embed
    a Swing content into a JavaFX application.
-   The content to be displayed is specified with the {@link #setContent} method
+   The content to be displayed is specified with the SwingNode.setContent method
    that accepts an instance of Swing {@code JComponent}. The hierarchy of components
    contained in the {@code JComponent} instance should not contain any heavyweight
    components, otherwise {@code SwingNode} may fail to paint it. The content gets

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/package.html
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/package.html
@@ -43,17 +43,17 @@
    {@link javafx.embed.swing.JFXPanel} (for embedding JavaFX inside a Swing
    application). </p>
 <p>The {@link javafx.embed.swing.JFXPanel JFXPanel} class defines a
-lightweight Swing component, which accepts and renders an instance of
-{@link javafx.scene.Scene Scene} and forwards all input events from Swing
-to the attached JavaFX scene.
-The {@link javafx.embed.swing.SwingNode} class is used to embed
+   lightweight Swing component, which accepts and renders an instance of
+   {@link javafx.scene.Scene Scene} and forwards all input events from Swing
+   to the attached JavaFX scene.
+   The {@link javafx.embed.swing.SwingNode} class is used to embed
    a Swing content into a JavaFX application.
- * The content to be displayed is specified with the {@link #setContent} method
- * that accepts an instance of Swing {@code JComponent}. The hierarchy of components
- * contained in the {@code JComponent} instance should not contain any heavyweight
- * components, otherwise {@code SwingNode} may fail to paint it. The content gets
- * repainted automatically. All the input and focus events are forwarded to the
- * {@code JComponent} instance transparently to the developer.</p>
+   The content to be displayed is specified with the {@link #setContent} method
+   that accepts an instance of Swing {@code JComponent}. The hierarchy of components
+   contained in the {@code JComponent} instance should not contain any heavyweight
+   components, otherwise {@code SwingNode} may fail to paint it. The content gets
+   repainted automatically. All the input and focus events are forwarded to the
+   {@code JComponent} instance transparently to the developer.</p>
 
 </body>
 


### PR DESCRIPTION
The API docs for the javafx.embed.swing package are misleading in that they only talk about the JFXPanel capability (embedding a JavaFX Scene in a Swing JComponent) and ignore the SwingNode functionality entirely. 
Fix the package doc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272779](https://bugs.openjdk.java.net/browse/JDK-8272779): Package docs for javafx.embed.swing are misleading


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/609/head:pull/609` \
`$ git checkout pull/609`

Update a local copy of the PR: \
`$ git checkout pull/609` \
`$ git pull https://git.openjdk.java.net/jfx pull/609/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 609`

View PR using the GUI difftool: \
`$ git pr show -t 609`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/609.diff">https://git.openjdk.java.net/jfx/pull/609.diff</a>

</details>
