### PR TITLE
8244234: MenuButton: NPE on removing from scene with open popup

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuButtonSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuButtonSkinBase.java
@@ -154,7 +154,7 @@ public class MenuButtonSkinBase<C extends MenuButton> extends SkinBase<C> {
                 ControlAcceleratorSupport.removeAcceleratorsFromScene(getSkinnable().getItems(), oldValue);
 
                 // We only need to remove the mnemonics from the old scene,
-                // they will be added to the new one as soon as the pop becomes visible again.
+                // they will be added to the new one as soon as the popup becomes visible again.
                 removeMnemonicsFromScene(mnemonics, oldValue);
             }
 
@@ -247,31 +247,31 @@ public class MenuButtonSkinBase<C extends MenuButton> extends SkinBase<C> {
     /** {@inheritDoc} */
     @Override protected double computeMinWidth(double height, double topInset, double rightInset, double bottomInset, double leftInset) {
         return leftInset
-               + label.minWidth(height)
-               + snapSizeX(arrowButton.minWidth(height))
-               + rightInset;
+                + label.minWidth(height)
+                + snapSizeX(arrowButton.minWidth(height))
+                + rightInset;
     }
 
     /** {@inheritDoc} */
     @Override protected double computeMinHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset) {
         return topInset
-               + Math.max(label.minHeight(width), snapSizeY(arrowButton.minHeight(-1)))
-               + bottomInset;
+                + Math.max(label.minHeight(width), snapSizeY(arrowButton.minHeight(-1)))
+                + bottomInset;
     }
 
     /** {@inheritDoc} */
     @Override protected double computePrefWidth(double height, double topInset, double rightInset, double bottomInset, double leftInset) {
         return leftInset
-               + label.prefWidth(height)
-               + snapSizeX(arrowButton.prefWidth(height))
-               + rightInset;
+                + label.prefWidth(height)
+                + snapSizeX(arrowButton.prefWidth(height))
+                + rightInset;
     }
 
     /** {@inheritDoc} */
     @Override protected double computePrefHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset) {
         return topInset
-               + Math.max(label.prefHeight(width), snapSizeY(arrowButton.prefHeight(-1)))
-               + bottomInset;
+                + Math.max(label.prefHeight(width), snapSizeY(arrowButton.prefHeight(-1)))
+                + bottomInset;
     }
 
     /** {@inheritDoc} */

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuButtonSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuButtonSkinBase.java
@@ -148,12 +148,17 @@ public class MenuButtonSkinBase<C extends MenuButton> extends SkinBase<C> {
             ControlAcceleratorSupport.addAcceleratorsIntoScene(getSkinnable().getItems(), getSkinnable());
         }
 
+        List<Mnemonic> mnemonics = new ArrayList<>();
         sceneChangeListener = (scene, oldValue, newValue) -> {
             if (oldValue != null) {
                 ControlAcceleratorSupport.removeAcceleratorsFromScene(getSkinnable().getItems(), oldValue);
+
+                // We only need to remove the mnemonics from the old scene,
+                // they will be added to the new one as soon as the pop becomes visible again.
+                removeMnemonicsFromScene(mnemonics, oldValue);
             }
 
-             // FIXME: null skinnable should not happen
+            // FIXME: null skinnable should not happen
             if (getSkinnable() != null && getSkinnable().getScene() != null) {
                 ControlAcceleratorSupport.addAcceleratorsIntoScene(getSkinnable().getItems(), getSkinnable());
             }
@@ -181,7 +186,6 @@ public class MenuButtonSkinBase<C extends MenuButton> extends SkinBase<C> {
             label.setMnemonicParsing(getSkinnable().isMnemonicParsing());
             getSkinnable().requestLayout();
         });
-        List<Mnemonic> mnemonics = new ArrayList<>();
         registerChangeListener(popup.showingProperty(), e -> {
             if (!popup.isShowing() && getSkinnable().isShowing()) {
                 // Popup was dismissed. Maybe user clicked outside or typed ESCAPE.
@@ -201,9 +205,10 @@ public class MenuButtonSkinBase<C extends MenuButton> extends SkinBase<C> {
                 // consumed to prevent them being used elsewhere).
                 // See JBS-8090026 for more detail.
                 Scene scene = getSkinnable().getScene();
-                List<Mnemonic> mnemonicsToRemove = new ArrayList<>(mnemonics);
-                mnemonics.clear();
-                Platform.runLater(() -> mnemonicsToRemove.forEach(scene::removeMnemonic));
+                // JDK-8244234: MenuButton: NPE on removing from scene with open popup
+                if (scene != null) {
+                    removeMnemonicsFromScene(mnemonics, scene);
+                }
             }
         });
     }
