### PR TITLE
8274022 Additional Memory Leak in ControlAcceleratorSupport

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlAcceleratorSupport.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlAcceleratorSupport.java
@@ -286,9 +286,11 @@ public class ControlAcceleratorSupport {
                 accelerators.remove(menuitem.getAccelerator());
 
                 WeakReference<ChangeListener<KeyCombination>> listenerW = changeListenerMap.get(menuitem);
-                ChangeListener<KeyCombination> listener = listenerW == null ? null : listenerW.get();
-                if (listener != null) {
-                    menuitem.acceleratorProperty().removeListener(listener);
+                if (listenerW  != null) {
+                    ChangeListener<KeyCombination> listener = listenerW.get();
+                    if (listener != null) {
+                        menuitem.acceleratorProperty().removeListener(listener);
+                    }
                     changeListenerMap.remove(menuitem);
                 }
             }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlAcceleratorSupport.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlAcceleratorSupport.java
@@ -28,7 +28,7 @@ import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.value.ChangeListener;
- import javafx.beans.value.WeakChangeListener;
+import javafx.beans.value.WeakChangeListener;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.event.Event;
@@ -86,7 +86,7 @@ public class ControlAcceleratorSupport {
         // Remove previously added listener if any
         if (sceneChangeListenerMap.containsKey(anchor)) {
             ChangeListener<Scene> listener = sceneChangeListenerMap.get(anchor).get();
-            if(listener != null) {
+            if (listener != null) {
                 anchor.sceneProperty().removeListener(listener);
             }
             sceneChangeListenerMap.remove(anchor);
@@ -252,7 +252,7 @@ public class ControlAcceleratorSupport {
             // at the time of installing the accelerators.
             if (sceneChangeListenerMap.containsKey(anchor)) {
                 ChangeListener<Scene> listener = sceneChangeListenerMap.get(anchor).get();
-                if(listener != null) {
+                if (listener != null) {
                     anchor.sceneProperty().removeListener(listener);
                 }
                 sceneChangeListenerMap.remove(anchor);

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlAcceleratorSupport.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlAcceleratorSupport.java
@@ -28,7 +28,6 @@ import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.value.ChangeListener;
-import javafx.beans.value.WeakChangeListener;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.event.Event;

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlAcceleratorSupport.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlAcceleratorSupport.java
@@ -28,6 +28,7 @@ import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.value.ChangeListener;
+ import javafx.beans.value.WeakChangeListener;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.event.Event;
@@ -45,6 +46,7 @@ import javafx.scene.control.TableColumnBase;
 import javafx.scene.control.TreeTableColumn;
 import javafx.scene.input.KeyCombination;
 
+import java.lang.ref.WeakReference;
 import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -83,7 +85,10 @@ public class ControlAcceleratorSupport {
         // 2. Removing accelerators when Control is removed from Scene
         // Remove previously added listener if any
         if (sceneChangeListenerMap.containsKey(anchor)) {
-            anchor.sceneProperty().removeListener(sceneChangeListenerMap.get(anchor));
+            ChangeListener<Scene> listener = sceneChangeListenerMap.get(anchor).get();
+            if(listener != null) {
+                anchor.sceneProperty().removeListener(listener);
+            }
             sceneChangeListenerMap.remove(anchor);
         }
         // Add a new listener
@@ -113,10 +118,12 @@ public class ControlAcceleratorSupport {
         }
     }
 
-    private static Map<Object, ChangeListener<Scene>> sceneChangeListenerMap = new WeakHashMap<>();
+    /* It's okay to have the value Weak, because we only remember it to remove the listener later on */
+    private static Map<Object, WeakReference<ChangeListener<Scene>>> sceneChangeListenerMap = new WeakHashMap<>();
 
     private static ChangeListener<Scene> getSceneChangeListener(Object anchor, ObservableList<MenuItem> items) {
-        ChangeListener<Scene> sceneChangeListener = sceneChangeListenerMap.get(anchor);
+        WeakReference<ChangeListener<Scene>> sceneChangeListenerW = sceneChangeListenerMap.get(anchor);
+        ChangeListener<Scene> sceneChangeListener = sceneChangeListenerW == null ? null : sceneChangeListenerW.get();
         if (sceneChangeListener == null) {
              sceneChangeListener = (ov, oldScene, newScene) -> {
                 if (oldScene != null) {
@@ -126,7 +133,7 @@ public class ControlAcceleratorSupport {
                     doAcceleratorInstall(items, newScene);
                 }
             };
-            sceneChangeListenerMap.put(anchor, sceneChangeListener);
+            sceneChangeListenerMap.put(anchor, new WeakReference<>(sceneChangeListener));
         }
         return sceneChangeListener;
     }
@@ -193,11 +200,13 @@ public class ControlAcceleratorSupport {
         }
     }
 
-    private static Map<MenuItem, ChangeListener<KeyCombination>> changeListenerMap = new WeakHashMap<>();
+    /* It's okay to have the value Weak, because we only remember it to remove the listener later on */
+    private static Map<MenuItem, WeakReference<ChangeListener<KeyCombination>>> changeListenerMap = new WeakHashMap<>();
 
     private static ChangeListener<KeyCombination> getListener(final Scene scene, MenuItem menuItem) {
 
-        ChangeListener<KeyCombination> listener = changeListenerMap.get(menuItem);
+        WeakReference<ChangeListener<KeyCombination>> listenerW = changeListenerMap.get(menuItem);
+        ChangeListener<KeyCombination> listener = listenerW == null ? null : listenerW.get();
         if (listener == null) {
             listener = (observable, oldValue, newValue) -> {
                 final Map<KeyCombination, Runnable> accelerators = scene.getAccelerators();
@@ -210,7 +219,7 @@ public class ControlAcceleratorSupport {
                     accelerators.put(newValue, _acceleratorRunnable);
                 }
             };
-            changeListenerMap.put(menuItem, listener);
+            changeListenerMap.put(menuItem, new WeakReference<>(listener));
         }
         return listener;
     }
@@ -242,7 +251,10 @@ public class ControlAcceleratorSupport {
             // The Node is not part of a Scene: Remove the Scene listener that was added
             // at the time of installing the accelerators.
             if (sceneChangeListenerMap.containsKey(anchor)) {
-                anchor.sceneProperty().removeListener(sceneChangeListenerMap.get(anchor));
+                ChangeListener<Scene> listener = sceneChangeListenerMap.get(anchor).get();
+                if(listener != null) {
+                    anchor.sceneProperty().removeListener(listener);
+                }
                 sceneChangeListenerMap.remove(anchor);
             }
         }
@@ -272,7 +284,8 @@ public class ControlAcceleratorSupport {
                 final Map<KeyCombination, Runnable> accelerators = scene.getAccelerators();
                 accelerators.remove(menuitem.getAccelerator());
 
-                ChangeListener<KeyCombination> listener = changeListenerMap.get(menuitem);
+                WeakReference<ChangeListener<KeyCombination>> listenerW = changeListenerMap.get(menuitem);
+                ChangeListener<KeyCombination> listener = listenerW == null ? null : listenerW.get();
                 if (listener != null) {
                     menuitem.acceleratorProperty().removeListener(listener);
                     changeListenerMap.remove(menuitem);

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlAcceleratorSupport.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlAcceleratorSupport.java
@@ -84,8 +84,9 @@ public class ControlAcceleratorSupport {
         // 1. Installing accelerators when Control is added to Scene
         // 2. Removing accelerators when Control is removed from Scene
         // Remove previously added listener if any
-        if (sceneChangeListenerMap.containsKey(anchor)) {
-            ChangeListener<Scene> listener = sceneChangeListenerMap.get(anchor).get();
+        WeakReference<ChangeListener<Scene>> listenerW = sceneChangeListenerMap.get(anchor);
+        if (listenerW != null) {
+            ChangeListener<Scene> listener = listenerW.get();
             if (listener != null) {
                 anchor.sceneProperty().removeListener(listener);
             }
@@ -250,8 +251,9 @@ public class ControlAcceleratorSupport {
         if (scene == null) {
             // The Node is not part of a Scene: Remove the Scene listener that was added
             // at the time of installing the accelerators.
-            if (sceneChangeListenerMap.containsKey(anchor)) {
-                ChangeListener<Scene> listener = sceneChangeListenerMap.get(anchor).get();
+            WeakReference<ChangeListener<Scene>> listenerW = sceneChangeListenerMap.get(anchor);
+            if (listenerW  != null) {
+                ChangeListener<Scene> listener = listenerW.get();
                 if (listener != null) {
                     anchor.sceneProperty().removeListener(listener);
                 }


### PR DESCRIPTION
This fixes the new ControlAcceleratorBug which was Introduced in JavaFX17.
To fix it, I've made the Value of the WeakHashMap also weak. 
We only keep this value to remove it as a listener later on. Therefore there shouldn't be issues by making this value weak.


I've seen this Bug very very often, in the last weeks. Most of the applications I've seen are somehow affected by this bug.

It basically **breaks every application with menu bars and multiple stages** - which is the majority of enterprise applications. It's especially annoying because it takes some time until the application gets unstable.

Therefore **I would recommend** after this fix is approved, **to make a new version for JavaFX17** with this fix because this bug is so severe.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274022](https://bugs.openjdk.java.net/browse/JDK-8274022): Additional Memory Leak in ControlAcceleratorSupport


### Reviewers
 * [Michael Strauß](https://openjdk.java.net/census#mstrauss) (@mstr2 - Author)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/659/head:pull/659` \
`$ git checkout pull/659`

Update a local copy of the PR: \
`$ git checkout pull/659` \
`$ git pull https://git.openjdk.java.net/jfx pull/659/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 659`

View PR using the GUI difftool: \
`$ git pr show -t 659`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/659.diff">https://git.openjdk.java.net/jfx/pull/659.diff</a>

</details>
