### PR TITLE
8278425: TreeTableCellStartEditTest uses deprecated TreeTableCell methods

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TreeTableCellStartEditTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TreeTableCellStartEditTest.java
@@ -106,8 +106,8 @@ public class TreeTableCellStartEditTest {
     public void testStartEditRespectsEditable() {
         treeTableCell.updateIndex(0);
 
-        treeTableCell.updateTreeTableColumn((TreeTableColumn) treeTableColumn);
-        treeTableCell.updateTreeTableRow(treeTableRow);
+        treeTableCell.updateTableColumn((TreeTableColumn) treeTableColumn);
+        treeTableCell.updateTableRow(treeTableRow);
         treeTableCell.updateTreeTableView(treeTable);
 
         for (boolean isTableEditable : EDITABLE_STATES) {


### PR DESCRIPTION
This PR replaces 2 deprecations which were added in https://bugs.openjdk.java.net/browse/JDK-8188026

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278425](https://bugs.openjdk.java.net/browse/JDK-8278425): TreeTableCellStartEditTest uses deprecated TreeTableCell methods


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/692/head:pull/692` \
`$ git checkout pull/692`

Update a local copy of the PR: \
`$ git checkout pull/692` \
`$ git pull https://git.openjdk.java.net/jfx pull/692/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 692`

View PR using the GUI difftool: \
`$ git pr show -t 692`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/692.diff">https://git.openjdk.java.net/jfx/pull/692.diff</a>

</details>
