### PR TITLE
8282134: Certain regex can cause a JS trap in WebView

### DIFF
--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -2135,7 +2135,7 @@ class YarrGenerator final : public YarrJITInfo, private MacroAssembler {
 
         if (!nonGreedyFailuresDecrementIndex.empty()) {
             nonGreedyFailuresDecrementIndex.link(this);
-            breakpoint();
+            sub32(TrustedImm32(1), index);
         }
         nonGreedyFailures.link(this);
         sub32(countRegister, index);

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/LoadTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/LoadTest.java
@@ -423,4 +423,12 @@ public class LoadTest extends TestBase {
             throw new AssertionError(ex);
         }
     }
+
+    // JDK-8282134 Certain regex can cause a JS trap in WebView
+    @Test public void jsRegexpTrapTest() {
+        final String FILE = "src/test/resources/test/html/unicode.html";
+        load(new File(FILE));
+        WebEngine web = getEngine();
+        assertTrue("Load task completed successfully", getLoadState() == SUCCEEDED);
+    }
 }

--- a/modules/javafx.web/src/test/resources/test/html/unicode.html
+++ b/modules/javafx.web/src/test/resources/test/html/unicode.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+    let a = "\ud800\ud800\udc00"
+    let b = /(.*[^x]+?)[^]*([1])/u
+    b.exec(a)
+</script>
+
+<p id="regtest">PASS</p>
+
+</body>
+</html>


### PR DESCRIPTION
Fix YarrJIT backtrackCharacterClassNonGreedy breakpoint() Certain regex can cause a JS trap in WebView

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282134](https://bugs.openjdk.java.net/browse/JDK-8282134): Certain regex can cause a JS trap in WebView


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/739/head:pull/739` \
`$ git checkout pull/739`

Update a local copy of the PR: \
`$ git checkout pull/739` \
`$ git pull https://git.openjdk.java.net/jfx pull/739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 739`

View PR using the GUI difftool: \
`$ git pr show -t 739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/739.diff">https://git.openjdk.java.net/jfx/pull/739.diff</a>

</details>
