### PR TITLE
8282703: Axis is not cached in the LinuxTouchTransform class

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxTouchTransform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxTouchTransform.java
@@ -117,6 +117,7 @@ class LinuxTouchTransform {
     private void initTransform(int axis, int index) {
         double range;
         String axisName;
+        axes[index] = axis;
         switch (axis) {
             case LinuxInput.ABS_X:
             case LinuxInput.ABS_MT_POSITION_X:

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxTouchTransform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxTouchTransform.java
@@ -62,6 +62,18 @@ class LinuxTouchTransform {
                                         + product + ".flipXY");
             return null;
         });
+
+        int index = 0;
+
+        if(device.isTouch()) {
+            initTransform(LinuxInput.ABS_X, index++);
+            initTransform(LinuxInput.ABS_Y, index++);
+        }
+
+        if (device.isMultiTouch()) {
+            initTransform(LinuxInput.ABS_MT_POSITION_X, index++);
+            initTransform(LinuxInput.ABS_MT_POSITION_Y, index++);
+        }
     }
 
     /** Gets the transformed pixel coordinate of the current event in the buffer
@@ -78,14 +90,6 @@ class LinuxTouchTransform {
             if (axes[i] == axis) {
                 return transform(i, value);
             }
-        }
-        if (i == axes.length) {
-            axes = Arrays.copyOf(axes, axes.length * 2);
-            Arrays.fill(axes, i + 1, axes.length - 1, -1);
-            translates = Arrays.copyOf(translates, translates.length * 2);
-            scalars = Arrays.copyOf(scalars, scalars.length * 2);
-            mins = Arrays.copyOf(mins, mins.length * 2);
-            maxs = Arrays.copyOf(maxs, maxs.length * 2);
         }
         initTransform(axis, i);
         return transform(i, value);
@@ -115,6 +119,16 @@ class LinuxTouchTransform {
     }
 
     private void initTransform(int axis, int index) {
+
+        if (index == axes.length) {
+            axes = Arrays.copyOf(axes, axes.length * 2);
+            Arrays.fill(axes, index + 1, axes.length - 1, -1);
+            translates = Arrays.copyOf(translates, translates.length * 2);
+            scalars = Arrays.copyOf(scalars, scalars.length * 2);
+            mins = Arrays.copyOf(mins, mins.length * 2);
+            maxs = Arrays.copyOf(maxs, maxs.length * 2);
+        }
+
         double range;
         String axisName;
         axes[index] = axis;


### PR DESCRIPTION
An axis is not cached in the LinuxTouchTransform class.

To reproduce the issue I added `System.out.printf("initTransform: axis: %d, index: %d%n", axis, index);` log to the LinuxTouchTransform.initTransform() method:
https://github.com/openjdk/jfx/blob/5112be957be70dd6521e6fb6ee64e669c148729c/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxTouchTransform.java#L117
run the [JFXButtonExample](https://bugs.openjdk.java.net/secure/attachment/98181/JFXButtonExample.java) sample and tapped the touch screen on a Raspberry Pi with Touchscreen.

The result was
```
initTransform: axis: 47, index: 0
initTransform: axis: 57, index: 0
initTransform: axis: 53, index: 0
initTransform: axis: 54, index: 0
initTransform: axis: 0, index: 0
initTransform: axis: 1, index: 0
initTransform: axis: 53, index: 0
initTransform: axis: 54, index: 0
initTransform: axis: 0, index: 0
initTransform: axis: 1, index: 0
initTransform: axis: 53, index: 0
initTransform: axis: 54, index: 0
initTransform: axis: 0, index: 0
initTransform: axis: 1, index: 0
```
The initTransform() is called several times for axis 0,1,47,53,54 and index is always set to zero.

The straight forward fix is to store the given axis in the axes array: "axes[index] = axis". This is the first commit for the current fix.
Using this fix the output with printf from initTransform() method looks like:
```
initTransform: axis: 47, index: 0
initTransform: axis: 57, index: 1
initTransform: axis: 53, index: 2
initTransform: axis: 54, index: 4
initTransform: axis: 1, index: 5
```
Now all axes are printed only once and the index value is different for each axes.

However, the minimum/maximum values are retrieved and cached for ABS_X/Y and ABS_MT_POSITION_X/Y axes after the fist tap on the screen.
The second commit improves this moving the ABS_X/Y and ABS_MT_POSITION_X/Y axes initialization into the LinuxTouchTransform constructor.

Now the touch logs look like:
```
// LinuxTouchTransform constructor
// device: /dev/input/mouse0
initTransform: axis: 0, index: 0
initTransform: axis: 1, index: 1
initTransform: axis: 53, index: 2
initTransform: axis: 54, index: 3

// LinuxTouchTransform constructor
// device: /dev/input/event2
initTransform: axis: 0, index: 0
initTransform: axis: 1, index: 1
initTransform: axis: 53, index: 2
initTransform: axis: 54, index: 3

// the first tap
initTransform: axis: 57, index: 4
initTransform: axis: 47, index: 5
```

The ABS_X/Y and ABS_MT_POSITION_X/Y axes and corresponding minimum/maximum values are initialized in the constructor. The other axes which stores only default values in translates and scalars arrays are initialized during touch events.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282703](https://bugs.openjdk.org/browse/JDK-8282703): Axis is not cached in the LinuxTouchTransform class (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/747/head:pull/747` \
`$ git checkout pull/747`

Update a local copy of the PR: \
`$ git checkout pull/747` \
`$ git pull https://git.openjdk.org/jfx.git pull/747/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 747`

View PR using the GUI difftool: \
`$ git pr show -t 747`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/747.diff">https://git.openjdk.org/jfx/pull/747.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/747#issuecomment-1059787637)