### PR TITLE
8274433: All Cells: misbehavior of startEdit

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -368,6 +368,7 @@ public class ListCell<T> extends IndexedCell<T> {
         // by calling super.startEdit().
         super.startEdit();
 
+        if (!isEditing()) return;
          // Inform the ListView of the edit starting.
         if (list != null) {
             list.fireEvent(new ListView.EditEvent<T>(list,

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
@@ -331,6 +331,7 @@ public class TableCell<S,T> extends IndexedCell<T> {
         // by calling super.startEdit().
         super.startEdit();
 
+        if (!isEditing()) return;
         editingCellAtStartEdit = new TablePosition<>(table, getIndex(), column);
         if (column != null) {
             CellEditEvent<S,?> editEvent = new CellEditEvent<>(

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeCell.java
@@ -376,6 +376,7 @@ public class TreeCell<T> extends IndexedCell<T> {
         // by calling super.startEdit().
         super.startEdit();
 
+        if (!isEditing()) return;
          // Inform the TreeView of the edit starting.
         if (tree != null) {
             tree.fireEvent(new TreeView.EditEvent<T>(tree,

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
@@ -348,6 +348,7 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
         // by calling super.startEdit().
         super.startEdit();
 
+        if (!isEditing()) return;
         editingCellAtStartEdit = new TreeTablePosition<>(table, getIndex(), column);
         if (column != null) {
             CellEditEvent<S, T> editEvent = new CellEditEvent<>(

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -857,7 +857,7 @@ public class ListCellTest {
         list.setEditable(true);
         cell.updateListView(list);
         cell.updateIndex(list.getItems().size());
-        List<EditEvent> events = new ArrayList<>();
+        List<EditEvent<?>> events = new ArrayList<>();
         list.addEventHandler(ListView.editStartEvent(), events::add);
         cell.startEdit();
         assertFalse("sanity: off-range cell must not be editing", cell.isEditing());
@@ -871,7 +871,7 @@ public class ListCellTest {
         cell.updateIndex(list.getItems().size());
         cell.startEdit();
         assertFalse("sanity: off-range cell must not be editing", cell.isEditing());
-        assertEquals("list editing location must not be updated", - 1, list.getEditingIndex());
+        assertEquals("list editing location must not be updated", -1, list.getEditingIndex());
     }
 
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -852,6 +852,28 @@ public class ListCellTest {
         assertEquals("editing location of cancel event", editingIndex, events.get(0).getIndex());
     }
 
+    @Test
+    public void testStartEditOffRangeMustNotFireStartEdit() {
+        list.setEditable(true);
+        cell.updateListView(list);
+        cell.updateIndex(list.getItems().size());
+        List<EditEvent> events = new ArrayList<>();
+        list.addEventHandler(ListView.editStartEvent(), events::add);
+        cell.startEdit();
+        assertFalse("sanity: off-range cell must not be editing", cell.isEditing());
+        assertEquals("must not fire editStart", 0, events.size());
+    }
+
+    @Test
+    public void testStartEditOffRangeMustNotUpdateEditingLocation() {
+        list.setEditable(true);
+        cell.updateListView(list);
+        cell.updateIndex(list.getItems().size());
+        cell.startEdit();
+        assertFalse("sanity: off-range cell must not be editing", cell.isEditing());
+        assertEquals("list editing location must not be updated", - 1, list.getEditingIndex());
+    }
+
 
     // When the list view item's change and affects a cell that is editing, then what?
     // When the list cell's index is changed while it is editing, then what?

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.sun.javafx.tk.Toolkit;
@@ -699,6 +700,34 @@ public class TableCellTest {
          setupForcedEditing(null, null);
          cell.startEdit();
          cell.commitEdit("edited");
+     }
+
+     @Test
+     public void testStartEditOffRangeMustNotFireStartEdit() {
+         setupForEditing();
+         int editingRow = table.getItems().size();
+         cell.updateIndex(editingRow);
+         List<CellEditEvent> events = new ArrayList<>();
+         editingColumn.addEventHandler(TableColumn.editStartEvent(), events::add);
+         cell.startEdit();
+         assertFalse("sanity: off-range cell must not be editing", cell.isEditing());
+         assertEquals("must not fire editStart", 0, events.size());
+     }
+
+     /**
+      *  Note: this is a false green until JDK-8187474 (update control editing location) is fixed
+      */
+     @Ignore("JDK-8187474")
+     @Test
+     public void testStartEditOffRangeMustNotUpdateEditingLocation() {
+         setupForEditing();
+         int editingRow = table.getItems().size();
+         cell.updateIndex(editingRow);
+         List<CellEditEvent> events = new ArrayList<>();
+         editingColumn.addEventHandler(TableColumn.editStartEvent(), events::add);
+         cell.startEdit();
+         assertFalse("sanity: off-range cell must not be editing", cell.isEditing());
+         assertNull("table editing location must not be updated", table.getEditingCell());
      }
 
  //--------- test the test setup

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
@@ -707,7 +707,7 @@ public class TableCellTest {
          setupForEditing();
          int editingRow = table.getItems().size();
          cell.updateIndex(editingRow);
-         List<CellEditEvent> events = new ArrayList<>();
+         List<CellEditEvent<?, ?>> events = new ArrayList<>();
          editingColumn.addEventHandler(TableColumn.editStartEvent(), events::add);
          cell.startEdit();
          assertFalse("sanity: off-range cell must not be editing", cell.isEditing());
@@ -723,8 +723,6 @@ public class TableCellTest {
          setupForEditing();
          int editingRow = table.getItems().size();
          cell.updateIndex(editingRow);
-         List<CellEditEvent> events = new ArrayList<>();
-         editingColumn.addEventHandler(TableColumn.editStartEvent(), events::add);
          cell.startEdit();
          assertFalse("sanity: off-range cell must not be editing", cell.isEditing());
          assertNull("table editing location must not be updated", table.getEditingCell());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellTest.java
@@ -849,7 +849,7 @@ public class TreeCellTest {
         tree.setEditable(true);
         cell.updateTreeView(tree);
         cell.updateIndex(tree.getExpandedItemCount());
-        List<EditEvent> events = new ArrayList<>();
+        List<EditEvent<?>> events = new ArrayList<>();
         tree.addEventHandler(TreeView.editStartEvent(), events::add);
         cell.startEdit();
         assertFalse("sanity: off-range cell must not be editing", cell.isEditing());
@@ -867,7 +867,7 @@ public class TreeCellTest {
         cell.updateIndex(tree.getExpandedItemCount());
         cell.startEdit();
         assertFalse("sanity: off-range cell must not be editing", cell.isEditing());
-        assertEquals("editing location", null, tree.getEditingItem());
+        assertNull("tree editing location must not be updated", tree.getEditingItem());
     }
 
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellTest.java
@@ -844,6 +844,33 @@ public class TreeCellTest {
         assertEquals("treeItem must be gc'ed", null, itemRef.get());
     }
 
+    @Test
+    public void testStartEditOffRangeMustNotFireStartEdit() {
+        tree.setEditable(true);
+        cell.updateTreeView(tree);
+        cell.updateIndex(tree.getExpandedItemCount());
+        List<EditEvent> events = new ArrayList<>();
+        tree.addEventHandler(TreeView.editStartEvent(), events::add);
+        cell.startEdit();
+        assertFalse("sanity: off-range cell must not be editing", cell.isEditing());
+        assertEquals("cell must not fire editStart if not editing", 0, events.size());
+    }
+
+    /**
+     *  Note: this is a false green until JDK-8187474 (update control editing location) is fixed
+     */
+    @Ignore("JDK-8187474")
+    @Test
+    public void testStartEditOffRangeMustNotUpdateEditingLocation() {
+        tree.setEditable(true);
+        cell.updateTreeView(tree);
+        cell.updateIndex(tree.getExpandedItemCount());
+        cell.startEdit();
+        assertFalse("sanity: off-range cell must not be editing", cell.isEditing());
+        assertEquals("editing location", null, tree.getEditingItem());
+    }
+
+
     // When the tree view item's change and affects a cell that is editing, then what?
     // When the tree cell's index is changed while it is editing, then what?
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
@@ -1027,6 +1027,31 @@ public class TreeTableCellTest {
          cell.commitEdit("edited");
      }
 
+     @Test
+     public void testStartEditOffRangeMustNotFireStartEdit() {
+         setupForEditing();
+         cell.updateIndex(tree.getExpandedItemCount());
+         List<CellEditEvent> events = new ArrayList<>();
+         editingColumn.addEventHandler(TreeTableColumn.editStartEvent(), events::add);
+         cell.startEdit();
+         assertFalse("sanity: off-range cell must not be editing", cell.isEditing());
+         assertEquals("cell must not fire editStart if not editing", 0, events.size());
+     }
+
+     /**
+      *  Note: this would be a false green until JDK-8187474 (update control editing location) is fixed
+      */
+     @Ignore("JDK-8187474")
+     @Test
+     public void testStartEditOffRangeMustNotUpdateEditingLocation() {
+         setupForEditing();
+         cell.updateIndex(tree.getExpandedItemCount());
+         cell.startEdit();
+         assertFalse("sanity: off-range cell must not be editing", cell.isEditing());
+         assertEquals("editing location", null, tree.getEditingCell());
+     }
+
+
  //--------- test the test setup
 
      @Test

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
@@ -1031,7 +1031,7 @@ public class TreeTableCellTest {
      public void testStartEditOffRangeMustNotFireStartEdit() {
          setupForEditing();
          cell.updateIndex(tree.getExpandedItemCount());
-         List<CellEditEvent> events = new ArrayList<>();
+         List<CellEditEvent<?, ?>> events = new ArrayList<>();
          editingColumn.addEventHandler(TreeTableColumn.editStartEvent(), events::add);
          cell.startEdit();
          assertFalse("sanity: off-range cell must not be editing", cell.isEditing());
@@ -1048,7 +1048,7 @@ public class TreeTableCellTest {
          cell.updateIndex(tree.getExpandedItemCount());
          cell.startEdit();
          assertFalse("sanity: off-range cell must not be editing", cell.isEditing());
-         assertEquals("editing location", null, tree.getEditingCell());
+         assertNull("treetable editing location must not be updated", tree.getEditingCell());
      }
 
 


### PR DESCRIPTION
The misbehavior happens if (super) startEdit didn't succeed (== !cell.isEditing):

- must not fire editStart event
- must not update control's editing location

fix is to back out of startEdit if super.startEdit doesn't switch the cell into editing mode

Added tests that failed/passed before/after the fix. Note that for Tree-, Table-, TreeTableCell one of the added tests would be a false green due to those cells not updating the editing location on its control [JDK-8187474](https://bugs.openjdk.java.net/browse/JDK-8187474), so it's ignore until that's fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274433](https://bugs.openjdk.java.net/browse/JDK-8274433): All Cells: misbehavior of startEdit


### Reviewers
 * [Marius Hanl](https://openjdk.java.net/census#mhanl) (@Maran23 - Author)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/636/head:pull/636` \
`$ git checkout pull/636`

Update a local copy of the PR: \
`$ git checkout pull/636` \
`$ git pull https://git.openjdk.java.net/jfx pull/636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 636`

View PR using the GUI difftool: \
`$ git pr show -t 636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/636.diff">https://git.openjdk.java.net/jfx/pull/636.diff</a>

</details>
