### PR TITLE
8278938: [Win] Robot can target wrong key for punctuation and symbols

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/KeyTable.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/KeyTable.cpp
@@ -185,18 +185,133 @@ jint WindowsKeyToJavaKey(UINT wKey)
     return com_sun_glass_events_KeyEvent_VK_UNDEFINED;
 }
 
-void JavaKeyToWindowsKey(jint jkey, UINT &vkey, UINT &modifiers)
+static UINT const oemKeys[] = {
+    VK_OEM_1,
+    VK_OEM_PLUS,
+    VK_OEM_COMMA,
+    VK_OEM_MINUS,
+    VK_OEM_PERIOD,
+    VK_OEM_2,
+    VK_OEM_3,
+    VK_OEM_4,
+    VK_OEM_5,
+    VK_OEM_6,
+    VK_OEM_7,
+    VK_OEM_8,
+    VK_OEM_102
+};
+static constexpr size_t numOEMKeys = sizeof(oemKeys) / sizeof(oemKeys[0]);
+
+static BOOL isOEMKey(UINT vkey)
 {
+    for (size_t i = 0; i < numOEMKeys; ++i)
+    {
+        if (oemKeys[i] == vkey)
+            return true;
+    }
+    return false;
+}
+
+jint OEMCharToJavaKey(UINT ch, bool deadKey)
+{
+    jint jKeyCode = com_sun_glass_events_KeyEvent_VK_UNDEFINED;
+    if (deadKey)
+    {
+        switch (ch) {
+            case L'`':   jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_GRAVE; break;
+            case L'\'':  jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_ACUTE; break;
+            case 0x00B4: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_ACUTE; break;
+            case L'^':   jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_CIRCUMFLEX; break;
+            case L'~':   jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_TILDE; break;
+            case 0x02DC: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_TILDE; break;
+            case 0x00AF: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_MACRON; break;
+            case 0x02D8: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_BREVE; break;
+            case 0x02D9: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_ABOVEDOT; break;
+            case L'"':   jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_DIAERESIS; break;
+            case 0x00A8: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_DIAERESIS; break;
+            case 0x02DA: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_ABOVERING; break;
+            case 0x02DD: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_DOUBLEACUTE; break;
+            case 0x02C7: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_CARON; break;            // aka hacek
+            case L',':   jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_CEDILLA; break;
+            case 0x00B8: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_CEDILLA; break;
+            case 0x02DB: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_OGONEK; break;
+            case 0x037A: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_IOTA; break;             // ASCII ???
+            case 0x309B: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_VOICED_SOUND; break;
+            case 0x309C: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_SEMIVOICED_SOUND; break;
+        }
+    }
+    else
+    {
+        switch (ch) {
+            case L'!':   jKeyCode = com_sun_glass_events_KeyEvent_VK_EXCLAMATION; break;
+            case L'"':   jKeyCode = com_sun_glass_events_KeyEvent_VK_DOUBLE_QUOTE; break;
+            case L'#':   jKeyCode = com_sun_glass_events_KeyEvent_VK_NUMBER_SIGN; break;
+            case L'$':   jKeyCode = com_sun_glass_events_KeyEvent_VK_DOLLAR; break;
+            case L'&':   jKeyCode = com_sun_glass_events_KeyEvent_VK_AMPERSAND; break;
+            case L'\'':  jKeyCode = com_sun_glass_events_KeyEvent_VK_QUOTE; break;
+            case L'(':   jKeyCode = com_sun_glass_events_KeyEvent_VK_LEFT_PARENTHESIS; break;
+            case L')':   jKeyCode = com_sun_glass_events_KeyEvent_VK_RIGHT_PARENTHESIS; break;
+            case L'*':   jKeyCode = com_sun_glass_events_KeyEvent_VK_ASTERISK; break;
+            case L'+':   jKeyCode = com_sun_glass_events_KeyEvent_VK_PLUS; break;
+            case L',':   jKeyCode = com_sun_glass_events_KeyEvent_VK_COMMA; break;
+            case L'-':   jKeyCode = com_sun_glass_events_KeyEvent_VK_MINUS; break;
+            case L'.':   jKeyCode = com_sun_glass_events_KeyEvent_VK_PERIOD; break;
+            case L'/':   jKeyCode = com_sun_glass_events_KeyEvent_VK_SLASH; break;
+            case L':':   jKeyCode = com_sun_glass_events_KeyEvent_VK_COLON; break;
+            case L';':   jKeyCode = com_sun_glass_events_KeyEvent_VK_SEMICOLON; break;
+            case L'<':   jKeyCode = com_sun_glass_events_KeyEvent_VK_LESS; break;
+            case L'=':   jKeyCode = com_sun_glass_events_KeyEvent_VK_EQUALS; break;
+            case L'>':   jKeyCode = com_sun_glass_events_KeyEvent_VK_GREATER; break;
+            case L'@':   jKeyCode = com_sun_glass_events_KeyEvent_VK_AT; break;
+            case L'[':   jKeyCode = com_sun_glass_events_KeyEvent_VK_OPEN_BRACKET; break;
+            case L'\\':  jKeyCode = com_sun_glass_events_KeyEvent_VK_BACK_SLASH; break;
+            case L']':   jKeyCode = com_sun_glass_events_KeyEvent_VK_CLOSE_BRACKET; break;
+            case L'^':   jKeyCode = com_sun_glass_events_KeyEvent_VK_CIRCUMFLEX; break;
+            case L'_':   jKeyCode = com_sun_glass_events_KeyEvent_VK_UNDERSCORE; break;
+            case L'`':   jKeyCode = com_sun_glass_events_KeyEvent_VK_BACK_QUOTE; break;
+            case L'{':   jKeyCode = com_sun_glass_events_KeyEvent_VK_BRACELEFT; break;
+            case L'}':   jKeyCode = com_sun_glass_events_KeyEvent_VK_BRACERIGHT; break;
+            case 0x00A1: jKeyCode = com_sun_glass_events_KeyEvent_VK_INV_EXCLAMATION; break;
+            case 0x20A0: jKeyCode = com_sun_glass_events_KeyEvent_VK_EURO_SIGN; break;
+        }
+    }
+    return jKeyCode;
+}
+
+void JavaKeyToWindowsKey(jint jkey, UINT &vkey, UINT& modifiers)
+{
+    vkey = 0;
+    modifiers = 0;
+
+    if (jkey == com_sun_glass_events_KeyEvent_VK_UNDEFINED)
+        return;
+
     for (int i = 0; keyMapTable[i].windowsKey; i++) {
         if (keyMapTable[i].javaKey == jkey) {
             vkey = keyMapTable[i].windowsKey;
-            modifiers = 0;
-            return;
+            break;
         }
     }
 
-    vkey = 0;
-    modifiers = 0;
+    if (!vkey || isOEMKey(vkey)) {
+        // The table is missing entries for keys that don't appear on US
+        // layouts, like KeyCode.PLUS. Even if we found a key it may be
+        // an OEM key and the relationship between OEM keys and the
+        // characters they generate is not fixed even for US English
+        // layouts. So in these instances we search through the OEM keys
+        // looking for the Java code.
+        for (size_t i = 0; i < numOEMKeys; ++i)
+        {
+            UINT ch = ::MapVirtualKey(oemKeys[i], 2);
+            bool deadKey = (ch & 0x80000000);
+            jint trialCode = OEMCharToJavaKey(LOWORD(ch), deadKey);
+            if (trialCode == jkey)
+            {
+                vkey = oemKeys[i];
+                break;
+            }
+        }
+    }
 }
 
 BOOL IsExtendedKey(UINT vkey) {

--- a/modules/javafx.graphics/src/main/native-glass/win/KeyTable.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/KeyTable.h
@@ -29,5 +29,5 @@
 jint WindowsKeyToJavaKey(UINT wKey);
 void JavaKeyToWindowsKey(jint jkey, UINT &vkey, UINT &modifiers);
 BOOL IsExtendedKey(UINT vkey);
-
+jint OEMCharToJavaKey(UINT ch, bool deadKey);
 #endif // _KEY_TABLE_

--- a/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
@@ -406,65 +406,9 @@ void ViewContainer::HandleViewKeyEvent(HWND hwnd, UINT msg, WPARAM wParam, LPARA
         case 0x00E2:// VK_OEM_102
             if (unicodeConverted < 0) {
                 // Dead key
-                switch (wChar[0]) {
-                    case L'`':   jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_GRAVE; break;
-                    case L'\'':  jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_ACUTE; break;
-                    case 0x00B4: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_ACUTE; break;
-                    case L'^':   jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_CIRCUMFLEX; break;
-                    case L'~':   jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_TILDE; break;
-                    case 0x02DC: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_TILDE; break;
-                    case 0x00AF: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_MACRON; break;
-                    case 0x02D8: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_BREVE; break;
-                    case 0x02D9: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_ABOVEDOT; break;
-                    case L'"':   jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_DIAERESIS; break;
-                    case 0x00A8: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_DIAERESIS; break;
-                    case 0x02DA: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_ABOVERING; break;
-                    case 0x02DD: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_DOUBLEACUTE; break;
-                    case 0x02C7: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_CARON; break;            // aka hacek
-                    case L',':   jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_CEDILLA; break;
-                    case 0x00B8: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_CEDILLA; break;
-                    case 0x02DB: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_OGONEK; break;
-                    case 0x037A: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_IOTA; break;             // ASCII ???
-                    case 0x309B: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_VOICED_SOUND; break;
-                    case 0x309C: jKeyCode = com_sun_glass_events_KeyEvent_VK_DEAD_SEMIVOICED_SOUND; break;
-
-                    default:     jKeyCode = com_sun_glass_events_KeyEvent_VK_UNDEFINED; break;
-                };
+                jKeyCode = OEMCharToJavaKey(wChar[0], true);
             } else if (unicodeConverted == 1) {
-                switch (wChar[0]) {
-                    case L'!':   jKeyCode = com_sun_glass_events_KeyEvent_VK_EXCLAMATION; break;
-                    case L'"':   jKeyCode = com_sun_glass_events_KeyEvent_VK_DOUBLE_QUOTE; break;
-                    case L'#':   jKeyCode = com_sun_glass_events_KeyEvent_VK_NUMBER_SIGN; break;
-                    case L'$':   jKeyCode = com_sun_glass_events_KeyEvent_VK_DOLLAR; break;
-                    case L'&':   jKeyCode = com_sun_glass_events_KeyEvent_VK_AMPERSAND; break;
-                    case L'\'':  jKeyCode = com_sun_glass_events_KeyEvent_VK_QUOTE; break;
-                    case L'(':   jKeyCode = com_sun_glass_events_KeyEvent_VK_LEFT_PARENTHESIS; break;
-                    case L')':   jKeyCode = com_sun_glass_events_KeyEvent_VK_RIGHT_PARENTHESIS; break;
-                    case L'*':   jKeyCode = com_sun_glass_events_KeyEvent_VK_ASTERISK; break;
-                    case L'+':   jKeyCode = com_sun_glass_events_KeyEvent_VK_PLUS; break;
-                    case L',':   jKeyCode = com_sun_glass_events_KeyEvent_VK_COMMA; break;
-                    case L'-':   jKeyCode = com_sun_glass_events_KeyEvent_VK_MINUS; break;
-                    case L'.':   jKeyCode = com_sun_glass_events_KeyEvent_VK_PERIOD; break;
-                    case L'/':   jKeyCode = com_sun_glass_events_KeyEvent_VK_SLASH; break;
-                    case L':':   jKeyCode = com_sun_glass_events_KeyEvent_VK_COLON; break;
-                    case L';':   jKeyCode = com_sun_glass_events_KeyEvent_VK_SEMICOLON; break;
-                    case L'<':   jKeyCode = com_sun_glass_events_KeyEvent_VK_LESS; break;
-                    case L'=':   jKeyCode = com_sun_glass_events_KeyEvent_VK_EQUALS; break;
-                    case L'>':   jKeyCode = com_sun_glass_events_KeyEvent_VK_GREATER; break;
-                    case L'@':   jKeyCode = com_sun_glass_events_KeyEvent_VK_AT; break;
-                    case L'[':   jKeyCode = com_sun_glass_events_KeyEvent_VK_OPEN_BRACKET; break;
-                    case L'\\':  jKeyCode = com_sun_glass_events_KeyEvent_VK_BACK_SLASH; break;
-                    case L']':   jKeyCode = com_sun_glass_events_KeyEvent_VK_CLOSE_BRACKET; break;
-                    case L'^':   jKeyCode = com_sun_glass_events_KeyEvent_VK_CIRCUMFLEX; break;
-                    case L'_':   jKeyCode = com_sun_glass_events_KeyEvent_VK_UNDERSCORE; break;
-                    case L'`':   jKeyCode = com_sun_glass_events_KeyEvent_VK_BACK_QUOTE; break;
-                    case L'{':   jKeyCode = com_sun_glass_events_KeyEvent_VK_BRACELEFT; break;
-                    case L'}':   jKeyCode = com_sun_glass_events_KeyEvent_VK_BRACERIGHT; break;
-                    case 0x00A1: jKeyCode = com_sun_glass_events_KeyEvent_VK_INV_EXCLAMATION; break;
-                    case 0x20A0: jKeyCode = com_sun_glass_events_KeyEvent_VK_EURO_SIGN; break;
-
-                    default:     jKeyCode = com_sun_glass_events_KeyEvent_VK_UNDEFINED; break;
-                }
+                jKeyCode = OEMCharToJavaKey(wChar[0], false);
             } else if (unicodeConverted == 0 || unicodeConverted > 1) {
                 jKeyCode = com_sun_glass_events_KeyEvent_VK_UNDEFINED;
             }


### PR DESCRIPTION
When processing a `WM_CHAR` event on an OEM key (punctuation, symbol, dead key) the glass code will dynamically query the key's unshifted character to determine the Java code to assign to it. This is necessary since the relationship between OEM key codes and the characters they generate varies from layout to layout.

The Robot implementation was consulting a table which assumed a fixed relationship between Java codes and Windows key codes even for the OEM keys. The table was also missing entries for any Java code not on a US QWERTY layout, like PLUS.

In this PR if we don't find the Java code in the table or if it maps to an OEM key (which may be wrong) we sweep through all the OEM keys looking for the matching Java code.