### PR TITLE
8279345: Realign class docs of LightBase and subclasses

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/AmbientLight.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/AmbientLight.java
@@ -26,15 +26,16 @@
 package javafx.scene;
 
 import com.sun.javafx.scene.AmbientLightHelper;
-import com.sun.javafx.scene.DirtyBits;
-import com.sun.javafx.scene.NodeHelper;
 import com.sun.javafx.sg.prism.NGAmbientLight;
 import com.sun.javafx.sg.prism.NGNode;
 import javafx.scene.paint.Color;
 
 /**
- * Defines an ambient light source object. Ambient light is a light source
- * that seems to come from all directions.
+ * A light that illuminates an object from all directions equally.
+ * <p>
+ * {@code AmbientLight}s can represent strong light sources in an enclosed area where the lights bounces from many
+ * objects, causing them to be illuminated from many directions. A strong light in a room and moonlight are common light
+ * source that can be simulated with this light type.
  *
  * @since JavaFX 8.0
  */

--- a/modules/javafx.graphics/src/main/java/javafx/scene/DirectionalLight.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/DirectionalLight.java
@@ -38,16 +38,12 @@ import javafx.scene.paint.Color;
 import javafx.scene.paint.PhongMaterial;
 
 /**
- * A light that illuminates an object from a specific direction.
- * The direction is defined by the {@link #directionProperty() direction} vector property of the light. The direction
- * can be rotated by setting a rotation transform on the {@code DirectionalLight}. For example, if the direction vector
- * is {@code (1, 1, 1)} and the light is not rotated, it will point in the {@code (1, 1, 1)} direction, and if the light
- * is rotated 90 degrees on the y axis, it will point in the {@code (1, 1, -1)} direction.
+ * A light that illuminates an object from a specific direction. The <a href="LightBase.html#Direction">direction</a>
+ * is defined by the {@link #directionProperty() direction} vector property.
  * <p>
  * {@code DirectionalLight}s can represent strong light sources that are far enough from the objects they illuminate
  * that their light rays appear to be parallel. Because these light sources are considered to be infinitely far, they
- * cannot be attenuated. A decrease in intensity can be achieved by using a darker color. The sun is a common light
- * source that can be simulated with this light type.
+ * cannot be attenuated. The sun's light on Earth is a common light source that can be simulated with this light type.
  *
  * @since 18
  * @see PhongMaterial

--- a/modules/javafx.graphics/src/main/java/javafx/scene/LightBase.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/LightBase.java
@@ -56,33 +56,112 @@ import javafx.scene.shape.Shape3D;
 import com.sun.javafx.logging.PlatformLogger;
 
 /**
- * The {@code LightBase} class provides definitions of common properties for
- * objects that represent a form of light source. These properties
- * include:
+ * The {@code LightBase} class is the base class for all objects that represent a form of light source. All light types
+ * share the following common properties that are defined in this class:
  * <ul>
- * <li>{@code color} - the color of the light source</li>
- * <li>{@code scope} - a list of nodes the light source affects</li>
- * <li>{@code exlusionScope} - a list of nodes the light source does not affect</li>
+ *   <li>{@code color} - the color of the light source</li>
+ *   <li>{@code scope} - a list of nodes the light source affects</li>
+ *   <li>{@code exlusionScope} - a list of nodes the light source does not affect</li>
  * </ul>
  *
+ * In addition to these, each light type supports a different set of properties, summarized in the following table:
+ *
+ * <div style="display:flex; flex-direction: column; justify-content: center; align-items: center">
+ * <table border="1">
+ *   <caption>Summary of Light types by attributes</caption>
+ *   <tr>
+ *     <th>Light type</th>
+ *     <th>Rotation and Direction</th>
+ *     <th>Location and Attenuation</th>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link AmbientLight}</td>
+ *     <td style="text-align:center">&#10007;</td>
+ *     <td style="text-align:center">&#10007;</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link DirectionalLight}</td>
+ *     <td style="text-align:center">&#10003;</td>
+ *     <td style="text-align:center">&#10007;</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link PointLight}</td>
+ *     <td style="text-align:center">&#10007;</td>
+ *     <td style="text-align:center">&#10003;</td>
+ *   </tr>
+ *   <tr>
+ *     <td>{@link SpotLight}*</td>
+ *     <td style="text-align:center">&#10003;</td>
+ *     <td style="text-align:center">&#10003;</td>
+ *   </tr>
+ * </table>
+ *
+ * * Supports spotlight attenuation factors as described in its class docs.
+ * </div>
  * <p>
- * A node can exist in only one of the lists, if it is added to one, it is silently removed from the other. If a node
- * does not exist in any list, it inherits its affected state from its parent, recursively. An exception to this is that
- * a light with an empty {@code scope} affects all nodes in its scene/subscene implicitly (except for those in its
- * {@code exlusionScope}) as if the root of the scene is in the {@code scope}. <br>
+ * An application cannot add its own light types. Extending {@code LightBase} directly may lead to an
+ * {@code UnsupportedOperationException} being thrown.
+ * <p>
+ * All light types are not affected by scaling and shearing transforms.
+ *
+ * <h2><a id="Color">Color</a></h2>
+ * A light source produces a light of a single color. The appearance of an object illuminated by the light is a result
+ * of the color of the light and the material the object is made of. For example, for a blue light, a white object will
+ * appear blue, a black object will appear black, and a (255, 0, 255)-colored object will appear blue, as the light
+ * "selects" only the blue component of the material color. The mathematical definition of the material-light
+ * interaction is available in {@link javafx.scene.paint.PhongMaterial PhongMaterial}.
+ * <p>
+ * Notes about the current implementation:
+ * <ol>
+ *   <li> A black colored light is ignored since its contribution is 0.
+ *   <li> The transparency (alpha) component of a light is ignored.
+ * </ol>
+ * There are no guarantee that these behaviors will not change.
+ *
+ * <h2><a id="Scopes">Scopes</a></h2>
+ * A light has a {@code scope} list and an {@code exclusionScope} list that define which nodes are illuminated by it and
+ * which aren't. A node can exist in only one of the lists: if it is added to one, it is silently removed from the
+ * other. If a node does not exist in any list, it inherits its affected state from its parent, recursively. An
+ * exception to this is that a light with an empty {@code scope} affects all nodes in its scene/subscene implicitly
+ * (except for those in its {@code exlusionScope}) as if the root of the scene is in the {@code scope}.
+ * <p>
  * The {@code exlusionScope} is useful only for nodes that would otherwise be in scope of the light. Excluding a node is
  * a convenient alternative to traversing the scenegraph hierarchy and adding all of the other nodes to the light's
- * scope. Instead, the scope can remain wide and specific nodes can be excluded.
+ * scope. Instead, the scope can remain wide, and specific nodes can be excluded with the exclusion scope.
+ *
+ * <h2><a id="Direction">Direction</a></h2>
+ * The direction the light is facing, defined by the {@code direction} vector property of the light. The light's
+ * direction can be rotated by setting a rotation transform on the light. For example, if the direction vector is
+ * {@code (1, 1, 1)} and the light is not rotated, it will point in the {@code (1, 1, 1)} direction, and if the light is
+ * rotated 90 degrees on the y axis, it will point in the {@code (1, 1, -1)} direction.
+ * <p>
+ * Light types that do not have a direction are not affected by rotation transforms.
+ *
+ * <h2><a id="Attenuation">Distance Attenuation</a></h2>
+ * Any pixel within the range of the light will be illuminated by it (unless it belongs to a {@code Shape3D} outside of
+ * its <a href="#Scopes">scope</a>). The distance is measured from the light's position to the pixel's position, and is
+ * checked to be within the maximum range of the light, as defined by its {@code maxRange} property. The light's
+ * position can be changed by setting a translation transform on the light.
+ * <p>
+ * The light's intensity can be set to change over distance by attenuating it. The attenuation formula
+ * <p>
+ * {@code attn = 1 / (ca + la * dist + qa * dist^2)}
+ * <p>
+ * defines 3 coefficients: {@code ca}, {@code la}, and {@code qa}, which control the constant, linear, and quadratic
+ * behaviors of intensity falloff over distance, respectively. The effective color of the light at a given point in
+ * space is {@code color * attn}. It is possible, albeit unrealistic, to specify negative values to attenuation
+ * coefficients. This allows the resulting attenuation factor to be negative, which results in the light's color being
+ * subtracted from the material color instead of added to it, thus creating a "shadow caster".
+ * <p>
+ * For a realistic effect, {@code maxRange} should be set to a distance at which the attenuation is close to 0, as this
+ * will give a soft cutoff.
+ * <p>
+ * Light types that are not distance-attenuated are not affected by translation transforms. For these types, a decrease
+ * in intensity can be achieved by using a darker color.
  *
  * <p>
- * Note that this is a conditional feature. See
- * {@link javafx.application.ConditionalFeature#SCENE3D ConditionalFeature.SCENE3D}
- * for more information.
- *
- * <p>
- * An application should not extend the {@code LightBase} class directly. Doing so may lead to
- * an {@code UnsupportedOperationException} being thrown.
- * </p>
+ * <b>Note</b>: this is a conditional feature. See
+ * {@link javafx.application.ConditionalFeature#SCENE3D ConditionalFeature.SCENE3D} for more information.
  *
  * @since JavaFX 8.0
  */
