### PR TITLE
8273998: Clarify specification for Window properties controlled by the window manager

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
@@ -619,8 +619,8 @@ public class Stage extends Window {
      * </p>
      * <p>
      * This property is read-only because it can be changed externally
-     * by the underlying platform. A value set by the application might be
-     * ignored on some platforms.
+     * by the underlying platform.
+     * Further, setting this property might be ignored on some platforms.
      * </p>
      *
      * The user can unconditionally exit full-screen mode
@@ -769,8 +769,8 @@ public class Stage extends Window {
      * </p>
      * <p>
      * This property is read-only because it can be changed externally
-     * by the underlying platform. A value set by the application might be
-     * ignored on some platforms.
+     * by the underlying platform.
+     * Further, setting this property might be ignored on some platforms.
      * </p>
      *
      * @defaultValue false
@@ -807,8 +807,8 @@ public class Stage extends Window {
      * </p>
      * <p>
      * This property is read-only because it can be changed externally
-     * by the underlying platform. A value set by the application might be
-     * ignored on some platforms.
+     * by the underlying platform.
+     * Further, setting this property might be ignored on some platforms.
      * </p>
      *
      * @defaultValue false
@@ -854,8 +854,8 @@ public class Stage extends Window {
      * </p>
      * <p>
      * This property is read-only because it can be changed externally
-     * by the underlying platform. A value set by the application might be
-     * ignored on some platforms.
+     * by the underlying platform.
+     * Further, setting this property might be ignored on some platforms.
      * </p>
      *
      * @defaultValue false
@@ -1203,8 +1203,22 @@ public class Stage extends Window {
     }
 
     /**
-     * Bring the {@code Window} to the foreground.  If the {@code Window} is
-     * already in the foreground there is no visible difference.
+     * Brings this {@code Stage} to the front if the stage is visible.
+     * This action places this {@code Stage} at the top of the stacking
+     * order and shows it in front of any other {@code Stage} created by this
+     * application.
+     * <p>
+     * Some platforms do not allow applications to control the stacking order
+     * at all, in which case this method does nothing.
+     * Other platforms have restrictions on stacking order, so might not
+     * place a window above another application's windows
+     * nor allow a window that owns other windows to appear on top of those
+     * owned windows.
+     * Every attempt will be made to move this {@code Stage} as high as
+     * possible in the stacking order; however, developers should not assume
+     * that this method will move this {@code Stage} above all other windows
+     * in every situation.
+     * </p>
      */
     public void toFront() {
         if (getPeer() != null) {
@@ -1213,10 +1227,22 @@ public class Stage extends Window {
     }
 
     /**
-     * Send the {@code Window} to the background.  If the {@code Window} is
-     * already in the background there is no visible difference.  This action
-     * places this {@code Window} at the bottom of the stacking order on
-     * platforms that support stacking.
+     * Sends this {@code Stage} to the back if the stage is visible.
+     * This action places this {@code Stage} at the bottom of the stacking
+     * order and shows it behind any other {@code Stage} created by this
+     * application.
+     * <p>
+     * Some platforms do not allow applications to control the stacking order
+     * at all, in which case this method does nothing.
+     * Other platforms have restrictions on stacking order, so might not
+     * place a window below another application's windows
+     * nor allow a window that is owned by another window to appear below their
+     * owner.
+     * Every attempt will be made to move this {@code Stage} as low as
+     * possible in the stacking order; however, developers should not assume
+     * that this method will move this {@code Stage} below all other windows
+     * in every situation.
+     * </p>
      */
     public void toBack() {
         if (getPeer() != null) {

--- a/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
@@ -72,9 +72,13 @@ import javafx.beans.value.ObservableValue;
  * the {@link Platform#startup(Runnable)} method for more information.
  * </p>
  * <p>
- * Many of the {@code Stage} properties are read only because they can
- * be changed externally by the underlying platform and therefore must
- * not be bindable.
+ * Some {@code Stage} properties are read-only, even though they have
+ * corresponding set methods, because they can be changed externally by the
+ * underlying platform, and therefore must not be bindable.
+ * Further, these properties might be ignored on some platforms, depending on
+ * whether or not there is a window manager and how it is configured.
+ * For example, a platform without a window manager might ignore the
+ * {@code iconified} property.
  * </p>
  *
  * <p><b>Style</b></p>
@@ -614,8 +618,9 @@ public class Stage extends Window {
      * strongest to weakest).
      * </p>
      * <p>
-     * The property is read only because it can be changed externally
-     * by the underlying platform and therefore must not be bindable.
+     * This property is read-only because it can be changed externally
+     * by the underlying platform. A value set by the application might be
+     * ignored on some platforms.
      * </p>
      *
      * The user can unconditionally exit full-screen mode
@@ -763,8 +768,9 @@ public class Stage extends Window {
      * hide the {@code Stage} but not show an icon for it.
      * </p>
      * <p>
-     * The property is read only because it can be changed externally
-     * by the underlying platform and therefore must not be bindable.
+     * This property is read-only because it can be changed externally
+     * by the underlying platform. A value set by the application might be
+     * ignored on some platforms.
      * </p>
      *
      * @defaultValue false
@@ -800,8 +806,9 @@ public class Stage extends Window {
      * strongest to weakest).
      * </p>
      * <p>
-     * The property is read only because it can be changed externally
-     * by the underlying platform and therefore must not be bindable.
+     * This property is read-only because it can be changed externally
+     * by the underlying platform. A value set by the application might be
+     * ignored on some platforms.
      * </p>
      *
      * @defaultValue false
@@ -846,8 +853,9 @@ public class Stage extends Window {
      * and the property value will be restored to {@code false}.
      * </p>
      * <p>
-     * The property is read only because it can be changed externally
-     * by the underlying platform and therefore must not be bindable.
+     * This property is read-only because it can be changed externally
+     * by the underlying platform. A value set by the application might be
+     * ignored on some platforms.
      * </p>
      *
      * @defaultValue false

--- a/modules/javafx.graphics/src/main/java/javafx/stage/Window.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/Window.java
@@ -542,8 +542,8 @@ public class Window implements EventTarget {
      * becomes false.
      * <p>
      * This property is read-only because it can be changed externally
-     * by the underlying platform. A value set by the application might be
-     * ignored on some platforms.
+     * by the underlying platform.
+     * Further, setting this property might be ignored on some platforms.
      * </p>
      */
     private ReadOnlyDoubleWrapper x =
@@ -573,8 +573,8 @@ public class Window implements EventTarget {
      * becomes false.
      * <p>
      * This property is read-only because it can be changed externally
-     * by the underlying platform. A value set by the application might be
-     * ignored on some platforms.
+     * by the underlying platform.
+     * Further, setting this property might be ignored on some platforms.
      * </p>
      */
     private ReadOnlyDoubleWrapper y =
@@ -621,8 +621,8 @@ public class Window implements EventTarget {
      * becomes false.
      * <p>
      * This property is read-only because it can be changed externally
-     * by the underlying platform. A value set by the application might be
-     * ignored on some platforms.
+     * by the underlying platform.
+     * Further, setting this property might be ignored on some platforms.
      * </p>
      */
     private ReadOnlyDoubleWrapper width =
@@ -653,8 +653,8 @@ public class Window implements EventTarget {
      * becomes false.
      * <p>
      * This property is read-only because it can be changed externally
-     * by the underlying platform. A value set by the application might be
-     * ignored on some platforms.
+     * by the underlying platform.
+     * Further, setting this property might be ignored on some platforms.
      * </p>
      */
     private ReadOnlyDoubleWrapper height =

--- a/modules/javafx.graphics/src/main/java/javafx/stage/Window.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/Window.java
@@ -85,6 +85,16 @@ import com.sun.javafx.scene.SceneHelper;
  * the JavaFX runtime. See the {@link javafx.application.Application} class and
  * the {@link Platform#startup(Runnable)} method for more information.
  * </p>
+ * <p>
+ * Some {@code Window} properties are read-only, even though they have
+ * corresponding set methods, because they can be changed externally by the
+ * underlying platform, and therefore must not be bindable.
+ * Further, these properties might be ignored on some platforms, depending on
+ * whether or not there is a window manager and how it is configured.
+ * For example, a tiling window manager might ignore the {@code x} and {@code y}
+ * properties, or treat them as hints, placing the window in a location of its
+ * choosing.
+ * </p>
  *
  * @since JavaFX 2.0
  */
@@ -521,6 +531,7 @@ public class Window implements EventTarget {
     }
 
     private boolean xExplicit = false;
+
     /**
      * The horizontal location of this {@code Window} on the screen. Changing
      * this attribute will move the {@code Window} horizontally. If this
@@ -529,6 +540,11 @@ public class Window implements EventTarget {
      * {@link Stage#fullScreenProperty() fullScreen} is true, but will be honored
      * by the {@code Window} once {@link Stage#fullScreenProperty() fullScreen}
      * becomes false.
+     * <p>
+     * This property is read-only because it can be changed externally
+     * by the underlying platform. A value set by the application might be
+     * ignored on some platforms.
+     * </p>
      */
     private ReadOnlyDoubleWrapper x =
             new ReadOnlyDoubleWrapper(this, "x", Double.NaN);
@@ -546,6 +562,7 @@ public class Window implements EventTarget {
     }
 
     private boolean yExplicit = false;
+
     /**
      * The vertical location of this {@code Window} on the screen. Changing this
      * attribute will move the {@code Window} vertically. If this
@@ -554,6 +571,11 @@ public class Window implements EventTarget {
      * {@link Stage#fullScreenProperty() fullScreen} is true, but will be honored
      * by the {@code Window} once {@link Stage#fullScreenProperty() fullScreen}
      * becomes false.
+     * <p>
+     * This property is read-only because it can be changed externally
+     * by the underlying platform. A value set by the application might be
+     * ignored on some platforms.
+     * </p>
      */
     private ReadOnlyDoubleWrapper y =
             new ReadOnlyDoubleWrapper(this, "y", Double.NaN);
@@ -598,8 +620,9 @@ public class Window implements EventTarget {
      * by the {@code Window} once {@link Stage#fullScreenProperty() fullScreen}
      * becomes false.
      * <p>
-     * The property is read only because it can be changed externally
-     * by the underlying platform and therefore must not be bindable.
+     * This property is read-only because it can be changed externally
+     * by the underlying platform. A value set by the application might be
+     * ignored on some platforms.
      * </p>
      */
     private ReadOnlyDoubleWrapper width =
@@ -614,6 +637,7 @@ public class Window implements EventTarget {
     public final ReadOnlyDoubleProperty widthProperty() { return width.getReadOnlyProperty(); }
 
     private boolean heightExplicit = false;
+
     /**
      * The height of this {@code Window}. Changing this attribute will shrink
      * or heighten the height of the {@code Window}. This value includes any and all
@@ -628,8 +652,9 @@ public class Window implements EventTarget {
      * by the {@code Window} once {@link Stage#fullScreenProperty() fullScreen}
      * becomes false.
      * <p>
-     * The property is read only because it can be changed externally
-     * by the underlying platform and therefore must not be bindable.
+     * This property is read-only because it can be changed externally
+     * by the underlying platform. A value set by the application might be
+     * ignored on some platforms.
      * </p>
      */
     private ReadOnlyDoubleWrapper height =
@@ -657,10 +682,6 @@ public class Window implements EventTarget {
 
     /**
      * Whether or not this {@code Window} has the keyboard or input focus.
-     * <p>
-     * The property is read only because it can be changed externally
-     * by the underlying platform and therefore must not be bindable.
-     * </p>
      */
     private ReadOnlyBooleanWrapper focused = new ReadOnlyBooleanWrapper() {
         @Override protected void invalidated() {


### PR DESCRIPTION
Update the API specification for the `Window` and `Stage` classes to clarify that the values for some properties and methods can be changed or ignored by the platform. Several of the properties already have a comment to the effect that the value can change externally, and thus the properties are not bindable, but this should be clarified further and for all such properties and methods.

See the Description of the JBS issues for this bug and its associated CSR for more details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8273998](https://bugs.openjdk.java.net/browse/JDK-8273998): Clarify specification for Window properties controlled by the window manager
 * [JDK-8279620](https://bugs.openjdk.java.net/browse/JDK-8279620): Clarify specification for Window properties controlled by the window manager (**CSR**)


### Reviewers
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/708/head:pull/708` \
`$ git checkout pull/708`

Update a local copy of the PR: \
`$ git checkout pull/708` \
`$ git pull https://git.openjdk.java.net/jfx pull/708/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 708`

View PR using the GUI difftool: \
`$ git pr show -t 708`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/708.diff">https://git.openjdk.java.net/jfx/pull/708.diff</a>

</details>
