### PR TITLE
8271085: TabPane: Redundant API docs

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TabPane.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TabPane.java
@@ -170,8 +170,8 @@ public class TabPane extends Control {
     }
 
     /**
-     * <p>Sets the model used for tab selection.  By changing the model you can alter
-     * how the tabs are selected and which tabs are first or last.</p>
+     * The selection model used for selecting tabs. Changing the model alters
+     * how the tabs are selected and which tabs are first or last.
      */
     private ObjectProperty<SingleSelectionModel<Tab>> selectionModel = new SimpleObjectProperty<SingleSelectionModel<Tab>>(this, "selectionModel");
 
@@ -182,10 +182,9 @@ public class TabPane extends Control {
     public final ObjectProperty<SingleSelectionModel<Tab>> selectionModelProperty() { return selectionModel; }
 
     /**
-     * <p>The position to place the tabs in this TabPane. Whenever this changes
-     * the TabPane will immediately update the location of the tabs to reflect
-     * this.</p>
-     * The default position for the tabs is {@code Side.Top}.
+     * The position to place the tabs in this {@code TabPane}. Changes to the value of this property
+     * immediately updates the location of the tabs.
+     * @defaultValue {@code Side.Top}
      */
     private ObjectProperty<Side> side;
 
@@ -226,22 +225,12 @@ public class TabPane extends Control {
     }
 
     /**
-     * <p>Specifies how the TabPane handles tab closing from an end-users
-     * perspective. The options are:</p>
-     *
-     * <ul>
-     *   <li> TabClosingPolicy.UNAVAILABLE: Tabs can not be closed by the user
-     *   <li> TabClosingPolicy.SELECTED_TAB: Only the currently selected tab will
-     *          have the option to be closed, with a graphic next to the tab
-     *          text being shown. The graphic will disappear when a tab is no
-     *          longer selected.
-     *   <li> TabClosingPolicy.ALL_TABS: All tabs will have the option to be
-     *          closed.
-     * </ul>
+     * <p>Specifies how the {@code TabPane} handles tab closing from an end-user's
+     * perspective.
      *
      * <p>Refer to the {@link TabClosingPolicy} enumeration for further details.</p>
      *
-     * The default closing policy is TabClosingPolicy.SELECTED_TAB
+     * @defaultValue {@code TabClosingPolicy.SELECTED_TAB}
      */
     private ObjectProperty<TabClosingPolicy> tabClosingPolicy;
 
@@ -261,13 +250,13 @@ public class TabPane extends Control {
     }
 
     /**
-     * <p>Specifies whether the graphic inside a Tab is rotated or not, such
-     * that it is always upright, or rotated in the same way as the Tab text is.</p>
+     * <p>Specifies whether the graphic inside a {@code Tab} is rotated or not, such
+     * that it is always upright, or rotated in the same way as the {@code Tab} text is.</p>
      *
-     * <p>By default rotateGraphic is set to false, to represent the fact that
-     * the graphic isn't rotated, resulting in it always appearing upright. If
-     * rotateGraphic is set to {@code true}, the graphic will rotate such that it
-     * rotates with the tab text.</p>
+     * <p>If the value is {@code false}, the graphic isn't rotated, resulting in it always appearing upright.
+     * If the value is {@code true}, the graphic is rotated with the {@code Tab} text.</p>
+     *
+     * @defaultValue {@code false}
      */
     private BooleanProperty rotateGraphic;
 
@@ -287,12 +276,14 @@ public class TabPane extends Control {
     }
 
     /**
-     * <p>The minimum width of the tabs in the TabPane.  This can be used to limit
-     * the length of text in tabs to prevent truncation.  Setting the min equal
-     * to the max will fix the width of the tab.  By default the min equals to the max.
-     *
+     * <p>The minimum width of a {@code Tab} in the {@code TabPane}.
+     * This can be used to limit the length of text in tabs to prevent truncation.
+     * Setting the same minimum and maximum widths will fix the width of the {@code Tab}.
+     * <p>
      * This value can also be set via CSS using {@code -fx-tab-min-width}.
      * </p>
+     *
+     * @defaultValue 0
      */
     private DoubleProperty tabMinWidth;
 
@@ -328,13 +319,15 @@ public class TabPane extends Control {
     }
 
     /**
-     * <p>The maximum width of the tabs in the TabPane.  This can be used to limit
-     * the length of text in tabs.  If the tab text is longer than the maximum
-     * width the text will be truncated.  Setting the max equal
-     * to the min will fix the width of the tab.  By default the min equals to the max.
-     *
+     * <p>The maximum width of a {@code Tab} in the {@code TabPane}.
+     * This can be used to limit the length of text in tabs to prevent truncation.
+     * If the {@code Tab} text is longer than the maximum width, the text will be truncated.
+     * Setting the same minimum and maximum widths will fix the width of the {@code Tab}.
+     * <p>
      * This value can also be set via CSS using {@code -fx-tab-max-width}.
      * </p>
+     *
+     * @defaultValue {@code Double.MAX_VALUE}
      */
     private DoubleProperty tabMaxWidth;
 
@@ -370,12 +363,14 @@ public class TabPane extends Control {
     }
 
     /**
-     * <p>The minimum height of the tabs in the TabPane.  This can be used to limit
-     * the height in tabs. Setting the min equal to the max will fix the height
-     * of the tab.  By default the min equals to the max.
-     *
+     * <p>The minimum height of a {@code Tab} in the {@code TabPane}.
+     * This can be used to limit the height of tabs.
+     * Setting the same minimum and maximum heights will fix the height of the {@code Tab}.
+     * <p>
      * This value can also be set via CSS using {@code -fx-tab-min-height}.
      * </p>
+     *
+     * @defaultValue 0
      */
     private DoubleProperty tabMinHeight;
 
@@ -411,12 +406,14 @@ public class TabPane extends Control {
     }
 
     /**
-     * <p>The maximum height of the tabs in the TabPane.  This can be used to limit
-     * the height in tabs. Setting the max equal to the min will fix the height
-     * of the tab.  By default the min equals to the max.
-     *
+     * <p>The maximum height of a {@code Tab} in the {@code TabPane}.
+     * This can be used to limit the height of tabs.
+     * Setting the same minimum and maximum heights will fix the height of the {@code Tab}.
+     * <p>
      * This value can also be set via CSS using {@code -fx-tab-max-height}.
      * </p>
+     *
+     * @defaultValue {@code Double.MAX_VALUE}
      */
     private DoubleProperty tabMaxHeight;
 
@@ -738,16 +735,16 @@ public class TabPane extends Control {
     }
 
     /**
-     * <p>This specifies how the TabPane handles tab closing from an end-users
+     * <p>This specifies how the {@code TabPane} handles tab closing from an end-user's
      * perspective. The options are:</p>
      *
      * <ul>
-     *   <li> TabClosingPolicy.UNAVAILABLE: Tabs can not be closed by the user
-     *   <li> TabClosingPolicy.SELECTED_TAB: Only the currently selected tab will
+     *   <li> {@code TabClosingPolicy.UNAVAILABLE}: Tabs can not be closed by the user
+     *   <li> {@code TabClosingPolicy.SELECTED_TAB}: Only the currently selected tab will
      *          have the option to be closed, with a graphic next to the tab
      *          text being shown. The graphic will disappear when a tab is no
      *          longer selected.
-     *   <li> TabClosingPolicy.ALL_TABS: All tabs will have the option to be
+     *   <li> {@code TabClosingPolicy.ALL_TABS}: All tabs will have the option to be
      *          closed.
      * </ul>
      * @since JavaFX 2.0
@@ -774,9 +771,9 @@ public class TabPane extends Control {
 
 
     /**
-     * The drag policy for the tabs. The policy can be changed dynamically.
+     * The drag policy for the tabs. It specifies if tabs can be reordered or not.
      *
-     * @defaultValue TabDragPolicy.FIXED
+     * @defaultValue {@code TabDragPolicy.FIXED}
      * @since 10
      */
     private ObjectProperty<TabDragPolicy> tabDragPolicy;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TabPane.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TabPane.java
@@ -169,54 +169,34 @@ public class TabPane extends Control {
         return tabs;
     }
 
-    private ObjectProperty<SingleSelectionModel<Tab>> selectionModel = new SimpleObjectProperty<SingleSelectionModel<Tab>>(this, "selectionModel");
-
     /**
      * <p>Sets the model used for tab selection.  By changing the model you can alter
      * how the tabs are selected and which tabs are first or last.</p>
-     * @param value the selection model
      */
+    private ObjectProperty<SingleSelectionModel<Tab>> selectionModel = new SimpleObjectProperty<SingleSelectionModel<Tab>>(this, "selectionModel");
+
     public final void setSelectionModel(SingleSelectionModel<Tab> value) { selectionModel.set(value); }
 
-    /**
-     * <p>Gets the model used for tab selection.</p>
-     * @return the model used for tab selection
-     */
     public final SingleSelectionModel<Tab> getSelectionModel() { return selectionModel.get(); }
 
-    /**
-     * The selection model used for selecting tabs.
-     * @return selection model property
-     */
     public final ObjectProperty<SingleSelectionModel<Tab>> selectionModelProperty() { return selectionModel; }
-
-    private ObjectProperty<Side> side;
 
     /**
      * <p>The position to place the tabs in this TabPane. Whenever this changes
      * the TabPane will immediately update the location of the tabs to reflect
      * this.</p>
-     *
-     * @param value the side
+     * The default position for the tabs is {@code Side.Top}.
      */
+    private ObjectProperty<Side> side;
+
     public final void setSide(Side value) {
         sideProperty().set(value);
     }
 
-    /**
-     * The current position of the tabs in the TabPane.  The default position
-     * for the tabs is Side.Top.
-     *
-     * @return The current position of the tabs in the TabPane.
-     */
     public final Side getSide() {
         return side == null ? Side.TOP : side.get();
     }
 
-    /**
-     * The position of the tabs in the TabPane.
-     * @return the side property
-     */
     public final ObjectProperty<Side> sideProperty() {
         if (side == null) {
             side = new ObjectPropertyBase<Side>(Side.TOP) {
@@ -245,8 +225,6 @@ public class TabPane extends Control {
         return side;
     }
 
-    private ObjectProperty<TabClosingPolicy> tabClosingPolicy;
-
     /**
      * <p>Specifies how the TabPane handles tab closing from an end-users
      * perspective. The options are:</p>
@@ -264,33 +242,23 @@ public class TabPane extends Control {
      * <p>Refer to the {@link TabClosingPolicy} enumeration for further details.</p>
      *
      * The default closing policy is TabClosingPolicy.SELECTED_TAB
-     * @param value the closing policy
      */
+    private ObjectProperty<TabClosingPolicy> tabClosingPolicy;
+
     public final void setTabClosingPolicy(TabClosingPolicy value) {
         tabClosingPolicyProperty().set(value);
     }
 
-    /**
-     * The closing policy for the tabs.
-     *
-     * @return The closing policy for the tabs.
-     */
     public final TabClosingPolicy getTabClosingPolicy() {
         return tabClosingPolicy == null ? TabClosingPolicy.SELECTED_TAB : tabClosingPolicy.get();
     }
 
-    /**
-     * The closing policy for the tabs.
-     * @return the closing policy property
-     */
     public final ObjectProperty<TabClosingPolicy> tabClosingPolicyProperty() {
         if (tabClosingPolicy == null) {
             tabClosingPolicy = new SimpleObjectProperty<TabClosingPolicy>(this, "tabClosingPolicy", TabClosingPolicy.SELECTED_TAB);
         }
         return tabClosingPolicy;
     }
-
-    private BooleanProperty rotateGraphic;
 
     /**
      * <p>Specifies whether the graphic inside a Tab is rotated or not, such
@@ -300,27 +268,17 @@ public class TabPane extends Control {
      * the graphic isn't rotated, resulting in it always appearing upright. If
      * rotateGraphic is set to {@code true}, the graphic will rotate such that it
      * rotates with the tab text.</p>
-     *
-     * @param value a flag indicating whether to rotate the graphic
      */
+    private BooleanProperty rotateGraphic;
+
     public final void setRotateGraphic(boolean value) {
         rotateGraphicProperty().set(value);
     }
 
-    /**
-     * Returns {@code true} if the graphic inside a Tab is rotated. The
-     * default is {@code false}
-     *
-     * @return the rotatedGraphic state.
-     */
     public final boolean isRotateGraphic() {
         return rotateGraphic == null ? false : rotateGraphic.get();
     }
 
-    /**
-     * The rotateGraphic state of the tabs in the TabPane.
-     * @return the rotateGraphic property
-     */
     public final BooleanProperty rotateGraphicProperty() {
         if (rotateGraphic == null) {
             rotateGraphic = new SimpleBooleanProperty(this, "rotateGraphic", false);
@@ -328,35 +286,24 @@ public class TabPane extends Control {
         return rotateGraphic;
     }
 
-    private DoubleProperty tabMinWidth;
-
     /**
      * <p>The minimum width of the tabs in the TabPane.  This can be used to limit
      * the length of text in tabs to prevent truncation.  Setting the min equal
      * to the max will fix the width of the tab.  By default the min equals to the max.
      *
-     * This value can also be set via CSS using {@code -fx-tab-min-width}
-     *
+     * This value can also be set via CSS using {@code -fx-tab-min-width}.
      * </p>
-     * @param value the minimum width of the tabs
      */
+    private DoubleProperty tabMinWidth;
+
     public final void setTabMinWidth(double value) {
         tabMinWidthProperty().setValue(value);
     }
 
-    /**
-     * The minimum width of the tabs in the TabPane.
-     *
-     * @return The minimum width of the tabs
-     */
     public final double getTabMinWidth() {
         return tabMinWidth == null ? DEFAULT_TAB_MIN_WIDTH : tabMinWidth.getValue();
     }
 
-    /**
-     * The minimum width of the tabs in the TabPane.
-     * @return the minimum width property
-     */
     public final DoubleProperty tabMinWidthProperty() {
         if (tabMinWidth == null) {
             tabMinWidth = new StyleableDoubleProperty(DEFAULT_TAB_MIN_WIDTH) {
@@ -381,31 +328,24 @@ public class TabPane extends Control {
     }
 
     /**
-     * <p>Specifies the maximum width of a tab.  This can be used to limit
+     * <p>The maximum width of the tabs in the TabPane.  This can be used to limit
      * the length of text in tabs.  If the tab text is longer than the maximum
      * width the text will be truncated.  Setting the max equal
-     * to the min will fix the width of the tab.  By default the min equals to the max
+     * to the min will fix the width of the tab.  By default the min equals to the max.
      *
-     * This value can also be set via CSS using {@code -fx-tab-max-width}.</p>
+     * This value can also be set via CSS using {@code -fx-tab-max-width}.
+     * </p>
      */
     private DoubleProperty tabMaxWidth;
+
     public final void setTabMaxWidth(double value) {
         tabMaxWidthProperty().setValue(value);
     }
 
-    /**
-     * The maximum width of the tabs in the TabPane.
-     *
-     * @return The maximum width of the tabs
-     */
     public final double getTabMaxWidth() {
         return tabMaxWidth == null ? DEFAULT_TAB_MAX_WIDTH : tabMaxWidth.getValue();
     }
 
-    /**
-     * The maximum width of the tabs in the TabPane.
-     * @return the maximum width property
-     */
     public final DoubleProperty tabMaxWidthProperty() {
         if (tabMaxWidth == null) {
             tabMaxWidth = new StyleableDoubleProperty(DEFAULT_TAB_MAX_WIDTH) {
@@ -429,34 +369,24 @@ public class TabPane extends Control {
         return tabMaxWidth;
     }
 
-    private DoubleProperty tabMinHeight;
-
     /**
      * <p>The minimum height of the tabs in the TabPane.  This can be used to limit
      * the height in tabs. Setting the min equal to the max will fix the height
      * of the tab.  By default the min equals to the max.
      *
-     * This value can also be set via CSS using {@code -fx-tab-min-height}
+     * This value can also be set via CSS using {@code -fx-tab-min-height}.
      * </p>
-     * @param value the minimum height of the tabs
      */
+    private DoubleProperty tabMinHeight;
+
     public final void setTabMinHeight(double value) {
         tabMinHeightProperty().setValue(value);
     }
 
-    /**
-     * The minimum height of the tabs in the TabPane.
-     *
-     * @return the minimum height of the tabs
-     */
     public final double getTabMinHeight() {
         return tabMinHeight == null ? DEFAULT_TAB_MIN_HEIGHT : tabMinHeight.getValue();
     }
 
-    /**
-     * The minimum height of the tab.
-     * @return the minimum height property
-     */
     public final DoubleProperty tabMinHeightProperty() {
         if (tabMinHeight == null) {
             tabMinHeight = new StyleableDoubleProperty(DEFAULT_TAB_MIN_HEIGHT) {
@@ -481,31 +411,23 @@ public class TabPane extends Control {
     }
 
     /**
-     * <p>The maximum height if the tabs in the TabPane.  This can be used to limit
+     * <p>The maximum height of the tabs in the TabPane.  This can be used to limit
      * the height in tabs. Setting the max equal to the min will fix the height
      * of the tab.  By default the min equals to the max.
      *
-     * This value can also be set via CSS using -fx-tab-max-height
+     * This value can also be set via CSS using {@code -fx-tab-max-height}.
      * </p>
      */
     private DoubleProperty tabMaxHeight;
+
     public final void setTabMaxHeight(double value) {
         tabMaxHeightProperty().setValue(value);
     }
 
-    /**
-     * The maximum height of the tabs in the TabPane.
-     *
-     * @return The maximum height of the tabs
-     */
     public final double getTabMaxHeight() {
         return tabMaxHeight == null ? DEFAULT_TAB_MAX_HEIGHT : tabMaxHeight.getValue();
     }
 
-    /**
-     * <p>The maximum height of the tabs in the TabPane.</p>
-     * @return the maximum height of the tabs
-     */
     public final DoubleProperty tabMaxHeightProperty() {
         if (tabMaxHeight == null) {
             tabMaxHeight = new StyleableDoubleProperty(DEFAULT_TAB_MAX_HEIGHT) {
@@ -851,16 +773,14 @@ public class TabPane extends Control {
     }
 
 
-    // TabDragPolicy //
-    private ObjectProperty<TabDragPolicy> tabDragPolicy;
-
     /**
      * The drag policy for the tabs. The policy can be changed dynamically.
      *
      * @defaultValue TabDragPolicy.FIXED
-     * @return The tab drag policy property
      * @since 10
      */
+    private ObjectProperty<TabDragPolicy> tabDragPolicy;
+
     public final ObjectProperty<TabDragPolicy> tabDragPolicyProperty() {
         if (tabDragPolicy == null) {
             tabDragPolicy = new SimpleObjectProperty<TabDragPolicy>(this, "tabDragPolicy", TabDragPolicy.FIXED);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TabPane.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TabPane.java
@@ -58,8 +58,8 @@ import javafx.css.StyleableProperty;
 import javafx.scene.Node;
 
 /**
- * <p>A control that allows switching between a group of {@link Tab Tabs}.  Only one tab
- * is visible at a time. Tabs are added to the TabPane by using the {@link #getTabs}.</p>
+ * A control that allows switching between a group of {@link Tab Tabs}.  Only one tab
+ * is visible at a time. Tabs are added to the TabPane by using the {@link #getTabs}.
  *
  * <p>Tabs in a TabPane can be positioned at any of the four sides by specifying the
  * {@link Side}. </p>
@@ -155,9 +155,9 @@ public class TabPane extends Control {
     private ObservableList<Tab> tabs = new TabObservableList<>(new ArrayList<>());
 
     /**
-     * <p>The tabs to display in this TabPane. Changing this ObservableList will
+     * The tabs to display in this TabPane. Changing this ObservableList will
      * immediately result in the TabPane updating to display the new contents
-     * of this ObservableList.</p>
+     * of this ObservableList.
      *
      * <p>If the tabs ObservableList changes, the selected tab will remain the previously
      * selected tab, if it remains within this ObservableList. If the previously
@@ -225,7 +225,7 @@ public class TabPane extends Control {
     }
 
     /**
-     * <p>Specifies how the {@code TabPane} handles tab closing from an end-user's
+     * Specifies how the {@code TabPane} handles tab closing from an end-user's
      * perspective.
      *
      * <p>Refer to the {@link TabClosingPolicy} enumeration for further details.</p>
@@ -250,8 +250,8 @@ public class TabPane extends Control {
     }
 
     /**
-     * <p>Specifies whether the graphic inside a {@code Tab} is rotated or not, such
-     * that it is always upright, or rotated in the same way as the {@code Tab} text is.</p>
+     * Specifies whether the graphic inside a {@code Tab} is rotated or not, such
+     * that it is always upright, or rotated in the same way as the {@code Tab} text is.
      *
      * <p>If the value is {@code false}, the graphic isn't rotated, resulting in it always appearing upright.
      * If the value is {@code true}, the graphic is rotated with the {@code Tab} text.</p>
@@ -276,12 +276,11 @@ public class TabPane extends Control {
     }
 
     /**
-     * <p>The minimum width of a {@code Tab} in the {@code TabPane}.
+     * The minimum width of a {@code Tab} in the {@code TabPane}.
      * This can be used to limit the length of text in tabs to prevent truncation.
      * Setting the same minimum and maximum widths will fix the width of the {@code Tab}.
-     * <p>
-     * This value can also be set via CSS using {@code -fx-tab-min-width}.
-     * </p>
+     *
+     * <p>This value can also be set via CSS using {@code -fx-tab-min-width}.</p>
      *
      * @defaultValue 0
      */
@@ -319,13 +318,12 @@ public class TabPane extends Control {
     }
 
     /**
-     * <p>The maximum width of a {@code Tab} in the {@code TabPane}.
+     * The maximum width of a {@code Tab} in the {@code TabPane}.
      * This can be used to limit the length of text in tabs to prevent truncation.
      * If the {@code Tab} text is longer than the maximum width, the text will be truncated.
      * Setting the same minimum and maximum widths will fix the width of the {@code Tab}.
-     * <p>
-     * This value can also be set via CSS using {@code -fx-tab-max-width}.
-     * </p>
+     *
+     * <p>This value can also be set via CSS using {@code -fx-tab-max-width}.</p>
      *
      * @defaultValue {@code Double.MAX_VALUE}
      */
@@ -363,12 +361,11 @@ public class TabPane extends Control {
     }
 
     /**
-     * <p>The minimum height of a {@code Tab} in the {@code TabPane}.
+     * The minimum height of a {@code Tab} in the {@code TabPane}.
      * This can be used to limit the height of tabs.
      * Setting the same minimum and maximum heights will fix the height of the {@code Tab}.
-     * <p>
-     * This value can also be set via CSS using {@code -fx-tab-min-height}.
-     * </p>
+     *
+     * <p>This value can also be set via CSS using {@code -fx-tab-min-height}.</p>
      *
      * @defaultValue 0
      */
@@ -406,12 +403,11 @@ public class TabPane extends Control {
     }
 
     /**
-     * <p>The maximum height of a {@code Tab} in the {@code TabPane}.
+     * The maximum height of a {@code Tab} in the {@code TabPane}.
      * This can be used to limit the height of tabs.
      * Setting the same minimum and maximum heights will fix the height of the {@code Tab}.
-     * <p>
-     * This value can also be set via CSS using {@code -fx-tab-max-height}.
-     * </p>
+     *
+     * <p>This value can also be set via CSS using {@code -fx-tab-max-height}.</p>
      *
      * @defaultValue {@code Double.MAX_VALUE}
      */
@@ -735,8 +731,8 @@ public class TabPane extends Control {
     }
 
     /**
-     * <p>This specifies how the {@code TabPane} handles tab closing from an end-user's
-     * perspective. The options are:</p>
+     * Specifies how the {@code TabPane} handles tab closing from an end-user's
+     * perspective. The options are:
      *
      * <ul>
      *   <li> {@code TabClosingPolicy.UNAVAILABLE}: Tabs can not be closed by the user


### PR DESCRIPTION
This is a Javadoc cleanup and correction fix for the TabPane as described in the JBS.

Changes done for all the Properties of the TabPane -
- Moved the property description to be over the property field.
- Removed the unnecessary docs on property setter/getter and Property method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271085](https://bugs.openjdk.java.net/browse/JDK-8271085): TabPane: Redundant API docs


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Nir Lisker](https://openjdk.java.net/census#nlisker) (@nlisker - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/728/head:pull/728` \
`$ git checkout pull/728`

Update a local copy of the PR: \
`$ git checkout pull/728` \
`$ git pull https://git.openjdk.java.net/jfx pull/728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 728`

View PR using the GUI difftool: \
`$ git pr show -t 728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/728.diff">https://git.openjdk.java.net/jfx/pull/728.diff</a>

</details>
