### PR TITLE
8251480: TableColumnHeader: calc of cell width must respect row styling

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
@@ -53,6 +53,7 @@ import javafx.scene.AccessibleRole;
 import javafx.scene.Node;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Label;
+import javafx.scene.control.SkinBase;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableColumnBase;
@@ -645,9 +646,11 @@ public class TableColumnHeader extends Region {
             Region r = (Region) n;
             padding = r.snappedLeftInset() + r.snappedRightInset();
         }
-
-        TableRow<T> tableRow = new TableRow<>();
-        tableRow.updateTableView(tv);
+        Callback<TableView<T>, TableRow<T>> rowFactory = tv.getRowFactory();
+        TableRow<T> tableRow = rowFactory != null ? rowFactory.call(tv) : new TableRow<>();
+        tableSkin.getChildren().add(tableRow);
+        tableRow.applyCss();
+        ((SkinBase<?>) tableRow.getSkin()).getChildren().add(cell);
 
         int rows = maxRows == -1 ? items.size() : Math.min(items.size(), maxRows);
         double maxWidth = 0;
@@ -660,7 +663,7 @@ public class TableColumnHeader extends Region {
             cell.updateIndex(row);
 
             if ((cell.getText() != null && !cell.getText().isEmpty()) || cell.getGraphic() != null) {
-                tableSkin.getChildren().add(cell);
+                tableRow.applyCss();
                 cell.applyCss();
                 maxWidth = Math.max(maxWidth, cell.prefWidth(-1));
                 tableSkin.getChildren().remove(cell);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
@@ -712,7 +712,6 @@ public class TableColumnHeader extends Region {
             // have a SkinBase-derived skin
             tableRow = createMeasureRow(tv, tableSkin, null);
         }
-        assert tableRow.getSkin() instanceof SkinBase<?>;
         return tableRow;
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
@@ -647,9 +647,7 @@ public class TableColumnHeader extends Region {
             padding = r.snappedLeftInset() + r.snappedRightInset();
         }
         Callback<TableView<T>, TableRow<T>> rowFactory = tv.getRowFactory();
-        TableRow<T> tableRow = rowFactory != null ? rowFactory.call(tv) : new TableRow<>();
-        tableSkin.getChildren().add(tableRow);
-        tableRow.applyCss();
+        TableRow<T> tableRow = createMeasureRow(tv, tableSkin, rowFactory);
         ((SkinBase<?>) tableRow.getSkin()).getChildren().add(cell);
 
         int rows = maxRows == -1 ? items.size() : Math.min(items.size(), maxRows);
@@ -664,7 +662,6 @@ public class TableColumnHeader extends Region {
 
             if ((cell.getText() != null && !cell.getText().isEmpty()) || cell.getGraphic() != null) {
                 tableRow.applyCss();
-                cell.applyCss();
                 maxWidth = Math.max(maxWidth, cell.prefWidth(-1));
                 tableSkin.getChildren().remove(cell);
             }
@@ -702,6 +699,21 @@ public class TableColumnHeader extends Region {
         } else {
             TableColumnBaseHelper.setWidth(tc, maxWidth);
         }
+    }
+
+    private <T> TableRow<T> createMeasureRow(TableView<T> tv, TableViewSkinBase tableSkin,
+            Callback<TableView<T>, TableRow<T>> rowFactory) {
+        TableRow<T> tableRow = rowFactory != null ? rowFactory.call(tv) : new TableRow<>();
+        tableSkin.getChildren().add(tableRow);
+        tableRow.applyCss();
+        if (!(tableRow.getSkin() instanceof SkinBase<?>)) {
+            tableSkin.getChildren().remove(tableRow);
+            // recreate with null rowFactory will result in a standard TableRow that will
+            // have a SkinBase-derived skin
+            tableRow = createMeasureRow(tv, tableSkin, null);
+        }
+        assert tableRow.getSkin() instanceof SkinBase<?>;
+        return tableRow;
     }
 
     private <T,S> void resizeColumnToFitContent(TreeTableView<T> ttv, TreeTableColumn<T, S> tc, TableViewSkinBase tableSkin, int maxRows) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableColumnHeaderTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableColumnHeaderTest.java
@@ -30,6 +30,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.event.Event;
 import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.control.skin.TableColumnHeader;
@@ -252,4 +253,34 @@ public class TableColumnHeaderTest {
         assertEquals("Width must be equal to initial value",
                 width, column.getWidth(), 0.001);
     }
+
+    /**
+     * @test
+     * @bug 8251480 Row style must affect the required column width
+     */
+    @Test
+    public void test_resizeColumnToFitContentRowStyle() {
+        TableColumn column = tableView.getColumns().get(0);
+
+        tableView.setRowFactory(this::createSmallRow);
+        TableColumnHeaderShim.resizeColumnToFitContent(firstColumnHeader, -1);
+        double width = column.getWidth();
+
+        tableView.setRowFactory(this::createLargeRow);
+        TableColumnHeaderShim.resizeColumnToFitContent(firstColumnHeader, -1);
+        assertTrue("Column width must be greater", width < column.getWidth());
+    }
+
+    private TableRow<Person> createSmallRow(TableView<Person> param) {
+        TableRow<Person> row = new TableRow<>();
+        row.setStyle("-fx-font: 24 Amble");
+        return row;
+    }
+
+    private TableRow<Person> createLargeRow(TableView<Person> param) {
+        TableRow<Person> row = new TableRow<>();
+        row.setStyle("-fx-font: 48 Amble");
+        return row;
+    }
+
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableColumnHeaderTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableColumnHeaderTest.java
@@ -273,12 +273,6 @@ public class TableColumnHeaderTest {
         assertTrue("Column width must be greater", width < column.getWidth());
     }
 
-    private TableRow<Person> createSmallRow(TableView<Person> tableView) {
-        TableRow<Person> row = new TableRow<>();
-        row.setStyle("-fx-font: 24 Amble");
-        return row;
-    }
-
     /** Test resizeColumnToFitContent in the presence of a non-standard row skin */
     @Test
     public void test_resizeColumnToFitContentCustomRowSkin() {
@@ -292,7 +286,7 @@ public class TableColumnHeaderTest {
 
     private TableRow<Person> createCustomRow(TableView<Person> tableView) {
         TableRow<Person> row = new TableRow<>() {
-            protected javafx.scene.control.Skin<?> createDefaultSkin() {
+            protected Skin<?> createDefaultSkin() {
                 return new CustomSkin(this);
             };
         };
@@ -322,6 +316,12 @@ public class TableColumnHeaderTest {
         public void dispose() {
             node = null;
         }
+    }
+
+    private TableRow<Person> createSmallRow(TableView<Person> tableView) {
+        TableRow<Person> row = new TableRow<>();
+        row.setStyle("-fx-font: 24 Amble");
+        return row;
     }
 
     private TableRow<Person> createLargeRow(TableView<Person> param) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableColumnHeaderTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableColumnHeaderTest.java
@@ -29,6 +29,9 @@ import com.sun.javafx.tk.Toolkit;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.event.Event;
+import javafx.scene.Node;
+import javafx.scene.control.Skin;
+import javafx.scene.control.Skinnable;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
@@ -36,6 +39,8 @@ import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.control.skin.TableColumnHeader;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.HBox;
+
 import org.junit.Before;
 import org.junit.After;
 import org.junit.Test;
@@ -254,10 +259,7 @@ public class TableColumnHeaderTest {
                 width, column.getWidth(), 0.001);
     }
 
-    /**
-     * @test
-     * @bug 8251480 Row style must affect the required column width
-     */
+    /** Row style must affect the required column width */
     @Test
     public void test_resizeColumnToFitContentRowStyle() {
         TableColumn column = tableView.getColumns().get(0);
@@ -271,10 +273,55 @@ public class TableColumnHeaderTest {
         assertTrue("Column width must be greater", width < column.getWidth());
     }
 
-    private TableRow<Person> createSmallRow(TableView<Person> param) {
+    private TableRow<Person> createSmallRow(TableView<Person> tableView) {
         TableRow<Person> row = new TableRow<>();
         row.setStyle("-fx-font: 24 Amble");
         return row;
+    }
+
+    /** Test resizeColumnToFitContent in the presence of a non-standard row skin */
+    @Test
+    public void test_resizeColumnToFitContentCustomRowSkin() {
+        TableColumn column = tableView.getColumns().get(0);
+
+        tableView.setRowFactory(this::createCustomRow);
+        TableColumnHeaderShim.resizeColumnToFitContent(firstColumnHeader, -1);
+        double width = column.getWidth();
+        assertTrue(width > 0);
+    }
+
+    private TableRow<Person> createCustomRow(TableView<Person> tableView) {
+        TableRow<Person> row = new TableRow<>() {
+            protected javafx.scene.control.Skin<?> createDefaultSkin() {
+                return new CustomSkin(this);
+            };
+        };
+        return row;
+    }
+
+    private static class CustomSkin implements Skin<TableRow<?>> {
+
+        private TableRow<?> row;
+        private Node node = new HBox();
+
+        CustomSkin(TableRow<?> row) {
+            this.row = row;
+        }
+
+        @Override
+        public TableRow<?> getSkinnable() {
+            return row;
+        }
+
+        @Override
+        public Node getNode() {
+            return node;
+        }
+
+        @Override
+        public void dispose() {
+            node = null;
+        }
     }
 
     private TableRow<Person> createLargeRow(TableView<Person> param) {


### PR DESCRIPTION
This fix respects a row factory, if present.
It will put the cell that is used to measure the column width as child below the row.
In that way the row's style will be used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8251480](https://bugs.openjdk.java.net/browse/JDK-8251480): TableColumnHeader: calc of cell width must respect row styling


### Reviewers
 * [Marius Hanl](https://openjdk.java.net/census#mhanl) (@Maran23 - Author)
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/757/head:pull/757` \
`$ git checkout pull/757`

Update a local copy of the PR: \
`$ git checkout pull/757` \
`$ git pull https://git.openjdk.java.net/jfx pull/757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 757`

View PR using the GUI difftool: \
`$ git pr show -t 757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/757.diff">https://git.openjdk.java.net/jfx/pull/757.diff</a>

</details>
