### PR TITLE
8284812: Change JavaFX release version in jfx18 branch to 18.0.1

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -24,7 +24,7 @@
 [general]
 project=openjfx
 jbs=jdk
-version=openjfx18
+version=openjfx18.0.1
 
 [repository]
 tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9]((\.\d{1,3}){0,2})-((b\d{2,3})|(ga))|[1-9]u(\d{1,3})-((b\d{2,3})|(ga))

--- a/build.properties
+++ b/build.properties
@@ -41,7 +41,7 @@ jfx.release.suffix=-ea
 # UPDATE THE FOLLOWING VALUES FOR A NEW RELEASE
 jfx.release.major.version=18
 jfx.release.minor.version=0
-jfx.release.security.version=0
+jfx.release.security.version=1
 jfx.release.patch.version=0
 
 # Note: The release version is now calculated in build.gradle as the


### PR DESCRIPTION
Update JavaFX release version to 18.0.1 in jfx18 branch

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8284812](https://bugs.openjdk.java.net/browse/JDK-8284812): Change JavaFX release version in jfx18 branch to 18.0.1


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/769/head:pull/769` \
`$ git checkout pull/769`

Update a local copy of the PR: \
`$ git checkout pull/769` \
`$ git pull https://git.openjdk.java.net/jfx pull/769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 769`

View PR using the GUI difftool: \
`$ git pr show -t 769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/769.diff">https://git.openjdk.java.net/jfx/pull/769.diff</a>

</details>
