### PR TITLE
8276313: ScrollPane scroll delta incorrectly depends on content height

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ScrollPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ScrollPaneSkin.java
@@ -893,7 +893,7 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
                 double vRange = getSkinnable().getVmax()-getSkinnable().getVmin();
                 double vPixelValue;
                 if (nodeHeight > 0.0) {
-                    vPixelValue = vRange / nodeHeight;
+                    vPixelValue = vRange / (nodeHeight - contentHeight);
                 }
                 else {
                     vPixelValue = 0.0;
@@ -925,7 +925,7 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
                 double hRange = getSkinnable().getHmax()-getSkinnable().getHmin();
                 double hPixelValue;
                 if (nodeWidth > 0.0) {
-                    hPixelValue = hRange / nodeWidth;
+                    hPixelValue = hRange / (nodeWidth - contentWidth);
                 }
                 else {
                     hPixelValue = 0.0;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ScrollPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ScrollPaneSkin.java
@@ -891,8 +891,8 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
             */
             if (vsb.getVisibleAmount() < vsb.getMax()) {
                 double vRange = getSkinnable().getVmax()-getSkinnable().getVmin();
-                double vPixelValue = vRange / (nodeHeight - contentHeight);
-                vPixelValue = Double.isFinite(vPixelValue) ? vPixelValue : 0.0;
+                double hDelta = nodeHeight - contentHeight;
+                double vPixelValue = hDelta > 0.0 ? vRange / hDelta : 0.0;
                 double newValue = vsb.getValue()+(-event.getDeltaY())*vPixelValue;
                 if (!Properties.IS_TOUCH_SUPPORTED) {
                     if ((event.getDeltaY() > 0.0 && vsb.getValue() > vsb.getMin()) ||
@@ -918,8 +918,8 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
 
             if (hsb.getVisibleAmount() < hsb.getMax()) {
                 double hRange = getSkinnable().getHmax()-getSkinnable().getHmin();
-                double hPixelValue = hRange / (nodeWidth - contentWidth);
-                hPixelValue = Double.isFinite(hPixelValue) ? hPixelValue : 0.0;
+                double wDelta = nodeWidth - contentWidth;
+                double hPixelValue = wDelta > 0.0 ? hRange / wDelta : 0.0;
                 double newValue = hsb.getValue()+(-event.getDeltaX())*hPixelValue;
                 if (!Properties.IS_TOUCH_SUPPORTED) {
                     if ((event.getDeltaX() > 0.0 && hsb.getValue() > hsb.getMin()) ||
@@ -987,16 +987,16 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
         // But to do this we have to set the scrollbars' values appropriately.
 
         if (dx != 0) {
-            double sdx = dx * (hsb.getMax() - hsb.getMin()) / (nodeWidth - contentWidth);
-            sdx = Double.isFinite(sdx) ? sdx : 0.0;
+            double wd = nodeWidth - contentWidth;
+            double sdx = wd > 0.0 ? dx * (hsb.getMax() - hsb.getMin()) / wd : 0;
             // Adjust back for some amount so that the Node border is not too close to view border
             sdx += -1 * Math.signum(sdx) * hsb.getUnitIncrement() / 5; // This accounts to 2% of view width
             hsb.setValue(hsb.getValue() + sdx);
             getSkinnable().requestLayout();
         }
         if (dy != 0) {
-            double sdy = dy * (vsb.getMax() - vsb.getMin()) / (nodeHeight - contentHeight);
-            sdy = Double.isFinite(sdy) ? sdy : 0.0;
+            double hd = nodeHeight - contentHeight;
+            double sdy = hd > 0.0 ? dy * (vsb.getMax() - vsb.getMin()) / hd : 0.0;
             // Adjust back for some amount so that the Node border is not too close to view border
             sdy += -1 * Math.signum(sdy) * vsb.getUnitIncrement() / 5; // This accounts to 2% of view height
             vsb.setValue(vsb.getValue() + sdy);
@@ -1170,8 +1170,8 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
     private double updatePosX() {
         final ScrollPane sp = getSkinnable();
         double x = isReverseNodeOrientation() ? (hsb.getMax() - (posX - hsb.getMin())) : posX;
-        double minX = Math.min((- x / (hsb.getMax() - hsb.getMin()) * (nodeWidth - contentWidth)), 0);
-        minX = Double.isFinite(minX) ? minX : 0.0;
+        double hsbRange = hsb.getMax() - hsb.getMin();
+        double minX = hsbRange > 0 ? Math.min(-x / hsbRange * (nodeWidth - contentWidth), 0) : 0;
         viewContent.setLayoutX(snapPositionX(minX));
         if (!sp.hvalueProperty().isBound()) sp.setHvalue(Utils.clamp(sp.getHmin(), posX, sp.getHmax()));
         return posX;
@@ -1179,8 +1179,8 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
 
     private double updatePosY() {
         final ScrollPane sp = getSkinnable();
-        double minY = Math.min((- posY / (vsb.getMax() - vsb.getMin()) * (nodeHeight - contentHeight)), 0);
-        minY = Double.isFinite(minY) ? minY : 0.0;
+        double vsbRange = vsb.getMax() - vsb.getMin();
+        double minY = vsbRange > 0 ? Math.min(-posY / vsbRange * (nodeHeight - contentHeight), 0) : 0;
         viewContent.setLayoutY(snapPositionY(minY));
         if (!sp.vvalueProperty().isBound()) sp.setVvalue(Utils.clamp(sp.getVmin(), posY, sp.getVmax()));
         return posY;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ScrollPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ScrollPaneSkin.java
@@ -891,13 +891,8 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
             */
             if (vsb.getVisibleAmount() < vsb.getMax()) {
                 double vRange = getSkinnable().getVmax()-getSkinnable().getVmin();
-                double vPixelValue;
-                if (nodeHeight > 0.0) {
-                    vPixelValue = vRange / (nodeHeight - contentHeight);
-                }
-                else {
-                    vPixelValue = 0.0;
-                }
+                double vPixelValue = vRange / (nodeHeight - contentHeight);
+                vPixelValue = Double.isFinite(vPixelValue) ? vPixelValue : 0.0;
                 double newValue = vsb.getValue()+(-event.getDeltaY())*vPixelValue;
                 if (!Properties.IS_TOUCH_SUPPORTED) {
                     if ((event.getDeltaY() > 0.0 && vsb.getValue() > vsb.getMin()) ||
@@ -923,14 +918,8 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
 
             if (hsb.getVisibleAmount() < hsb.getMax()) {
                 double hRange = getSkinnable().getHmax()-getSkinnable().getHmin();
-                double hPixelValue;
-                if (nodeWidth > 0.0) {
-                    hPixelValue = hRange / (nodeWidth - contentWidth);
-                }
-                else {
-                    hPixelValue = 0.0;
-                }
-
+                double hPixelValue = hRange / (nodeWidth - contentWidth);
+                hPixelValue = Double.isFinite(hPixelValue) ? hPixelValue : 0.0;
                 double newValue = hsb.getValue()+(-event.getDeltaX())*hPixelValue;
                 if (!Properties.IS_TOUCH_SUPPORTED) {
                     if ((event.getDeltaX() > 0.0 && hsb.getValue() > hsb.getMin()) ||
@@ -999,6 +988,7 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
 
         if (dx != 0) {
             double sdx = dx * (hsb.getMax() - hsb.getMin()) / (nodeWidth - contentWidth);
+            sdx = Double.isFinite(sdx) ? sdx : 0.0;
             // Adjust back for some amount so that the Node border is not too close to view border
             sdx += -1 * Math.signum(sdx) * hsb.getUnitIncrement() / 5; // This accounts to 2% of view width
             hsb.setValue(hsb.getValue() + sdx);
@@ -1006,6 +996,7 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
         }
         if (dy != 0) {
             double sdy = dy * (vsb.getMax() - vsb.getMin()) / (nodeHeight - contentHeight);
+            sdy = Double.isFinite(sdy) ? sdy : 0.0;
             // Adjust back for some amount so that the Node border is not too close to view border
             sdy += -1 * Math.signum(sdy) * vsb.getUnitIncrement() / 5; // This accounts to 2% of view height
             vsb.setValue(vsb.getValue() + sdy);
@@ -1180,6 +1171,7 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
         final ScrollPane sp = getSkinnable();
         double x = isReverseNodeOrientation() ? (hsb.getMax() - (posX - hsb.getMin())) : posX;
         double minX = Math.min((- x / (hsb.getMax() - hsb.getMin()) * (nodeWidth - contentWidth)), 0);
+        minX = Double.isFinite(minX) ? minX : 0.0;
         viewContent.setLayoutX(snapPositionX(minX));
         if (!sp.hvalueProperty().isBound()) sp.setHvalue(Utils.clamp(sp.getHmin(), posX, sp.getHmax()));
         return posX;
@@ -1188,6 +1180,7 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
     private double updatePosY() {
         final ScrollPane sp = getSkinnable();
         double minY = Math.min((- posY / (vsb.getMax() - vsb.getMin()) * (nodeHeight - contentHeight)), 0);
+        minY = Double.isFinite(minY) ? minY : 0.0;
         viewContent.setLayoutY(snapPositionY(minY));
         if (!sp.vvalueProperty().isBound()) sp.setVvalue(Utils.clamp(sp.getVmin(), posY, sp.getVmax()));
         return posY;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/ScrollPaneSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/ScrollPaneSkinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -745,7 +745,56 @@ public class ScrollPaneSkinTest {
         assertTrue(scrollPaneInner.getHvalue() > 0.0);
     }
 
+    @Test
+    public void testScrollDeltaIsIndependentOfScrollPaneHeight() {
+        var content = new Rectangle();
+        content.setHeight(200);
+        content.setWidth(100);
 
+        var scrollPane = new ScrollPane();
+        scrollPane.setSkin(new ScrollPaneSkinMock(scrollPane));
+        scrollPane.setContent(content);
+        scrollPane.setPrefWidth(100);
+        scrollPane.setPrefHeight(100);
+
+        Stage stage = new Stage();
+        stage.setScene(new Scene(new Group(scrollPane), 500, 500));
+        stage.show();
+
+        Event.fireEvent(content, new ScrollEvent(
+            ScrollEvent.SCROLL,
+            50, 50,
+            50, 50,
+            false, false, false, false, true, false,
+            0.0, -10.0, 0.0, -10.0,
+            ScrollEvent.HorizontalTextScrollUnits.NONE, 0.0,
+            ScrollEvent.VerticalTextScrollUnits.NONE, 0.0,
+            0, null));
+
+        double firstY = content.getLocalToSceneTransform().transform(0, 0).getY();
+        scrollPane.setPrefHeight(150);
+        scrollPane.setVvalue(0);
+
+        stage.close();
+        stage = new Stage();
+        stage.setScene(new Scene(new Group(scrollPane), 500, 500));
+        stage.show();
+
+        Event.fireEvent(content, new ScrollEvent(
+            ScrollEvent.SCROLL,
+            50, 50,
+            50, 50,
+            false, false, false, false, true, false,
+            0.0, -10.0, 0.0, -10.0,
+            ScrollEvent.HorizontalTextScrollUnits.NONE, 0.0,
+            ScrollEvent.VerticalTextScrollUnits.NONE, 0.0,
+            0, null));
+
+        double secondY = content.getLocalToSceneTransform().transform(0, 0).getY();
+        stage.close();
+
+        assertEquals(firstY, secondY, 0.001);
+    }
 
     public static final class ScrollPaneSkinMock extends ScrollPaneSkinShim {
         boolean propertyChanged = false;


### PR DESCRIPTION
This PR fixes an issue where the scroll delta of ScrollPane incorrectly depends on the size of its content.
This leads to extremely slow scrolling when the content is only slightly larger than the ScrollPane.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276313](https://bugs.openjdk.java.net/browse/JDK-8276313): ScrollPane scroll delta incorrectly depends on content height


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/660/head:pull/660` \
`$ git checkout pull/660`

Update a local copy of the PR: \
`$ git checkout pull/660` \
`$ git pull https://git.openjdk.java.net/jfx pull/660/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 660`

View PR using the GUI difftool: \
`$ git pr show -t 660`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/660.diff">https://git.openjdk.java.net/jfx/pull/660.diff</a>

</details>
