### PR TITLE
8276179 PrismFontFile.isInstalledFont is dead code and should be removed

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
@@ -727,31 +727,6 @@ public abstract class PrismFontFactory implements FontFactory {
         return null;
     }
 
-    boolean isInstalledFont(String fileName) {
-        // avoid loading the full windows map. Ignore drive letter
-        // as its common to install on D: too in multi-boot.
-        String fileKey;
-        if (isWindows) {
-            if (fileName.toLowerCase().contains("\\windows\\fonts")) {
-                return true;
-            }
-            File f = new File(fileName);
-            fileKey = f.getName();
-        } else {
-            if (isMacOSX && fileName.toLowerCase().contains("/library/fonts")) {
-                // Most fonts are installed in either /System/Library/Fonts/
-                // or /Library/Fonts/
-                return true;
-            }
-            File f = new File(fileName);
-            // fileToFontMap key is the full path on non-windows
-            fileKey = f.getPath();
-        }
-
-        getFullNameToFileMap();
-        return fileToFontMap.get(fileKey.toLowerCase()) != null;
-    }
-
     /* To be called only by methods that already inited the maps
      */
     synchronized private FontResource

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFile.java
@@ -42,8 +42,6 @@ import static com.sun.javafx.font.PrismMetrics.*;
 
 public abstract class PrismFontFile implements FontResource, FontConstants {
 
-    private int fontInstallationType = -1; // unknown, 0=embedded, 1=system
-
     // TrueType fonts can have multiple names, most notably split up by
     // platform and locale. Whilst fonts that have different names for
     // different platforms are arguable buggy, those with localised names
@@ -156,13 +154,6 @@ public abstract class PrismFontFile implements FontResource, FontConstants {
         return AA_GREYSCALE;
     }
 
-    public boolean isInstalledFont() {
-        if (fontInstallationType == -1) {
-            PrismFontFactory factory = PrismFontFactory.getFontFactory();
-            fontInstallationType = factory.isInstalledFont(filename) ? 1 : 0;
-        }
-        return fontInstallationType > 0;
-    }
 
 
     /* A TTC file resource is shared, so reference count and delete


### PR DESCRIPTION
removing dead code.
When looking into the font code, I've noticed that this code is no longer used, so I thought I should make a PR with a minor cleanup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276179](https://bugs.openjdk.java.net/browse/JDK-8276179): PrismFontFile.isInstalledFont is dead code and should be removed


### Reviewers
 * [Phil Race](https://openjdk.java.net/census#prr) (@prrace - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/658/head:pull/658` \
`$ git checkout pull/658`

Update a local copy of the PR: \
`$ git checkout pull/658` \
`$ git pull https://git.openjdk.java.net/jfx pull/658/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 658`

View PR using the GUI difftool: \
`$ git pr show -t 658`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/658.diff">https://git.openjdk.java.net/jfx/pull/658.diff</a>

</details>
