### PR TITLE
8273969: Memory Leak on the Runnable provided to Platform.startup

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
@@ -376,6 +376,7 @@ public final class QuantumToolkit extends Toolkit {
         launchLatch.countDown();
         try {
             Application.invokeAndWait(this.userRunnable);
+            this.userRunnable = null;
 
             if (getPrimaryTimer().isFullspeed()) {
                 /*

--- a/tests/system/src/test/java/test/com/sun/javafx/application/PlatformStartupMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/application/PlatformStartupMemoryLeakTest.java
@@ -23,18 +23,19 @@
  * questions.
  */
 
-package test.javafx.scene;
+package test.com.sun.javafx.application;
 
-import org.junit.Test;
-import test.util.memory.JMemoryBuddy;
 import javafx.application.Platform;
+import org.junit.Test;
+import org.junit.AfterClass;
+import test.util.memory.JMemoryBuddy;
 
 public class PlatformStartupMemoryLeakTest {
 
     @Test
     public void testStartupLeak() {
         JMemoryBuddy.memoryTest((checker) -> {
-            // Doesn't work as lambda for some reason, due to "BoundMethodHandle$Species_L"
+            // This Runnable must not turn into a lambda, because then the test wouldn't work anymore.
             Runnable r = new Runnable() {
                 @Override
                 public void run() {
@@ -45,4 +46,10 @@ public class PlatformStartupMemoryLeakTest {
             checker.assertCollectable(r);
         });
     }
+
+    @AfterClass
+    public static void tearDown() {
+        Platform.exit();
+    }
+
 }

--- a/tests/system/src/test/java/test/javafx/scene/PlatformStartupMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/PlatformStartupMemoryLeakTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene;
+
+import org.junit.Test;
+import test.util.memory.JMemoryBuddy;
+import javafx.application.Platform;
+
+public class PlatformStartupMemoryLeakTest {
+
+    @Test
+    public void testStartupLeak() {
+        JMemoryBuddy.memoryTest((checker) -> {
+            // Doesn't work as lambda for some reason, due to "BoundMethodHandle$Species_L"
+            Runnable r = new Runnable() {
+                @Override
+                public void run() {
+                    System.out.println("Startup called!");
+                }
+            };
+            Platform.startup(r);
+            checker.assertCollectable(r);
+        });
+    }
+}


### PR DESCRIPTION
Probably my most boring PR. ;)
Setting the lambda to null, after it has been used, fixes the leak.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273969](https://bugs.openjdk.java.net/browse/JDK-8273969): Memory Leak on the Runnable provided to Platform.startup


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/626/head:pull/626` \
`$ git checkout pull/626`

Update a local copy of the PR: \
`$ git checkout pull/626` \
`$ git pull https://git.openjdk.java.net/jfx pull/626/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 626`

View PR using the GUI difftool: \
`$ git pr show -t 626`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/626.diff">https://git.openjdk.java.net/jfx/pull/626.diff</a>

</details>
