### PR TITLE
8251483: TableCell: NPE on modifying item's list

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/IndexedCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/IndexedCell.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/IndexedCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/IndexedCell.java
@@ -72,12 +72,17 @@ public class IndexedCell<T> extends Cell<T> {
      *                                                                         *
      **************************************************************************/
 
+    private int oldIndex = -1;
+
     // --- Index
     private ReadOnlyIntegerWrapper index = new ReadOnlyIntegerWrapper(this, "index", -1) {
         @Override protected void invalidated() {
-            boolean active = ((get() % 2) == 0);
+            int newIndex = get();
+            boolean active = ((newIndex % 2) == 0);
             pseudoClassStateChanged(PSEUDO_CLASS_EVEN,  active);
             pseudoClassStateChanged(PSEUDO_CLASS_ODD,  !active);
+
+            indexChanged(oldIndex, newIndex);
         }
     };
 
@@ -112,19 +117,25 @@ public class IndexedCell<T> extends Cell<T> {
      * Note: This function is intended to be used by experts, primarily
      *       by those implementing new Skins. It is not common
      *       for developers or designers to access this function directly.
-     * @param i the index associated with this indexed cell
+     * @param newIndex the index associated with this indexed cell
      */
-    public void updateIndex(int i) {
-        final int oldIndex = index.get();
-        index.set(i);
-        indexChanged(oldIndex, i);
+    public void updateIndex(int newIndex) {
+        oldIndex = index.get();
+
+        if (oldIndex == newIndex) {
+            // When the index wasn't changed the index property will not be invalidated,
+            // therefore indexChanged() is not called, so we will manually call it here.
+            indexChanged(oldIndex, newIndex);
+        } else {
+            index.set(newIndex);
+        }
     }
 
     /**
      * This method is called whenever the index is changed, regardless of whether
      * the new index is the same as the old index.
-     * @param oldIndex
-     * @param newIndex
+     * @param oldIndex the old index
+     * @param newIndex the new index
      */
     void indexChanged(int oldIndex, int newIndex) {
         // no-op

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
@@ -29,6 +29,7 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
 
+import javafx.beans.property.SimpleStringProperty;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -360,6 +361,33 @@ public class TableCellTest {
         table.getColumns().add(tableColumn);
 
         stageLoader = new StageLoader(table);
+    }
+
+    /**
+     * The item of the {@link TableRow} should not be null, when the {@link TableCell} is not empty.
+     * See also: JDK-8251483
+     */
+    @Test
+    public void testRowItemIsNotNullForNonEmptyCell() {
+        TableColumn<String, String> tableColumn = new TableColumn<>();
+        tableColumn.setCellValueFactory(cc -> new SimpleStringProperty(cc.getValue()));
+        tableColumn.setCellFactory(col -> new TableCell<>() {
+            @Override
+            protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+
+                if (!empty) {
+                    assertNotNull(getTableRow().getItem());
+                }
+            }
+        });
+        table.getColumns().add(tableColumn);
+
+        stageLoader = new StageLoader(table);
+
+        // Will create a new row and cell.
+        table.getItems().add("newItem");
+        Toolkit.getToolkit().firePulse();
     }
 
     /**

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
@@ -25,6 +25,7 @@
 
 package test.javafx.scene.control;
 
+import javafx.beans.property.SimpleStringProperty;
 import javafx.scene.control.skin.TreeTableCellSkin;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
@@ -701,6 +702,33 @@ public class TreeTableCellTest {
         tree.getColumns().add(treeTableColumn);
 
         stageLoader = new StageLoader(tree);
+    }
+
+    /**
+     * The item of the {@link TreeTableRow} should not be null, when the {@link TreeTableCell} is not empty.
+     * See also: JDK-8251483
+     */
+    @Test
+    public void testRowItemIsNotNullForNonEmptyCell() {
+        TreeTableColumn<String, String> treeTableColumn = new TreeTableColumn<>();
+        treeTableColumn.setCellValueFactory(cc -> new SimpleStringProperty(cc.getValue().getValue()));
+        treeTableColumn.setCellFactory(col -> new TreeTableCell<>() {
+            @Override
+            protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+
+                if (!empty) {
+                    assertNotNull(getTableRow().getItem());
+                }
+            }
+        });
+        tree.getColumns().add(treeTableColumn);
+
+        stageLoader = new StageLoader(tree);
+
+        // Will create a new row and cell.
+        tree.getRoot().getChildren().add(new TreeItem<>("newItem"));
+        Toolkit.getToolkit().firePulse();
     }
 
     /**


### PR DESCRIPTION
This PR fixes an issue where the item of the table row is null, although the cell itself is not empty (non null value).

The fix is to call `indexChanged(..)` immediately after the index was changed, but before all `indexProperty()` listener are notified.
The then notified listener in `TableRowSkinBase` will update the underlying cells, which will eventually result in an call to  `updateItem(..)`, where the NPE happened (and now not anymore, since the table row is now correctly setup before).

There is one special case: When the index didn't changed at all, we manually call `indexChanged(..)` (just like before) since when a property is not changed, `invalidated()` is not called, but we need to notify subclasses that `updateIndex(..)` was called.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8251483](https://bugs.openjdk.org/browse/JDK-8251483): TableCell: NPE on modifying item's list


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/741/head:pull/741` \
`$ git checkout pull/741`

Update a local copy of the PR: \
`$ git checkout pull/741` \
`$ git pull https://git.openjdk.org/jfx pull/741/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 741`

View PR using the GUI difftool: \
`$ git pr show -t 741`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/741.diff">https://git.openjdk.org/jfx/pull/741.diff</a>

</details>
