### PR TITLE
8283183: Skip failing PredefinedMeshManagerTest tests

### DIFF
--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/shape/PredefinedMeshManagerTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/shape/PredefinedMeshManagerTest.java
@@ -34,6 +34,7 @@ import javafx.scene.shape.Shape3D;
 import javafx.scene.shape.Sphere;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.sun.javafx.scene.NodeHelper;
@@ -78,6 +79,7 @@ public class PredefinedMeshManagerTest {
         testShapeAddition(box1again, 2);
     }
 
+    @Ignore("JDK-8282449")
     @Test
     public void sphereCacheTest() {
         Sphere sphere1 = new Sphere(10, 1000);
@@ -93,6 +95,7 @@ public class PredefinedMeshManagerTest {
         testShapeAddition(sphere1again, 2);
     }
 
+    @Ignore("JDK-8282449")
     @Test
     public void cylinderCacheTest() {
         Cylinder cylinder1 = new Cylinder(10, 20, 1000);


### PR DESCRIPTION
We continue to get intermittent test failures in `PredefinedMeshManagerTest` due to an OOM error. See the GitHub Actions run for [PR 753](https://github.com/openjdk/jfx/pull/753/checks?check_run_id=5559141397) for a recent failure. This test failure is tracked by [JDK-8282449](https://bugs.openjdk.java.net/browse/JDK-8282449). Until that test bug is fixed, I propose to skip the two test methods, `cylinderCacheTest` and `sphereCacheTest`, that allocate large meshes and are prone to OOM errors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283183](https://bugs.openjdk.java.net/browse/JDK-8283183): Skip failing PredefinedMeshManagerTest tests


### Reviewers
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/754/head:pull/754` \
`$ git checkout pull/754`

Update a local copy of the PR: \
`$ git checkout pull/754` \
`$ git pull https://git.openjdk.java.net/jfx pull/754/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 754`

View PR using the GUI difftool: \
`$ git pr show -t 754`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/754.diff">https://git.openjdk.java.net/jfx/pull/754.diff</a>

</details>
