### PR TITLE
8282886: Mouse event is generated outside of node  on Raspberry Pi with Touchscreen

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxStatefulMultiTouchProcessor.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxStatefulMultiTouchProcessor.java
@@ -39,6 +39,8 @@ class LinuxStatefulMultiTouchProcessor extends LinuxTouchProcessor {
     private int currentID = ID_UNASSIGNED;
     private int currentSlot = 0;
     private final int[] slotToID;
+    private final int[] slotToX;
+    private final int[] slotToY;
 
     LinuxStatefulMultiTouchProcessor(LinuxInputDevice device) {
         super(device);
@@ -47,7 +49,11 @@ class LinuxStatefulMultiTouchProcessor extends LinuxTouchProcessor {
                 .getAbsoluteInputCapabilities(LinuxInput.ABS_MT_SLOT)
                 .getMaximum();
         slotToID = new int[maxSlots];
+        slotToX = new int[maxSlots];
+        slotToY = new int[maxSlots];
         Arrays.fill(slotToID, ID_UNASSIGNED);
+        Arrays.fill(slotToX, COORD_UNDEFINED);
+        Arrays.fill(slotToY, COORD_UNDEFINED);
     }
 
     @Override
@@ -157,12 +163,12 @@ class LinuxStatefulMultiTouchProcessor extends LinuxTouchProcessor {
             p.id = currentID;
             p = state.addPoint(p);
         }
-        if (x != COORD_UNDEFINED) {
-            p.x = x;
-        }
-        if (y != COORD_UNDEFINED) {
-            p.y = y;
-        }
+
+        p.x = (x != COORD_UNDEFINED) ? x : slotToX[currentSlot];
+        p.y = (y != COORD_UNDEFINED) ? y : slotToY[currentSlot];
+
+        slotToX[currentSlot] = p.x;
+        slotToY[currentSlot] = p.y;
     }
 
 }


### PR DESCRIPTION
Tapping on a circle in the center of the screen sometimes generates mouse click events outside the circle with x coordinates set to zero.

To reproduce the issue run the [JFXCircle](https://bugs.openjdk.java.net/secure/attachment/98241/JFXCircle.java) sample.
It has a circle in the center of the screen and a large rectangle under the circle which covers the whole screen.
Tap quickly 10 times on the circle. The output is:
```
circle mouse pressed [416.000000, 199.000000]: 1
circle mouse pressed [416.000000, 199.000000]: 2
circle mouse pressed [419.000000, 196.000000]: 3
circle mouse pressed [416.000000, 188.000000]: 4
circle mouse pressed [419.000000, 190.000000]: 5
rectangle mouse pressed [0.000000, 188.000000]
circle mouse pressed [422.000000, 185.000000]: 6
circle mouse pressed [418.000000, 191.000000]: 7
circle mouse pressed [417.000000, 187.000000]: 8
circle mouse pressed [420.000000, 185.000000]: 9
circle mouse pressed [416.000000, 187.000000]: 10
circle mouse pressed [417.000000, 192.000000]: 11
circle mouse pressed [420.000000, 188.000000]: 12 
```
One mouse event is reported by the rectangle with zero x coordinate.

The issue occurs when one of ABS_MT_POSITION_X or Y position is not reported.
For example, the output from `evtest /dev/input/event2`
```
Event: time 1646845728.905383, -------------- SYN_REPORT ------------
Event: time 1646845728.935382, type 3 (EV_ABS), code 57 (ABS_MT_TRACKING_ID), value 1308
Event: time 1646845728.935382, type 3 (EV_ABS), code 53 (ABS_MT_POSITION_X), value 449
Event: time 1646845728.935382, type 3 (EV_ABS), code 54 (ABS_MT_POSITION_Y), value 240
Event: time 1646845728.935382, type 1 (EV_KEY), code 330 (BTN_TOUCH), value 1
Event: time 1646845728.935382, type 3 (EV_ABS), code 0 (ABS_X), value 449
Event: time 1646845728.935382, type 3 (EV_ABS), code 1 (ABS_Y), value 240
Event: time 1646845728.935382, -------------- SYN_REPORT ------------
Event: time 1646845729.025363, type 3 (EV_ABS), code 54 (ABS_MT_POSITION_Y), value 242
Event: time 1646845729.025363, type 3 (EV_ABS), code 1 (ABS_Y), value 242
Event: time 1646845729.025363, -------------- SYN_REPORT ------------
Event: time 1646845729.055379, type 3 (EV_ABS), code 57 (ABS_MT_TRACKING_ID), value -1
Event: time 1646845729.055379, type 1 (EV_KEY), code 330 (BTN_TOUCH), value 0
Event: time 1646845729.055379, -------------- SYN_REPORT ------------
```
The first SYN_REPORT reports ABS_MT_POSITION_X/Y [449, 240] coordinates.
The second SYN_REPORT reports only ABS_MT_POSITION_Y value 242 and the ABS_MT_POSITION_X becomes undefined.
As a result, the LinuxStatefulMultiTouchProcessor.updatePoint(x, y) method does not set the p.x value and it is left as zero.
https://github.com/openjdk/jfx/blob/c6069d6845df4b90cca226e2b3dff49e3b48d8ac/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/LinuxStatefulMultiTouchProcessor.java#L161

The fix checks if ABS_MT_POSITION_X/Y value is undefined to use the previous ABS_MT_POSITION_X/Y value for the current slot.

The first commit queries ABS_MT_SLOT maximum value to store slot IDs in an array.
The second commit stores ABS_MT_POSITION_X/Y values in slotToX/Y values and uses them for current undefined values.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with the updated jcheck configuration)

### Issue
 * [JDK-8282886](https://bugs.openjdk.org/browse/JDK-8282886): Mouse event is generated outside of node  on Raspberry Pi with Touchscreen (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/749/head:pull/749` \
`$ git checkout pull/749`

Update a local copy of the PR: \
`$ git checkout pull/749` \
`$ git pull https://git.openjdk.org/jfx.git pull/749/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 749`

View PR using the GUI difftool: \
`$ git pr show -t 749`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/749.diff">https://git.openjdk.org/jfx/pull/749.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/749#issuecomment-1063228248)