### PR TITLE
8275723: Crash on macOS 12 in GlassRunnable::dealloc

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -98,28 +98,19 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
     {
         assert(pthread_main_np() == 1);
         JNIEnv *env = jEnv;
-        if (env != NULL)
+        if (env != NULL && self->jRunnable != NULL)
         {
             (*env)->CallVoidMethod(env, self->jRunnable, jRunnableRun);
             GLASS_CHECK_EXCEPTION(env);
+
+            (*env)->DeleteGlobalRef(env, self->jRunnable);
         }
+
+        self->jRunnable = NULL;
 
         [self release];
     }
     [pool drain];
-}
-
-- (void)dealloc
-{
-    assert(pthread_main_np() == 1);
-    JNIEnv *env = jEnv;
-    if (env != NULL)
-    {
-        (*env)->DeleteGlobalRef(env, self->jRunnable);
-    }
-    self->jRunnable = NULL;
-
-    [super dealloc];
 }
 
 @end


### PR DESCRIPTION
GlassRunnable uses jni environment (jEnv) associated with the main application thread both for run() and dealloc() methods. Both these methods are supposed to be scheduled for execution on the main thread:
```
if (jEnv != NULL)
{
  GlassRunnable *runnable = [[GlassRunnable alloc] initWithRunnable:(*env)->NewGlobalRef(env, jRunnable)];
  [runnable performSelectorOnMainThread:@selector(run) withObject:nil waitUntilDone:NO];
} 
```

However, it appears that on macOS 12 only the run() method is executed the main thread, whereas the dealloc() method is executed on the InvokeLaterDispatcher thread, that leads to usage of the main thread jni env in the context of another thread. This problem is more visible on aarch64, where the thread check is triggered by the W^X machinery, but the problem is present on x64 as well. 

Proposed fix just encapsulates all jni-related work in the run() method, reducing risks to misuse the jni environment of the  main thread.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275723](https://bugs.openjdk.java.net/browse/JDK-8275723): Crash on macOS 12 in GlassRunnable::dealloc


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/661/head:pull/661` \
`$ git checkout pull/661`

Update a local copy of the PR: \
`$ git checkout pull/661` \
`$ git pull https://git.openjdk.java.net/jfx pull/661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 661`

View PR using the GUI difftool: \
`$ git pr show -t 661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/661.diff">https://git.openjdk.java.net/jfx/pull/661.diff</a>

</details>
