### PR TITLE
8273754: Re-introduce Automatic-Module-Name in empty jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4790,6 +4790,11 @@ compileTargets { t ->
         def modularEmptyPublicationJarTask = project.task("moduleEmptyPublicationJar${t.capital}", type: Jar) {
             destinationDirectory = file("${dstModularJarDir}")
             archiveFileName = modularEmptyPublicationJarName
+            manifest {
+                attributes(
+                        'Automatic-Module-Name':"${moduleName}Empty"
+                )
+            }
         }
 
         def modularPublicationJarName = "${moduleName}-${t.name}.jar"


### PR DESCRIPTION
Re-introduce `Automatic-Module-Name` for empty jars until a better alternative to empty jars has been finalized.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273754](https://bugs.openjdk.java.net/browse/JDK-8273754): Re-introduce Automatic-Module-Name in empty jars


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/623/head:pull/623` \
`$ git checkout pull/623`

Update a local copy of the PR: \
`$ git checkout pull/623` \
`$ git pull https://git.openjdk.java.net/jfx pull/623/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 623`

View PR using the GUI difftool: \
`$ git pr show -t 623`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/623.diff">https://git.openjdk.java.net/jfx/pull/623.diff</a>

</details>
