### PR TITLE
8283346: Optimize observable ArrayList creation in FXCollections

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/collections/FXCollections.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/FXCollections.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -347,7 +347,7 @@ public class FXCollections {
      * @see #observableArrayList()
      */
     public static <E> ObservableList<E> observableArrayList(E... items) {
-        ObservableList<E> list = observableArrayList();
+        ObservableList<E> list = observableList(new ArrayList<>(items.length));
         list.addAll(items);
         return list;
     }
@@ -360,9 +360,7 @@ public class FXCollections {
      * @return a newly created observableArrayList
      */
     public static <E> ObservableList<E> observableArrayList(Collection<? extends E> col) {
-        ObservableList<E> list = observableArrayList();
-        list.addAll(col);
-        return list;
+        return observableList(new ArrayList<>(col));
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/collections/FXCollections.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/FXCollections.java
@@ -347,8 +347,7 @@ public class FXCollections {
      * @see #observableArrayList()
      */
     public static <E> ObservableList<E> observableArrayList(E... items) {
-        ArrayList<E> backingList = new ArrayList<>(items.length);
-        backingList.addAll(Arrays.asList(items));
+        ArrayList<E> backingList = new ArrayList<>(Arrays.asList(items));
         return observableList(backingList);
     }
 

--- a/modules/javafx.base/src/main/java/javafx/collections/FXCollections.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/FXCollections.java
@@ -347,8 +347,7 @@ public class FXCollections {
      * @see #observableArrayList()
      */
     public static <E> ObservableList<E> observableArrayList(E... items) {
-        ArrayList<E> backingList = new ArrayList<>(Arrays.asList(items));
-        return observableList(backingList);
+        return observableList(new ArrayList<>(Arrays.asList(items)));
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/collections/FXCollections.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/FXCollections.java
@@ -347,9 +347,9 @@ public class FXCollections {
      * @see #observableArrayList()
      */
     public static <E> ObservableList<E> observableArrayList(E... items) {
-        ObservableList<E> list = observableList(new ArrayList<>(items.length));
-        list.addAll(items);
-        return list;
+        ArrayList<E> backingList = new ArrayList<>(items.length);
+        backingList.addAll(Arrays.asList(items));
+        return observableList(backingList);
     }
 
     /**

--- a/modules/javafx.base/src/test/java/test/javafx/collections/FXCollectionsTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/FXCollectionsTest.java
@@ -53,7 +53,7 @@ public class FXCollectionsTest {
     }
 
     @Test
-    public void testCreateObservableArrayListFromList() {
+    public void testCreateObservableArrayListFromCollection() {
         List<String> list = List.of("1", "2", "3");
         ObservableList<String> observableList = FXCollections.observableArrayList(list);
 

--- a/modules/javafx.base/src/test/java/test/javafx/collections/FXCollectionsTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/FXCollectionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,47 @@ import javafx.collections.ObservableSet;
 import static org.junit.Assert.*;
 
 public class FXCollectionsTest {
+
+    @Test
+    public void testCreateObservableArrayListFromArray() {
+        ObservableList<String> observableList = FXCollections.observableArrayList("1", "2", "3");
+
+        assertEquals(3, observableList.size());
+        assertTrue(observableList.contains("1"));
+        assertTrue(observableList.contains("2"));
+        assertTrue(observableList.contains("3"));
+    }
+
+    @Test
+    public void testCreateObservableArrayListFromList() {
+        List<String> list = List.of("1", "2", "3");
+        ObservableList<String> observableList = FXCollections.observableArrayList(list);
+
+        assertEquals(3, observableList.size());
+        assertTrue(observableList.contains("1"));
+        assertTrue(observableList.contains("2"));
+        assertTrue(observableList.contains("3"));
+    }
+
+    @Test
+    public void testCreateObservableArrayListWithNullCollection() {
+        assertThrows(NullPointerException.class, () -> FXCollections.observableArrayList((Collection<Object>) null));
+    }
+
+    @Test
+    public void testCreateObservableArrayListWithNullArray() {
+        assertThrows(NullPointerException.class, () -> FXCollections.observableArrayList((Object[]) null));
+    }
+
+    @Test
+    public void testCreateObservableArrayListDoesNotModifyBackingCollection() {
+        List<String> list = List.of("1", "2", "3");
+        ObservableList<String> observableList = FXCollections.observableArrayList(list);
+        observableList.add("4");
+
+        assertEquals(4, observableList.size());
+        assertEquals(3, list.size());
+    }
 
     @Test
     @SuppressWarnings("unchecked")

--- a/modules/javafx.base/src/test/java/test/javafx/collections/FXCollectionsTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/FXCollectionsTest.java
@@ -44,23 +44,23 @@ public class FXCollectionsTest {
 
     @Test
     public void testCreateObservableArrayListFromArray() {
-        ObservableList<String> observableList = FXCollections.observableArrayList("1", "2", "3");
+        ObservableList<String> observableList = FXCollections.observableArrayList("1", "2", null);
 
         assertEquals(3, observableList.size());
         assertTrue(observableList.contains("1"));
         assertTrue(observableList.contains("2"));
-        assertTrue(observableList.contains("3"));
+        assertTrue(observableList.contains(null));
     }
 
     @Test
     public void testCreateObservableArrayListFromCollection() {
-        List<String> list = List.of("1", "2", "3");
+        List<String> list = Arrays.asList("1", "2", null);
         ObservableList<String> observableList = FXCollections.observableArrayList(list);
 
         assertEquals(3, observableList.size());
         assertTrue(observableList.contains("1"));
         assertTrue(observableList.contains("2"));
-        assertTrue(observableList.contains("3"));
+        assertTrue(observableList.contains(null));
     }
 
     @Test

--- a/modules/javafx.base/src/test/java/test/javafx/collections/FXCollectionsTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/FXCollectionsTest.java
@@ -74,7 +74,7 @@ public class FXCollectionsTest {
     }
 
     @Test
-    public void testCreateObservableArrayListDoesNotModifyBackingCollection() {
+    public void testCreateObservableArrayListDoesNotModifyOriginalCollection() {
         List<String> list = List.of("1", "2", "3");
         ObservableList<String> observableList = FXCollections.observableArrayList(list);
         observableList.add("4");


### PR DESCRIPTION
This simple PR optimizes the observable `ArrayList` creation by using the ArrayList constructor/array size so that the underlying array will be initialized at the correct size which will speed up the creation as the array does not need to grow as a result of the `addAll` call.

I also added tests which will succeed before and after to verify that nothing got broken by this change.
Also I made a benchmark test. Results:

| Benchmark | Mode| Cnt | Score | Error | Units
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| ListBenchmark OLD  | thrpt | 25 | 722,842 | ± 26,93 | ops/s
| ListBenchmark NEW | thrpt  | 25 | 29262,274 | ± 2088,712 | ops/s

Edit: I also made a synthetic benchmark by measuring the same code below 100 times with `System.nanoTime`.
ListBenchmark OLD (avg): 21-23ms
ListBenchmark NEW (avg): 2 ms

<details><summary>Benchmark code</summary>

```
import javafx.collections.FXCollections;
import javafx.collections.ObservableList;
import org.openjdk.jmh.annotations.Benchmark;
import org.openjdk.jmh.annotations.Scope;
import org.openjdk.jmh.annotations.Setup;
import org.openjdk.jmh.annotations.State;
import org.openjdk.jmh.annotations.TearDown;

import java.util.ArrayList;
import java.util.List;

@State(Scope.Benchmark)
public class ListBenchmark {

    List<String> strings;

    @Setup
    public void setup() {
        strings = new ArrayList<>();
        for(int i = 0; i< 100000;i++) {
            strings.add("abc: " + i);
        }
    }

    @TearDown
    public void tearDown() {
        strings = null;
    }

    @Benchmark
    public ObservableList<String> init() {
        return FXCollections.observableArrayList(strings);
    }
}
```

</details>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8283346](https://bugs.openjdk.org/browse/JDK-8283346): Optimize observable ArrayList creation in FXCollections


### Reviewers
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Author)
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/758/head:pull/758` \
`$ git checkout pull/758`

Update a local copy of the PR: \
`$ git checkout pull/758` \
`$ git pull https://git.openjdk.org/jfx pull/758/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 758`

View PR using the GUI difftool: \
`$ git pr show -t 758`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/758.diff">https://git.openjdk.org/jfx/pull/758.diff</a>

</details>
