### PR TITLE
8278260: JavaFX shared libraries not stripped on Linux or macOS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4977,6 +4977,9 @@ compileTargets { t ->
 
         def library = targetProperties.library
 
+        def doStrip = targetProperties.containsKey('strip') && !IS_DEBUG_NATIVE
+        def strip = doStrip ? targetProperties.strip : null
+        def stripArgs = doStrip ? targetProperties.stripArgs : null
         def useLipo = targetProperties.containsKey('useLipo') ? targetProperties.useLipo : false
         def modLibDest = targetProperties.modLibDest
         def moduleNativeDirName = "${platformPrefix}module-$modLibDest"
@@ -5025,7 +5028,8 @@ compileTargets { t ->
             group = "Basic"
             description = "copies javafx.graphics native libraries"
 
-            into "${graphicsProject.buildDir}/${moduleNativeDirName}"
+            def destDirName = "${graphicsProject.buildDir}/${moduleNativeDirName}"
+            into destDirName
 
             from("${graphicsProject.buildDir}/libs/jsl-decora/${t.name}/${library(targetProperties.decora.lib)}")
             def libs = ['font', 'prism', 'prismSW', 'glass', 'iio']
@@ -5051,13 +5055,32 @@ compileTargets { t ->
                     from ("$winsdklib");
                 }
             }
+
+            if (doStrip) {
+                doLast {
+                    def inputFiles = fileTree(dir: destDirName)
+                    inputFiles.include("*.dll")
+                    inputFiles.include("*.dylib")
+                    inputFiles.include("*.so")
+                    // FIXME: if we ever need to strip on Windows platforms, we must
+                    // exclude the Microsoft DLLs (VS2017DLLNames and WinSDKDLLNames)
+
+                    inputFiles.each { file ->
+                        exec {
+                            def cmd = [ strip, stripArgs, file ].flatten()
+                            commandLine(cmd)
+                        }
+                    }
+                }
+            }
         }
 
         def buildModuleMediaTask = task("buildModuleMedia$t.capital", type: Copy, dependsOn: [mediaProject.assemble, prepOpenJfxStubs]) {
             group = "Basic"
             description = "copies javafx.media native libraries"
 
-            into "${mediaProject.buildDir}/${moduleNativeDirName}"
+            def destDirName = "${mediaProject.buildDir}/${moduleNativeDirName}"
+            into destDirName
 
             def mediaBuildType = project(":media").ext.buildType
             if (IS_COMPILE_MEDIA) {
@@ -5088,19 +5111,52 @@ compileTargets { t ->
                     from ("$MEDIA_STUB/${library("glib-lite")}")
                 }
             }
+
+            if (doStrip && IS_COMPILE_MEDIA) {
+                doLast {
+                    def inputFiles = fileTree(dir: destDirName)
+                    inputFiles.include("*.dll")
+                    inputFiles.include("*.dylib")
+                    inputFiles.include("*.so")
+
+                    inputFiles.each { file ->
+                        exec {
+                            def cmd = [ strip, stripArgs, file ].flatten()
+                            commandLine(cmd)
+                        }
+                    }
+                }
+            }
         }
 
         def buildModuleWeb = task("buildModuleWeb$t.capital", type: Copy, dependsOn: [webProject.assemble, prepOpenJfxStubs]) {
             group = "Basic"
             description = "copies javafx.web native libraries"
 
-            into "${webProject.buildDir}/${moduleNativeDirName}"
+            def destDirName = "${webProject.buildDir}/${moduleNativeDirName}"
+            into destDirName
 
             if (IS_COMPILE_WEBKIT) {
                 from ("${webProject.buildDir}/libs/${t.name}/${library('jfxwebkit')}")
             } else {
                 if (t.name != "android" && t.name != "ios" && t.name != "dalvik") {
                     from ("$WEB_STUB/${library('jfxwebkit')}")
+                }
+            }
+
+            if (doStrip && IS_COMPILE_WEBKIT) {
+                doLast {
+                    def inputFiles = fileTree(dir: destDirName)
+                    inputFiles.include("*.dll")
+                    inputFiles.include("*.dylib")
+                    inputFiles.include("*.so")
+
+                    inputFiles.each { file ->
+                        exec {
+                            def cmd = [ strip, stripArgs, file ].flatten()
+                            commandLine(cmd)
+                        }
+                    }
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -461,6 +461,7 @@ ext.IS_WORKER_DEBUG = Boolean.parseBoolean(WORKER_DEBUG);
 defineProperty("CONF", "Debug")
 ext.IS_DEBUG_JAVA = CONF == "Debug" || CONF == "DebugNative"
 ext.IS_DEBUG_NATIVE = CONF == "DebugNative"
+ext.IS_RELEASE = !ext.IS_DEBUG_JAVA
 
 // Specifies whether to enable the Maven publishing tasks
 defineProperty("MAVEN_PUBLISH", "false")
@@ -4977,7 +4978,7 @@ compileTargets { t ->
 
         def library = targetProperties.library
 
-        def doStrip = targetProperties.containsKey('strip') && !IS_DEBUG_NATIVE
+        def doStrip = targetProperties.containsKey('strip') && IS_RELEASE
         def strip = doStrip ? targetProperties.strip : null
         def stripArgs = doStrip ? targetProperties.stripArgs : null
         def useLipo = targetProperties.containsKey('useLipo') ? targetProperties.useLipo : false

--- a/buildSrc/linux.gradle
+++ b/buildSrc/linux.gradle
@@ -211,6 +211,10 @@ setupTools("linux_freetype_tools",
 def compiler = IS_COMPILE_PARFAIT ? "parfait-gcc" : "${toolchainDir}gcc";
 def linker = IS_STATIC_BUILD ? "ar" : IS_COMPILE_PARFAIT ? "parfait-g++" : "${toolchainDir}g++";
 
+// Strip native .so shared libraries as a postprocess step when copying them
+LINUX.strip = "${toolchainDir}strip"
+LINUX.stripArgs = [ "-x" ]
+
 LINUX.glass = [:]
 LINUX.glass.variants = ["glass", "glassgtk2", "glassgtk3"]
 

--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -175,6 +175,10 @@ if (hasProperty('toolchainDir')) {
 def compiler = IS_COMPILE_PARFAIT ? "parfait-clang" : "${toolchainDir}clang";
 def linker = IS_STATIC_BUILD ? "libtool" : IS_COMPILE_PARFAIT ? "parfait-clang++" : "${toolchainDir}clang++";
 
+// Strip native .dylib shared libraries as a postprocess step when copying them
+MAC.strip = "${toolchainDir}strip"
+MAC.stripArgs = [ "-x" ]
+
 MAC.glass = [:]
 MAC.glass.javahInclude = [
     "com/sun/glass/events/**",


### PR DESCRIPTION
Build change to strip the non-global symbols from native shared libraries on Linux and macOS by running `strip -x`, unless doing a `-PCONF=DebugNative` build.

Here is a before / after size comparison. All sizes in KBytes:

### Linux

| Native Library | Current | Stripped |
| --------------- | --------- | -------- |
| libavplugin-54.so | 52 | 48 |
| libavplugin-56.so | 52 | 48 |
| libavplugin-57.so | 52 | 48 |
| libavplugin-ffmpeg-56.so | 52 | 48 |
| libavplugin-ffmpeg-57.so | 52 | 48 |
| libavplugin-ffmpeg-58.so | 52 | 48 |
| libdecora_sse.so | 76 | 72 |
| libfxplugins.so | 56 | 52 |
| libglass.so | 16 | 12 |
| libglassgtk2.so | 932 | 324 |
| libglassgtk3.so | 932 | 324 |
| libgstreamer-lite.so | 2,280 | 2,100 |
| libjavafx_font.so | 20 | 16 |
| libjavafx_font_freetype.so | 28 | 28 |
| libjavafx_font_pango.so | 28 | 24 |
| libjavafx_iio.so | 148 | 140 |
| libjfxmedia.so | 2,048 | 516 |
| libjfxwebkit.so | 106,696 | 88,428 |
| libprism_common.so | 8 | 8 |
| libprism_es2.so | 64 | 64 |
| libprism_sw.so | 68 | 64 |

### macOS

| Native Library | Current | Stripped |
| --------------- | --------- | -------- |
| libdecora_sse.dylib | 88 | 88 |
| libfxplugins.dylib | 88 | 84 |
| libglass.dylib | 360 | 324 |
| libglib-lite.dylib | 1,192 | 1,148 |
| libgstreamer-lite.dylib | 1,708 | 1584 |
| libjavafx_font.dylib | 64 | 64 |
| libjavafx_iio.dylib | 308 | 300 |
| libjfxmedia.dylib | 212 | 200 |
| libjfxmedia_avf.dylib | 100 | 88 |
| libjfxwebkit.dylib | 85,896 | 71,636 |
| libprism_common.dylib | 20 | 20 |
| libprism_es2.dylib | 64 | 64 |
| libprism_sw.dylib | 88 | 88 |

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278260](https://bugs.openjdk.java.net/browse/JDK-8278260): JavaFX shared libraries not stripped on Linux or macOS


### Reviewers
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/695/head:pull/695` \
`$ git checkout pull/695`

Update a local copy of the PR: \
`$ git checkout pull/695` \
`$ git pull https://git.openjdk.java.net/jfx pull/695/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 695`

View PR using the GUI difftool: \
`$ git pr show -t 695`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/695.diff">https://git.openjdk.java.net/jfx/pull/695.diff</a>

</details>
