### PR TITLE
8282100: Missed top/left bouncing for ScrollPane on Raspberry Pi with Touchscreen

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ScrollPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ScrollPaneSkin.java
@@ -1171,7 +1171,10 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
         final ScrollPane sp = getSkinnable();
         double x = isReverseNodeOrientation() ? (hsb.getMax() - (posX - hsb.getMin())) : posX;
         double hsbRange = hsb.getMax() - hsb.getMin();
-        double minX = hsbRange > 0 ? Math.min(-x / hsbRange * (nodeWidth - contentWidth), 0) : 0;
+        double minX = hsbRange > 0 ? -x / hsbRange * (nodeWidth - contentWidth) : 0;
+        if (!Properties.IS_TOUCH_SUPPORTED) {
+            minX = Math.min(minX, 0);
+        }
         viewContent.setLayoutX(snapPositionX(minX));
         if (!sp.hvalueProperty().isBound()) sp.setHvalue(Utils.clamp(sp.getHmin(), posX, sp.getHmax()));
         return posX;
@@ -1180,7 +1183,10 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
     private double updatePosY() {
         final ScrollPane sp = getSkinnable();
         double vsbRange = vsb.getMax() - vsb.getMin();
-        double minY = vsbRange > 0 ? Math.min(-posY / vsbRange * (nodeHeight - contentHeight), 0) : 0;
+        double minY = vsbRange > 0 ? -posY / vsbRange * (nodeHeight - contentHeight) : 0;
+        if (!Properties.IS_TOUCH_SUPPORTED) {
+            minY = Math.min(minY, 0);
+        }
         viewContent.setLayoutY(snapPositionY(minY));
         if (!sp.vvalueProperty().isBound()) sp.setVvalue(Utils.clamp(sp.getVmin(), posY, sp.getVmax()));
         return posY;


### PR DESCRIPTION
There is the bouncing when scrolling a node on a ScrollPane to the right/bottom (the node on the scroll pane is scrolled further than its width/height so the background is visible and then automatically is scrolled back to the node bounds) on Raspberry Pi with Touchscreen.
There is no bouncing when node is scrolled to the left/top.

The fix updates ScrollPaneSkin.updatePosX()/updatePosY() methods to not discard out of the range top/left minX/Y values in case the touch is supported.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282100](https://bugs.openjdk.java.net/browse/JDK-8282100): Missed top/left bouncing for ScrollPane on Raspberry Pi with Touchscreen


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/736/head:pull/736` \
`$ git checkout pull/736`

Update a local copy of the PR: \
`$ git checkout pull/736` \
`$ git pull https://git.openjdk.java.net/jfx pull/736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 736`

View PR using the GUI difftool: \
`$ git pr show -t 736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/736.diff">https://git.openjdk.java.net/jfx/pull/736.diff</a>

</details>
