### PR TITLE
8281089: JavaFX built with VS2019 and jlinked into JDK 11.x fails to start

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5343,13 +5343,6 @@ compileTargets { t ->
         def standaloneSdkDir = "${rootProject.buildDir}/${standaloneSdkDirName}"
         def standaloneLegalDir = "${standaloneSdkDir}/legal"
 
-        def excludeNativeLibs = []
-        if (IS_WINDOWS) {
-            // List of duplicate Microsoft DLLs to exclude
-            excludeNativeLibs += targetProperties.VS2017DLLNames
-            excludeNativeLibs += targetProperties.WinSDKDLLNames
-        }
-
         moduleProjList.each { project ->
             def moduleName = project.ext.moduleName
             def buildDir = project.buildDir
@@ -5358,9 +5351,36 @@ compileTargets { t ->
             def srcLibDir = "${buildDir}/${platformPrefix}module-lib"
             def srcLegalDir = "${standaloneLegalDir}/${moduleName}"
 
+            def jmodLibDir = srcLibDir
+            if (IS_WINDOWS) {
+                jmodLibDir = "${srcLibDir}-jmod"
+            }
+
             def jmodName = "${moduleName}.jmod"
             def jmodFile = "${jmodsDir}/${jmodName}"
-            def jmodTask = project.task("jmod$t.capital", group: "Build", dependsOn: sdk) {
+
+            // On Windows, copy the native libraries in the jmod image
+            // to a "javafx" subdir to avoid conflicting with the Microsoft
+            // DLLs that are shipped with the JDK
+            def jmodCopyLibTask = project.task("jmodCopyLib$t.capital", type: Copy, dependsOn: sdk) {
+                enabled = IS_WINDOWS
+
+                group = "Basic"
+                description = "copied Windows DLLs into javafx subdir for jmods"
+
+                into jmodLibDir
+
+                from (srcLibDir) {
+                    exclude("*.dll")
+                }
+
+                from (srcLibDir) {
+                    include("*.dll")
+                    into("javafx")
+                }
+            }
+
+            def jmodTask = project.task("jmod$t.capital", group: "Build", dependsOn: [sdk, jmodCopyLibTask]) {
                 doLast {
                     mkdir jmodsDir
                     delete(jmodFile);
@@ -5371,16 +5391,9 @@ compileTargets { t ->
                         args(srcClassesDir)
                         args("--module-version", "$RELEASE_VERSION_SHORT")
                         // Not all modules have a "lib" dir
-                        if (file(srcLibDir).isDirectory()) {
+                        if (file(jmodLibDir).isDirectory()) {
                             args("--libs")
-                            args(srcLibDir)
-                        }
-                        // Exclude duplicate native libs from javafx.graphics.jmod
-                        if (moduleName == "javafx.graphics") {
-                            excludeNativeLibs.each { name ->
-                                args("--exclude")
-                                args(name)
-                            }
+                            args(jmodLibDir)
                         }
                         args("--legal-notices")
                         args(srcLegalDir)

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
@@ -69,7 +69,6 @@ public class NativeLibLoader {
 
     private static boolean verbose = false;
 
-    private static boolean usingModules = false;
     private static File libDir = null;
     private static String libPrefix = "";
     private static String libSuffix = "";
@@ -116,8 +115,9 @@ public class NativeLibLoader {
 
     private static void loadLibraryInternal(String libraryName, List<String> dependencies, Class caller) {
         // The search order for native library loading is:
-        // - try to load the native library from the same folder as this jar
-        //   (only on non-modular builds)
+        // - try to load the native library from either ${java.home}
+        //   (for jlinked javafx modules) or from the same folder as
+        //   this jar (if using modular jars)
         // - if the native library comes bundled as a resource it is extracted
         //   and loaded
         // - the java.library.path is searched for the library in definition
@@ -130,7 +130,7 @@ public class NativeLibLoader {
             // since it isn't applicable to Jigsaw.
             loadLibraryFullPath(libraryName);
         } catch (UnsatisfiedLinkError ex) {
-            if (verbose && !usingModules) {
+            if (verbose) {
                 System.err.println("WARNING: " + ex);
             }
 
@@ -326,15 +326,57 @@ public class NativeLibLoader {
     }
 
 
+    private static File libDirForJRT() {
+        String javaHome = System.getProperty("java.home");
+
+        if (javaHome == null || javaHome.isEmpty()) {
+            throw new UnsatisfiedLinkError("Cannot find java.home");
+        }
+
+        // Set the native directory based on the OS
+        String osName = System.getProperty("os.name");
+        String relativeDir = null;
+        if (osName.startsWith("Windows")) {
+            relativeDir = "bin/javafx";
+        } else if (osName.startsWith("Mac")) {
+            relativeDir = "lib";
+        } else if (osName.startsWith("Linux")) {
+            relativeDir = "lib";
+        }
+
+        // Location of native libraries relative to java.home
+        return new File(javaHome + "/" + relativeDir);
+    }
+
+    private static File libDirForJarFile(String classUrlString) throws Exception {
+        // Strip out the "jar:" and everything after and including the "!"
+        String tmpStr = classUrlString.substring(4, classUrlString.lastIndexOf('!'));
+        // Strip everything after the last "/" or "\" to get rid of the jar filename
+        int lastIndexOfSlash = Math.max(tmpStr.lastIndexOf('/'), tmpStr.lastIndexOf('\\'));
+
+        // Set the native directory based on the OS
+        String osName = System.getProperty("os.name");
+        String relativeDir = null;
+        if (osName.startsWith("Windows")) {
+            relativeDir = "../bin";
+        } else if (osName.startsWith("Mac")) {
+            relativeDir = ".";
+        } else if (osName.startsWith("Linux")) {
+            relativeDir = ".";
+        }
+
+        // Location of native libraries relative to jar file
+        String libDirUrlString = tmpStr.substring(0, lastIndexOfSlash)
+                + "/" + relativeDir;
+        return new File(new URI(libDirUrlString).getPath());
+    }
+
     /**
-     * Load the native library from the same directory as the jar file
-     * containing this class.
+     * Load the native library either from the same directory as the jar file
+     * containing this class, or from the Java runtime.
      */
     private static void loadLibraryFullPath(String libraryName) {
         try {
-            if (usingModules) {
-                throw new UnsatisfiedLinkError("ignored");
-            }
             if (libDir == null) {
                 // Get the URL for this class, if it is a jar URL, then get the
                 // filename associated with it.
@@ -342,35 +384,15 @@ public class NativeLibLoader {
                 Class theClass = NativeLibLoader.class;
                 String classUrlString = theClass.getResource(theClassFile).toString();
                 if (classUrlString.startsWith("jrt:")) {
-                    // Suppress warning messages
-                    usingModules = true;
-                    throw new UnsatisfiedLinkError("ignored");
-                }
-                if (!classUrlString.startsWith("jar:file:") || classUrlString.indexOf('!') == -1) {
+                    libDir = libDirForJRT();
+                } else if (classUrlString.startsWith("jar:file:") && classUrlString.indexOf('!') > 0) {
+                    libDir = libDirForJarFile(classUrlString);
+                } else {
                     throw new UnsatisfiedLinkError("Invalid URL for class: " + classUrlString);
                 }
-                // Strip out the "jar:" and everything after and including the "!"
-                String tmpStr = classUrlString.substring(4, classUrlString.lastIndexOf('!'));
-                // Strip everything after the last "/" or "\" to get rid of the jar filename
-                int lastIndexOfSlash = Math.max(tmpStr.lastIndexOf('/'), tmpStr.lastIndexOf('\\'));
-
-                // Set the native directory based on the OS
-                String osName = System.getProperty("os.name");
-                String relativeDir = null;
-                if (osName.startsWith("Windows")) {
-                    relativeDir = "../bin";
-                } else if (osName.startsWith("Mac")) {
-                    relativeDir = ".";
-                } else if (osName.startsWith("Linux")) {
-                    relativeDir = ".";
-                }
-
-                // Location of native libraries relative to jar file
-                String libDirUrlString = tmpStr.substring(0, lastIndexOfSlash)
-                        + "/" + relativeDir;
-                libDir = new File(new URI(libDirUrlString).getPath());
 
                 // Set the lib prefix and suffix based on the OS
+                String osName = System.getProperty("os.name");
                 if (osName.startsWith("Windows")) {
                     libPrefix = "";
                     libSuffix = ".dll";


### PR DESCRIPTION
The `javafx.graphics` module has a number of native libraries, including the redistributable Microsoft DLLs on Windows. When running an application using the standalone JavaFX SDK, we load all of the needed DLLs from the SDK `bin` directory and everything works as expected.

When creating the jmods, we currently exclude the Microsoft DLLs from `javafx.graphics.jmod` to avoid the problem described in [JDK-8207015](https://bugs.openjdk.java.net/browse/JDK-8207015) where `jlink` complains about two modules (`java.base` and `javafx.graphics`) deliver the same file(s). That works as long as the set of Microsoft DLLs delivered by the JDK is from the same or newer version of Microsoft Visual Studio. This means that you can't take, for example, JDK 11.0.x and run the latest version of JavaFX, since JDK 11.x uses VS 2017 and JavaFX 15 (and later) uses VS 2019.

Up until now this has just been a minor bug, but we are now at the point where we need to update to VS 2019 for building JavaFX 11.0.15, which means that a jlinked JDK 11.0.X + JavaFX 11.0.15 will no longer work.

This fix is to add the Microsoft DLLs back into `javafx.graphics.jmod` (i.e., stop excluding them at build time), but deliver them in `bin/javafx` so they don't conflict with the ones delivered by the JDK.

The changes are:

1. `build.gradle` - When creating the jmods on Windows, copy all of the DLLs to a javafx sub-directory
2. `NativeLibLoader.java` - in the case of JavaFX modules jlinked into the Java runtime, load the libraries first from `${java.home}` rather than always falling back to `System::loadLibrary`. Most of the changes are just simple refactoring. The additional logic is in the new `libDirForJRT` method.

When running using the SDK or the modules on maven central, there is no change in behavior.

I've tested this on all platforms, including a test of a custom JDK 11.x created with jlink. On a Windows I tested it on a system where a key VS 2019 runtime library was not present in C:\Windows\System32 and it now runs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281089](https://bugs.openjdk.java.net/browse/JDK-8281089): JavaFX built with VS2019 and jlinked into JDK 11.x fails to start


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)
 * [Joeri Sykora](https://openjdk.java.net/census#sykora) (@tiainen - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/734/head:pull/734` \
`$ git checkout pull/734`

Update a local copy of the PR: \
`$ git checkout pull/734` \
`$ git pull https://git.openjdk.java.net/jfx pull/734/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 734`

View PR using the GUI difftool: \
`$ git pr show -t 734`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/734.diff">https://git.openjdk.java.net/jfx/pull/734.diff</a>

</details>
