### PR TITLE
8282054: Mediaplayer not working with HTTP Live Stream link with query parameter appended with file extension m3u8

### DIFF
--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/MediaUtils.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/MediaUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -158,13 +158,20 @@ public class MediaUtils {
                 contentType = CONTENT_TYPE_MP4;
             else if ((buf[8] & 0xff) == 0x4D && (buf[9] & 0xff) == 0x50 && (buf[10] & 0xff) == 0x34 && (buf[11] & 0xff) == 0x20) // 'MP4 '
                 contentType = CONTENT_TYPE_MP4;
+        } else if ((buf[0] & 0xff) == 0x23
+                && (buf[1] & 0xff) == 0x45
+                && (buf[2] & 0xff) == 0x58
+                && (buf[3] & 0xff) == 0x54
+                && (buf[4] & 0xff) == 0x4d
+                && (buf[5] & 0xff) == 0x33
+                && (buf[6] & 0xff) == 0x55) { // "#EXTM3U"
+            contentType = CONTENT_TYPE_M3U8;
         } else {
             throw new MediaException("Unrecognized file signature!");
         }
 
         return contentType;
     }
-
     /**
      * Returns the content type given the file name.
      *
@@ -172,35 +179,41 @@ public class MediaUtils {
      * @return content type
      */
     public static String filenameToContentType(String filename) {
-        String contentType = Locator.DEFAULT_CONTENT_TYPE;
+        if (filename == null) {
+            return Locator.DEFAULT_CONTENT_TYPE;
+        }
 
         int dotIndex = filename.lastIndexOf(".");
-
         if (dotIndex != -1) {
             String extension = filename.toLowerCase().substring(dotIndex + 1);
 
-            if (extension.equals(FILE_TYPE_AIF) || extension.equals(FILE_TYPE_AIFF)) {
-                contentType = CONTENT_TYPE_AIFF;
-            } else if (extension.equals(FILE_TYPE_FLV) || extension.equals(FILE_TYPE_FXM)) {
-                contentType = CONTENT_TYPE_JFX;
-            } else if (extension.equals(FILE_TYPE_MPA)) {
-                contentType = CONTENT_TYPE_MPA;
-            } else if (extension.equals(FILE_TYPE_WAV)) {
-                contentType = CONTENT_TYPE_WAV;
-            } else if (extension.equals(FILE_TYPE_MP4)) {
-                contentType = CONTENT_TYPE_MP4;
-            } else if (extension.equals(FILE_TYPE_M4A)) {
-                contentType = CONTENT_TYPE_M4A;
-            } else if (extension.equals(FILE_TYPE_M4V)) {
-                contentType = CONTENT_TYPE_M4V;
-            } else if (extension.equals(FILE_TYPE_M3U8)) {
-                contentType = CONTENT_TYPE_M3U8;
-            } else if (extension.equals(FILE_TYPE_M3U)) {
-                contentType = CONTENT_TYPE_M3U;
+            switch (extension) {
+                case FILE_TYPE_AIF:
+                case FILE_TYPE_AIFF:
+                    return CONTENT_TYPE_AIFF;
+                case FILE_TYPE_FLV:
+                case FILE_TYPE_FXM:
+                    return CONTENT_TYPE_JFX;
+                case FILE_TYPE_MPA:
+                    return CONTENT_TYPE_MPA;
+                case FILE_TYPE_WAV:
+                    return CONTENT_TYPE_WAV;
+                case FILE_TYPE_MP4:
+                    return CONTENT_TYPE_MP4;
+                case FILE_TYPE_M4A:
+                    return CONTENT_TYPE_M4A;
+                case FILE_TYPE_M4V:
+                    return CONTENT_TYPE_M4V;
+                case FILE_TYPE_M3U8:
+                    return CONTENT_TYPE_M3U8;
+                case FILE_TYPE_M3U:
+                    return CONTENT_TYPE_M3U;
+                default:
+                    break;
             }
         }
 
-        return contentType;
+        return Locator.DEFAULT_CONTENT_TYPE;
     }
 
     /**


### PR DESCRIPTION
- Problem was that our code which checks if URI ends with file extension was not considering that URI can have query parameters. Fixed by checking URI path, instead of actual URI.
- Also, creation of HLS Connection holder was missing checking for mimetype, since we do support URI without extensions as long as they provide correct mimetype.
- Added #EXTM3U to file signature check in case if extension and mimetype checks failed to determine stream type. All playlists of HLS based on spec should start with #EXTM3U. For some reason this particular stream has mimetype of "audio/x-mpegurl" and it is not mimetype from spec. Based on spec it should be "audio/mpegurl". Thus check for signature was added in case if URI does not use extension and has unsupported mimetype.

Note: audio will not work on Windows and Linux for stream provided in this bug report due to provided example uses separate audio stream via EXT-X-MEDIA tag and it is not supported. I filed separate issue for this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282054](https://bugs.openjdk.java.net/browse/JDK-8282054): Mediaplayer not working with HTTP Live Stream link with query parameter appended with file extension m3u8


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/750/head:pull/750` \
`$ git checkout pull/750`

Update a local copy of the PR: \
`$ git checkout pull/750` \
`$ git pull https://git.openjdk.java.net/jfx pull/750/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 750`

View PR using the GUI difftool: \
`$ git pr show -t 750`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/750.diff">https://git.openjdk.java.net/jfx/pull/750.diff</a>

</details>
