### PR TITLE
8279013 : ES2Pipeline fails to detect AMD vega20 graphics card

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/es2/X11GLFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/es2/X11GLFactory.java
@@ -41,6 +41,7 @@ class X11GLFactory extends GLFactory {
     // Limit es2 pipe qualification check to supported drivers and GPUs
     private GLGPUInfo preQualificationFilter[] = {
         new GLGPUInfo("advanced micro devices", null),
+        new GLGPUInfo("amd", null),
         new GLGPUInfo("ati", null),
         new GLGPUInfo("intel", null),
         new GLGPUInfo("nvidia", null),


### PR DESCRIPTION
I have an AMD Radeon VII (vega20) series GPU which is identifying with a vendor string of "AMD".

This is not present in the `X11GLFactory` list of `preQualificationFilter` vendor names, so my system (and probably any other vega20 based cards under Linux) will always fall back to software rendering.

This adds the "amd" string to the `preQualificationFilter` list.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279013](https://bugs.openjdk.java.net/browse/JDK-8279013): ES2Pipeline fails to detect AMD vega20 graphics card


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/698/head:pull/698` \
`$ git checkout pull/698`

Update a local copy of the PR: \
`$ git checkout pull/698` \
`$ git pull https://git.openjdk.java.net/jfx pull/698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 698`

View PR using the GUI difftool: \
`$ git pr show -t 698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/698.diff">https://git.openjdk.java.net/jfx/pull/698.diff</a>

</details>
