### PR TITLE
8273824: Update JavaFX release version to 17.0.0.1 in jfx/jfx17 branch

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -42,7 +42,7 @@ jfx.release.suffix=-ea
 jfx.release.major.version=17
 jfx.release.minor.version=0
 jfx.release.security.version=0
-jfx.release.patch.version=0
+jfx.release.patch.version=1
 
 # Note: The release version is now calculated in build.gradle as the
 # dot-separated concatenation of the previous four fields with trailing zero


### PR DESCRIPTION
This release is needed with a backport of JDK-8273754

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273824](https://bugs.openjdk.java.net/browse/JDK-8273824): Update JavaFX release version to 17.0.0.1 in jfx/jfx17 branch


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/624/head:pull/624` \
`$ git checkout pull/624`

Update a local copy of the PR: \
`$ git checkout pull/624` \
`$ git pull https://git.openjdk.java.net/jfx pull/624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 624`

View PR using the GUI difftool: \
`$ git pr show -t 624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/624.diff">https://git.openjdk.java.net/jfx/pull/624.diff</a>

</details>
