### PR TITLE
8232812: [MacOS] Double click title bar does not restore window size

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
@@ -183,7 +183,10 @@
 {
     GET_MAIN_JENV;
 
-    if ([window isZoomed]) {
+    // This is called both to zoom a window and to unzoom it. If the window was
+    // zoomed when it was initially created the OS might try to unzoom it to a
+    // very small size.
+    if (newFrame.size.width <= 1 || newFrame.size.height <= 1) {
         return NO;
     }
 


### PR DESCRIPTION
The test case for JDK-8160241 creates a window in a zoomed state (as defined by macOS). When the OS later goes to unzoom the window it will try to shrink it down to 1 point wide. This was entered as JDK-8163137 but the fix for that bug inadvertently disabled unzooming altogether. This PR fixes 8163137 in a slightly different way.

Access to the zoom/unzoom feature has changed with newer versions of macOS. To reproduce this you have to change `System Preferences > Dock & Menu Bar > Double-click a window's title bar` to `zoom`. Then use double-clicks in the title bar to test the feature. The green button in the title bar no longer has anything to do with zoom/unzoom.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8232812](https://bugs.openjdk.java.net/browse/JDK-8232812): [MacOS] Double click title bar does not restore window size


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/639/head:pull/639` \
`$ git checkout pull/639`

Update a local copy of the PR: \
`$ git checkout pull/639` \
`$ git pull https://git.openjdk.java.net/jfx pull/639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 639`

View PR using the GUI difftool: \
`$ git pr show -t 639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/639.diff">https://git.openjdk.java.net/jfx/pull/639.diff</a>

</details>
