### PR TITLE
8282104: Node zoom/rotate flickers on Raspberry Pi with Touchscreen

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxStatefulMultiTouchProcessor.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxStatefulMultiTouchProcessor.java
@@ -85,12 +85,18 @@ class LinuxStatefulMultiTouchProcessor extends LinuxTouchProcessor {
                             }
                             break;
                         case LinuxInput.ABS_X:
+                            if (currentSlot != 0) {
+                                break;
+                            }
                         case LinuxInput.ABS_MT_POSITION_X:
                             if (x == COORD_UNDEFINED) {
                                 x = value;
                             }
                             break;
                         case LinuxInput.ABS_Y:
+                            if (currentSlot != 0) {
+                                break;
+                            }
                         case LinuxInput.ABS_MT_POSITION_Y:
                             if (y == COORD_UNDEFINED) {
                                 y = value;


### PR DESCRIPTION
Zoomed/Rotated with two fingers rectangle flickers (unexpectedly becomes pretty small or large and then returns back to previous size several times during zooming/rotating) on a Raspberry Pi with Touchscreen.

The log with traced events shows that it is possible that only one ABS_MT_POSITION_X or ABS_MT_POSITION_Y can be sent for a given slot. In this case the corresponding omitted Y/X value is undefined and is assigned from ABS_Y/X value. This produces incorrect result for slots different from 0.

Example of the trace events log, enabled by `-Dmonocle.input.traceEvents.verbose=true -Dmonocle.input.traceEvents=true` flags:
```
traceEvent: Processing EV_ABS ABS_MT_SLOT 1 [index=48]
traceEvent: Processing EV_ABS ABS_MT_TRACKING_ID 302 [index=64]
traceEvent: Processing EV_ABS ABS_MT_POSITION_X 399 [index=80]
traceEvent: Processing EV_ABS ABS_MT_POSITION_Y 272 [index=96]
traceEvent: Processing EV_KEY BTN_TOUCH 1 [index=112]
traceEvent: Read EV_ABS ABS_MT_SLOT 0 [index=176]
traceEvent: Read EV_ABS ABS_MT_POSITION_Y 315 [index=192]
traceEvent: Read EV_ABS ABS_Y 315 [index=208]
traceEvent: Read EV_SYN SYN_REPORT 0 [index=224]

...

traceEvent: Read EV_ABS ABS_MT_SLOT 1 [index=320]
traceEvent: Read EV_ABS ABS_MT_POSITION_Y 271 [index=336]
traceEvent: Read EV_ABS ABS_X 552 [index=352]
traceEvent: Read EV_ABS ABS_Y 322 [index=368]
traceEvent: Read EV_SYN SYN_REPORT 0 [index=384]
```
First both ABS_MT_POSITION_X/Y events with values x: 399 and y: 272 are received for the slot 1.
Next only ABS_MT_POSITION_Y with y: 271 value is received (which implies that the x value has not been changed) for the slot 1.
The x value is undefined in the LinuxStatefulMultiTouchProcessor.processEvents() loop and is unexpectedly assigned to the ABS_X 552 value which belongs to the slot 0.

The fix skips setting ABS_X/Y values for slots different from 0.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282104](https://bugs.openjdk.org/browse/JDK-8282104): Node zoom/rotate flickers on Raspberry Pi with Touchscreen (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/737/head:pull/737` \
`$ git checkout pull/737`

Update a local copy of the PR: \
`$ git checkout pull/737` \
`$ git pull https://git.openjdk.org/jfx.git pull/737/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 737`

View PR using the GUI difftool: \
`$ git pr show -t 737`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/737.diff">https://git.openjdk.org/jfx/pull/737.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/737#issuecomment-1044858379)