### PR TITLE
8276174: JavaFX build fails on macOS aarch64

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -408,7 +408,9 @@ if (IS_STATIC_BUILD && IS_COMPILE_MEDIA) {
 }
 
 // By default, target architecture = host architecture, but we allow different ones.
-defineProperty("TARGET_ARCH", OS_ARCH)
+// On Apple Silicon, default architecture must be "arm64", because clang does not accept
+// aarch64 as -arch parameter.
+defineProperty("TARGET_ARCH", (IS_MAC && IS_AARCH64) ? "arm64" : OS_ARCH)
 
 // BUILD_TOOLS_DOWNLOAD_SCRIPT specifies a path of a gradle script which downloads
 // required build tools.

--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -130,7 +130,7 @@ def commonParams = [
         "-mmacosx-version-min=$MACOSX_MIN_VERSION",
         "-isysroot", "$MACOSX_SDK_PATH",
         "-iframework$MACOSX_SDK_PATH/System/Library/Frameworks",
-        "-arch", "$TARGET_ARCH"]
+        "-arch", isAarch64 ? "arm64" : "$TARGET_ARCH"]
 
 if (hasProperty('TARGET_ARCH')) {
     commonParams = ["-target", "${TARGET_ARCH}-apple-macos-11", commonParams].flatten()

--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -130,7 +130,7 @@ def commonParams = [
         "-mmacosx-version-min=$MACOSX_MIN_VERSION",
         "-isysroot", "$MACOSX_SDK_PATH",
         "-iframework$MACOSX_SDK_PATH/System/Library/Frameworks",
-        "-arch", isAarch64 ? "arm64" : "$TARGET_ARCH"]
+        "-arch", "$TARGET_ARCH"]
 
 if (hasProperty('TARGET_ARCH')) {
     commonParams = ["-target", "${TARGET_ARCH}-apple-macos-11", commonParams].flatten()


### PR DESCRIPTION
By changing the value for the clang -arch parameter to "arm64", the jfx project compiles on an apple silicon system. Are there any side effects which I might be missing in this simple solution?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276174](https://bugs.openjdk.java.net/browse/JDK-8276174): JavaFX build fails on macOS aarch64


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/666/head:pull/666` \
`$ git checkout pull/666`

Update a local copy of the PR: \
`$ git checkout pull/666` \
`$ git pull https://git.openjdk.java.net/jfx pull/666/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 666`

View PR using the GUI difftool: \
`$ git pr show -t 666`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/666.diff">https://git.openjdk.java.net/jfx/pull/666.diff</a>

</details>
