### PR TITLE
8276170: Create Sources when publishing to Maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4818,7 +4818,7 @@ compileTargets { t ->
             from project.sourceSets.main.allJava
         }
 
-        buildModulesTask.dependsOn(modularPublicationSourcesJarTask)        
+        buildModulesTask.dependsOn(modularPublicationSourcesJarTask)
 
     }
     // ============================================================

--- a/build.gradle
+++ b/build.gradle
@@ -1618,6 +1618,9 @@ void addMavenPublication(Project project, List<String> projectDependencies) {
                         artifact project.tasks."modularPublicationJar$t.capital" {
                             classifier "$t.name"
                         }
+                        artifact project.tasks."modularPublicationSourcesJar" {
+                            classifier "sources"
+                        }
                     }
 
                     pom.withXml {
@@ -4806,6 +4809,16 @@ compileTargets { t ->
         }
 
         buildModulesTask.dependsOn(modularPublicationJarTask)
+
+        // build source jar and copy it to the 'publication' directory
+        def modularPublicationSourcesJarName = "${moduleName}-sources.jar"
+        def modularPublicationSourcesJarTask = project.task("modularPublicationSourcesJar", type: Jar) {
+            destinationDirectory = file("${dstModularJarDir}")
+            archiveFileName = modularPublicationSourcesJarName
+            from project.sourceSets.main.allJava
+        }
+
+        buildModulesTask.dependsOn(modularPublicationSourcesJarTask)        
 
     }
     // ============================================================


### PR DESCRIPTION
Create sources.jars and attach they to the publish task, so that they can be uploaded to the (e.g. maven) repository automatically.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8276170](https://bugs.openjdk.java.net/browse/JDK-8276170): Create Sources when publishing to Maven


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/657/head:pull/657` \
`$ git checkout pull/657`

Update a local copy of the PR: \
`$ git checkout pull/657` \
`$ git pull https://git.openjdk.java.net/jfx pull/657/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 657`

View PR using the GUI difftool: \
`$ git pr show -t 657`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/657.diff">https://git.openjdk.java.net/jfx/pull/657.diff</a>

</details>
