### PR TITLE
Cache native libraries with architecture-dependent paths

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -235,8 +235,9 @@ public class NativeLibLoader {
     private static String cacheLibrary(InputStream is, String name, Class caller) throws IOException {
         String jfxVersion = System.getProperty("javafx.runtime.version", "versionless");
         String userCache = System.getProperty("javafx.cachedir", "");
+        String arch = System.getProperty("os.arch");
         if (userCache.isEmpty()) {
-            userCache = System.getProperty("user.home") + "/.openjfx/cache/" + jfxVersion;
+            userCache = System.getProperty("user.home") + "/.openjfx/cache/" + jfxVersion + "/" + arch;
         }
         File cacheDir = new File(userCache);
         boolean cacheDirOk = true;
@@ -257,7 +258,8 @@ public class NativeLibLoader {
         }
         if (!cacheDirOk) {
             String username = System.getProperty("user.name", "anonymous");
-            String tmpCache = System.getProperty("java.io.tmpdir") + "/.openjfx_" + username + "/cache/" + jfxVersion;
+            String tmpCache = System.getProperty("java.io.tmpdir") + "/.openjfx_" + username
+                    + "/cache/" + jfxVersion + "/" + arch;
             cacheDir = new File(tmpCache);
             if (cacheDir.exists()) {
                 if (!cacheDir.isDirectory()) {


### PR DESCRIPTION
Currently, OpenJFX extracts the native library into a local folder and loads it when it is not part of the JRE.

Now we have a notable problem with the fact that a platform may actually run programs of multiple CPU architectures.

Most commonly, 32-bit x86 applications can be executed on Windows AMD64. In addition to this, ARM machines may also execute AMD64 programs by transpiling.

For OpenJFX of different architectures on the same system, their native libraries have the same file name, but their contents are different. Since they will try to unpack the native library into the same folder, this will cause file conflicts.

A practical example is when I run the same JavaFX application with both 32-bit and 64-bit Java on a Windows AMD64 platform, and the application that starts later crashes because it cannot unzip the native libraries:

Crash logs (The length exceeds the GitHub limit): https://paste.ubuntu.com/p/NZBK3pNrh7/

Here I avoid the problem by adding `os.arch` to the cache path. 

I ran the tests on Ubuntu 20.04 after the modification and no tests were broken.