### PR TITLE
8278905 JavaFX: EnumConverter has a typo in the toString method

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/EnumConverter.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/EnumConverter.java
@@ -224,6 +224,6 @@ public final class EnumConverter<E extends Enum<E>> extends StyleConverter<Strin
 
     @Override
     public String toString() {
-        return "EnumConveter[" + enumClass.getName() + "]";
+        return "EnumConverter[" + enumClass.getName() + "]";
     }
 }


### PR DESCRIPTION
Fixing typo in EnumConverter

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278905](https://bugs.openjdk.java.net/browse/JDK-8278905): JavaFX: EnumConverter has a typo in the toString method


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/697/head:pull/697` \
`$ git checkout pull/697`

Update a local copy of the PR: \
`$ git checkout pull/697` \
`$ git pull https://git.openjdk.java.net/jfx pull/697/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 697`

View PR using the GUI difftool: \
`$ git pr show -t 697`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/697.diff">https://git.openjdk.java.net/jfx/pull/697.diff</a>

</details>
