### PR TITLE
8277853: With Touch enabled devices scrollbar disappears and the table is scrolled to the beginning

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -2342,7 +2342,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
         // Bring the clipView.clipX back to 0 if control is vertical or
         // the hbar isn't visible (fix for RT-11666)
         if (isVertical()) {
-            if (hbar.isVisible()) {
+            if (needBreadthBar) {
                 clipView.setClipX(hbar.getValue());
             } else {
                 // all cells are now less than the width of the flow,

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -798,6 +798,36 @@ public class TableViewTest {
     /*********************************************************************
      * Tests for specific bugs                                           *
      ********************************************************************/
+    @Test public void test_jdk_8277853() {
+        TableView<Person> table = new TableView<>(personTestData);
+        StageLoader sl = new StageLoader(table);
+
+        TableColumn firstNameCol = new TableColumn("First Name");
+        firstNameCol.setCellValueFactory(new PropertyValueFactory<Person, String>("firstName"));
+
+        TableColumn lastNameCol = new TableColumn("Last Name");
+        lastNameCol.setCellValueFactory(new PropertyValueFactory<Person, String>("lastName"));
+
+        TableColumn emailCol = new TableColumn("Email");
+        emailCol.setCellValueFactory(new PropertyValueFactory<Person, String>("email"));
+
+        table.getColumns().addAll(firstNameCol, lastNameCol, emailCol);
+        table.setItems(personTestData);
+
+        Toolkit.getToolkit().firePulse();
+
+        ScrollBar horizontalBar = VirtualFlowTestUtils.getVirtualFlowHorizontalScrollbar(table);
+        if (horizontalBar != null) {
+            double scrollbarPosition = horizontalBar.getMax();
+            horizontalBar.setValue(scrollbarPosition);
+
+            assertEquals(scrollbarPosition, horizontalBar.getValue(), 0);
+            horizontalBar.setVisible(false);
+            assertEquals(scrollbarPosition, horizontalBar.getValue(), 0);
+        }
+        sl.dispose();
+    }
+
     @Test public void test_rt16019() {
         // RT-16019: NodeMemory TableView tests fail with
         // IndexOutOfBoundsException (ObservableListWrapper.java:336)

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -817,14 +817,15 @@ public class TableViewTest {
         Toolkit.getToolkit().firePulse();
 
         ScrollBar horizontalBar = VirtualFlowTestUtils.getVirtualFlowHorizontalScrollbar(table);
-        if (horizontalBar != null) {
-            double scrollbarPosition = horizontalBar.getMax();
-            horizontalBar.setValue(scrollbarPosition);
+        assertNotNull(horizontalBar);
 
-            assertEquals(scrollbarPosition, horizontalBar.getValue(), 0);
-            horizontalBar.setVisible(false);
-            assertEquals(scrollbarPosition, horizontalBar.getValue(), 0);
-        }
+        double scrollbarPosition = horizontalBar.getMax();
+        horizontalBar.setValue(scrollbarPosition);
+
+        assertEquals(scrollbarPosition, horizontalBar.getValue(), 0);
+        horizontalBar.setVisible(false);
+        assertEquals(scrollbarPosition, horizontalBar.getValue(), 0);
+
         sl.dispose();
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -798,7 +798,11 @@ public class TableViewTest {
     /*********************************************************************
      * Tests for specific bugs                                           *
      ********************************************************************/
-    @Test public void test_jdk_8277853() {
+
+    /**
+     * JDK-8277853
+     */
+    @Test public void testInvisibleScrollbarDoesNotScrollTableToBeginning() {
         TableView<Person> table = new TableView<>(personTestData);
         StageLoader sl = new StageLoader(table);
 


### PR DESCRIPTION
With a touch-enabled device, the scrollbar disappears a short while after it's used. During the layout, updateHbar() checks the hbar visibility and resets the clip, causing the user to be scrolled fully to the left when trying to access columns on the right. Using hbar.isVisible() is not feasible as there are times when the scrollbar is necessary but not visible (such as on touch-enabled devices where the scrollbar disappears when not in use, or when hidden by CSS). Hence, it is more reliable to use the variable that determines whether the hbar is necessary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277853](https://bugs.openjdk.java.net/browse/JDK-8277853): With Touch enabled devices scrollbar disappears and the table is scrolled to the beginning


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Marius Hanl](https://openjdk.java.net/census#mhanl) (@Maran23 - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/688/head:pull/688` \
`$ git checkout pull/688`

Update a local copy of the PR: \
`$ git checkout pull/688` \
`$ git pull https://git.openjdk.java.net/jfx pull/688/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 688`

View PR using the GUI difftool: \
`$ git pr show -t 688`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/688.diff">https://git.openjdk.java.net/jfx/pull/688.diff</a>

</details>
