### PR TITLE
8269871: CellEditEvent: must not throw NPE in accessors

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableColumn.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableColumn.java
@@ -290,8 +290,8 @@ public class TableColumn<S,T> extends TableColumnBase<S,T> implements EventTarge
      **************************************************************************/
 
     private EventHandler<CellEditEvent<S,T>> DEFAULT_EDIT_COMMIT_HANDLER = t -> {
-        int index = t.getTablePosition().getRow();
-        List<S> list = t.getTableView().getItems();
+        int index = t.getTablePosition() != null ? t.getTablePosition().getRow() : -1;
+        List<S> list = t.getTableView() != null ? t.getTableView().getItems() : null;
         if (list == null || index < 0 || index >= list.size()) return;
         S rowData = list.get(index);
         ObservableValue<T> ov = getCellObservableValue(rowData);
@@ -795,7 +795,7 @@ public class TableColumn<S,T> extends TableColumnBase<S,T> implements EventTarge
          * @return The TableView control upon which this event occurred.
          */
         public TableView<S> getTableView() {
-            return pos.getTableView();
+            return pos != null ? pos.getTableView() : null;
         }
 
         /**
@@ -804,7 +804,7 @@ public class TableColumn<S,T> extends TableColumnBase<S,T> implements EventTarge
          * @return The TableColumn that the edit occurred in.
          */
         public TableColumn<S,T> getTableColumn() {
-            return pos.getTableColumn();
+            return pos != null ? pos.getTableColumn() : null;
         }
 
         /**
@@ -853,10 +853,10 @@ public class TableColumn<S,T> extends TableColumnBase<S,T> implements EventTarge
          * @return the value for the row
          */
         public S getRowValue() {
-            List<S> items = getTableView().getItems();
+            List<S> items = getTableView() != null ? getTableView().getItems() : null;
             if (items == null) return null;
 
-            int row = pos.getRow();
+            int row = pos != null ? pos.getRow() : -1;
             if (row < 0 || row >= items.size()) return null;
 
             return items.get(row);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableColumn.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableColumn.java
@@ -285,7 +285,9 @@ public class TreeTableColumn<S,T> extends TableColumnBase<TreeItem<S>,T> impleme
 
     private EventHandler<TreeTableColumn.CellEditEvent<S,T>> DEFAULT_EDIT_COMMIT_HANDLER =
             t -> {
-                ObservableValue<T> ov = getCellObservableValue(t.getRowValue());
+                TreeItem<S> rowValue = t.getRowValue();
+                if (rowValue == null) return;
+                ObservableValue<T> ov = getCellObservableValue(rowValue);
                 if (ov instanceof WritableValue) {
                     ((WritableValue)ov).setValue(t.getNewValue());
                 }
@@ -772,7 +774,7 @@ public class TreeTableColumn<S,T> extends TableColumnBase<TreeItem<S>,T> impleme
          * @return The TableView control upon which this event occurred.
          */
         public TreeTableView<S> getTreeTableView() {
-            return pos.getTreeTableView();
+            return pos != null ? pos.getTreeTableView() : null;
         }
 
         /**
@@ -781,7 +783,7 @@ public class TreeTableColumn<S,T> extends TableColumnBase<TreeItem<S>,T> impleme
          * @return The TreeTableColumn that the edit occurred in.
          */
         public TreeTableColumn<S,T> getTableColumn() {
-            return pos.getTableColumn();
+            return pos != null ? pos.getTableColumn() : null;
         }
 
         /**
@@ -830,12 +832,10 @@ public class TreeTableColumn<S,T> extends TableColumnBase<TreeItem<S>,T> impleme
          * @return the row value
          */
         public TreeItem<S> getRowValue() {
-//            List<S> items = getTreeTableView().getItems();
-//            if (items == null) return null;
-
             TreeTableView<S> treeTable = getTreeTableView();
-            int row = pos.getRow();
-            if (row < 0 || row >= treeTable.getExpandedItemCount()) return null;
+            int row = pos != null ? pos.getRow() : -1;
+            int expandedItemCount = treeTable != null ? treeTable.getExpandedItemCount() : 0;
+            if (row < 0 || row >= expandedItemCount) return null;
 
             return treeTable.getTreeItem(row);
         }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellEditEventOfTableColumnTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellEditEventOfTableColumnTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.control;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static javafx.scene.control.TableColumn.*;
+import static org.junit.Assert.*;
+
+import javafx.beans.property.SimpleStringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.event.Event;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableColumn.CellEditEvent;
+import javafx.scene.control.TablePosition;
+import javafx.scene.control.TableView;
+
+/**
+ * Test cell edit event for TableColumn: must not throw NPE in accessors (JDK-8269871).
+ */
+public class CellEditEventOfTableColumnTest {
+
+    private TableView<String> table;
+    private TableColumn<String, String> editingColumn;
+
+//---------------- default commit handler
+
+    @Test
+    public void testDefaultOnCommitHandlerTablePositionWithNullTable() {
+        String edited = "edited";
+        TablePosition<String, String> pos = new TablePosition<>(null, 1, editingColumn);
+        CellEditEvent<String, String> event = new CellEditEvent<>(table, pos, editCommitEvent(), edited);
+        Event.fireEvent(editingColumn, event);
+    }
+
+    @Test
+    public void testDefaultOnCommitHandlerNullTablePosition() {
+        String edited = "edited";
+        CellEditEvent<String, String> event = new CellEditEvent<>(table, null, editCommitEvent(), edited);
+        Event.fireEvent(editingColumn, event);
+    }
+
+//---------------- accessors in CellEditEvent
+
+    @Test
+    public void testNullTablePositionGetTableView() {
+        CellEditEvent<String, String> ev = new CellEditEvent<>(table, null, editAnyEvent(), null);
+        assertNull("table must be null for null pos", ev.getTableView());
+    }
+
+    @Test
+    public void testNullTablePositionGetTableColumn() {
+        CellEditEvent<String, String> ev = new CellEditEvent<>(table, null, editAnyEvent(), null);
+        assertNull("column must be null for null pos", ev.getTableColumn());
+    }
+
+    @Test
+    public void testNullTablePositionGetOldValue() {
+        CellEditEvent<String, String> ev = new CellEditEvent<>(table, null, editAnyEvent(), null);
+        assertNull("oldValue must be null for null pos", ev.getOldValue());
+    }
+
+    @Test
+    public void testNullTablePositionGetRowValue() {
+        CellEditEvent<String, String> ev = new CellEditEvent<>(table, null, editAnyEvent(), null);
+        assertNull("rowValue must be null for null pos", ev.getRowValue());
+    }
+
+    @Test
+    public void testNullTablePositionGetNewValue() {
+        String editedValue = "edited";
+        CellEditEvent<String, String> ev = new CellEditEvent<>(table, null, editAnyEvent(), editedValue);
+        assertEquals("editedValue must be available for null pos", editedValue, ev.getNewValue());
+    }
+
+    @Test
+    public void testTablePositionWithNullTable() {
+        String editedValue = "edited";
+        TablePosition<String, String> pos = new TablePosition<>(null, 1, editingColumn);
+        CellEditEvent<String, String> ev = new CellEditEvent<>(table, pos, editAnyEvent(), editedValue);
+        assertNull("rowValue must be null for null pos", ev.getRowValue());
+    }
+
+//---------- event source
+
+    @Ignore("JDK-8271474")
+    @Test
+    public void testNullTable() {
+        new CellEditEvent<Object, Object>(null, // null table must not throw NPE
+                new TablePosition<>(null, -1, null), editAnyEvent(), null);
+    }
+
+    @Test
+    public void testCellEditEventDifferentSource() {
+        assertCellEditEvent(new TableView<>());
+    }
+
+    @Test
+    public void testCellEditEventSameSource() {
+        assertCellEditEvent(table);
+    }
+
+    @Ignore("JDK-8271474")
+    @Test
+    public void testCellEditEventNullSource() {
+        assertCellEditEvent(null);
+    }
+
+    /**
+     * Creates a CellEditEvent with the given source and TablePosition
+     * having default values and asserts its state.
+     */
+    private void assertCellEditEvent(TableView<String> source) {
+        int editingRow = 1;
+        String editedValue = "edited";
+        String rowValue = table.getItems().get(editingRow);
+        String oldValue = editingColumn.getCellData(editingRow);
+        TablePosition<String, String> pos = new TablePosition<>(table, editingRow, editingColumn);
+        CellEditEvent<String, String> event = new CellEditEvent<>(source, pos, editAnyEvent(), editedValue);
+        if (source != null) {
+            assertEquals(source, event.getSource());
+        }
+        assertCellEditEventState(event, table, editingColumn, pos, editedValue, oldValue, rowValue);
+    }
+
+    /**
+     * Asserts state of the CellEditEvent.
+     */
+    private <S, T> void assertCellEditEventState(CellEditEvent<S, T> event,
+            TableView<S> table, TableColumn<S, T> tableColumn, TablePosition<S, T> pos,
+            T newValue, T oldValue, S rowValue) {
+        assertEquals(newValue, event.getNewValue());
+        assertEquals(oldValue, event.getOldValue());
+        assertEquals(rowValue, event.getRowValue());
+        assertEquals(tableColumn, event.getTableColumn());
+        assertEquals(pos, event.getTablePosition());
+        assertEquals(table, event.getTableView());
+    }
+
+//------------ init
+
+    @Before public void setup() {
+        Thread.currentThread().setUncaughtExceptionHandler((thread, throwable) -> {
+            if (throwable instanceof RuntimeException) {
+                throw (RuntimeException)throwable;
+            } else {
+                Thread.currentThread().getThreadGroup().uncaughtException(thread, throwable);
+            }
+        });
+
+        ObservableList<String> model = FXCollections.observableArrayList("Four", "Five", "Fear");
+            // "Flop", "Food", "Fizz"
+        table = new TableView<String>(model);
+        editingColumn = new TableColumn<>("TEST");
+        editingColumn.setCellValueFactory(e -> new SimpleStringProperty(e.getValue()));
+        table.getColumns().addAll(editingColumn);
+    }
+
+    @After
+    public void cleanup() {
+        Thread.currentThread().setUncaughtExceptionHandler(null);
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellEditEventOfTableColumnTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellEditEventOfTableColumnTest.java
@@ -176,7 +176,6 @@ public class CellEditEventOfTableColumnTest {
         });
 
         ObservableList<String> model = FXCollections.observableArrayList("Four", "Five", "Fear");
-            // "Flop", "Food", "Fizz"
         table = new TableView<String>(model);
         editingColumn = new TableColumn<>("TEST");
         editingColumn.setCellValueFactory(e -> new SimpleStringProperty(e.getValue()));

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellEditEventOfTreeTableColumnTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellEditEventOfTreeTableColumnTest.java
@@ -183,7 +183,6 @@ public class CellEditEventOfTreeTableColumnTest {
         TreeItem<String> root = new TreeItem<>("root");
         root.setExpanded(true);
         ObservableList<String> model = FXCollections.observableArrayList("Four", "Five", "Fear");
-            // "Flop", "Food", "Fizz"
         root.getChildren().addAll(model.stream().map(TreeItem::new).collect(Collectors.toList()));
         table = new TreeTableView<String>(root);
         editingColumn = new TreeTableColumn<>("TEST");

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellEditEventOfTreeTableColumnTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellEditEventOfTreeTableColumnTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.control;
+
+import java.util.stream.Collectors;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static javafx.scene.control.TreeTableColumn.editCommitEvent;
+import static javafx.scene.control.TreeTableColumn.*;
+import static org.junit.Assert.*;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.event.Event;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeTableColumn;
+import javafx.scene.control.TreeTableColumn.CellEditEvent;
+import javafx.scene.control.TreeTablePosition;
+import javafx.scene.control.TreeTableView;
+
+/**
+ * Test cell edit event for TableColumn: must not throw NPE in accessors (JDK-8269871).
+ */
+public class CellEditEventOfTreeTableColumnTest {
+
+    private TreeTableView<String> table;
+    private TreeTableColumn<String, String> editingColumn;
+
+//------------ default commit handler
+
+    @Test
+    public void testDefaultOnCommitHandlerTablePositionWithNullTable() {
+        String edited = "edited";
+        TreeTablePosition<String, String> pos = new TreeTablePosition<>(null, 1, editingColumn);
+        CellEditEvent<String, String> event = new CellEditEvent<>(table, pos, editCommitEvent(), edited);
+        Event.fireEvent(editingColumn, event);
+    }
+
+    @Test
+    public void testDefaultOnCommitHandlerNullTablePosition() {
+        String edited = "edited";
+        CellEditEvent<String, String> event = new CellEditEvent<>(table, null, editCommitEvent(), edited);
+        Event.fireEvent(editingColumn, event);
+    }
+
+  //---------------- accessors in CellEditEvent
+
+    @Test
+    public void testNullTablePositionGetTableView() {
+        CellEditEvent<String, String> ev = new CellEditEvent<>(table, null, editAnyEvent(), null);
+        assertNull("treeTable must be null if pos is null", ev.getTreeTableView());
+    }
+
+    @Test
+    public void testNullTablePositionGetTableColumn() {
+        CellEditEvent<String, String> ev = new CellEditEvent<>(table, null, editAnyEvent(), null);
+        assertNull("column must be null for null pos", ev.getTableColumn());
+    }
+
+    @Test
+    public void testNullTablePositionGetOldValue() {
+        CellEditEvent<String, String> ev = new CellEditEvent<>(table, null, editAnyEvent(), null);
+        assertNull("oldValue must be null for null pos", ev.getOldValue());
+    }
+
+    @Test
+    public void testNullTablePositionGetRowValue() {
+        CellEditEvent<String, String> ev = new CellEditEvent<>(table, null, editAnyEvent(), null);
+        assertNull("rowValue must be null for null pos", ev.getRowValue());
+    }
+
+    @Test
+    public void testNullTablePositionGetNewValue() {
+        String editedValue = "edited";
+        CellEditEvent<String, String> ev = new CellEditEvent<>(table, null, editAnyEvent(), editedValue);
+        assertEquals("editedValue must be available for null pos", editedValue, ev.getNewValue());
+    }
+
+    @Test
+    public void testTablePositionWithNullTable() {
+        String editedValue = "edited";
+        TreeTablePosition<String, String> pos = new TreeTablePosition<>(null, 1, editingColumn);
+        CellEditEvent<String, String> ev = new CellEditEvent<>(table, pos, editAnyEvent(), editedValue);
+        assertNull("rowValue must be null for null pos", ev.getRowValue());
+    }
+
+// ------------- event source
+
+    @Ignore("JDK-8271474")
+    @Test
+    public void testNullTable() {
+        new CellEditEvent<Object, Object>(null, // null table must not throw NPE
+                new TreeTablePosition<>(null, -1, null), editAnyEvent(), null);
+    }
+
+    @Test
+    public void testCellEditEventDifferentSource() {
+        assertCellEditEvent(new TreeTableView<>());
+    }
+
+    @Test
+    public void testCellEditEventSameSource() {
+        assertCellEditEvent(table);
+    }
+
+    @Ignore("JDK-8271474")
+    @Test
+    public void testCellEditEventNullSource() {
+        assertCellEditEvent(null);
+    }
+
+    /**
+     * Creates a CellEditEvent with the given source, not-null position and asserts
+     * all properties of the event.
+     *
+     * @param source the source of the event
+     */
+    private void assertCellEditEvent(TreeTableView<String> source) {
+        int editingRow = 1;
+        String editedValue = "edited";
+        TreeItem<String> rowValue = table.getTreeItem(editingRow);
+        String oldValue = rowValue.getValue();
+        TreeTablePosition<String, String> pos = new TreeTablePosition<>(table, editingRow, editingColumn);
+        CellEditEvent<String,String> ev = new CellEditEvent<String, String>(source, pos, editAnyEvent(), editedValue);
+        if (source != null) {
+            assertEquals(source, ev.getSource());
+        }
+        assertCellEditEventState(ev, table, editingColumn, pos, editedValue, oldValue, rowValue);
+    }
+
+    /**
+     * Asserts all properties of the event against the given expected values.
+     */
+    private <S, T> void assertCellEditEventState(CellEditEvent<S, T> event,
+            TreeTableView<S> table, TreeTableColumn<S, T> tableColumn, TreeTablePosition<S, T> pos,
+            T newValue, T oldValue, TreeItem<S> rowValue) {
+        assertEquals(newValue, event.getNewValue());
+        assertEquals(oldValue, event.getOldValue());
+        assertEquals(rowValue, event.getRowValue());
+        assertEquals(tableColumn, event.getTableColumn());
+        assertEquals(pos, event.getTreeTablePosition());
+        assertEquals(table, event.getTreeTableView());
+    }
+
+//------------ init
+
+    @Before public void setup() {
+        Thread.currentThread().setUncaughtExceptionHandler((thread, throwable) -> {
+            if (throwable instanceof RuntimeException) {
+                throw (RuntimeException)throwable;
+            } else {
+                Thread.currentThread().getThreadGroup().uncaughtException(thread, throwable);
+            }
+        });
+
+        TreeItem<String> root = new TreeItem<>("root");
+        root.setExpanded(true);
+        ObservableList<String> model = FXCollections.observableArrayList("Four", "Five", "Fear");
+            // "Flop", "Food", "Fizz"
+        root.getChildren().addAll(model.stream().map(TreeItem::new).collect(Collectors.toList()));
+        table = new TreeTableView<String>(root);
+        editingColumn = new TreeTableColumn<>("TEST");
+        table.getColumns().addAll(editingColumn);
+        editingColumn.setCellValueFactory(e -> e.getValue().valueProperty());
+    }
+
+    @After
+    public void cleanup() {
+        Thread.currentThread().setUncaughtExceptionHandler(null);
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableColumnTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableColumnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1054,11 +1054,10 @@ public class TableColumnTest {
                 null, pos, (EventType) eventType, "Richard Bair"));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void defaultOnEditCommitHandlerDealsWithNullTablePosition() {
         table.getColumns().add(column);
         column.setCellValueFactory(param -> param.getValue().firstNameProperty());
-        TablePosition<Person,String> pos = new TablePosition<Person, String>(table, 0, column);
         EventType<TableColumn.CellEditEvent<Person,String>> eventType = TableColumn.editCommitEvent();
         column.getOnEditCommit().handle(new TableColumn.CellEditEvent<Person, String>(
                 table, null, (EventType) eventType, "Richard Bair"));

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableColumnTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableColumnTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1080,11 +1080,10 @@ public class TreeTableColumnTest {
                 null, pos, (EventType) eventType, "Richard Bair"));
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void defaultOnEditCommitHandlerDealsWithNullTablePosition() {
         table.getColumns().add(column);
         column.setCellValueFactory(param -> param.getValue().getValue().firstNameProperty());
-        TreeTablePosition<Person,String> pos = new TreeTablePosition<Person, String>(table, 0, column);
         EventType<TreeTableColumn.CellEditEvent<Person,String>> eventType = TreeTableColumn.editCommitEvent();
         column.getOnEditCommit().handle(new TreeTableColumn.CellEditEvent<Person, String>(
                 table, null, (EventType) eventType, "Richard Bair"));


### PR DESCRIPTION
The issue is unguarded access to tablePosition though it might be null (since [JDK-8120610](https://bugs.openjdk.java.net/browse/JDK-8120610)

The fix is to check against null in each accessor. Also required to fix the default onEditCommit handlers in Tree/TableColumn to really cope with null TablePostion on the event.

Added tests that failed/pass before/after the fix.

Note that there was an old test (in Tree/TableColumnTest each), that failed after the fix because it expected the NPE. Fixed by removing the expected parameter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269871](https://bugs.openjdk.java.net/browse/JDK-8269871): CellEditEvent: must not throw NPE in accessors


### Reviewers
 * [Marius Hanl](https://openjdk.java.net/census#mhanl) (@Maran23 - Author) 🔄 Re-review required (review applies to b6540a2d6f6ec351399db793a785159e7387b324)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/611/head:pull/611` \
`$ git checkout pull/611`

Update a local copy of the PR: \
`$ git checkout pull/611` \
`$ git pull https://git.openjdk.java.net/jfx pull/611/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 611`

View PR using the GUI difftool: \
`$ git pr show -t 611`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/611.diff">https://git.openjdk.java.net/jfx/pull/611.diff</a>

</details>
