### PR TITLE
8278595: Provide more information when a pipeline can't be used

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/GraphicsPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/GraphicsPipeline.java
@@ -237,6 +237,11 @@ public abstract class GraphicsPipeline {
                 if (PrismSettings.verbose) {
                     System.err.println("GraphicsPipeline.createPipeline: error"+
                                        " initializing pipeline "+ className);
+                    if (newPipeline == null) {
+                        System.err.println("Reason: could not create an instance");
+                    } else {
+                        System.err.println("Reason: could not initialize the instance");
+                    }
                 }
             } catch (Throwable t) {
                 if (PrismSettings.verbose) {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/GraphicsPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/GraphicsPipeline.java
@@ -235,7 +235,7 @@ public abstract class GraphicsPipeline {
                     newPipeline = null;
                 }
                 if (PrismSettings.verbose) {
-                    System.err.println("GraphicsPipeline.createPipeline: error"+
+                    System.err.println("GraphicsPipeline.createPipeline: error" +
                                        " initializing pipeline "+ className);
                     if (newPipeline == null) {
                         System.err.println("Reason: could not create an instance");

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/GraphicsPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/GraphicsPipeline.java
@@ -236,7 +236,7 @@ public abstract class GraphicsPipeline {
                 }
                 if (PrismSettings.verbose) {
                     System.err.println("GraphicsPipeline.createPipeline: error" +
-                                       " initializing pipeline "+ className);
+                                       " initializing pipeline " + className);
                     if (newPipeline == null) {
                         System.err.println("Reason: could not create an instance");
                     } else {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Pipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Pipeline.java
@@ -72,13 +72,19 @@ public class ES2Pipeline extends GraphicsPipeline {
 
         creator = Thread.currentThread();
 
+
         if (glFactory != null) {
             es2Enabled = glFactory.initialize(PrismSettings.class,
                     pixelFormatAttributes);
+            if (!es2Enabled && PrismSettings.verbose) {
+                System.out.println("GLFactory " + glFactory + "could not be initialized. ES2Pipeline not available.");
+            }
         } else {
+            if (PrismSettings.verbose) {
+                System.out.println("No GLFactory found. ES2Pipeline not available.");
+            }
             es2Enabled = false;
         }
-
         if (es2Enabled) {
             theInstance = new ES2Pipeline();
             factories = new ES2ResourceFactory[glFactory.getAdapterCount()];
@@ -93,7 +99,6 @@ public class ES2Pipeline extends GraphicsPipeline {
             npotSupported = false;
             supports3D = false;
         }
-
     }
     private static Thread creator;
     private static final ES2Pipeline theInstance;

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Pipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/ES2Pipeline.java
@@ -72,12 +72,11 @@ public class ES2Pipeline extends GraphicsPipeline {
 
         creator = Thread.currentThread();
 
-
         if (glFactory != null) {
             es2Enabled = glFactory.initialize(PrismSettings.class,
                     pixelFormatAttributes);
             if (!es2Enabled && PrismSettings.verbose) {
-                System.out.println("GLFactory " + glFactory + "could not be initialized. ES2Pipeline not available.");
+                System.out.println("GLFactory " + glFactory + " could not be initialized. ES2Pipeline not available.");
             }
         } else {
             if (PrismSettings.verbose) {


### PR DESCRIPTION
This PR provides at least some basic information when a pipeline can't be used. 
There are a number of reasons why a candidate pipeline can't be used, and this PR makes it clear at which point the pipeline fails. 

The changes are only applied in case `prism.verbose` is already set to `true`, so there is no unwanted logging.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278595](https://bugs.openjdk.java.net/browse/JDK-8278595): Provide more information when a pipeline can't be used


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/693/head:pull/693` \
`$ git checkout pull/693`

Update a local copy of the PR: \
`$ git checkout pull/693` \
`$ git pull https://git.openjdk.java.net/jfx pull/693/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 693`

View PR using the GUI difftool: \
`$ git pr show -t 693`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/693.diff">https://git.openjdk.java.net/jfx/pull/693.diff</a>

</details>
