### PR TITLE
8282099: Cherry-pick WebKit 613.1 stabilization fixes (2)

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/PageBlock.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/PageBlock.h
@@ -37,14 +37,15 @@ namespace WTF {
 // and recompiled. Sorry.
 //
 // macOS x86_64 uses 4 KiB, but Apple's aarch64 systems use 16 KiB. Use 16 KiB on all Apple systems
-// for consistency.
+// for consistency. Linux on Apple Silicon also needs to use 16KiB for best performance, so use that
+// for Linux on aarch64 as well.
 //
 // Most Linux and Windows systems use a page size of 4 KiB.
 //
 // On Linux, Power systems normally use 64 KiB pages.
 //
 // Use 64 KiB for any unknown CPUs to be conservative.
-#if OS(DARWIN) || PLATFORM(PLAYSTATION) || CPU(MIPS) || CPU(MIPS64)
+#if OS(DARWIN) || PLATFORM(PLAYSTATION) || CPU(MIPS) || CPU(MIPS64) || (OS(LINUX) && CPU(ARM64))
 constexpr size_t CeilingOnPageSize = 16 * KB;
 #elif CPU(PPC) || CPU(PPC64) || CPU(PPC64LE) || CPU(UNKNOWN)
 constexpr size_t CeilingOnPageSize = 64 * KB;

--- a/modules/javafx.web/src/main/native/Source/WebCore/CMakeLists.txt
+++ b/modules/javafx.web/src/main/native/Source/WebCore/CMakeLists.txt
@@ -1435,13 +1435,10 @@ elseif (USE_LIBEPOXY)
     add_definitions(${LIBEPOXY_DEFINITIONS})
 else ()
     if (USE_OPENGL)
-        list(APPEND WebCore_SYSTEM_INCLUDE_DIRECTORIES
-            ${OPENGL_INCLUDE_DIRS}
-        )
-        list(APPEND WebCore_LIBRARIES
-            ${OPENGL_LIBRARIES}
-        )
-        add_definitions(${OPENGL_DEFINITIONS})
+        list(APPEND WebCore_LIBRARIES OpenGL::OpenGL)
+        if (TARGET OpenGL::GLX)
+            list(APPEND WebCore_LIBRARIES OpenGL::GLX)
+        endif ()
     elseif (USE_OPENGL_ES)
         list(APPEND WebCore_LIBRARIES OpenGL::GLES)
     endif ()

--- a/modules/javafx.web/src/main/native/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -582,6 +582,7 @@ static bool isOnlyPseudoClassFunction(CSSSelector::PseudoClassType pseudoClassTy
     case CSSSelector::PseudoClassIs:
     case CSSSelector::PseudoClassMatches:
     case CSSSelector::PseudoClassWhere:
+    case CSSSelector::PseudoClassHas:
     case CSSSelector::PseudoClassNthChild:
     case CSSSelector::PseudoClassNthLastChild:
     case CSSSelector::PseudoClassNthOfType:

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
@@ -389,23 +389,24 @@ void InsertParagraphSeparatorCommand::doApply()
 
     // Move the start node and the siblings of the start node.
     if (VisiblePosition(insertionPosition) != VisiblePosition(positionBeforeNode(blockToInsert.get()))) {
-        Node* n;
+        RefPtr<Node> n;
         if (insertionPosition.containerNode() == startBlock)
             n = insertionPosition.computeNodeAfterPosition();
         else {
-            Node* splitTo = insertionPosition.containerNode();
+            RefPtr<Node> splitTo = insertionPosition.containerNode();
             if (is<Text>(*splitTo) && insertionPosition.offsetInContainerNode() >= caretMaxOffset(*splitTo))
                 splitTo = NodeTraversal::next(*splitTo, startBlock.get());
-            ASSERT(splitTo);
-            splitTreeToNode(*splitTo, *startBlock);
+            if (splitTo) {
+                splitTreeToNode(*splitTo, *startBlock);
 
-            for (n = startBlock->firstChild(); n; n = n->nextSibling()) {
-                if (VisiblePosition(insertionPosition) <= VisiblePosition(positionBeforeNode(n)))
-                    break;
+                for (n = startBlock->firstChild(); n; n = n->nextSibling()) {
+                    if (VisiblePosition(insertionPosition) <= VisiblePosition(positionBeforeNode(n.get())))
+                        break;
+                }
             }
         }
 
-        moveRemainingSiblingsToNewParent(n, blockToInsert.get(), *blockToInsert);
+        moveRemainingSiblingsToNewParent(n.get(), blockToInsert.get(), *blockToInsert);
     }
 
     // Handle whitespace that occurs after the split

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/FrameLoader.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/FrameLoader.cpp
@@ -1107,7 +1107,7 @@ void FrameLoader::setFirstPartyForCookies(const URL& url)
 
 // This does the same kind of work that didOpenURL does, except it relies on the fact
 // that a higher level already checked that the URLs match and the scrolling is the right thing to do.
-void FrameLoader::loadInSameDocument(const URL& url, SerializedScriptValue* stateObject, bool isNewNavigation)
+void FrameLoader::loadInSameDocument(URL url, RefPtr<SerializedScriptValue> stateObject, bool isNewNavigation)
 {
     FRAMELOADER_RELEASE_LOG(ResourceLoading, "loadInSameDocument: frame load started");
 
@@ -1169,7 +1169,7 @@ void FrameLoader::loadInSameDocument(const URL& url, SerializedScriptValue* stat
 
     m_client->dispatchDidNavigateWithinPage();
 
-    m_frame.document()->statePopped(stateObject ? Ref<SerializedScriptValue> { *stateObject } : SerializedScriptValue::nullValue());
+    m_frame.document()->statePopped(stateObject ? stateObject.releaseNonNull() : SerializedScriptValue::nullValue());
     m_client->dispatchDidPopStateWithinPage();
 
     if (hashChange) {
@@ -3223,7 +3223,7 @@ void FrameLoader::continueFragmentScrollAfterNavigationPolicy(const ResourceRequ
     }
 
     bool isRedirect = m_quickRedirectComing || policyChecker().loadType() == FrameLoadType::RedirectWithLockedBackForwardList;
-    loadInSameDocument(request.url(), 0, !isRedirect);
+    loadInSameDocument(request.url(), nullptr, !isRedirect);
 }
 
 bool FrameLoader::shouldPerformFragmentNavigation(bool isFormSubmission, const String& httpMethod, FrameLoadType loadType, const URL& url)

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/FrameLoader.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/FrameLoader.h
@@ -391,7 +391,7 @@ private:
     WEBCORE_EXPORT void detachChildren();
     void closeAndRemoveChild(Frame&);
 
-    void loadInSameDocument(const URL&, SerializedScriptValue* stateObject, bool isNewNavigation);
+    void loadInSameDocument(URL, RefPtr<SerializedScriptValue> stateObject, bool isNewNavigation);
 
     void prepareForLoadStart();
     void provisionalLoadStarted();

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/adwaita/ScrollbarThemeAdwaita.cpp
@@ -117,7 +117,7 @@ bool ScrollbarThemeAdwaita::paint(Scrollbar& scrollbar, GraphicsContext& graphic
     if (graphicsContext.paintingDisabled())
         return false;
 
-    if (!scrollbar.enabled())
+    if (!scrollbar.enabled() && usesOverlayScrollbars())
         return true;
 
     IntRect rect = scrollbar.frameRect();

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/GLContext.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/GLContext.cpp
@@ -25,13 +25,20 @@
 #include <wtf/ThreadSpecific.h>
 #include <wtf/text/StringToIntegerConversion.h>
 
+#if USE(LIBEPOXY)
+#include <epoxy/gl.h>
+#elif USE(OPENGL_ES)
+#include <GLES2/gl2.h>
+#else
+#include "OpenGLShims.h"
+#endif
+
 #if USE(EGL)
 #include "GLContextEGL.h"
 #endif
 
 #if USE(GLX)
 #include "GLContextGLX.h"
-#include "OpenGLShims.h"
 #endif
 
 using WTF::ThreadSpecific;

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/GLContext.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/GLContext.h
@@ -24,23 +24,21 @@
 #include "PlatformDisplay.h"
 #include <wtf/Noncopyable.h>
 
-#if USE(LIBEPOXY)
-#include <epoxy/gl.h>
-#elif USE(OPENGL_ES)
-#include <GLES2/gl2.h>
-#endif
-
 #if USE(EGL) && !PLATFORM(GTK)
-#if PLATFORM(WPE)
 // FIXME: For now default to the GBM EGL platform, but this should really be
-// somehow deducible from the build configuration.
+// somehow deducible from the build configuration. This is needed with libepoxy
+// as it could have been configured with X11 support enabled, resulting in
+// transitive inclusions of headers with definitions that clash with WebCore.
 #define __GBM__ 1
-#endif // PLATFORM(WPE)
+#if USE(LIBEPOXY)
+#include <epoxy/egl.h>
+#else // !USE(LIBEPOXY)
 #include <EGL/eglplatform.h>
+#endif // USE(LIBEPOXY)
 typedef EGLNativeWindowType GLNativeWindowType;
 #else // !USE(EGL) || PLATFORM(GTK)
 typedef uint64_t GLNativeWindowType;
-#endif
+#endif // USE(EGL) && !PLATFORM(GTK)
 
 #if USE(CAIRO)
 typedef struct _cairo_device cairo_device_t;

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/LayerOverlapMap.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/LayerOverlapMap.cpp
@@ -195,10 +195,9 @@ void OverlapMapContainer::mergeClippingScopesRecursive(const ClippingScope& sour
 
     for (auto& sourceChildScope : sourceScope.children) {
         ClippingScope* destChild = destScope.childWithLayer(sourceChildScope.layer);
-        if (destChild) {
-            destChild->rectList.append(sourceChildScope.rectList);
+        if (destChild)
             mergeClippingScopesRecursive(sourceChildScope, *destChild);
-        } else {
+        else {
             // New child, just copy the whole subtree.
             destScope.addChild(sourceChildScope);
         }

--- a/modules/javafx.web/src/main/native/Source/cmake/FindOpenGL.cmake
+++ b/modules/javafx.web/src/main/native/Source/cmake/FindOpenGL.cmake
@@ -1,12 +1,4 @@
-# - Try to Find OpenGL
-# Once done, this will define
-#
-#  OPENGL_FOUND - system has OpenGL installed.
-#  OPENGL_INCLUDE_DIRS - directories which contain the OpenGL headers.
-#  OPENGL_LIBRARIES - libraries required to link against OpenGL.
-#  OPENGL_DEFINITIONS - Compiler switches required for using OpenGL.
-#
-# Copyright (C) 2015 Igalia S.L.
+# Copyright (C) 2015, 2022 Igalia S.L.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -28,38 +20,125 @@
 # WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 # OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#[=======================================================================[.rst:
+FindOpenGL
+----------
+
+Find OpenGL headers and libraries.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+``OpenGL::OpenGL``
+  The main OpenGL library, if found. It must *not* be assumed that this
+  library provides symbols other than the base OpenGL set.
+``OpenGL::GLX``
+  The library containing the GL extension for the X11 windowing system,
+  if found.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables in your project:
+
+``OpenGL_FOUND``
+  True if the OpenGL library is available.
+``OpenGL_VERSION``
+  The version of the found OpenGL library, if possible to determine it at
+  build configuration time. The variable may be undefined.
+
+#]=======================================================================]
+
+# TODO:
+#  - Make GLX an optional component of the find-module.
+#  - Make EGL an optional component here, remove FindEGL.cmake.
+#  - Consider whether FindGLES2.cmake could be moved here as well.
 
 find_package(PkgConfig QUIET)
+pkg_check_modules(PC_OPENGL IMPORTED_TARGET opengl)
 
-pkg_check_modules(PC_OPENGL gl)
+if (PC_OPENGL_FOUND AND TARGET PkgConfig::PC_OPENGL)
+    #
+    # If the "opengl" module exists, it should be preferred; and the library
+    # name will typically be libOpenGL.so; in this case if GLX support is
+    # available a "glx" module will *also* be available. This is a modern
+    # Unix-ish convention and expected to be always provided by pkg-config
+    # modules, so there is no need to fall-back to manually using find_path()
+    # and find_library().
+    #
+    if (NOT TARGET OpenGL::OpenGL)
+        add_library(OpenGL::OpenGL INTERFACE IMPORTED GLOBAL)
+        set_property(TARGET OpenGL::OpenGL PROPERTY
+            INTERFACE_LINK_LIBRARIES PkgConfig::PC_OPENGL
+        )
+    endif ()
 
-if (PC_OPENGL_FOUND)
-    set(OPENGL_DEFINITIONS ${PC_OPENGL_CFLAGS_OTHER})
+    get_target_property(OpenGL_LIBRARY PkgConfig::PC_OPENGL INTERFACE_LINK_LIBRARIES)
+
+    pkg_check_modules(PC_GLX IMPORTED_TARGET glx)
+    if (TARGET PkgConfig::PC_GLX AND NOT TARGET OpenGL::GLX)
+        add_library(OpenGL::GLX INTERFACE IMPORTED GLOBAL)
+        set_property(TARGET OpenGL::GLX PROPERTY
+            INTERFACE_LINK_LIBRARIES PkgConfig::PC_GLX
+        )
+    endif ()
+else ()
+    # Otherwise, if an "opengl" pkg-config module does not exist, check for
+    # the "gl" one, which may or may not be present.
+    #
+    pkg_check_modules(PC_OPENGL gl)
+    find_path(OpenGL_INCLUDE_DIR
+        NAMES GL/gl.h
+        HINTS ${PC_OPENGL_INCLUDEDIR} ${PC_OPENGL_INCLUDE_DIRS}
+    )
+
+    find_library(OpenGL_LIBRARY
+        NAMES ${OpenGL_NAMES} gl GL
+        HINTS ${PC_OPENGL_LIBDIR} ${PC_OPENGL_LIBRARY_DIRS}
+    )
+
+    if (OpenGL_LIBRARY AND NOT TARGET OpenGL::OpenGL)
+        add_library(OpenGL::OpenGL UNKNOWN IMPORTED GLOBAL)
+        set_target_properties(OpenGL::OpenGL PROPERTIES
+            IMPORTED_LOCATION "${OpenGL_LIBRARY}"
+            INTERFACE_COMPILE_OPTIONS "${PC_OPENGL_CFLAGS_OTHER}"
+            INTERFACE_INCLUDE_DIRECTORIES "${OpenGL_INCLUDE_DIR}"
+        )
+    endif ()
+
+    if (TARGET OpenGL::OpenGL)
+        # We don't use find_package for GLX because it is part of -lGL, unlike EGL. We need to
+        # have OPENGL_INCLUDE_DIRS as part of the directories check_include_files() looks for in
+        # case OpenGL is installed into a non-standard location.
+        include(CMakePushCheckState)
+        CMAKE_PUSH_CHECK_STATE()
+        set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${OpenGL_INCLUDE_DIR})
+        include(CheckIncludeFiles)
+        check_include_files("GL/glx.h" OpenGL_GLX_FOUND)
+        CMAKE_POP_CHECK_STATE()
+
+        if (OpenGL_GLX_FOUND)
+            # XXX: Should this actually check that the OpenGL library contains the GLX symbols?
+            add_library(OpenGL::GLX INTERFACE IMPORTED GLOBAL)
+            set_property(TARGET OpenGL::GLX PROPERTY
+                INTERFACE_LINK_LIBRARIES OpenGL::OpenGL
+            )
+        endif ()
+    endif ()
 endif ()
 
-find_path(OPENGL_INCLUDE_DIRS NAMES GL/gl.h
-    HINTS ${PC_OPENGL_INCLUDEDIR} ${PC_OPENGL_INCLUDE_DIRS}
-)
-
-set(OPENGL_NAMES ${OPENGL_NAMES} gl GL)
-find_library(OPENGL_LIBRARIES NAMES ${OPENGL_NAMES}
-    HINTS ${PC_OPENGL_LIBDIR} ${PC_OPENGL_LIBRARY_DIRS}
-)
+set(OpenGL_VERSION "${PC_OPENGL_VERSION}")
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(OpenGL REQUIRED_VARS OPENGL_INCLUDE_DIRS OPENGL_LIBRARIES
-                                  FOUND_VAR OPENGL_FOUND)
+find_package_handle_standard_args(OpenGL
+    REQUIRED_VARS OpenGL_LIBRARY
+    FOUND_VAR OpenGL_FOUND
+)
 
-mark_as_advanced(OPENGL_INCLUDE_DIRS OPENGL_LIBRARIES)
+mark_as_advanced(OpenGL_INCLUDE_DIR OpenGL_LIBRARY)
 
-if (OPENGL_FOUND)
-    # We don't use find_package for GLX because it is part of -lGL, unlike EGL. We need to
-    # have OPENGL_INCLUDE_DIRS as part of the directories check_include_files() looks for in
-    # case OpenGL is installed into a non-standard location.
-    include(CMakePushCheckState)
-    CMAKE_PUSH_CHECK_STATE()
-    set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES} ${OPENGL_INCLUDE_DIRS})
-    include(CheckIncludeFiles)
-    check_include_files("GL/glx.h" GLX_FOUND)
-    CMAKE_POP_CHECK_STATE()
+if (OpenGL_FOUND)
+    set(OpenGL_LIBRARIES ${OpenGL_LIBRARY})
+    set(OpenGL_INCLUDE_DIRS ${OpenGL_INCLUDE_DIR})
 endif ()


### PR DESCRIPTION
Include additional stabilization fixes of WebKit 613.1
Sanity testing did not show any concerns.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282099](https://bugs.openjdk.java.net/browse/JDK-8282099): Cherry-pick WebKit 613.1 stabilization fixes (2)


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/740/head:pull/740` \
`$ git checkout pull/740`

Update a local copy of the PR: \
`$ git checkout pull/740` \
`$ git pull https://git.openjdk.java.net/jfx pull/740/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 740`

View PR using the GUI difftool: \
`$ git pr show -t 740`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/740.diff">https://git.openjdk.java.net/jfx/pull/740.diff</a>

</details>
