### PR TITLE
8275848: Deprecate for removal mistakenly exposed field from class javafx.scene.shape.Box

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/shape/Box.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/shape/Box.java
@@ -87,7 +87,7 @@ public class Box extends Shape3D {
 
     /**
      * Default size of the {@code Box}.
-     * @deprecated This field was exposed mistakenly and will be removed
+     * @deprecated This field was exposed mistakenly and will be removed.
      */
     @Deprecated(since = "18", forRemoval = true)
     public static final double DEFAULT_SIZE = 2;


### PR DESCRIPTION
This PR deprecates mistakenly exposed field from class javafx.scene.shape.Box.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275848](https://bugs.openjdk.java.net/browse/JDK-8275848): Deprecate for removal mistakenly exposed field from class javafx.scene.shape.Box


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Nir Lisker](https://openjdk.java.net/census#nlisker) (@nlisker - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/655/head:pull/655` \
`$ git checkout pull/655`

Update a local copy of the PR: \
`$ git checkout pull/655` \
`$ git pull https://git.openjdk.java.net/jfx pull/655/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 655`

View PR using the GUI difftool: \
`$ git pr show -t 655`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/655.diff">https://git.openjdk.java.net/jfx/pull/655.diff</a>

</details>
