### PR TITLE
8273946: Move clearQuad method to BaseShaderGraphics superclass

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DGraphics.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DGraphics.java
@@ -26,17 +26,15 @@
 package com.sun.prism.d3d;
 
 import com.sun.javafx.geom.transform.Affine3D;
-import com.sun.prism.CompositeMode;
 import com.sun.prism.Graphics;
 import com.sun.prism.RenderTarget;
 import com.sun.prism.impl.PrismSettings;
 import com.sun.prism.impl.ps.BaseShaderGraphics;
 import com.sun.prism.paint.Color;
-import com.sun.prism.paint.Paint;
 
 class D3DGraphics extends BaseShaderGraphics implements D3DContextSource {
 
-    private D3DContext context;
+    private final D3DContext context;
 
     private D3DGraphics(D3DContext context, RenderTarget target) {
         super(context, target);
@@ -63,24 +61,6 @@ class D3DGraphics extends BaseShaderGraphics implements D3DContextSource {
         }
 
         return new D3DGraphics(context, target);
-    }
-
-    @Override
-    public void clearQuad(float x1, float y1, float x2, float y2) {
-        // note that unlike clear(), this method does not currently
-        // attempt to clear the depth buffer...
-        context.setRenderTarget(this);
-        context.flushVertexBuffer();
-        // set the blend mode to CLEAR and any regular Color as paint
-        CompositeMode oldMode = getCompositeMode();
-        setCompositeMode(CompositeMode.CLEAR);
-        Paint oldPaint = getPaint();
-        setPaint(Color.BLACK); // any color will do...
-        fillQuad(x1, y1, x2, y2);
-        context.flushVertexBuffer();
-        // restore prior paint and blend mode
-        setPaint(oldPaint);
-        setCompositeMode(oldMode);
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Graphics.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Graphics.java
@@ -27,12 +27,10 @@ package com.sun.prism.es2;
 
 import com.sun.javafx.geom.transform.BaseTransform;
 import com.sun.javafx.sg.prism.NGCamera;
-import com.sun.prism.CompositeMode;
 import com.sun.prism.GraphicsPipeline;
 import com.sun.prism.RenderTarget;
 import com.sun.prism.impl.ps.BaseShaderGraphics;
 import com.sun.prism.paint.Color;
-import com.sun.prism.paint.Paint;
 
 public class ES2Graphics extends BaseShaderGraphics {
 
@@ -55,24 +53,6 @@ public class ES2Graphics extends BaseShaderGraphics {
         context.getGLContext().clearBuffers(color, clearColor, clearDepth,
                 ignoreScissor);
 
-    }
-
-    @Override
-    public void clearQuad(float x1, float y1, float x2, float y2) {
-        // note that unlike clear(), this method does not currently
-        // attempt to clear the depth buffer...
-        context.setRenderTarget(this);
-        context.flushVertexBuffer();
-        CompositeMode mode = getCompositeMode();
-        // set the blend mode to CLEAR
-        setCompositeMode(CompositeMode.CLEAR);
-        Paint oldPaint = getPaint();
-        setPaint(Color.BLACK); // any color will do...
-        fillQuad(x1, y1, x2, y2);
-        context.flushVertexBuffer();
-        setPaint(oldPaint);
-        // restore default blend mode
-        setCompositeMode(mode);
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/ps/BaseShaderGraphics.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/ps/BaseShaderGraphics.java
@@ -126,6 +126,24 @@ public abstract class BaseShaderGraphics
     public final NGLightBase[] getLights() { return this.lights; }
 
     @Override
+    public void clearQuad(float x1, float y1, float x2, float y2) {
+        // note that unlike clear(), this method does not currently
+        // attempt to clear the depth buffer...
+        context.setRenderTarget(this);
+        context.flushVertexBuffer();
+        // set the blend mode to CLEAR and any regular Color as paint
+        CompositeMode oldMode = getCompositeMode();
+        setCompositeMode(CompositeMode.CLEAR);
+        Paint oldPaint = getPaint();
+        setPaint(Color.BLACK); // any color will do...
+        fillQuad(x1, y1, x2, y2);
+        context.flushVertexBuffer();
+        // restore prior paint and blend mode
+        setPaint(oldPaint);
+        setCompositeMode(oldMode);
+    }
+
+    @Override
     public void drawTexture(Texture tex,
                             float dx1, float dy1, float dx2, float dy2,
                             float sx1, float sy1, float sx2, float sy2)


### PR DESCRIPTION
As mentioned in JBS, the `clearQuad` methods in `D3DGraphics` and `ES2Graphics` are now identical, which should have been the case all along. The fact that they weren't identical was the source of a bug that was only discovered during the testing of [JDK-8090547](https://bugs.openjdk.java.net/browse/JDK-8090547) on the es2 pipeline.

This PR moves the `clearQuad` method to the `BaseShaderGraphics` superclass to get rid of the unnecessary code duplication. This will be helpful when implementing the metal pipeline as well. As a note, I made the `context` field in the `D3DGraphics` final, which it should have been. This is necessary to ensure that moving the method to the super-class is equivalent.

No new tests are needed, since this is just refactoring.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273946](https://bugs.openjdk.java.net/browse/JDK-8273946): Move clearQuad method to BaseShaderGraphics superclass


### Reviewers
 * [Jose Pereda](https://openjdk.java.net/census#jpereda) (@jperedadnr - Committer)
 * [Nir Lisker](https://openjdk.java.net/census#nlisker) (@nlisker - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/628/head:pull/628` \
`$ git checkout pull/628`

Update a local copy of the PR: \
`$ git checkout pull/628` \
`$ git pull https://git.openjdk.java.net/jfx pull/628/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 628`

View PR using the GUI difftool: \
`$ git pr show -t 628`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/628.diff">https://git.openjdk.java.net/jfx/pull/628.diff</a>

</details>
