### PR TITLE
8205915: [macOS] Accelerator assigned to button in dialog fires menuItem in owning stage

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
@@ -898,6 +898,11 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_mac_MacWindow__1close
         // this call will always close the window
         // without calling the windowShouldClose
 
+        // If this window is closed from within performKeyEquivalent the OS might
+        // try to send the same event to the new key window. To prevent this we
+        // ensure that performKeyEquivalent returns YES.
+        window->isClosed = YES;
+
         // RT-39813 When closing a window as the result of a global right-click
         //          mouse event outside the bounds of the window, using an immediate
         //          [window->nsWindow close] crashes the JDK as the AppKit at this

--- a/tests/system/src/test/java/test/robot/javafx/scene/DoubleShortcutProcessing.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/DoubleShortcutProcessing.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.robot.javafx.scene;
+
+import com.sun.javafx.PlatformUtil;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.input.KeyCode;
+import javafx.scene.layout.VBox;
+import javafx.scene.robot.Robot;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+
+// When a key equivalent closes a window it can be passed
+// to the new key window and processed twice.
+public class DoubleShortcutProcessing {
+
+    static CountDownLatch startupLatch = new CountDownLatch(1);
+    static CountDownLatch dialogLatch = new CountDownLatch(1);
+
+    static volatile Stage stage;
+    static volatile TestApp testApp;
+
+    @Test
+    void testDoubleShortcut()
+    {
+        Assumptions.assumeTrue(PlatformUtil.isMac());
+        testApp.startTest();
+        waitForLatch(dialogLatch, 5, "Dialog never received shortcut");
+        if (testApp.failed())
+            Assertions.fail("performKeyEquivalent was handled twice in separate windows");
+    }
+
+    @BeforeAll
+    static void initFX() throws Exception {
+        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
+        waitForLatch(startupLatch, 10, "FX runtime failed to start.");
+    }
+
+    @AfterAll
+    static void exit() {
+        Platform.runLater(() -> {
+            stage.hide();
+        });
+        Platform.exit();
+    }
+
+    public static class TestApp extends Application {
+
+        private boolean failure = false;
+        private Dialog dialog = null;
+
+        @Override
+        public void start(Stage primaryStage) {
+
+            testApp = this;
+            stage = primaryStage;
+
+            // Main window
+            Label label = new Label("Testing double performKeyEquivalent");
+            Scene scene = new Scene(new VBox(label), 200, 200);
+            scene.addEventHandler(KeyEvent.KEY_PRESSED, event -> {
+                if (event.getCode() == KeyCode.ENTER && event.isShortcutDown()) {
+                    failure = true;
+                    event.consume();
+                }
+            });
+            stage.setScene(scene);
+
+            // Dialog
+            VBox pane = new VBox(new Label("Pressing Cmd+Enter"));
+            dialog = new Dialog(stage, pane);
+
+            stage.setOnShown(e -> { startupLatch.countDown(); });
+            stage.show();
+        }
+
+        public void startTest()
+        {
+            Platform.runLater(() -> {
+                // Need to ensure Cmd is present so this is handled
+                // as a key equivalent.
+                dialog.setOnShown(e -> {
+                    Robot robot = new Robot();
+                    robot.keyPress(KeyCode.COMMAND);
+                    robot.keyPress(KeyCode.ENTER);
+                    robot.keyRelease(KeyCode.ENTER);
+                    robot.keyRelease(KeyCode.COMMAND);
+                });
+                dialog.showAndWait();
+                dialogLatch.countDown();
+            });
+        }
+
+        public boolean failed()
+        {
+            return failure;
+        }
+
+        private static class Dialog extends Stage {
+
+            public Dialog(Stage owner, Parent layout) {
+                super(StageStyle.DECORATED);
+                Scene layoutScene = new Scene(layout, 100, 100);
+                this.setScene(layoutScene);
+
+                layoutScene.addEventHandler(KeyEvent.KEY_PRESSED, event -> {
+                    if (event.getCode() == KeyCode.ENTER && event.isShortcutDown()) {
+                        close();
+                        event.consume();
+                    }
+                });
+
+                this.hide();
+                this.initModality(Modality.APPLICATION_MODAL);
+                this.initOwner(owner);
+                this.setResizable(true);
+            }
+        }
+    }
+
+    private static void waitForLatch(CountDownLatch latch, int seconds, String msg) {
+        try {
+            if (!latch.await(seconds, TimeUnit.SECONDS)) {
+                Assertions.fail(msg);
+            }
+        } catch (Exception ex) {
+            Assertions.fail("Unexpected exception: " + ex);
+        }
+    }
+}

