### PR TITLE
8279228 Leak in ScrollPaneSkin, related to touch events

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ScrollPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ScrollPaneSkin.java
@@ -25,6 +25,7 @@
 
 package javafx.scene.control.skin;
 
+import com.sun.javafx.scene.NodeHelper;
 import com.sun.javafx.scene.ParentHelper;
 import com.sun.javafx.scene.control.Properties;
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
@@ -1200,7 +1201,7 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
             sbTouchTimeline = new Timeline();
             sbTouchKF1 = new KeyFrame(Duration.millis(0), event -> {
                 tempVisibility = true;
-                if (touchDetected == true || mouseDown == true) {
+                if ((touchDetected == true || mouseDown == true) && NodeHelper.isTreeShowing(getSkinnable())) {
                     sbTouchTimeline.playFromStart();
                 }
             });


### PR DESCRIPTION
Fixing memoryleak, related to touch events in ScrollPaneWhen touchDetected or mouseDown is true, the sbTouch animation is running, 
and the node is removed from the Scene, then the animation will never stop, causing a memory leak.
A simple fix is to also check, whether the Node is visible, by checking the "isTreeShowing" property.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279228](https://bugs.openjdk.java.net/browse/JDK-8279228): Leak in ScrollPaneSkin, related to touch events


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/701/head:pull/701` \
`$ git checkout pull/701`

Update a local copy of the PR: \
`$ git checkout pull/701` \
`$ git pull https://git.openjdk.java.net/jfx pull/701/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 701`

View PR using the GUI difftool: \
`$ git pr show -t 701`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/701.diff">https://git.openjdk.java.net/jfx/pull/701.diff</a>

</details>
