### PR TITLE
8277309: Add support for H.265/HEVC to HTTP Live Streaming

### DIFF
--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/locator/ConnectionHolder.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/locator/ConnectionHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -155,17 +155,6 @@ public abstract class ConnectionHolder {
      */
     int property(int prop, int value) {
         return 0;
-    }
-
-    /**
-     * Get stream size.
-     * Behavior can vary based on subclass implementation.
-     * For example HLS will load next segment and return segment size.
-     *
-     * @return - Stream size.
-     */
-    int getStreamSize() {
-        return -1;
     }
 
     private static class FileConnectionHolder extends ConnectionHolder {

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/locator/HLSConnectionHolder.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/locator/HLSConnectionHolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,11 @@ import com.sun.media.jfxmediaimpl.MediaUtils;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.*;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLConnection;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
@@ -43,6 +47,8 @@ import java.util.concurrent.Semaphore;
 final class HLSConnectionHolder extends ConnectionHolder {
 
     private URLConnection urlConnection = null;
+    private URLConnection headerConnection = null;
+    private ReadableByteChannel headerChannel = null;
     private PlaylistThread playlistThread = new PlaylistThread();
     private VariantPlaylist variantPlaylist = null;
     private Playlist currentPlaylist = null;
@@ -52,12 +58,18 @@ final class HLSConnectionHolder extends ConnectionHolder {
     private boolean isPlaylistClosed = false;
     private boolean isBitrateAdjustable = false;
     private long startTime = -1;
+    private boolean sendHeader = true;
     private static final long HLS_VALUE_FLOAT_MULTIPLIER = 1000;
     private static final int HLS_PROP_GET_DURATION = 1;
     private static final int HLS_PROP_GET_HLS_MODE = 2;
     private static final int HLS_PROP_GET_MIMETYPE = 3;
+    private static final int HLS_PROP_LOAD_SEGMENT = 4;
+    private static final int HLS_PROP_SEGMENT_START_TIME = 5;
+    private static final int HLS_VALUE_MIMETYPE_UNKNOWN = -1;
     private static final int HLS_VALUE_MIMETYPE_MP2T = 1;
     private static final int HLS_VALUE_MIMETYPE_MP3 = 2;
+    private static final int HLS_VALUE_MIMETYPE_FMP4 = 3;
+    private static final int HLS_VALUE_MIMETYPE_AAC = 4;
     private static final String CHARSET_UTF_8 = "UTF-8";
     private static final String CHARSET_US_ASCII = "US-ASCII";
 
@@ -77,6 +89,19 @@ final class HLSConnectionHolder extends ConnectionHolder {
             startTime = System.currentTimeMillis();
         }
 
+        if (headerChannel != null) {
+            buffer.rewind();
+            if (buffer.limit() < buffer.capacity()) {
+                buffer.limit(buffer.capacity());
+            }
+            int read = headerChannel.read(buffer);
+            if (read == -1) {
+                resetHeaderConnection();
+            } else {
+                return read;
+            }
+        }
+
         int read = super.readNextBlock();
         if (isBitrateAdjustable && read == -1) {
             long readTime = System.currentTimeMillis() - startTime;
@@ -87,26 +112,31 @@ final class HLSConnectionHolder extends ConnectionHolder {
         return read;
     }
 
+    @Override
     int readBlock(long position, int size) throws IOException {
         throw new IOException();
     }
 
+    @Override
     boolean needBuffer() {
         return true;
     }
 
+    @Override
     boolean isSeekable() {
         return true;
     }
 
+    @Override
     boolean isRandomAccess() {
         return false; // Only by segments
     }
 
+    @Override
     public long seek(long position) {
         try {
             readySignal.await();
-        } catch (Exception e) {
+        } catch (InterruptedException e) {
             return -1;
         }
 
@@ -125,47 +155,81 @@ final class HLSConnectionHolder extends ConnectionHolder {
     int property(int prop, int value) {
         try {
             readySignal.await();
-        } catch (Exception e) {
+        } catch (InterruptedException e) {
             return -1;
         }
 
-        if (prop == HLS_PROP_GET_DURATION) {
-            return (int) (currentPlaylist.getDuration() * HLS_VALUE_FLOAT_MULTIPLIER);
-        } else if (prop == HLS_PROP_GET_HLS_MODE) {
-            return 1;
-        } else if (prop == HLS_PROP_GET_MIMETYPE) {
-            return currentPlaylist.getMimeType();
+        switch (prop) {
+            case HLS_PROP_GET_DURATION:
+                return (int)(currentPlaylist.getDuration() * HLS_VALUE_FLOAT_MULTIPLIER);
+            case HLS_PROP_GET_HLS_MODE:
+                return 1;
+            case HLS_PROP_GET_MIMETYPE:
+                return currentPlaylist.getMimeType();
+            case HLS_PROP_LOAD_SEGMENT:
+                return loadNextSegment();
+            case HLS_PROP_SEGMENT_START_TIME:
+                return (int)(currentPlaylist.getMediaFileStartTime() * HLS_VALUE_FLOAT_MULTIPLIER);
+            default:
+                return -1;
         }
-
-        return -1;
-    }
-
-    @Override
-    int getStreamSize() {
-        try {
-            readySignal.await();
-        } catch (Exception e) {
-            return -1;
-        }
-
-        return loadNextSegment();
     }
 
     private void resetConnection() {
         super.closeConnection();
 
+        resetHeaderConnection();
+
         Locator.closeConnection(urlConnection);
         urlConnection = null;
     }
 
+    private void resetHeaderConnection() {
+        try {
+            if (headerChannel != null) {
+                headerChannel.close();
+            }
+        } catch (IOException ioex) {}
+        finally {
+            headerChannel = null;
+        }
+
+        Locator.closeConnection(headerConnection);
+        headerConnection = null;
+    }
+
+
     // Returns -1 EOS or critical error
-    // Returns positive size of segment if no isssues.
+    // Returns positive size of segment if no issues.
     // Returns negative size of segment if discontinuity.
     private int loadNextSegment() {
         resetConnection();
 
-        String mediaFile = currentPlaylist.getNextMediaFile();
+        String mediaFile;
+        int headerLength = 0;
+
+        if (sendHeader) {
+            mediaFile = currentPlaylist.getHeaderFile();
+            if (mediaFile == null) {
+                return -1;
+            }
+
+            try {
+                URI uri = new URI(mediaFile);
+                headerConnection = uri.toURL().openConnection();
+                headerChannel = openHeaderChannel();
+                headerLength = headerConnection.getContentLength();
+            } catch (IOException | URISyntaxException e) {
+                return -1;
+            }
+            sendHeader = false;
+        }
+
+        mediaFile = currentPlaylist.getNextMediaFile();
         if (mediaFile == null) {
+            if (isFragmentedMP4()) {
+                sendHeader = true;
+            }
             return -1;
         }
 
@@ -173,19 +237,23 @@ final class HLSConnectionHolder extends ConnectionHolder {
             URI uri = new URI(mediaFile);
             urlConnection = uri.toURL().openConnection();
             channel = openChannel();
-        } catch (Exception e) {
+        } catch (IOException | URISyntaxException e) {
             return -1;
         }
 
         if (currentPlaylist.isCurrentMediaFileDiscontinuity()) {
-            return (-1 * urlConnection.getContentLength());
+            return (-1 * (urlConnection.getContentLength() + headerLength));
         } else {
-            return urlConnection.getContentLength();
+            return (urlConnection.getContentLength() + headerLength);
         }
     }
 
     private ReadableByteChannel openChannel() throws IOException {
         return Channels.newChannel(urlConnection.getInputStream());
+    }
+
+    private ReadableByteChannel openHeaderChannel() throws IOException {
+        return Channels.newChannel(headerConnection.getInputStream());
     }
 
     private void adjustBitrate(long readTime) {
@@ -200,7 +268,14 @@ final class HLSConnectionHolder extends ConnectionHolder {
 
             playlist.setForceDiscontinuity(true);
             currentPlaylist = playlist;
+            if (isFragmentedMP4()) {
+                sendHeader = true;
+            }
         }
+    }
+
+    private boolean isFragmentedMP4() {
+        return (currentPlaylist.getMimeType() == HLS_VALUE_MIMETYPE_FMP4);
     }
 
     private static String stripParameters(String mediaFile) {
@@ -216,7 +291,7 @@ final class HLSConnectionHolder extends ConnectionHolder {
         public static final int STATE_INIT = 0;
         public static final int STATE_EXIT = 1;
         public static final int STATE_RELOAD_PLAYLIST = 2;
-        private BlockingQueue<Integer> stateQueue = new LinkedBlockingQueue<Integer>();
+        private final BlockingQueue<Integer> stateQueue = new LinkedBlockingQueue<>();
         private URI playlistURI = null;
         private Playlist reloadPlaylist = null;
         private final Object reloadLock = new Object();
@@ -255,7 +330,7 @@ final class HLSConnectionHolder extends ConnectionHolder {
                         default:
                             break;
                     }
-                } catch (Exception e) {
+                } catch (InterruptedException e) {
                 }
             }
         }
@@ -274,58 +349,64 @@ final class HLSConnectionHolder extends ConnectionHolder {
                 return;
             }
 
-            PlaylistParser parser = new PlaylistParser();
-            parser.load(playlistURI);
+            try {
+                PlaylistParser parser = new PlaylistParser();
+                parser.load(playlistURI);
 
-            if (parser.isVariantPlaylist()) {
-                variantPlaylist = new VariantPlaylist(playlistURI);
+                if (parser.isVariantPlaylist()) {
+                    variantPlaylist = new VariantPlaylist(playlistURI);
 
-                while (parser.hasNext()) {
-                    variantPlaylist.addPlaylistInfo(parser.getString(), parser.getInteger());
-                }
-            } else {
-                if (currentPlaylist == null) {
-                    currentPlaylist = new Playlist(parser.isLivePlaylist(), parser.getTargetDuration());
-                    currentPlaylist.setPlaylistURI(playlistURI);
-                }
-
-                if (currentPlaylist.setSequenceNumber(parser.getSequenceNumber())) {
                     while (parser.hasNext()) {
-                        currentPlaylist.addMediaFile(parser.getString(), parser.getDouble(), parser.getBoolean());
+                        variantPlaylist.addPlaylistInfo(parser.getString(), parser.getInteger());
                     }
-                }
+                } else {
+                    if (currentPlaylist == null) {
+                        currentPlaylist = new Playlist(parser.isLivePlaylist(), parser.getTargetDuration());
+                        currentPlaylist.setPlaylistURI(playlistURI);
+                    }
 
-                if (variantPlaylist != null) {
-                    variantPlaylist.addPlaylist(currentPlaylist);
-                }
-            }
+                    if (currentPlaylist.setSequenceNumber(parser.getSequenceNumber())) {
+                        while (parser.hasNext()) {
+                            currentPlaylist.addMediaFile(parser.getString(), parser.getDouble(), parser.getBoolean());
+                        }
+                    }
 
-            // Update variant playlists
-            if (variantPlaylist != null) {
-                while (variantPlaylist.hasNext()) {
-                    try {
-                        currentPlaylist = new Playlist(variantPlaylist.getPlaylistURI());
-                        currentPlaylist.update(null);
+                    if (variantPlaylist != null) {
                         variantPlaylist.addPlaylist(currentPlaylist);
-                    } catch (URISyntaxException e) {
-                    } catch (MalformedURLException e) {
                     }
                 }
-            }
 
-            // Always start with first data playlist
-            if (variantPlaylist != null) {
-                currentPlaylist = variantPlaylist.getPlaylist(0);
-                isBitrateAdjustable = true;
-            }
+                // Update variant playlists
+                if (variantPlaylist != null) {
+                    while (variantPlaylist.hasNext()) {
+                        try {
+                            currentPlaylist = new Playlist(variantPlaylist.getPlaylistURI());
+                            currentPlaylist.update(null);
+                            variantPlaylist.addPlaylist(currentPlaylist);
+                        } catch (URISyntaxException | MalformedURLException e) {
+                        }
+                    }
+                }
 
-            // Start reloading live playlist
-            if (currentPlaylist.isLive()) {
-                setReloadPlaylist(currentPlaylist);
-                putState(STATE_RELOAD_PLAYLIST);
-            }
+                // Always start with first data playlist
+                if (variantPlaylist != null) {
+                    currentPlaylist = variantPlaylist.getPlaylist(0);
+                    isBitrateAdjustable = true;
+                }
 
-            readySignal.countDown();
+                // Start reloading live playlist
+                if (currentPlaylist.isLive()) {
+                    setReloadPlaylist(currentPlaylist);
+                    putState(STATE_RELOAD_PLAYLIST);
+                }
+
+                if (isFragmentedMP4()) {
+                    mediaFileIndex = 0;
+                }
+            } catch (Exception e) {
+            } finally {
+                readySignal.countDown();
+            }
         }
 
         private void stateReloadPlaylist() {
@@ -358,10 +439,10 @@ final class HLSConnectionHolder extends ConnectionHolder {
         private int targetDuration = 0;
         private int sequenceNumber = 0;
         private int dataListIndex = -1;
-        private List<String> dataListString = new ArrayList<String>();
-        private List<Integer> dataListInteger = new ArrayList<Integer>();
-        private List<Double> dataListDouble = new ArrayList<Double>();
-        private List<Boolean> dataListBoolean = new ArrayList<Boolean>();
+        private List<String> dataListString = new ArrayList<>();
+        private List<Integer> dataListInteger = new ArrayList<>();
+        private List<Double> dataListDouble = new ArrayList<>();
+        private List<Boolean> dataListBoolean = new ArrayList<>();
 
         private void load(URI uri) {
             HttpURLConnection connection = null;
@@ -416,11 +497,10 @@ final class HLSConnectionHolder extends ConnectionHolder {
 
         private boolean hasNext() {
             dataListIndex++;
-            if (dataListString.size() > dataListIndex || dataListInteger.size() > dataListIndex || dataListDouble.size() > dataListIndex || dataListBoolean.size() > dataListIndex) {
-                return true;
-            } else {
-                return false;
-            }
+            return dataListString.size() > dataListIndex ||
+                    dataListInteger.size() > dataListIndex ||
+                    dataListDouble.size() > dataListIndex ||
+                    dataListBoolean.size() > dataListIndex;
         }
 
         private String getString() {
@@ -514,14 +594,40 @@ final class HLSConnectionHolder extends ConnectionHolder {
                 isEndList = true;
             } else if (line.startsWith("#EXT-X-DISCONTINUITY")) { // #EXT-X-DISCONTINUITY
                 isDiscontinuity = true;
+            } else if (line.startsWith("#EXT-X-MAP")) {
+                String[] s1 = line.split(":");
+                if (s1.length == 2 && s1[1].length() > 0) {
+                    String[] s2 = s1[1].split(",");
+                    if (s2.length > 0) {
+                        for (int i = 0; i < s2.length; i++) {
+                            s2[i] = s2[i].trim();
+                            if (s2[i].startsWith("URI")) {
+                                String[] s3 = s2[i].split("=");
+                                if (s3.length == 2 && s3[1].length() > 0) {
+                                    String dataFile =
+                                            s3[1].replaceAll("^\"+|\"+$", "");
+                                    dataListString.add(dataFile);
+                                    // GStreamer expects start of stream to be
+                                    // discontinuity.
+                                    dataListBoolean.add(true);
+                                    dataListDouble.add(Double.valueOf(targetDuration));
+                                }
+                            }
+                        }
+                    }
+                }
             } else if (isLinePlaylistURI) {
                 isLinePlaylistURI = false;
                 dataListString.add(line);
             } else if (isLineMediaFileURI) {
-                isLineMediaFileURI = false;
-                dataListString.add(line);
-                dataListBoolean.add(isDiscontinuity);
-                isDiscontinuity = false;
+                // We can have additional tags after #EXTINF such as
+                // #EXT-X-BITRATE for fMP4 playlist, so ignore them.
+                if (!line.startsWith("#")) {
+                    isLineMediaFileURI = false;
+                    dataListString.add(line);
+                    dataListBoolean.add(isDiscontinuity);
+                    isDiscontinuity = false;
+                }
             }
 
             return true;
@@ -546,9 +652,9 @@ final class HLSConnectionHolder extends ConnectionHolder {
 
         private URI playlistURI = null;
         private int infoIndex = -1;
-        private List<String> playlistsLocations = new ArrayList<String>();
-        private List<Integer> playlistsBitrates = new ArrayList<Integer>();
-        private List<Playlist> playlists = new ArrayList<Playlist>();
+        private List<String> playlistsLocations = new ArrayList<>();
+        private List<Integer> playlistsBitrates = new ArrayList<>();
+        private List<Playlist> playlists = new ArrayList<>();
         private String mediaFileExtension = null; // Will be set to media file extension of first playlist
 
         private VariantPlaylist(URI uri) {
@@ -584,11 +690,8 @@ final class HLSConnectionHolder extends ConnectionHolder {
 
         private boolean hasNext() {
             infoIndex++;
-            if (playlistsLocations.size() > infoIndex && playlistsBitrates.size() > infoIndex) {
-                return true;
-            } else {
-                return false;
-            }
+            return playlistsLocations.size() > infoIndex &&
+                    playlistsBitrates.size() > infoIndex;
         }
 
         private URI getPlaylistURI() throws URISyntaxException, MalformedURLException {
@@ -647,9 +750,9 @@ final class HLSConnectionHolder extends ConnectionHolder {
         private long targetDuration = 0;
         private URI playlistURI = null;
         private final Object lock = new Object();
-        private List<String> mediaFiles = new ArrayList<String>();
-        private List<Double> mediaFilesStartTimes = new ArrayList<Double>();
-        private List<Boolean> mediaFilesDiscontinuities = new ArrayList<Boolean>();
+        private final List<String> mediaFiles = new ArrayList<>();
+        private final List<Double> mediaFilesStartTimes = new ArrayList<>();
+        private final List<Boolean> mediaFilesDiscontinuities = new ArrayList<>();
         private boolean needBaseURI = true;
         private String baseURI = null;
         private double duration = 0.0;
@@ -657,6 +760,7 @@ final class HLSConnectionHolder extends ConnectionHolder {
         private int sequenceNumberStart = -1;
         private boolean sequenceNumberUpdated = false;
         private boolean forceDiscontinuity = false;
+        private int mimeType = HLS_VALUE_MIMETYPE_UNKNOWN;
 
         private Playlist(boolean isLive, int targetDuration) {
             this.isLive = isLive;
@@ -794,6 +898,24 @@ final class HLSConnectionHolder extends ConnectionHolder {
             }
         }
 
+        private String getHeaderFile() {
+            synchronized (lock) {
+                if (mediaFiles.size() > 0) {
+                    if (baseURI != null) {
+                        return baseURI + mediaFiles.get(0);
+                    } else {
+                        return mediaFiles.get(0);
+                    }
+                } else {
+                    return null;
+                }
+            }
+        }
+
+        private double getMediaFileStartTime() {
+            return mediaFilesStartTimes.get(mediaFileIndex);
+        }
+
         private double getDuration() {
             return duration;
         }
@@ -815,7 +937,12 @@ final class HLSConnectionHolder extends ConnectionHolder {
             synchronized (lock) {
                 if (isLive) {
                     if (time == 0) {
-                        mediaFileIndex = -1;
+                        if (isFragmentedMP4()) {
+                            mediaFileIndex = 0; // Skip header at 0 index
+                            // we will send it with first segment if needed.
+                        } else {
+                            mediaFileIndex = -1;
+                        }
                         if (isLiveWaiting) {
                             isLiveStop = true;
                             liveSemaphore.release();
@@ -831,12 +958,20 @@ final class HLSConnectionHolder extends ConnectionHolder {
                         if (time >= mediaFilesStartTimes.get(index)) {
                             if (index + 1 < mediaFileStartTimeSize) {
                                 if (time < mediaFilesStartTimes.get(index + 1)) {
-                                    mediaFileIndex = index - 1; // Seek will load segment and increment mediaFileIndex
+                                    if (isFragmentedMP4()) {
+                                        mediaFileIndex = index;
+                                    } else {
+                                        mediaFileIndex = index - 1; // Seek will load segment and increment mediaFileIndex
+                                    }
                                     return mediaFilesStartTimes.get(index);
                                 }
                             } else {
                                 if ((time - targetDuration / 2000) < duration) {
-                                    mediaFileIndex = index - 1; // Seek will load segment and increment mediaFileIndex
+                                    if (isFragmentedMP4()) {
+                                        mediaFileIndex = index;
+                                    } else {
+                                        mediaFileIndex = index - 1; // Seek will load segment and increment mediaFileIndex
+                                    }
                                     return mediaFilesStartTimes.get(index);
                                 } else if (Double.compare(time - targetDuration / 2000, duration) == 0) {
                                     return duration;
@@ -852,16 +987,23 @@ final class HLSConnectionHolder extends ConnectionHolder {
 
         private int getMimeType() {
             synchronized (lock) {
-                if (mediaFiles.size() > 0) {
-                    if (stripParameters(mediaFiles.get(0)).endsWith(".ts")) {
-                        return HLS_VALUE_MIMETYPE_MP2T;
-                    } else if (stripParameters(mediaFiles.get(0)).endsWith(".mp3")) {
-                        return HLS_VALUE_MIMETYPE_MP3;
+                if (mimeType == HLS_VALUE_MIMETYPE_UNKNOWN) {
+                    if (mediaFiles.size() > 0) {
+                        if (stripParameters(mediaFiles.get(0)).endsWith(".ts")) {
+                            mimeType = HLS_VALUE_MIMETYPE_MP2T;
+                        } else if (stripParameters(mediaFiles.get(0)).endsWith(".mp3")) {
+                            mimeType = HLS_VALUE_MIMETYPE_MP3;
+                        } else if (stripParameters(mediaFiles.get(0)).endsWith(".mp4")
+                                || stripParameters(mediaFiles.get(0)).endsWith(".m4s")) {
+                            mimeType = HLS_VALUE_MIMETYPE_FMP4;
+                        } else if (stripParameters(mediaFiles.get(0)).endsWith(".aac")) {
+                            mimeType = HLS_VALUE_MIMETYPE_AAC;
+                        }
                     }
                 }
             }
 
-            return -1;
+            return mimeType;
         }
 
         private String getMediaFileExtension() {

--- a/modules/javafx.media/src/main/java/javafx/scene/media/package.html
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/package.html
@@ -2,7 +2,7 @@
 
 <!--
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -99,6 +99,14 @@ supported by Java FX Media.
     <td>AAC</td><td>application/vnd.apple.mpegurl, audio/mpegurl</td><td>.m3u8</td></tr>
 <tr><th scope="row">HLS (*)</th><td>MP3 HTTP Live Streaming (audio-only)</td><td>N/A</td>
     <td>MP3</td><td>application/vnd.apple.mpegurl, audio/mpegurl</td><td>.m3u8</td></tr>
+<tr><th scope="row">HLS (*)</th><td>fMP4 HTTP Live Streaming (audiovisual)</td><td>H.264/AVC</td>
+    <td>AAC</td><td>application/vnd.apple.mpegurl, audio/mpegurl</td><td>.m3u8</td></tr>
+<tr><th scope="row">HLS (*)</th><td>fMP4 HTTP Live Streaming (audiovisual)</td><td>H.265/HEVC</td>
+    <td>AAC</td><td>application/vnd.apple.mpegurl, audio/mpegurl</td><td>.m3u8</td></tr>
+<tr><th scope="row">HLS (*)</th><td>fMP4 HTTP Live Streaming (audio-only)</td><td>N/A</td>
+    <td>AAC</td><td>application/vnd.apple.mpegurl, audio/mpegurl</td><td>.m3u8</td></tr>
+<tr><th scope="row">HLS (*)</th><td>AAC HTTP Live Streaming (audio-only)</td><td>N/A</td>
+    <td>AAC</td><td>application/vnd.apple.mpegurl, audio/mpegurl</td><td>.m3u8</td></tr>
 <tr><th scope="row">MP3</th><td>MPEG-1, 2, 2.5 raw audio stream possibly with ID3 metadata v2.3 or v2.4</td>
     <td>N/A</td><td>MP3</td><td>audio/mpeg</td><td>.mp3</td></tr>
 <tr><th scope="row">MP4</th><td>MPEG-4 Part 14</td><td>H.264/AVC</td>

--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/gst/audioparsers/gstaacparse.c
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/gst/audioparsers/gstaacparse.c
@@ -1,0 +1,1674 @@
+/* GStreamer AAC parser plugin
+ * Copyright (C) 2008 Nokia Corporation. All rights reserved.
+ *
+ * Contact: Stefan Kost <stefan.kost@nokia.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+/**
+ * SECTION:element-aacparse
+ * @title: aacparse
+ * @short_description: AAC parser
+ * @see_also: #GstAmrParse
+ *
+ * This is an AAC parser which handles both ADIF and ADTS stream formats.
+ *
+ * As ADIF format is not framed, it is not seekable and stream duration cannot
+ * be determined either. However, ADTS format AAC clips can be seeked, and parser
+ * can also estimate playback position and clip duration.
+ *
+ * ## Example launch line
+ * |[
+ * gst-launch-1.0 filesrc location=abc.aac ! aacparse ! faad ! audioresample ! audioconvert ! alsasink
+ * ]|
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <string.h>
+
+#include <gst/base/gstbitreader.h>
+#include <gst/pbutils/pbutils.h>
+#include "gstaacparse.h"
+
+
+static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",
+    GST_PAD_SRC,
+    GST_PAD_ALWAYS,
+    GST_STATIC_CAPS ("audio/mpeg, "
+        "framed = (boolean) true, " "mpegversion = (int) { 2, 4 }, "
+        "stream-format = (string) { raw, adts, adif, loas };"));
+
+static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",
+    GST_PAD_SINK,
+    GST_PAD_ALWAYS,
+    GST_STATIC_CAPS ("audio/mpeg, mpegversion = (int) { 2, 4 };"));
+
+GST_DEBUG_CATEGORY_STATIC (aacparse_debug);
+#define GST_CAT_DEFAULT aacparse_debug
+
+
+#define ADIF_MAX_SIZE 40        /* Should be enough */
+#define ADTS_MAX_SIZE 10        /* Should be enough */
+#define LOAS_MAX_SIZE 3         /* Should be enough */
+#define RAW_MAX_SIZE  1         /* Correct framing is required */
+
+#define ADTS_HEADERS_LENGTH 7UL /* Total byte-length of fixed and variable
+                                   headers prepended during raw to ADTS
+                                   conversion */
+
+#define AAC_FRAME_DURATION(parse) (GST_SECOND/parse->frames_per_sec)
+
+static const gint loas_sample_rate_table[16] = {
+  96000, 88200, 64000, 48000, 44100, 32000, 24000, 22050,
+  16000, 12000, 11025, 8000, 7350, 0, 0, 0
+};
+
+static const gint loas_channels_table[16] = {
+  0, 1, 2, 3, 4, 5, 6, 8,
+  0, 0, 0, 7, 8, 0, 8, 0
+};
+
+static gboolean gst_aac_parse_start (GstBaseParse * parse);
+static gboolean gst_aac_parse_stop (GstBaseParse * parse);
+
+static gboolean gst_aac_parse_sink_setcaps (GstBaseParse * parse,
+    GstCaps * caps);
+static GstCaps *gst_aac_parse_sink_getcaps (GstBaseParse * parse,
+    GstCaps * filter);
+
+static GstFlowReturn gst_aac_parse_handle_frame (GstBaseParse * parse,
+    GstBaseParseFrame * frame, gint * skipsize);
+static GstFlowReturn gst_aac_parse_pre_push_frame (GstBaseParse * parse,
+    GstBaseParseFrame * frame);
+static gboolean gst_aac_parse_src_event (GstBaseParse * parse,
+    GstEvent * event);
+
+static gboolean gst_aac_parse_read_audio_specific_config (GstAacParse *
+    aacparse, GstBitReader * br, gint * object_type, gint * sample_rate,
+    gint * channels, gint * frame_samples);
+
+
+#define gst_aac_parse_parent_class parent_class
+G_DEFINE_TYPE (GstAacParse, gst_aac_parse, GST_TYPE_BASE_PARSE);
+
+/**
+ * gst_aac_parse_class_init:
+ * @klass: #GstAacParseClass.
+ *
+ */
+static void
+gst_aac_parse_class_init (GstAacParseClass * klass)
+{
+  GstElementClass *element_class = GST_ELEMENT_CLASS (klass);
+  GstBaseParseClass *parse_class = GST_BASE_PARSE_CLASS (klass);
+
+  GST_DEBUG_CATEGORY_INIT (aacparse_debug, "aacparse", 0,
+      "AAC audio stream parser");
+
+  gst_element_class_add_static_pad_template (element_class, &sink_template);
+  gst_element_class_add_static_pad_template (element_class, &src_template);
+
+  gst_element_class_set_static_metadata (element_class,
+      "AAC audio stream parser", "Codec/Parser/Audio",
+      "Advanced Audio Coding parser", "Stefan Kost <stefan.kost@nokia.com>");
+
+  parse_class->start = GST_DEBUG_FUNCPTR (gst_aac_parse_start);
+  parse_class->stop = GST_DEBUG_FUNCPTR (gst_aac_parse_stop);
+  parse_class->set_sink_caps = GST_DEBUG_FUNCPTR (gst_aac_parse_sink_setcaps);
+  parse_class->get_sink_caps = GST_DEBUG_FUNCPTR (gst_aac_parse_sink_getcaps);
+  parse_class->handle_frame = GST_DEBUG_FUNCPTR (gst_aac_parse_handle_frame);
+  parse_class->pre_push_frame =
+      GST_DEBUG_FUNCPTR (gst_aac_parse_pre_push_frame);
+  parse_class->src_event = GST_DEBUG_FUNCPTR (gst_aac_parse_src_event);
+}
+
+
+/**
+ * gst_aac_parse_init:
+ * @aacparse: #GstAacParse.
+ * @klass: #GstAacParseClass.
+ *
+ */
+static void
+gst_aac_parse_init (GstAacParse * aacparse)
+{
+  GST_DEBUG ("initialized");
+  GST_PAD_SET_ACCEPT_INTERSECT (GST_BASE_PARSE_SINK_PAD (aacparse));
+  GST_PAD_SET_ACCEPT_TEMPLATE (GST_BASE_PARSE_SINK_PAD (aacparse));
+
+  aacparse->last_parsed_sample_rate = 0;
+  aacparse->last_parsed_channels = 0;
+}
+
+
+/**
+ * gst_aac_parse_set_src_caps:
+ * @aacparse: #GstAacParse.
+ * @sink_caps: (proposed) caps of sink pad
+ *
+ * Set source pad caps according to current knowledge about the
+ * audio stream.
+ *
+ * Returns: TRUE if caps were successfully set.
+ */
+static gboolean
+gst_aac_parse_set_src_caps (GstAacParse * aacparse, GstCaps * sink_caps)
+{
+  GstStructure *s;
+  GstCaps *src_caps = NULL, *peercaps;
+  gboolean res = FALSE;
+  const gchar *stream_format;
+  guint8 codec_data[2];
+  guint16 codec_data_data;
+  gint sample_rate_idx;
+
+  GST_DEBUG_OBJECT (aacparse, "sink caps: %" GST_PTR_FORMAT, sink_caps);
+  if (sink_caps)
+    src_caps = gst_caps_copy (sink_caps);
+  else
+    src_caps = gst_caps_new_empty_simple ("audio/mpeg");
+
+  gst_caps_set_simple (src_caps, "framed", G_TYPE_BOOLEAN, TRUE,
+      "mpegversion", G_TYPE_INT, aacparse->mpegversion, NULL);
+
+  aacparse->output_header_type = aacparse->header_type;
+  switch (aacparse->header_type) {
+    case DSPAAC_HEADER_NONE:
+      stream_format = "raw";
+      break;
+    case DSPAAC_HEADER_ADTS:
+      stream_format = "adts";
+      break;
+    case DSPAAC_HEADER_ADIF:
+      stream_format = "adif";
+      break;
+    case DSPAAC_HEADER_LOAS:
+      stream_format = "loas";
+      break;
+    default:
+      stream_format = NULL;
+  }
+
+  /* Generate codec data to be able to set profile/level on the caps */
+  sample_rate_idx =
+      gst_codec_utils_aac_get_index_from_sample_rate (aacparse->sample_rate);
+  if (sample_rate_idx < 0)
+    goto not_a_known_rate;
+  codec_data_data =
+      (aacparse->object_type << 11) |
+      (sample_rate_idx << 7) | (aacparse->channels << 3);
+  GST_WRITE_UINT16_BE (codec_data, codec_data_data);
+  gst_codec_utils_aac_caps_set_level_and_profile (src_caps, codec_data, 2);
+
+  s = gst_caps_get_structure (src_caps, 0);
+  if (aacparse->sample_rate > 0)
+    gst_structure_set (s, "rate", G_TYPE_INT, aacparse->sample_rate, NULL);
+  if (aacparse->channels > 0)
+    gst_structure_set (s, "channels", G_TYPE_INT, aacparse->channels, NULL);
+  if (stream_format)
+    gst_structure_set (s, "stream-format", G_TYPE_STRING, stream_format, NULL);
+
+  peercaps = gst_pad_peer_query_caps (GST_BASE_PARSE_SRC_PAD (aacparse), NULL);
+  if (peercaps && !gst_caps_can_intersect (src_caps, peercaps)) {
+    GST_DEBUG_OBJECT (GST_BASE_PARSE (aacparse)->srcpad,
+        "Caps can not intersect");
+    if (aacparse->header_type == DSPAAC_HEADER_ADTS) {
+      GST_DEBUG_OBJECT (GST_BASE_PARSE (aacparse)->srcpad,
+          "Input is ADTS, trying raw");
+      gst_caps_set_simple (src_caps, "stream-format", G_TYPE_STRING, "raw",
+          NULL);
+      if (gst_caps_can_intersect (src_caps, peercaps)) {
+        GstBuffer *codec_data_buffer;
+
+        GST_DEBUG_OBJECT (GST_BASE_PARSE (aacparse)->srcpad,
+            "Caps can intersect, we will drop the ADTS layer");
+        aacparse->output_header_type = DSPAAC_HEADER_NONE;
+
+        /* The codec_data data is according to AudioSpecificConfig,
+           ISO/IEC 14496-3, 1.6.2.1 */
+        codec_data_buffer = gst_buffer_new_and_alloc (2);
+        gst_buffer_fill (codec_data_buffer, 0, codec_data, 2);
+        gst_caps_set_simple (src_caps, "codec_data", GST_TYPE_BUFFER,
+            codec_data_buffer, NULL);
+        gst_buffer_unref (codec_data_buffer);
+      }
+    } else if (aacparse->header_type == DSPAAC_HEADER_NONE) {
+      GST_DEBUG_OBJECT (GST_BASE_PARSE (aacparse)->srcpad,
+          "Input is raw, trying ADTS");
+      gst_caps_set_simple (src_caps, "stream-format", G_TYPE_STRING, "adts",
+          NULL);
+      if (gst_caps_can_intersect (src_caps, peercaps)) {
+        GST_DEBUG_OBJECT (GST_BASE_PARSE (aacparse)->srcpad,
+            "Caps can intersect, we will prepend ADTS headers");
+        aacparse->output_header_type = DSPAAC_HEADER_ADTS;
+      }
+    }
+  }
+  if (peercaps)
+    gst_caps_unref (peercaps);
+
+  aacparse->last_parsed_channels = 0;
+  aacparse->last_parsed_sample_rate = 0;
+
+  GST_DEBUG_OBJECT (aacparse, "setting src caps: %" GST_PTR_FORMAT, src_caps);
+
+  res = gst_pad_set_caps (GST_BASE_PARSE (aacparse)->srcpad, src_caps);
+  gst_caps_unref (src_caps);
+  return res;
+
+not_a_known_rate:
+  GST_ERROR_OBJECT (aacparse, "Not a known sample rate: %d",
+      aacparse->sample_rate);
+  gst_caps_unref (src_caps);
+  return FALSE;
+}
+
+
+/**
+ * gst_aac_parse_sink_setcaps:
+ * @sinkpad: GstPad
+ * @caps: GstCaps
+ *
+ * Implementation of "set_sink_caps" vmethod in #GstBaseParse class.
+ *
+ * Returns: TRUE on success.
+ */
+static gboolean
+gst_aac_parse_sink_setcaps (GstBaseParse * parse, GstCaps * caps)
+{
+  GstAacParse *aacparse;
+  GstStructure *structure;
+  gchar *caps_str;
+  const GValue *value;
+
+  aacparse = GST_AAC_PARSE (parse);
+  structure = gst_caps_get_structure (caps, 0);
+  caps_str = gst_caps_to_string (caps);
+
+  GST_DEBUG_OBJECT (aacparse, "setcaps: %s", caps_str);
+  g_free (caps_str);
+
+  /* This is needed at least in case of RTP
+   * Parses the codec_data information to get ObjectType,
+   * number of channels and samplerate */
+  value = gst_structure_get_value (structure, "codec_data");
+  if (value) {
+    GstBuffer *buf = gst_value_get_buffer (value);
+
+    if (buf && gst_buffer_get_size (buf) >= 2) {
+      GstMapInfo map;
+      GstBitReader br;
+
+      if (!gst_buffer_map (buf, &map, GST_MAP_READ))
+        return FALSE;
+      gst_bit_reader_init (&br, map.data, map.size);
+      gst_aac_parse_read_audio_specific_config (aacparse, &br,
+          &aacparse->object_type, &aacparse->sample_rate, &aacparse->channels,
+          &aacparse->frame_samples);
+
+      aacparse->header_type = DSPAAC_HEADER_NONE;
+      aacparse->mpegversion = 4;
+      gst_buffer_unmap (buf, &map);
+
+      GST_DEBUG ("codec_data: object_type=%d, sample_rate=%d, channels=%d, "
+          "samples=%d", aacparse->object_type, aacparse->sample_rate,
+          aacparse->channels, aacparse->frame_samples);
+
+      /* arrange for metadata and get out of the way */
+      gst_aac_parse_set_src_caps (aacparse, caps);
+      if (aacparse->header_type == aacparse->output_header_type)
+        gst_base_parse_set_passthrough (parse, TRUE);
+
+      /* input is already correctly framed */
+      gst_base_parse_set_min_frame_size (parse, RAW_MAX_SIZE);
+    } else {
+      return FALSE;
+    }
+
+    /* caps info overrides */
+    gst_structure_get_int (structure, "rate", &aacparse->sample_rate);
+    gst_structure_get_int (structure, "channels", &aacparse->channels);
+  } else {
+    const gchar *stream_format =
+        gst_structure_get_string (structure, "stream-format");
+
+    if (g_strcmp0 (stream_format, "raw") == 0) {
+      GST_ERROR_OBJECT (parse, "Need codec_data for raw AAC");
+      return FALSE;
+    } else {
+      aacparse->sample_rate = 0;
+      aacparse->channels = 0;
+      aacparse->header_type = DSPAAC_HEADER_NOT_PARSED;
+      gst_base_parse_set_passthrough (parse, FALSE);
+    }
+  }
+  return TRUE;
+}
+
+
+/**
+ * gst_aac_parse_adts_get_frame_len:
+ * @data: block of data containing an ADTS header.
+ *
+ * This function calculates ADTS frame length from the given header.
+ *
+ * Returns: size of the ADTS frame.
+ */
+static inline guint
+gst_aac_parse_adts_get_frame_len (const guint8 * data)
+{
+  return ((data[3] & 0x03) << 11) | (data[4] << 3) | ((data[5] & 0xe0) >> 5);
+}
+
+
+/**
+ * gst_aac_parse_check_adts_frame:
+ * @aacparse: #GstAacParse.
+ * @data: Data to be checked.
+ * @avail: Amount of data passed.
+ * @framesize: If valid ADTS frame was found, this will be set to tell the
+ *             found frame size in bytes.
+ * @needed_data: If frame was not found, this may be set to tell how much
+ *               more data is needed in the next round to detect the frame
+ *               reliably. This may happen when a frame header candidate
+ *               is found but it cannot be guaranteed to be the header without
+ *               peeking the following data.
+ *
+ * Check if the given data contains contains ADTS frame. The algorithm
+ * will examine ADTS frame header and calculate the frame size. Also, another
+ * consecutive ADTS frame header need to be present after the found frame.
+ * Otherwise the data is not considered as a valid ADTS frame. However, this
+ * "extra check" is omitted when EOS has been received. In this case it is
+ * enough when data[0] contains a valid ADTS header.
+ *
+ * This function may set the #needed_data to indicate that a possible frame
+ * candidate has been found, but more data (#needed_data bytes) is needed to
+ * be absolutely sure. When this situation occurs, FALSE will be returned.
+ *
+ * When a valid frame is detected, this function will use
+ * gst_base_parse_set_min_frame_size() function from #GstBaseParse class
+ * to set the needed bytes for next frame.This way next data chunk is already
+ * of correct size.
+ *
+ * Returns: TRUE if the given data contains a valid ADTS header.
+ */
+static gboolean
+gst_aac_parse_check_adts_frame (GstAacParse * aacparse,
+    const guint8 * data, const guint avail, gboolean drain,
+    guint * framesize, guint * needed_data)
+{
+  guint crc_size;
+
+  *needed_data = 0;
+
+  /* Absolute minimum to perform the ADTS syncword,
+     layer and sampling frequency tests */
+  if (G_UNLIKELY (avail < 3)) {
+    *needed_data = 3;
+    return FALSE;
+  }
+
+  /* Syncword and layer tests */
+  if ((data[0] == 0xff) && ((data[1] & 0xf6) == 0xf0)) {
+
+    /* Sampling frequency test */
+    if (G_UNLIKELY ((data[2] & 0x3C) >> 2 == 15))
+      return FALSE;
+
+    /* This looks like an ADTS frame header but
+       we need at least 6 bytes to proceed */
+    if (G_UNLIKELY (avail < 6)) {
+      *needed_data = 6;
+      return FALSE;
+    }
+
+    *framesize = gst_aac_parse_adts_get_frame_len (data);
+
+    /* If frame has CRC, it needs 2 bytes
+       for it at the end of the header */
+    crc_size = (data[1] & 0x01) ? 0 : 2;
+
+    /* CRC size test */
+    if (*framesize < 7 + crc_size) {
+      *needed_data = 7 + crc_size;
+      return FALSE;
+    }
+
+    /* In EOS mode this is enough. No need to examine the data further.
+       We also relax the check when we have sync, on the assumption that
+       if we're not looking at random data, we have a much higher chance
+       to get the correct sync, and this avoids losing two frames when
+       a single bit corruption happens. */
+    if (drain || !GST_BASE_PARSE_LOST_SYNC (aacparse)) {
+      return TRUE;
+    }
+
+    if (*framesize + ADTS_MAX_SIZE > avail) {
+      /* We have found a possible frame header candidate, but can't be
+         sure since we don't have enough data to check the next frame */
+      GST_DEBUG ("NEED MORE DATA: we need %d, available %d",
+          *framesize + ADTS_MAX_SIZE, avail);
+      *needed_data = *framesize + ADTS_MAX_SIZE;
+      gst_base_parse_set_min_frame_size (GST_BASE_PARSE (aacparse),
+          *framesize + ADTS_MAX_SIZE);
+      return FALSE;
+    }
+
+    if ((data[*framesize] == 0xff) && ((data[*framesize + 1] & 0xf6) == 0xf0)) {
+      guint nextlen = gst_aac_parse_adts_get_frame_len (data + (*framesize));
+
+      GST_LOG ("ADTS frame found, len: %d bytes", *framesize);
+      gst_base_parse_set_min_frame_size (GST_BASE_PARSE (aacparse),
+          nextlen + ADTS_MAX_SIZE);
+      return TRUE;
+    }
+  }
+  return FALSE;
+}
+
+static gboolean
+gst_aac_parse_latm_get_value (GstAacParse * aacparse, GstBitReader * br,
+    guint32 * value)
+{
+  guint8 bytes, i, byte;
+
+  *value = 0;
+  if (!gst_bit_reader_get_bits_uint8 (br, &bytes, 2))
+    return FALSE;
+  for (i = 0; i <= bytes; ++i) {
+    *value <<= 8;
+    if (!gst_bit_reader_get_bits_uint8 (br, &byte, 8))
+      return FALSE;
+    *value += byte;
+  }
+  return TRUE;
+}
+
+static gboolean
+gst_aac_parse_get_audio_object_type (GstAacParse * aacparse, GstBitReader * br,
+    guint8 * audio_object_type)
+{
+  if (!gst_bit_reader_get_bits_uint8 (br, audio_object_type, 5))
+    return FALSE;
+  if (*audio_object_type == 31) {
+    if (!gst_bit_reader_get_bits_uint8 (br, audio_object_type, 6))
+      return FALSE;
+    *audio_object_type += 32;
+  }
+  GST_LOG_OBJECT (aacparse, "audio object type %u", *audio_object_type);
+  return TRUE;
+}
+
+static gboolean
+gst_aac_parse_get_audio_sample_rate (GstAacParse * aacparse, GstBitReader * br,
+    gint * sample_rate)
+{
+  guint8 sampling_frequency_index;
+  if (!gst_bit_reader_get_bits_uint8 (br, &sampling_frequency_index, 4))
+    return FALSE;
+  GST_LOG_OBJECT (aacparse, "sampling_frequency_index: %u",
+      sampling_frequency_index);
+  if (sampling_frequency_index == 0xf) {
+    guint32 sampling_rate;
+    if (!gst_bit_reader_get_bits_uint32 (br, &sampling_rate, 24))
+      return FALSE;
+    *sample_rate = sampling_rate;
+  } else {
+    *sample_rate = loas_sample_rate_table[sampling_frequency_index];
+    if (!*sample_rate)
+      return FALSE;
+  }
+  aacparse->last_parsed_sample_rate = *sample_rate;
+  return TRUE;
+}
+
+/* See table 1.13 in ISO/IEC 14496-3 */
+static gboolean
+gst_aac_parse_read_audio_specific_config (GstAacParse * aacparse,
+    GstBitReader * br, gint * object_type, gint * sample_rate, gint * channels,
+    gint * frame_samples)
+{
+  guint8 audio_object_type;
+  guint8 G_GNUC_UNUSED extension_audio_object_type;
+  guint8 channel_configuration, extension_channel_configuration;
+  gboolean G_GNUC_UNUSED sbr = FALSE, ps = FALSE;
+
+  if (!gst_aac_parse_get_audio_object_type (aacparse, br, &audio_object_type))
+    return FALSE;
+  if (object_type)
+    *object_type = audio_object_type;
+
+  if (!gst_aac_parse_get_audio_sample_rate (aacparse, br, sample_rate))
+    return FALSE;
+
+  if (!gst_bit_reader_get_bits_uint8 (br, &channel_configuration, 4))
+    return FALSE;
+  *channels = loas_channels_table[channel_configuration];
+  GST_LOG_OBJECT (aacparse, "channel_configuration: %d", channel_configuration);
+  if (!*channels)
+    return FALSE;
+
+  if (audio_object_type == 5 || audio_object_type == 29) {
+    extension_audio_object_type = 5;
+    sbr = TRUE;
+    if (audio_object_type == 29) {
+      ps = TRUE;
+      /* Parametric stereo. If we have a one-channel configuration, we can
+       * override it to stereo */
+      if (*channels == 1)
+        *channels = 2;
+    }
+
+    GST_LOG_OBJECT (aacparse,
+        "Audio object type 5 or 29, so rereading sampling rate (was %d)...",
+        *sample_rate);
+    if (!gst_aac_parse_get_audio_sample_rate (aacparse, br, sample_rate))
+      return FALSE;
+
+    if (!gst_aac_parse_get_audio_object_type (aacparse, br, &audio_object_type))
+      return FALSE;
+
+    if (audio_object_type == 22) {
+      /* extension channel configuration */
+      if (!gst_bit_reader_get_bits_uint8 (br, &extension_channel_configuration,
+              4))
+        return FALSE;
+      GST_LOG_OBJECT (aacparse, "extension channel_configuration: %d",
+          extension_channel_configuration);
+      *channels = loas_channels_table[extension_channel_configuration];
+      if (!*channels)
+        return FALSE;
+    }
+  } else {
+    extension_audio_object_type = 0;
+  }
+
+  GST_INFO_OBJECT (aacparse, "Parsed AudioSpecificConfig: %d Hz, %d channels",
+      *sample_rate, *channels);
+
+  if (frame_samples && audio_object_type == 23) {
+    guint8 frame_flag;
+    /* Read the Decoder Configuration (GASpecificConfig) if present */
+    /* We only care about the first bit to know what the number of samples
+     * in a frame is */
+    if (!gst_bit_reader_get_bits_uint8 (br, &frame_flag, 1))
+      return FALSE;
+    *frame_samples = frame_flag ? 960 : 1024;
+  }
+
+  /* There's LOTS of stuff next, but we ignore it for now as we have
+     what we want (sample rate and number of channels */
+  GST_DEBUG_OBJECT (aacparse,
+      "Need more code to parse humongous LOAS data, currently ignored");
+  aacparse->last_parsed_channels = *channels;
+  return TRUE;
+}
+
+
+static gboolean
+gst_aac_parse_read_loas_config (GstAacParse * aacparse, const guint8 * data,
+    guint avail, gint * sample_rate, gint * channels, gint * version)
+{
+  GstBitReader br;
+  guint8 u8, v, vA;
+
+  /* No version in the bitstream, but the spec has LOAS in the MPEG-4 section */
+  if (version)
+    *version = 4;
+
+  gst_bit_reader_init (&br, data, avail);
+
+  /* skip sync word (11 bits) and size (13 bits) */
+  if (!gst_bit_reader_skip (&br, 11 + 13))
+    return FALSE;
+
+  /* First bit is "use last config" */
+  if (!gst_bit_reader_get_bits_uint8 (&br, &u8, 1))
+    return FALSE;
+  if (u8) {
+    GST_LOG_OBJECT (aacparse, "Frame uses previous config");
+    if (!aacparse->last_parsed_sample_rate || !aacparse->last_parsed_channels) {
+      GST_DEBUG_OBJECT (aacparse,
+          "No previous config to use. We'll look for more data.");
+      return FALSE;
+    }
+    *sample_rate = aacparse->last_parsed_sample_rate;
+    *channels = aacparse->last_parsed_channels;
+    return TRUE;
+  }
+
+  GST_DEBUG_OBJECT (aacparse, "Frame contains new config");
+
+  /* audioMuxVersion */
+  if (!gst_bit_reader_get_bits_uint8 (&br, &v, 1))
+    return FALSE;
+  if (v) {
+    /* audioMuxVersionA */
+    if (!gst_bit_reader_get_bits_uint8 (&br, &vA, 1))
+      return FALSE;
+  } else
+    vA = 0;
+
+  GST_LOG_OBJECT (aacparse, "v %d, vA %d", v, vA);
+  if (vA == 0) {
+    guint8 same_time, subframes, num_program, prog;
+    if (v == 1) {
+      guint32 value;
+      /* taraBufferFullness */
+      if (!gst_aac_parse_latm_get_value (aacparse, &br, &value))
+        return FALSE;
+    }
+    if (!gst_bit_reader_get_bits_uint8 (&br, &same_time, 1))
+      return FALSE;
+    if (!gst_bit_reader_get_bits_uint8 (&br, &subframes, 6))
+      return FALSE;
+    if (!gst_bit_reader_get_bits_uint8 (&br, &num_program, 4))
+      return FALSE;
+    GST_LOG_OBJECT (aacparse, "same_time %d, subframes %d, num_program %d",
+        same_time, subframes, num_program);
+
+    for (prog = 0; prog <= num_program; ++prog) {
+      guint8 num_layer, layer;
+      if (!gst_bit_reader_get_bits_uint8 (&br, &num_layer, 3))
+        return FALSE;
+      GST_LOG_OBJECT (aacparse, "Program %d: %d layers", prog, num_layer);
+
+      for (layer = 0; layer <= num_layer; ++layer) {
+        guint8 use_same_config;
+        if (prog == 0 && layer == 0) {
+          use_same_config = 0;
+        } else {
+          if (!gst_bit_reader_get_bits_uint8 (&br, &use_same_config, 1))
+            return FALSE;
+        }
+        if (!use_same_config) {
+          if (v == 0) {
+            if (!gst_aac_parse_read_audio_specific_config (aacparse, &br, NULL,
+                    sample_rate, channels, NULL))
+              return FALSE;
+          } else {
+            guint32 asc_len;
+            if (!gst_aac_parse_latm_get_value (aacparse, &br, &asc_len))
+              return FALSE;
+            if (!gst_aac_parse_read_audio_specific_config (aacparse, &br, NULL,
+                    sample_rate, channels, NULL))
+              return FALSE;
+            if (!gst_bit_reader_skip (&br, asc_len))
+              return FALSE;
+          }
+        }
+      }
+    }
+    GST_LOG_OBJECT (aacparse, "More data ignored");
+  } else {
+    GST_WARNING_OBJECT (aacparse, "Spec says \"TBD\"...");
+    return FALSE;
+  }
+  return TRUE;
+}
+
+/**
+ * gst_aac_parse_loas_get_frame_len:
+ * @data: block of data containing a LOAS header.
+ *
+ * This function calculates LOAS frame length from the given header.
+ *
+ * Returns: size of the LOAS frame.
+ */
+static inline guint
+gst_aac_parse_loas_get_frame_len (const guint8 * data)
+{
+  return (((data[1] & 0x1f) << 8) | data[2]) + 3;
+}
+
+
+/**
+ * gst_aac_parse_check_loas_frame:
+ * @aacparse: #GstAacParse.
+ * @data: Data to be checked.
+ * @avail: Amount of data passed.
+ * @framesize: If valid LOAS frame was found, this will be set to tell the
+ *             found frame size in bytes.
+ * @needed_data: If frame was not found, this may be set to tell how much
+ *               more data is needed in the next round to detect the frame
+ *               reliably. This may happen when a frame header candidate
+ *               is found but it cannot be guaranteed to be the header without
+ *               peeking the following data.
+ *
+ * Check if the given data contains contains LOAS frame. The algorithm
+ * will examine LOAS frame header and calculate the frame size. Also, another
+ * consecutive LOAS frame header need to be present after the found frame.
+ * Otherwise the data is not considered as a valid LOAS frame. However, this
+ * "extra check" is omitted when EOS has been received. In this case it is
+ * enough when data[0] contains a valid LOAS header.
+ *
+ * This function may set the #needed_data to indicate that a possible frame
+ * candidate has been found, but more data (#needed_data bytes) is needed to
+ * be absolutely sure. When this situation occurs, FALSE will be returned.
+ *
+ * When a valid frame is detected, this function will use
+ * gst_base_parse_set_min_frame_size() function from #GstBaseParse class
+ * to set the needed bytes for next frame.This way next data chunk is already
+ * of correct size.
+ *
+ * LOAS can have three different formats, if I read the spec correctly. Only
+ * one of them is supported here, as the two samples I have use this one.
+ *
+ * Returns: TRUE if the given data contains a valid LOAS header.
+ */
+static gboolean
+gst_aac_parse_check_loas_frame (GstAacParse * aacparse,
+    const guint8 * data, const guint avail, gboolean drain,
+    guint * framesize, guint * needed_data)
+{
+  *needed_data = 0;
+
+  /* 3 byte header */
+  if (G_UNLIKELY (avail < 3)) {
+    *needed_data = 3;
+    return FALSE;
+  }
+
+  if ((data[0] == 0x56) && ((data[1] & 0xe0) == 0xe0)) {
+    *framesize = gst_aac_parse_loas_get_frame_len (data);
+    GST_DEBUG_OBJECT (aacparse, "Found possible %u byte LOAS frame",
+        *framesize);
+
+    /* In EOS mode this is enough. No need to examine the data further.
+       We also relax the check when we have sync, on the assumption that
+       if we're not looking at random data, we have a much higher chance
+       to get the correct sync, and this avoids losing two frames when
+       a single bit corruption happens. */
+    if (drain || !GST_BASE_PARSE_LOST_SYNC (aacparse)) {
+      return TRUE;
+    }
+
+    if (*framesize + LOAS_MAX_SIZE > avail) {
+      /* We have found a possible frame header candidate, but can't be
+         sure since we don't have enough data to check the next frame */
+      GST_DEBUG ("NEED MORE DATA: we need %d, available %d",
+          *framesize + LOAS_MAX_SIZE, avail);
+      *needed_data = *framesize + LOAS_MAX_SIZE;
+      gst_base_parse_set_min_frame_size (GST_BASE_PARSE (aacparse),
+          *framesize + LOAS_MAX_SIZE);
+      return FALSE;
+    }
+
+    if ((data[*framesize] == 0x56) && ((data[*framesize + 1] & 0xe0) == 0xe0)) {
+      guint nextlen = gst_aac_parse_loas_get_frame_len (data + (*framesize));
+
+      GST_LOG ("LOAS frame found, len: %d bytes", *framesize);
+      gst_base_parse_set_min_frame_size (GST_BASE_PARSE (aacparse),
+          nextlen + LOAS_MAX_SIZE);
+      return TRUE;
+    } else {
+      GST_DEBUG_OBJECT (aacparse, "That was a false positive");
+    }
+  }
+  return FALSE;
+}
+
+/* caller ensure sufficient data */
+static inline void
+gst_aac_parse_parse_adts_header (GstAacParse * aacparse, const guint8 * data,
+    gint * rate, gint * channels, gint * object, gint * version)
+{
+
+  if (rate) {
+    gint sr_idx = (data[2] & 0x3c) >> 2;
+
+    *rate = gst_codec_utils_aac_get_sample_rate_from_index (sr_idx);
+  }
+  if (channels) {
+    *channels = ((data[2] & 0x01) << 2) | ((data[3] & 0xc0) >> 6);
+    if (*channels == 7)
+      *channels = 8;
+  }
+
+  if (version)
+    *version = (data[1] & 0x08) ? 2 : 4;
+  if (object)
+    *object = ((data[2] & 0xc0) >> 6) + 1;
+}
+
+/**
+ * gst_aac_parse_detect_stream:
+ * @aacparse: #GstAacParse.
+ * @data: A block of data that needs to be examined for stream characteristics.
+ * @avail: Size of the given datablock.
+ * @framesize: If valid stream was found, this will be set to tell the
+ *             first frame size in bytes.
+ * @skipsize: If valid stream was found, this will be set to tell the first
+ *            audio frame position within the given data.
+ *
+ * Examines the given piece of data and try to detect the format of it. It
+ * checks for "ADIF" header (in the beginning of the clip) and ADTS frame
+ * header. If the stream is detected, TRUE will be returned and #framesize
+ * is set to indicate the found frame size. Additionally, #skipsize might
+ * be set to indicate the number of bytes that need to be skipped, a.k.a. the
+ * position of the frame inside given data chunk.
+ *
+ * Returns: TRUE on success.
+ */
+static gboolean
+gst_aac_parse_detect_stream (GstAacParse * aacparse,
+    const guint8 * data, const guint avail, gboolean drain,
+    guint * framesize, gint * skipsize)
+{
+  gboolean found = FALSE;
+  guint need_data_adts = 0, need_data_loas;
+  guint i = 0;
+
+  GST_DEBUG_OBJECT (aacparse, "Parsing header data");
+
+  /* FIXME: No need to check for ADIF if we are not in the beginning of the
+     stream */
+
+  /* Can we even parse the header? */
+  if (avail < MAX (ADTS_MAX_SIZE, LOAS_MAX_SIZE)) {
+    GST_DEBUG_OBJECT (aacparse, "Not enough data to check");
+    return FALSE;
+  }
+
+  for (i = 0; i < avail - 4; i++) {
+    if (((data[i] == 0xff) && ((data[i + 1] & 0xf6) == 0xf0)) ||
+        ((data[i] == 0x56) && ((data[i + 1] & 0xe0) == 0xe0)) ||
+        strncmp ((char *) data + i, "ADIF", 4) == 0) {
+      GST_DEBUG_OBJECT (aacparse, "Found signature at offset %u", i);
+      found = TRUE;
+
+      if (i) {
+        /* Trick: tell the parent class that we didn't find the frame yet,
+           but make it skip 'i' amount of bytes. Next time we arrive
+           here we have full frame in the beginning of the data. */
+        *skipsize = i;
+        return FALSE;
+      }
+      break;
+    }
+  }
+  if (!found) {
+    if (i)
+      *skipsize = i;
+    return FALSE;
+  }
+
+  if (gst_aac_parse_check_adts_frame (aacparse, data, avail, drain,
+          framesize, &need_data_adts)) {
+    gint rate, channels;
+
+    GST_INFO ("ADTS ID: %d, framesize: %d", (data[1] & 0x08) >> 3, *framesize);
+
+    gst_aac_parse_parse_adts_header (aacparse, data, &rate, &channels,
+        &aacparse->object_type, &aacparse->mpegversion);
+
+    if (!channels || !framesize) {
+      GST_DEBUG_OBJECT (aacparse, "impossible ADTS configuration");
+      return FALSE;
+    }
+
+    aacparse->header_type = DSPAAC_HEADER_ADTS;
+    gst_base_parse_set_frame_rate (GST_BASE_PARSE (aacparse), rate,
+        aacparse->frame_samples, 2, 2);
+
+    GST_DEBUG ("ADTS: samplerate %d, channels %d, objtype %d, version %d",
+        rate, channels, aacparse->object_type, aacparse->mpegversion);
+
+    gst_base_parse_set_syncable (GST_BASE_PARSE (aacparse), TRUE);
+
+    return TRUE;
+  }
+
+  if (gst_aac_parse_check_loas_frame (aacparse, data, avail, drain,
+          framesize, &need_data_loas)) {
+    gint rate = 0, channels = 0;
+
+    GST_INFO ("LOAS, framesize: %d", *framesize);
+
+    aacparse->header_type = DSPAAC_HEADER_LOAS;
+
+    if (!gst_aac_parse_read_loas_config (aacparse, data, avail, &rate,
+            &channels, &aacparse->mpegversion)) {
+      /* This is pretty normal when skipping data at the start of
+       * random stream (MPEG-TS capture for example) */
+      GST_LOG_OBJECT (aacparse, "Error reading LOAS config");
+      return FALSE;
+    }
+
+    if (rate && channels) {
+      gst_base_parse_set_frame_rate (GST_BASE_PARSE (aacparse), rate,
+          aacparse->frame_samples, 2, 2);
+
+      /* Don't store the sample rate and channels yet -
+       * this is just format detection. */
+      GST_DEBUG ("LOAS: samplerate %d, channels %d, objtype %d, version %d",
+          rate, channels, aacparse->object_type, aacparse->mpegversion);
+    }
+
+    gst_base_parse_set_syncable (GST_BASE_PARSE (aacparse), TRUE);
+
+    return TRUE;
+  }
+
+  if (need_data_adts || need_data_loas) {
+    /* This tells the parent class not to skip any data */
+    *skipsize = 0;
+    return FALSE;
+  }
+
+  if (avail < ADIF_MAX_SIZE)
+    return FALSE;
+
+  if (memcmp (data + i, "ADIF", 4) == 0) {
+    const guint8 *adif;
+    int skip_size = 0;
+    int bitstream_type;
+    int sr_idx;
+    GstCaps *sinkcaps;
+
+    aacparse->header_type = DSPAAC_HEADER_ADIF;
+    aacparse->mpegversion = 4;
+
+    /* Skip the "ADIF" bytes */
+    adif = data + i + 4;
+
+    /* copyright string */
+    if (adif[0] & 0x80)
+      skip_size += 9;           /* skip 9 bytes */
+
+    bitstream_type = adif[0 + skip_size] & 0x10;
+    aacparse->bitrate =
+        ((unsigned int) (adif[0 + skip_size] & 0x0f) << 19) |
+        ((unsigned int) adif[1 + skip_size] << 11) |
+        ((unsigned int) adif[2 + skip_size] << 3) |
+        ((unsigned int) adif[3 + skip_size] & 0xe0);
+
+    /* CBR */
+    if (bitstream_type == 0) {
+#if 0
+      /* Buffer fullness parsing. Currently not needed... */
+      guint num_elems = 0;
+      guint fullness = 0;
+
+      num_elems = (adif[3 + skip_size] & 0x1e);
+      GST_INFO ("ADIF num_config_elems: %d", num_elems);
+
+      fullness = ((unsigned int) (adif[3 + skip_size] & 0x01) << 19) |
+          ((unsigned int) adif[4 + skip_size] << 11) |
+          ((unsigned int) adif[5 + skip_size] << 3) |
+          ((unsigned int) (adif[6 + skip_size] & 0xe0) >> 5);
+
+      GST_INFO ("ADIF buffer fullness: %d", fullness);
+#endif
+      aacparse->object_type = ((adif[6 + skip_size] & 0x01) << 1) |
+          ((adif[7 + skip_size] & 0x80) >> 7);
+      sr_idx = (adif[7 + skip_size] & 0x78) >> 3;
+    }
+    /* VBR */
+    else {
+      aacparse->object_type = (adif[4 + skip_size] & 0x18) >> 3;
+      sr_idx = ((adif[4 + skip_size] & 0x07) << 1) |
+          ((adif[5 + skip_size] & 0x80) >> 7);
+    }
+
+    /* FIXME: This gives totally wrong results. Duration calculation cannot
+       be based on this */
+    aacparse->sample_rate =
+        gst_codec_utils_aac_get_sample_rate_from_index (sr_idx);
+
+    /* baseparse is not given any fps,
+     * so it will give up on timestamps, seeking, etc */
+
+    /* FIXME: Can we assume this? */
+    aacparse->channels = 2;
+
+    GST_INFO ("ADIF: br=%d, samplerate=%d, objtype=%d",
+        aacparse->bitrate, aacparse->sample_rate, aacparse->object_type);
+
+    gst_base_parse_set_min_frame_size (GST_BASE_PARSE (aacparse), 512);
+
+    /* arrange for metadata and get out of the way */
+    sinkcaps = gst_pad_get_current_caps (GST_BASE_PARSE_SINK_PAD (aacparse));
+    gst_aac_parse_set_src_caps (aacparse, sinkcaps);
+    if (sinkcaps)
+      gst_caps_unref (sinkcaps);
+
+    /* not syncable, not easily seekable (unless we push data from start */
+    gst_base_parse_set_syncable (GST_BASE_PARSE_CAST (aacparse), FALSE);
+    gst_base_parse_set_passthrough (GST_BASE_PARSE_CAST (aacparse), TRUE);
+    gst_base_parse_set_average_bitrate (GST_BASE_PARSE_CAST (aacparse), 0);
+
+    *framesize = avail;
+    return TRUE;
+  }
+
+  /* This should never happen */
+  return FALSE;
+}
+
+/**
+ * gst_aac_parse_get_audio_profile_object_type
+ * @aacparse: #GstAacParse.
+ *
+ * Gets the MPEG-2 profile or the MPEG-4 object type value corresponding to the
+ * mpegversion and profile of @aacparse's src pad caps, according to the
+ * values defined by table 1.A.11 in ISO/IEC 14496-3.
+ *
+ * Returns: the profile or object type value corresponding to @aacparse's src
+ * pad caps, if such a value exists; otherwise G_MAXUINT8.
+ */
+static guint8
+gst_aac_parse_get_audio_profile_object_type (GstAacParse * aacparse)
+{
+  GstCaps *srccaps;
+  GstStructure *srcstruct;
+  const gchar *profile;
+  guint8 ret;
+
+  srccaps = gst_pad_get_current_caps (GST_BASE_PARSE_SRC_PAD (aacparse));
+  if (G_UNLIKELY (srccaps == NULL)) {
+    return G_MAXUINT8;
+  }
+
+  srcstruct = gst_caps_get_structure (srccaps, 0);
+  profile = gst_structure_get_string (srcstruct, "profile");
+  if (G_UNLIKELY (profile == NULL)) {
+    gst_caps_unref (srccaps);
+    return G_MAXUINT8;
+  }
+
+  if (g_strcmp0 (profile, "main") == 0) {
+    ret = (guint8) 0U;
+  } else if (g_strcmp0 (profile, "lc") == 0) {
+    ret = (guint8) 1U;
+  } else if (g_strcmp0 (profile, "ssr") == 0) {
+    ret = (guint8) 2U;
+  } else if (g_strcmp0 (profile, "ltp") == 0) {
+    if (G_LIKELY (aacparse->mpegversion == 4))
+      ret = (guint8) 3U;
+    else
+      ret = G_MAXUINT8;         /* LTP Object Type allowed only for MPEG-4 */
+  } else {
+    ret = G_MAXUINT8;
+  }
+
+  gst_caps_unref (srccaps);
+  return ret;
+}
+
+/**
+ * gst_aac_parse_get_audio_channel_configuration
+ * @num_channels: number of audio channels.
+ *
+ * Gets the Channel Configuration value, as defined by table 1.19 in ISO/IEC
+ * 14496-3, for a given number of audio channels.
+ *
+ * Returns: the Channel Configuration value corresponding to @num_channels, if
+ * such a value exists; otherwise G_MAXUINT8.
+ */
+static guint8
+gst_aac_parse_get_audio_channel_configuration (gint num_channels)
+{
+  if (num_channels >= 1 && num_channels <= 6)   /* Mono up to & including 5.1 */
+    return (guint8) num_channels;
+  else if (num_channels == 8)   /* 7.1 */
+    return (guint8) 7U;
+  else
+    return G_MAXUINT8;
+
+  /* FIXME: Add support for configurations 11, 12 and 14 from
+   * ISO/IEC 14496-3:2009/PDAM 4 based on the actual channel layout
+   */
+}
+
+/**
+ * gst_aac_parse_get_audio_sampling_frequency_index:
+ * @sample_rate: audio sampling rate.
+ *
+ * Gets the Sampling Frequency Index value, as defined by table 1.18 in ISO/IEC
+ * 14496-3, for a given sampling rate.
+ *
+ * Returns: the Sampling Frequency Index value corresponding to @sample_rate,
+ * if such a value exists; otherwise G_MAXUINT8.
+ */
+static guint8
+gst_aac_parse_get_audio_sampling_frequency_index (gint sample_rate)
+{
+  switch (sample_rate) {
+    case 96000:
+      return 0x0U;
+    case 88200:
+      return 0x1U;
+    case 64000:
+      return 0x2U;
+    case 48000:
+      return 0x3U;
+    case 44100:
+      return 0x4U;
+    case 32000:
+      return 0x5U;
+    case 24000:
+      return 0x6U;
+    case 22050:
+      return 0x7U;
+    case 16000:
+      return 0x8U;
+    case 12000:
+      return 0x9U;
+    case 11025:
+      return 0xAU;
+    case 8000:
+      return 0xBU;
+    case 7350:
+      return 0xCU;
+    default:
+      return G_MAXUINT8;
+  }
+}
+
+/**
+ * gst_aac_parse_prepend_adts_headers:
+ * @aacparse: #GstAacParse.
+ * @frame: raw AAC frame to which ADTS headers shall be prepended.
+ *
+ * Prepends ADTS headers to a raw AAC audio frame.
+ *
+ * Returns: TRUE if ADTS headers were successfully prepended; FALSE otherwise.
+ */
+static gboolean
+gst_aac_parse_prepend_adts_headers (GstAacParse * aacparse,
+    GstBaseParseFrame * frame)
+{
+  GstMemory *mem;
+  guint8 *adts_headers;
+  gsize buf_size;
+  gsize frame_size;
+  guint8 id, profile, channel_configuration, sampling_frequency_index;
+
+  id = (aacparse->mpegversion == 4) ? 0x0U : 0x1U;
+  profile = gst_aac_parse_get_audio_profile_object_type (aacparse);
+  if (profile == G_MAXUINT8) {
+    GST_ERROR_OBJECT (aacparse, "Unsupported audio profile or object type");
+    return FALSE;
+  }
+  channel_configuration =
+      gst_aac_parse_get_audio_channel_configuration (aacparse->channels);
+  if (channel_configuration == G_MAXUINT8) {
+    GST_ERROR_OBJECT (aacparse, "Unsupported number of channels");
+    return FALSE;
+  }
+  sampling_frequency_index =
+      gst_aac_parse_get_audio_sampling_frequency_index (aacparse->sample_rate);
+  if (sampling_frequency_index == G_MAXUINT8) {
+    GST_ERROR_OBJECT (aacparse, "Unsupported sampling frequency");
+    return FALSE;
+  }
+
+  frame->out_buffer = gst_buffer_copy (frame->buffer);
+  buf_size = gst_buffer_get_size (frame->out_buffer);
+  frame_size = buf_size + ADTS_HEADERS_LENGTH;
+
+  if (G_UNLIKELY (frame_size >= 0x4000)) {
+    GST_ERROR_OBJECT (aacparse, "Frame size is too big for ADTS");
+    return FALSE;
+  }
+
+  adts_headers = (guint8 *) g_malloc0 (ADTS_HEADERS_LENGTH);
+
+  /* Note: no error correction bits are added to the resulting ADTS frames */
+  adts_headers[0] = 0xFFU;
+  adts_headers[1] = 0xF0U | (id << 3) | 0x1U;
+  adts_headers[2] = (profile << 6) | (sampling_frequency_index << 2) | 0x2U |
+      ((channel_configuration & 0x4U) >> 2);
+  adts_headers[3] = ((channel_configuration & 0x3U) << 6) | 0x30U |
+      (guint8) (frame_size >> 11);
+  adts_headers[4] = (guint8) ((frame_size >> 3) & 0x00FF);
+  adts_headers[5] = (guint8) (((frame_size & 0x0007) << 5) + 0x1FU);
+  adts_headers[6] = 0xFCU;
+
+  mem = gst_memory_new_wrapped (0, adts_headers, ADTS_HEADERS_LENGTH, 0,
+      ADTS_HEADERS_LENGTH, adts_headers, g_free);
+  gst_buffer_prepend_memory (frame->out_buffer, mem);
+
+  return TRUE;
+}
+
+/**
+ * gst_aac_parse_check_valid_frame:
+ * @parse: #GstBaseParse.
+ * @frame: #GstBaseParseFrame.
+ * @skipsize: How much data parent class should skip in order to find the
+ *            frame header.
+ *
+ * Implementation of "handle_frame" vmethod in #GstBaseParse class.
+ *
+ * Also determines frame overhead.
+ * ADTS streams have a 7 byte header in each frame. MP4 and ADIF streams don't have
+ * a per-frame header. LOAS has 3 bytes.
+ *
+ * We're making a couple of simplifying assumptions:
+ *
+ * 1. We count Program Configuration Elements rather than searching for them
+ *    in the streams to discount them - the overhead is negligible.
+ *
+ * 2. We ignore CRC. This has a worst-case impact of (num_raw_blocks + 1)*16
+ *    bits, which should still not be significant enough to warrant the
+ *    additional parsing through the headers
+ *
+ * Returns: a #GstFlowReturn.
+ */
+static GstFlowReturn
+gst_aac_parse_handle_frame (GstBaseParse * parse,
+    GstBaseParseFrame * frame, gint * skipsize)
+{
+  GstMapInfo map;
+  GstAacParse *aacparse;
+  gboolean ret = FALSE;
+  gboolean lost_sync;
+  GstBuffer *buffer;
+  guint framesize;
+  gint rate = 0, channels = 0;
+
+  aacparse = GST_AAC_PARSE (parse);
+  buffer = frame->buffer;
+
+  gst_buffer_map (buffer, &map, GST_MAP_READ);
+
+  *skipsize = -1;
+  lost_sync = GST_BASE_PARSE_LOST_SYNC (parse);
+
+  if (aacparse->header_type == DSPAAC_HEADER_ADIF ||
+      aacparse->header_type == DSPAAC_HEADER_NONE) {
+    /* There is nothing to parse */
+    framesize = map.size;
+    ret = TRUE;
+
+  } else if (aacparse->header_type == DSPAAC_HEADER_NOT_PARSED || lost_sync) {
+
+    ret = gst_aac_parse_detect_stream (aacparse, map.data, map.size,
+        GST_BASE_PARSE_DRAINING (parse), &framesize, skipsize);
+
+  } else if (aacparse->header_type == DSPAAC_HEADER_ADTS) {
+    guint needed_data = 1024;
+
+    ret = gst_aac_parse_check_adts_frame (aacparse, map.data, map.size,
+        GST_BASE_PARSE_DRAINING (parse), &framesize, &needed_data);
+
+    if (!ret && needed_data) {
+      GST_DEBUG ("buffer didn't contain valid frame");
+      *skipsize = 0;
+      gst_base_parse_set_min_frame_size (GST_BASE_PARSE (aacparse),
+          needed_data);
+    }
+
+  } else if (aacparse->header_type == DSPAAC_HEADER_LOAS) {
+    guint needed_data = 1024;
+
+    ret = gst_aac_parse_check_loas_frame (aacparse, map.data,
+        map.size, GST_BASE_PARSE_DRAINING (parse), &framesize, &needed_data);
+
+    if (!ret && needed_data) {
+      GST_DEBUG ("buffer didn't contain valid frame");
+      *skipsize = 0;
+      gst_base_parse_set_min_frame_size (GST_BASE_PARSE (aacparse),
+          needed_data);
+    }
+
+  } else {
+    GST_DEBUG ("buffer didn't contain valid frame");
+    gst_base_parse_set_min_frame_size (GST_BASE_PARSE (aacparse),
+        ADTS_MAX_SIZE);
+  }
+
+  if (G_UNLIKELY (!ret))
+    goto exit;
+
+  if (aacparse->header_type == DSPAAC_HEADER_ADTS) {
+    /* see above */
+    frame->overhead = 7;
+
+    gst_aac_parse_parse_adts_header (aacparse, map.data,
+        &rate, &channels, NULL, NULL);
+
+    GST_LOG_OBJECT (aacparse, "rate: %d, chans: %d", rate, channels);
+
+    if (G_UNLIKELY (rate != aacparse->sample_rate
+            || channels != aacparse->channels)) {
+      aacparse->sample_rate = rate;
+      aacparse->channels = channels;
+
+      if (!gst_aac_parse_set_src_caps (aacparse, NULL)) {
+        /* If linking fails, we need to return appropriate error */
+        ret = GST_FLOW_NOT_LINKED;
+      }
+
+      gst_base_parse_set_frame_rate (GST_BASE_PARSE (aacparse),
+          aacparse->sample_rate, aacparse->frame_samples, 2, 2);
+    }
+  } else if (aacparse->header_type == DSPAAC_HEADER_LOAS) {
+    gboolean setcaps = FALSE;
+
+    /* see above */
+    frame->overhead = 3;
+
+    if (!gst_aac_parse_read_loas_config (aacparse, map.data, map.size, &rate,
+            &channels, NULL) || !rate || !channels) {
+      /* This is pretty normal when skipping data at the start of
+       * random stream (MPEG-TS capture for example) */
+      GST_DEBUG_OBJECT (aacparse, "Error reading LOAS config. Skipping.");
+      /* Since we don't fully parse the LOAS config, we don't know for sure
+       * how much to skip. Just skip 1 to end up to the next marker and
+       * resume parsing from there */
+      *skipsize = 1;
+      goto exit;
+    }
+
+    if (G_UNLIKELY (rate != aacparse->sample_rate
+            || channels != aacparse->channels)) {
+      aacparse->sample_rate = rate;
+      aacparse->channels = channels;
+      setcaps = TRUE;
+      GST_INFO_OBJECT (aacparse, "New LOAS config: %d Hz, %d channels", rate,
+          channels);
+    }
+
+    /* We want to set caps both at start, and when rate/channels change.
+       Since only some LOAS frames have that info, we may receive frames
+       before knowing about rate/channels. */
+    if (setcaps
+        || !gst_pad_has_current_caps (GST_BASE_PARSE_SRC_PAD (aacparse))) {
+      if (!gst_aac_parse_set_src_caps (aacparse, NULL)) {
+        /* If linking fails, we need to return appropriate error */
+        ret = GST_FLOW_NOT_LINKED;
+      }
+
+      gst_base_parse_set_frame_rate (GST_BASE_PARSE (aacparse),
+          aacparse->sample_rate, aacparse->frame_samples, 2, 2);
+    }
+  }
+
+  if (aacparse->header_type == DSPAAC_HEADER_NONE
+      && aacparse->output_header_type == DSPAAC_HEADER_ADTS) {
+    if (!gst_aac_parse_prepend_adts_headers (aacparse, frame)) {
+      GST_ERROR_OBJECT (aacparse, "Failed to prepend ADTS headers to frame");
+      ret = GST_FLOW_ERROR;
+    }
+  }
+
+exit:
+  gst_buffer_unmap (buffer, &map);
+
+  if (ret) {
+    /* found, skip if needed */
+    if (*skipsize > 0)
+      return GST_FLOW_OK;
+    *skipsize = 0;
+  } else {
+    if (*skipsize < 0)
+      *skipsize = 1;
+  }
+
+  if (ret && framesize <= map.size) {
+    return gst_base_parse_finish_frame (parse, frame, framesize);
+  }
+
+  return GST_FLOW_OK;
+}
+
+static GstFlowReturn
+gst_aac_parse_pre_push_frame (GstBaseParse * parse, GstBaseParseFrame * frame)
+{
+  GstAacParse *aacparse = GST_AAC_PARSE (parse);
+
+  if (!aacparse->sent_codec_tag) {
+    GstTagList *taglist;
+    GstCaps *caps;
+
+    /* codec tag */
+    caps = gst_pad_get_current_caps (GST_BASE_PARSE_SRC_PAD (parse));
+    if (caps == NULL) {
+      if (GST_PAD_IS_FLUSHING (GST_BASE_PARSE_SRC_PAD (parse))) {
+        GST_INFO_OBJECT (parse, "Src pad is flushing");
+        return GST_FLOW_FLUSHING;
+      } else {
+        GST_INFO_OBJECT (parse, "Src pad is not negotiated!");
+        return GST_FLOW_NOT_NEGOTIATED;
+      }
+    }
+
+    taglist = gst_tag_list_new_empty ();
+    gst_pb_utils_add_codec_description_to_tag_list (taglist,
+        GST_TAG_AUDIO_CODEC, caps);
+    gst_caps_unref (caps);
+
+    gst_base_parse_merge_tags (parse, taglist, GST_TAG_MERGE_REPLACE);
+    gst_tag_list_unref (taglist);
+
+    /* also signals the end of first-frame processing */
+    aacparse->sent_codec_tag = TRUE;
+  }
+
+  /* As a special case, we can remove the ADTS framing and output raw AAC. */
+  if (aacparse->header_type == DSPAAC_HEADER_ADTS
+      && aacparse->output_header_type == DSPAAC_HEADER_NONE) {
+    guint header_size;
+    GstMapInfo map;
+    frame->out_buffer = gst_buffer_make_writable (frame->buffer);
+    frame->buffer = NULL;
+    gst_buffer_map (frame->out_buffer, &map, GST_MAP_READ);
+    header_size = (map.data[1] & 1) ? 7 : 9;    /* optional CRC */
+    gst_buffer_unmap (frame->out_buffer, &map);
+    gst_buffer_resize (frame->out_buffer, header_size,
+        gst_buffer_get_size (frame->out_buffer) - header_size);
+  }
+
+  frame->flags |= GST_BASE_PARSE_FRAME_FLAG_CLIP;
+
+  return GST_FLOW_OK;
+}
+
+
+/**
+ * gst_aac_parse_start:
+ * @parse: #GstBaseParse.
+ *
+ * Implementation of "start" vmethod in #GstBaseParse class.
+ *
+ * Returns: TRUE if startup succeeded.
+ */
+static gboolean
+gst_aac_parse_start (GstBaseParse * parse)
+{
+  GstAacParse *aacparse;
+
+  aacparse = GST_AAC_PARSE (parse);
+  GST_DEBUG ("start");
+  aacparse->frame_samples = 1024;
+  gst_base_parse_set_min_frame_size (GST_BASE_PARSE (aacparse), ADTS_MAX_SIZE);
+  aacparse->sent_codec_tag = FALSE;
+  aacparse->last_parsed_channels = 0;
+  aacparse->last_parsed_sample_rate = 0;
+  aacparse->object_type = 0;
+  aacparse->bitrate = 0;
+  aacparse->header_type = DSPAAC_HEADER_NOT_PARSED;
+  aacparse->output_header_type = DSPAAC_HEADER_NOT_PARSED;
+  aacparse->channels = 0;
+  aacparse->sample_rate = 0;
+  return TRUE;
+}
+
+
+/**
+ * gst_aac_parse_stop:
+ * @parse: #GstBaseParse.
+ *
+ * Implementation of "stop" vmethod in #GstBaseParse class.
+ *
+ * Returns: TRUE is stopping succeeded.
+ */
+static gboolean
+gst_aac_parse_stop (GstBaseParse * parse)
+{
+  GST_DEBUG ("stop");
+  return TRUE;
+}
+
+static void
+remove_fields (GstCaps * caps)
+{
+  guint i, n;
+
+  n = gst_caps_get_size (caps);
+  for (i = 0; i < n; i++) {
+    GstStructure *s = gst_caps_get_structure (caps, i);
+
+    gst_structure_remove_field (s, "framed");
+  }
+}
+
+static void
+add_conversion_fields (GstCaps * caps)
+{
+  guint i, n;
+
+  n = gst_caps_get_size (caps);
+  for (i = 0; i < n; i++) {
+    GstStructure *s = gst_caps_get_structure (caps, i);
+
+    if (gst_structure_has_field (s, "stream-format")) {
+      const GValue *v = gst_structure_get_value (s, "stream-format");
+
+      if (G_VALUE_HOLDS_STRING (v)) {
+        const gchar *str = g_value_get_string (v);
+
+        if (strcmp (str, "adts") == 0 || strcmp (str, "raw") == 0) {
+          GValue va = G_VALUE_INIT;
+          GValue vs = G_VALUE_INIT;
+
+          g_value_init (&va, GST_TYPE_LIST);
+          g_value_init (&vs, G_TYPE_STRING);
+          g_value_set_string (&vs, "adts");
+          gst_value_list_append_value (&va, &vs);
+          g_value_set_string (&vs, "raw");
+          gst_value_list_append_value (&va, &vs);
+          gst_structure_set_value (s, "stream-format", &va);
+          g_value_unset (&va);
+          g_value_unset (&vs);
+        }
+      } else if (GST_VALUE_HOLDS_LIST (v)) {
+        gboolean contains_raw = FALSE;
+        gboolean contains_adts = FALSE;
+        guint m = gst_value_list_get_size (v), j;
+
+        for (j = 0; j < m; j++) {
+          const GValue *ve = gst_value_list_get_value (v, j);
+          const gchar *str;
+
+          if (G_VALUE_HOLDS_STRING (ve) && (str = g_value_get_string (ve))) {
+            if (strcmp (str, "adts") == 0)
+              contains_adts = TRUE;
+            else if (strcmp (str, "raw") == 0)
+              contains_raw = TRUE;
+          }
+        }
+
+        if (contains_adts || contains_raw) {
+          GValue va = G_VALUE_INIT;
+          GValue vs = G_VALUE_INIT;
+
+          g_value_init (&va, GST_TYPE_LIST);
+          g_value_init (&vs, G_TYPE_STRING);
+          g_value_copy (v, &va);
+
+          if (!contains_raw) {
+            g_value_set_string (&vs, "raw");
+            gst_value_list_append_value (&va, &vs);
+          }
+          if (!contains_adts) {
+            g_value_set_string (&vs, "adts");
+            gst_value_list_append_value (&va, &vs);
+          }
+
+          gst_structure_set_value (s, "stream-format", &va);
+
+          g_value_unset (&vs);
+          g_value_unset (&va);
+        }
+      }
+    }
+  }
+}
+
+static GstCaps *
+gst_aac_parse_sink_getcaps (GstBaseParse * parse, GstCaps * filter)
+{
+  GstCaps *peercaps, *templ;
+  GstCaps *res;
+
+  templ = gst_pad_get_pad_template_caps (GST_BASE_PARSE_SINK_PAD (parse));
+
+  if (filter) {
+    GstCaps *fcopy = gst_caps_copy (filter);
+    /* Remove the fields we convert */
+    remove_fields (fcopy);
+    add_conversion_fields (fcopy);
+    peercaps = gst_pad_peer_query_caps (GST_BASE_PARSE_SRC_PAD (parse), fcopy);
+    gst_caps_unref (fcopy);
+  } else
+    peercaps = gst_pad_peer_query_caps (GST_BASE_PARSE_SRC_PAD (parse), NULL);
+
+  if (peercaps) {
+    peercaps = gst_caps_make_writable (peercaps);
+    /* Remove the fields we convert */
+    remove_fields (peercaps);
+    add_conversion_fields (peercaps);
+
+    res = gst_caps_intersect_full (peercaps, templ, GST_CAPS_INTERSECT_FIRST);
+    gst_caps_unref (peercaps);
+    gst_caps_unref (templ);
+  } else {
+    res = templ;
+  }
+
+  if (filter) {
+    GstCaps *intersection;
+
+    intersection =
+        gst_caps_intersect_full (filter, res, GST_CAPS_INTERSECT_FIRST);
+    gst_caps_unref (res);
+    res = intersection;
+  }
+
+  return res;
+}
+
+static gboolean
+gst_aac_parse_src_event (GstBaseParse * parse, GstEvent * event)
+{
+  GstAacParse *aacparse = GST_AAC_PARSE (parse);
+
+  if (GST_EVENT_TYPE (event) == GST_EVENT_FLUSH_STOP) {
+    aacparse->last_parsed_channels = 0;
+    aacparse->last_parsed_sample_rate = 0;
+  }
+
+  return GST_BASE_PARSE_CLASS (parent_class)->src_event (parse, event);
+}

--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/gst/audioparsers/gstaacparse.h
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/gst/audioparsers/gstaacparse.h
@@ -1,0 +1,105 @@
+/* GStreamer AAC parser
+ * Copyright (C) 2008 Nokia Corporation. All rights reserved.
+ *
+ * Contact: Stefan Kost <stefan.kost@nokia.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __GST_AAC_PARSE_H__
+#define __GST_AAC_PARSE_H__
+
+#include <gst/gst.h>
+#include <gst/base/gstbaseparse.h>
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_AAC_PARSE \
+  (gst_aac_parse_get_type())
+#define GST_AAC_PARSE(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj), GST_TYPE_AAC_PARSE, GstAacParse))
+#define GST_AAC_PARSE_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST((klass), GST_TYPE_AAC_PARSE, GstAacParseClass))
+#define GST_IS_AAC_PARSE(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE((obj), GST_TYPE_AAC_PARSE))
+#define GST_IS_AAC_PARSE_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_TYPE((klass), GST_TYPE_AAC_PARSE))
+
+
+/**
+ * GstAacHeaderType:
+ * @DSPAAC_HEADER_NOT_PARSED: Header not parsed yet.
+ * @DSPAAC_HEADER_UNKNOWN: Unknown (not recognized) header.
+ * @DSPAAC_HEADER_ADIF: ADIF header found.
+ * @DSPAAC_HEADER_ADTS: ADTS header found.
+ * @DSPAAC_HEADER_LOAS: LOAS header found.
+ * @DSPAAC_HEADER_NONE: Raw stream, no header.
+ *
+ * Type header enumeration set in #header_type.
+ */
+typedef enum {
+  DSPAAC_HEADER_NOT_PARSED,
+  DSPAAC_HEADER_UNKNOWN,
+  DSPAAC_HEADER_ADIF,
+  DSPAAC_HEADER_ADTS,
+  DSPAAC_HEADER_LOAS,
+  DSPAAC_HEADER_NONE
+} GstAacHeaderType;
+
+
+typedef struct _GstAacParse GstAacParse;
+typedef struct _GstAacParseClass GstAacParseClass;
+
+/**
+ * GstAacParse:
+ *
+ * The opaque GstAacParse data structure.
+ */
+struct _GstAacParse {
+  GstBaseParse element;
+
+  /* Stream type -related info */
+  gint           object_type;
+  gint           bitrate;
+  gint           sample_rate;
+  gint           channels;
+  gint           mpegversion;
+  gint           frame_samples;
+
+  GstAacHeaderType header_type;
+  GstAacHeaderType output_header_type;
+
+  gboolean sent_codec_tag;
+
+  gint last_parsed_sample_rate;
+  gint last_parsed_channels;
+};
+
+/**
+ * GstAacParseClass:
+ * @parent_class: Element parent class.
+ *
+ * The opaque GstAacParseClass data structure.
+ */
+struct _GstAacParseClass {
+  GstBaseParseClass parent_class;
+};
+
+GType gst_aac_parse_get_type (void);
+
+G_END_DECLS
+
+#endif /* __GST_AAC_PARSE_H__ */

--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/gst/audioparsers/parsersplugin.c
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-good/gst/audioparsers/parsersplugin.c
@@ -33,6 +33,9 @@
 #include "gstdcaparse.h"
 #include "gstflacparse.h"
 #endif // GSTREAMER_LITE
+#ifdef LINUX
+#include "gstaacparse.h"
+#endif // LINUX
 #include "gstmpegaudioparse.h"
 #ifndef GSTREAMER_LITE
 #include "gstsbcparse.h"
@@ -69,8 +72,15 @@ plugin_init (GstPlugin * plugin)
 
   return ret;
 #else // GSTREAMER_LITE
+#ifdef LINUX
+  return gst_element_register (plugin, "aacparse",
+      GST_RANK_PRIMARY + 1, GST_TYPE_AAC_PARSE) &
+         gst_element_register (plugin, "mpegaudioparse",
+      GST_RANK_PRIMARY + 2, GST_TYPE_MPEG_AUDIO_PARSE);
+#else // LINUX
   return gst_element_register (plugin, "mpegaudioparse",
       GST_RANK_PRIMARY + 2, GST_TYPE_MPEG_AUDIO_PARSE);
+#endif // LINUX
 #endif // GSTREAMER_LITE
 }
 

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/av/mpegtsdemuxer.c
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/av/mpegtsdemuxer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -474,8 +474,6 @@ static gboolean mpegts_demuxer_sink_event(GstPad *pad, GstObject *parent, GstEve
                     g_print("MpegTS: Process_input thread created\n");
 #endif
                 }
-                else
-                    post_message(demuxer, "Demuxer thread is not null", GST_MESSAGE_ERROR, GST_CORE_ERROR, GST_CORE_ERROR_THREAD);
             }
             g_mutex_unlock(&demuxer->lock);
             break;

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/av/videodecoder.c
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/av/videodecoder.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -172,10 +172,8 @@ static void videodecoder_init(VideoDecoder *decoder)
     gst_element_add_pad(GST_ELEMENT(decoder), base->srcpad);
 }
 
-static void videodecoder_dispose(GObject* object)
+void videodecoder_close_decoder(VideoDecoder *decoder)
 {
-    VideoDecoder *decoder = VIDEODECODER(object);
-
 #if HEVC_SUPPORT
     if (decoder->dest_frame)
     {
@@ -195,6 +193,13 @@ static void videodecoder_dispose(GObject* object)
         decoder->swscale_module = NULL;
     }
 #endif // HEVC_SUPPORT
+}
+
+static void videodecoder_dispose(GObject* object)
+{
+    VideoDecoder *decoder = VIDEODECODER(object);
+
+    basedecoder_close_decoder(decoder);
 
     G_OBJECT_CLASS(parent_class)->dispose(object);
 }
@@ -379,14 +384,29 @@ static gboolean videodecoder_configure(VideoDecoder *decoder, GstCaps *sink_caps
 {
     BaseDecoder *base = BASEDECODER(decoder);
     const gchar *mimetype = NULL;
-
-    if (base->is_initialized)
-        return TRUE;
+    gint width = 0;
+    gint height = 0;
 
     if(gst_caps_get_size(sink_caps) < 1)
         return FALSE;
 
     GstStructure *s = gst_caps_get_structure(sink_caps, 0);
+
+    // Reload decoder if input resolution changed.
+    if (gst_structure_get_int(s, "width", &width) && gst_structure_get_int(s, "height", &height))
+    {
+        if (decoder->width != 0 && decoder->height != 0 &&
+                (decoder->width != width || decoder->height != height))
+        {
+            videodecoder_state_reset(decoder);
+            basedecoder_close_decoder(BASEDECODER(decoder));
+            videodecoder_close_decoder(decoder);
+            videodecoder_init_state(decoder);
+        }
+    }
+
+    if (base->is_initialized)
+        return TRUE;
 
     // Pass stencil context to init against if there is one.
     basedecoder_set_codec_data(base, s);

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/dshowwrapper.cpp
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/dshowwrapper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,9 @@ using namespace std;
 #define MP2T_PTS_DEBUG 0
 #define H264_PTS_DEBUG 0
 #define AAC_PTS_DEBUG 0
+#define MP2T_PTS_INPUT_DEBUG 0
+#define H264_PTS_INPUT_DEBUG 0
+#define AAC_PTS_INPUT_DEBUG 0
 #define EOS_DEBUG 0
 
 #define MAX_HEADER_SIZE 256
@@ -356,6 +359,11 @@ static void gst_dshowwrapper_init (GstDShowWrapper *decoder)
     decoder->base_pts = GST_CLOCK_TIME_NONE;
 
     decoder->pending_event = NULL;
+
+    decoder->fragmented = FALSE;
+    decoder->width = 0;
+    decoder->height = 0;
+    decoder->lengthSizeMinusOne = 0;
 }
 
 static void gst_dshowwrapper_dispose(GObject* object)
@@ -748,20 +756,20 @@ int dshowwrapper_deliver(GstBuffer *pBuffer, sUserData *pUserData)
             if (decoder->eOutputFormat[pUserData->output_index] == MEDIA_FORMAT_VIDEO_H264)
             {
                 if (GST_BUFFER_TIMESTAMP_IS_VALID(decoder->out_buffer[pUserData->output_index]) && GST_BUFFER_DURATION_IS_VALID(decoder->out_buffer[pUserData->output_index]))
-                    g_print("JFXMEDIA MP2T H264 %I64u %I64u\n", GST_BUFFER_TIMESTAMP(decoder->out_buffer[pUserData->output_index]), GST_BUFFER_DURATION(decoder->out_buffer[pUserData->output_index]));
+                    g_print("JFXMEDIA OUTPUT MP2T H264 %I64u %I64u\n", GST_BUFFER_TIMESTAMP(decoder->out_buffer[pUserData->output_index]), GST_BUFFER_DURATION(decoder->out_buffer[pUserData->output_index]));
                 else if (GST_BUFFER_TIMESTAMP_IS_VALID(decoder->out_buffer[pUserData->output_index]) && !GST_BUFFER_DURATION_IS_VALID(decoder->out_buffer[pUserData->output_index]))
-                    g_print("DEBUG MP2T H264 %I64u -1\n", GST_BUFFER_TIMESTAMP(decoder->out_buffer[pUserData->output_index]));
+                    g_print("JFXMEDIA OUTPUT MP2T H264 %I64u -1\n", GST_BUFFER_TIMESTAMP(decoder->out_buffer[pUserData->output_index]));
                 else
-                    g_print("JFXMEDIA MP2T H264 -1\n");
+                    g_print("JFXMEDIA OUTPUT MP2T H264 -1\n");
             }
             if (decoder->eOutputFormat[pUserData->output_index] == MEDIA_FORMAT_AUDIO_AAC)
             {
                 if (GST_BUFFER_TIMESTAMP_IS_VALID(decoder->out_buffer[pUserData->output_index]) && GST_BUFFER_DURATION_IS_VALID(decoder->out_buffer[pUserData->output_index]))
-                    g_print("JFXMEDIA MP2T AAC  %I64u %I64u\n", GST_BUFFER_TIMESTAMP(decoder->out_buffer[pUserData->output_index]), GST_BUFFER_DURATION(decoder->out_buffer[pUserData->output_index]));
+                    g_print("JFXMEDIA OUTPUT MP2T AAC  %I64u %I64u\n", GST_BUFFER_TIMESTAMP(decoder->out_buffer[pUserData->output_index]), GST_BUFFER_DURATION(decoder->out_buffer[pUserData->output_index]));
                 else if (GST_BUFFER_TIMESTAMP_IS_VALID(decoder->out_buffer[pUserData->output_index]) && !GST_BUFFER_DURATION_IS_VALID(decoder->out_buffer[pUserData->output_index]))
-                    g_print("JFXMEDIA MP2T AAC  %I64u -1\n", GST_BUFFER_TIMESTAMP(decoder->out_buffer[pUserData->output_index]));
+                    g_print("JFXMEDIA OUTPUT MP2T AAC  %I64u -1\n", GST_BUFFER_TIMESTAMP(decoder->out_buffer[pUserData->output_index]));
                 else
-                    g_print("JFXMEDIA MP2T AAC  -1\n");
+                    g_print("JFXMEDIA OUTPUT MP2T AAC  -1\n");
             }
         }
 #endif
@@ -769,22 +777,22 @@ int dshowwrapper_deliver(GstBuffer *pBuffer, sUserData *pUserData)
         if (decoder->eInputFormat == MEDIA_FORMAT_VIDEO_H264 || decoder->eInputFormat == MEDIA_FORMAT_VIDEO_AVC1)
         {
             if (GST_BUFFER_TIMESTAMP_IS_VALID(decoder->out_buffer[pUserData->output_index]) && GST_BUFFER_DURATION_IS_VALID(decoder->out_buffer[pUserData->output_index]))
-                g_print("JFXMEDIA H264 %I64u %I64u\n", GST_BUFFER_TIMESTAMP(decoder->out_buffer[pUserData->output_index]), GST_BUFFER_DURATION(decoder->out_buffer[pUserData->output_index]));
+                g_print("JFXMEDIA OUTPUT H264 %I64u %I64u\n", GST_BUFFER_TIMESTAMP(decoder->out_buffer[pUserData->output_index]), GST_BUFFER_DURATION(decoder->out_buffer[pUserData->output_index]));
             else if (GST_BUFFER_TIMESTAMP_IS_VALID(decoder->out_buffer[pUserData->output_index]) && !GST_BUFFER_DURATION_IS_VALID(decoder->out_buffer[pUserData->output_index]))
-                g_print("JFXMEDIA H264 %I64u -1\n", GST_BUFFER_TIMESTAMP(decoder->out_buffer[pUserData->output_index]));
+                g_print("JFXMEDIA OUTPUT H264 %I64u -1\n", GST_BUFFER_TIMESTAMP(decoder->out_buffer[pUserData->output_index]));
             else
-                g_print("JFXMEDIA H264 -1\n");
+                g_print("JFXMEDIA OUTPUT H264 -1\n");
         }
 #endif
 #if AAC_PTS_DEBUG
         if (decoder->eInputFormat == MEDIA_FORMAT_AUDIO_AAC)
         {
             if (GST_BUFFER_TIMESTAMP_IS_VALID(decoder->out_buffer[pUserData->output_index]) && GST_BUFFER_DURATION_IS_VALID(decoder->out_buffer[pUserData->output_index]))
-                g_print("JFXMEDIA AAC  %I64u %I64u\n", GST_BUFFER_TIMESTAMP(decoder->out_buffer[pUserData->output_index]), GST_BUFFER_DURATION(decoder->out_buffer[pUserData->output_index]));
+                g_print("JFXMEDIA OUTPUT AAC  %I64u %I64u\n", GST_BUFFER_TIMESTAMP(decoder->out_buffer[pUserData->output_index]), GST_BUFFER_DURATION(decoder->out_buffer[pUserData->output_index]));
             else if (GST_BUFFER_TIMESTAMP_IS_VALID(decoder->out_buffer[pUserData->output_index]) && !GST_BUFFER_DURATION_IS_VALID(decoder->out_buffer[pUserData->output_index]))
-                g_print("JFXMEDIA AAC  %I64u -1\n", GST_BUFFER_TIMESTAMP(decoder->out_buffer[pUserData->output_index]));
+                g_print("JFXMEDIA OUTPUT AAC  %I64u -1\n", GST_BUFFER_TIMESTAMP(decoder->out_buffer[pUserData->output_index]));
             else
-                g_print("JFXMEDIA AAC  -1\n");
+                g_print("JFXMEDIA OUTPUT AAC  -1\n");
         }
 #endif
 
@@ -1189,14 +1197,13 @@ static void dshowwrapper_destroy_graph (GstDShowWrapper *decoder)
         CoUninitialize();
 }
 
-gsize dshowwrapper_get_avc_config(void *in, gsize in_size, BYTE *out, gsize out_size, guint *avcProfile, guint *avcLevel, guint *lengthSizeMinusOne)
+gsize dshowwrapper_get_avc_config(void *in, gsize in_size, BYTE *out, gsize out_size, guint *lengthSizeMinusOne)
 {
     guintptr bdata = (guintptr)in;
     AVCCHeader *header = NULL;
     guint ppsCount = 0;
-    guint16 structSize = 0;
+    guint16 nalUnitLength = 0;
     guint ii = 0;
-    gsize size = 0;
     gsize in_bytes_count = 0;
     gsize out_bytes_count = 0;
 
@@ -1208,70 +1215,62 @@ gsize dshowwrapper_get_avc_config(void *in, gsize in_size, BYTE *out, gsize out_
     header->lengthSizeMinusOne &= 0x03;
     header->spsCount &= 0x1F;
 
-    *avcProfile = header->avcProfile;
-    *avcLevel = header->avcLevel;
     *lengthSizeMinusOne = header->lengthSizeMinusOne;
 
     bdata += sizeof(AVCCHeader); // length of first SPS struct, if any
     in_bytes_count += sizeof(AVCCHeader);
 
-    for (ii = 0; ii < header->spsCount; ii++) {
-
+    for (ii = 0; ii < header->spsCount; ii++)
+    {
         if ((in_bytes_count + 2) > in_size)
             return 0;
 
-        structSize = ((guint16)*(guint8*)bdata) << 8;
-        bdata++;
-        structSize |= (guint16)*(guint8*)bdata;
-        bdata++;
+        nalUnitLength = ((guint16)*(guint8*)bdata) << 8;
+        nalUnitLength |= (guint16)*(guint8*)(bdata + 1);
+        nalUnitLength += 2; // Copy nalUnitLength
 
-        out_bytes_count += (structSize + 2);
-        if (out_bytes_count > out_size)
+        if ((out_bytes_count + nalUnitLength) > out_size)
             return 0;
 
-        in_bytes_count += structSize;
-        if (in_bytes_count > in_size)
+        if ((in_bytes_count + nalUnitLength) > in_size)
             return 0;
 
-        memcpy(out, ((guint8*)bdata - 2), structSize + 2);
-        size += structSize + 2;
-        out += size;
-        bdata += structSize;
+        // Copy nal unit
+        memcpy(out, (guint8*)bdata, nalUnitLength);
+        bdata += nalUnitLength; in_bytes_count += nalUnitLength;
+        out += nalUnitLength; out_bytes_count += nalUnitLength;
     }
 
     if ((in_bytes_count + 1) > in_size)
-            return 0;
+        return 0;
 
     ppsCount = *(guint8*)bdata;
     bdata++;
 
     in_bytes_count += 1;
 
-    for (ii = 0; ii < ppsCount; ii++) {
-
+    for (ii = 0; ii < ppsCount; ii++)
+    {
         if ((in_bytes_count + 2) > in_size)
             return 0;
 
-        structSize = ((guint16)*(guint8*)bdata) << 8;
-        bdata++;
-        structSize |= (guint16)*(guint8*)bdata;
-        bdata++;
+        nalUnitLength = ((guint16)*(guint8*)bdata) << 8;
+        nalUnitLength |= (guint16)*(guint8*)(bdata + 1);
+        nalUnitLength += 2; // Copy nalUnitLength
 
-        out_bytes_count += (structSize + 2);
-        if (out_bytes_count > out_size)
+       if ((out_bytes_count + nalUnitLength) > out_size)
             return 0;
 
-        in_bytes_count += structSize;
-        if (in_bytes_count > in_size)
+        if ((in_bytes_count + nalUnitLength) > in_size)
             return 0;
 
-        memcpy(out, ((guint8*)bdata - 2), structSize + 2);
-        size += structSize + 2;
-        out += size;
-        bdata += structSize;
+        // Copy nal unit
+        memcpy(out, (guint8*)bdata, nalUnitLength);
+        bdata += nalUnitLength; in_bytes_count += nalUnitLength;
+        out += nalUnitLength; out_bytes_count += nalUnitLength;
     }
 
-    return size;
+    return out_bytes_count;
 }
 
 static gboolean dshowwrapper_is_decoder_by_codec_id_supported(gint codec_id)
@@ -1308,7 +1307,7 @@ static gboolean dshowwrapper_is_decoder_by_codec_id_supported(gint codec_id)
         }
         break;
     case JFX_CODEC_ID_AVC1:
-        count = sizeof(szAACDecoders)/sizeof(WCHAR*);
+        count = sizeof(szAVCDecoders)/sizeof(WCHAR*);
         decoderCLSID = GUID_NULL;
         for (int i = 0; i < count; i++)
         {
@@ -1463,6 +1462,9 @@ static gboolean dshowwrapper_load_decoder_aac(GstStructure *s, GstDShowWrapper *
     gboolean ret = FALSE;
     gint rate = 48000;
     gint channels = 2;
+
+    if (decoder->pDecoder != NULL)
+        return TRUE;
 
     // Load decoder
     int count = sizeof(szAACDecoders)/sizeof(WCHAR*);
@@ -1645,6 +1647,9 @@ static gboolean dshowwrapper_load_decoder_mp3(GstStructure *s, GstDShowWrapper *
 {
     gboolean ret = FALSE;
     gint layer = 0;
+
+    if (decoder->pDecoder != NULL)
+        return TRUE;
 
     if (!gst_structure_get_int(s, "layer", &layer))
         return FALSE;
@@ -1836,6 +1841,9 @@ static void dshowwrapper_load_decoder_h264(GstDShowWrapper *decoder, JFX_CODEC_I
     HRESULT hr = S_OK;
     CLSID decoderCLSID = GUID_NULL;
 
+    if (decoder->pDecoder != NULL)
+        return;
+
     if (codecID == JFX_CODEC_ID_H264)
     {
         hr = CLSIDFromString(L"{212690FB-83E5-4526-8FD7-74478B7939CD}", &decoderCLSID);
@@ -1931,9 +1939,66 @@ static void dshowwrapper_load_decoder_h264(GstDShowWrapper *decoder, JFX_CODEC_I
     }
 }
 
+static gboolean dshowwrapper_reload_decoder_h264_fragmented(GstDShowWrapper *decoder, sInputFormat *pInputFormat, sOutputFormat *pOutputFormat)
+{
+    HRESULT hr = S_OK;
+    OAFilterState fs = 0;
+    IPin *pOutput = NULL;
+
+    if (decoder->pMediaControl)
+    {
+        decoder->pMediaControl->Stop();
+        decoder->pMediaControl->GetState(5000, &fs);
+    }
+
+    if (decoder->pDecoder != NULL && decoder->pGraph != NULL)
+    {
+        decoder->pGraph->RemoveFilter(decoder->pDecoder);
+        decoder->pDecoder->Release();
+        decoder->pDecoder = NULL;
+    }
+
+    hr = decoder->pSrc->InitMediaType(pInputFormat);
+    if (FAILED(hr))
+        return FALSE;
+
+    hr = decoder->pSink[0]->InitMediaType(pOutputFormat);
+    if (FAILED(hr))
+        return FALSE;
+
+    dshowwrapper_load_decoder_h264(decoder, JFX_CODEC_ID_AVC1);
+    if (decoder->pDecoder == NULL)
+        return FALSE;
+
+    // Add decoder
+    hr = decoder->pGraph->AddFilter(decoder->pDecoder, L"Decoder");
+    if (FAILED(hr))
+    {
+        return FALSE;
+    }
+
+    if (!dshowwrapper_connect_filters(decoder, decoder->pISrc, decoder->pDecoder))
+    {
+        return FALSE;
+    }
+
+    if (!dshowwrapper_connect_filters(decoder, decoder->pDecoder, decoder->pISink[0]))
+    {
+        return FALSE;
+    }
+
+    if (decoder->pMediaControl)
+        decoder->pMediaControl->Run();
+
+    return TRUE;
+}
+
 static gboolean dshowwrapper_load_decoder_h264(GstStructure *s, GstDShowWrapper *decoder)
 {
     gboolean ret = FALSE;
+    HRESULT hr = S_OK;
+
+    gboolean reloadDecoder = FALSE;
 
     // Init input
     sInputFormat inputFormat;
@@ -1947,14 +2012,15 @@ static gboolean dshowwrapper_load_decoder_h264(GstStructure *s, GstDShowWrapper 
     gint height = 0;
     const GValue *v = NULL;
     GstBuffer *codec_data = NULL;
+    GstMapInfo codec_data_info;
+    BYTE header[MAX_HEADER_SIZE];
+    gint header_size = 0;
+
+    if (!gst_structure_get_boolean(s, "fragmented", &decoder->fragmented))
+        decoder->fragmented = FALSE;
 
     if (gst_structure_get_int(s, "width", &width) && gst_structure_get_int(s, "height", &height))
     {
-        // Load AVC1 decoder
-        dshowwrapper_load_decoder_h264(decoder, JFX_CODEC_ID_AVC1);
-        if (decoder->pDecoder == NULL)
-            return FALSE;
-
         v = gst_structure_get_value(s, "codec_data");
         if (v == NULL)
             return FALSE;
@@ -1962,21 +2028,33 @@ static gboolean dshowwrapper_load_decoder_h264(GstStructure *s, GstDShowWrapper 
         codec_data = gst_value_get_buffer(v);
         if (codec_data == NULL)
             return FALSE;
+    }
+
+    if (decoder->pDecoder != NULL)
+    {
+        if (decoder->fragmented &&
+              (decoder->width != width || decoder->height != height) &&
+               decoder->width != 0 && decoder->height != 0)
+            reloadDecoder = TRUE;
+        else
+            return TRUE;
+    }
+
+    if (width != 0 && height != 0)
+    {
+        // Load AVC1 decoder
+        dshowwrapper_load_decoder_h264(decoder, JFX_CODEC_ID_AVC1);
+        if (decoder->pDecoder == NULL)
+            return FALSE;
 
         // GetAVCConfig
-        BYTE header[MAX_HEADER_SIZE];
-        gint header_size = 0;
-        guint avcProfile = 0;
-        guint avcLevel = 0;
-        guint lengthSizeMinusOne = 0;
-        GstMapInfo info;
         if (codec_data != NULL && gst_buffer_get_size(codec_data) <= MAX_HEADER_SIZE)
         {
-            if (gst_buffer_map(codec_data, &info, GST_MAP_READ))
+            if (gst_buffer_map(codec_data, &codec_data_info, GST_MAP_READ))
             {
-                if (info.size <= MAX_HEADER_SIZE)
-                    header_size = dshowwrapper_get_avc_config(info.data, info.size, header, 256, &avcProfile, &avcLevel, &lengthSizeMinusOne);
-                gst_buffer_unmap(codec_data, &info);
+                if (codec_data_info.size <= MAX_HEADER_SIZE)
+                    header_size = dshowwrapper_get_avc_config(codec_data_info.data, codec_data_info.size, header, MAX_HEADER_SIZE, &decoder->lengthSizeMinusOne);
+                gst_buffer_unmap(codec_data, &codec_data_info);
             }
         }
         else
@@ -2018,7 +2096,7 @@ static gboolean dshowwrapper_load_decoder_h264(GstStructure *s, GstDShowWrapper 
         pbFormat->hdr.bmiHeader.biPlanes = 1;
 
         // MPEG2VIDEOINFO
-        pbFormat->dwFlags = lengthSizeMinusOne + 1;
+        pbFormat->dwFlags = decoder->lengthSizeMinusOne + 1;
         memcpy(pbFormat->dwSequenceHeader, header, header_size);
         pbFormat->cbSequenceHeader = header_size;
 
@@ -2030,6 +2108,9 @@ static gboolean dshowwrapper_load_decoder_h264(GstStructure *s, GstDShowWrapper 
         // See JDK-8133841.
         if ((width < height) || (width > 1920 && height > 1080))
             outputFormat.bEnableDynamicFormatChanges = 1;
+
+        decoder->width = width;
+        decoder->height = height;
     }
     else
     {
@@ -2065,7 +2146,7 @@ static gboolean dshowwrapper_load_decoder_h264(GstStructure *s, GstDShowWrapper 
         hdr->bmiHeader.biCompression = '462H';
     }
 
-    if (!dshowwrapper_create_ds_source(decoder, &inputFormat))
+    if (!reloadDecoder && !dshowwrapper_create_ds_source(decoder, &inputFormat))
         goto exit;
 
     gint framerate_num = 0;
@@ -2176,8 +2257,15 @@ static gboolean dshowwrapper_load_decoder_h264(GstStructure *s, GstDShowWrapper 
         goto exit;
     }
 
-    if (!dshowwrapper_create_ds_sink(decoder, &outputFormat, 0, true))
+    if (!reloadDecoder && !dshowwrapper_create_ds_sink(decoder, &outputFormat, 0, true))
         goto exit;
+
+
+    if (reloadDecoder)
+    {
+        if (!dshowwrapper_reload_decoder_h264_fragmented(decoder, &inputFormat, &outputFormat))
+            goto exit;
+    }
 
     ret = TRUE;
 
@@ -2801,6 +2889,40 @@ static GstFlowReturn dshowwrapper_chain (GstPad * pad, GstObject *parent, GstBuf
         return GST_FLOW_OK;
     }
 
+#if MP2T_PTS_INPUT_DEBUG
+    if (decoder->eInputFormat == MEDIA_FORMAT_STREAM_MP2T)
+    {
+        if (GST_BUFFER_TIMESTAMP_IS_VALID(buf) && GST_BUFFER_DURATION_IS_VALID(buf))
+             g_print("JFXMEDIA INPUT MP2T %I64u %I64u\n", GST_BUFFER_TIMESTAMP(buf), GST_BUFFER_DURATION(buf));
+        else if (GST_BUFFER_TIMESTAMP_IS_VALID(buf) && !GST_BUFFER_DURATION_IS_VALID(buf))
+            g_print("JFXMEDIA INPUT MP2T %I64u -1\n", GST_BUFFER_TIMESTAMP(buf));
+        else
+            g_print("JFXMEDIA INPUT MP2T -1\n");
+    }
+#endif
+#if H264_PTS_INPUT_DEBUG
+    if (decoder->eInputFormat == MEDIA_FORMAT_VIDEO_H264 || decoder->eInputFormat == MEDIA_FORMAT_VIDEO_AVC1)
+    {
+        if (GST_BUFFER_TIMESTAMP_IS_VALID(buf) && GST_BUFFER_DURATION_IS_VALID(buf))
+            g_print("JFXMEDIA INPUT H264 %I64u %I64u\n", GST_BUFFER_TIMESTAMP(buf), GST_BUFFER_DURATION(buf));
+        else if (GST_BUFFER_TIMESTAMP_IS_VALID(buf) && !GST_BUFFER_DURATION_IS_VALID(buf))
+            g_print("JFXMEDIA INPUT H264 %I64u -1\n", GST_BUFFER_TIMESTAMP(buf));
+        else
+            g_print("JFXMEDIA INPUT H264 -1\n");
+    }
+#endif
+#if AAC_PTS_INPUT_DEBUG
+    if (decoder->eInputFormat == MEDIA_FORMAT_AUDIO_AAC)
+    {
+        if (GST_BUFFER_TIMESTAMP_IS_VALID(buf) && GST_BUFFER_DURATION_IS_VALID(buf))
+            g_print("JFXMEDIA INPUT AAC  %I64u %I64u\n", GST_BUFFER_TIMESTAMP(buf), GST_BUFFER_DURATION(buf));
+        else if (GST_BUFFER_TIMESTAMP_IS_VALID(buf) && !GST_BUFFER_DURATION_IS_VALID(buf))
+            g_print("JFXMEDIA INPUT AAC  %I64u -1\n", GST_BUFFER_TIMESTAMP(buf));
+        else
+            g_print("JFXMEDIA INPUT AAC  -1\n");
+    }
+#endif
+
     if (GST_BUFFER_TIMESTAMP_IS_VALID(buf))
     {
         decoder->enable_pts = TRUE;
@@ -2875,9 +2997,9 @@ static gboolean dshowwrapper_sink_event(GstPad* pad, GstObject *parent, GstEvent
     switch (GST_EVENT_TYPE (event))
     {
     case GST_EVENT_SEGMENT:
+        gst_event_copy_segment(event, &segment);
         if (decoder->enable_position)
         {
-            gst_event_copy_segment(event, &segment);
             if (segment.format == GST_FORMAT_TIME)
             {
                 decoder->last_stop = segment.position;
@@ -2885,7 +3007,6 @@ static gboolean dshowwrapper_sink_event(GstPad* pad, GstObject *parent, GstEvent
         }
         if (decoder->eInputFormat == MEDIA_FORMAT_STREAM_MP2T) // Resend new segment event with GST_FORMAT_TIME
         {
-            gst_event_copy_segment(event, &segment);
             // INLINE - gst_event_unref()
             gst_event_unref (event);
 
@@ -2914,11 +3035,11 @@ static gboolean dshowwrapper_sink_event(GstPad* pad, GstObject *parent, GstEvent
         {
             decoder->is_eos[i] = FALSE;
         }
+
         break;
     case GST_EVENT_FLUSH_START:
         {
             CAutoLock lock(decoder->pDSLock);
-            HRESULT hr = S_OK;
 
             if (decoder->skip_flush)
             {
@@ -2938,7 +3059,6 @@ static gboolean dshowwrapper_sink_event(GstPad* pad, GstObject *parent, GstEvent
     case GST_EVENT_FLUSH_STOP:
         {
             CAutoLock lock(decoder->pDSLock);
-            HRESULT hr = S_OK;
 
             if (decoder->skip_flush)
             {

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/dshowwrapper.h
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/dshowwrapper.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,6 +152,11 @@ struct _GstDShowWrapper
     GstClockTime offset_pts[MAX_OUTPUT_DS_STREAMS];
 
     GstEvent *pending_event;
+
+    gboolean fragmented;
+    gint width;
+    gint height;
+    guint lengthSizeMinusOne;
 };
 
 struct _GstDShowWrapperClass

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/javasource/javasource.c
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/javasource/javasource.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,6 +39,8 @@ GST_DEBUG_CATEGORY (java_source_debug);
 ***********************************************************************************/
 // From HLSConnectionHolder.java
 #define HLS_PROP_GET_DURATION                1
+#define HLS_PROP_LOAD_SEGMENT                4
+#define HLS_PROP_SEGMENT_START_TIME          5
 #define HLS_VALUE_FLOAT_MULTIPLIER           1000
 
 /***********************************************************************************
@@ -52,7 +54,6 @@ enum
     SIGNAL_COPY_BLOCK,
     SIGNAL_CLOSE_CONNECTION,
     SIGNAL_PROPERTY,
-    SIGNAL_GET_STREAM_SIZE,
     LAST_SIGNAL
 };
 
@@ -283,16 +284,6 @@ static void java_source_class_init (JavaSourceClass *klass)
         G_TYPE_INT, /* return_type */
         2,    /* n_params */
         G_TYPE_INT, G_TYPE_INT);
-
-    klass->signals[SIGNAL_GET_STREAM_SIZE] = g_signal_new ("get-stream-size",
-        G_TYPE_FROM_CLASS (klass),
-        G_SIGNAL_RUN_LAST | G_SIGNAL_NO_RECURSE | G_SIGNAL_NO_HOOKS,
-        0,
-        NULL, /* accumulator */
-        NULL, /* accu_data */
-        source_marshal_INT__VOID,
-        G_TYPE_INT, /* return_type */
-        0    /* n_params */ );
 }
 
 static void java_source_init(JavaSource *element)
@@ -574,8 +565,14 @@ next_event:
                 if ((element->mode & MODE_HLS) == MODE_HLS)
                 {
                     gint result = 0;
+                    gint start_time = 0;
                     gboolean wrong_state = FALSE;
-                    g_signal_emit(element, JAVA_SOURCE_GET_CLASS(element)->signals[SIGNAL_GET_STREAM_SIZE], 0, &result);
+                    g_signal_emit(element,
+                        JAVA_SOURCE_GET_CLASS(element)->signals[SIGNAL_PROPERTY],
+                        0, HLS_PROP_LOAD_SEGMENT, 0, &result);
+                    g_signal_emit(element,
+                        JAVA_SOURCE_GET_CLASS(element)->signals[SIGNAL_PROPERTY],
+                        0, HLS_PROP_SEGMENT_START_TIME, 0, &start_time);
 
                     g_mutex_lock(&element->lock);
                     wrong_state = (element->srcresult == GST_FLOW_FLUSHING);
@@ -599,7 +596,7 @@ next_event:
                     if (element->update)
                         segment.flags |= GST_SEGMENT_FLAG_UPDATE;
                     segment.rate = element->rate;
-                    segment.start = 0;
+                    segment.start = ((gint64)start_time*GST_SECOND) / HLS_VALUE_FLOAT_MULTIPLIER;
                     segment.stop = result;
                     segment.time = element->position_time;
                     segment.position = element->position_time;
@@ -661,7 +658,15 @@ next_event:
                         {
                             GstCaps *caps = NULL;
                             GstEvent *caps_event = NULL;
-                            caps = gst_caps_new_simple (element->mimetype, NULL, NULL);
+                            // Special case for HLS AAC elementary stream.
+                            // It has "audio/aac" mimetype which is same as
+                            // "audio/mpeg" mpegversion=4. We changing it here
+                            // so downstream will undestand it.
+                            if (strstr(element->mimetype, "audio/aac") != NULL)
+                                caps = gst_caps_new_simple("audio/mpeg", "mpegversion", G_TYPE_INT, 4, NULL);
+                            else
+                                caps = gst_caps_new_simple(element->mimetype, NULL, NULL);
+
                             caps_event = gst_event_new_caps(caps);
                             if (caps_event)
                                 gst_pad_push_event(element->srcpad, caps_event);

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/mfwrapper/mfwrapper.cpp
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/mfwrapper/mfwrapper.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -188,7 +188,9 @@ static void gst_mfwrapper_init(GstMFWrapper *decoder)
     decoder->is_flushing = FALSE;
     decoder->is_eos_received = FALSE;
     decoder->is_eos = FALSE;
+    decoder->is_decoder_initialized = FALSE;
     decoder->force_discontinuity = FALSE;
+    decoder->force_output_discontinuity = FALSE;
 
     // Initialize Media Foundation
     bool bCallCoUninitialize = true;
@@ -326,7 +328,10 @@ static void mfwrapper_set_src_caps(GstMFWrapper *decoder)
 
     GstEvent *caps_event = gst_event_new_caps(srcCaps);
     if (caps_event)
+    {
         gst_pad_push_event(decoder->srcpad, caps_event);
+        decoder->force_output_discontinuity = TRUE;
+    }
     gst_caps_unref(srcCaps);
 
     // Allocate or update decoder output buffer
@@ -715,6 +720,13 @@ static GstFlowReturn mfwrapper_deliver_sample(GstMFWrapper *decoder, IMFSample *
         {
             hr = pSample->GetSampleDuration(&llDuration);
             GST_BUFFER_DURATION(pGstBuffer) = llDuration * 100;
+        }
+
+        if (SUCCEEDED(hr) && decoder->force_output_discontinuity)
+        {
+            pGstBuffer = gst_buffer_make_writable(pGstBuffer);
+            GST_BUFFER_FLAG_SET(pGstBuffer, GST_BUFFER_FLAG_DISCONT);
+            decoder->force_output_discontinuity = FALSE;
         }
 
 #if PTS_DEBUG
@@ -1185,25 +1197,29 @@ static HRESULT mfwrapper_set_output_media_type(GstMFWrapper *decoder, GstCaps *c
 
 static gboolean mfwrapper_init_mf(GstMFWrapper *decoder, GstCaps *caps)
 {
+    HRESULT hr = S_OK;
     DWORD dwStatus = 0;
     GstStructure *s = NULL;
     const GValue *codec_data_value = NULL;
     GstBuffer *codec_data = NULL;
     gint skipSize = 0;
+    IMFAttributes *pAttributes = NULL;
+    UINT32 unFormatChange = FALSE;
 
-    HRESULT hr = mfwrapper_load_decoder(decoder, caps);
+    if (!decoder->is_decoder_initialized)
+    {
+        if (SUCCEEDED(hr))
+            hr = mfwrapper_set_input_media_type(decoder, caps);
 
-    if (SUCCEEDED(hr))
-        hr = mfwrapper_set_input_media_type(decoder, caps);
+        if (SUCCEEDED(hr))
+            hr = mfwrapper_set_output_media_type(decoder, caps);
 
-    if (SUCCEEDED(hr))
-        hr = mfwrapper_set_output_media_type(decoder, caps);
+        if (SUCCEEDED(hr))
+            hr = decoder->pDecoder->GetInputStatus(0, &dwStatus);
 
-    if (SUCCEEDED(hr))
-        hr = decoder->pDecoder->GetInputStatus(0, &dwStatus);
-
-    if (FAILED(hr) || dwStatus != MFT_INPUT_STATUS_ACCEPT_DATA) {
-        return FALSE;
+        if (FAILED(hr) || dwStatus != MFT_INPUT_STATUS_ACCEPT_DATA) {
+            return FALSE;
+        }
     }
 
     if (SUCCEEDED(hr))
@@ -1225,6 +1241,10 @@ static gboolean mfwrapper_init_mf(GstMFWrapper *decoder, GstCaps *caps)
     {
         if (gst_buffer_map(codec_data, &info, GST_MAP_READ) && info.size > 0)
         {
+            // Free old one if exist
+            if (decoder->header)
+                delete[] decoder->header;
+
             decoder->header = new BYTE[info.size * 2]; // Should be enough, since we will only add several 4 bytes start codes to 3 nal units
             if (decoder->header == NULL)
             {
@@ -1244,14 +1264,20 @@ static gboolean mfwrapper_init_mf(GstMFWrapper *decoder, GstCaps *caps)
         }
     }
 
-    if (SUCCEEDED(hr))
-        hr = decoder->pDecoder->ProcessMessage(MFT_MESSAGE_COMMAND_FLUSH, NULL);
+    if (!decoder->is_decoder_initialized)
+    {
+        if (SUCCEEDED(hr))
+            hr = decoder->pDecoder->ProcessMessage(MFT_MESSAGE_COMMAND_FLUSH, NULL);
 
-    if (SUCCEEDED(hr))
-        hr = decoder->pDecoder->ProcessMessage(MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, NULL);
+        if (SUCCEEDED(hr))
+            hr = decoder->pDecoder->ProcessMessage(MFT_MESSAGE_NOTIFY_BEGIN_STREAMING, NULL);
 
-    if (SUCCEEDED(hr))
-        hr = decoder->pDecoder->ProcessMessage(MFT_MESSAGE_NOTIFY_START_OF_STREAM, NULL);
+        if (SUCCEEDED(hr))
+            hr = decoder->pDecoder->ProcessMessage(MFT_MESSAGE_NOTIFY_START_OF_STREAM, NULL);
+
+        if (SUCCEEDED(hr))
+            decoder->is_decoder_initialized = TRUE;
+    }
 
     if (SUCCEEDED(hr))
         return TRUE;

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/mfwrapper/mfwrapper.h
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/mfwrapper/mfwrapper.h
@@ -60,8 +60,10 @@ struct _GstMFWrapper
     gboolean is_flushing;
     gboolean is_eos_received;
     gboolean is_eos;
+    gboolean is_decoder_initialized;
 
     gboolean force_discontinuity;
+    gboolean force_output_discontinuity;
 
     HRESULT hr_mfstartup;
 

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/progressbuffer/hlsprogressbuffer.c
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/progressbuffer/hlsprogressbuffer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,20 +39,30 @@ GST_DEBUG_CATEGORY (hls_progress_buffer_debug);
  ***********************************************************************************/
 #define NUM_OF_CACHED_SEGMENTS 3
 
+enum
+{
+    HLS_FORMAT_UNKNOWN = 0x0,
+    HLS_FORMAT_MP2T,
+    HLS_FORMAT_FMP4
+};
+
 struct _HLSProgressBuffer
 {
     GstElement    parent;
 
+    gint          hls_format;
+
     GstPad*       sinkpad;
     GstPad*       srcpad;
 
-    GMutex       lock;
-    GCond        add_cond;
-    GCond        del_cond;
+    GMutex        lock;
+    GCond         add_cond;
+    GCond         del_cond;
 
     Cache*        cache[NUM_OF_CACHED_SEGMENTS];
     guint         cache_size[NUM_OF_CACHED_SEGMENTS];
     gboolean      cache_write_ready[NUM_OF_CACHED_SEGMENTS];
+    gboolean      cache_discont[NUM_OF_CACHED_SEGMENTS];
     gint          cache_write_index;
     gint          cache_read_index;
 
@@ -64,7 +74,7 @@ struct _HLSProgressBuffer
 
     GstFlowReturn srcresult;
 
-    GstClockTime buffer_pts;
+    GstClockTime  buffer_pts;
 };
 
 struct _HLSProgressBufferClass
@@ -161,7 +171,7 @@ static void hls_progress_buffer_class_init (HLSProgressBufferClass *klass)
  */
 static void hls_progress_buffer_init(HLSProgressBuffer *element)
 {
-    int i = 0;
+    element->hls_format = HLS_FORMAT_FMP4;
 
     element->sinkpad = gst_pad_new_from_template (gst_element_class_get_pad_template (GST_ELEMENT_GET_CLASS(element), "sink"), "sink");
     gst_pad_set_chain_function(element->sinkpad, hls_progress_buffer_chain);
@@ -176,11 +186,12 @@ static void hls_progress_buffer_init(HLSProgressBuffer *element)
     g_cond_init(&element->add_cond);
     g_cond_init(&element->del_cond);
 
-    for (i = 0; i < NUM_OF_CACHED_SEGMENTS; i++)
+    for (int i = 0; i < NUM_OF_CACHED_SEGMENTS; i++)
     {
         element->cache[i] = create_cache();
         element->cache_size[i] = 0;
         element->cache_write_ready[i] = TRUE;
+        element->cache_discont[i] = FALSE;
     }
 
     element->cache_write_index = -1;
@@ -322,6 +333,11 @@ static GstFlowReturn hls_progress_buffer_chain(GstPad *pad, GstObject *parent, G
     g_mutex_lock(&element->lock);
     if (element->srcresult != GST_FLOW_FLUSHING)
     {
+        if (GST_BUFFER_FLAG_IS_SET(data, GST_BUFFER_FLAG_DISCONT))
+        {
+            element->cache_discont[element->cache_write_index] = TRUE;
+        }
+
         cache_write_buffer(element->cache[element->cache_write_index], data);
         g_cond_signal(&element->add_cond);
     }
@@ -415,6 +431,13 @@ static void hls_progress_buffer_loop(void *data)
         GstBuffer *buffer = NULL;
         guint64 read_position = cache_read_buffer(element->cache[element->cache_read_index], &buffer);
 
+        if (element->cache_discont[element->cache_read_index])
+        {
+            buffer = gst_buffer_make_writable(buffer);
+            GST_BUFFER_FLAG_SET(buffer, GST_BUFFER_FLAG_DISCONT);
+            element->cache_discont[element->cache_read_index] = FALSE;
+        }
+
         if (read_position == element->cache_size[element->cache_read_index])
         {
             element->cache_write_ready[element->cache_read_index] = TRUE;
@@ -493,29 +516,24 @@ static gboolean hls_progress_buffer_sink_event(GstPad *pad, GstObject *parent, G
             gst_event_unref(event);
             ret = TRUE;
 
-            if (segment.stop - segment.start <= 0)
-            {
-                gst_element_message_full(GST_ELEMENT(element), GST_MESSAGE_ERROR, GST_STREAM_ERROR, GST_STREAM_ERROR_WRONG_TYPE, g_strdup("Only limited content is supported by hlsprogressbuffer."), NULL, ("hlsprogressbuffer.c"), ("hls_progress_buffer_sink_event"), 0);
-                return TRUE;
-            }
-
             if (element->send_new_segment)
             {
                 GstSegment new_segment;
-                gst_segment_init (&new_segment, GST_FORMAT_TIME);
+                gst_segment_init(&new_segment, GST_FORMAT_TIME);
                 new_segment.flags = segment.flags;
                 new_segment.rate = segment.rate;
-                new_segment.start = segment.position;
+                new_segment.start = segment.start;
                 new_segment.stop = -1;
                 new_segment.position = segment.position;
-                new_segment.time = segment.position;
+                new_segment.time = segment.time;
 
                 element->buffer_pts = segment.position;
 
-                event = gst_event_new_segment (&new_segment);
-                element->send_new_segment = FALSE;
+                event = gst_event_new_segment(&new_segment);
+                if (segment.start != 0)
+                  element->send_new_segment = FALSE;
                 ret = gst_pad_push_event(element->srcpad, event);
-            }
+             }
 
             // Get and prepare next write segment
             g_mutex_lock(&element->lock);

--- a/modules/javafx.media/src/main/native/gstreamer/projects/linux/gstreamer-lite/Makefile
+++ b/modules/javafx.media/src/main/native/gstreamer/projects/linux/gstreamer-lite/Makefile
@@ -235,6 +235,7 @@ SOURCES = gstreamer/gst/gst.c \
           gst-plugins-base/gst/app/gstapp.c \
           gst-plugins-base/gst/typefind/gsttypefindfunctions.c \
           gst-plugins-good/gst/audioparsers/gstmpegaudioparse.c \
+          gst-plugins-good/gst/audioparsers/gstaacparse.c \
           gst-plugins-good/gst/audioparsers/parsersplugin.c \
           gst-plugins-good/gst/equalizer/gstiirequalizer.c \
           gst-plugins-good/gst/equalizer/gstiirequalizernbands.c \

--- a/modules/javafx.media/src/main/native/jfxmedia/Locator/LocatorStream.h
+++ b/modules/javafx.media/src/main/native/jfxmedia/Locator/LocatorStream.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,9 +71,6 @@ public:
 
     /* Get or set properties. Value parameter and return value depends on prop value. */
     virtual int Property(int prop, int value) = 0;
-
-    /* Get stream size. */
-    virtual int GetStreamSize() = 0;
 
     /* Virtual destructor */
     virtual ~CStreamCallbacks() {}

--- a/modules/javafx.media/src/main/native/jfxmedia/MediaManagement/MediaTypes.h
+++ b/modules/javafx.media/src/main/native/jfxmedia/MediaManagement/MediaTypes.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,5 +40,7 @@
 #define CONTENT_TYPE_M3U8   "application/vnd.apple.mpegurl"
 #define CONTENT_TYPE_M3U    "audio/mpegurl"
 #define CONTENT_TYPE_MP2T   "video/MP2T"
+#define CONTENT_TYPE_FMP4   "video/quicktime"
+#define CONTENT_TYPE_AAC    "audio/aac"
 
 #endif

--- a/modules/javafx.media/src/main/native/jfxmedia/jni/JavaInputStreamCallbacks.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/jni/JavaInputStreamCallbacks.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,6 @@ jmethodID CJavaInputStreamCallbacks::m_IsRandomAccessMID = 0;
 jmethodID CJavaInputStreamCallbacks::m_SeekMID = 0;
 jmethodID CJavaInputStreamCallbacks::m_CloseConnectionMID = 0;
 jmethodID CJavaInputStreamCallbacks::m_PropertyMID = 0;
-jmethodID CJavaInputStreamCallbacks::m_GetStreamSizeMID = 0;
 
 CJavaInputStreamCallbacks::CJavaInputStreamCallbacks()
     : m_ConnectionHolder(0)
@@ -139,12 +138,6 @@ bool CJavaInputStreamCallbacks::Init(JNIEnv *env, jobject jLocator)
         if (!hasException)
         {
             m_PropertyMID = env->GetMethodID(klass, "property", "(II)I");
-            hasException = javaEnv.reportException();
-        }
-
-        if (!hasException)
-        {
-            m_GetStreamSizeMID = env->GetMethodID(klass, "getStreamSize", "()I");
             hasException = javaEnv.reportException();
         }
 
@@ -321,25 +314,6 @@ int CJavaInputStreamCallbacks::Property(int prop, int value)
         jobject connection = pEnv->NewLocalRef(m_ConnectionHolder);
         if (connection) {
             result = pEnv->CallIntMethod(connection, m_PropertyMID, (jint)prop, (jint)value);
-            pEnv->DeleteLocalRef(connection);
-        }
-
-        javaEnv.reportException();
-    }
-
-    return result;
-}
-
-int CJavaInputStreamCallbacks::GetStreamSize()
-{
-    CJavaEnvironment javaEnv(m_jvm);
-    JNIEnv *pEnv = javaEnv.getEnvironment();
-    int result = 0;
-
-    if (pEnv) {
-        jobject connection = pEnv->NewLocalRef(m_ConnectionHolder);
-        if (connection) {
-            result = pEnv->CallIntMethod(connection, m_GetStreamSizeMID);
             pEnv->DeleteLocalRef(connection);
         }
 

--- a/modules/javafx.media/src/main/native/jfxmedia/jni/JavaInputStreamCallbacks.h
+++ b/modules/javafx.media/src/main/native/jfxmedia/jni/JavaInputStreamCallbacks.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,6 @@ virtual ~CJavaInputStreamCallbacks();
     int64_t Seek(int64_t position);
     void CloseConnection();
     int  Property(int prop, int value);
-    int  GetStreamSize();
 
 private:
     jobject          m_ConnectionHolder;
@@ -61,7 +60,6 @@ private:
     static jmethodID m_SeekMID;
     static jmethodID m_CloseConnectionMID;
     static jmethodID m_PropertyMID;
-    static jmethodID m_GetStreamSizeMID;
 };
 
 #endif // _JAVA_INPUT_STREAM_CALLBACKS_H_

--- a/modules/javafx.media/src/main/native/jfxmedia/platform/gstreamer/GstAudioPlaybackPipeline.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/platform/gstreamer/GstAudioPlaybackPipeline.cpp
@@ -986,6 +986,21 @@ bool CGstAudioPlaybackPipeline::IsCodecSupported(GstCaps *pCaps)
                         }
                     }
                 }
+                else if (strstr(mimetype, CONTENT_TYPE_AAC) != NULL)
+                {
+                    gboolean is_supported = FALSE;
+                    g_object_set(m_Elements[AUDIO_DECODER], "codec-id", (gint)JFX_CODEC_ID_AAC, NULL);
+                    g_object_get(m_Elements[AUDIO_DECODER], "is-supported", &is_supported, NULL);
+                    if (is_supported)
+                    {
+                        return TRUE;
+                    }
+                    else
+                    {
+                        m_audioCodecErrorCode = ERROR_MEDIA_AAC_FORMAT_UNSUPPORTED;
+                        return FALSE;
+                    }
+                }
             }
         }
     }
@@ -1819,6 +1834,10 @@ void CGstAudioPlaybackPipeline::SendTrackEvent()
                 encoding = CTrack::AAC;
             else
                 encoding = CTrack::CUSTOM;
+        }
+        else if (m_AudioTrackInfo.mimeType.find(CONTENT_TYPE_AAC))
+        {
+            encoding = CTrack::AAC;
         }
         else
             encoding = CTrack::CUSTOM;

--- a/modules/javafx.media/src/main/native/jfxmedia/platform/gstreamer/GstPipelineFactory.h
+++ b/modules/javafx.media/src/main/native/jfxmedia/platform/gstreamer/GstPipelineFactory.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,7 +91,6 @@ private:
     static gint64   SourceSeekData(GstElement *src, guint64 offset, gpointer data);
     static void     SourceCloseConnection(GstElement *src, gpointer data);
     static int      SourceProperty(GstElement *src, int prop, int value, gpointer data);
-    static int      SourceGetStreamSize(GstElement *src, gpointer data);
 
 private:
     ContentTypesList m_ContentTypes;

--- a/modules/javafx.media/src/main/native/vs_project/gstreamer/gstreamer.vcxproj
+++ b/modules/javafx.media/src/main/native/vs_project/gstreamer/gstreamer.vcxproj
@@ -205,9 +205,11 @@
     <ClCompile Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\equalizer\gstiirequalizernbands.c">
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">WIN32;_WINDOWS;LIBGSTELEMENTS_EXPORTS;HAVE_CONFIG_H;_WIN32_DCOM;COBJMACROS;GSTREAMER_LITE;GST_REMOVE_DEPRECATED;GST_DISABLE_GST_DEBUG;GST_DISABLE_LOADSAVE;_USE_MATH_DEFINES;_USRDLL;_WINDLL;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <ClCompile Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\gstisoff.c" />
     <ClCompile Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\isomp4-plugin.c">
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">WIN32;_WINDOWS;LIBGSTELEMENTS_EXPORTS;HAVE_CONFIG_H;_WIN32_DCOM;COBJMACROS;GSTREAMER_LITE;GST_REMOVE_DEPRECATED;GST_DISABLE_GST_DEBUG;GST_DISABLE_LOADSAVE;_USE_MATH_DEFINES;_USRDLL;_WINDLL;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <ClCompile Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\properties.c" />
     <ClCompile Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux.c">
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">WIN32;_WINDOWS;LIBGSTELEMENTS_EXPORTS;HAVE_CONFIG_H;_WIN32_DCOM;COBJMACROS;GSTREAMER_LITE;GST_REMOVE_DEPRECATED;GST_DISABLE_GST_DEBUG;GST_DISABLE_LOADSAVE;_USE_MATH_DEFINES;_USRDLL;_WINDLL;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
@@ -217,6 +219,8 @@
     <ClCompile Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux_lang.c">
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">WIN32;_WINDOWS;LIBGSTELEMENTS_EXPORTS;HAVE_CONFIG_H;_WIN32_DCOM;COBJMACROS;GSTREAMER_LITE;GST_REMOVE_DEPRECATED;GST_DISABLE_GST_DEBUG;GST_DISABLE_LOADSAVE;_USE_MATH_DEFINES;_USRDLL;_WINDLL;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <ClCompile Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux_tags.c" />
+    <ClCompile Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux_tree.c" />
     <ClCompile Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux_types.c">
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">WIN32;_WINDOWS;LIBGSTELEMENTS_EXPORTS;HAVE_CONFIG_H;_WIN32_DCOM;COBJMACROS;GSTREAMER_LITE;GST_REMOVE_DEPRECATED;GST_DISABLE_GST_DEBUG;GST_DISABLE_LOADSAVE;_USE_MATH_DEFINES;_USRDLL;_WINDLL;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
@@ -519,6 +523,20 @@
     <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-base\gst-libs\gst\video\video.h" />
     <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-base\gst-libs\gst\video\videoorientation.h" />
     <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-base\gst-libs\gst\video\videooverlay.h" />
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\audioparsers\gstmpegaudioparse.h" />
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\descriptors.h" />
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\fourcc.h" />
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\gstisoff.h" />
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\properties.h" />
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtatomparser.h" />
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux.h" />
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux_debug.h" />
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux_dump.h" />
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux_lang.h" />
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux_tags.h" />
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux_tree.h" />
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux_types.h" />
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtpalette.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\gstreamer\gstreamer-lite\gst-plugins-base\gst-libs\gst\video\video-orc.orc" />

--- a/modules/javafx.media/src/main/native/vs_project/gstreamer/gstreamer.vcxproj.filters
+++ b/modules/javafx.media/src/main/native/vs_project/gstreamer/gstreamer.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="gstreamer">
@@ -669,6 +669,18 @@
     <ClCompile Include="..\..\gstreamer\gstreamer-lite\gst-plugins-base\gst-libs\gst\video\video-tile.c">
       <Filter>gst-plugins-base\gst-libs\gst\video</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\gstisoff.c">
+      <Filter>gst-plugins-good\gst\isomp4</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\properties.c">
+      <Filter>gst-plugins-good\gst\isomp4</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux_tags.c">
+      <Filter>gst-plugins-good\gst\isomp4</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux_tree.c">
+      <Filter>gst-plugins-good\gst\isomp4</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-base\gst-libs\gst\audio\audio.h">
@@ -814,6 +826,48 @@
     </ClInclude>
     <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-base\gst-libs\gst\video\video-tile.h">
       <Filter>gst-plugins-base\gst-libs\gst\video</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\descriptors.h">
+      <Filter>gst-plugins-good\gst\isomp4</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\fourcc.h">
+      <Filter>gst-plugins-good\gst\isomp4</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\gstisoff.h">
+      <Filter>gst-plugins-good\gst\isomp4</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\properties.h">
+      <Filter>gst-plugins-good\gst\isomp4</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtatomparser.h">
+      <Filter>gst-plugins-good\gst\isomp4</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux.h">
+      <Filter>gst-plugins-good\gst\isomp4</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux_debug.h">
+      <Filter>gst-plugins-good\gst\isomp4</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux_dump.h">
+      <Filter>gst-plugins-good\gst\isomp4</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux_lang.h">
+      <Filter>gst-plugins-good\gst\isomp4</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux_tags.h">
+      <Filter>gst-plugins-good\gst\isomp4</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux_tree.h">
+      <Filter>gst-plugins-good\gst\isomp4</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtdemux_types.h">
+      <Filter>gst-plugins-good\gst\isomp4</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\isomp4\qtpalette.h">
+      <Filter>gst-plugins-good\gst\isomp4</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\gstreamer\gstreamer-lite\gst-plugins-good\gst\audioparsers\gstmpegaudioparse.h">
+      <Filter>gst-plugins-good\gst\audioparsers</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/modules/javafx.media/src/main/native/vs_project/plugins/plugins.vcxproj
+++ b/modules/javafx.media/src/main/native/vs_project/plugins/plugins.vcxproj
@@ -44,6 +44,9 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\gstreamer\plugins\progressbuffer\cache.h" />
+    <ClInclude Include="..\..\gstreamer\plugins\progressbuffer\hlsprogressbuffer.h" />
+    <ClInclude Include="..\..\gstreamer\plugins\progressbuffer\progressbuffer.h" />
     <ClInclude Include="..\..\gstreamer\plugins\dshowwrapper\Allocator.h" />
     <ClInclude Include="..\..\gstreamer\plugins\dshowwrapper\dshowwrapper.h" />
     <ClInclude Include="..\..\gstreamer\plugins\dshowwrapper\Sink.h" />

--- a/modules/javafx.media/src/main/native/vs_project/plugins/plugins.vcxproj.filters
+++ b/modules/javafx.media/src/main/native/vs_project/plugins/plugins.vcxproj.filters
@@ -65,4 +65,15 @@
     </ClInclude>
     <ClInclude Include="..\..\gstreamer\plugins\fxplugins_common.h" />
   </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\gstreamer\plugins\progressbuffer\cache.h">
+      <Filter>progressbuffer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\gstreamer\plugins\progressbuffer\hlsprogressbuffer.h">
+      <Filter>progressbuffer</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\gstreamer\plugins\progressbuffer\progressbuffer.h">
+      <Filter>progressbuffer</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
 - Added support for fragmented MP4 with HEVC/H.265, H.264 and AAC. 
 - Added support for elementary AAC streams without any container for audio only streams.
 - Added "aacparse" plugin from GStreamer. Required on Linux, since decoder cannot handle AAC elementary streams directly. DirectShow decoder works without it.
 - DirectShow H.264 decoder on Windows and H.265/H.264 decoder on Linux will be reloaded when fMP4 stream changes resolution. Dynamic format change did not worked for these streams on Windows and Linux.