### PR TITLE
8281459: WebKit 613.1 build broken on M1

### DIFF
--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -1654,16 +1654,6 @@ public:
         loadDouble(Address(src, offset.m_value + 8), dest2);
     }
 
-    void loadPair64(RegisterID src, FPRegisterID dest1, FPRegisterID dest2)
-    {
-        loadPair64(src, TrustedImm32(0), dest1, dest2);
-    }
-
-    void loadPair64(RegisterID src, TrustedImm32 offset, FPRegisterID dest1, FPRegisterID dest2)
-    {
-        m_assembler.ldp<64>(dest1, dest2, src, offset.m_value);
-    }
-
     void abortWithReason(AbortReason reason)
     {
         // It is safe to use dataTempRegister directly since this is a crashing JIT Assert.
@@ -2043,16 +2033,6 @@ public:
         }
         storeDouble(src1, Address(dest, offset.m_value));
         storeDouble(src2, Address(dest, offset.m_value + 8));
-    }
-
-    void storePair64(FPRegisterID src1, FPRegisterID src2, RegisterID dest)
-    {
-        storePair64(src1, src2, dest, TrustedImm32(0));
-    }
-
-    void storePair64(FPRegisterID src1, FPRegisterID src2, RegisterID dest, TrustedImm32 offset)
-    {
-        m_assembler.stp<64>(src1, src2, dest, offset.m_value);
     }
 
     void store32(RegisterID src, ImplicitAddress address)


### PR DESCRIPTION
Reviewed-by: kcr, jvos

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281459](https://bugs.openjdk.java.net/browse/JDK-8281459): WebKit 613.1 build broken on M1


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/771/head:pull/771` \
`$ git checkout pull/771`

Update a local copy of the PR: \
`$ git checkout pull/771` \
`$ git pull https://git.openjdk.java.net/jfx pull/771/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 771`

View PR using the GUI difftool: \
`$ git pr show -t 771`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/771.diff">https://git.openjdk.java.net/jfx/pull/771.diff</a>

</details>