@@ -242,31 +247,31 @@ public class MenuButtonSkinBase<C extends MenuButton> extends SkinBase<C> {
     /** {@inheritDoc} */
     @Override protected double computeMinWidth(double height, double topInset, double rightInset, double bottomInset, double leftInset) {
         return leftInset
-                + label.minWidth(height)
-                + snapSizeX(arrowButton.minWidth(height))
-                + rightInset;
+               + label.minWidth(height)
+               + snapSizeX(arrowButton.minWidth(height))
+               + rightInset;
     }
 
     /** {@inheritDoc} */
     @Override protected double computeMinHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset) {
         return topInset
-                + Math.max(label.minHeight(width), snapSizeY(arrowButton.minHeight(-1)))
-                + bottomInset;
+               + Math.max(label.minHeight(width), snapSizeY(arrowButton.minHeight(-1)))
+               + bottomInset;
     }
 
     /** {@inheritDoc} */
     @Override protected double computePrefWidth(double height, double topInset, double rightInset, double bottomInset, double leftInset) {
         return leftInset
-                + label.prefWidth(height)
-                + snapSizeX(arrowButton.prefWidth(height))
-                + rightInset;
+               + label.prefWidth(height)
+               + snapSizeX(arrowButton.prefWidth(height))
+               + rightInset;
     }
 
     /** {@inheritDoc} */
     @Override protected double computePrefHeight(double width, double topInset, double rightInset, double bottomInset, double leftInset) {
         return topInset
-                + Math.max(label.prefHeight(width), snapSizeY(arrowButton.prefHeight(-1)))
-                + bottomInset;
+               + Math.max(label.prefHeight(width), snapSizeY(arrowButton.prefHeight(-1)))
+               + bottomInset;
     }
 
     /** {@inheritDoc} */
@@ -309,6 +314,12 @@ public class MenuButtonSkinBase<C extends MenuButton> extends SkinBase<C> {
         if (popup.isShowing()) {
             popup.hide();
         }
+    }
+
+    private void removeMnemonicsFromScene(List<Mnemonic> mnemonics, Scene scene) {
+        List<Mnemonic> mnemonicsToRemove = new ArrayList<>(mnemonics);
+        mnemonics.clear();
+        Platform.runLater(() -> mnemonicsToRemove.forEach(scene::removeMnemonic));
     }
 
     boolean requestFocusOnFirstMenuItem = false;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/MenuButtonSkinBaseTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/MenuButtonSkinBaseTest.java
@@ -1,0 +1,89 @@
+package test.javafx.scene.control.skin;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.scene.Scene;
+import javafx.scene.control.MenuButton;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.skin.MenuButtonSkinBase;
+import javafx.scene.input.Mnemonic;
+import javafx.stage.Stage;
+
+public class MenuButtonSkinBaseTest {
+
+    private MenuButton menubutton;
+    private MenuItem menuItem;
+
+    @Before
+    public void setup() {
+        menubutton = new MenuButton();
+        menuItem = new MenuItem("Menu Item");
+        menubutton.getItems().add(menuItem);
+        menubutton.setSkin(new MenuButtonSkinBase<>(menubutton));
+    }
+
+    @Test
+    public void testNoNullPointerOnRemovingFromTheSceneWhilePopupIsShowing() {
+        Thread.UncaughtExceptionHandler originalExceptionHandler = Thread.currentThread().getUncaughtExceptionHandler();
+
+        Thread.currentThread().setUncaughtExceptionHandler((t, e) -> {
+            Assert.fail("No exception expected, but was a " + e);
+            e.printStackTrace();
+        });
+
+        try {
+            Scene scene = new Scene(menubutton);
+            Stage stage = new Stage();
+            stage.setScene(scene);
+            stage.show();
+
+            menubutton.show();
+            menuItem.setOnAction(e -> scene.setRoot(new MenuButton()));
+            menuItem.fire();
+
+        } finally {
+            Thread.currentThread().setUncaughtExceptionHandler(originalExceptionHandler);
+        }
+    }
+
+    @Test
+    public void testMnemonicsRemovedOnRemovingFromTheSceneWhilePopupIsShowing() {
+        menuItem.setText("_Menu Item");
+        menuItem.setMnemonicParsing(true);
+
+        ObjectProperty<Mnemonic> menuItemMnemonic = new SimpleObjectProperty<>();
+
+        Scene scene = new Scene(menubutton) {
+            @Override
+            public void addMnemonic(Mnemonic m) {
+                if (menuItemMnemonic.get() != null) {
+                    // The test is designed for only one mnemonic.
+                    Assert.fail("Test failure: More than one Mnemonic registered.");
+                }
+                menuItemMnemonic.set(m);
+                super.addMnemonic(m);
+            }
+
+            @Override
+            public void removeMnemonic(Mnemonic m) {
+                if (m == menuItemMnemonic.get()) {
+                    menuItemMnemonic.set(null);
+                }
+                super.removeMnemonic(m);
+            }
+        };
+        Stage stage = new Stage();
+        stage.setScene(scene);
+        stage.show();
+
+        menubutton.show();
+        menuItem.setOnAction(e -> scene.setRoot(new MenuButton()));
+        menuItem.fire();
+
+        Assert.assertNull("Mnemonic was not removed from the scene,", menuItemMnemonic.get());
+    }
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/MenuButtonSkinBaseTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/MenuButtonSkinBaseTest.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package test.javafx.scene.control.skin;
 
 import org.junit.Assert;


### PR DESCRIPTION
The NPE occurs when the skinnable is removed from the scene while the popup is showing.
The MenuButtonSkinBase, when popup becomes hidden, tries to remove Mnemonics from the scene and runs into NPE.
To avoid NPE a null-check is added to the 'showing' listener.

Since the mnemonics cannot be removed from the scene in standard way, when popup becomes hidden.
They are now also removed from the scene, when the skinnable is removed from it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8244234](https://bugs.openjdk.java.net/browse/JDK-8244234): MenuButton: NPE on removing from scene with open popup


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/713/head:pull/713` \
`$ git checkout pull/713`

Update a local copy of the PR: \
`$ git checkout pull/713` \
`$ git pull https://git.openjdk.java.net/jfx pull/713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 713`

View PR using the GUI difftool: \
`$ git pr show -t 713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/713.diff">https://git.openjdk.java.net/jfx/pull/713.diff</a>

</details>
