### PR TITLE
8281953: NullPointer in InputMethod components in JFXPanel

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextInputControlSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextInputControlSkin.java
@@ -334,7 +334,10 @@ public abstract class TextInputControlSkin<T extends TextInputControl> extends S
         control.setInputMethodRequests(new ExtendedInputMethodRequests() {
             @Override public Point2D getTextLocation(int offset) {
                 Scene scene = getSkinnable().getScene();
-                Window window = scene.getWindow();
+                Window window = scene != null ? scene.getWindow() : null;
+                if (window == null) {
+                    return new Point2D(0, 0);
+                }
                 // Don't use imstart here because it isn't initialized yet.
                 Rectangle2D characterBounds = getCharacterBounds(control.getSelection().getStart() + offset);
                 Point2D p = getSkinnable().localToScene(characterBounds.getMinX(), characterBounds.getMaxY());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TextInputControlSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TextInputControlSkinTest.java
@@ -26,12 +26,14 @@
 package test.javafx.scene.control.skin;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import javafx.geometry.Point2D;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.skin.TextAreaSkin;
 import javafx.scene.control.skin.TextFieldSkin;
 import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -90,6 +92,17 @@ public class TextInputControlSkinTest {
         PasswordField passwordField = new PasswordField();
         passwordField.setSkin(new TextFieldSkin(passwordField));
         passwordField.setText(null);
+    }
+
+    @Test public void noNullPointerIfTextInputNotInScene() {
+        TextField textField = new TextField();
+        TextFieldSkin skin = new TextFieldSkin(textField);
+        textField.setSkin(skin);
+
+        // Check that no NullPointerException is thrown if the TextField is not in scene
+        // and that the default point is returned.
+        Point2D point = textField.getInputMethodRequests().getTextLocation(0);
+        assertEquals(new Point2D(0,0), point);
     }
 
     public class FocusableTextField extends TextField {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TextInputControlSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TextInputControlSkinTest.java
@@ -102,7 +102,7 @@ public class TextInputControlSkinTest {
         // Check that no NullPointerException is thrown if the TextField is not in scene
         // and that the default point is returned.
         Point2D point = textField.getInputMethodRequests().getTextLocation(0);
-        assertEquals(new Point2D(0,0), point);
+        assertEquals(new Point2D(0, 0), point);
     }
 
     public class FocusableTextField extends TextField {


### PR DESCRIPTION
If the InputMethod's node is not in the scene, the default text location point is returned.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281953](https://bugs.openjdk.java.net/browse/JDK-8281953): NullPointer in InputMethod components in JFXPanel


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/735/head:pull/735` \
`$ git checkout pull/735`

Update a local copy of the PR: \
`$ git checkout pull/735` \
`$ git pull https://git.openjdk.java.net/jfx pull/735/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 735`

View PR using the GUI difftool: \
`$ git pr show -t 735`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/735.diff">https://git.openjdk.java.net/jfx/pull/735.diff</a>

</details>
