### PR TITLE
8254956: [REDO] Memoryleak: Closed focused Stages are not collected with Monocle

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleView.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleView.java
@@ -201,7 +201,9 @@ final class MonocleView extends View {
                                        boolean hideCursor) {
         MonocleWindowManager wm = MonocleWindowManager.getInstance();
         MonocleWindow focusedWindow = wm.getFocusedWindow();
-        focusedWindow.setFullScreen(true);
+        if (focusedWindow != null) {
+            focusedWindow.setFullScreen(true);
+        }
         if (hideCursor) {
             resetCursorVisibility = true;
             NativeCursor nativeCursor =
@@ -216,7 +218,9 @@ final class MonocleView extends View {
     protected void _exitFullscreen(long ptr, boolean animate) {
         MonocleWindowManager wm = MonocleWindowManager.getInstance();
         MonocleWindow focusedWindow = wm.getFocusedWindow();
-        focusedWindow.setFullScreen(false);
+        if (focusedWindow != null) {
+            focusedWindow.setFullScreen(false);
+        }
         if (resetCursorVisibility) {
             resetCursorVisibility = false;
             NativeCursor nativeCursor =

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleWindowManager.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleWindowManager.java
@@ -107,6 +107,9 @@ final class MonocleWindowManager {
             windowsToNotify.get(i).notifyClose();
         }
         window.notifyDestroy();
+        if (focusedWindow == window) {
+            focusedWindow = null;
+        }
         return true;
 
     }
@@ -176,7 +179,10 @@ final class MonocleWindowManager {
             @Override
             public void run() {
                 Screen.notifySettingsChanged();
-                instance.getFocusedWindow().setFullScreen(true);
+                MonocleWindow focusedWindow = instance.getFocusedWindow();
+                if (focusedWindow != null) {
+                    focusedWindow.setFullScreen(true);
+                }
                 instance.repaintAll();
                 Toolkit.getToolkit().requestNextPulse();
             }

--- a/tests/system/src/test/java/test/javafx/stage/FocusedWindowMonocleTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/FocusedWindowMonocleTest.java
@@ -28,7 +28,6 @@ package test.javafx.stage;
 import javafx.application.Platform;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class FocusedWindowMonocleTest extends FocusedWindowTestBase {
@@ -36,6 +35,7 @@ public class FocusedWindowMonocleTest extends FocusedWindowTestBase {
     static {
         System.setProperty("glass.platform","Monocle");
         System.setProperty("monocle.platform","Headless");
+        System.setProperty("prism.order","sw");
     }
 
     @BeforeClass
@@ -43,7 +43,6 @@ public class FocusedWindowMonocleTest extends FocusedWindowTestBase {
         initFXBase();
     }
 
-    @Ignore("JDK-8254956")
     @Test
     public void testClosedFocusedStageLeak() throws Exception {
         testClosedFocusedStageLeakBase();

--- a/tests/system/src/test/java/test/javafx/stage/FocusedWindowTestBase.java
+++ b/tests/system/src/test/java/test/javafx/stage/FocusedWindowTestBase.java
@@ -25,13 +25,10 @@
 
 package test.javafx.stage;
 
-import javafx.application.Application;
 import javafx.application.Platform;
-import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.TextField;
 import javafx.stage.Stage;
-import javafx.stage.WindowEvent;
 
 import java.lang.ref.WeakReference;
 import java.util.concurrent.CountDownLatch;
@@ -43,7 +40,6 @@ import test.util.Util;
 public abstract class FocusedWindowTestBase {
 
     static CountDownLatch startupLatch;
-    static Stage stage = null;
 
     public static void initFXBase() throws Exception {
         startupLatch = new CountDownLatch(1);


### PR DESCRIPTION
This PR fixes a memory leak, as a follow-up of [JDK-8241840](https://bugs.openjdk.java.net/browse/JDK-8241840).

The tests pass on desktop (Linux/macOS/Windows) and there is no regression on Android (see [JDK-8254605](https://bugs.openjdk.java.net/browse/JDK-8254605)).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8254956](https://bugs.openjdk.java.net/browse/JDK-8254956): [REDO] Memoryleak: Closed focused Stages are not collected with Monocle


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/677/head:pull/677` \
`$ git checkout pull/677`

Update a local copy of the PR: \
`$ git checkout pull/677` \
`$ git pull https://git.openjdk.java.net/jfx pull/677/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 677`

View PR using the GUI difftool: \
`$ git pr show -t 677`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/677.diff">https://git.openjdk.java.net/jfx/pull/677.diff</a>

</details>
