### PR TITLE
8274137: TableView scrollbar/header misaligned when reloading data

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -2336,7 +2336,6 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
     }
 
     void updateHbar() {
-        if (! isVisible() || getScene() == null) return;
         // Bring the clipView.clipX back to 0 if control is vertical or
         // the hbar isn't visible (fix for RT-11666)
         if (isVertical()) {

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/VirtualFlowShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/VirtualFlowShim.java
@@ -84,6 +84,10 @@ public class VirtualFlowShim<T extends IndexedCell> extends VirtualFlow<T> {
     public double get_clipView_getHeight() {
         return super.clipView.getHeight();
     }
+    
+    public double get_clipView_getX() {
+    	return - super.clipView.getLayoutX();
+    }
 
 
     public StackPane get_corner() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -40,10 +40,12 @@ import javafx.beans.InvalidationListener;
 import javafx.event.Event;
 import javafx.scene.control.IndexedCell;
 import javafx.scene.Node;
+import javafx.scene.Scene;
 import javafx.scene.shape.Circle;
 
 import test.javafx.scene.control.SkinStub;
 import javafx.scene.input.ScrollEvent;
+import javafx.scene.layout.HBox;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -1317,6 +1319,33 @@ public class VirtualFlowTest {
             if (cell != null) assertFalse(cell.isVisible());
         }
     }
+        
+    @Test public void testScrollBarClipSyncWhileInvisibleOrNoScene() {
+        flow.setCellCount(3);
+        flow.resize(50, flow.getHeight());
+        pulse();
+    	
+        flow.setVisible(true);
+        Scene scene = new Scene(flow);
+        // sync works with both scene in place and flow visible
+        assertEquals(flow.shim_getHbar().getValue(), flow.get_clipView_getX(), 0);
+        flow.shim_getHbar().setValue(42);
+        assertEquals(flow.shim_getHbar().getValue(), flow.get_clipView_getX(), 0);
+        
+        // sync works with flow invisible
+        flow.setVisible(false);
+        flow.shim_getHbar().setValue(21);
+        flow.setVisible(true);
+        assertEquals(flow.shim_getHbar().getValue(), flow.get_clipView_getX(), 0);
+        
+        // sync works with no scene
+        scene.setRoot(new HBox());
+        assertEquals(null, flow.getScene());
+        flow.shim_getHbar().setValue(10);
+        scene.setRoot(flow);
+        assertEquals(flow.shim_getHbar().getValue(), flow.get_clipView_getX(), 0);        
+    }
+    
 }
 
 class GraphicalCellStub extends IndexedCellShim<Node> {


### PR DESCRIPTION
This PR fixes JDK-8274137 by removing the optimization from updateHbar() that will no-op the method in case the VirtualFlow is invisible or currently has no scene.
Since changes to the hBar's value can happen even if the VirtualFlow is not currently visible, the synchronisation between hBar and clipX must happen all the time.

A test agains VirtualFlow has been added that will fail before the change and pass afterwards.