### PR TITLE
8273071: SeparatorSkin: must remove child on dispose

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SeparatorSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SeparatorSkin.java
@@ -26,14 +26,10 @@
 package javafx.scene.control.skin;
 
 import javafx.geometry.Orientation;
-import javafx.scene.Node;
-import javafx.scene.control.Accordion;
 import javafx.scene.control.Control;
 import javafx.scene.control.Separator;
 import javafx.scene.control.SkinBase;
 import javafx.scene.layout.Region;
-
-import java.util.Collections;
 
 /**
  * Default skin implementation for the {@link Separator} control.
@@ -108,6 +104,13 @@ public class SeparatorSkin extends SkinBase<Separator> {
      * Public API                                                              *
      *                                                                         *
      **************************************************************************/
+
+
+    @Override
+    public void dispose() {
+        getChildren().remove(line);
+        super.dispose();
+    }
 
     /**
      * We only need to deal with the single "line" child region. The important

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinMemoryLeakTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinMemoryLeakTest.java
@@ -54,7 +54,6 @@ import javafx.scene.control.Pagination;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.ScrollBar;
 import javafx.scene.control.ScrollPane;
-import javafx.scene.control.Separator;
 import javafx.scene.control.Skin;
 import javafx.scene.control.Spinner;
 import javafx.scene.control.SplitMenuButton;
@@ -141,8 +140,6 @@ public class SkinMemoryLeakTest {
                 PasswordField.class,
                 ScrollBar.class,
                 ScrollPane.class,
-                // @Ignore("8273071")
-                Separator.class,
                 // @Ignore("8245145")
                 Spinner.class,
                 SplitMenuButton.class,


### PR DESCRIPTION
minor skin cleanup issue: SeparatorSkin didn't remove the line it added to the control's children

fix is to override dispose and include the removal
for testing: removed the exclusion of SeparatorSkin from memoryLeakTest - doing so lets it fail/pass before/after this fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273071](https://bugs.openjdk.java.net/browse/JDK-8273071): SeparatorSkin: must remove child on dispose


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/616/head:pull/616` \
`$ git checkout pull/616`

Update a local copy of the PR: \
`$ git checkout pull/616` \
`$ git pull https://git.openjdk.java.net/jfx pull/616/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 616`

View PR using the GUI difftool: \
`$ git pr show -t 616`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/616.diff">https://git.openjdk.java.net/jfx/pull/616.diff</a>

</details>
