### PR TITLE
8273754: Re-introduce Automatic-Module-Name in empty jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4786,6 +4786,11 @@ compileTargets { t ->
         def modularEmptyPublicationJarTask = project.task("moduleEmptyPublicationJar${t.capital}", type: Jar) {
             destinationDirectory = file("${dstModularJarDir}")
             archiveFileName = modularEmptyPublicationJarName
+            manifest {
+                attributes(
+                        'Automatic-Module-Name':"${moduleName}Empty"
+                )
+            }
         }
 
         def modularPublicationJarName = "${moduleName}-${t.name}.jar"


### PR DESCRIPTION
Reviewed-by: kcr, jvos

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8273754](https://bugs.openjdk.java.net/browse/JDK-8273754): Re-introduce Automatic-Module-Name in empty jars


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/625/head:pull/625` \
`$ git checkout pull/625`

Update a local copy of the PR: \
`$ git checkout pull/625` \
`$ git pull https://git.openjdk.java.net/jfx pull/625/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 625`

View PR using the GUI difftool: \
`$ git pr show -t 625`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/625.diff">https://git.openjdk.java.net/jfx/pull/625.diff</a>

</details>
