### PR TITLE
8087370: [odroid] Monocle: Touch is still broken on Odroid

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/TouchPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/TouchPipeline.java
@@ -109,12 +109,14 @@ class TouchPipeline {
         return false;
     }
 
+    private TouchState filterState = new TouchState();
     void pushState(TouchState state) {
         if (MonocleSettings.settings.traceEventsVerbose) {
             MonocleTrace.traceEvent("Pushing %s to %s", state, this);
         }
-        if (!filter(state)) {
-            touch.setState(state);
+        state.copyTo(filterState);
+        if (!filter(filterState)) {
+            touch.setState(filterState);
         }
     }
 


### PR DESCRIPTION
There are sometimes multitouch events detected, when only a single touch should be detected under certain conditions. This lead to touch events on previous touch positions.

The referenced bug is closed with "won't fix" with the justification it would be platform specific. But this is not correct. It affects all Linux platforms combined with a touch controller, which sends the touch events in an uncommon, but valid(!), order.

We encountered this problem with the touch controller ILI2511 with firmware V6000_V1 in the Tianma display TM070JVHG33. This patch fixes the problem. It is the same patch attached to above bug report.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8087370](https://bugs.openjdk.org/browse/JDK-8087370): [odroid] Monocle: Touch is still broken on Odroid (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/641/head:pull/641` \
`$ git checkout pull/641`

Update a local copy of the PR: \
`$ git checkout pull/641` \
`$ git pull https://git.openjdk.org/jfx.git pull/641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 641`

View PR using the GUI difftool: \
`$ git pr show -t 641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/641.diff">https://git.openjdk.org/jfx/pull/641.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/641#issuecomment-1110629346)