--- a/tests/system/src/test/java/test/robot/javafx/scene/DoubleShortcutProcessingTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/DoubleShortcutProcessingTest.java
@@ -50,7 +50,7 @@ import javafx.stage.StageStyle;
 
 // When a key equivalent closes a window it can be passed
 // to the new key window and processed twice.
-public class DoubleShortcutProcessing {
+public class DoubleShortcutProcessingTest {
 
     static CountDownLatch startupLatch = new CountDownLatch(1);
     static CountDownLatch dialogLatch = new CountDownLatch(1);
@@ -59,8 +59,7 @@ public class DoubleShortcutProcessing {
     static volatile TestApp testApp;
 
     @Test
-    void testDoubleShortcut()
-    {
+    void testDoubleShortcut() {
         Assumptions.assumeTrue(PlatformUtil.isMac());
         testApp.startTest();
         waitForLatch(dialogLatch, 5, "Dialog never received shortcut");
@@ -76,9 +75,7 @@ public class DoubleShortcutProcessing {
 
     @AfterAll
     static void exit() {
-        Platform.runLater(() -> {
-            stage.hide();
-        });
+        Platform.runLater(stage::hide);
         Platform.exit();
     }
 
@@ -112,8 +109,7 @@ public class DoubleShortcutProcessing {
             stage.show();
         }
 
-        public void startTest()
-        {
+        public void startTest() {
             Platform.runLater(() -> {
                 // Need to ensure Cmd is present so this is handled
                 // as a key equivalent.
@@ -129,8 +125,7 @@ public class DoubleShortcutProcessing {
             });
         }
 
-        public boolean failed()
-        {
+        public boolean failed() {
             return failure;
         }
 

--- a/tests/system/src/test/java/test/robot/javafx/scene/DoubleShortcutProcessingTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/DoubleShortcutProcessingTest.java
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package test.robot.javafx.scene;
 
 import com.sun.javafx.PlatformUtil;
@@ -63,8 +64,9 @@ public class DoubleShortcutProcessingTest {
         Assumptions.assumeTrue(PlatformUtil.isMac());
         testApp.startTest();
         waitForLatch(dialogLatch, 5, "Dialog never received shortcut");
-        if (testApp.failed())
+        if (testApp.failed()) {
             Assertions.fail("performKeyEquivalent was handled twice in separate windows");
+        }
     }
 
     @BeforeAll


### PR DESCRIPTION
When a window is closed while handling performKeyEquivalent the same NSEvent might be passed to the new key window causing it to being processed twice. Long ago a fix was put in for this case; when the GlassWindow was closed a flag was set to ensure that we would return YES from performKeyEquivalent. To fix RT-39813 the closing of the window was deferred causing the flag to be set too late. This PR simply sets that flag when we schedule the close event instead of when the OS actually closes the window.

This is a spot-fix for a larger problem, namely that we have no way of knowing whether a performKeyEquivalent event was consumed or not. The changes for fixing that are in PR #694. The changes got bundled into that PR only because there's a lot of files involved and the exact same code paths are touched.

System test is included (I'm surprised, it really is possible to generate Cmd+Enter using a Robot). This is new territory for me so I have a manual test I can submit as a backup.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8205915](https://bugs.openjdk.java.net/browse/JDK-8205915): [macOS] Accelerator assigned to button in dialog fires menuItem in owning stage


### Reviewers
 * [Jose Pereda](https://openjdk.java.net/census#jpereda) (@jperedadnr - Committer)
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/715/head:pull/715` \
`$ git checkout pull/715`

Update a local copy of the PR: \
`$ git checkout pull/715` \
`$ git pull https://git.openjdk.java.net/jfx pull/715/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 715`

View PR using the GUI difftool: \
`$ git pr show -t 715`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/715.diff">https://git.openjdk.java.net/jfx/pull/715.diff</a>

</details>
