### PR TITLE
8280951: Testbug: fix commented asserts in XXViewTest.test_rt_29650

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
@@ -821,7 +821,7 @@ public class ListViewTest {
         listView.setOnEditStart(t -> {
             rt_29650_start_count++;
         });
-        listView.setOnEditCommit(t -> {
+        listView.addEventHandler(ListView.editCommitEvent(), t -> {
             rt_29650_commit_count++;
         });
         listView.setOnEditCancel(t -> {
@@ -844,8 +844,7 @@ public class ListViewTest {
         KeyEventFirer keyboard = new KeyEventFirer(textField);
         keyboard.doKeyPress(KeyCode.ENTER);
 
-        // TODO should the following assert be enabled?
-//        assertEquals("Testing!", listView.getItems().get(0));
+        assertEquals("Testing!", listView.getItems().get(0));
         assertEquals(1, rt_29650_start_count);
         assertEquals(1, rt_29650_commit_count);
         assertEquals(0, rt_29650_cancel_count);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -1915,7 +1915,7 @@ public class TableViewTest {
         first.setOnEditStart(t -> {
             rt_29650_start_count++;
         });
-        first.setOnEditCommit(t -> {
+        first.addEventHandler(TableColumn.editCommitEvent(), t -> {
             rt_29650_commit_count++;
         });
         first.setOnEditCancel(t -> {
@@ -1934,8 +1934,7 @@ public class TableViewTest {
         KeyEventFirer keyboard = new KeyEventFirer(textField);
         keyboard.doKeyPress(KeyCode.ENTER);
 
-        // TODO should the following assert be enabled?
-//        assertEquals("Testing!", listView.getItems().get(0));
+        assertEquals("Testing!", table.getItems().get(0).getFirstName());
         assertEquals(1, rt_29650_start_count);
         assertEquals(1, rt_29650_commit_count);
         assertEquals(0, rt_29650_cancel_count);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -2818,13 +2818,13 @@ public class TreeTableViewTest {
         TreeTableColumn<String, String> col = new TreeTableColumn<>("column");
         Callback<TreeTableColumn<String, String>, TreeTableCell<String, String>> factory = TextFieldTreeTableCell.forTreeTableColumn();
         col.setCellFactory(factory);
-        col.setCellValueFactory(param -> new ReadOnlyObjectWrapper<>(param.getValue().getValue()));
+        col.setCellValueFactory(param -> param.getValue().valueProperty());
         treeTableView.getColumns().add(col);
 
         col.setOnEditStart(t -> {
             rt_29650_start_count++;
         });
-        col.setOnEditCommit(t -> {
+        col.addEventHandler(TreeTableColumn.editCommitEvent(), t -> {
             rt_29650_commit_count++;
         });
         col.setOnEditCancel(t -> {
@@ -2843,8 +2843,7 @@ public class TreeTableViewTest {
         KeyEventFirer keyboard = new KeyEventFirer(textField);
         keyboard.doKeyPress(KeyCode.ENTER);
 
-        // TODO should the following assert be enabled?
-//        assertEquals("Testing!", listView.getItems().get(0));
+        assertEquals("Testing!", treeTableView.getTreeItem(0).getValue());
         assertEquals(1, rt_29650_start_count);
         assertEquals(1, rt_29650_commit_count);
         assertEquals(0, rt_29650_cancel_count);


### PR DESCRIPTION
the issue was commented asserts in a test methods - they had been failing due to incorrect usage of registering an edit commit handler

fix was to correct the registration and uncomment the assert (ListViewTest). For Tree/TableViewTest, had to adjust value access also (was: c&p from ListViewTest). Verified that the uncommented (corrected) asserts are failing/passing before/after fix of test bug

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280951](https://bugs.openjdk.java.net/browse/JDK-8280951): Testbug: fix commented asserts in XXViewTest.test_rt_29650


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/725/head:pull/725` \
`$ git checkout pull/725`

Update a local copy of the PR: \
`$ git checkout pull/725` \
`$ git pull https://git.openjdk.java.net/jfx pull/725/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 725`

View PR using the GUI difftool: \
`$ git pr show -t 725`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/725.diff">https://git.openjdk.java.net/jfx/pull/725.diff</a>

</details>
