### PR TITLE
8187474: Tree-/TableCell, TreeCell: editingCell/Item not updated in cell.startEdit

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -369,17 +369,18 @@ public class ListCell<T> extends IndexedCell<T> {
         super.startEdit();
 
         if (!isEditing()) return;
+
+        indexAtStartEdit = getIndex();
          // Inform the ListView of the edit starting.
         if (list != null) {
             list.fireEvent(new ListView.EditEvent<T>(list,
                     ListView.<T>editStartEvent(),
                     null,
-                    getIndex()));
-            list.edit(getIndex());
+                    indexAtStartEdit));
+            list.edit(indexAtStartEdit);
             list.requestFocus();
         }
 
-        indexAtStartEdit = getIndex();
     }
 
     /** {@inheritDoc} */

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
@@ -332,6 +332,7 @@ public class TableCell<S,T> extends IndexedCell<T> {
         super.startEdit();
 
         if (!isEditing()) return;
+
         editingCellAtStartEdit = new TablePosition<>(table, getIndex(), column);
         if (column != null) {
             CellEditEvent<S,?> editEvent = new CellEditEvent<>(
@@ -342,6 +343,9 @@ public class TableCell<S,T> extends IndexedCell<T> {
             );
 
             Event.fireEvent(column, editEvent);
+        }
+        if (table != null) {
+            table.edit(editingCellAtStartEdit.getRow(), editingCellAtStartEdit.getTableColumn());
         }
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeCell.java
@@ -377,17 +377,18 @@ public class TreeCell<T> extends IndexedCell<T> {
         super.startEdit();
 
         if (!isEditing()) return;
+
+        treeItemAtStartEdit = getTreeItem();
          // Inform the TreeView of the edit starting.
         if (tree != null) {
             tree.fireEvent(new TreeView.EditEvent<T>(tree,
                     TreeView.<T>editStartEvent(),
-                    getTreeItem(),
+                    treeItemAtStartEdit,
                     getItem(),
                     null));
-
+            tree.edit(treeItemAtStartEdit);
             tree.requestFocus();
         }
-        treeItemAtStartEdit = getTreeItem();
     }
 
      /** {@inheritDoc} */

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
@@ -349,6 +349,7 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
         super.startEdit();
 
         if (!isEditing()) return;
+
         editingCellAtStartEdit = new TreeTablePosition<>(table, getIndex(), column);
         if (column != null) {
             CellEditEvent<S, T> editEvent = new CellEditEvent<>(
@@ -359,6 +360,9 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
             );
 
             Event.fireEvent(column, editEvent);
+        }
+        if (table != null) {
+            table.edit(editingCellAtStartEdit.getRow(), editingCellAtStartEdit.getTableColumn());
         }
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
@@ -542,6 +542,28 @@ public class TableCellTest {
     }
 
     @Test
+    public void testEditStartOnCellUpdatesControl() {
+        setupForEditing();
+        int editingRow = 1;
+        cell.updateIndex(editingRow);
+        TablePosition<?,?> editingCell = new TablePosition<>(table, editingRow, editingColumn);
+        cell.startEdit();
+        assertEquals("table must be editing at", editingCell, table.getEditingCell());
+    }
+
+    @Test
+    public void testEditStartOnCellNoColumnUpdatesControl() {
+        int editingRow = 1;
+        // note: cell index must be != -1 because table.edit(-1, null) sets editingCell to null
+        cell.updateIndex(editingRow);
+        setupForcedEditing(table, null);
+        TablePosition<?,?> editingCell = new TablePosition<>(table, editingRow, null);
+        cell.startEdit();
+        assertTrue(cell.isEditing());
+        assertEquals("table must be editing at", editingCell, table.getEditingCell());
+    }
+
+    @Test
     public void testEditStartDoesNotFireEventWhileEditing() {
         setupForEditing();
         cell.updateIndex(1);
@@ -586,9 +608,7 @@ public class TableCellTest {
          setupForEditing();
          int editingIndex = 1;
          cell.updateIndex(editingIndex);
-         // FIXME JDK-8187474
-         // should use cell.startEdit for consistency with the following tests
-         table.edit(editingIndex, editingColumn);
+         cell.startEdit();
          TablePosition<?, ?> editingPosition = table.getEditingCell();
          List<CellEditEvent<?, ?>> events = new ArrayList<>();
          editingColumn.setOnEditCommit(events::add);
@@ -714,10 +734,6 @@ public class TableCellTest {
          assertEquals("must not fire editStart", 0, events.size());
      }
 
-     /**
-      *  Note: this is a false green until JDK-8187474 (update control editing location) is fixed
-      */
-     @Ignore("JDK-8187474")
      @Test
      public void testStartEditOffRangeMustNotUpdateEditingLocation() {
          setupForEditing();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellTest.java
@@ -599,7 +599,6 @@ public class TreeCellTest {
         assertNull(tree.getEditingItem());
     }
 
-    @Ignore // TODO file bug!
     @Test public void editCellWithTreeResultsInUpdatedEditingIndexProperty() {
         tree.setEditable(true);
         cell.updateTreeView(tree);
@@ -848,7 +847,8 @@ public class TreeCellTest {
     public void testStartEditOffRangeMustNotFireStartEdit() {
         tree.setEditable(true);
         cell.updateTreeView(tree);
-        cell.updateIndex(tree.getExpandedItemCount());
+        // update cell's treeItem so there is something to update
+        cell.updateTreeItem(new TreeItem<>("not-contained"));
         List<EditEvent<?>> events = new ArrayList<>();
         tree.addEventHandler(TreeView.editStartEvent(), events::add);
         cell.startEdit();
@@ -856,15 +856,12 @@ public class TreeCellTest {
         assertEquals("cell must not fire editStart if not editing", 0, events.size());
     }
 
-    /**
-     *  Note: this is a false green until JDK-8187474 (update control editing location) is fixed
-     */
-    @Ignore("JDK-8187474")
     @Test
     public void testStartEditOffRangeMustNotUpdateEditingLocation() {
         tree.setEditable(true);
         cell.updateTreeView(tree);
-        cell.updateIndex(tree.getExpandedItemCount());
+        // update cell's treeItem so there is something to update
+        cell.updateTreeItem(new TreeItem<>("not-contained"));
         cell.startEdit();
         assertFalse("sanity: off-range cell must not be editing", cell.isEditing());
         assertNull("tree editing location must not be updated", tree.getEditingItem());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
@@ -304,12 +304,20 @@ public class TreeTableCellTest {
         assertNull(tree.getEditingCell());
     }
 
-    @Ignore // TODO file bug!
     @Test public void editCellWithTreeResultsInUpdatedEditingIndexProperty() {
-        tree.setEditable(true);
-        cell.updateTreeTableView(tree);
+        setupForEditing();
         cell.updateIndex(1);
         cell.startEdit();
+        assertEquals(apples, tree.getEditingCell().getTreeItem());
+    }
+
+    @Test public void editCellWithTreeNoColumnResultsInUpdatedEditingIndexProperty() {
+        // note: cell index must be != -1 because table.edit(-1, null) sets editingCell to null
+        cell.updateIndex(1);
+        setupForcedEditing(tree, null);
+        cell.startEdit();
+        assertTrue(cell.isEditing());
+        assertNotNull(tree.getEditingCell());
         assertEquals(apples, tree.getEditingCell().getTreeItem());
     }
 
@@ -911,9 +919,7 @@ public class TreeTableCellTest {
          setupForEditing();
          int editingIndex = 1;
          cell.updateIndex(editingIndex);
-         // FIXME JDK-8187474
-         // should use cell.startEdit for consistency with the following tests
-         tree.edit(editingIndex, editingColumn);
+         cell.startEdit();
          TreeTablePosition<?, ?> editingPosition = tree.getEditingCell();
          List<CellEditEvent<?, ?>> events = new ArrayList<>();
          editingColumn.setOnEditCommit(events::add);
@@ -1038,10 +1044,6 @@ public class TreeTableCellTest {
          assertEquals("cell must not fire editStart if not editing", 0, events.size());
      }
 
-     /**
-      *  Note: this would be a false green until JDK-8187474 (update control editing location) is fixed
-      */
-     @Ignore("JDK-8187474")
      @Test
      public void testStartEditOffRangeMustNotUpdateEditingLocation() {
          setupForEditing();


### PR DESCRIPTION
cell startEdit is supposed to update the editing location on its associated control - was done in ListCell, not in Tree-/TableCell nor TreeCell.

Fix was to add control.edit(..). Note that ListCell was also touched to use the exact same method call pattern as the fixed cell types.

Added/unignored cell tests that are failing/passing before/after the fix.