### PR TITLE
8236689: macOS 10.15 Catalina: LCD text renders badly

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
@@ -133,7 +133,7 @@ public abstract class PrismFontFactory implements FontFactory {
                         }
                     }
 
-                    boolean lcdTextOff = isIOS || isAndroid || isEmbedded;
+                    boolean lcdTextOff = isMacOSX || isIOS || isAndroid || isEmbedded;
                     String defLCDProp = lcdTextOff ? "false" : "true";
                     String lcdProp = System.getProperty("prism.lcdtext", defLCDProp);
                     lcdEnabled = lcdProp.equals("true");

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTGlyph.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTGlyph.java
@@ -26,6 +26,7 @@
 package com.sun.javafx.font.coretext;
 
 import com.sun.javafx.font.FontResource;
+import com.sun.javafx.font.PrismFontFactory;
 import com.sun.javafx.font.Glyph;
 import com.sun.javafx.geom.RectBounds;
 import com.sun.javafx.geom.Shape;
@@ -39,7 +40,7 @@ class CTGlyph implements Glyph {
     private boolean drawShapes;
 
     /* Always using BRGA context has the same performance as gray */
-    private static boolean LCD_CONTEXT = true;
+    private static boolean LCD_CONTEXT = PrismFontFactory.getFontFactory().isLCDTextSupported();
     private static boolean CACHE_CONTEXT = true;
 
     private static long cachedContextRef;


### PR DESCRIPTION
On an external (non-retina) monitor JavaFX LCD text on macOS is painful on the eyes.
Retina diminishes it rather than cures it.

The problem is a mix of a couple of things
1) CoreText no longer generates LCD glyphs (except perhaps if you change some system settings at your own risk)
2) Prism's LCD shader assumes it got LCD glyphs and makes sub-pixel positioning adjustments that turn greyscale
glyphs into multi-coloured glyphs that weren't meant to be ...

The fix here is to just disable LCD by default on macOS as is already done (eg) on iOS
This ripples through to make everything use grey scale even if you asked for the LCD (which you can't have)
It also means if you REALLY want it (and perhaps are tweaking those magical settings) you can have it back
by just specifying -Dprism.lcdtext=on

Also it means the pieces of support for this on macos are still there if Apple ever bring it back (unlikely).
Not that much code would be removed anyway .. a fair amount of it is needed for Windows and Linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8236689](https://bugs.openjdk.java.net/browse/JDK-8236689): macOS 10.15 Catalina: LCD text renders badly


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/642/head:pull/642` \
`$ git checkout pull/642`

Update a local copy of the PR: \
`$ git checkout pull/642` \
`$ git pull https://git.openjdk.java.net/jfx pull/642/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 642`

View PR using the GUI difftool: \
`$ git pr show -t 642`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/642.diff">https://git.openjdk.java.net/jfx/pull/642.diff</a>

</details>
