### PR TITLE
8275911: Keyboard doesn't show when tapping inside an iOS text input control

### DIFF
--- a/modules/javafx.controls/src/ios/java/javafx/scene/control/skin/TextAreaSkinIos.java
+++ b/modules/javafx.controls/src/ios/java/javafx/scene/control/skin/TextAreaSkinIos.java
@@ -26,27 +26,57 @@
 package javafx.scene.control.skin;
 
 import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
+import javafx.beans.value.WeakChangeListener;
+import javafx.event.EventHandler;
 import javafx.scene.control.TextArea;
-import javafx.scene.control.skin.TextAreaSkin;
+import javafx.scene.input.MouseEvent;
 
 public class TextAreaSkinIos extends TextAreaSkin {
+
+    /**************************************************************************
+     *
+     * Private fields
+     *
+     **************************************************************************/
+
+    private final EventHandler<MouseEvent> mouseEventListener = e -> {
+        if (getSkinnable().isEditable() && getSkinnable().isFocused()) {
+            showSoftwareKeyboard();
+        }
+    };
+
+    private final ChangeListener<Boolean> focusChangeListener = (observable, wasFocused, isFocused) -> {
+        if (wasFocused && !isFocused) {
+            hideSoftwareKeyboard();
+        }
+    };
+    private final WeakChangeListener<Boolean> weakFocusChangeListener = new WeakChangeListener<>(focusChangeListener);
+
+    /**************************************************************************
+     *
+     * Constructors
+     *
+     **************************************************************************/
 
     public TextAreaSkinIos(final TextArea textArea) {
         super(textArea);
 
-        textArea.focusedProperty().addListener(new ChangeListener<Boolean>() {
-            public void changed(ObservableValue<? extends Boolean> observable,
-                    Boolean wasFocused, Boolean isFocused) {
-                if (textArea.isEditable()) {
-                    if (isFocused) {
-                        showSoftwareKeyboard();
-                    } else {
-                        hideSoftwareKeyboard();
-                    }
-                }
-            }
-        });
+        textArea.addEventHandler(MouseEvent.MOUSE_CLICKED, mouseEventListener);
+        textArea.focusedProperty().addListener(weakFocusChangeListener);
+    }
+
+    /***************************************************************************
+     *                                                                         *
+     * Public API                                                              *
+     *                                                                         *
+     **************************************************************************/
+
+    /** {@inheritDoc} */
+    @Override public void dispose() {
+        if (getSkinnable() == null) return;
+        getSkinnable().removeEventHandler(MouseEvent.MOUSE_CLICKED, mouseEventListener);
+        getSkinnable().focusedProperty().removeListener(weakFocusChangeListener);
+        super.dispose();
     }
 
     native void showSoftwareKeyboard();

--- a/modules/javafx.controls/src/ios/java/javafx/scene/control/skin/TextFieldSkinIos.java
+++ b/modules/javafx.controls/src/ios/java/javafx/scene/control/skin/TextFieldSkinIos.java
@@ -26,29 +26,57 @@
 package javafx.scene.control.skin;
 
 import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
+import javafx.beans.value.WeakChangeListener;
+import javafx.event.EventHandler;
 import javafx.scene.control.TextField;
-
-import com.sun.javafx.scene.control.behavior.TextFieldBehavior;
-import javafx.scene.control.skin.TextFieldSkin;
+import javafx.scene.input.MouseEvent;
 
 public class TextFieldSkinIos extends TextFieldSkin {
+
+    /**************************************************************************
+     *
+     * Private fields
+     *
+     **************************************************************************/
+
+    private final EventHandler<MouseEvent> mouseEventListener = e -> {
+        if (getSkinnable().isEditable() && getSkinnable().isFocused()) {
+            showSoftwareKeyboard();
+        }
+    };
+
+    private final ChangeListener<Boolean> focusChangeListener = (observable, wasFocused, isFocused) -> {
+        if (wasFocused && !isFocused) {
+            hideSoftwareKeyboard();
+        }
+    };
+    private final WeakChangeListener<Boolean> weakFocusChangeListener = new WeakChangeListener<>(focusChangeListener);
+
+    /**************************************************************************
+     *
+     * Constructors
+     *
+     **************************************************************************/
 
     public TextFieldSkinIos(final TextField textField) {
         super(textField);
 
-        textField.focusedProperty().addListener(new ChangeListener<Boolean>() {
-            public void changed(ObservableValue<? extends Boolean> observable,
-                    Boolean wasFocused, Boolean isFocused) {
-                if (textField.isEditable()) {
-                    if (isFocused) {
-                        showSoftwareKeyboard();
-                    } else {
-                        hideSoftwareKeyboard();
-                    }
-                }
-            }
-        });
+        textField.addEventHandler(MouseEvent.MOUSE_CLICKED, mouseEventListener);
+        textField.focusedProperty().addListener(weakFocusChangeListener);
+    }
+
+    /***************************************************************************
+     *                                                                         *
+     * Public API                                                              *
+     *                                                                         *
+     **************************************************************************/
+
+    /** {@inheritDoc} */
+    @Override public void dispose() {
+        if (getSkinnable() == null) return;
+        getSkinnable().removeEventHandler(MouseEvent.MOUSE_CLICKED, mouseEventListener);
+        getSkinnable().focusedProperty().removeListener(weakFocusChangeListener);
+        super.dispose();
     }
 
     native void showSoftwareKeyboard();


### PR DESCRIPTION
After [JDK-8245053](https://bugs.openjdk.java.net/browse/JDK-8245053) for Android, this PR applies the same approach on iOS: tapping on a text input control on iOS shows the keyboard, which hides after the control loses the focus. 

Now, both platforms have the same behaviour.

Tested on an iOS device.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275911](https://bugs.openjdk.java.net/browse/JDK-8275911): Keyboard doesn't show when tapping inside an iOS text input control


### Reviewers
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/653/head:pull/653` \
`$ git checkout pull/653`

Update a local copy of the PR: \
`$ git checkout pull/653` \
`$ git pull https://git.openjdk.java.net/jfx pull/653/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 653`

View PR using the GUI difftool: \
`$ git pr show -t 653`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/653.diff">https://git.openjdk.java.net/jfx/pull/653.diff</a>

</details>
