### PR TITLE
8283509: Invisible menus can lead to IndexOutOfBoundsException

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
@@ -1118,7 +1118,7 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
         int i = 0;
         int nextIndex = 0;
 
-        // Traverse all menus in menubar to find nextIndex
+        // Traverse all visible menus in menubar to find nextIndex
         while (i < totalMenus) {
             i++;
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuBarSkin.java
@@ -90,6 +90,8 @@ import com.sun.javafx.scene.SceneHelper;
 import com.sun.javafx.scene.control.GlobalMenuAdapter;
 import com.sun.javafx.tk.Toolkit;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
 import javafx.stage.Window;
 import javafx.util.Pair;
 
@@ -1110,7 +1112,9 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
             return Optional.empty();
         }
 
-        final int totalMenus = getSkinnable().getMenus().size();
+        List<Menu> visibleMenus = getSkinnable().getMenus().stream().filter(Menu::isVisible)
+                .collect(Collectors.toList());
+        final int totalMenus = visibleMenus.size();
         int i = 0;
         int nextIndex = 0;
 
@@ -1126,7 +1130,7 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
             }
 
             // if menu at nextIndex is disabled, skip it
-            if (getSkinnable().getMenus().get(nextIndex).isDisable()) {
+            if (visibleMenus.get(nextIndex).isDisable()) {
                 // Calculate new nextIndex by continuing loop
                 startIndex = nextIndex;
             } else {
@@ -1136,7 +1140,7 @@ public class MenuBarSkin extends SkinBase<MenuBar> {
         }
 
         clearMenuButtonHover();
-        return Optional.of(new Pair<>(getSkinnable().getMenus().get(nextIndex), nextIndex));
+        return Optional.of(new Pair<>(visibleMenus.get(nextIndex), nextIndex));
     }
 
     private void updateFocusedIndex() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/MenuBarSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/MenuBarSkinTest.java
@@ -28,10 +28,16 @@ package test.javafx.scene.control.skin;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
 import com.sun.javafx.menu.MenuBase;
 import com.sun.javafx.stage.WindowHelper;
-import test.com.sun.javafx.pgstub.StubToolkit;
 import com.sun.javafx.tk.Toolkit;
+
 import javafx.beans.value.ObservableValue;
 import javafx.geometry.Insets;
 import javafx.scene.Group;
@@ -39,14 +45,12 @@ import javafx.scene.Scene;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuBar;
 import javafx.scene.control.MenuItem;
-import javafx.stage.Stage;
-
-import java.util.List;
 import javafx.scene.control.skin.MenuBarSkin;
-
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import javafx.scene.control.skin.MenuBarSkinShim;
+import javafx.scene.input.KeyCode;
+import javafx.stage.Stage;
+import test.com.sun.javafx.pgstub.StubToolkit;
+import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
 
 /**
  * This fails with IllegalStateException because of the toolkit's check for the FX application thread
@@ -192,6 +196,16 @@ public class MenuBarSkinTest {
             // original menubar is the system menubar
             assertTrue(menubar.isUseSystemMenuBar());
         }
+    }
+
+    @Test
+    public void testInvisibleMenuNavigation() {
+        menubar.getMenus().get(0).setVisible(false);
+        MenuBarSkinShim.setFocusedMenuIndex(skin, 0);
+
+        KeyEventFirer keyboard = new KeyEventFirer(menubar);
+        keyboard.doKeyPress(KeyCode.LEFT);
+        tk.firePulse();
     }
 
     public static final class MenuBarSkinMock extends MenuBarSkin {


### PR DESCRIPTION
findSibling adapted to only use visible menus when calculating the
index.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283509](https://bugs.openjdk.java.net/browse/JDK-8283509): Invisible menus can lead to IndexOutOfBoundsException


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/759/head:pull/759` \
`$ git checkout pull/759`

Update a local copy of the PR: \
`$ git checkout pull/759` \
`$ git pull https://git.openjdk.java.net/jfx pull/759/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 759`

View PR using the GUI difftool: \
`$ git pr show -t 759`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/759.diff">https://git.openjdk.java.net/jfx/pull/759.diff</a>

</details>
