### PR TITLE
8272808: Update constant collections to use the new immutable collections - leftovers

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/FocusTraversalInputMap.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/FocusTraversalInputMap.java
@@ -32,7 +32,6 @@ import com.sun.javafx.scene.control.inputmap.InputMap;
 import com.sun.javafx.scene.control.inputmap.KeyBinding;
 import javafx.scene.input.KeyEvent;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static com.sun.javafx.scene.control.inputmap.InputMap.*;
@@ -44,29 +43,27 @@ import static javafx.scene.input.KeyCode.UP;
 
 public class FocusTraversalInputMap<N extends Node> {
 
-    private static final List<InputMap.Mapping<?>> mappings = new ArrayList<>();
-    static {
-        mappings.add(new KeyMapping(UP, e -> traverseUp(e)));
-        mappings.add(new KeyMapping(DOWN, e -> traverseDown(e)));
-        mappings.add(new KeyMapping(LEFT, e -> traverseLeft(e)));
-        mappings.add(new KeyMapping(RIGHT, e -> traverseRight(e)));
-        mappings.add(new KeyMapping(TAB, e -> traverseNext(e)));
-        mappings.add(new KeyMapping(new KeyBinding(TAB).shift(), e -> traversePrevious(e)));
+    private static final List<InputMap.Mapping<?>> MAPPINGS = List.of(
+        new KeyMapping(UP, e -> traverseUp(e)),
+        new KeyMapping(DOWN, e -> traverseDown(e)),
+        new KeyMapping(LEFT, e -> traverseLeft(e)),
+        new KeyMapping(RIGHT, e -> traverseRight(e)),
+        new KeyMapping(TAB, e -> traverseNext(e)),
+        new KeyMapping(new KeyBinding(TAB).shift(), e -> traversePrevious(e)),
 
-        mappings.add(new KeyMapping(new KeyBinding(UP).shift().alt().ctrl(), e -> traverseUp(e)));
-        mappings.add(new KeyMapping(new KeyBinding(DOWN).shift().alt().ctrl(), e -> traverseDown(e)));
-        mappings.add(new KeyMapping(new KeyBinding(LEFT).shift().alt().ctrl(), e -> traverseLeft(e)));
-        mappings.add(new KeyMapping(new KeyBinding(RIGHT).shift().alt().ctrl(), e -> traverseRight(e)));
-        mappings.add(new KeyMapping(new KeyBinding(TAB).shift().alt().ctrl(), e -> traverseNext(e)));
-        mappings.add(new KeyMapping(new KeyBinding(TAB).alt().ctrl(), e -> traversePrevious(e)));
-    }
+        new KeyMapping(new KeyBinding(UP).shift().alt().ctrl(), e -> traverseUp(e)),
+        new KeyMapping(new KeyBinding(DOWN).shift().alt().ctrl(), e -> traverseDown(e)),
+        new KeyMapping(new KeyBinding(LEFT).shift().alt().ctrl(), e -> traverseLeft(e)),
+        new KeyMapping(new KeyBinding(RIGHT).shift().alt().ctrl(), e -> traverseRight(e)),
+        new KeyMapping(new KeyBinding(TAB).shift().alt().ctrl(), e -> traverseNext(e)),
+        new KeyMapping(new KeyBinding(TAB).alt().ctrl(), e -> traversePrevious(e)));
 
     private FocusTraversalInputMap() {
         // no-op, just forcing use of static method
     }
 
     public static InputMap.Mapping<?>[] getFocusTraversalMappings() {
-        return mappings.toArray(new InputMap.Mapping[mappings.size()]);
+        return MAPPINGS.toArray(new InputMap.Mapping[MAPPINGS.size()]);
     }
 
     public static <N extends Node> InputMap<N> createInputMap(N node) {

--- a/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/JSLC.java
+++ b/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/JSLC.java
@@ -322,7 +322,7 @@ public class JSLC {
         public String genericsName;
         public String interfaceName;
         public String pkgName = rootPkg;
-        public Map<Integer, String> outNameMap = DEFAULT_INFO_MAP;
+        public Map<Integer, String> outNameMap = new HashMap<>(DEFAULT_INFO_MAP);
 
         private String extraOpts;
 

--- a/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/JSLC.java
+++ b/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/JSLC.java
@@ -130,14 +130,14 @@ public class JSLC {
      *   ../decora-prism-ps/build/gensrc/+ rootPkg + /impl/prism/ps
      */
     private static final Map<Integer, String> DEFAULT_INFO_MAP = Map.of(
-            OUT_D3D,        "decora-d3d/build/gensrc/{pkg}/impl/hw/d3d/hlsl/{name}.hlsl",
-            OUT_ES2,        "decora-es2/build/gensrc/{pkg}/impl/es2/glsl/{name}.frag",
-            OUT_JAVA,       "decora-jsw/build/gensrc/{pkg}/impl/sw/java/JSW{name}Peer.java",
-            OUT_PRISM,      "decora-prism-ps/build/gensrc/{pkg}/impl/prism/ps/PPS{name}Peer.java",
-            OUT_SSE_JAVA,   "decora-sse/build/gensrc/{pkg}/impl/sw/sse/SSE{name}Peer.java",
-            OUT_ME_JAVA,    "decora-me/build/gensrc/{pkg}/impl/sw/me/ME{name}Peer.java",
-            OUT_SSE_NATIVE, "decora-sse-native/build/gensrc/SSE{name}Peer.cc",
-            OUT_ME_NATIVE,  "decora-me-native/build/gensrc/ME{name}Peer.cc");
+        OUT_D3D,        "decora-d3d/build/gensrc/{pkg}/impl/hw/d3d/hlsl/{name}.hlsl",
+        OUT_ES2,        "decora-es2/build/gensrc/{pkg}/impl/es2/glsl/{name}.frag",
+        OUT_JAVA,       "decora-jsw/build/gensrc/{pkg}/impl/sw/java/JSW{name}Peer.java",
+        OUT_PRISM,      "decora-prism-ps/build/gensrc/{pkg}/impl/prism/ps/PPS{name}Peer.java",
+        OUT_SSE_JAVA,   "decora-sse/build/gensrc/{pkg}/impl/sw/sse/SSE{name}Peer.java",
+        OUT_ME_JAVA,    "decora-me/build/gensrc/{pkg}/impl/sw/me/ME{name}Peer.java",
+        OUT_SSE_NATIVE, "decora-sse-native/build/gensrc/SSE{name}Peer.cc",
+        OUT_ME_NATIVE,  "decora-me-native/build/gensrc/ME{name}Peer.cc");
 
     public static ParserInfo compile(JSLCInfo jslcinfo,
                                      String str,

--- a/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/JSLC.java
+++ b/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/JSLC.java
@@ -129,18 +129,15 @@ public class JSLC {
      *   ../decora-es2/build/gensrc/     + rootPkg + /impl/es2/glsl
      *   ../decora-prism-ps/build/gensrc/+ rootPkg + /impl/prism/ps
      */
-    private static Map<Integer, String> initDefaultInfoMap() {
-        Map<Integer, String> infoMap = new HashMap<Integer, String>();
-        infoMap.put(OUT_D3D,        "decora-d3d/build/gensrc/{pkg}/impl/hw/d3d/hlsl/{name}.hlsl");
-        infoMap.put(OUT_ES2,        "decora-es2/build/gensrc/{pkg}/impl/es2/glsl/{name}.frag");
-        infoMap.put(OUT_JAVA,       "decora-jsw/build/gensrc/{pkg}/impl/sw/java/JSW{name}Peer.java");
-        infoMap.put(OUT_PRISM,      "decora-prism-ps/build/gensrc/{pkg}/impl/prism/ps/PPS{name}Peer.java");
-        infoMap.put(OUT_SSE_JAVA,   "decora-sse/build/gensrc/{pkg}/impl/sw/sse/SSE{name}Peer.java");
-        infoMap.put(OUT_ME_JAVA,    "decora-me/build/gensrc/{pkg}/impl/sw/me/ME{name}Peer.java");
-        infoMap.put(OUT_SSE_NATIVE, "decora-sse-native/build/gensrc/SSE{name}Peer.cc");
-        infoMap.put(OUT_ME_NATIVE,  "decora-me-native/build/gensrc/ME{name}Peer.cc");
-        return infoMap;
-    }
+    private static final Map<Integer, String> DEFAULT_INFO_MAP = Map.of(
+            OUT_D3D,        "decora-d3d/build/gensrc/{pkg}/impl/hw/d3d/hlsl/{name}.hlsl",
+            OUT_ES2,        "decora-es2/build/gensrc/{pkg}/impl/es2/glsl/{name}.frag",
+            OUT_JAVA,       "decora-jsw/build/gensrc/{pkg}/impl/sw/java/JSW{name}Peer.java",
+            OUT_PRISM,      "decora-prism-ps/build/gensrc/{pkg}/impl/prism/ps/PPS{name}Peer.java",
+            OUT_SSE_JAVA,   "decora-sse/build/gensrc/{pkg}/impl/sw/sse/SSE{name}Peer.java",
+            OUT_ME_JAVA,    "decora-me/build/gensrc/{pkg}/impl/sw/me/ME{name}Peer.java",
+            OUT_SSE_NATIVE, "decora-sse-native/build/gensrc/SSE{name}Peer.cc",
+            OUT_ME_NATIVE,  "decora-me-native/build/gensrc/ME{name}Peer.cc");
 
     public static ParserInfo compile(JSLCInfo jslcinfo,
                                      String str,
@@ -325,7 +322,6 @@ public class JSLC {
         public String genericsName;
         public String interfaceName;
         public String pkgName = rootPkg;
-        public Map<Integer, String> outNameMap = initDefaultInfoMap();
 
         private String extraOpts;
 
@@ -465,7 +461,7 @@ public class JSLC {
         }
 
         public File getOutputFile(int outType) {
-            String fileName = outNameMap.get(outType);
+            String fileName = DEFAULT_INFO_MAP.get(outType);
             return getOutputFile(fileName);
         }
     }

--- a/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/JSLC.java
+++ b/modules/javafx.graphics/src/jslc/java/com/sun/scenario/effect/compiler/JSLC.java
@@ -322,6 +322,7 @@ public class JSLC {
         public String genericsName;
         public String interfaceName;
         public String pkgName = rootPkg;
+        public Map<Integer, String> outNameMap = DEFAULT_INFO_MAP;
 
         private String extraOpts;
 
@@ -461,7 +462,7 @@ public class JSLC {
         }
 
         public File getOutputFile(int outType) {
-            String fileName = DEFAULT_INFO_MAP.get(outType);
+            String fileName = outNameMap.get(outType);
             return getOutputFile(fileName);
         }
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/LogicalFont.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/LogicalFont.java
@@ -27,7 +27,6 @@ package com.sun.javafx.font;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -50,27 +49,24 @@ public class LogicalFont implements CompositeFontResource {
     public static final String STYLE_ITALIC      = "Italic";
     public static final String STYLE_BOLD_ITALIC = "Bold Italic";
 
-    static final HashMap<String, String>
-        canonicalFamilyMap = new  HashMap<String, String>();
-    static {
-        canonicalFamilyMap.put("system", SYSTEM);
+    private static final Map<String, String> CANONICAL_FAMILY_MAP = Map.of(
+        "system", SYSTEM,
 
-        canonicalFamilyMap.put("serif", SERIF);
+        "serif", SERIF,
 
-        canonicalFamilyMap.put("sansserif", SANS_SERIF);
-        canonicalFamilyMap.put("sans-serif", SANS_SERIF); // css style
-        canonicalFamilyMap.put("dialog", SANS_SERIF);
-        canonicalFamilyMap.put("default", SANS_SERIF);
+        "sansserif", SANS_SERIF,
+        "sans-serif", SANS_SERIF, // css style
+        "dialog", SANS_SERIF,
+        "default", SANS_SERIF,
 
-        canonicalFamilyMap.put("monospaced", MONOSPACED);
-        canonicalFamilyMap.put("monospace", MONOSPACED); // css style
-        canonicalFamilyMap.put("dialoginput", MONOSPACED);
-    }
+        "monospaced", MONOSPACED,
+        "monospace", MONOSPACED, // css style
+        "dialoginput", MONOSPACED);
 
     static boolean isLogicalFont(String name) {
         int spaceIndex = name.indexOf(' ');
         if (spaceIndex != -1) name = name.substring(0, spaceIndex);
-        return canonicalFamilyMap.get(name) != null;
+        return CANONICAL_FAMILY_MAP.get(name) != null;
     }
 
     private static String getCanonicalFamilyName(String name) {
@@ -78,7 +74,7 @@ public class LogicalFont implements CompositeFontResource {
              return SANS_SERIF;
          }
          String lcName = name.toLowerCase();
-         return canonicalFamilyMap.get(lcName);
+         return CANONICAL_FAMILY_MAP.get(lcName);
     }
 
     static LogicalFont[] logicalFonts = new LogicalFont[16];

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/WindowsFontMap.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/WindowsFontMap.java
@@ -110,13 +110,12 @@ class WindowsFontMap {
         courierFD.boldItalicFileName = "courbi.ttf";
 
         PLATFORM_FONT_MAP = Map.of(
-                "segoe", segoeFD,
-                "tahoma", tahomaFD,
-                "verdana", verdanaFD,
-                "arial", arialFD,
-                "times", timesFD,
-                "courier", courierFD
-        );
+            "segoe", segoeFD,
+            "tahoma", tahomaFD,
+            "verdana", verdanaFD,
+            "arial", arialFD,
+            "times", timesFD,
+            "courier", courierFD);
     }
 
     static String getPathName(String filename) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/WindowsFontMap.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/WindowsFontMap.java
@@ -25,103 +25,98 @@
 
 package com.sun.javafx.font;
 
-import java.util.HashMap;
+import java.util.Map;
 
 class WindowsFontMap {
 
-    static class FamilyDescription {
-        public String familyName;
-        public String plainFullName;
-        public String boldFullName;
-        public String italicFullName;
-        public String boldItalicFullName;
-        public String plainFileName;
-        public String boldFileName;
-        public String italicFileName;
-        public String boldItalicFileName;
+    private static class FamilyDescription {
+        private String familyName;
+        private String plainFullName;
+        private String boldFullName;
+        private String italicFullName;
+        private String boldItalicFullName;
+        private String plainFileName;
+        private String boldFileName;
+        private String italicFileName;
+        private String boldItalicFileName;
     }
 
-    static HashMap<String, FamilyDescription> platformFontMap;
+    private static Map<String, FamilyDescription> PLATFORM_FONT_MAP;
 
     /**
      * populate the map with the most common windows fonts.
      */
-    static HashMap<String, FamilyDescription> populateHardcodedFileNameMap() {
+    private static void populateHardcodedFileNameMap() {
+        var segoeFD = new FamilyDescription();
+        segoeFD.familyName = "Segoe UI";
+        segoeFD.plainFullName = "Segoe UI";
+        segoeFD.plainFileName = "segoeui.ttf";
+        segoeFD.boldFullName = "Segoe UI Bold";
+        segoeFD.boldFileName = "segoeuib.ttf";
+        segoeFD.italicFullName = "Segoe UI Italic";
+        segoeFD.italicFileName = "segoeuii.ttf";
+        segoeFD.boldItalicFullName = "Segoe UI Bold Italic";
+        segoeFD.boldItalicFileName = "segoeuiz.ttf";
 
-        HashMap<String, FamilyDescription> platformFontMap
-            = new HashMap<String, FamilyDescription>();
+        var tahomaFD = new FamilyDescription();
+        tahomaFD.familyName = "Tahoma";
+        tahomaFD.plainFullName = "Tahoma";
+        tahomaFD.plainFileName = "tahoma.ttf";
+        tahomaFD.boldFullName = "Tahoma Bold";
+        tahomaFD.boldFileName = "tahomabd.ttf";
 
-        FamilyDescription fd;
-        fd = new FamilyDescription();
-        fd.familyName = "Segoe UI";
-        fd.plainFullName = "Segoe UI";
-        fd.plainFileName = "segoeui.ttf";
-        fd.boldFullName = "Segoe UI Bold";
-        fd.boldFileName = "segoeuib.ttf";
-        fd.italicFullName = "Segoe UI Italic";
-        fd.italicFileName = "segoeuii.ttf";
-        fd.boldItalicFullName = "Segoe UI Bold Italic";
-        fd.boldItalicFileName = "segoeuiz.ttf";
-        platformFontMap.put("segoe", fd);
+        var verdanaFD = new FamilyDescription();
+        verdanaFD.familyName = "Verdana";
+        verdanaFD.plainFullName = "Verdana";
+        verdanaFD.plainFileName = "verdana.TTF";
+        verdanaFD.boldFullName = "Verdana Bold";
+        verdanaFD.boldFileName = "verdanab.TTF";
+        verdanaFD.italicFullName = "Verdana Italic";
+        verdanaFD.italicFileName = "verdanai.TTF";
+        verdanaFD.boldItalicFullName = "Verdana Bold Italic";
+        verdanaFD.boldItalicFileName = "verdanaz.TTF";
 
-        fd = new FamilyDescription();
-        fd.familyName = "Tahoma";
-        fd.plainFullName = "Tahoma";
-        fd.plainFileName = "tahoma.ttf";
-        fd.boldFullName = "Tahoma Bold";
-        fd.boldFileName = "tahomabd.ttf";
-        platformFontMap.put("tahoma", fd);
+        var arialFD = new FamilyDescription();
+        arialFD.familyName = "Arial";
+        arialFD.plainFullName = "Arial";
+        arialFD.plainFileName = "ARIAL.TTF";
+        arialFD.boldFullName = "Arial Bold";
+        arialFD.boldFileName = "ARIALBD.TTF";
+        arialFD.italicFullName = "Arial Italic";
+        arialFD.italicFileName = "ARIALI.TTF";
+        arialFD.boldItalicFullName = "Arial Bold Italic";
+        arialFD.boldItalicFileName = "ARIALBI.TTF";
 
-        fd = new FamilyDescription();
-        fd.familyName = "Verdana";
-        fd.plainFullName = "Verdana";
-        fd.plainFileName = "verdana.TTF";
-        fd.boldFullName = "Verdana Bold";
-        fd.boldFileName = "verdanab.TTF";
-        fd.italicFullName = "Verdana Italic";
-        fd.italicFileName = "verdanai.TTF";
-        fd.boldItalicFullName = "Verdana Bold Italic";
-        fd.boldItalicFileName = "verdanaz.TTF";
-        platformFontMap.put("verdana", fd);
+        var timesFD = new FamilyDescription();
+        timesFD.familyName = "Times New Roman";
+        timesFD.plainFullName = "Times New Roman";
+        timesFD.plainFileName = "times.ttf";
+        timesFD.boldFullName = "Times New Roman Bold";
+        timesFD.boldFileName = "timesbd.ttf";
+        timesFD.italicFullName = "Times New Roman Italic";
+        timesFD.italicFileName = "timesi.ttf";
+        timesFD.boldItalicFullName = "Times New Roman Bold Italic";
+        timesFD.boldItalicFileName = "timesbi.ttf";
 
-        fd = new FamilyDescription();
-        fd.familyName = "Arial";
-        fd.plainFullName = "Arial";
-        fd.plainFileName = "ARIAL.TTF";
-        fd.boldFullName = "Arial Bold";
-        fd.boldFileName = "ARIALBD.TTF";
-        fd.italicFullName = "Arial Italic";
-        fd.italicFileName = "ARIALI.TTF";
-        fd.boldItalicFullName = "Arial Bold Italic";
-        fd.boldItalicFileName = "ARIALBI.TTF";
-        platformFontMap.put("arial", fd);
+        var courierFD = new FamilyDescription();
+        courierFD.familyName = "Courier New";
+        courierFD.plainFullName = "Courier New";
+        courierFD.plainFileName = "cour.ttf";
+        courierFD.boldFullName = "Courier New Bold";
+        courierFD.boldFileName = "courbd.ttf";
+        courierFD.italicFullName = "Courier New Italic";
+        courierFD.italicFileName = "couri.ttf";
+        courierFD.boldItalicFullName = "Courier New Bold Italic";
+        courierFD.boldItalicFileName = "courbi.ttf";
 
-        fd = new FamilyDescription();
-        fd.familyName = "Times New Roman";
-        fd.plainFullName = "Times New Roman";
-        fd.plainFileName = "times.ttf";
-        fd.boldFullName = "Times New Roman Bold";
-        fd.boldFileName = "timesbd.ttf";
-        fd.italicFullName = "Times New Roman Italic";
-        fd.italicFileName = "timesi.ttf";
-        fd.boldItalicFullName = "Times New Roman Bold Italic";
-        fd.boldItalicFileName = "timesbi.ttf";
-        platformFontMap.put("times", fd);
-
-
-        fd = new FamilyDescription();
-        fd.familyName = "Courier New";
-        fd.plainFullName = "Courier New";
-        fd.plainFileName = "cour.ttf";
-        fd.boldFullName = "Courier New Bold";
-        fd.boldFileName = "courbd.ttf";
-        fd.italicFullName = "Courier New Italic";
-        fd.italicFileName = "couri.ttf";
-        fd.boldItalicFullName = "Courier New Bold Italic";
-        fd.boldItalicFileName = "courbi.ttf";
-        platformFontMap.put("courier", fd);
-
-        return platformFontMap;
+        PLATFORM_FONT_MAP = Map.of(
+                "segoe", segoeFD,
+                "tahoma", tahomaFD,
+                "verdana", verdanaFD,
+                "arial", arialFD,
+                "times", timesFD,
+                "courier", courierFD
+        );
     }
 
     static String getPathName(String filename) {
@@ -135,11 +130,11 @@ class WindowsFontMap {
     // determination so we lose the perf. gain. Need to make the
     // is it a platform font call see if it came from here first.
     static String findFontFile(String lcName, int style) {
-        if (platformFontMap == null) {
-            platformFontMap = populateHardcodedFileNameMap();
+        if (PLATFORM_FONT_MAP == null) {
+            populateHardcodedFileNameMap();
         }
 
-        if (platformFontMap == null || platformFontMap.size() == 0) {
+        if (PLATFORM_FONT_MAP == null || PLATFORM_FONT_MAP.size() == 0) {
             return null;
         }
 
@@ -149,7 +144,7 @@ class WindowsFontMap {
             firstWord = lcName.substring(0, spaceIndex);
         }
 
-        FamilyDescription fd = platformFontMap.get(firstWord);
+        FamilyDescription fd = PLATFORM_FONT_MAP.get(firstWord);
         if (fd == null) {
             return null;
         }

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/control/VideoFormat.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/control/VideoFormat.java
@@ -26,7 +26,6 @@
 package com.sun.media.jfxmedia.control;
 
 import java.lang.annotation.Native;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -47,7 +46,7 @@ public enum VideoFormat {
     private int nativeType; // value passed down to native code to represent this format
     private static final Map<Integer, VideoFormat> lookupMap = new HashMap<Integer, VideoFormat>();
     static {
-        for (VideoFormat fmt : EnumSet.allOf(VideoFormat.class)) {
+        for (VideoFormat fmt : VideoFormat.values()) {
             lookupMap.put(fmt.getNativeType(), fmt);
         }
     }

--- a/modules/javafx.web/src/android/java/com/sun/webkit/network/URLs.java
+++ b/modules/javafx.web/src/android/java/com/sun/webkit/network/URLs.java
@@ -28,8 +28,6 @@ package com.sun.webkit.network;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLStreamHandler;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -41,15 +39,10 @@ public final class URLs {
      * The mapping between WebPane-specific protocol names and their
      * respective handlers.
      */
-    private static final Map<String,URLStreamHandler> handlerMap;
-    static {
-        Map<String,URLStreamHandler> map =
-                new HashMap<String,URLStreamHandler>(2);
-//        map.put("about", new com.sun.webkit.network.about.Handler());
-//        map.put("data", new com.sun.webkit.network.data.Handler());
-        handlerMap = Collections.unmodifiableMap(map);
-    }
-
+    private static final Map<String,URLStreamHandler> HANDLER_MAP = Map.of(
+//        "about", new com.sun.webkit.network.about.Handler(),
+//        "data", new com.sun.webkit.network.data.Handler()
+    );
 
     /**
      * The private default constructor. Ensures non-instantiability.
@@ -92,7 +85,7 @@ public final class URLs {
             URLStreamHandler handler = null;
             int colonPosition = spec.indexOf(':');
             if (colonPosition != -1) {
-                handler = handlerMap.get(
+                handler = HANDLER_MAP.get(
                         spec.substring(0, colonPosition).toLowerCase());
             }
             if (handler == null) {

--- a/modules/javafx.web/src/android/java/javafx/scene/web/WebView.java
+++ b/modules/javafx.web/src/android/java/javafx/scene/web/WebView.java
@@ -115,8 +115,6 @@ final public class WebView extends Parent {
         });
     }
 
-    private static final Map<Object, Integer> idMap = new HashMap<Object, Integer>();
-
     private static final boolean DEFAULT_CONTEXT_MENU_ENABLED = true;
     private static final FontSmoothingType DEFAULT_FONT_SMOOTHING_TYPE = FontSmoothingType.LCD;
     private static final double DEFAULT_ZOOM = 1.0;

--- a/modules/javafx.web/src/main/java/com/sun/webkit/Utilities.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/Utilities.java
@@ -54,12 +54,8 @@ public abstract class Utilities {
     protected abstract PopupMenu createPopupMenu();
     protected abstract ContextMenu createContextMenu();
 
-    private static final Set<String> asSet(String... items) {
-        return new HashSet(Arrays.asList(items));
-    }
-
     // List of Class methods to allow
-    private static final Set<String> classMethodsAllowList = asSet(
+    private static final Set<String> CLASS_METHODS_ALLOW_LIST = Set.of(
         "getCanonicalName",
         "getEnumConstants",
         "getFields",
@@ -84,7 +80,7 @@ public abstract class Utilities {
     );
 
     // List of classes to reject
-    private static final Set<String> classesRejectList = asSet(
+    private static final Set<String> CLASSES_REJECT_LIST = Set.of(
         "java.lang.ClassLoader",
         "java.lang.Module",
         "java.lang.Runtime",
@@ -92,7 +88,7 @@ public abstract class Utilities {
     );
 
     // List of packages to reject
-    private static final List<String> packagesRejectList = Arrays.asList(
+    private static final List<String> PACKAGES_REJECT_LIST = List.of(
         "java.lang.invoke",
         "java.lang.module",
         "java.lang.reflect",
@@ -110,17 +106,17 @@ public abstract class Utilities {
         final Class<?> clazz = method.getDeclaringClass();
         if (clazz.equals(java.lang.Class.class)) {
             // check list of allowed Class methods
-            if (!classMethodsAllowList.contains(method.getName())) {
+            if (!CLASS_METHODS_ALLOW_LIST.contains(method.getName())) {
                 throw new UnsupportedOperationException("invocation not supported");
             }
         } else {
             // check list of rejected class names
             final String className = clazz.getName();
-            if (classesRejectList.contains(className)) {
+            if (CLASSES_REJECT_LIST.contains(className)) {
                 throw new UnsupportedOperationException("invocation not supported");
             }
             // check list of rejected packages
-            packagesRejectList.forEach(packageName -> {
+            PACKAGES_REJECT_LIST.forEach(packageName -> {
                 if (className.startsWith(packageName + ".")) {
                     throw new UnsupportedOperationException("invocation not supported");
                 }

--- a/modules/javafx.web/src/main/java/com/sun/webkit/Utilities.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/Utilities.java
@@ -31,11 +31,7 @@ import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public abstract class Utilities {


### PR DESCRIPTION
Replacements of more immutable collections.

One thing I found was that the field `idMap` in `com.sun.java.scene.web.WebViewHelper.WebView` seems unused. I can remove it if that's indeed the case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8272808](https://bugs.openjdk.java.net/browse/JDK-8272808): Update constant collections to use the new immutable collections - leftovers


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**) 🔄 Re-review required (review applies to 796065799c6e98650841bb10c44dbec8aadea917)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/627/head:pull/627` \
`$ git checkout pull/627`

Update a local copy of the PR: \
`$ git checkout pull/627` \
`$ git pull https://git.openjdk.java.net/jfx pull/627/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 627`

View PR using the GUI difftool: \
`$ git pr show -t 627`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/627.diff">https://git.openjdk.java.net/jfx/pull/627.diff</a>

</details>
