### PR TITLE
8273336: Clicking a selected cell from a group of selected cells in a TableView clears the selected items list but remains selected

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
@@ -168,8 +168,8 @@ class ControlUtils {
             sm.startAtomic();
             final List<Integer> removed = c.getRemoved().stream()
                     .map(TablePositionBase::getRow)
-                    .filter(removeRowFilter)
                     .distinct()
+                    .filter(removeRowFilter)
                     .peek(sm.selectedIndices::clear)
                     .collect(Collectors.toList());
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
@@ -36,7 +36,7 @@ import javafx.scene.Scene;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.function.Predicate;
+import java.util.function.IntPredicate;
 import java.util.stream.Collectors;
 
 class ControlUtils {
@@ -157,7 +157,7 @@ class ControlUtils {
         };
     }
 
-    public static <S> void updateSelectedIndices(MultipleSelectionModelBase<S> sm, ListChangeListener.Change<? extends TablePositionBase<?>> c, Predicate<Integer> removeRowFilter) {
+    public static <S> void updateSelectedIndices(MultipleSelectionModelBase<S> sm, ListChangeListener.Change<? extends TablePositionBase<?>> c, IntPredicate removeRowFilter) {
         sm.selectedIndices._beginChange();
 
         while (c.next()) {
@@ -167,14 +167,15 @@ class ControlUtils {
 
             sm.startAtomic();
             final List<Integer> removed = c.getRemoved().stream()
-                    .map(TablePositionBase::getRow)
+                    .mapToInt(TablePositionBase::getRow)
                     .distinct()
                     .filter(removeRowFilter)
+                    .boxed()
                     .peek(sm.selectedIndices::clear)
                     .collect(Collectors.toList());
 
             final int addedSize = (int)c.getAddedSubList().stream()
-                    .map(TablePositionBase::getRow)
+                    .mapToInt(TablePositionBase::getRow)
                     .distinct()
                     .peek(sm.selectedIndices::set)
                     .count();

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
@@ -36,6 +36,7 @@ import javafx.scene.Scene;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 class ControlUtils {
@@ -156,7 +157,7 @@ class ControlUtils {
         };
     }
 
-    public static <S> void updateSelectedIndices(MultipleSelectionModelBase<S> sm, ListChangeListener.Change<? extends TablePositionBase<?>> c) {
+    public static <S> void updateSelectedIndices(MultipleSelectionModelBase<S> sm, ListChangeListener.Change<? extends TablePositionBase<?>> c, Predicate<Integer> removeRowFilter) {
         sm.selectedIndices._beginChange();
 
         while (c.next()) {
@@ -167,6 +168,7 @@ class ControlUtils {
             sm.startAtomic();
             final List<Integer> removed = c.getRemoved().stream()
                     .map(TablePositionBase::getRow)
+                    .filter(removeRowFilter)
                     .distinct()
                     .peek(sm.selectedIndices::clear)
                     .collect(Collectors.toList());

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
@@ -35,7 +35,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.WeakHashMap;
-import java.util.function.Predicate;
+import java.util.function.IntPredicate;
 
 import com.sun.javafx.logging.PlatformLogger.Level;
 import com.sun.javafx.scene.control.Logging;
@@ -3027,7 +3027,7 @@ public class TableView<S> extends Control {
         private void fireCustomSelectedCellsListChangeEvent(ListChangeListener.Change<? extends TablePosition<S,?>> c) {
             // Allow removing the row index if cell selection is not enabled or
             // if such row doesn't have any selected cells
-            Predicate<Integer> removeRowFilter = row -> !isCellSelectionEnabled() ||
+            IntPredicate removeRowFilter = row -> !isCellSelectionEnabled() ||
                     getSelectedCells().stream().noneMatch(tp -> tp.getRow() == row);
             ControlUtils.updateSelectedIndices(this, c, removeRowFilter);
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
@@ -35,6 +35,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.function.Predicate;
 
 import com.sun.javafx.logging.PlatformLogger.Level;
 import com.sun.javafx.scene.control.Logging;
@@ -3024,7 +3025,11 @@ public class TableView<S> extends Control {
         }
 
         private void fireCustomSelectedCellsListChangeEvent(ListChangeListener.Change<? extends TablePosition<S,?>> c) {
-            ControlUtils.updateSelectedIndices(this, c);
+            // Allow removing the row index if cell selection is not enabled or
+            // if such row doesn't have any selected cells
+            Predicate<Integer> removeRowFilter = row -> !isCellSelectionEnabled() ||
+                    getSelectedCells().stream().noneMatch(tp -> tp.getRow() == row);
+            ControlUtils.updateSelectedIndices(this, c, removeRowFilter);
 
             if (isAtomic()) {
                 return;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -62,6 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
+import java.util.function.Predicate;
 
 import javafx.application.Platform;
 import javafx.beans.DefaultProperty;
@@ -3366,7 +3367,11 @@ public class TreeTableView<S> extends Control {
         }
 
         private void fireCustomSelectedCellsListChangeEvent(ListChangeListener.Change<? extends TreeTablePosition<S,?>> c) {
-            ControlUtils.updateSelectedIndices(this, c);
+            // Allow removing the row index if cell selection is not enabled or
+            // if such row doesn't have any selected cells
+            Predicate<Integer> removeRowFilter = row -> !isCellSelectionEnabled() ||
+                    getSelectedCells().stream().noneMatch(tp -> tp.getRow() == row);
+            ControlUtils.updateSelectedIndices(this, c, removeRowFilter);
 
             if (isAtomic()) {
                 return;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -62,7 +62,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
-import java.util.function.Predicate;
+import java.util.function.IntPredicate;
 
 import javafx.application.Platform;
 import javafx.beans.DefaultProperty;
@@ -3369,7 +3369,7 @@ public class TreeTableView<S> extends Control {
         private void fireCustomSelectedCellsListChangeEvent(ListChangeListener.Change<? extends TreeTablePosition<S,?>> c) {
             // Allow removing the row index if cell selection is not enabled or
             // if such row doesn't have any selected cells
-            Predicate<Integer> removeRowFilter = row -> !isCellSelectionEnabled() ||
+            IntPredicate removeRowFilter = row -> !isCellSelectionEnabled() ||
                     getSelectedCells().stream().noneMatch(tp -> tp.getRow() == row);
             ControlUtils.updateSelectedIndices(this, c, removeRowFilter);
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -5586,4 +5586,53 @@ public class TableViewTest {
 
         sl.dispose();
     }
+
+    @Test
+    public void test_clearAndSelectChangeMultipleSelectionCellMode() {
+        TableColumn<Person, String> firstNameCol = new TableColumn<>("First Name");
+        firstNameCol.setCellValueFactory(new PropertyValueFactory<>("firstName"));
+
+        TableColumn<Person, String> lastNameCol = new TableColumn<>("Last Name");
+        lastNameCol.setCellValueFactory(new PropertyValueFactory<>("lastName"));
+
+        TableView<Person> table = new TableView<>();
+        table.setItems(personTestData);
+        table.getColumns().addAll(firstNameCol, lastNameCol);
+
+        sm = table.getSelectionModel();
+        sm.setCellSelectionEnabled(true);
+        sm.setSelectionMode(SelectionMode.MULTIPLE);
+
+        StageLoader sl = new StageLoader(table);
+        KeyEventFirer keyboard = new KeyEventFirer(table);
+
+        assertEquals(0, sm.getSelectedItems().size());
+
+        sm.select(0, firstNameCol);
+        assertEquals(1, sm.getSelectedCells().size());
+        assertEquals(1, sm.getSelectedItems().size());
+
+        keyboard.doKeyPress(KeyCode.RIGHT, KeyModifier.SHIFT);
+        assertEquals(2, sm.getSelectedCells().size());
+        assertEquals(1, sm.getSelectedItems().size());
+
+        keyboard.doKeyPress(KeyCode.LEFT);
+        assertTrue(VirtualFlowTestUtils.getCell(table, 0, 0).isSelected());
+        assertFalse(VirtualFlowTestUtils.getCell(table, 0, 1).isSelected());
+        assertEquals(1, sm.getSelectedCells().size());
+        assertEquals(1, sm.getSelectedItems().size());
+
+        sm.clearSelection();
+
+        sm.selectRange(0, firstNameCol, 1, lastNameCol);
+        assertEquals(4, sm.getSelectedCells().size());
+        assertEquals(2, sm.getSelectedItems().size());
+
+        sm.clearAndSelect(0, firstNameCol);
+        assertEquals(1, sm.getSelectedCells().size());
+        assertEquals(1, sm.getSelectedItems().size());
+
+        sl.dispose();
+    }
+
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -6666,4 +6666,53 @@ public class TreeTableViewTest {
         observer.check1();
         observer.checkAddRemove(0, treeTableView.getSelectionModel().getSelectedItems(), List.of(c1, c2, c3), 1, 1);
     }
+
+    @Test
+    public void test_clearAndSelectChangeMultipleSelectionCellMode() {
+        TreeItem<Person> root = new TreeItem<>(new Person("root", "",""));
+        root.getChildren().setAll(
+                new TreeItem<>(new Person("Jacob", "Smith", "jacob.smith@example.com")),
+                new TreeItem<>(new Person("Isabella", "Johnson", "isabella.johnson@example.com")),
+                new TreeItem<>(new Person("Ethan", "Williams", "ethan.williams@example.com")),
+                new TreeItem<>(new Person("Emma", "Jones", "emma.jones@example.com")),
+                new TreeItem<>(new Person("Michael", "Brown", "michael.brown@example.com")));
+        root.setExpanded(true);
+
+        TreeTableColumn<Person, String> firstNameCol = new TreeTableColumn<>("First Name");
+        firstNameCol.setCellValueFactory(new TreeItemPropertyValueFactory<>("firstName"));
+
+        TreeTableColumn<Person, String> lastNameCol = new TreeTableColumn<>("Last Name");
+        lastNameCol.setCellValueFactory(new TreeItemPropertyValueFactory<>("lastName"));
+
+        TreeTableColumn<Person, String> emailCol = new TreeTableColumn<>("Email");
+        emailCol.setCellValueFactory(new TreeItemPropertyValueFactory<>("email"));
+
+        TreeTableView<Person> table = new TreeTableView<>(root);
+        table.getColumns().addAll(firstNameCol, lastNameCol, emailCol);
+        sm = table.getSelectionModel();
+        sm.setSelectionMode(SelectionMode.MULTIPLE);
+        sm.setCellSelectionEnabled(true);
+
+        assertEquals(0, sm.getSelectedItems().size());
+
+        sm.select(1, firstNameCol);
+        assertTrue(sm.isSelected(1, firstNameCol));
+        assertEquals(1, sm.getSelectedCells().size());
+        assertEquals(1, sm.getSelectedItems().size());
+
+        TreeTableCell<Person, String> cell_1_1 = (TreeTableCell<Person, String>) VirtualFlowTestUtils.getCell(table, 1, 1);
+        new MouseEventFirer(cell_1_1).fireMousePressAndRelease(KeyModifier.getShortcutKey());
+        assertTrue(sm.isSelected(1, firstNameCol));
+        assertTrue(sm.isSelected(1, lastNameCol));
+        assertEquals(2, sm.getSelectedCells().size());
+        assertEquals(1, sm.getSelectedItems().size());
+
+        TreeTableCell<Person, String> cell_1_0 = (TreeTableCell<Person, String>) VirtualFlowTestUtils.getCell(table, 1, 0);
+        new MouseEventFirer(cell_1_0).fireMousePressAndRelease();
+        assertTrue(sm.isSelected(1, firstNameCol));
+        assertFalse(sm.isSelected(1, lastNameCol));
+        assertEquals(1, sm.getSelectedCells().size());
+        assertEquals(1, sm.getSelectedItems().size());
+    }
+
 }


### PR DESCRIPTION
This PR adds a predicate to TableView and TreeTableView selection models order to remove rows from the selection only when there are no selected cells in that given row, when cell selection is enabled.

Two tests have been added as well, that fail without this PR and pass with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273336](https://bugs.openjdk.java.net/browse/JDK-8273336): Clicking a selected cell from a group of selected cells in a TableView clears the selected items list but remains selected


### Reviewers
 * [Michael Strauß](https://openjdk.java.net/census#mstrauss) (@mstr2 - Author)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/709/head:pull/709` \
`$ git checkout pull/709`

Update a local copy of the PR: \
`$ git checkout pull/709` \
`$ git pull https://git.openjdk.java.net/jfx pull/709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 709`

View PR using the GUI difftool: \
`$ git pr show -t 709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/709.diff">https://git.openjdk.java.net/jfx/pull/709.diff</a>

</details>
