### PR TITLE
8269081: Tree/ListViewSkin: must remove flow on dispose

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ListViewSkin.java
@@ -175,8 +175,6 @@ public class ListViewSkin<T> extends VirtualContainerBase<ListView<T>, ListCell<
     private WeakInvalidationListener
                 weakItemsChangeListener = new WeakInvalidationListener(itemsChangeListener);
 
-    private EventHandler<MouseEvent> ml;
-
     /* *************************************************************************
      *                                                                         *
      * Constructors                                                            *
@@ -218,7 +216,7 @@ public class ListViewSkin<T> extends VirtualContainerBase<ListView<T>, ListCell<
         flow.setFixedCellSize(control.getFixedCellSize());
         getChildren().add(flow);
 
-        ml = event -> {
+        EventHandler<MouseEvent> ml = event -> {
             // RT-15127: cancel editing on scroll. This is a bit extreme
             // (we are cancelling editing on touching the scrollbars).
             // This can be improved at a later date.
@@ -281,12 +279,7 @@ public class ListViewSkin<T> extends VirtualContainerBase<ListView<T>, ListCell<
             listViewItems.removeListener(weakListViewItemsListener);
             listViewItems = null;
         }
-        // flow related cleanup
-        // leaking without nulling factory
-        flow.setCellFactory(null);
-        // for completeness - but no effect with/out?
-        flow.getVbar().removeEventFilter(MouseEvent.MOUSE_PRESSED, ml);
-        flow.getHbar().removeEventFilter(MouseEvent.MOUSE_PRESSED, ml);
+        getChildren().remove(flow);
         super.dispose();
 
         if (behavior != null) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeViewSkin.java
@@ -136,11 +136,6 @@ public class TreeViewSkin<T> extends VirtualContainerBase<TreeView<T>, TreeCell<
     private WeakEventHandler<TreeModificationEvent<T>> weakRootListener;
 
 
-
-    private EventHandler<MouseEvent> ml;
-
-
-
     /* *************************************************************************
      *                                                                         *
      * Constructors                                                            *
@@ -170,7 +165,7 @@ public class TreeViewSkin<T> extends VirtualContainerBase<TreeView<T>, TreeCell<
 
         setRoot(getSkinnable().getRoot());
 
-        ml = event -> {
+        EventHandler<MouseEvent> ml = event -> {
             // RT-15127: cancel editing on scroll. This is a bit extreme
             // (we are cancelling editing on touching the scrollbars).
             // This can be improved at a later date.
@@ -235,13 +230,7 @@ public class TreeViewSkin<T> extends VirtualContainerBase<TreeView<T>, TreeCell<
 
         getSkinnable().getProperties().removeListener(propertiesMapListener);
         setRoot(null);
-        // leaking without nulling factory
-        flow.setCellFactory(null);
-        // for completeness - but no effect with/out? Same as in ListViewSkin
-        // don't without seeing any effect - it's not on the skinnable, but on a child, so shouldn't
-        flow.getVbar().removeEventFilter(MouseEvent.MOUSE_PRESSED, ml);
-        flow.getHbar().removeEventFilter(MouseEvent.MOUSE_PRESSED, ml);
-
+        getChildren().remove(flow);
         super.dispose();
 
         if (behavior != null) {


### PR DESCRIPTION
left-over issue from cleanup of Tree/ListViewSkin: direct children that have been added by the skin must be removed in dispose

fixed by removing the flow (which allowed to revert the previous cleanup of event handlers/cellfactory)

added tests to verify
- constant child count after replacing skin
- no memory leak when switching skin while showing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8269081](https://bugs.openjdk.java.net/browse/JDK-8269081): Tree/ListViewSkin: must remove flow on dispose


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/612/head:pull/612` \
`$ git checkout pull/612`

Update a local copy of the PR: \
`$ git checkout pull/612` \
`$ git pull https://git.openjdk.java.net/jfx pull/612/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 612`

View PR using the GUI difftool: \
`$ git pr show -t 612`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/612.diff">https://git.openjdk.java.net/jfx/pull/612.diff</a>

</details>
