### PR TITLE
8279615: Change JavaFX release version to 19

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -24,7 +24,7 @@
 [general]
 project=openjfx
 jbs=jdk
-version=openjfx18
+version=openjfx19
 
 [repository]
 tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9]((\.\d{1,3}){0,2})-((b\d{2,3})|(ga))|[1-9]u(\d{1,3})-((b\d{2,3})|(ga))

--- a/build.properties
+++ b/build.properties
@@ -39,7 +39,7 @@
 jfx.release.suffix=-ea
 
 # UPDATE THE FOLLOWING VALUES FOR A NEW RELEASE
-jfx.release.major.version=18
+jfx.release.major.version=19
 jfx.release.minor.version=0
 jfx.release.security.version=0
 jfx.release.patch.version=0
@@ -56,8 +56,8 @@ jfx.release.patch.version=0
 
 javadoc.bottom=<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2022, Oracle and/or its affiliates. All rights reserved.</small>
 
-javadoc.title=JavaFX 18
-javadoc.header=JavaFX&nbsp;18
+javadoc.title=JavaFX 19
+javadoc.header=JavaFX&nbsp;19
 
 ##############################################################################
 #

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
@@ -89,7 +89,7 @@ public class VersionInfoTest {
         String version = VersionInfo.getVersion();
         // Need to update major version number when we develop the next
         // major release.
-        assertTrue(version.startsWith("18"));
+        assertTrue(version.startsWith("19"));
         String runtimeVersion = VersionInfo.getRuntimeVersion();
         assertTrue(runtimeVersion.startsWith(version));
     }


### PR DESCRIPTION
Bump the version number of JavaFX to 19. I will integrate this immediately after forking the `jfx18` stabilization branch, which is scheduled for Thursday, January 13, 2022 at 16:00 UTC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279615](https://bugs.openjdk.java.net/browse/JDK-8279615): Change JavaFX release version to 19


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/707/head:pull/707` \
`$ git checkout pull/707`

Update a local copy of the PR: \
`$ git checkout pull/707` \
`$ git pull https://git.openjdk.java.net/jfx pull/707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 707`

View PR using the GUI difftool: \
`$ git pr show -t 707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/707.diff">https://git.openjdk.java.net/jfx/pull/707.diff</a>

</details>
