### PR TITLE
8274061: Tree-/TableRowSkin: misbehavior on switching skin

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkin.java
@@ -30,28 +30,24 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.TableRowBehavior;
+
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.property.DoubleProperty;
-import javafx.scene.control.Accordion;
-import javafx.scene.control.Button;
-import javafx.scene.control.TableCell;
-import javafx.scene.control.TableColumn;
-import javafx.scene.control.TablePosition;
-import javafx.scene.control.TableRow;
-import javafx.scene.control.TableView;
-
-import com.sun.javafx.scene.control.behavior.TableRowBehavior;
-
-import javafx.beans.property.ObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.AccessibleAttribute;
 import javafx.scene.Node;
 import javafx.scene.control.Control;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableColumnBase;
+import javafx.scene.control.TablePosition;
+import javafx.scene.control.TableRow;
+import javafx.scene.control.TableView;
 import javafx.scene.control.TableView.TableViewFocusModel;
-import javafx.scene.control.TreeTableView;
+import javafx.scene.layout.Region;
 
 /**
  * Default skin implementation for the {@link TableRow} control.
@@ -105,38 +101,7 @@ public class TableRowSkin<T> extends TableRowSkinBase<T, TableRow<T>, TableCell<
             }
         });
 
-        setupTreeTableViewListeners();
     }
-
-    private void setupTreeTableViewListeners() {
-        TableView<T> tableView = getSkinnable().getTableView();
-        if (tableView == null) {
-            getSkinnable().tableViewProperty().addListener(new InvalidationListener() {
-                @Override public void invalidated(Observable observable) {
-                    getSkinnable().tableViewProperty().removeListener(this);
-                    setupTreeTableViewListeners();
-                }
-            });
-        } else {
-            DoubleProperty fixedCellSizeProperty = tableView.fixedCellSizeProperty();
-            if (fixedCellSizeProperty != null) {
-                registerChangeListener(fixedCellSizeProperty, e -> {
-                    fixedCellSize = fixedCellSizeProperty.get();
-                    fixedCellSizeEnabled = fixedCellSize > 0;
-                });
-                fixedCellSize = fixedCellSizeProperty.get();
-                fixedCellSizeEnabled = fixedCellSize > 0;
-
-                // JDK-8144500:
-                // When in fixed cell size mode, we must listen to the width of the virtual flow, so
-                // that when it changes, we can appropriately add / remove cells that may or may not
-                // be required (because we remove all cells that are not visible).
-                registerChangeListener(getVirtualFlow().widthProperty(), e -> tableView.requestLayout());
-            }
-        }
-    }
-
-
 
     /* *************************************************************************
      *                                                                         *
@@ -207,6 +172,11 @@ public class TableRowSkin<T> extends TableRowSkinBase<T, TableRow<T>, TableCell<
      *                                                                         *
      **************************************************************************/
 
+    @Override
+    double getFixedCellSize() {
+        return getTableView() != null ? getTableView().getFixedCellSize() : Region.USE_COMPUTED_SIZE ;
+    }
+
     /** {@inheritDoc} */
     @Override protected TableCell<T, ?> createCell(TableColumnBase tcb) {
         TableColumn tableColumn = (TableColumn<T,?>) tcb;
@@ -243,6 +213,13 @@ public class TableRowSkin<T> extends TableRowSkinBase<T, TableRow<T>, TableCell<
         TableView<T> tableView = getSkinnable().getTableView();
         if (tableView != null && tableView.getSkin() instanceof TableViewSkin) {
             tableViewSkin = (TableViewSkin)tableView.getSkin();
+            registerChangeListener(getVirtualFlow().widthProperty(), e -> tableView.requestLayout());
         }
     }
+
+    // test-only
+    TableViewSkin<T> getTableViewSkin() {
+        return tableViewSkin;
+    }
+
 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkin.java
