### PR TITLE
8281723: Spinner with split horizontal arrows and a border places right arrow incorrectly

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
@@ -336,7 +336,7 @@ public class SpinnerSkin<T> extends SkinBase<Spinner<T>> {
 
             // decrement is at the bottom
             decrementArrowButton.resize(w, tallestArrowButton);
-            positionInArea(decrementArrowButton, x, h - tallestArrowButton,
+            positionInArea(decrementArrowButton, x, y + h - tallestArrowButton,
                     w, tallestArrowButton, 0, HPos.CENTER, VPos.CENTER);
         } else if (layoutMode == SPLIT_ARROWS_HORIZONTAL) {
             // decrement is on the left-hand side
@@ -349,7 +349,7 @@ public class SpinnerSkin<T> extends SkinBase<Spinner<T>> {
 
             // increment is on the right-hand side
             incrementArrowButton.resize(widestArrowButton, h);
-            positionInArea(incrementArrowButton, w - widestArrowButton, y,
+            positionInArea(incrementArrowButton, x + w - widestArrowButton, y,
                     widestArrowButton, h, 0, HPos.CENTER, VPos.CENTER);
         }
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SpinnerSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SpinnerSkinTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.control.skin;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import javafx.geometry.BoundingBox;
+import javafx.geometry.Insets;
+import javafx.scene.control.Spinner;
+import javafx.scene.control.skin.SpinnerSkin;
+import javafx.scene.layout.Region;
+
+/**
+ * Tests for SpinnerSkin
+ */
+public class SpinnerSkinTest {
+    private static final double CONTROL_WIDTH = 300;
+    private static final double CONTROL_HEIGHT = 300;
+    private static final double PADDING_TOP = 5;
+    private static final double PADDING_RIGHT = 7;
+    private static final double PADDING_BOTTOM = 11;
+    private static final double PADDING_LEFT = 13;
+    private static final double WIDTH = CONTROL_WIDTH - PADDING_LEFT - PADDING_RIGHT;
+    private static final double HEIGHT = CONTROL_HEIGHT - PADDING_TOP - PADDING_BOTTOM;
+    private static final double PADDING_DECREMENT_ARROW_TOP = 1;
+    private static final double PADDING_DECREMENT_ARROW_RIGHT = 2;
+    private static final double PADDING_DECREMENT_ARROW_BOTTOM = 3;
+    private static final double PADDING_DECREMENT_ARROW_LEFT = 4;
+    private static final double PADDING_INCREMENT_ARROW_TOP = 2;
+    private static final double PADDING_INCREMENT_ARROW_RIGHT = 1;
+    private static final double PADDING_INCREMENT_ARROW_BOTTOM = 4;
+    private static final double PADDING_INCREMENT_ARROW_LEFT = 3;
+    private static final double DECREMENT_ARROW_WIDTH = PADDING_DECREMENT_ARROW_LEFT + PADDING_DECREMENT_ARROW_RIGHT;
+    private static final double DECREMENT_ARROW_HEIGHT = PADDING_DECREMENT_ARROW_TOP + PADDING_DECREMENT_ARROW_BOTTOM;
+    private static final double INCREMENT_ARROW_WIDTH = PADDING_INCREMENT_ARROW_LEFT + PADDING_INCREMENT_ARROW_RIGHT;
+    private static final double INCREMENT_ARROW_HEIGHT = PADDING_INCREMENT_ARROW_TOP + PADDING_INCREMENT_ARROW_BOTTOM;
+
+    private Spinner<?> spinner;
+
+    private Region decrementArrowButton;
+    private Region incrementArrowButton;
+
+    @Before
+    public void before() {
+        spinner = new Spinner<>();
+        spinner.resize(CONTROL_WIDTH, CONTROL_HEIGHT);
+        spinner.setSkin(new SpinnerSkin<>(spinner));
+
+        decrementArrowButton = (Region)spinner.lookup(".decrement-arrow-button");
+        incrementArrowButton = (Region)spinner.lookup(".increment-arrow-button");
+
+        // Give everything some weird paddings so anomalies should not go undetected:
+        spinner.setPadding(new Insets(PADDING_TOP, PADDING_RIGHT, PADDING_BOTTOM, PADDING_LEFT));
+        decrementArrowButton.setPadding(new Insets(PADDING_DECREMENT_ARROW_TOP, PADDING_DECREMENT_ARROW_RIGHT, PADDING_DECREMENT_ARROW_BOTTOM, PADDING_DECREMENT_ARROW_LEFT));
+        incrementArrowButton.setPadding(new Insets(PADDING_INCREMENT_ARROW_TOP, PADDING_INCREMENT_ARROW_RIGHT, PADDING_INCREMENT_ARROW_BOTTOM, PADDING_INCREMENT_ARROW_LEFT));
+    }
+
+    @Test
+    public void shouldPositionArrowsRightAndAboveEachOther() {  // This is the default style
+        spinner.layout();
+
+        double widest = Math.max(DECREMENT_ARROW_WIDTH, INCREMENT_ARROW_WIDTH);
+
+        assertEquals(new BoundingBox(PADDING_LEFT + WIDTH - widest, PADDING_TOP + HEIGHT / 2, widest, HEIGHT / 2), decrementArrowButton.getBoundsInParent());
+        assertEquals(new BoundingBox(PADDING_LEFT + WIDTH - widest, PADDING_TOP, widest, HEIGHT / 2), incrementArrowButton.getBoundsInParent());
+    }
+
+    @Test
+    public void shouldPositionArrowsLeftAndAboveEachOther() {
+        spinner.getStyleClass().setAll(Spinner.STYLE_CLASS_ARROWS_ON_LEFT_VERTICAL);
+        spinner.layout();
+
+        double widest = Math.max(DECREMENT_ARROW_WIDTH, INCREMENT_ARROW_WIDTH);
+
+        assertEquals(new BoundingBox(PADDING_LEFT, PADDING_TOP + HEIGHT / 2, widest, HEIGHT / 2), decrementArrowButton.getBoundsInParent());
+        assertEquals(new BoundingBox(PADDING_LEFT, PADDING_TOP, widest, HEIGHT / 2), incrementArrowButton.getBoundsInParent());
+    }
+
+    @Test
+    public void shouldPositionArrowsLeftAndNextToEachOther() {
+        spinner.getStyleClass().setAll(Spinner.STYLE_CLASS_ARROWS_ON_LEFT_HORIZONTAL);
+        spinner.layout();
+
+        assertEquals(new BoundingBox(PADDING_LEFT, PADDING_TOP, DECREMENT_ARROW_WIDTH, HEIGHT), decrementArrowButton.getBoundsInParent());
+        assertEquals(new BoundingBox(PADDING_LEFT + DECREMENT_ARROW_WIDTH, PADDING_TOP, INCREMENT_ARROW_WIDTH, HEIGHT), incrementArrowButton.getBoundsInParent());
+    }
+
+    @Test
+    public void shouldPositionArrowsRightAndNextToEachOther() {
+        spinner.getStyleClass().setAll(Spinner.STYLE_CLASS_ARROWS_ON_RIGHT_HORIZONTAL);
+        spinner.layout();
+
+        assertEquals(new BoundingBox(PADDING_LEFT + WIDTH - DECREMENT_ARROW_WIDTH - INCREMENT_ARROW_WIDTH, PADDING_TOP, DECREMENT_ARROW_WIDTH, HEIGHT), decrementArrowButton.getBoundsInParent());
+        assertEquals(new BoundingBox(PADDING_LEFT + WIDTH - INCREMENT_ARROW_WIDTH, PADDING_TOP, INCREMENT_ARROW_WIDTH, HEIGHT), incrementArrowButton.getBoundsInParent());
+    }
+
+    @Test
+    public void shouldPositionArrowsSplitLeftAndRight() {
+        spinner.getStyleClass().setAll(Spinner.STYLE_CLASS_SPLIT_ARROWS_HORIZONTAL);
+        spinner.layout();
+
+        double widest = Math.max(DECREMENT_ARROW_WIDTH, INCREMENT_ARROW_WIDTH);
+
+        assertEquals(new BoundingBox(PADDING_LEFT, PADDING_TOP, widest, HEIGHT), decrementArrowButton.getBoundsInParent());
+        assertEquals(new BoundingBox(PADDING_LEFT + WIDTH - widest, PADDING_TOP, widest, HEIGHT), incrementArrowButton.getBoundsInParent());
+    }
+
+    @Test
+    public void shouldPositionArrowsSplitTopAndBottom() {
+        spinner.getStyleClass().setAll(Spinner.STYLE_CLASS_SPLIT_ARROWS_VERTICAL);
+        spinner.layout();
+
+        double tallest = Math.max(DECREMENT_ARROW_HEIGHT, INCREMENT_ARROW_HEIGHT);
+
+        assertEquals(new BoundingBox(PADDING_LEFT, PADDING_TOP + HEIGHT - tallest, WIDTH, tallest), decrementArrowButton.getBoundsInParent());
+        assertEquals(new BoundingBox(PADDING_LEFT, PADDING_TOP, WIDTH, tallest), incrementArrowButton.getBoundsInParent());
+    }
+}


### PR DESCRIPTION
I added a test case for `SpinnerSkin` that checks the arrow positioning.

While adding the tests I discovered more problems with the positioning aside from the one mentioned in the JBS ticket.

1) Vertical split arrow placement also forgot to take the padding into account while placing the decrement arrow button -- I've taken the liberty to fix that problem as well in the same PR.

2) When arrows are placed next to each other either on the right or left, the arrow widths are not normalized to be the width of the widest arrow.  All other placements will normalize either the width or height, except for these two.  Specifically, when the arrows are **split** on the left and right they **are** normalized to the same width.  

For point 2, here is the problem illustrated with actual widths on left and layout result on right:

     [ <----- ] [ -> ] [ spinner ]       -->          [ <----- ] [ -> ] [ spinner ]
     [ spinner ] [ <----- ] [ -> ]       -->          [ spinner ] [ <----- ] [ -> ]

While for split horizontal it does normalize the width to that of the widest arrow, and so layout becomes:

     [ <----- ] [ spinner ] [ -> ]       -->          [ <----- ] [ spinner ] [   ->   ]

While I'm here I could fix this as well, and adjust the test case to match.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281723](https://bugs.openjdk.java.net/browse/JDK-8281723): Spinner with split horizontal arrows and a border places right arrow incorrectly


### Reviewers
 * [Marius Hanl](https://openjdk.java.net/census#mhanl) (@Maran23 - Author)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/748/head:pull/748` \
`$ git checkout pull/748`

Update a local copy of the PR: \
`$ git checkout pull/748` \
`$ git pull https://git.openjdk.java.net/jfx pull/748/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 748`

View PR using the GUI difftool: \
`$ git pr show -t 748`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/748.diff">https://git.openjdk.java.net/jfx/pull/748.diff</a>

</details>
