### PR TITLE
8274669: Dialog sometimes ignores max height

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/DialogPane.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/DialogPane.java
@@ -847,7 +847,7 @@ public class DialogPane extends Pane {
         double h;
 
         if (prefHeight > currentHeight && prefHeight > minHeight && (prefHeight <= dialogHeight || dialogHeight == 0)) {
-            h = prefHeight;
+            h = Utils.boundedSize(prefHeight, minHeight, maxHeight);
             resize(w, h);
         } else {
             boolean isDialogGrowing = currentHeight > oldHeight;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/DialogTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/DialogTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.javafx.scene.control;
+
+import com.sun.javafx.tk.Toolkit;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Dialog;
+import javafx.scene.layout.StackPane;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/** Tests for the {@link Dialog} class. */
+public class DialogTest {
+
+    private Dialog<ButtonType> dialog;
+
+    @Before
+    public void setUp() {
+        dialog = new Dialog<>();
+    }
+
+    @After
+    public void cleanUp() {
+        // Set a dummy result so the dialog can be closed.
+        dialog.setResult(new ButtonType(""));
+        dialog.hide();
+    }
+
+    @Test
+    public void testDialogMaxHeight() {
+        int maxHeight = 400;
+
+        StackPane stackPane = new StackPane();
+        stackPane.setPrefHeight(700);
+
+        dialog.getDialogPane().setContent(stackPane);
+        dialog.getDialogPane().setMaxHeight(maxHeight);
+        dialog.show();
+
+        assertDialogPaneHeightEquals(maxHeight);
+
+        assertEquals(maxHeight, dialog.getDialogPane().getMaxHeight(), 0);
+    }
+
+    @Test
+    public void testDialogMinHeight() {
+        int minHeight = 400;
+
+        dialog.getDialogPane().setContent(new StackPane());
+        dialog.getDialogPane().setMinHeight(minHeight);
+        dialog.show();
+
+        assertDialogPaneHeightEquals(minHeight);
+
+        assertEquals(minHeight, dialog.getDialogPane().getMinHeight(), 0);
+    }
+
+    @Test
+    public void testDialogPrefHeight() {
+        int prefHeight = 400;
+
+        dialog.getDialogPane().setContent(new StackPane());
+        dialog.getDialogPane().setPrefHeight(prefHeight);
+        dialog.show();
+
+        assertDialogPaneHeightEquals(prefHeight);
+
+        assertEquals(prefHeight, dialog.getDialogPane().getPrefHeight(), 0);
+    }
+
+    private void assertDialogPaneHeightEquals(int height) {
+        Toolkit.getToolkit().firePulse();
+
+        assertEquals(height, dialog.getDialogPane().getHeight(), 0);
+
+        // Test the height after another layout pass.
+        Toolkit.getToolkit().firePulse();
+
+        assertEquals(height, dialog.getDialogPane().getHeight(), 0);
+    }
+
+}


### PR DESCRIPTION
This PR fixes a visual glitch which may happen when showing a dialog.
When a max height is set and the pref height of the dialog content is bigger the dialog starts to flicker between the max height and the pref height.

This happens because in one case the height is not bound between the min and the max height (-> max height is ignored).
- First layout pass: The dialog will incorrectly resize to a the pref height, which is bigger than the max height
- Second layout pass: The dialog will correctly resize to the max height
- repeat

The fix is to bound the height there as well (Fix in **layoutChildren()**).
Example where a red stackpane has a bigger pref height then the max height of the dialog (see also example in ticket):

https://user-images.githubusercontent.com/66004280/135734463-03b422f4-710d-4436-9715-c91bdb768d76.mp4