@@ -213,6 +213,10 @@ public class TableRowSkin<T> extends TableRowSkinBase<T, TableRow<T>, TableCell<
         TableView<T> tableView = getSkinnable().getTableView();
         if (tableView != null && tableView.getSkin() instanceof TableViewSkin) {
             tableViewSkin = (TableViewSkin)tableView.getSkin();
+            // JDK-8144500:
+            // When in fixed cell size mode, we must listen to the width of the virtual flow, so
+            // that when it changes, we can appropriately add / remove cells that may or may not
+            // be required (because we remove all cells that are not visible).
             registerChangeListener(getVirtualFlow().widthProperty(), e -> tableView.requestLayout());
         }
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableRowSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableRowSkin.java
@@ -129,7 +129,7 @@ public class TreeTableRowSkin<T> extends TableRowSkinBase<TreeItem<T>, TreeTable
             registerChangeListener(treeTableView.treeColumnProperty(), e -> {
                 // Fix for RT-27782: Need to set isDirty to true, rather than the
                 // cheaper updateCells, as otherwise the text indentation will not
-                // be recalculated in TreeTableCellSkin.leftLabelPadding()
+                // be recalculated in TreeTableCellSkin.calculateIndentation()
                 isDirty = true;
                 getSkinnable().requestLayout();
             });

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableRowSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableRowSkin.java
@@ -295,10 +295,7 @@ public class TreeTableRowSkin<T> extends TableRowSkinBase<TreeItem<T>, TreeTable
 
     /** {@inheritDoc} */
     @Override protected ObjectProperty<Node> graphicProperty() {
-        TreeTableRow<T> treeTableRow = getSkinnable();
-        // FIXME: illegal access if skinnable is null
         if (treeItem == null) return null;
-
         return treeItem.graphicProperty();
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableRowSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableRowSkin.java
@@ -369,6 +369,10 @@ public class TreeTableRowSkin<T> extends TableRowSkinBase<TreeItem<T>, TreeTable
         }
         if (tableView != null && tableView.getSkin() instanceof TreeTableViewSkin) {
             treeTableViewSkin = (TreeTableViewSkin)tableView.getSkin();
+            // JDK-8144500:
+            // When in fixed cell size mode, we must listen to the width of the virtual flow, so
+            // that when it changes, we can appropriately add / remove cells that may or may not
+            // be required (because we remove all cells that are not visible).
             registerChangeListener(getVirtualFlow().widthProperty(), e -> tableView.requestLayout());
         }
     }

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/SkinBaseShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/SkinBaseShim.java
@@ -28,7 +28,9 @@ package javafx.scene.control;
 import java.util.List;
 import java.util.function.Consumer;
 
+import javafx.beans.Observable;
 import javafx.beans.value.ObservableValue;
+import javafx.collections.ListChangeListener.Change;
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
 
@@ -38,23 +40,23 @@ public class SkinBaseShim<C extends Control> extends SkinBase<C> {
         super(control);
     }
 
-//--------------- statics --------------
+    //--------------- statics --------------
 
