### PR TITLE
8277572: ImageStorage should correctly handle MIME types for images encoded in data URIs

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ImageFormatDescription.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ImageFormatDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,13 +56,13 @@ public interface ImageFormatDescription {
      */
     List<Signature> getSignatures();
 
-//    /**
-//     * Get the MIME type(s) corresponding to this format, for example,
-//     * "image/jpeg," "image/png," etc.
-//     *
-//     * @return the MIME type(s) of this format.
-//     */
-//    String[] getMIMETypes();
+    /**
+     * Get the MIME subtype(s) of the "image" type corresponding to this format,
+     * for example, "jpeg" "png," etc.
+     *
+     * @return the MIME type(s) of this format.
+     */
+    List<String> getMIMESubtypes();
 
     /**
      * Represents a sequences of bytes which can appear at the beginning of

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ImageStorage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ImageStorage.java
@@ -485,9 +485,7 @@ public class ImageStorage {
 
     private ImageLoader getLoaderBySignature(InputStream stream, ImageLoadListener listener) throws IOException {
         byte[] header = new byte[getMaxSignatureLength()];
-        if (stream.read(header) <= 0) {
-            return null;
-        }
+        ImageTools.readFully(stream, header);
 
         for (final Entry<Signature, ImageLoaderFactory> factoryRegistration:
                  loaderFactoriesBySignature.entrySet()) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ImageStorage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ImageStorage.java
@@ -38,6 +38,7 @@ import com.sun.javafx.util.DataURI;
 import com.sun.javafx.util.Logging;
 
 import java.io.ByteArrayInputStream;
+import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.SequenceInputStream;
@@ -485,7 +486,12 @@ public class ImageStorage {
 
     private ImageLoader getLoaderBySignature(InputStream stream, ImageLoadListener listener) throws IOException {
         byte[] header = new byte[getMaxSignatureLength()];
-        ImageTools.readFully(stream, header);
+
+        try {
+            ImageTools.readFully(stream, header);
+        } catch (EOFException ignored) {
+            return null;
+        }
 
         for (final Entry<Signature, ImageLoaderFactory> factoryRegistration:
                  loaderFactoriesBySignature.entrySet()) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/bmp/BMPImageLoaderFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/bmp/BMPImageLoaderFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,12 +33,13 @@ import java.nio.ByteBuffer;
 final class BMPDescriptor extends ImageDescriptor {
 
     static final String formatName = "BMP";
-    static final String extensions[] = { "bmp" };
-    static final Signature signatures[] = {new Signature((byte)0x42, (byte)0x4D)};
+    static final String[] extensions = { "bmp" };
+    static final Signature[] signatures = {new Signature((byte)0x42, (byte)0x4D)};
+    static final String[] mimeSubtypes = { "bmp" };
     static final ImageDescriptor theInstance = new BMPDescriptor();
 
     private BMPDescriptor() {
-        super(formatName, extensions, signatures);
+        super(formatName, extensions, signatures, mimeSubtypes);
     }
 }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/common/ImageDescriptor.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/common/ImageDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,15 +34,16 @@ public class ImageDescriptor implements ImageFormatDescription {
     private final String formatName;
     private final List<String> extensions;
     private final List<Signature> signatures;
-//    private String[] MIMETypes;
+    private final List<String> mimeSubtypes;
 
-    public ImageDescriptor(String formatName, String[] extensions, Signature[] signatures) {
+    public ImageDescriptor(String formatName, String[] extensions, Signature[] signatures, String[] mimeSubtypes) {
         this.formatName = formatName;
         this.extensions = Collections.unmodifiableList(
                                           Arrays.asList(extensions));
         this.signatures = Collections.unmodifiableList(
                                           Arrays.asList(signatures));
-//        this.MIMETypes = MIMETypes;
+        this.mimeSubtypes = Collections.unmodifiableList(
+                                          Arrays.asList(mimeSubtypes));
     }
 
     public String getFormatName() {
@@ -57,7 +58,7 @@ public class ImageDescriptor implements ImageFormatDescription {
         return signatures;
     }
 
-//    public String[] getMIMETypes() {
-//        return MIMETypes;
-//    }
+    public List<String> getMIMESubtypes() {
+        return mimeSubtypes;
+    }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/common/ImageTools.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/common/ImageTools.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -697,7 +697,7 @@ public class ImageTools {
     public static ImageFrame scaleImageFrame(ImageFrame src,
             int destWidth, int destHeight, boolean isSmooth)
     {
-        int numBands = ImageStorage.getNumBands(src.getImageType());
+        int numBands = ImageStorage.getInstance().getNumBands(src.getImageType());
         ByteBuffer dst = scaleImage((ByteBuffer) src.getImageData(),
                 src.getWidth(), src.getHeight(), numBands,
                 destWidth, destHeight, isSmooth);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/gif/GIFDescriptor.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/gif/GIFDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,12 +37,12 @@ public class GIFDescriptor extends ImageDescriptor {
         new Signature(new byte[] { 'G', 'I', 'F', '8', '9', 'a' })
     };
 
-//    private static final String[] MIMETypes = { "image/gif" };
+    private static final String[] mimeSubtypes = { "gif" };
 
     private static ImageDescriptor theInstance = null;
 
     private GIFDescriptor() {
-        super(formatName, extensions, signatures);
+        super(formatName, extensions, signatures, mimeSubtypes);
     }
 
     public static synchronized ImageDescriptor getInstance() {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ios/IosDescriptor.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/ios/IosDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,10 +48,12 @@ public class IosDescriptor extends ImageDescriptor {
         new Signature(new byte[] {'G', 'I', 'F', '8', '9', 'a'})  // GIF89
     };
 
+    private static final String[] mimeSubtypes = { "bmp", "png", "x-png", "jpeg", "gif"};
+
     private static ImageDescriptor theInstance = null;
 
     private IosDescriptor() {
-        super(formatName, extensions, signatures);
+        super(formatName, extensions, signatures, mimeSubtypes);
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/jpeg/JPEGDescriptor.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/jpeg/JPEGDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,12 +37,12 @@ public class JPEGDescriptor extends ImageDescriptor {
     // 0xD8 == SOI, start of image
     private static final Signature[] signatures = { new Signature((byte) 0xff, (byte) 0xD8) };
 
-//    private static final String[] MIMETypes = { "image/jpeg" };
+    private static final String[] mimeSubtypes = { "jpeg" };
 
     private static ImageDescriptor theInstance = null;
 
     private JPEGDescriptor() {
-        super(formatName, extensions, signatures);
+        super(formatName, extensions, signatures, mimeSubtypes);
     }
 
     public static synchronized ImageDescriptor getInstance() {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/png/PNGDescriptor.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/png/PNGDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,12 +37,12 @@ public class PNGDescriptor extends ImageDescriptor {
         (byte) 13, (byte) 10, (byte) 26, (byte) 10)
     };
 
-//    private static final String[] MIMETypes = { "image/png", "image/x-png" };
+    private static final String[] mimeSubtypes = { "png", "x-png" };
 
     private static ImageDescriptor theInstance = null;
 
     private PNGDescriptor() {
-        super(formatName, extensions, signatures);
+        super(formatName, extensions, signatures, mimeSubtypes);
     }
 
     public static synchronized ImageDescriptor getInstance() {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PixelUtils.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PixelUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,7 +44,7 @@ class PixelUtils {
     }
 
     private static ImageFormatDescription[] supportedFormats =
-                                ImageStorage.getSupportedDescriptions();
+                                ImageStorage.getInstance().getSupportedDescriptions();
 
     protected static boolean supportedFormatType(String type) {
         for (ImageFormatDescription ifd: supportedFormats) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PrismImageLoader2.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/PrismImageLoader2.java
@@ -124,7 +124,7 @@ class PrismImageLoader2 implements com.sun.javafx.tk.ImageLoader {
         ImageLoadListener listener = new PrismLoadListener();
         try {
             ImageFrame[] imgFrames =
-                ImageStorage.loadAll(url, listener, w, h, preserveRatio, pixelScale, smooth);
+                ImageStorage.getInstance().loadAll(url, listener, w, h, preserveRatio, pixelScale, smooth);
             convertAll(imgFrames);
         } catch (ImageStorageException e) {
             handleException(e);
@@ -139,7 +139,7 @@ class PrismImageLoader2 implements com.sun.javafx.tk.ImageLoader {
         ImageLoadListener listener = new PrismLoadListener();
         try {
             ImageFrame[] imgFrames =
-                ImageStorage.loadAll(stream, listener, w, h, preserveRatio, 1.0f, smooth);
+                ImageStorage.getInstance().loadAll(stream, listener, w, h, preserveRatio, 1.0f, smooth);
             convertAll(imgFrames);
         } catch (ImageStorageException e) {
             handleException(e);

--- a/modules/javafx.graphics/src/main/java/javafx/scene/image/Image.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/image/Image.java
@@ -93,6 +93,10 @@ import javafx.beans.property.SimpleIntegerProperty;
  * the protocol handlers that are registered for the application.
  * If a URL uses the "data" scheme, the data must be base64-encoded
  * and the MIME type must be a subtype of the {@code image} type.
+ * The MIME type must match the image format of the data contained in
+ * the URL. In case of a mismatch between MIME type and image format,
+ * the image will be loaded if the image format can be determined by
+ * JavaFX, and a warning will be logged.
  *
  * <p>Use {@link ImageView} for displaying images loaded with this
  * class. The same {@code Image} instance can be displayed by multiple

--- a/modules/javafx.graphics/src/main/java/javafx/scene/image/Image.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/image/Image.java
@@ -92,8 +92,7 @@ import javafx.beans.property.SimpleIntegerProperty;
  * <p>The RFC 2397 "data" scheme for URLs is supported in addition to
  * the protocol handlers that are registered for the application.
  * If a URL uses the "data" scheme, the data must be base64-encoded
- * and the MIME type must either be empty or a subtype of the
- * {@code image} type.
+ * and the MIME type must be a subtype of the {@code image} type.
  *
  * <p>Use {@link ImageView} for displaying images loaded with this
  * class. The same {@code Image} instance can be displayed by multiple

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/iio/ImageHiDPITest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/iio/ImageHiDPITest.java
@@ -55,7 +55,7 @@ public class ImageHiDPITest {
     private ImageFrame loadImage(String path, float pixelScale) {
         try {
             ImageFrame[] imageFrames =
-                    ImageStorage.loadAll(path, null, 0, 0, true, pixelScale, true);
+                    new ImageStorage().loadAll(path, null, 0, 0, true, pixelScale, true);
 
             assertNotNull(imageFrames);
             assertEquals(1, imageFrames.length);

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/iio/ImageLoaderScalingTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/iio/ImageLoaderScalingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public class ImageLoaderScalingTest {
             throws Exception
     {
         ImageFrame[] imgFrames =
-            ImageStorage.loadAll(stream, null, width, height, false, 1.0f, false);
+            new ImageStorage().loadAll(stream, null, width, height, false, 1.0f, false);
         assertNotNull(imgFrames);
         assertTrue(imgFrames.length > 0);
         return Image.convertImageFrame(imgFrames[0]);

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/iio/ImageStorageTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/iio/ImageStorageTest.java
@@ -25,9 +25,13 @@
 
 package test.com.sun.javafx.iio;
 
+import com.sun.javafx.iio.ImageFormatDescription;
 import com.sun.javafx.iio.ImageFrame;
+import com.sun.javafx.iio.ImageLoader;
+import com.sun.javafx.iio.ImageLoaderFactory;
 import com.sun.javafx.iio.ImageStorage;
 import com.sun.javafx.iio.ImageStorageException;
+import com.sun.javafx.iio.common.ImageLoaderImpl;
 import com.sun.javafx.iio.common.ImageTools;
 import static org.junit.Assert.*;
 import org.junit.ComparisonFailure;
@@ -36,7 +40,10 @@ import org.junit.Test;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.util.Base64;
+import java.util.Collections;
+import java.util.List;
 import java.util.zip.GZIPInputStream;
 
 public class ImageStorageTest {
@@ -47,7 +54,7 @@ public class ImageStorageTest {
     @Test
     public void createImageFromNoExtensionURL() throws ImageStorageException {
         String path = getResourcePath("testpngnoextension");
-        assertNotNull(ImageStorage.loadAll(path, null, 0, 0, true, 2.0f, true));
+        assertNotNull(new ImageStorage().loadAll(path, null, 0, 0, true, 2.0f, true));
     }
 
     @Test
@@ -74,21 +81,21 @@ public class ImageStorageTest {
     @Test
     public void testCompleteAnimation() throws ImageStorageException {
         String path = getResourcePath("gif/animation/test3Frames.gif");
-        ImageFrame[] frames = ImageStorage.loadAll(path, null, 0, 0, true, 1.0f, true);
+        ImageFrame[] frames = new ImageStorage().loadAll(path, null, 0, 0, true, 1.0f, true);
         assertEquals(frames.length, 3);
     }
 
     @Test
     public void testIncompleteAnimation() throws ImageStorageException {
         String path = getResourcePath("gif/animation/test3rdFrameIncomplete.gif");
-        ImageFrame[] frames = ImageStorage.loadAll(path, null, 0, 0, true, 1.0f, true);
+        ImageFrame[] frames = new ImageStorage().loadAll(path, null, 0, 0, true, 1.0f, true);
         assertEquals(frames.length, 2);
     }
 
     @Test(expected = ImageStorageException.class)
     public void testCorruptFirstFrame() throws ImageStorageException  {
         String path = getResourcePath("gif/animation/testBad.gif");
-        ImageStorage.loadAll(path, null, 0, 0, false, 1.0f, false);
+        new ImageStorage().loadAll(path, null, 0, 0, false, 1.0f, false);
     }
 
     @Test
@@ -195,7 +202,7 @@ public class ImageStorageTest {
                     + "KRs93I0+6caAbmPIvqGHb46gN8dwmxOUzSnuplG6adZtWu2bdrhjxoF2zOEcCxTHEtexInWs6Rwb"
                     + "dsdHH3300UcfffTRRx999P8S+v9yvP+fn3zi/t+BrTq2UCIAAA==")));
 
-        ImageFrame[] frames = ImageStorage.loadAll(stream, null, 0, 0, false, 1.0f, false);
+        ImageFrame[] frames = new ImageStorage().loadAll(stream, null, 0, 0, false, 1.0f, false);
         assertNotNull(frames);
         assertEquals(1, frames.length);
     }
@@ -207,7 +214,7 @@ public class ImageStorageTest {
             + "nQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAcSURBVChTY/jPwADBZACyNMHAqGYSwZDU/P8/AB"
             + "ieT81GAGKoAAAAAElFTkSuQmCC";
 
-        ImageFrame[] frames = ImageStorage.loadAll(url, null, 20, 10, false, 1, false);
+        ImageFrame[] frames = new ImageStorage().loadAll(url, null, 20, 10, false, 1, false);
         assertEquals(1, frames.length);
 
         byte[] data = (byte[])frames[0].getImageData().array();
@@ -232,7 +239,7 @@ public class ImageStorageTest {
             + "nQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAcSURBVChTY/jPwADBZACyNMHAqGYSwZDU/P8/AB"
             + "ieT81GAGKoAAAAAElFTkSuQmCC";
 
-        ImageFrame[] frames = ImageStorage.loadAll(url, null, 20, 10, false, 1, false);
+        ImageFrame[] frames = new ImageStorage().loadAll(url, null, 20, 10, false, 1, false);
         assertEquals(1, frames.length);
 
         byte[] data = (byte[])frames[0].getImageData().array();
@@ -254,7 +261,7 @@ public class ImageStorageTest {
         String url = "data:image/foo;base64,";
 
         try {
-            ImageStorage.loadAll(url, null, 20, 10, false, 1, false);
+            new ImageStorage().loadAll(url, null, 20, 10, false, 1, false);
             fail();
         } catch (ImageStorageException ex) {
             assertTrue(ex.getMessage().startsWith("Unsupported MIME subtype"));
@@ -266,7 +273,7 @@ public class ImageStorageTest {
         String url = "data:application/octet-stream;base64,";
 
         try {
-            ImageStorage.loadAll(url, null, 20, 10, false, 1, false);
+            new ImageStorage().loadAll(url, null, 20, 10, false, 1, false);
             fail();
         } catch (ImageStorageException ex) {
             assertTrue(ex.getMessage().startsWith("Unexpected MIME type"));
@@ -278,10 +285,44 @@ public class ImageStorageTest {
         String url = "data:base64,";
 
         try {
-            ImageStorage.loadAll(url, null, 20, 10, false, 1, false);
+            new ImageStorage().loadAll(url, null, 20, 10, false, 1, false);
             fail();
         } catch (ImageStorageException ex) {
             assertTrue(ex.getMessage().startsWith("Unexpected MIME type"));
         }
+    }
+
+    @Test
+    public void testLoadImageFromDataURIWithoutDetectableSignatureByMimeType() throws IOException {
+        var formatWithoutSignature = new ImageFormatDescription() {
+            @Override public String getFormatName() { return "TEST"; }
+            @Override public List<String> getExtensions() { return List.of("test"); }
+            @Override public List<Signature> getSignatures() { return Collections.emptyList(); }
+            @Override public List<String> getMIMESubtypes() { return List.of("test"); }
+        };
+
+        var expectedImage = new ImageFrame(ImageStorage.ImageType.RGBA_PRE, ByteBuffer.wrap(new byte[0]),
+            0, 0, 0, null, null);
+
+        class TestFactory implements ImageLoaderFactory {
+            @Override public ImageFormatDescription getFormatDescription() { return formatWithoutSignature; }
+            @Override public ImageLoader createImageLoader(InputStream input) {
+                return new ImageLoaderImpl(formatWithoutSignature) {
+                    @Override public void dispose() {}
+                    @Override public ImageFrame load(int i, int w, int h, boolean p, boolean s) {
+                        return i == 0 ? expectedImage : null;
+                    }
+                };
+            }
+        }
+
+        String url = "data:image/test;base64,";
+
+        var imageStorage = new ImageStorage();
+        imageStorage.addImageLoaderFactory(new TestFactory());
+        var actualImage = imageStorage.loadAll(
+            url, null, 0, 0, false, 1, false)[0];
+
+        assertSame(expectedImage, actualImage);
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/iio/ImageStorageTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/iio/ImageStorageTest.java
@@ -225,11 +225,45 @@ public class ImageStorageTest {
     }
 
     @Test
-    public void testLoadImageFromDataURIWithWrongMimeTypeFails() {
+    public void testLoadImageFromDataURIWithMismatchedMimeSubtype() throws ImageStorageException {
+        // The data contained in this URI is actually a PNG image
         String url =
-            "data:application/octet-stream;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAKCAIAAAA7N+mxAAAAAXNSR0IArs4c6QAAAAR"
+            "data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAKCAIAAAA7N+mxAAAAAXNSR0IArs4c6QAAAAR"
             + "nQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAcSURBVChTY/jPwADBZACyNMHAqGYSwZDU/P8/AB"
             + "ieT81GAGKoAAAAAElFTkSuQmCC";
+
+        ImageFrame[] frames = ImageStorage.loadAll(url, null, 20, 10, false, 1, false);
+        assertEquals(1, frames.length);
+
+        byte[] data = (byte[])frames[0].getImageData().array();
+        assertEquals(-1, data[0]);
+        assertEquals(0, data[1]);
+        assertEquals(0, data[2]);
+
+        assertEquals(0, data[3]);
+        assertEquals(-1, data[4]);
+        assertEquals(0, data[5]);
+
+        assertEquals(0, data[6]);
+        assertEquals(0, data[7]);
+        assertEquals(-1, data[8]);
+    }
+
+    @Test
+    public void testLoadImageFromDataURIWithUnsupportedImageSubtypeFails() {
+        String url = "data:image/foo;base64,";
+
+        try {
+            ImageStorage.loadAll(url, null, 20, 10, false, 1, false);
+            fail();
+        } catch (ImageStorageException ex) {
+            assertTrue(ex.getMessage().startsWith("Unsupported MIME subtype"));
+        }
+    }
+
+    @Test
+    public void testLoadImageFromDataURIWithNonImageTypeFails() {
+        String url = "data:application/octet-stream;base64,";
 
         try {
             ImageStorage.loadAll(url, null, 20, 10, false, 1, false);
@@ -241,10 +275,7 @@ public class ImageStorageTest {
 
     @Test
     public void testLoadImageFromDataURIWithoutMimeTypeFails() {
-        String url =
-            "data:base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAKCAIAAAA7N+mxAAAAAXNSR0IArs4c6QAAAAR"
-            + "nQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAcSURBVChTY/jPwADBZACyNMHAqGYSwZDU/P8/AB"
-            + "ieT81GAGKoAAAAAElFTkSuQmCC";
+        String url = "data:base64,";
 
         try {
             ImageStorage.loadAll(url, null, 20, 10, false, 1, false);

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/iio/ImageStorageTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/iio/ImageStorageTest.java
@@ -223,4 +223,34 @@ public class ImageStorageTest {
         assertEquals(0, data[7]);
         assertEquals(-1, data[8]);
     }
+
+    @Test
+    public void testLoadImageFromDataURIWithWrongMimeTypeFails() {
+        String url =
+            "data:application/octet-stream;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAKCAIAAAA7N+mxAAAAAXNSR0IArs4c6QAAAAR"
+            + "nQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAcSURBVChTY/jPwADBZACyNMHAqGYSwZDU/P8/AB"
+            + "ieT81GAGKoAAAAAElFTkSuQmCC";
+
+        try {
+            ImageStorage.loadAll(url, null, 20, 10, false, 1, false);
+            fail();
+        } catch (ImageStorageException ex) {
+            assertTrue(ex.getMessage().startsWith("Unexpected MIME type"));
+        }
+    }
+
+    @Test
+    public void testLoadImageFromDataURIWithoutMimeTypeFails() {
+        String url =
+            "data:base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAAKCAIAAAA7N+mxAAAAAXNSR0IArs4c6QAAAAR"
+            + "nQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAcSURBVChTY/jPwADBZACyNMHAqGYSwZDU/P8/AB"
+            + "ieT81GAGKoAAAAAElFTkSuQmCC";
+
+        try {
+            ImageStorage.loadAll(url, null, 20, 10, false, 1, false);
+            fail();
+        } catch (ImageStorageException ex) {
+            assertTrue(ex.getMessage().startsWith("Unexpected MIME type"));
+        }
+    }
 }

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCImageDecoderImpl.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/WCImageDecoderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -176,7 +176,7 @@ final class WCImageDecoderImpl extends WCImageDecoder {
             log.fine(String.format("%X Decoding frames", hashCode()));
         }
         try {
-            return ImageStorage.loadAll(in, readerListener, 0, 0, true, 1.0f, false);
+            return ImageStorage.getInstance().loadAll(in, readerListener, 0, 0, true, 1.0f, false);
         } catch (ImageStorageException e) {
             return null; // consider image missing
         } finally {


### PR DESCRIPTION
`com.sun.javafx.iio.ImageStorage` currently ignores the MIME image subtype specified for images encoded in data URIs. This should be improved as follows:

1. If the specified image subtype is not supported, an exception will be thrown.
2. If the specified image subtype is supported, but the data contained in the URI is of a different (but also supported) image format, the image will be loaded and a warning will be logged. For example, if the MIME type is "image/jpeg", but the image data is PNG, the following warning will be generated:

```
Image format 'PNG' does not match MIME type 'image/jpeg' in URI 'data:image/jpeg;base64,iVBORw0KGgoAAA...AAAElFTkSuQmCC'
```

Also, the javadoc of `javafx.scene.image.Image` incorrectly states:

    94    * If a URL uses the "data" scheme, the data must be base64-encoded
    95    * and the MIME type must either be empty or a subtype of the
    96    * {@code image} type.

However, omitting the MIME type of a data URI is specified to imply "text/plain" (RFC 2397, section 2). Since the `com.sun.javafx.util.DataURI` class is implemented according to this specification, trying to load an image without MIME type correctly fails with an `ImageStorageException`: "Unexpected MIME type: text".

The solution is to fix the documentation:

      94    * If a URL uses the "data" scheme, the data must be base64-encoded
    - 95    * and the MIME type must either be empty or a subtype of the
    - 96    * {@code image} type.
    + 95    * and the MIME type must be a subtype of the {@code image} type.
    + 96    * The MIME type must match the image format of the data contained in
    + 97    * the URL. In case of a mismatch between MIME type and image format,
    + 98    * the image will be loaded if the image format can be determined by
    + 99    * JavaFX, and a warning will be logged.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8277572](https://bugs.openjdk.java.net/browse/JDK-8277572): ImageStorage should correctly handle MIME types for images encoded in data URIs
 * [JDK-8277653](https://bugs.openjdk.java.net/browse/JDK-8277653): ImageStorage should correctly handle MIME types for images encoded in data URIs (**CSR**)


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/676/head:pull/676` \
`$ git checkout pull/676`

Update a local copy of the PR: \
`$ git checkout pull/676` \
`$ git pull https://git.openjdk.java.net/jfx pull/676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 676`

View PR using the GUI difftool: \
`$ git pr show -t 676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/676.diff">https://git.openjdk.java.net/jfx/pull/676.diff</a>

</details>
