### PR TITLE
8278860: Streamline properties for Monocle

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/PlatformUtil.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/PlatformUtil.java
@@ -33,6 +33,7 @@ import java.io.InputStream;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Locale;
 import java.util.Properties;
 
 public class PlatformUtil {
@@ -63,7 +64,7 @@ public class PlatformUtil {
         embedded = bool1;
 
         @SuppressWarnings("removal")
-        String str2 = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("embedded"));
+        String str2 = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("glass.platform","").toLowerCase(Locale.ROOT));
         embeddedType = str2;
 
         @SuppressWarnings("removal")

--- a/modules/javafx.base/src/main/java/com/sun/javafx/PlatformUtil.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/PlatformUtil.java
@@ -64,7 +64,7 @@ public class PlatformUtil {
         embedded = bool1;
 
         @SuppressWarnings("removal")
-        String str2 = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("glass.platform","").toLowerCase(Locale.ROOT));
+        String str2 = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getProperty("glass.platform", "").toLowerCase(Locale.ROOT));
         embeddedType = str2;
 
         @SuppressWarnings("removal")


### PR DESCRIPTION
Base decisions in prism for embedded cases on the same glass.platform property that is also used in glass.
This PR replaces the property `embedded` with the property `glass.platform` .

There is only 1 place where the property `embedded` was read, which is in the PlatformUtil.java.

There are only 2 places where the value of that property is used, and in both cases the only check is to detect whether or not that property has a value of "monocle".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278860](https://bugs.openjdk.java.net/browse/JDK-8278860): Streamline properties for Monocle


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/696/head:pull/696` \
`$ git checkout pull/696`

Update a local copy of the PR: \
`$ git checkout pull/696` \
`$ git pull https://git.openjdk.java.net/jfx pull/696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 696`

View PR using the GUI difftool: \
`$ git pr show -t 696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/696.diff">https://git.openjdk.java.net/jfx/pull/696.diff</a>

</details>