-    public static List<Node> getChildren(SkinBase skin) {
+    public static List<Node> getChildren(SkinBase<?> skin) {
         return skin.getChildren();
     }
 
 //-------------- access listener api
 
-    public static Consumer<ObservableValue<?>> unregisterChangeListeners(SkinBase skin, ObservableValue<?> ov) {
+    public static Consumer<ObservableValue<?>> unregisterChangeListeners(SkinBase<?> skin, ObservableValue<?> ov) {
         return skin.unregisterChangeListeners(ov);
     }
 
-    public static Consumer<ObservableValue<?>> unregisterInvalidationListeners(SkinBase skin, ObservableValue<?> ov) {
-        return skin.unregisterChangeListeners(ov);
+    public static Consumer<Observable> unregisterInvalidationListeners(SkinBase<?> skin, Observable ov) {
+        return skin.unregisterInvalidationListeners(ov);
     }
 
-    public static Consumer<ObservableList<?>> unregisterListChangeListeners(SkinBase skin, ObservableList<?> ov) {
+    public static Consumer<Change<?>> unregisterListChangeListeners(SkinBase<?> skin, ObservableList<?> ov) {
         return skin.unregisterListChangeListeners(ov);
     }
 

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/SkinBaseShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/SkinBaseShim.java
@@ -26,6 +26,10 @@
 package javafx.scene.control;
 
 import java.util.List;
+import java.util.function.Consumer;
+
+import javafx.beans.value.ObservableValue;
+import javafx.collections.ObservableList;
 import javafx.scene.Node;
 
 public class SkinBaseShim<C extends Control> extends SkinBase<C> {
@@ -34,9 +38,24 @@ public class SkinBaseShim<C extends Control> extends SkinBase<C> {
         super(control);
     }
 
-    //--------------- statics --------------
+//--------------- statics --------------
 
     public static List<Node> getChildren(SkinBase skin) {
         return skin.getChildren();
     }
+
+//-------------- access listener api
+
+    public static Consumer<ObservableValue<?>> unregisterChangeListeners(SkinBase skin, ObservableValue<?> ov) {
+        return skin.unregisterChangeListeners(ov);
+    }
+
+    public static Consumer<ObservableValue<?>> unregisterInvalidationListeners(SkinBase skin, ObservableValue<?> ov) {
+        return skin.unregisterChangeListeners(ov);
+    }
+
+    public static Consumer<ObservableList<?>> unregisterListChangeListeners(SkinBase skin, ObservableList<?> ov) {
+        return skin.unregisterListChangeListeners(ov);
+    }
+
 }

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/TableSkinShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/TableSkinShim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/TableSkinShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/TableSkinShim.java
@@ -31,7 +31,6 @@ import javafx.beans.property.ObjectProperty;
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
 import javafx.scene.control.IndexedCell;
-import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
@@ -119,12 +118,12 @@ public class TableSkinShim {
 
     public static <T> boolean isFixedCellSizeEnabled(TableRow<T> tableRow) {
         TableRowSkin<T> skin = (TableRowSkin<T>) tableRow.getSkin();
-        return skin.isFixedCellSizeEnabled();
+        return skin.fixedCellSizeEnabled;
     }
 
     public static <T> boolean isFixedCellSizeEnabled(TreeTableRow<T> tableRow) {
         TreeTableRowSkin<T> skin = (TreeTableRowSkin<T>) tableRow.getSkin();
-        return skin.isFixedCellSizeEnabled();
+        return skin.fixedCellSizeEnabled;
     }
 
     public static <T> boolean isDirty(TableRow<T> tableRow) {

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/TableSkinShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/TableSkinShim.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package javafx.scene.control.skin;
+
+import java.util.List;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.collections.ObservableList;
+import javafx.scene.Node;
+import javafx.scene.control.IndexedCell;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableRow;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeTableRow;
+import javafx.scene.control.TreeTableView;
+
+/**
+ * Utility methods to access package-private api in Table-related skins.
+ */
+public class TableSkinShim {
+
+    /**
+     * Returns the TableHeaderRow of the skin's table if that is of type TableViewSkinBase
+     * or null if not.
+     *
+     * @param <T>
+     * @param table the table to get the TableHeaderRow from
+     * @return the tableHeaderRow of the table's skin or null if the skin not of type
+     *    TableViewSkinBase
+     */
+    public static <T> TableHeaderRow getTableHeaderRow(TableView<T> table) {
+        if (table.getSkin() instanceof TableViewSkinBase) {
+            return getTableHeaderRow((TableViewSkinBase) table.getSkin());
+        }
+        return null;
+    }
+
+    /**
+     * Returns the TableHeaderRow of the given skin.
+     *
+     * @param <T>
+     * @param skin the skin to get the TableHeaderRow from
+     * @return
+     * @throws NullPointerException if skin is null
+     */
+    public static <T> TableHeaderRow getTableHeaderRow(TableViewSkinBase skin) {
+        return skin.getTableHeaderRow();
+    }
+
+    /**
+     * Returns the TableColumnHeader for the given column or null if not available.
+     *
+     * @param <T>
+     * @param column
+     * @return
+     */
+    public static <T> TableColumnHeader getColumnHeaderFor(TableColumn<T, ?> column) {
+        TableView<T> table = column.getTableView();
+        TableHeaderRow tableHeader = getTableHeaderRow(table);
+        if (tableHeader != null) {
+            return tableHeader.getColumnHeaderFor(column);
+        }
+        return null;
+    }
+
+    /**
+     * Returns the VirtualFlow from the table's skin which must be of type
+     * TableViewSkin.
+     */
+    public static VirtualFlow<?> getVirtualFlow(TableView<?> table) {
+        TableViewSkin<?> skin = (TableViewSkin<?>) table.getSkin();
+        return skin.getVirtualFlow();
+    }
+
+    /**
+     * Returns the VirtualFlow from the table's skin which must be of type
+     * TreeTableViewSkin.
+     */
+    public static VirtualFlow<?> getVirtualFlow(TreeTableView<?> table) {
+        TreeTableViewSkin<?> skin = (TreeTableViewSkin<?>) table.getSkin();
+        return skin.getVirtualFlow();
+    }
+
+//    public static <T> TableRow<T> getCell(TableView<T> table, int index) {
+//        VirtualFlow flow = getVirtualFlow(table);
+//        return (TableRow<T>) flow.getCell(index);
+//    }
+//
+//    public static <T> TreeTableRow<T> getCell(TreeTableView<T> table, int index) {
+//        VirtualFlow flow = getVirtualFlow(table);
+//        return (TreeTableRow<T>) flow.getCell(index);
+//    }
+//----------------- Tree/TableRowSkin state
+
+    public static <T> boolean isFixedCellSizeEnabled(TableRow<T> tableRow) {
+        TableRowSkin<T> skin = (TableRowSkin<T>) tableRow.getSkin();
+        return skin.isFixedCellSizeEnabled();
+    }
+
+    public static <T> boolean isFixedCellSizeEnabled(TreeTableRow<T> tableRow) {
+        TreeTableRowSkin<T> skin = (TreeTableRowSkin<T>) tableRow.getSkin();
+        return skin.isFixedCellSizeEnabled();
+    }
+
+    public static <T> boolean isDirty(TableRow<T> tableRow) {
+        TableRowSkin<T> skin = (TableRowSkin<T>) tableRow.getSkin();
+        return skin.isDirty();
+    }
+
+    public static <T> boolean isDirty(TreeTableRow<T> tableRow) {
+        TreeTableRowSkin<T> skin = (TreeTableRowSkin<T>) tableRow.getSkin();
+        return skin.isDirty();
+    }
+
+    public static <T> void setDirty(TableRow<T> tableRow, boolean dirty) {
+        TableRowSkin<T> skin = (TableRowSkin<T>) tableRow.getSkin();
+        skin.setDirty(dirty);
+    }
+
+    public static <T> ObservableList<TableColumn<T, ?>> getVisibleLeafColumns(TableRow<T> tableRow) {
+        TableRowSkin<T> skin = (TableRowSkin<T>) tableRow.getSkin();
+        return skin.getVisibleLeafColumns();
+    }
+
+    public static <T> TableViewSkin<T> getTableViewSkin(TableRow<T> tableRow) {
+        TableRowSkin<T> skin = (TableRowSkin<T>) tableRow.getSkin();
+        return skin.getTableViewSkin();
+    }
+
+    public static <T> TreeTableViewSkin<T> getTableViewSkin(TreeTableRow<T> tableRow) {
+        TreeTableRowSkin<T> skin = (TreeTableRowSkin<T>) tableRow.getSkin();
+        return skin.getTableViewSkin();
+    }
+
+    public static <T> TreeItem<T> getTreeItem(TreeTableRow<T> tableRow) {
+        TreeTableRowSkin<T> skin = (TreeTableRowSkin<T>) tableRow.getSkin();
+        return skin.getTreeItem();
+    }
+
+    public static <T> ObjectProperty<Node> graphicProperty(TreeTableRow<T> tableRow) {
+        TreeTableRowSkin<T> skin = (TreeTableRowSkin<T>) tableRow.getSkin();
+        return skin.graphicProperty();
+    }
+
+
+    public static <T> VirtualFlow<?> getVirtualFlow(TableRow<T> table) {
+        TableRowSkin<T> skin = (TableRowSkin<T>) table.getSkin();
+        return skin.getVirtualFlow();
+    }
+
+    public static <T> VirtualFlow<?> getVirtualFlow(TreeTableRow<T> table) {
+        TreeTableRowSkin<T> skin = (TreeTableRowSkin<T>) table.getSkin();
+        return skin.getVirtualFlow();
+    }
+
+    public static List<IndexedCell<?>> getCells(TableRow tableRow) {
+        TableRowSkin skin = (TableRowSkin) tableRow.getSkin();
+        return skin.cells;
+    }
+
+    public static List<IndexedCell<?>> getCells(TreeTableRow<?> tableRow) {
+        TreeTableRowSkin skin = (TreeTableRowSkin) tableRow.getSkin();
+        return skin.cells;
+    }
+
+
+
+}

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/test/Person.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/test/Person.java
@@ -30,6 +30,8 @@ import javafx.beans.property.ReadOnlyIntegerWrapper;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 
 public class Person {
     private final SimpleBooleanProperty invited;
@@ -106,5 +108,15 @@ public class Person {
 
     @Override public String toString() {
         return getFirstName() + " " + getLastName();
+    }
+
+    public static ObservableList<Person> persons() {
+        return FXCollections.observableArrayList(
+                new Person("Jacob", "Smith", "jacob.smith@example.com"),
+                new Person("Isabella", "Johnson", "isabella.johnson@example.com"),
+                new Person("Ethan", "Williams", "ethan.williams@example.com"),
+                new Person("Emma", "Jones", "emma.jones@example.com"),
+                new Person("Michael", "Brown", "michael.brown@example.com")
+                );
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinCleanupTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinCleanupTest.java
@@ -99,7 +99,8 @@ public class SkinCleanupTest {
 //------------- TreeTableRow
 
     /**
-     * Sanity test: child cells are updated on changing visible columns.
+     * Sanity test: listener to treeColumn working without side-effects
+     * after replacing skin.
      */
     @Test
     public void testTreeTableRowTreeColumnListenerReplaceSkin() {
@@ -113,7 +114,7 @@ public class SkinCleanupTest {
     }
 
     /**
-     * Sanity test: child cells are updated on changing visible columns.
+     * Sanity test: listener to treeColumn working.
      */
     @Test
     public void testTreeTableRowTreeColumnListener() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinMemoryLeakTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinMemoryLeakTest.java
@@ -58,9 +58,7 @@ import javafx.scene.control.Skin;
 import javafx.scene.control.Spinner;
 import javafx.scene.control.SplitMenuButton;
 import javafx.scene.control.SplitPane;
-import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
-import javafx.scene.control.TreeTableRow;
 import javafx.scene.control.TreeTableView;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
@@ -144,9 +142,7 @@ public class SkinMemoryLeakTest {
                 Spinner.class,
                 SplitMenuButton.class,
                 SplitPane.class,
-                TableRow.class,
                 TableView.class,
-                TreeTableRow.class,
                 TreeTableView.class
         );
         // remove the known issues to make the test pass


### PR DESCRIPTION
Cleanup of Tree-/TableRowSkin to support switching skins

The misbehavior/s
- memory leaks due to manually registered listeners that were not removed
- side-effects due to listeners still active on old skin (like NPEs)

Fix
- use skin api for all listener registration (for automatic removal in dispose)
- ~~do not install listeners that are not needed (fixedCellSize, same as in fix of ListCellSkin [JDK-8246745](https://bugs.openjdk.java.net/browse/JDK-8246745))~~ not handled here, see [JDK-8277000](https://bugs.openjdk.java.net/browse/JDK-8277000)

Added tests for each listener involved in the fix to guarantee it's still working and does not have unwanted side-effects after switching skins.

Note: there are pecularities in row skins (like not updating themselves on property changes of its control, throwing NPEs when not added to a VirtualFlow) which are not part of this issue but covered in [JDK-8274065](https://bugs.openjdk.java.net/browse/JDK-8274065)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274061](https://bugs.openjdk.java.net/browse/JDK-8274061): Tree-/TableRowSkin: misbehavior on switching skin


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/632/head:pull/632` \
`$ git checkout pull/632`

Update a local copy of the PR: \
`$ git checkout pull/632` \
`$ git pull https://git.openjdk.java.net/jfx pull/632/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 632`

View PR using the GUI difftool: \
`$ git pr show -t 632`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/632.diff">https://git.openjdk.java.net/jfx/pull/632.diff</a>

</details>
