### PR TITLE
8280275: JUnit5 tests using Assumptions API fail to compile in some cases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1963,13 +1963,13 @@ allprojects {
         testImplementation group: "org.hamcrest", name: "hamcrest-core", version: "1.3"
         testImplementation group: "org.junit.jupiter", name: "junit-jupiter", version: "5.8.1"
         testImplementation group: "org.junit.jupiter", name: "junit-jupiter-api", version: "5.8.1"
+        testImplementation group: "org.opentest4j", name: "opentest4j", version: "1.2.0"
         testRuntimeOnly group: "org.apiguardian", name: "apiguardian-api", version: "1.1.2"
         testRuntimeOnly group: "org.junit.jupiter", name: "junit-jupiter-engine", version: "5.8.1"
         testRuntimeOnly group: "org.junit.jupiter", name: "junit-jupiter-params", version: "5.8.1"
         testRuntimeOnly group: "org.junit.platform", name: "junit-platform-commons", version: "1.8.1"
         testRuntimeOnly group: "org.junit.platform", name: "junit-platform-engine", version: "1.8.1"
         testRuntimeOnly group: "org.junit.vintage", name: "junit-vintage-engine", version: "5.8.1"
-        testRuntimeOnly group: "org.opentest4j", name: "opentest4j", version: "1.2.0"
 
         if (BUILD_CLOSED && DO_JCOV)  {
             testImplementation name: "jcov"

--- a/modules/javafx.base/src/test/java/test/JUnit5Test.java
+++ b/modules/javafx.base/src/test/java/test/JUnit5Test.java
@@ -26,6 +26,7 @@
 package test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +34,9 @@ public class JUnit5Test {
 
     @Test
     void junit5ShouldWork() {
-        System.err.println("JUnit 5 test working!");
+        assumeTrue(this != null);
+
         assertNotNull(this);
+        System.err.println("JUnit 5 test working!");
     }
 }


### PR DESCRIPTION
Fixed a test dependency issue in `build.gradle` that causes a compilation failure when running `gradle test` if the `Assumptions` API from JUnit5 is used. I added a test that fails to compile without the build fix and passes with the fix.

This was first discovered when testing the patch for PR #715, which fails to compile on my local macOS system. After applying this fix, I can compile and run the test from that PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280275](https://bugs.openjdk.java.net/browse/JDK-8280275): JUnit5 tests using Assumptions API fail to compile in some cases


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/720/head:pull/720` \
`$ git checkout pull/720`

Update a local copy of the PR: \
`$ git checkout pull/720` \
`$ git pull https://git.openjdk.java.net/jfx pull/720/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 720`

View PR using the GUI difftool: \
`$ git pr show -t 720`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/720.diff">https://git.openjdk.java.net/jfx/pull/720.diff</a>

</details>
