### PR TITLE
8278134: Move static utility methods to infrastructure (EditAndScrollTest)

### DIFF
--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/VirtualizedControlTestUtils.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/VirtualizedControlTestUtils.java
@@ -83,7 +83,7 @@ public class VirtualizedControlTestUtils {
     }
 
     /**
-     * Returns a vertical ScrollBar of the control.
+     * Returns a horizontal ScrollBar of the control.
      * @throws IllegalStateException if control's skin is not VirtualContainerBase
      */
     public static ScrollBar getHorizontalScrollBar(Control control) {

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/VirtualizedControlTestUtils.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/VirtualizedControlTestUtils.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.javafx.scene.control.infrastructure;
+
+import com.sun.javafx.tk.Toolkit;
+
+import static javafx.scene.control.skin.VirtualFlowShim.*;
+
+import javafx.scene.control.Control;
+import javafx.scene.control.ScrollBar;
+import javafx.scene.control.skin.VirtualContainerBase;
+import javafx.scene.control.skin.VirtualFlow;
+import javafx.scene.layout.Region;
+
+/**
+ * Utility methods to test virtualized controls and cells contained within.
+ *
+ * Note: there's a certain overlap with VirtualFlowTestUtils - differences:
+ * - the controls passed as parameters must already have a skin extending VirtualContainerBase
+ * - uses newer api (in VirtualizedContainerBase/VirtualFlow) to access children (vs. lookup)
+ * - uses alternative constructor of MouseEventFirer for exact control of mouse location
+ *
+ */
+public class VirtualizedControlTestUtils {
+
+    /**
+     * Fires a mouse event onto the middle of the vertical scrollbar's track.
+     * @throws IllegalStateException if control's skin is not VirtualContainerBase
+     */
+    public static void fireMouseOnVerticalTrack(Control control) {
+        ScrollBar scrollBar = getVerticalScrollBar(control);
+        Region track = (Region) scrollBar.lookup(".track");
+        MouseEventFirer firer = new MouseEventFirer(track, true);
+        firer.fireMousePressAndRelease();
+        Toolkit.getToolkit().firePulse();
+    }
+
+    /**
+     * Fires a mouse event onto the middle of the horizontal scrollbar's track.
+     * @throws IllegalStateException if control's skin is not VirtualContainerBase
+     */
+    public static void fireMouseOnHorizontalTrack(Control control) {
+        ScrollBar scrollBar = getHorizontalScrollBar(control);
+        Region track = (Region) scrollBar.lookup(".track");
+        MouseEventFirer firer = new MouseEventFirer(track, true);
+        firer.fireMousePressAndRelease();
+        Toolkit.getToolkit().firePulse();
+    }
+
+    /**
+     * Returns a vertical ScrollBar of the control.
+     * @throws IllegalStateException if control's skin is not VirtualContainerBase
+     */
+    public static ScrollBar getVerticalScrollBar(Control control) {
+        if (control.getSkin() instanceof VirtualContainerBase) {
+            VirtualFlow<?> flow = getVirtualFlow((VirtualContainerBase<?, ?>) control.getSkin());
+            return getVBar(flow);
+        }
+        throw new IllegalStateException("control's skin must be of type VirtualContainerBase but was: " + control.getSkin());
+    }
+
+    /**
+     * Returns a vertical ScrollBar of the control.
+     * @throws IllegalStateException if control's skin is not VirtualContainerBase
+     */
+    public static ScrollBar getHorizontalScrollBar(Control control) {
+        if (control.getSkin() instanceof VirtualContainerBase) {
+            VirtualFlow<?> flow = getVirtualFlow((VirtualContainerBase<?, ?>) control.getSkin());
+            return getHBar(flow);
+        }
+        throw new IllegalStateException("control's skin must be of type VirtualContainerBase but was: " + control.getSkin());
+    };
+
+    private VirtualizedControlTestUtils() {}
+
+}

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/VirtualizedControlTestUtilsTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/VirtualizedControlTestUtilsTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.javafx.scene.control.infrastructure;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static test.com.sun.javafx.scene.control.infrastructure.VirtualizedControlTestUtils.*;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.Scene;
+import javafx.scene.control.Control;
+import javafx.scene.control.ListView;
+import javafx.scene.control.ScrollBar;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+/**
+ * Rudimentary test of VirtualizedControlTestUtils.
+ */
+public class VirtualizedControlTestUtilsTest {
+
+    private Scene scene;
+    private Stage stage;
+    private Pane root;
+
+    int rows;
+
+    /**
+     * Test that firing on the vertical bar scrolls the control.
+     */
+    @Test
+    public void testFireMouseOnVerticalTrack() {
+        ListView<?> list = createAndShowListView();
+        ScrollBar scrollBar = getVerticalScrollBar(list);
+        assertEquals("sanity: initial value of scrollBar", 0, scrollBar.getValue(), 0.1);
+        fireMouseOnVerticalTrack(list);
+        assertTrue("mouse on track must have scrolled", scrollBar.getValue() > 0);
+    }
+
+    /**
+     * Test that firing on the horizontal bar scrolls the control.
+     */
+    @Test
+    public void testFireMouseOnHorizontalTrack() {
+        ListView<?> list = createAndShowListView();
+        ScrollBar scrollBar = getHorizontalScrollBar(list);
+        assertEquals("sanity: initial value of scrollBar", 0, scrollBar.getValue(), 0.1);
+        fireMouseOnHorizontalTrack(list);
+        assertTrue("mouse on track must have scrolled", scrollBar.getValue() > 0);
+    }
+
+    @Test (expected=IllegalStateException.class)
+    public void testGetVerticalScrollBarThrowsWithoutSkin() {
+        ListView<?> list = new ListView<>();
+        getVerticalScrollBar(list);
+    }
+
+    @Test (expected=IllegalStateException.class)
+    public void testGetHorizontalScrollBarThrowsWithoutSkin() {
+        ListView<?> list = new ListView<>();
+        getHorizontalScrollBar(list);
+    }
+
+    /**
+     * Test the test setup.
+     */
+    @Test
+    public void testListViewEditing() {
+        ListView<?> control = createAndShowListView();
+        assertEquals(rows, control.getItems().size());
+        assertEquals(100, scene.getWidth(), 1);
+        assertEquals(330, scene.getHeight(), 1);
+        assertTrue("sanity: vertical scrollbar visible for list " ,
+                getHorizontalScrollBar(control).isVisible());
+        assertTrue("sanity: vertical scrollbar visible for list " ,
+                getVerticalScrollBar(control).isVisible());
+    }
+
+  //----------------- setup
+
+    /**
+     * Creates and shows a ListView configured to be scrollable both vertically and horizontally.
+     */
+    private ListView<?> createAndShowListView() {
+        ObservableList<String> baseData = createData(rows, true);
+        ListView<String> control = new ListView<>(baseData);
+        showControl(control, true, 100, 330);
+        return control;
+    }
+
+    /**
+     * Creates and returns a list of long/short (depending on wide parameter) Strings.
+     */
+    private ObservableList<String> createData(int size, boolean wide) {
+        ObservableList<String> data = FXCollections.observableArrayList();
+        String item = wide ? "something that really really guarantees a horizontal scrollbar is visible  " : "item";
+        for (int i = 0; i < size; i++) {
+            data.add(item + i);
+        }
+        return data;
+    }
+
+    /**
+     * Ensures the control is shown in an active scenegraph. Requests
+     * focus on the control if focused == true.
+     *
+     * @param control the control to show
+     * @param focused if true, requests focus on the added control
+     */
+    protected void showControl(Control control, boolean focused) {
+        showControl(control, focused, -1, -1);
+    }
+
+    /**
+     * Ensures the control is shown in an active scenegraph. Requests
+     * focus on the control if focused == true.
+     * On first call, sizes the scene to width/height if width > 0
+     *
+     * @param control the control to show
+     * @param focused if true, requests focus on the added control
+     * @param width the width of the scene or -1 for auto-sizing
+     * @param height the height of the scene or -1 for auto-sizing
+     */
+    protected void showControl(Control control, boolean focused, double width, double height) {
+        if (root == null) {
+            root = new VBox();
+            if (width > 0) {
+                scene = new Scene(root, width, height);
+            } else {
+                scene = new Scene(root);
+            }
+            stage = new Stage();
+            stage.setScene(scene);
+        }
+        if (!root.getChildren().contains(control)) {
+            root.getChildren().add(control);
+        }
+        stage.show();
+        if (focused) {
+            stage.requestFocus();
+            control.requestFocus();
+            assertTrue(control.isFocused());
+            assertSame(control, scene.getFocusOwner());
+        }
+    }
+
+    @Before public void setup() {
+        Thread.currentThread().setUncaughtExceptionHandler((thread, throwable) -> {
+            if (throwable instanceof RuntimeException) {
+                throw (RuntimeException)throwable;
+            } else {
+                Thread.currentThread().getThreadGroup().uncaughtException(thread, throwable);
+            }
+        });
+        rows = 60;
+    }
+
+    @After public void cleanup() {
+        if (stage != null) stage.hide();
+        Thread.currentThread().setUncaughtExceptionHandler(null);
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/EditAndScrollTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/EditAndScrollTest.java
@@ -29,9 +29,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.sun.javafx.tk.Toolkit;
-
-import static javafx.scene.control.skin.VirtualFlowShim.*;
+import static test.com.sun.javafx.scene.control.infrastructure.VirtualizedControlTestUtils.*;
 import static org.junit.Assert.*;
 
 import javafx.collections.FXCollections;
@@ -42,7 +40,6 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Control;
 import javafx.scene.control.ListView;
 import javafx.scene.control.MenuItem;
-import javafx.scene.control.ScrollBar;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TablePosition;
 import javafx.scene.control.TableView;
@@ -57,14 +54,10 @@ import javafx.scene.control.cell.TextFieldTableCell;
 import javafx.scene.control.cell.TextFieldTreeCell;
 import javafx.scene.control.cell.TextFieldTreeTableCell;
 import javafx.scene.control.cell.TreeItemPropertyValueFactory;
-import javafx.scene.control.skin.VirtualContainerBase;
-import javafx.scene.control.skin.VirtualFlow;
 import javafx.scene.layout.Pane;
-import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import javafx.util.converter.DefaultStringConverter;
-import test.com.sun.javafx.scene.control.infrastructure.MouseEventFirer;
 
 /**
  * Test scrolling while editing, mainly fix for JDK-8272118 - do not cancel edit on mouse click.
@@ -404,56 +397,6 @@ public class EditAndScrollTest {
                 control, scene.getFocusOwner());
     }
 
-
-//----------------- Utility methods (TODO: move into infrastructure)
-
-    /**
-     * Fires a mouse event onto the middle of the vertical scrollbar's track.
-     * @throws IllegalStateException if control's skin is not VirtualContainerBase
-     */
-    public static void fireMouseOnVerticalTrack(Control control) {
-        ScrollBar scrollBar = getVerticalScrollBar(control);
-        Region track = (Region) scrollBar.lookup(".track");
-        MouseEventFirer firer = new MouseEventFirer(track, true);
-        firer.fireMousePressAndRelease();
-        Toolkit.getToolkit().firePulse();
-    }
-
-    /**
-     * Fires a mouse event onto the middle of the horizontal scrollbar's track.
-     * @throws IllegalStateException if control's skin is not VirtualContainerBase
-     */
-    public static void fireMouseOnHorizontalTrack(Control control) {
-        ScrollBar scrollBar = getHorizontalScrollBar(control);
-        Region track = (Region) scrollBar.lookup(".track");
-        MouseEventFirer firer = new MouseEventFirer(track, true);
-        firer.fireMousePressAndRelease();
-        Toolkit.getToolkit().firePulse();
-    }
-
-    /**
-     * Returns a vertical ScrollBar of the control.
-     * @throws IllegalStateException if control's skin is not VirtualContainerBase
-     */
-    public static ScrollBar getVerticalScrollBar(Control control) {
-        if (control.getSkin() instanceof VirtualContainerBase) {
-            VirtualFlow<?> flow = getVirtualFlow((VirtualContainerBase<?, ?>) control.getSkin());
-            return getVBar(flow);
-        }
-        throw new IllegalStateException("control's skin must be of type VirtualContainerBase but was: " + control.getSkin());
-    }
-
-    /**
-     * Returns a vertical ScrollBar of the control.
-     * @throws IllegalStateException if control's skin is not VirtualContainerBase
-     */
-    public static ScrollBar getHorizontalScrollBar(Control control) {
-        if (control.getSkin() instanceof VirtualContainerBase) {
-            VirtualFlow<?> flow = getVirtualFlow((VirtualContainerBase<?, ?>) control.getSkin());
-            return getHBar(flow);
-        }
-        throw new IllegalStateException("control's skin must be of type VirtualContainerBase but was: " + control.getSkin());
-    }
 
 //----------------- setup
 


### PR DESCRIPTION
Extracted static test utility methods from EditAndScrollTest into new VirtualizedControlTestUtils, added rudimentary tests for the methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278134](https://bugs.openjdk.java.net/browse/JDK-8278134): Move static utility methods to infrastructure (EditAndScrollTest)


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/690/head:pull/690` \
`$ git checkout pull/690`

Update a local copy of the PR: \
`$ git checkout pull/690` \
`$ git pull https://git.openjdk.java.net/jfx pull/690/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 690`

View PR using the GUI difftool: \
`$ git pr show -t 690`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/690.diff">https://git.openjdk.java.net/jfx/pull/690.diff</a>

</details>
