### PR TITLE
8187307: ListView, TableView, TreeView: receives editCancel event when edit is committed

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -386,15 +386,6 @@ public class ListCell<T> extends IndexedCell<T> {
     /** {@inheritDoc} */
     @Override public void commitEdit(T newValue) {
         if (! isEditing()) return;
-        ListView<T> list = getListView();
-
-        if (list != null) {
-            // Inform the ListView of the edit being ready to be committed.
-            list.fireEvent(new ListView.EditEvent<T>(list,
-                    ListView.<T>editCommitEvent(),
-                    newValue,
-                    list.getEditingIndex()));
-        }
 
         // inform parent classes of the commit, so that they can switch us
         // out of the editing state.
@@ -402,6 +393,16 @@ public class ListCell<T> extends IndexedCell<T> {
         // call cancelEdit(), resulting in both commit and cancel events being
         // fired (as identified in RT-29650)
         super.commitEdit(newValue);
+
+        ListView<T> list = getListView();
+        // JDK-8187307: fire the commit after updating cell's editing state
+        if (list != null) {
+            // Inform the ListView of the edit being ready to be committed.
+            list.fireEvent(new ListView.EditEvent<T>(list,
+                    ListView.<T>editCommitEvent(),
+                    newValue,
+                    list.getEditingIndex()));
+        }
 
         // update the item within this cell, so that it represents the new value
         updateItem(newValue, false);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
@@ -353,25 +353,26 @@ public class TableCell<S,T> extends IndexedCell<T> {
     @Override public void commitEdit(T newValue) {
         if (!isEditing()) return;
 
-        final TableView<S> table = getTableView();
-        if (getTableColumn() != null) {
-            // Inform the TableColumn of the edit being ready to be committed.
-            CellEditEvent<S, T> editEvent = new CellEditEvent<>(
-                table,
-                editingCellAtStartEdit,
-                TableColumn.editCommitEvent(),
-                newValue
-            );
-
-            Event.fireEvent(getTableColumn(), editEvent);
-        }
-
         // inform parent classes of the commit, so that they can switch us
         // out of the editing state.
         // This MUST come before the updateItem call below, otherwise it will
         // call cancelEdit(), resulting in both commit and cancel events being
         // fired (as identified in RT-29650)
         super.commitEdit(newValue);
+
+        final TableView<S> table = getTableView();
+        // JDK-8187307: fire the commit after updating cell's editing state
+        if (getTableColumn() != null) {
+            // Inform the TableColumn of the edit being ready to be committed.
+            CellEditEvent<S, T> editEvent = new CellEditEvent<>(
+                    table,
+                    editingCellAtStartEdit,
+                    TableColumn.editCommitEvent(),
+                    newValue
+                    );
+
+            Event.fireEvent(getTableColumn(), editEvent);
+        }
 
         // update the item within this cell, so that it represents the new value
         updateItem(newValue, false);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeCell.java
@@ -394,8 +394,17 @@ public class TreeCell<T> extends IndexedCell<T> {
      /** {@inheritDoc} */
     @Override public void commitEdit(T newValue) {
         if (! isEditing()) return;
+
+        // inform parent classes of the commit, so that they can switch us
+        // out of the editing state.
+        // This MUST come before the updateItem call below, otherwise it will
+        // call cancelEdit(), resulting in both commit and cancel events being
+        // fired (as identified in RT-29650)
+        super.commitEdit(newValue);
+
         final TreeItem<T> treeItem = getTreeItem();
         final TreeView<T> tree = getTreeView();
+        // JDK-8187307: fire the commit after updating cell's editing state
         if (tree != null) {
             // Inform the TreeView of the edit being ready to be committed.
             tree.fireEvent(new TreeView.EditEvent<T>(tree,
@@ -404,13 +413,6 @@ public class TreeCell<T> extends IndexedCell<T> {
                     getItem(),
                     newValue));
         }
-
-        // inform parent classes of the commit, so that they can switch us
-        // out of the editing state.
-        // This MUST come before the updateItem call below, otherwise it will
-        // call cancelEdit(), resulting in both commit and cancel events being
-        // fired (as identified in RT-29650)
-        super.commitEdit(newValue);
 
         // update the item within this cell, so that it represents the new value
         if (treeItem != null) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
@@ -370,25 +370,26 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
     @Override public void commitEdit(T newValue) {
         if (!isEditing()) return;
 
-        final TreeTableView<S> table = getTreeTableView();
-        if (getTableColumn() != null) {
-            // Inform the TreeTableColumn of the edit being ready to be committed.
-            CellEditEvent<S,T> editEvent = new CellEditEvent<S,T>(
-                table,
-                editingCellAtStartEdit,
-                TreeTableColumn.<S,T>editCommitEvent(),
-                newValue
-            );
-
-            Event.fireEvent(getTableColumn(), editEvent);
-        }
-
         // inform parent classes of the commit, so that they can switch us
         // out of the editing state.
         // This MUST come before the updateItem call below, otherwise it will
         // call cancelEdit(), resulting in both commit and cancel events being
         // fired (as identified in RT-29650)
         super.commitEdit(newValue);
+
+        final TreeTableView<S> table = getTreeTableView();
+        // JDK-8187307: fire the commit after updating cell's editing state
+        if (getTableColumn() != null) {
+            // Inform the TreeTableColumn of the edit being ready to be committed.
+            CellEditEvent<S,T> editEvent = new CellEditEvent<S,T>(
+                    table,
+                    editingCellAtStartEdit,
+                    TreeTableColumn.<S,T>editCommitEvent(),
+                    newValue
+                    );
+
+            Event.fireEvent(getTableColumn(), editEvent);
+        }
 
         // update the item within this cell, so that it represents the new value
         updateItem(newValue, false);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -874,6 +874,26 @@ public class ListCellTest {
         assertEquals("list editing location must not be updated", -1, list.getEditingIndex());
     }
 
+    @Test
+    public void testCommitEditMustNotFireCancel() {
+        list.setEditable(true);
+        // JDK-8187307: handler that resets control's editing state
+        list.setOnEditCommit(e -> {
+            int index = e.getIndex();
+            list.getItems().set(index, e.getNewValue());
+            list.edit(-1);
+        });
+        cell.updateListView(list);
+        int editingIndex = 1;
+        cell.updateIndex(editingIndex);
+        list.edit(editingIndex);
+        List<EditEvent<String>> events = new ArrayList<>();
+        list.setOnEditCancel(events::add);
+        String value = "edited";
+        cell.commitEdit(value);
+        assertEquals("sanity: value committed", value, list.getItems().get(editingIndex));
+        assertEquals("commit must not have fired editCancel", 0, events.size());
+    }
 
     // When the list view item's change and affects a cell that is editing, then what?
     // When the list cell's index is changed while it is editing, then what?

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
@@ -600,7 +600,28 @@ public class TableCellTest {
     }
 
 //------------- commitEdit
- // fix of JDK-8271474 changed the implementation of how the editing location is evaluated
+
+    @Test
+    public void testCommitEditMustNotFireCancel() {
+        setupForEditing();
+        // JDK-8187307: handler that resets control's editing state
+        editingColumn.setOnEditCommit(e -> {
+            table.getItems().set(e.getTablePosition().getRow(), e.getNewValue());
+            table.edit(-1, null);
+        });
+        int editingRow = 1;
+        cell.updateIndex(editingRow);
+        table.edit(editingRow, editingColumn);
+        List<CellEditEvent<?, ?>> events = new ArrayList<>();
+        editingColumn.setOnEditCancel(events::add);
+        String value = "edited";
+        cell.commitEdit(value);
+        assertEquals("sanity: value committed", value, table.getItems().get(editingRow));
+        assertEquals("commit must not have fired editCancel", 0, events.size());
+    }
+
+
+// fix of JDK-8271474 changed the implementation of how the editing location is evaluated
 
      @Test
      public void testEditCommitEvent() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellTest.java
@@ -867,6 +867,27 @@ public class TreeCellTest {
         assertNull("tree editing location must not be updated", tree.getEditingItem());
     }
 
+    @Test
+    public void testCommitEditMustNotFireCancel() {
+        tree.setEditable(true);
+        int editingIndex = 1;
+        TreeItem<String> editingItem = tree.getTreeItem(editingIndex);
+        // JDK-8187307: handler that resets control's editing state
+        tree.setOnEditCommit(e -> {
+            editingItem.setValue(e.getNewValue());
+            tree.edit(null);
+        });
+        cell.updateTreeView(tree);
+        cell.updateIndex(editingIndex);
+        List<EditEvent<String>> events = new ArrayList<>();
+        tree.setOnEditCancel(events::add);
+        tree.edit(editingItem);
+        String value = "edited";
+        cell.commitEdit(value);
+        assertEquals("sanity: value committed", value, tree.getTreeItem(editingIndex).getValue());
+        assertEquals("commit must not have fired editCancel", 0, events.size());
+    }
+
 
     // When the tree view item's change and affects a cell that is editing, then what?
     // When the tree cell's index is changed while it is editing, then what?

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
@@ -912,7 +912,28 @@ public class TreeTableCellTest {
     }
 
  //------------- commitEdit
- // fix of JDK-8271474 changed the implementation of how the editing location is evaluated
+
+    @Test
+    public void testCommitEditMustNotFireCancel() {
+        setupForEditing();
+        // JDK-8187307: handler that resets control's editing state
+        editingColumn.setOnEditCommit(e -> {
+            TreeItem<String> treeItem = tree.getTreeItem(e.getTreeTablePosition().getRow());
+            treeItem.setValue(e.getNewValue());
+            tree.edit(-1, null);
+        });
+        int editingRow = 1;
+        cell.updateIndex(editingRow);
+        tree.edit(editingRow, editingColumn);
+        List<CellEditEvent<?, ?>> events = new ArrayList<>();
+        editingColumn.setOnEditCancel(events::add);
+        String value = "edited";
+        cell.commitEdit(value);
+        assertEquals("sanity: value committed", value, tree.getTreeItem(editingRow).getValue());
+        assertEquals("commit must not have fired editCancel", 0, events.size());
+    }
+
+// fix of JDK-8271474 changed the implementation of how the editing location is evaluated
 
      @Test
      public void testEditCommitEvent() {


### PR DESCRIPTION
The misbehaviour was that an edit handler received both a commit and cancel event when cell commitEdit is called. That happened whenever a collaborator reset the controls editing state (either directly or indirectly) while processing the editCommit event. The reason was that the cell had not yet updated its own editing state when receiving the change of editing from the control.

Fix is to update cell's editing state before firing the event, that is change the sequence or method calls from fire/super.commit to super.commit/fire.

Added tests that fail/pass before/after the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8187307](https://bugs.openjdk.java.net/browse/JDK-8187307): ListView, TableView, TreeView: receives editCancel event when edit is committed


### Reviewers
 * [Marius Hanl](https://openjdk.java.net/census#mhanl) (@Maran23 - Author)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/684/head:pull/684` \
`$ git checkout pull/684`

Update a local copy of the PR: \
`$ git checkout pull/684` \
`$ git pull https://git.openjdk.java.net/jfx pull/684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 684`

View PR using the GUI difftool: \
`$ git pr show -t 684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/684.diff">https://git.openjdk.java.net/jfx/pull/684.diff</a>

</details>
