### PR TITLE
8274699: Certain blend modes cannot be set from CSS

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
@@ -814,18 +814,12 @@ final public class CssParser {
             ParsedValueImpl value = parseStrokeType(root);
             if (value == null) error(root, "Expected \'centered', \'inside\' or \'outside\'");
             return value;
-        } else if ("-fx-font-smoothing-type".equals(prop)) {
-            // TODO: Figure out a way that these properties don't need to be
-            // special cased.
-            String str = null;
-            int ttype = -1;
-            final Token token = root.token;
+        } else if ("-fx-font-smoothing-type".equals(prop) || "-fx-blend-mode".equals(prop)) {
+            // TODO: Figure out a way that these properties don't need to be special cased.
+            String str = root.token.getText();
+            int ttype = root.token.getType();
 
-            if (root.token == null
-                    || ((ttype = root.token.getType()) != CssLexer.STRING
-                         && ttype != CssLexer.IDENT)
-                    || (str = root.token.getText()) == null
-                    || str.isEmpty()) {
+            if (ttype != CssLexer.STRING && ttype != CssLexer.IDENT || str == null || str.isEmpty()) {
                 error(root,  "Expected STRING or IDENT");
             }
             return new ParsedValueImpl<String, String>(stripQuotes(str), null, false);

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/NodeTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/NodeTest.java
@@ -25,6 +25,7 @@
 
 package test.javafx.scene;
 
+import javafx.scene.effect.BlendMode;
 import test.javafx.scene.shape.TestUtils;
 import test.javafx.scene.shape.CircleTest;
 import com.sun.javafx.geom.PickRay;
@@ -1928,6 +1929,14 @@ public class NodeTest {
         Scene s = new Scene(node);
         node.applyCss();
         assertFalse(node.isManaged());
+    }
+
+    @Test public void testBlendModeSetFromCSS() {
+        final AnchorPane node = new AnchorPane();
+        node.setStyle("-fx-blend-mode: red");
+        new Scene(node);
+        node.applyCss();
+        assertEquals(BlendMode.RED, node.getBlendMode());
     }
 
     private Node createTestRect() {


### PR DESCRIPTION
This PR fixes a bug where the blend mode will be falsely recognized as a color and therefore won't be set. 
Also a ClassCastException is thrown (The converter expects a String, but gets a Color).

Note: There is another similar bug but I can't reproduce this (Tried on 18-ea+3).
https://bugs.openjdk.java.net/browse/JDK-8268657