### PR TITLE
8242544: CMD+ENTER key event crashes the application when invoked on dialog

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
@@ -843,7 +843,9 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_mac_MacWindow__1setView
         }
         else
         {
-            [window->nsWindow performSelectorOnMainThread:@selector(setContentView:) withObject:nil waitUntilDone:YES];
+            // If the contentView is set to nil within performKeyEquivalent: the OS will crash.
+            NSView* dummy = [[NSView alloc] initWithFrame: NSMakeRect(0, 0, 10, 10)];
+            [window->nsWindow performSelectorOnMainThread:@selector(setContentView:) withObject:dummy waitUntilDone:YES];
         }
     }
     GLASS_POOL_EXIT;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
@@ -846,6 +846,7 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_mac_MacWindow__1setView
             // If the contentView is set to nil within performKeyEquivalent: the OS will crash.
             NSView* dummy = [[NSView alloc] initWithFrame: NSMakeRect(0, 0, 10, 10)];
             [window->nsWindow performSelectorOnMainThread:@selector(setContentView:) withObject:dummy waitUntilDone:YES];
+            [dummy release];
         }
     }
     GLASS_POOL_EXIT;


### PR DESCRIPTION
The OS crashes if the contentView of a window is set to nil while handling processKeyEquivalent. With this PR we just set the contentView to a basic do-nothing NSView for the interim.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8242544](https://bugs.openjdk.java.net/browse/JDK-8242544): CMD+ENTER key event crashes the application when invoked on dialog


### Reviewers
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**) 🔄 Re-review required (review applies to 5674733b734a82d7085e556b5e03d6dfd41b47cb)
 * [Jose Pereda](https://openjdk.java.net/census#jpereda) (@jperedadnr - Committer)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/714/head:pull/714` \
`$ git checkout pull/714`

Update a local copy of the PR: \
`$ git checkout pull/714` \
`$ git pull https://git.openjdk.java.net/jfx pull/714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 714`

View PR using the GUI difftool: \
`$ git pr show -t 714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/714.diff">https://git.openjdk.java.net/jfx/pull/714.diff</a>

</details>
