### PR TITLE
8279328: CssParser uses default charset instead of UTF-8

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CssParser.java
@@ -97,6 +97,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -236,7 +237,7 @@ final public class CssParser {
         final Stylesheet stylesheet = new Stylesheet(path);
         if (url != null) {
             setInputSource(path, null);
-            try (Reader reader = new BufferedReader(new InputStreamReader(url.openStream()))) {
+            try (Reader reader = new BufferedReader(new InputStreamReader(url.openStream(), StandardCharsets.UTF_8))) {
                 parse(stylesheet, reader);
             }
         }

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/CssParserTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/CssParserTest.java
@@ -27,11 +27,16 @@ package test.javafx.css;
 
 import com.sun.javafx.css.*;
 
+import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -314,5 +319,29 @@ public class CssParserTest {
         value = new CssParserShim().parseExpr("foo", "indefinite;");
         observed = value.convert(null);
         assertEquals(Duration.INDEFINITE, observed);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testUTF8EncodedMultibyteSymbolIsCorrectlyParsed() throws IOException {
+        File file = null;
+
+        try {
+            file = File.createTempFile("CssParserTest", ".css");
+
+            try (var writer = new BufferedWriter(new OutputStreamWriter(
+                    new FileOutputStream(file), StandardCharsets.UTF_8))) {
+                writer.write(".foo { bar: '\u2713' }");
+            }
+
+            var stylesheet = new CssParser().parse(file.toURI().toURL());
+            ParsedValue<String, ?> parsedValue = stylesheet.getRules().get(0).getDeclarations().get(0).getParsedValue();
+
+            assertEquals("\u2713", parsedValue.getValue());
+        } finally {
+            if (file != null) {
+                file.delete();
+            }
+        }
     }
 }


### PR DESCRIPTION
`CssParser.parse(URL)` is specified to assume UTF-8 file encoding, but (implicitly) uses the default charset to read the file, potentially resulting in incorrect interpretation of the file content.

This can be fixed by explicitly specifying the UTF-8 charset for `InputStreamReader`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279328](https://bugs.openjdk.java.net/browse/JDK-8279328): CssParser uses default charset instead of UTF-8


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/705/head:pull/705` \
`$ git checkout pull/705`

Update a local copy of the PR: \
`$ git checkout pull/705` \
`$ git pull https://git.openjdk.java.net/jfx pull/705/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 705`

View PR using the GUI difftool: \
`$ git pr show -t 705`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/705.diff">https://git.openjdk.java.net/jfx/pull/705.diff</a>

</details>
