### PR TITLE
8191995: Regression: DatePicker must commit on focusLost

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/DatePicker.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/DatePicker.java
@@ -157,6 +157,12 @@ public class DatePicker extends ComboBoxBase<LocalDate> {
         getStyleClass().add(DEFAULT_STYLE_CLASS);
         setAccessibleRole(AccessibleRole.DATE_PICKER);
         setEditable(true);
+
+        focusedProperty().addListener(o -> {
+            if (!isFocused()) {
+                commitValue();
+            }
+        });
     }
 
 
@@ -424,6 +430,41 @@ public class DatePicker extends ComboBoxBase<LocalDate> {
     @Override protected Skin<?> createDefaultSkin() {
         return new DatePickerSkin(this);
     }
+
+    /**
+     * If the {@link DatePicker} is {@link #editableProperty() editable}, calling this method will attempt to
+     * commit the current text and convert it to a {@link #valueProperty() value}.
+     * @since 18
+     */
+    public final void commitValue() {
+        if (!isEditable()) {
+            return;
+        }
+        String text = getEditor().getText();
+        StringConverter<LocalDate> converter = getConverter();
+        if (converter != null) {
+            LocalDate value = converter.fromString(text);
+            setValue(value);
+        }
+    }
+
+    /**
+     * If the {@link DatePicker} is {@link #editableProperty() editable}, calling this method will attempt to
+     * replace the editor text with the last committed {@link #valueProperty() value}.
+     * @since 18
+     */
+    public final void cancelEdit() {
+        if (!isEditable()) {
+            return;
+        }
+        LocalDate committedValue = getValue();
+        StringConverter<LocalDate> converter = getConverter();
+        if (converter != null) {
+            String valueString = converter.toString(committedValue);
+            getEditor().setText(valueString);
+        }
+    }
+
 
 
     /* *************************************************************************

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/DatePickerTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/DatePickerTest.java
@@ -29,6 +29,8 @@ import java.time.LocalDate;
 import java.time.chrono.*;
 import java.util.*;
 
+import javafx.scene.control.Button;
+import javafx.scene.layout.HBox;
 import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
 import test.com.sun.javafx.scene.control.infrastructure.KeyModifier;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
@@ -617,4 +619,94 @@ public class DatePickerTest {
 
         sl.dispose();
     }
+
+    @Test
+    public void testCommitValue() {
+        datePicker.setEditable(true);
+        datePicker.getEditor().setText("11/24/2021");
+        datePicker.commitValue();
+
+        assertEquals(LocalDate.of(2021, 11, 24), datePicker.getValue());
+        assertEquals("11/24/2021", datePicker.getEditor().getText());
+    }
+
+    @Test
+    public void testNotEditableCommitValue() {
+        datePicker.setEditable(false);
+        datePicker.getEditor().setText("11/24/2021");
+        datePicker.commitValue();
+
+        assertNull(datePicker.getValue());
+        assertEquals("11/24/2021", datePicker.getEditor().getText());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testCommitValueWrongType() {
+        datePicker.setEditable(true);
+        datePicker.getEditor().setText("Some Date");
+        datePicker.commitValue();
+
+        assertNull(datePicker.getValue());
+        assertEquals("Some Date", datePicker.getEditor().getText());
+    }
+
+    @Test
+    public void testCancelEdit() {
+        LocalDate date = LocalDate.of(2021, 11, 24);
+        String dateString = "11/24/2021";
+
+        datePicker.setEditable(true);
+        datePicker.getEditor().setText(dateString);
+        datePicker.commitValue();
+
+        assertEquals(date, datePicker.getValue());
+        assertEquals(dateString, datePicker.getEditor().getText());
+
+        datePicker.getEditor().setText("12/26/2021");
+        datePicker.cancelEdit();
+
+        assertEquals(date, datePicker.getValue());
+        assertEquals(dateString, datePicker.getEditor().getText());
+    }
+
+    @Test
+    public void testNotEditableCancelEdit() {
+        LocalDate date = LocalDate.of(2021, 11, 24);
+
+        datePicker.getEditor().setText("11/24/2021");
+        datePicker.commitValue();
+
+        assertEquals(date, datePicker.getValue());
+        assertEquals("11/24/2021", datePicker.getEditor().getText());
+
+        datePicker.setEditable(false);
+        datePicker.getEditor().setText("12/26/2021");
+        datePicker.cancelEdit();
+
+        assertEquals(date, datePicker.getValue());
+        assertEquals("12/26/2021", datePicker.getEditor().getText());
+    }
+
+    @Test
+    public void testFocusLost() {
+        datePicker.setEditable(true);
+        assertNull(datePicker.getValue());
+
+        Button button = new Button();
+        StageLoader stageLoader = new StageLoader(new HBox(datePicker, button));
+
+        stageLoader.getStage().requestFocus();
+        datePicker.requestFocus();
+        datePicker.getEditor().setText("11/24/2021");
+
+        assertNull(datePicker.getValue());
+
+        button.requestFocus();
+
+        assertEquals(LocalDate.of(2021, 11, 24), datePicker.getValue());
+        assertEquals("11/24/2021", datePicker.getEditor().getText());
+
+        stageLoader.dispose();
+    }
+
 }


### PR DESCRIPTION
This PR fixes an issue where the `DatePicker` is not committing his text as value when the focus is lost. 
As the ticket also mentions, this is a regression which last worked on JavaFX 8 and got broken by this refactoring: [JDK-8150946](https://bugs.openjdk.java.net/browse/JDK-8150946)

The fix is to provide the same api  to the `DatePicker` which was introduced by [JDK-8150946](https://bugs.openjdk.java.net/browse/JDK-8150946) for `ComboBox` and `Spinner`.

Note: While fixing this I found a possible bug which I tracked here: [JDK-8277756](https://bugs.openjdk.java.net/browse/JDK-8277756)
-> When creating a `DatePicker` with the second constructor (with `LocalDate` as parameter) two listener won't be added since they are only added at the first constructor (That's also why I added the focusProperty listener in the second constructor).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8191995](https://bugs.openjdk.java.net/browse/JDK-8191995): Regression: DatePicker must commit on focusLost
 * [JDK-8277782](https://bugs.openjdk.java.net/browse/JDK-8277782): Regression: DatePicker must commit on focusLost (**CSR**)


### Reviewers
 * [Jeanette Winzenburg](https://openjdk.java.net/census#fastegal) (@kleopatra - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/679/head:pull/679` \
`$ git checkout pull/679`

Update a local copy of the PR: \
`$ git checkout pull/679` \
`$ git pull https://git.openjdk.java.net/jfx pull/679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 679`

View PR using the GUI difftool: \
`$ git pr show -t 679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/679.diff">https://git.openjdk.java.net/jfx/pull/679.diff</a>

</details>
