### PR TITLE
8276915: Crash on iOS 15.1 in GlassRunnable::dealloc

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassApplication.m
@@ -251,28 +251,19 @@ jclass classForName(JNIEnv *env, char *className)
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     {
         NSAssert([[NSThread currentThread] isMainThread] == YES, @"must be on main thread" );
-        if (jEnv != NULL)
+        if (jEnv != NULL && self.jRunnable != NULL)
         {
             (*jEnv)->CallVoidMethod(jEnv, self.jRunnable, jRunnableRun);
             GLASS_CHECK_EXCEPTION(jEnv);
+
+            (*jEnv)->DeleteGlobalRef(jEnv, self.jRunnable);
         }
+
+        self.jRunnable = NULL;
 
         [self release];
     }
     [pool drain];
-}
-
-
-- (void)dealloc
-{
-    NSAssert([[NSThread currentThread] isMainThread] == YES, @"must be on main thread" );
-    if (jEnv != NULL)
-    {
-        (*jEnv)->DeleteGlobalRef(jEnv, self.jRunnable);
-    }
-    self.jRunnable = NULL;
-
-    [super dealloc];
 }
 
 @end


### PR DESCRIPTION
After https://bugs.openjdk.java.net/browse/JDK-8275723 and the fix applied to `GlassApplication.m` for macOS, this PR is a follow-up and applies the same fix to `GlassApplication.m` on iOS to prevent the crash.

I've only tested on iOS 15.0 building from macOS 11.6, but it should fix the crash when building from macOS 12.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276915](https://bugs.openjdk.java.net/browse/JDK-8276915): Crash on iOS 15.1 in GlassRunnable::dealloc


### Reviewers
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/665/head:pull/665` \
`$ git checkout pull/665`

Update a local copy of the PR: \
`$ git checkout pull/665` \
`$ git pull https://git.openjdk.java.net/jfx pull/665/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 665`

View PR using the GUI difftool: \
`$ git pr show -t 665`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/665.diff">https://git.openjdk.java.net/jfx/pull/665.diff</a>

</details>
