### PR TITLE
8277122: SplitPane divider drag can hang the layout

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SplitPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SplitPaneSkin.java
@@ -36,7 +36,6 @@ import javafx.geometry.Orientation;
 import javafx.geometry.VPos;
 import javafx.scene.Cursor;
 import javafx.scene.Node;
-import javafx.scene.control.Accordion;
 import javafx.scene.control.Control;
 import javafx.scene.control.SkinBase;
 import javafx.scene.control.SplitPane;
@@ -65,6 +64,12 @@ public class SplitPaneSkin extends SkinBase<SplitPane> {
     private ObservableList<Content> contentRegions;
     private ObservableList<ContentDivider> contentDividers;
     private boolean horizontal;
+    /**
+     * Flag which is set to <code>true</code> during {@link #layoutChildren(double, double, double, double)}
+     * and to <code>false</code> after. It is used to determine whether we need to request layout when a
+     * divider position changed or not.
+     */
+    private boolean duringLayout;
 
 
 
@@ -216,8 +221,8 @@ public class SplitPaneSkin extends SkinBase<SplitPane> {
             previousSize = horizontal ? sw : sh;
         }
 
-        // If the window is less than the min size we want to resize
-        // proportionally
+        // If the window is less than the min size we want to resize proportionally
+        duringLayout = true;
         double minSize = totalMinSize();
         if (minSize > (horizontal ? w : h)) {
             double percentage = 0;
@@ -235,6 +240,7 @@ public class SplitPaneSkin extends SkinBase<SplitPane> {
             setupContentAndDividerForLayout();
             layoutDividersAndContent(w, h);
             resize = false;
+            duringLayout = false;
             return;
         }
 
@@ -411,6 +417,7 @@ public class SplitPaneSkin extends SkinBase<SplitPane> {
         }
 
         layoutDividersAndContent(w, h);
+        duringLayout = false;
         resize = false;
     }
 
@@ -617,7 +624,7 @@ public class SplitPaneSkin extends SkinBase<SplitPane> {
         ChangeListener<Number> posPropertyListener = new PosPropertyListener(c);
         c.setPosPropertyListener(posPropertyListener);
         d.positionProperty().addListener(posPropertyListener);
-        initializeDivderEventHandlers(c);
+        initializeDividerEventHandlers(c);
         contentDividers.add(c);
         getChildren().add(c);
     }
@@ -633,7 +640,7 @@ public class SplitPaneSkin extends SkinBase<SplitPane> {
         lastDividerUpdate = 0;
     }
 
-    private void initializeDivderEventHandlers(final ContentDivider divider) {
+    private void initializeDividerEventHandlers(final ContentDivider divider) {
         // TODO: do we need to consume all mouse events?
         // they only bubble to the skin which consumes them by default
         divider.addEventHandler(MouseEvent.ANY, event -> {
@@ -954,7 +961,9 @@ public class SplitPaneSkin extends SkinBase<SplitPane> {
                 // When checking is enforced, we know that the position was set explicitly
                 divider.posExplicit = true;
             }
-            getSkinnable().requestLayout();
+            if (!duringLayout) {
+                getSkinnable().requestLayout();
+            }
         }
     }
 


### PR DESCRIPTION
When a divider is moved via drag or code it will call **requestLayout()** for the **SplitPane**.
While this is fine, it is also called when the **layoutChildren(..)** method is repositioning the divider.

This makes no sense since we are currently layouting everything, so we don't need to request it again (-> We are doing it right now).
After positioning the dividers the **SplitPane** content is layouted (based of the may new positioned dividers).

This PR fixes this by not requesting layout when we are currently doing it (and thus repositioning the dividers as part of it).

Note: I also fixed a simple typo of a private method in SplitPaneSkin:
initializeDivderEventHandlers -> initializeDividerEventHandlers