### PR TITLE
8273089: Deprecate JavaFX GTK 2 library for removal

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
@@ -56,6 +56,15 @@ final class GtkApplication extends Application implements
     private static final String SWT_INTERNAL_CLASS =
             "org.eclipse.swt.internal.gtk.OS";
     private static final int forcedGtkVersion;
+    private static boolean gtk2WarningIssued = false;
+    private static final String GTK2_ALREADY_LOADED_WARNING =
+        "WARNING: Found GTK 2 library already loaded";
+    private static final String GTK2_SPECIFIED_WARNING =
+        "WARNING: A command line option has enabled the GTK 2 library";
+    private static final String GTK2_FALLBACK_WARNING =
+        "WARNING: Using GTK 2 library because GTK 3 cannot be loaded ";
+    private static final String GTK2_DEPRECATION_WARNING =
+        "WARNING: The JavaFX GTK 2 library is deprecated and will be removed in a future release";
 
 
     static  {
@@ -103,6 +112,11 @@ final class GtkApplication extends Application implements
                 ver = 3;
             }
             forcedGtkVersion = ver;
+            if (ver == 2 && !gtk2WarningIssued) {
+                System.err.println(GTK2_ALREADY_LOADED_WARNING);
+                System.err.println(GTK2_DEPRECATION_WARNING);
+                gtk2WarningIssued = true;
+            }
         } else {
             forcedGtkVersion = 0;
         }
@@ -159,6 +173,13 @@ final class GtkApplication extends Application implements
                 }
                 return ret;
             }) : forcedGtkVersion;
+
+        if (gtkVersion == 2 && !gtk2WarningIssued) {
+            System.err.println(GTK2_SPECIFIED_WARNING);
+            System.err.println(GTK2_DEPRECATION_WARNING);
+            gtk2WarningIssued = true;
+        }
+
         @SuppressWarnings("removal")
         boolean gtkVersionVerbose =
                 AccessController.doPrivileged((PrivilegedAction<Boolean>) () -> {
@@ -188,6 +209,11 @@ final class GtkApplication extends Application implements
                     System.out.println("Glass GTK library to load is glassgtk2");
                 }
                 NativeLibLoader.loadLibrary("glassgtk2");
+                if (!gtk2WarningIssued) {
+                    System.err.println(GTK2_FALLBACK_WARNING);
+                    System.err.println(GTK2_DEPRECATION_WARNING);
+                    gtk2WarningIssued = true;
+                }
             } else if (libraryToLoad == QUERY_LOAD_GTK3) {
                 if (gtkVersionVerbose) {
                     System.out.println("Glass GTK library to load is glassgtk3");

--- a/tests/system/src/test/java/test/com/sun/glass/ui/gtk/Gtk2Deprecation1Test.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/gtk/Gtk2Deprecation1Test.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.glass.ui.gtk;
+
+import com.sun.javafx.PlatformUtil;
+import java.io.ByteArrayOutputStream;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+public class Gtk2Deprecation1Test extends Gtk2DeprecationCommon {
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        doSetup(true);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        doTeardown();
+    }
+
+    @Test
+    public void testDeprecationMessage() throws Exception {
+        assumeTrue(PlatformUtil.isLinux());
+
+        final String output = out.toString();
+        System.err.println(output);
+        assertTrue("Missing warning message", output.contains("WARNING"));
+        assertTrue("Missing warning message", output.contains("deprecated"));
+        assertTrue("Missing warning message", output.contains("removed"));
+    }
+
+}

--- a/tests/system/src/test/java/test/com/sun/glass/ui/gtk/Gtk2Deprecation2Test.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/gtk/Gtk2Deprecation2Test.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.glass.ui.gtk;
+
+import com.sun.javafx.PlatformUtil;
+import java.io.ByteArrayOutputStream;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assume.assumeTrue;
+
+public class Gtk2Deprecation2Test extends Gtk2DeprecationCommon {
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        doSetup(false);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        doTeardown();
+    }
+
+    @Test
+    public void testNoDeprecationMessage() throws Exception {
+        assumeTrue(PlatformUtil.isLinux());
+
+        final String output = out.toString();
+        System.err.println(output);
+        assertFalse("Unexpected warning message", output.contains("WARNING"));
+        assertFalse("Unexpected warning message", output.contains("deprecated"));
+        assertFalse("Unexpected warning message", output.contains("removed"));
+    }
+
+}

--- a/tests/system/src/test/java/test/com/sun/glass/ui/gtk/Gtk2DeprecationCommon.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/gtk/Gtk2DeprecationCommon.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.glass.ui.gtk;
+
+import com.sun.javafx.PlatformUtil;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javafx.application.Platform;
+import test.util.Util;
+
+import static org.junit.Assert.fail;
+
+public class Gtk2DeprecationCommon {
+
+    private static final CountDownLatch startupLatch = new CountDownLatch(1);
+    private static final PrintStream defaultErrorStream = System.err;
+    protected static final ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+    public static void doSetup(boolean forceGtk2) throws Exception {
+        if (!PlatformUtil.isLinux()) return;
+
+        if (forceGtk2) {
+            System.setProperty("jdk.gtk.version", "2");
+        }
+
+        System.setErr(new PrintStream(out, true));
+
+        Platform.startup(() -> {
+            startupLatch.countDown();
+        });
+
+        if (!startupLatch.await(15, TimeUnit.SECONDS)) {
+            System.setErr(defaultErrorStream);
+            System.err.println(out.toString());
+            fail("Timeout waiting for FX runtime to start");
+        }
+
+        Thread.sleep(250);
+        System.setErr(defaultErrorStream);
+    }
+
+    public static void doTeardown() {
+        if (!PlatformUtil.isLinux()) return;
+
+        Platform.exit();
+    }
+
+}


### PR DESCRIPTION
This PR deprecates the JavaFX glass GTK 2 library for removal. Since there isn't an associated API, the mechanism for doing this is to print a "deprecated for removal" warning message when the `glassgtk2` library it is loaded. A message is printed regardless of why the GTK 2 library was loaded, which can happen for one of the following reasons:

1. The application or end user has explicitly requested GTK 2 using the `jdk.gtk.version` system property.
2. Another native library has already loaded the GTK 2 library (an application cannot load both the GTK 2 and GTK 3 libraries in the same process)
3. As a fallback if the gtk3 libraries are not available on the system.

The warning messages are patterned after the security manager deprecation messages added as part of [JEP 411](https://openjdk.java.net/jeps/411).

I added two system tests, one that sets the `jdk.gtk.version` system property to `2` and verifies that the warning message is printed, and one that doesn't set `jdk.gtk.version` and verifies that no warning message is printed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8273089](https://bugs.openjdk.java.net/browse/JDK-8273089): Deprecate JavaFX GTK 2 library for removal
 * [JDK-8277962](https://bugs.openjdk.java.net/browse/JDK-8277962): Deprecate JavaFX GTK 2 library for removal (**CSR**)


### Reviewers
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) (@pankaj-bansal - Committer)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/685/head:pull/685` \
`$ git checkout pull/685`

Update a local copy of the PR: \
`$ git checkout pull/685` \
`$ git pull https://git.openjdk.java.net/jfx pull/685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 685`

View PR using the GUI difftool: \
`$ git pr show -t 685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/685.diff">https://git.openjdk.java.net/jfx/pull/685.diff</a>

</details>