@@ -319,7 +398,7 @@ public abstract class LightBase extends Node {
     private void markChildrenDirty(Node node) {
         if (node instanceof Shape3D) {
             // Dirty using a lightweight DirtyBits.NODE_DRAWMODE bit
-            NodeHelper.markDirty(((Shape3D) node), DirtyBits.NODE_DRAWMODE);
+            NodeHelper.markDirty(node, DirtyBits.NODE_DRAWMODE);
         } else if (node instanceof Parent) {
             for (Node child : ((Parent) node).getChildren()) {
                 if ((scope != null && getScope().contains(child)) ||

--- a/modules/javafx.graphics/src/main/java/javafx/scene/PointLight.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/PointLight.java
@@ -36,22 +36,12 @@ import javafx.scene.paint.PhongMaterial;
 
 /**
  * A light source that radiates light equally in all directions away from itself. The location of the light
- * source is a single point in space. Any pixel within the range of the light will be illuminated by it,
- * unless it belongs to a {@code Shape3D} outside of its {@code scope}.
+ * source is a single point in space. It is <a href="LightBase.html#Attenuation">attenuated</a> with the
+ * {@link #constantAttenuationProperty() constantAttenuation}, {@link #linearAttenuationProperty() linearAttenuation}, 
+ * {@link #quadraticAttenuationProperty() quadraticAttenuation}, and {@link #maxRangeProperty() maxRange} properties.
  * <p>
- * The light's intensity can be set to decrease over distance by attenuating it. The attenuation formula
- * <p>
- * {@code attn = 1 / (ca + la * dist + qa * dist^2)}
- * <p>
- * defines 3 coefficients: {@code ca}, {@code la}, and {@code qa}, which control the constant, linear, and
- * quadratic behaviors of intensity falloff over distance, respectively. The effective color of the light
- * at a given point in space is {@code color * attn}. It is possible, albeit unrealistic, to specify negative
- * values to attenuation coefficients. This allows the resulting attenuation factor to be negative, which
- * results in the light's color being subtracted from the material instead of added to it, thus creating a
- * "shadow caster".
- * <p>
- * For a realistic effect, {@code maxRange} should be set to a distance at which the attenuation is close to 0
- * as this will give a soft cutoff.
+ * {@code PointLight}s can represent point-like light sources with little to no directionality. Light bulbs and candles
+ * are common light sources that can be simulated with this light type.
  *
  * @since JavaFX 8.0
  * @see PhongMaterial

--- a/modules/javafx.graphics/src/main/java/javafx/scene/SpotLight.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/SpotLight.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,14 +39,12 @@ import javafx.scene.paint.Color;
 import javafx.scene.paint.PhongMaterial;
 
 /**
- * A {@code SpotLight} is a {@code PointLight} that radiates light in a cone in a specific direction.
- * The direction is defined by the {@link #directionProperty() direction} vector property of the light. The direction
- * can be rotated by setting a rotation transform on the {@code SpotLight}. For example, if the direction vector is
- * {@code (1, 1, 1)} and the light is not rotated, it will point in the {@code (1, 1, 1)} direction, and if the light is
- * rotated 90 degrees on the y axis, it will point in the {@code (1, 1, -1)} direction.
+ * A light source that radiates light in a cone in a specific direction away from itself. The
+ * <a href="LightBase.html#Direction">direction</a> is defined by the {@link #directionProperty() direction} vector
+ * property.
  * <p>
- * In addition to the factors that control the light intensity of a {@code PointLight}, a {@code SpotLight} has a
- * light-cone attenuation factor, {@code spot}, that is determined by 3 properties:
+ * In addition to the <a href="LightBase.html#Attenuation">attenuation</a> factors that control the light intensity over
+ * distance, a {@code SpotLight} has a light-cone attenuation factor, {@code spot}, that is determined by 3 properties:
  * <ul>
  * <li> {@link #innerAngleProperty() innerAngle}: the angle of the inner cone (see image below)
  * <li> {@link #outerAngleProperty() outerAngle}: the angle of the outer cone (see image below)
@@ -67,6 +65,9 @@ import javafx.scene.paint.PhongMaterial;
  * which represents a drop in intensity from the inner angle to the outer angle.
  * </ul>
  * As a result, {@code 0 <= spot <= 1}. The overall intensity of the light is {@code I = lambert * atten * spot}.
+ * <p>
+ * {@code SpotLight}s can represent point-like light sources with directionality. Flashlights and floodlights are
+ * common light sources that can be simulated with this light type.
  * <p>
  * <img src="doc-files/spotlight.png" alt="Image of the Spotlight">
  *


### PR DESCRIPTION
Now that the standard concrete light types were added, there is an opportunity to rearrange and rewrite some of the class docs. Here is a summary of the changes:

* Moved the explanations of attenuation and direction up to `LightBase` since different light types share characteristics. `LightBase` now contains a summary of its subtypes and all the explanations of the properties/characteristics of the lights divided into sections: Color, Scope, Direction, Attenuation.
* Each light type links to the relevant section in `LightBase` when it mentioned the properties it has.
* Added examples of real-world applications for each light type.
* Consolidated the writing style for all the subclasses.