### PR TITLE
8282702: Button is pressed one more time on Raspberry Pi with Touchscreen

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxStatefulMultiTouchProcessor.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxStatefulMultiTouchProcessor.java
@@ -37,6 +37,7 @@ class LinuxStatefulMultiTouchProcessor extends LinuxTouchProcessor {
     private static final int COORD_UNDEFINED = Integer.MIN_VALUE;
     private int currentID = ID_UNASSIGNED;
     private int currentSlot = 0;
+    private TouchState pipelineState = new TouchState();
 
     private final Map<Integer, Integer> slotToIDMap =
             new HashMap<Integer, Integer>();
@@ -137,7 +138,8 @@ class LinuxStatefulMultiTouchProcessor extends LinuxTouchProcessor {
                             } else if (allPointsReleased) {
                                 state.clear();
                             }
-                            pipeline.pushState(state);
+                            state.copyTo(pipelineState);
+                            pipeline.pushState(pipelineState);
                             x = y = COORD_UNDEFINED;
                             allPointsReleased = false;
                             break;


### PR DESCRIPTION
Tapping on a button and next tapping on another place on the screen leads that the button is pressed twice on a Raspberry Pi with Touchscreen.

For example, run the [JFXButtonExample](https://bugs.openjdk.java.net/secure/attachment/98181/JFXButtonExample.java) 
app and first tap on the button in the left bottom side of the screen and second tap on the center of the screen.

This is a log of the state from LinuxStatefulMultiTouchProcessor.processEvents() method when `System.out.printf("state: %s%n", state);` code is added before the line:
https://github.com/openjdk/jfx/blob/2e8a4a5e97bb88a5807ae5fe075b98e1d54a4ca0/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxStatefulMultiTouchProcessor.java#L140
```
state: TouchState[1,TouchState.Point[id=91,x=257,y=419]]
state: TouchState[1,TouchState.Point[id=91,x=257,y=420]]
state: TouchState[0]
Hello World!
state: TouchState[2,TouchState.Point[id=91,x=257,y=419],TouchState.Point[id=92,x=410,y=265]]
state: TouchState[2,TouchState.Point[id=91,x=257,y=419],TouchState.Point[id=92,x=409,y=267]]
state: TouchState[2,TouchState.Point[id=91,x=257,y=419],TouchState.Point[id=92,x=408,y=286]]
state: TouchState[0]
Hello World!
```
The TouchState contains only button coordinates (x=257,y=419) for the first tap on the button.
The TouchState contains both the button coordinates  (x=257,y=419) and coordinates of the center of screen (x=408,y=286) for the second tap on the center of the screen.

This happens because when LinuxStatefulMultiTouchProcessor.processEvents() pushes the state with current touches to the pipeline the LookaheadTouchFilter  saves the current state and copies the previous saved state to the current state.
https://github.com/openjdk/jfx/blob/2e8a4a5e97bb88a5807ae5fe075b98e1d54a4ca0/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LookaheadTouchFilter.java#L74

That leads that the already deleted touch state (which contains the button coordinate) is restored. 

The proposed solution is to put the copy of the touch state to the pipeline .

Printing the touch state after the fix shows the log:
```
state: TouchState[1,TouchState.Point[id=65,x=267,y=423]]
state: TouchState[1,TouchState.Point[id=65,x=269,y=425]]
state: TouchState[0]
Hello World!
state: TouchState[1,TouchState.Point[id=66,x=414,y=243]]
state: TouchState[1,TouchState.Point[id=66,x=414,y=238]]
state: TouchState[0]
```
The TouchState does not contains the button coordinates for the second tap.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282702](https://bugs.openjdk.org/browse/JDK-8282702): Button is pressed one more time on Raspberry Pi with Touchscreen


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/746/head:pull/746` \
`$ git checkout pull/746`

Update a local copy of the PR: \
`$ git checkout pull/746` \
`$ git pull https://git.openjdk.org/jfx.git pull/746/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 746`

View PR using the GUI difftool: \
`$ git pr show -t 746`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/746.diff">https://git.openjdk.org/jfx/pull/746.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/746#issuecomment-1059771124)