### PR TITLE
8271474: Tree-/TableCell: inconsistent edit event firing pattern

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
@@ -301,6 +301,10 @@ public class TableCell<S,T> extends IndexedCell<T> {
 
     // editing location at start of edit - fix for JDK-8187229
     private TablePosition<S, T> editingCellAtStartEdit;
+    // test-only
+    TablePosition<S, T> getEditingCellAtStartEdit() {
+        return editingCellAtStartEdit;
+    }
 
     /** {@inheritDoc} */
     @Override public void startEdit() {
@@ -342,14 +346,14 @@ public class TableCell<S,T> extends IndexedCell<T> {
 
     /** {@inheritDoc} */
     @Override public void commitEdit(T newValue) {
-        if (! isEditing()) return;
+        if (!isEditing()) return;
 
         final TableView<S> table = getTableView();
-        if (table != null) {
-            // Inform the TableView of the edit being ready to be committed.
-            CellEditEvent editEvent = new CellEditEvent(
+        if (getTableColumn() != null) {
+            // Inform the TableColumn of the edit being ready to be committed.
+            CellEditEvent<S, T> editEvent = new CellEditEvent<>(
                 table,
-                table.getEditingCell(),
+                editingCellAtStartEdit,
                 TableColumn.editCommitEvent(),
                 newValue
             );
@@ -381,22 +385,22 @@ public class TableCell<S,T> extends IndexedCell<T> {
 
     /** {@inheritDoc} */
     @Override public void cancelEdit() {
-        if (! isEditing()) return;
-
-        final TableView<S> table = getTableView();
+        if (!isEditing()) return;
 
         super.cancelEdit();
 
-        // reset the editing index on the TableView
+        final TableView<S> table = getTableView();
         if (table != null) {
+            // reset the editing index on the TableView
             if (updateEditingIndex) table.edit(-1, null);
-
             // request focus back onto the table, only if the current focus
             // owner has the table as a parent (otherwise the user might have
             // clicked out of the table entirely and given focus to something else.
             // It would be rude of us to request it back again.
             ControlUtils.requestFocusOnControlOnlyIfCurrentFocusOwnerIsChild(table);
+        }
 
+        if (getTableColumn() != null) {
             CellEditEvent<S,?> editEvent = new CellEditEvent<>(
                 table,
                 editingCellAtStartEdit,

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableColumn.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableColumn.java
@@ -30,7 +30,6 @@ import javafx.scene.control.skin.NestedTableColumnHeader;
 import javafx.scene.control.skin.TableColumnHeader;
 import javafx.scene.control.skin.TableHeaderRow;
 import javafx.scene.control.skin.TableViewSkin;
-import javafx.scene.control.skin.TableViewSkinBase;
 
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -783,9 +782,6 @@ public class TableColumn<S,T> extends TableColumnBase<S,T> implements EventTarge
                 EventType<CellEditEvent<S,T>> eventType, T newValue) {
             super(table, Event.NULL_SOURCE_TARGET, eventType);
 
-            if (table == null) {
-                throw new NullPointerException("TableView can not be null");
-            }
             this.pos = pos;
             this.newValue = newValue;
         }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableColumn.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableColumn.java
@@ -762,9 +762,6 @@ public class TreeTableColumn<S,T> extends TableColumnBase<TreeItem<S>,T> impleme
                 EventType<TreeTableColumn.CellEditEvent<S,T>> eventType, T newValue) {
             super(table, Event.NULL_SOURCE_TARGET, eventType);
 
-            if (table == null) {
-                throw new NullPointerException("TableView can not be null");
-            }
             this.pos = pos;
             this.newValue = newValue;
         }

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/TableCellShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/TableCellShim.java
@@ -31,8 +31,11 @@ public class TableCellShim<S,T> extends TableCell<S,T> {
         super.updateItem(item, empty);
     }
 
-    public static void set_lockItemOnEdit(TableCell tc, boolean b) {
+    public static <S, T> void set_lockItemOnEdit(TableCell<S, T> tc, boolean b) {
         tc.lockItemOnEdit = b;
     }
 
+    public static <S, T> TablePosition<S, T> getEditingCellAtStartEdit(TableCell<S, T> cell) {
+        return cell.getEditingCellAtStartEdit();
+    }
 }

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/TreeTableCellShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/TreeTableCellShim.java
@@ -31,8 +31,12 @@ public class TreeTableCellShim<S,T> extends TreeTableCell<S,T> {
         super.updateItem(item, empty);
     }
 
-    public static void set_lockItemOnEdit(TreeTableCell tc, boolean b) {
+    public static <S, T> void set_lockItemOnEdit(TreeTableCell<S, T> tc, boolean b) {
         tc.lockItemOnEdit = b;
+    }
+
+    public static <S, T> TreeTablePosition<S, T> getEditingCellAtStartEdit(TreeTableCell<S, T> cell) {
+        return cell.getEditingCellAtStartEdit();
     }
 
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellEditEventOfTableColumnTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellEditEventOfTableColumnTest.java
@@ -27,7 +27,6 @@ package test.javafx.scene.control;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static javafx.scene.control.TableColumn.*;
@@ -110,7 +109,6 @@ public class CellEditEventOfTableColumnTest {
 
 //---------- event source
 
-    @Ignore("JDK-8271474")
     @Test
     public void testNullTable() {
         new CellEditEvent<Object, Object>(null, // null table must not throw NPE
@@ -127,7 +125,6 @@ public class CellEditEventOfTableColumnTest {
         assertCellEditEvent(table);
     }
 
-    @Ignore("JDK-8271474")
     @Test
     public void testCellEditEventNullSource() {
         assertCellEditEvent(null);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellEditEventOfTreeTableColumnTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellEditEventOfTreeTableColumnTest.java
@@ -29,7 +29,6 @@ import java.util.stream.Collectors;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static javafx.scene.control.TreeTableColumn.editCommitEvent;
@@ -113,7 +112,6 @@ public class CellEditEventOfTreeTableColumnTest {
 
 // ------------- event source
 
-    @Ignore("JDK-8271474")
     @Test
     public void testNullTable() {
         new CellEditEvent<Object, Object>(null, // null table must not throw NPE
@@ -130,7 +128,6 @@ public class CellEditEventOfTreeTableColumnTest {
         assertCellEditEvent(table);
     }
 
-    @Ignore("JDK-8271474")
     @Test
     public void testCellEditEventNullSource() {
         assertCellEditEvent(null);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableColumnTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableColumnTest.java
@@ -1044,7 +1044,7 @@ public class TableColumnTest {
         assertEquals(76, table.getItems().get(0).getAge());
     }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void defaultOnEditCommitHandlerDealsWithNullTableView() {
         table.getColumns().add(column);
         column.setCellValueFactory(param -> param.getValue().firstNameProperty());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableColumnTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableColumnTest.java
@@ -1070,11 +1070,12 @@ public class TreeTableColumnTest {
 //        assertEquals(76, table.getItems().get(0).getAge());
 //    }
 
-    @Test(expected=NullPointerException.class)
+    @Test
     public void defaultOnEditCommitHandlerDealsWithNullTableView() {
         table.getColumns().add(column);
+        // FIXME: this factory will throw if treeItem has null value - as is the case for root
         column.setCellValueFactory(param -> param.getValue().getValue().firstNameProperty());
-        TreeTablePosition<Person,String> pos = new TreeTablePosition<Person, String>(table, 0, column);
+        TreeTablePosition<Person,String> pos = new TreeTablePosition<Person, String>(table, 1, column);
         EventType<TreeTableColumn.CellEditEvent<Person,String>> eventType = TreeTableColumn.editCommitEvent();
         column.getOnEditCommit().handle(new TreeTableColumn.CellEditEvent<Person, String>(
                 null, pos, (EventType) eventType, "Richard Bair"));


### PR DESCRIPTION
this PR fixes the inconsistent event firing pattern in cell's xxEdit methods (please see the issue for more details):

- fires event if column != null
- accesses table state if table != null

The first requires a change in CellEditEvent which now allows null table in its constructor.

Added tests that failed/passed before/after the fix (along with some that also passed before for complete coverage of state permutations). Changed two old test methods which passed/failed before/after the fix - but did test the wrong thingy anyway ;)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271474](https://bugs.openjdk.java.net/browse/JDK-8271474): Tree-/TableCell: inconsistent edit event firing pattern


### Reviewers
 * [Marius Hanl](https://openjdk.java.net/census#mhanl) (@Maran23 - Author)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/620/head:pull/620` \
`$ git checkout pull/620`

Update a local copy of the PR: \
`$ git checkout pull/620` \
`$ git pull https://git.openjdk.java.net/jfx pull/620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 620`

View PR using the GUI difftool: \
`$ git pr show -t 620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/620.diff">https://git.openjdk.java.net/jfx/pull/620.diff</a>

</details>
