### PR TITLE
8279396: Define version in .jcheck/conf

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -24,6 +24,7 @@
 [general]
 project=openjfx
 jbs=jdk
+version=openjfx18
 
 [repository]
 tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9]((\.\d{1,3}){0,2})-((b\d{2,3})|(ga))|[1-9]u(\d{1,3})-((b\d{2,3})|(ga))

--- a/UPDATING-VERSION.md
+++ b/UPDATING-VERSION.md
@@ -10,6 +10,9 @@ for a recent example.
 Here are the steps to increment the JavaFX release version number to a new
 feature version (for example, from 13 to 14).
 
+* In `.jcheck/conf`, modify the `version` property in the `[general]`
+section to increment the version number from `openjfx$N` to `openjfx$N+1`.
+
 * In `build.properties`, modify the following properties to increment the
 feature version number from `N` to `N+1`:
 
@@ -28,6 +31,10 @@ from `N` to `N+1`.
 
 Here are the steps to increment the JavaFX release version number to a new
 security version (for example, from 13 to 13.0.1).
+
+* In `.jcheck/conf`, modify the `version` property in the `[general]`
+section to increment the version number from `openjfx$N` to `openjfx$N.0.1`
+or from `openjfx$N.0.M` to `openjfx$N.0.$M+1`.
 
 * In `build.properties`, modify the `jfx.release.security.version` property
 to increment the security version number from `M` to `M+1`.


### PR DESCRIPTION
This patch adds the version property to `.jcheck/conf`. By doing this we can remove the corresponding configuration from the Skara bots, which in turn reduces the need for timing and general complexity of starting a new JavaFX release. See openjdk/jdk#6929 for the similar PR for the `jdk` repo.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279396](https://bugs.openjdk.java.net/browse/JDK-8279396): Define version in .jcheck/conf


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - no project role)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/706/head:pull/706` \
`$ git checkout pull/706`

Update a local copy of the PR: \
`$ git checkout pull/706` \
`$ git pull https://git.openjdk.java.net/jfx pull/706/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 706`

View PR using the GUI difftool: \
`$ git pr show -t 706`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/706.diff">https://git.openjdk.java.net/jfx/pull/706.diff</a>

</details>
