### PR TITLE
8197991: Selecting many items in a TableView is very slow

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ReadOnlyUnbackedObservableList.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ReadOnlyUnbackedObservableList.java
@@ -113,7 +113,7 @@ public abstract class ReadOnlyUnbackedObservableList<E> extends ObservableListBa
     @Override public int indexOf(Object o) {
         if (o == null) return -1;
 
-        for (int i = 0; i < size(); i++) {
+        for (int i = 0, max = size(); i < max; i++) {
             Object obj = get(i);
             if (o.equals(obj)) return i;
         }
@@ -185,8 +185,9 @@ public abstract class ReadOnlyUnbackedObservableList<E> extends ObservableListBa
 
     @Override
     public Object[] toArray() {
-        Object[] arr = new Object[size()];
-        for (int i = 0; i < size(); i++) {
+        int max = size();
+        Object[] arr = new Object[max];
+        for (int i = 0; i < max; i++) {
             arr[i] = get(i);
         }
         return arr;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/MultipleSelectionModelBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/MultipleSelectionModelBase.java
@@ -355,6 +355,7 @@ abstract class MultipleSelectionModelBase<T> extends MultipleSelectionModel<T> {
         BitSet selectedIndicesCopy = new BitSet();
         selectedIndicesCopy.or(selectedIndices.bitset);
         selectedIndicesCopy.clear(row);
+        // No modifications should be made to 'selectedIndicesCopy' to honour the constructor.
         List<Integer> previousSelectedIndices = new SelectedIndicesList(selectedIndicesCopy);
 
         // RT-32411 We used to call quietClearSelection() here, but this
@@ -649,10 +650,18 @@ abstract class MultipleSelectionModelBase<T> extends MultipleSelectionModel<T> {
 //            throw new RuntimeException("callObservers unavailable");
 //        }
 
+        /**
+         * Constructs a new instance of SelectedIndicesList
+         */
         public SelectedIndicesList() {
             this(new BitSet());
         }
 
+        /**
+         * Constructs a new instance of SelectedIndicesList from the provided BitSet.
+         * The underlying source BitSet shouldn't be modified once it has been passed to the constructor.
+         * @param bitset Bitset to be used.
+         */
         public SelectedIndicesList(BitSet bitset) {
             this.bitset = bitset;
         }
@@ -821,46 +830,6 @@ abstract class MultipleSelectionModelBase<T> extends MultipleSelectionModel<T> {
             _nextRemove(indicesIndex, index);
             _endChange();
         }
-
-//        public void clearAndSelect(int index) {
-//            if (index < 0 || index >= getItemCount()) {
-//                clearSelection();
-//                return;
-//            }
-//
-//            final boolean wasSelected = isSelected(index);
-//
-//            // RT-33558 if this method has been called with a given row, and that
-//            // row is the only selected row currently, then this method becomes a no-op.
-//            if (wasSelected && getSelectedIndices().size() == 1) {
-//                // before we return, we double-check that the selected item
-//                // is equal to the item in the given index
-//                if (getSelectedItem() == getModelItem(index)) {
-//                    return;
-//                }
-//            }
-//
-//            List<Integer> removed = bitset.stream().boxed().collect(Collectors.toList());
-//            boolean isSelected = removed.contains(index);
-//            if (isSelected) {
-//                removed.remove((Object)index);
-//            }
-//
-//            if (removed.isEmpty()) {
-//                set(index);
-//            }
-//
-//            bitset.clear();
-//            bitset.set(index);
-//            _beginChange();
-//            if (isSelected) {
-//                _nextRemove(0, removed);
-//            } else {
-//                _nextAdd(0, 1);
-//                _nextRemove(0, removed);
-//            }
-//            _endChange();
-//        }
 
         public boolean isSelected(int index) {
             return bitset.get(index);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/MultipleSelectionModelImplTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/MultipleSelectionModelImplTest.java
@@ -1396,4 +1396,53 @@ public class MultipleSelectionModelImplTest {
         assertEquals(2, model.getSelectedItems().size());
         assertEquals(1, counter.get());
     }
+
+    // Test for MultipleSelectionModelBase.SelectedIndicesList#set(int index)
+    @Test public void testSelectedIndicesList_SetMethod() {
+        model.clearSelection();
+        model.setSelectionMode(SelectionMode.MULTIPLE);
+        model.select(1);
+
+        assertTrue(model.isSelected(1));
+    }
+
+    // Test for MultipleSelectionModelBase.SelectedIndicesList#set(int index, int end, boolean isSet)
+    @Test public void testSelectedIndicesList_SetRangeMethod() {
+        model.clearSelection();
+        model.setSelectionMode(SelectionMode.MULTIPLE);
+        model.selectAll();
+
+        assertEquals(data.size(), model.getSelectedItems().size());
+    }
+
+    // Test for MultipleSelectionModelBase.SelectedIndicesList#set(int index, int... indices)
+    @Test public void testSelectedIndicesList_SetIndicesMethod() {
+        model.clearSelection();
+        model.setSelectionMode(SelectionMode.MULTIPLE);
+        model.selectIndices(1, 2, 5);
+
+        assertTrue(model.isSelected(1));
+        assertTrue(model.isSelected(2));
+        assertTrue(model.isSelected(5));
+        assertFalse(model.isSelected(0));
+    }
+
+    // Test for MultipleSelectionModelBase.SelectedIndicesList#clear()
+    @Test public void testSelectedIndicesList_ClearMethod() {
+        model.setSelectionMode(SelectionMode.MULTIPLE);
+        model.selectIndices(1, 2, 5);
+        model.clearSelection();
+
+        assertTrue(model.getSelectedIndices().isEmpty());
+    }
+
+    // Test for MultipleSelectionModelBase.SelectedIndicesList#clear()
+    @Test public void testSelectedIndicesList_ClearIndexMethod() {
+        model.clearSelection();
+        model.setSelectionMode(SelectionMode.MULTIPLE);
+        model.selectIndices(1, 2, 5);
+        model.clearSelection(2);
+
+        assertEquals(2, model.getSelectedIndices().size());
+    }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/MultipleSelectionModelImplTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/MultipleSelectionModelImplTest.java
@@ -1424,7 +1424,7 @@ public class MultipleSelectionModelImplTest {
         assertTrue(model.isSelected(1));
         assertTrue(model.isSelected(2));
         assertTrue(model.isSelected(5));
-        assertFalse(model.isSelected(0));
+        assertEquals(3, model.getSelectedIndices().size());
     }
 
     // Test for MultipleSelectionModelBase.SelectedIndicesList#clear()

--- a/tests/manual/controls/SelectListViewTest.java
+++ b/tests/manual/controls/SelectListViewTest.java
@@ -11,9 +11,10 @@ import javafx.stage.Stage;
 public class SelectListViewTest extends Application {
 
     final int ROW_COUNT = 70_000;
-    //	final int ROW_COUNT = 400_000;
-    //	final int ROW_COUNT = 10_000_000;
-	// final int ROW_COUNT = 7_000;
+    //  final int ROW_COUNT = 400_000;
+    //  final int ROW_COUNT = 400_000;
+    //  final int ROW_COUNT = 10_000_000;
+    // final int ROW_COUNT = 7_000;
 
     @Override
     public void start(Stage stage) {
@@ -59,16 +60,19 @@ public class SelectListViewTest extends Application {
         listView.getSelectionModel().selectAll();
         System.out.println("time:"+ (System.currentTimeMillis() - t));
     }
+
     private void clearSelection(ListView listView) {
         long t = System.currentTimeMillis();
         listView.getSelectionModel().clearSelection();
         System.out.println("time:"+ (System.currentTimeMillis() - t));
     }
+
     private void selectToStart(ListView listView) {
         long t = System.currentTimeMillis();
         listView.getSelectionModel().selectRange(0, listView.getSelectionModel().getSelectedIndex());
         System.out.println("time:"+ (System.currentTimeMillis() - t));
     }
+
     private void selectToLast(ListView listView) {
         long t = System.currentTimeMillis();
         listView.getSelectionModel().selectRange(listView.getSelectionModel().getSelectedIndex(), listView.getItems().size());

--- a/tests/manual/controls/SelectListViewTest.java
+++ b/tests/manual/controls/SelectListViewTest.java
@@ -1,0 +1,92 @@
+import javafx.application.Application;
+import javafx.collections.ObservableList;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.ListView;
+import javafx.scene.control.SelectionMode;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+public class SelectListViewTest extends Application {
+
+    final int ROW_COUNT = 70_000;
+    //	final int ROW_COUNT = 400_000;
+    //	final int ROW_COUNT = 10_000_000;
+	// final int ROW_COUNT = 7_000;
+
+    @Override
+    public void start(Stage stage) {
+        ListView<String> listView = new ListView<>();
+        listView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+
+        ObservableList<String> items = listView.getItems();
+        for(int i=0; i<ROW_COUNT; i++) {
+            String rec = String.valueOf(i);
+            items.add(rec);
+        }
+
+        BorderPane root = new BorderPane(listView);
+        Button selectAll = new Button("selectAll");
+        Button clearSelection = new Button("clearSelection");
+        Button selectToStart = new Button("selectToStart");
+        Button selectToEnd = new Button("selectToEnd");
+        Button selectPrevious = new Button("selectPrevious");
+        Button selectNext= new Button("selectNext");
+
+        selectAll.setFocusTraversable(true);
+        clearSelection.setFocusTraversable(true);
+        selectToStart.setFocusTraversable(true);
+        selectToEnd.setFocusTraversable(true);
+        selectPrevious.setFocusTraversable(true);
+        selectNext.setFocusTraversable(true);
+
+        root.setRight(new VBox(6, selectAll, selectToStart, selectToEnd, selectPrevious, selectNext, clearSelection));
+        stage.setScene(new Scene(root, 600, 600));
+
+        selectAll.setOnAction((e)->selectAll(listView));
+        clearSelection.setOnAction((e)->clearSelection(listView));
+        selectToStart.setOnAction((e)->selectToStart(listView));
+        selectToEnd.setOnAction((e)->selectToLast(listView));
+        selectPrevious.setOnAction((e)->selectPrevious(listView));
+        selectNext.setOnAction((e)->selectNext(listView));
+
+        stage.show();
+    }
+
+    private void selectAll(ListView listView) {
+        long t = System.currentTimeMillis();
+        listView.getSelectionModel().selectAll();
+        System.out.println("time:"+ (System.currentTimeMillis() - t));
+    }
+    private void clearSelection(ListView listView) {
+        long t = System.currentTimeMillis();
+        listView.getSelectionModel().clearSelection();
+        System.out.println("time:"+ (System.currentTimeMillis() - t));
+    }
+    private void selectToStart(ListView listView) {
+        long t = System.currentTimeMillis();
+        listView.getSelectionModel().selectRange(0, listView.getSelectionModel().getSelectedIndex());
+        System.out.println("time:"+ (System.currentTimeMillis() - t));
+    }
+    private void selectToLast(ListView listView) {
+        long t = System.currentTimeMillis();
+        listView.getSelectionModel().selectRange(listView.getSelectionModel().getSelectedIndex(), listView.getItems().size());
+        System.out.println("time:"+ (System.currentTimeMillis() - t));
+    }
+
+    private void selectPrevious(ListView listView) {
+        long t = System.currentTimeMillis();
+        listView.getSelectionModel().selectPrevious();
+        System.out.println("time:"+ (System.currentTimeMillis() - t));
+    }
+
+    private void selectNext(ListView listView) {
+        long t = System.currentTimeMillis();
+        listView.getSelectionModel().selectNext();
+        System.out.println("time:"+ (System.currentTimeMillis() - t));
+    }
+    public static void main(String[] args) {
+        Application.launch(args);
+    }
+}

--- a/tests/manual/controls/SelectListViewTest.java
+++ b/tests/manual/controls/SelectListViewTest.java
@@ -12,9 +12,8 @@ public class SelectListViewTest extends Application {
 
     final int ROW_COUNT = 70_000;
     //  final int ROW_COUNT = 400_000;
-    //  final int ROW_COUNT = 400_000;
     //  final int ROW_COUNT = 10_000_000;
-    // final int ROW_COUNT = 7_000;
+    //  final int ROW_COUNT = 7_000;
 
     @Override
     public void start(Stage stage) {

--- a/tests/manual/controls/SelectListViewTest.java
+++ b/tests/manual/controls/SelectListViewTest.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 import javafx.application.Application;
 import javafx.collections.ObservableList;
 import javafx.scene.Scene;
@@ -21,7 +46,7 @@ public class SelectListViewTest extends Application {
         listView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
 
         ObservableList<String> items = listView.getItems();
-        for(int i=0; i<ROW_COUNT; i++) {
+        for(int i = 0; i < ROW_COUNT; i++) {
             String rec = String.valueOf(i);
             items.add(rec);
         }
@@ -44,12 +69,12 @@ public class SelectListViewTest extends Application {
         root.setRight(new VBox(6, selectAll, selectToStart, selectToEnd, selectPrevious, selectNext, clearSelection));
         stage.setScene(new Scene(root, 600, 600));
 
-        selectAll.setOnAction((e)->selectAll(listView));
-        clearSelection.setOnAction((e)->clearSelection(listView));
-        selectToStart.setOnAction((e)->selectToStart(listView));
-        selectToEnd.setOnAction((e)->selectToLast(listView));
-        selectPrevious.setOnAction((e)->selectPrevious(listView));
-        selectNext.setOnAction((e)->selectNext(listView));
+        selectAll.setOnAction(e -> selectAll(listView));
+        clearSelection.setOnAction(e -> clearSelection(listView));
+        selectToStart.setOnAction(e -> selectToStart(listView));
+        selectToEnd.setOnAction(e -> selectToLast(listView));
+        selectPrevious.setOnAction(e -> selectPrevious(listView));
+        selectNext.setOnAction(e -> selectNext(listView));
 
         stage.show();
     }

--- a/tests/manual/controls/SelectListViewTest.java
+++ b/tests/manual/controls/SelectListViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,37 +82,37 @@ public class SelectListViewTest extends Application {
     private void selectAll(ListView listView) {
         long t = System.currentTimeMillis();
         listView.getSelectionModel().selectAll();
-        System.out.println("time:"+ (System.currentTimeMillis() - t));
+        System.out.println("time:" + (System.currentTimeMillis() - t));
     }
 
     private void clearSelection(ListView listView) {
         long t = System.currentTimeMillis();
         listView.getSelectionModel().clearSelection();
-        System.out.println("time:"+ (System.currentTimeMillis() - t));
+        System.out.println("time:" + (System.currentTimeMillis() - t));
     }
 
     private void selectToStart(ListView listView) {
         long t = System.currentTimeMillis();
         listView.getSelectionModel().selectRange(0, listView.getSelectionModel().getSelectedIndex());
-        System.out.println("time:"+ (System.currentTimeMillis() - t));
+        System.out.println("time:" + (System.currentTimeMillis() - t));
     }
 
     private void selectToLast(ListView listView) {
         long t = System.currentTimeMillis();
         listView.getSelectionModel().selectRange(listView.getSelectionModel().getSelectedIndex(), listView.getItems().size());
-        System.out.println("time:"+ (System.currentTimeMillis() - t));
+        System.out.println("time:" + (System.currentTimeMillis() - t));
     }
 
     private void selectPrevious(ListView listView) {
         long t = System.currentTimeMillis();
         listView.getSelectionModel().selectPrevious();
-        System.out.println("time:"+ (System.currentTimeMillis() - t));
+        System.out.println("time:" + (System.currentTimeMillis() - t));
     }
 
     private void selectNext(ListView listView) {
         long t = System.currentTimeMillis();
         listView.getSelectionModel().selectNext();
-        System.out.println("time:"+ (System.currentTimeMillis() - t));
+        System.out.println("time:" + (System.currentTimeMillis() - t));
     }
     public static void main(String[] args) {
         Application.launch(args);

--- a/tests/manual/controls/SelectTableViewTest.java
+++ b/tests/manual/controls/SelectTableViewTest.java
@@ -12,11 +12,11 @@ import javafx.stage.Stage;
 
 public class SelectTableViewTest extends Application {
 
-    final int ROW_COUNT = 700_00;
+    final int COL_COUNT = 3;
+    final int ROW_COUNT = 70_000;
     //  final int ROW_COUNT = 80_000;
     //  final int ROW_COUNT = 50_000;
     //  final int ROW_COUNT = 8_000;
-    final int COL_COUNT = 3;
 
     @Override
     public void start(Stage stage) {

--- a/tests/manual/controls/SelectTableViewTest.java
+++ b/tests/manual/controls/SelectTableViewTest.java
@@ -1,0 +1,108 @@
+import javafx.application.Application;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.collections.ObservableList;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.SelectionMode;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+public class SelectTableViewTest extends Application {
+
+    final int COL_COUNT = 3;
+    final int ROW_COUNT = 700_00;
+    //	final int ROW_COUNT = 80_000;
+    //	final int ROW_COUNT = 50_000;
+    //	final int ROW_COUNT = 8_000;
+
+    @Override
+    public void start(Stage stage) {
+        TableView<String[]> tableView = new TableView<>();
+        tableView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+
+        final ObservableList<TableColumn<String[], ?>> columns = tableView.getColumns();
+        for(int i=0; i<COL_COUNT; i++) {
+            TableColumn<String[], String> column = new TableColumn<>("Col"+i);
+            final int colIndex=i;
+            column.setCellValueFactory((cell)->new SimpleStringProperty(cell.getValue()[colIndex]));
+            column.setPrefWidth(150);
+            columns.add(column);
+        }
+
+        ObservableList<String[]> items = tableView.getItems();
+        for(int i=0; i<ROW_COUNT; i++) {
+            String[] rec = new String[COL_COUNT];
+            for(int j=0; j<rec.length; j++) {
+                rec[j] = i+":"+j;
+            }
+            items.add(rec);
+        }
+
+        BorderPane root = new BorderPane(tableView);
+        Button selectAll = new Button("selectAll");
+        Button clearSelection = new Button("clearSelection");
+        Button selectToStart = new Button("selectToStart");
+        Button selectToEnd = new Button("selectToEnd");
+        Button selectPrevious = new Button("selectPrevious");
+        Button selectNext= new Button("selectNext");
+
+        selectAll.setFocusTraversable(true);
+        clearSelection.setFocusTraversable(true);
+        selectToStart.setFocusTraversable(true);
+        selectToEnd.setFocusTraversable(true);
+        selectPrevious.setFocusTraversable(true);
+        selectNext.setFocusTraversable(true);
+
+        root.setRight(new VBox(6, selectAll, selectToStart, selectToEnd, selectPrevious, selectNext, clearSelection));
+        stage.setScene(new Scene(root, 600, 600));
+
+        selectAll.setOnAction((e)->selectAll(tableView));
+        clearSelection.setOnAction((e)->clearSelection(tableView));
+        selectToStart.setOnAction((e)->selectToStart(tableView));
+        selectToEnd.setOnAction((e)->selectToLast(tableView));
+        selectPrevious.setOnAction((e)->selectPrevious(tableView));
+        selectNext.setOnAction((e)->selectNext(tableView));
+
+        stage.show();
+    }
+
+    private void selectAll(TableView tableView) {
+        long t = System.currentTimeMillis();
+        tableView.getSelectionModel().selectAll();
+        System.out.println("time:"+ (System.currentTimeMillis() - t));
+    }
+    private void clearSelection(TableView tableView) {
+        long t = System.currentTimeMillis();
+        tableView.getSelectionModel().clearSelection();
+        System.out.println("time:"+ (System.currentTimeMillis() - t));
+    }
+    private void selectToStart(TableView tableView) {
+        long t = System.currentTimeMillis();
+        tableView.getSelectionModel().selectRange(0, tableView.getSelectionModel().getFocusedIndex());
+        System.out.println("time:"+ (System.currentTimeMillis() - t));
+    }
+    private void selectToLast(TableView tableView) {
+        long t = System.currentTimeMillis();
+        tableView.getSelectionModel().selectRange(tableView.getSelectionModel().getFocusedIndex(), tableView.getItems().size());
+        System.out.println("time:"+ (System.currentTimeMillis() - t));
+    }
+
+    private void selectPrevious(TableView tableView) {
+        long t = System.currentTimeMillis();
+        tableView.getSelectionModel().selectPrevious();
+        System.out.println("time:"+ (System.currentTimeMillis() - t));
+    }
+
+    private void selectNext(TableView tableView) {
+        long t = System.currentTimeMillis();
+        tableView.getSelectionModel().selectNext();
+        System.out.println("time:"+ (System.currentTimeMillis() - t));
+    }
+
+    public static void main(String[] args) {
+        Application.launch(args);
+    }
+}

--- a/tests/manual/controls/SelectTableViewTest.java
+++ b/tests/manual/controls/SelectTableViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import javafx.stage.Stage;
 
 public class SelectTableViewTest extends Application {
 
-    final int ROW_COUNT = 700_000;
+    final int ROW_COUNT = 70_000;
     //  final int ROW_COUNT = 80_000;
     //  final int ROW_COUNT = 50_000;
     //  final int ROW_COUNT = 8_000;
@@ -98,37 +98,37 @@ public class SelectTableViewTest extends Application {
     private void selectAll(TableView tableView) {
         long t = System.currentTimeMillis();
         tableView.getSelectionModel().selectAll();
-        System.out.println("time:"+ (System.currentTimeMillis() - t));
+        System.out.println("time:" + (System.currentTimeMillis() - t));
     }
 
     private void clearSelection(TableView tableView) {
         long t = System.currentTimeMillis();
         tableView.getSelectionModel().clearSelection();
-        System.out.println("time:"+ (System.currentTimeMillis() - t));
+        System.out.println("time:" + (System.currentTimeMillis() - t));
     }
 
     private void selectToStart(TableView tableView) {
         long t = System.currentTimeMillis();
         tableView.getSelectionModel().selectRange(0, tableView.getSelectionModel().getFocusedIndex());
-        System.out.println("time:"+ (System.currentTimeMillis() - t));
+        System.out.println("time:" + (System.currentTimeMillis() - t));
     }
 
     private void selectToLast(TableView tableView) {
         long t = System.currentTimeMillis();
         tableView.getSelectionModel().selectRange(tableView.getSelectionModel().getFocusedIndex(), tableView.getItems().size());
-        System.out.println("time:"+ (System.currentTimeMillis() - t));
+        System.out.println("time:" + (System.currentTimeMillis() - t));
     }
 
     private void selectPrevious(TableView tableView) {
         long t = System.currentTimeMillis();
         tableView.getSelectionModel().selectPrevious();
-        System.out.println("time:"+ (System.currentTimeMillis() - t));
+        System.out.println("time:" + (System.currentTimeMillis() - t));
     }
 
     private void selectNext(TableView tableView) {
         long t = System.currentTimeMillis();
         tableView.getSelectionModel().selectNext();
-        System.out.println("time:"+ (System.currentTimeMillis() - t));
+        System.out.println("time:" + (System.currentTimeMillis() - t));
     }
 
     public static void main(String[] args) {

--- a/tests/manual/controls/SelectTableViewTest.java
+++ b/tests/manual/controls/SelectTableViewTest.java
@@ -12,11 +12,11 @@ import javafx.stage.Stage;
 
 public class SelectTableViewTest extends Application {
 
-    final int COL_COUNT = 3;
-    final int ROW_COUNT = 70_000;
+    final int ROW_COUNT = 700_000;
     //  final int ROW_COUNT = 80_000;
     //  final int ROW_COUNT = 50_000;
     //  final int ROW_COUNT = 8_000;
+    final int COL_COUNT = 3;
 
     @Override
     public void start(Stage stage) {

--- a/tests/manual/controls/SelectTableViewTest.java
+++ b/tests/manual/controls/SelectTableViewTest.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 import javafx.application.Application;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.ObservableList;
@@ -25,18 +50,18 @@ public class SelectTableViewTest extends Application {
 //      tableView.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
 
         final ObservableList<TableColumn<String[], ?>> columns = tableView.getColumns();
-        for(int i=0; i<COL_COUNT; i++) {
+        for(int i = 0; i < COL_COUNT; i++) {
             TableColumn<String[], String> column = new TableColumn<>("Col"+i);
             final int colIndex=i;
-            column.setCellValueFactory((cell)->new SimpleStringProperty(cell.getValue()[colIndex]));
+            column.setCellValueFactory(cell -> new SimpleStringProperty(cell.getValue()[colIndex]));
             column.setPrefWidth(150);
             columns.add(column);
         }
 
         ObservableList<String[]> items = tableView.getItems();
-        for(int i=0; i<ROW_COUNT; i++) {
+        for(int i = 0; i < ROW_COUNT; i++) {
             String[] rec = new String[COL_COUNT];
-            for(int j=0; j<rec.length; j++) {
+            for(int j = 0; j < rec.length; j++) {
                 rec[j] = i+":"+j;
             }
             items.add(rec);
@@ -60,12 +85,12 @@ public class SelectTableViewTest extends Application {
         root.setRight(new VBox(6, selectAll, selectToStart, selectToEnd, selectPrevious, selectNext, clearSelection));
         stage.setScene(new Scene(root, 600, 600));
 
-        selectAll.setOnAction((e)->selectAll(tableView));
-        clearSelection.setOnAction((e)->clearSelection(tableView));
-        selectToStart.setOnAction((e)->selectToStart(tableView));
-        selectToEnd.setOnAction((e)->selectToLast(tableView));
-        selectPrevious.setOnAction((e)->selectPrevious(tableView));
-        selectNext.setOnAction((e)->selectNext(tableView));
+        selectAll.setOnAction(e -> selectAll(tableView));
+        clearSelection.setOnAction(e -> clearSelection(tableView));
+        selectToStart.setOnAction(e -> selectToStart(tableView));
+        selectToEnd.setOnAction(e -> selectToLast(tableView));
+        selectPrevious.setOnAction(e -> selectPrevious(tableView));
+        selectNext.setOnAction(e -> selectNext(tableView));
 
         stage.show();
     }

--- a/tests/manual/controls/SelectTableViewTest.java
+++ b/tests/manual/controls/SelectTableViewTest.java
@@ -12,16 +12,17 @@ import javafx.stage.Stage;
 
 public class SelectTableViewTest extends Application {
 
-    final int COL_COUNT = 3;
     final int ROW_COUNT = 700_00;
-    //	final int ROW_COUNT = 80_000;
-    //	final int ROW_COUNT = 50_000;
-    //	final int ROW_COUNT = 8_000;
+    //  final int ROW_COUNT = 80_000;
+    //  final int ROW_COUNT = 50_000;
+    //  final int ROW_COUNT = 8_000;
+    final int COL_COUNT = 3;
 
     @Override
     public void start(Stage stage) {
         TableView<String[]> tableView = new TableView<>();
         tableView.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+//      tableView.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
 
         final ObservableList<TableColumn<String[], ?>> columns = tableView.getColumns();
         for(int i=0; i<COL_COUNT; i++) {
@@ -74,16 +75,19 @@ public class SelectTableViewTest extends Application {
         tableView.getSelectionModel().selectAll();
         System.out.println("time:"+ (System.currentTimeMillis() - t));
     }
+
     private void clearSelection(TableView tableView) {
         long t = System.currentTimeMillis();
         tableView.getSelectionModel().clearSelection();
         System.out.println("time:"+ (System.currentTimeMillis() - t));
     }
+
     private void selectToStart(TableView tableView) {
         long t = System.currentTimeMillis();
         tableView.getSelectionModel().selectRange(0, tableView.getSelectionModel().getFocusedIndex());
         System.out.println("time:"+ (System.currentTimeMillis() - t));
     }
+
     private void selectToLast(TableView tableView) {
         long t = System.currentTimeMillis();
         tableView.getSelectionModel().selectRange(tableView.getSelectionModel().getFocusedIndex(), tableView.getItems().size());

--- a/tests/manual/controls/SelectTableViewTest.java
+++ b/tests/manual/controls/SelectTableViewTest.java
@@ -62,7 +62,7 @@ public class SelectTableViewTest extends Application {
         for(int i = 0; i < ROW_COUNT; i++) {
             String[] rec = new String[COL_COUNT];
             for(int j = 0; j < rec.length; j++) {
-                rec[j] = i+":"+j;
+                rec[j] = i + ":" + j;
             }
             items.add(rec);
         }


### PR DESCRIPTION
This work improves the performance of `MultipleSelectionModel`  over large data sets by caching some values and avoiding unnecessary calls to `SelectedIndicesList#size`. It further improves the performance by reducing the number of iterations required to find the index of an element in the BitSet.

The work is based on [an abandoned patch](https://github.com/openjdk/jfx/pull/127) submitted by @yososs

There are currently 2 manual tests for this fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8197991](https://bugs.openjdk.java.net/browse/JDK-8197991): Selecting many items in a TableView is very slow


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Contributors
 * Naohiro Yoshimoto `<yosbits@gmail.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/673/head:pull/673` \
`$ git checkout pull/673`

Update a local copy of the PR: \
`$ git checkout pull/673` \
`$ git pull https://git.openjdk.java.net/jfx pull/673/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 673`

View PR using the GUI difftool: \
`$ git pr show -t 673`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/673.diff">https://git.openjdk.java.net/jfx/pull/673.diff</a>

</details>
