### PR TITLE
8281711: Cherry-pick WebKit 613.1 stabilization fixes

### DIFF
--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/API/JSRetainPtr.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/API/JSRetainPtr.h
@@ -32,6 +32,7 @@
 #include <JavaScriptCore/JSObjectRef.h>
 #include <JavaScriptCore/JSStringRef.h>
 #include <algorithm>
+#include <utility>
 
 inline void JSRetain(JSClassRef context) { JSClassRetain(context); }
 inline void JSRelease(JSClassRef context) { JSClassRelease(context); }

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/assembler/MacroAssemblerX86Common.cpp
@@ -176,6 +176,7 @@ static_assert((PROBE_EXECUTOR_OFFSET + PTR_SIZE) <= (PROBE_SIZE + OUT_SIZE), "Mu
 #if CPU(X86)
 #if COMPILER(GCC_COMPATIBLE)
 asm (
+    ".text" "\n"
     ".globl " SYMBOL_STRING(ctiMasmProbeTrampoline) "\n"
     HIDE_SYMBOL(ctiMasmProbeTrampoline) "\n"
     SYMBOL_STRING(ctiMasmProbeTrampoline) ":" "\n"
@@ -516,6 +517,7 @@ extern "C" __declspec(naked) void ctiMasmProbeTrampoline()
 #if CPU(X86_64)
 #if COMPILER(GCC_COMPATIBLE)
 asm (
+    ".text" "\n"
     ".globl " SYMBOL_STRING(ctiMasmProbeTrampoline) "\n"
     HIDE_SYMBOL(ctiMasmProbeTrampoline) "\n"
     SYMBOL_STRING(ctiMasmProbeTrampoline) ":" "\n"

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/bytecode/AccessCase.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/bytecode/AccessCase.cpp
@@ -123,16 +123,50 @@ Ref<AccessCase> AccessCase::create(VM& vm, JSCell* owner, AccessType type, Cache
 
 RefPtr<AccessCase> AccessCase::createTransition(
     VM& vm, JSCell* owner, CacheableIdentifier identifier, PropertyOffset offset, Structure* oldStructure, Structure* newStructure,
-    const ObjectPropertyConditionSet& conditionSet, RefPtr<PolyProtoAccessChain>&& prototypeAccessChain)
+    const ObjectPropertyConditionSet& conditionSet, RefPtr<PolyProtoAccessChain>&& prototypeAccessChain, const StructureStubInfo& stubInfo)
 {
     RELEASE_ASSERT(oldStructure == newStructure->previousID());
 
     // Skip optimizing the case where we need a realloc, if we don't have
     // enough registers to make it happen.
-    if (GPRInfo::numberOfRegisters < 6
-        && oldStructure->outOfLineCapacity() != newStructure->outOfLineCapacity()
-        && oldStructure->outOfLineCapacity()) {
-        return nullptr;
+    if (oldStructure->outOfLineCapacity() != newStructure->outOfLineCapacity()) {
+        // In 64 bits jsc uses 1 register for value, and it uses 2 registers in 32 bits
+        size_t requiredRegisters = 1; // stubInfo.valueRegs()
+#if USE(JSVALUE32_64)
+        ++requiredRegisters;
+#endif
+
+        // 1 register for the property in 64 bits
+        ++requiredRegisters;
+#if USE(JSVALUE32_64)
+        // In 32 bits, jsc uses may use one extra register, if it is not a Cell
+        if (stubInfo.propertyRegs().tagGPR() != InvalidGPRReg)
+            ++requiredRegisters;
+#endif
+
+        // 1 register for the base in 64 bits
+        ++requiredRegisters;
+#if USE(JSVALUE32_64)
+        // In 32 bits, jsc uses may use one extra register, if it is not a Cell
+        if (stubInfo.baseRegs().tagGPR() != InvalidGPRReg)
+            ++requiredRegisters;
+#endif
+
+        if (stubInfo.m_stubInfoGPR != InvalidGPRReg)
+            ++requiredRegisters;
+        if (stubInfo.m_arrayProfileGPR != InvalidGPRReg)
+            ++requiredRegisters;
+
+        // One extra register for scratchGPR
+        ++requiredRegisters;
+
+        // Check if we have enough registers when reallocating
+        if (oldStructure->outOfLineCapacity() && GPRInfo::numberOfRegisters < requiredRegisters)
+            return nullptr;
+
+        // If we are (re)allocating inline, jsc needs two extra scratchGPRs
+        if (!oldStructure->couldHaveIndexingHeader() && GPRInfo::numberOfRegisters < (requiredRegisters + 2))
+            return nullptr;
     }
 
     return adoptRef(*new AccessCase(vm, owner, Transition, identifier, offset, newStructure, conditionSet, WTFMove(prototypeAccessChain)));
@@ -1484,11 +1518,10 @@ void AccessCase::generateWithGuard(
                 notInt.link(&jit);
 #if USE(JSVALUE64)
                 jit.unboxDoubleWithoutAssertions(valueRegs.payloadGPR(), scratch2GPR, state.scratchFPR);
-                failAndRepatch.append(jit.branchIfNaN(state.scratchFPR));
 #else
-                failAndRepatch.append(jit.branch32(CCallHelpers::Above, valueRegs.tagGPR(), CCallHelpers::TrustedImm32(JSValue::LowestTag)));
                 jit.unboxDouble(valueRegs, state.scratchFPR);
 #endif
+                failAndRepatch.append(jit.branchIfNaN(state.scratchFPR));
                 ready.link(&jit);
 
                 jit.zeroExtend32ToWord(propertyGPR, scratch2GPR);
@@ -2250,7 +2283,7 @@ void AccessCase::generateImpl(AccessGenerationState& state)
 
     case Transition: {
         ASSERT(!viaProxy());
-        // AccessCase::transition() should have returned null if this wasn't true.
+        // AccessCase::createTransition() should have returned null if this wasn't true.
         RELEASE_ASSERT(GPRInfo::numberOfRegisters >= 6 || !structure()->outOfLineCapacity() || structure()->outOfLineCapacity() == newStructure()->outOfLineCapacity());
 
         // NOTE: This logic is duplicated in AccessCase::doesCalls(). It's important that doesCalls() knows

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/bytecode/AccessCase.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/bytecode/AccessCase.h
@@ -167,7 +167,7 @@ public:
         Structure* = nullptr, const ObjectPropertyConditionSet& = ObjectPropertyConditionSet(), RefPtr<PolyProtoAccessChain>&& = nullptr);
 
     static RefPtr<AccessCase> createTransition(VM&, JSCell* owner, CacheableIdentifier, PropertyOffset, Structure* oldStructure,
-        Structure* newStructure, const ObjectPropertyConditionSet&, RefPtr<PolyProtoAccessChain>&&);
+        Structure* newStructure, const ObjectPropertyConditionSet&, RefPtr<PolyProtoAccessChain>&&, const StructureStubInfo&);
 
     static Ref<AccessCase> createDelete(VM&, JSCell* owner, CacheableIdentifier, PropertyOffset, Structure* oldStructure,
         Structure* newStructure);

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3141,8 +3141,19 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             Structure* structure = nullptr;
             if (base.isNull())
                 structure = globalObject->nullPrototypeObjectStructure();
-            else if (base.isObject())
-                structure = m_vm.structureCache.emptyObjectStructureConcurrently(globalObject, base.getObject(), JSFinalObject::defaultInlineCapacity());
+            else if (base.isObject()) {
+                // Having a bad time clears the structureCache, and so it should invalidate this structure.
+                bool isHavingABadTime = globalObject->isHavingABadTime();
+                WTF::loadLoadFence();
+                if (!isHavingABadTime)
+                    m_graph.watchpoints().addLazily(globalObject->havingABadTimeWatchpoint());
+                // Normally, we would always install a watchpoint. In this case, however, if we haveABadTime, we
+                // still want to optimize. There is no watchpoint for that case though, so we need to make sure this load
+                // does not get hoisted above the check.
+                WTF::loadLoadFence();
+                structure = m_vm.structureCache
+                    .emptyObjectStructureConcurrently(globalObject, base.getObject(), JSFinalObject::defaultInlineCapacity());
+            }
 
             if (structure) {
                 m_state.setShouldTryConstantFolding(true);

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -6482,7 +6482,9 @@ void ByteCodeParser::parseBlock(unsigned limit)
                         FrozenValue* frozen = m_graph.freezeStrong(symbol);
                         addToGraph(CheckIsConstant, OpInfo(frozen), property);
                     } else if (auto* string = property->dynamicCastConstant<JSString*>(*m_vm)) {
-                        if (auto* impl = string->tryGetValueImpl(); impl->isAtom() && !parseIndex(*const_cast<StringImpl*>(impl))) {
+                        auto* impl = string->tryGetValueImpl();
+                        ASSERT(impl); // FIXME: rdar://83902782
+                        if (impl && impl->isAtom() && !parseIndex(*const_cast<StringImpl*>(impl))) {
                             uid = bitwise_cast<UniquedStringImpl*>(impl);
                             propertyCell = string;
                             m_graph.freezeStrong(string);
@@ -8864,7 +8866,9 @@ void ByteCodeParser::handlePutByVal(Bytecode bytecode, BytecodeIndex osrExitInde
                 FrozenValue* frozen = m_graph.freezeStrong(symbol);
                 addToGraph(CheckIsConstant, OpInfo(frozen), property);
             } else if (auto* string = property->dynamicCastConstant<JSString*>(*m_vm)) {
-                if (auto* impl = string->tryGetValueImpl(); impl->isAtom() && !parseIndex(*const_cast<StringImpl*>(impl))) {
+                auto* impl = string->tryGetValueImpl();
+                ASSERT(impl); // FIXME: rdar://83902782
+                if (impl && impl->isAtom() && !parseIndex(*const_cast<StringImpl*>(impl))) {
                     uid = bitwise_cast<UniquedStringImpl*>(impl);
                     propertyCell = string;
                     m_graph.freezeStrong(string);

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -839,8 +839,19 @@ private:
                     Structure* structure = nullptr;
                     if (base.isNull())
                         structure = globalObject->nullPrototypeObjectStructure();
-                    else if (base.isObject())
-                        structure = globalObject->vm().structureCache.emptyObjectStructureConcurrently(globalObject, base.getObject(), JSFinalObject::defaultInlineCapacity());
+                    else if (base.isObject()) {
+                        // Having a bad time clears the structureCache, and so it should invalidate this structure.
+                        bool isHavingABadTime = globalObject->isHavingABadTime();
+                        WTF::loadLoadFence();
+                        if (!isHavingABadTime)
+                            m_graph.watchpoints().addLazily(globalObject->havingABadTimeWatchpoint());
+                        // Normally, we would always install a watchpoint. In this case, however, if we haveABadTime, we
+                        // still want to optimize. There is no watchpoint for that case though, so we need to make sure this load
+                        // does not get hoisted above the check.
+                        WTF::loadLoadFence();
+                        structure = globalObject->vm().structureCache
+                            .emptyObjectStructureConcurrently(globalObject, base.getObject(), JSFinalObject::defaultInlineCapacity());
+                    }
 
                     if (structure) {
                         node->convertToNewObject(m_graph.registerStructure(structure));

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -1843,10 +1843,12 @@ bool Graph::canDoFastSpread(Node* node, const AbstractValue& value)
     if (!value.m_structure.isFinite())
         return false;
 
-    ArrayPrototype* arrayPrototype = globalObjectFor(node->child1()->origin.semantic)->arrayPrototype();
+    JSGlobalObject* globalObject = globalObjectFor(node->child1()->origin.semantic);
+    ArrayPrototype* arrayPrototype = globalObject->arrayPrototype();
     bool allGood = true;
     value.m_structure.forEach([&] (RegisteredStructure structure) {
-        allGood &= structure->hasMonoProto()
+        allGood &= structure->globalObject() == globalObject
+            && structure->hasMonoProto()
             && structure->storedPrototype() == arrayPrototype
             && !structure->isDictionary()
             && structure->getConcurrently(m_vm.propertyNames->iteratorSymbol.impl()) == invalidOffset

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2015-2021 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -228,8 +228,17 @@ public:
         if (*this == other)
             return true;
 
-        if (m_right->isInt32Constant() && other.m_right->isInt32Constant())
-            return (m_right->asInt32() + m_offset) == (other.m_right->asInt32() + other.m_offset);
+        if (m_right->isInt32Constant() && other.m_right->isInt32Constant()) {
+            int thisRight = m_right->asInt32();
+            int otherRight = other.m_right->asInt32();
+
+            if (sumOverflows<int>(thisRight, m_offset))
+                return false;
+            if (sumOverflows<int>(otherRight, other.m_offset))
+                return false;
+
+            return (thisRight + m_offset) == (otherRight + other.m_offset);
+        }
         return false;
     }
 
@@ -1391,7 +1400,25 @@ private:
         case ArithAbs: {
             if (node->child1().useKind() != Int32Use)
                 break;
-            setRelationship(Relationship(node, m_zero, Relationship::GreaterThan, -1));
+
+            // If ArithAbs cares about overflow, then INT32_MIN input will cause OSR exit.
+            // Thus we can safely say `x >= 0`.
+            if (shouldCheckOverflow(node->arithMode())) {
+                setRelationship(Relationship(node, m_zero, Relationship::GreaterThan, -1));
+                break;
+            }
+
+            // If ArithAbs does not care about overflow, it can return INT32_MIN if the input is INT32_MIN.
+            // If minValue is not INT32_MIN, we can still say it is `x >= 0`.
+            int minValue = std::numeric_limits<int>::min();
+            auto iter = m_relationships.find(node->child1().node());
+            if (iter != m_relationships.end()) {
+                for (Relationship relationship : iter->value)
+                    minValue = std::max(minValue, relationship.minValueOfLeft());
+            }
+
+            if (minValue > std::numeric_limits<int>::min())
+                setRelationship(Relationship(node, m_zero, Relationship::GreaterThan, -1));
             break;
         }
 

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -2538,6 +2538,18 @@ JSC_DEFINE_JIT_OPERATION(operationEnumeratorInByVal, EncodedJSValue, (JSGlobalOb
     RELEASE_AND_RETURN(scope, JSValue::encode(jsBoolean(CommonSlowPaths::opInByVal(globalObject, base, propertyName))));
 }
 
+JSC_DEFINE_JIT_OPERATION(operationEnumeratorGetByValGeneric, EncodedJSValue, (JSGlobalObject* globalObject, JSCell* baseCell, EncodedJSValue propertyNameValue, uint32_t index, int32_t modeNumber, JSPropertyNameEnumerator* enumerator))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue property = JSValue::decode(propertyNameValue);
+    JSPropertyNameEnumerator::Mode mode = static_cast<JSPropertyNameEnumerator::Mode>(modeNumber);
+    RELEASE_AND_RETURN(scope, JSValue::encode(CommonSlowPaths::opEnumeratorGetByVal(globalObject, baseCell, property, index, mode, enumerator)));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationEnumeratorHasOwnProperty, EncodedJSValue, (JSGlobalObject* globalObject, EncodedJSValue baseValue, EncodedJSValue propertyNameValue, uint32_t index, int32_t modeNumber))
 {
     VM& vm = globalObject->vm();

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -112,6 +112,7 @@ JSC_DECLARE_JIT_OPERATION(operationEnumeratorNextUpdatePropertyName, EncodedJSVa
 JSC_DECLARE_JIT_OPERATION(operationEnumeratorInByVal, EncodedJSValue, (JSGlobalObject*, EncodedJSValue, EncodedJSValue, uint32_t, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationEnumeratorHasOwnProperty, EncodedJSValue, (JSGlobalObject*, EncodedJSValue, EncodedJSValue, uint32_t, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationEnumeratorRecoverNameAndGetByVal, EncodedJSValue, (JSGlobalObject*, JSCell*, uint32_t, JSPropertyNameEnumerator*));
+JSC_DECLARE_JIT_OPERATION(operationEnumeratorGetByValGeneric, EncodedJSValue, (JSGlobalObject*, JSCell*, EncodedJSValue, uint32_t, int32_t, JSPropertyNameEnumerator*));
 
 JSC_DECLARE_JIT_OPERATION(operationNewRegexpWithLastIndex, JSCell*, (JSGlobalObject*, JSCell*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationNewArray, char*, (JSGlobalObject*, Structure*, void*, size_t));

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -13623,119 +13623,11 @@ void SpeculativeJIT::compileEnumeratorNextUpdatePropertyName(Node* node)
     jsValueResult(resultRegs, node);
 }
 
-void SpeculativeJIT::compileEnumeratorGetByVal(Node* node)
-{
-    Edge baseEdge = m_graph.varArgChild(node, 0);
-    auto generate = [&] (GPRReg baseCellGPR) {
-        MacroAssembler::JumpList doneCases;
-        JSValueRegsTemporary result;
-        JSValueRegs resultRegs;
-        GPRReg indexGPR;
-        GPRReg enumeratorGPR;
-        MacroAssembler::Jump badStructureSlowPath;
-
-        compileGetByVal(node, scopedLambda<std::tuple<JSValueRegs, DataFormat>(DataFormat)>([&] (DataFormat) {
-            Edge storageEdge = m_graph.varArgChild(node, 2);
-            StorageOperand storage;
-            if (storageEdge)
-                storage.emplace(this, storageEdge);
-            SpeculateStrictInt32Operand index(this, m_graph.varArgChild(node, 3));
-            SpeculateStrictInt32Operand mode(this, m_graph.varArgChild(node, 4));
-            SpeculateCellOperand enumerator(this, m_graph.varArgChild(node, 5));
-
-            GPRReg modeGPR = mode.gpr();
-            indexGPR = index.gpr();
-            enumeratorGPR = enumerator.gpr();
-
-            result = JSValueRegsTemporary(this);
-            resultRegs = result.regs();
-            GPRReg scratchGPR = resultRegs.payloadGPR();
-
-            bool haveStorage = !!storageEdge;
-            GPRTemporary storageTemporary;
-            GPRReg storageGPR;
-            if (!haveStorage) {
-                storageTemporary = GPRTemporary(this, Reuse, enumerator);
-                storageGPR = storageTemporary.gpr();
-            } else
-                storageGPR = storage.gpr();
-
-            MacroAssembler::JumpList notFastNamedCases;
-
-            // FIXME: We shouldn't generate this code if we know base is not an object.
-            notFastNamedCases.append(m_jit.branchTest32(MacroAssembler::NonZero, modeGPR, TrustedImm32(JSPropertyNameEnumerator::IndexedMode | JSPropertyNameEnumerator::GenericMode)));
-            {
-                if (!m_state.forNode(baseEdge).isType(SpecCell))
-                    notFastNamedCases.append(m_jit.branchIfNotCell(baseCellGPR));
-
-                // Check the structure
-                // FIXME: If we know there's only one structure for base we can just embed it here.
-                m_jit.load32(MacroAssembler::Address(baseCellGPR, JSCell::structureIDOffset()), scratchGPR);
-
-                auto badStructure = m_jit.branch32(
-                    MacroAssembler::NotEqual,
-                    scratchGPR,
-                    MacroAssembler::Address(
-                        enumeratorGPR, JSPropertyNameEnumerator::cachedStructureIDOffset()));
-
-                // FIXME: Maybe we should have a better way to represent Indexed+Named?
-                if (m_graph.varArgChild(node, 1).node() == m_graph.varArgChild(node, 3).node())
-                    badStructureSlowPath = badStructure;
-                else
-                    notFastNamedCases.append(badStructure);
-
-                // Compute the offset
-                // If index is less than the enumerator's cached inline storage, then it's an inline access
-                MacroAssembler::Jump outOfLineAccess = m_jit.branch32(MacroAssembler::AboveOrEqual,
-                    indexGPR, MacroAssembler::Address(enumeratorGPR, JSPropertyNameEnumerator::cachedInlineCapacityOffset()));
-
-                m_jit.loadValue(MacroAssembler::BaseIndex(baseCellGPR, indexGPR, MacroAssembler::TimesEight, JSObject::offsetOfInlineStorage()), resultRegs);
-
-                doneCases.append(m_jit.jump());
-
-                // Otherwise it's out of line
-                outOfLineAccess.link(&m_jit);
-                m_jit.move(indexGPR, scratchGPR);
-                m_jit.sub32(MacroAssembler::Address(enumeratorGPR, JSPropertyNameEnumerator::cachedInlineCapacityOffset()), scratchGPR);
-                m_jit.neg32(scratchGPR);
-                m_jit.signExtend32ToPtr(scratchGPR, scratchGPR);
-                if (!haveStorage)
-                    m_jit.loadPtr(MacroAssembler::Address(baseCellGPR, JSObject::butterflyOffset()), storageGPR);
-                constexpr intptr_t offsetOfFirstProperty = offsetInButterfly(firstOutOfLineOffset) * static_cast<intptr_t>(sizeof(EncodedJSValue));
-                m_jit.loadValue(MacroAssembler::BaseIndex(storageGPR, scratchGPR, MacroAssembler::TimesEight, offsetOfFirstProperty), resultRegs);
-                doneCases.append(m_jit.jump());
-            }
-
-            notFastNamedCases.link(&m_jit);
-            return std::make_pair(resultRegs, DataFormatJS);
-        }));
-
-        // We rely on compileGetByVal to call jsValueResult for us.
-        // FIXME: This is kinda hacky...
-        ASSERT(generationInfo(node).jsValueRegs() == resultRegs && generationInfo(node).registerFormat() == DataFormatJS);
-
-        if (badStructureSlowPath.isSet())
-            addSlowPathGenerator(slowPathCall(badStructureSlowPath, this, operationEnumeratorRecoverNameAndGetByVal, resultRegs, TrustedImmPtr::weakPointer(m_graph, m_graph.globalObjectFor(node->origin.semantic)), baseCellGPR, indexGPR, enumeratorGPR));
-
-        doneCases.link(&m_jit);
-    };
-
-    if (isCell(baseEdge.useKind())) {
-        // Use manual operand speculation since Fixup may have picked a UseKind more restrictive than CellUse.
-        speculate(node, baseEdge);
-        SpeculateCellOperand baseOperand(this, baseEdge, ManualOperandSpeculation);
-        generate(baseOperand.gpr());
-    } else {
-        JSValueOperand baseOperand(this, baseEdge);
-        generate(baseOperand.gpr());
-    }
-}
-
 template<typename SlowPathFunctionType>
 void SpeculativeJIT::compileEnumeratorHasProperty(Node* node, SlowPathFunctionType slowPathFunction)
 {
     Edge baseEdge = m_graph.varArgChild(node, 0);
-    auto generate = [&] (auto base, GPRReg baseCellGPR) {
+    auto generate = [&] (JSValueRegs baseRegs) {
         JSValueOperand propertyName(this, m_graph.varArgChild(node, 1));
         SpeculateStrictInt32Operand index(this, m_graph.varArgChild(node, 2));
         SpeculateStrictInt32Operand mode(this, m_graph.varArgChild(node, 3));
@@ -13754,12 +13646,12 @@ void SpeculativeJIT::compileEnumeratorHasProperty(Node* node, SlowPathFunctionTy
         MacroAssembler::JumpList operationCases;
 
         if (m_state.forNode(baseEdge).m_type & ~SpecCell)
-            operationCases.append(m_jit.branchIfNotCell(base));
+            operationCases.append(m_jit.branchIfNotCell(baseRegs));
 
         // FIXME: We shouldn't generate this code if we know base is not a cell.
         operationCases.append(m_jit.branchTest32(MacroAssembler::Zero, modeGPR, TrustedImm32(JSPropertyNameEnumerator::OwnStructureMode)));
 
-        m_jit.load32(MacroAssembler::Address(baseCellGPR, JSCell::structureIDOffset()), resultRegs.payloadGPR());
+        m_jit.load32(MacroAssembler::Address(baseRegs.payloadGPR(), JSCell::structureIDOffset()), resultRegs.payloadGPR());
         operationCases.append(m_jit.branch32(MacroAssembler::NotEqual, resultRegs.payloadGPR(), MacroAssembler::Address(enumeratorGPR, JSPropertyNameEnumerator::cachedStructureIDOffset())));
 
         moveTrueTo(resultRegs.payloadGPR());
@@ -13767,13 +13659,10 @@ void SpeculativeJIT::compileEnumeratorHasProperty(Node* node, SlowPathFunctionTy
 
         operationCases.link(&m_jit);
 
-#if USE(JSVALUE32_64)
-        m_jit.move(TrustedImm32(JSValue::CellTag), resultRegs.tagGPR());
-        auto baseRegs = JSValueRegs(baseCellGPR, resultRegs.tagGPR());
-#else
-        auto baseRegs = base;
-#endif
-        callOperation(slowPathFunction, resultRegs, TrustedImmPtr::weakPointer(m_graph, m_graph.globalObjectFor(node->origin.semantic)), baseRegs, propertyNameRegs, indexGPR, modeGPR);
+        if (baseRegs.tagGPR() == InvalidGPRReg)
+            callOperation(slowPathFunction, resultRegs, TrustedImmPtr::weakPointer(m_graph, m_graph.globalObjectFor(node->origin.semantic)), CCallHelpers::CellValue(baseRegs.payloadGPR()), propertyNameRegs, indexGPR, modeGPR);
+        else
+            callOperation(slowPathFunction, resultRegs, TrustedImmPtr::weakPointer(m_graph, m_graph.globalObjectFor(node->origin.semantic)), baseRegs, propertyNameRegs, indexGPR, modeGPR);
         m_jit.exceptionCheck();
 
         done.link(&m_jit);
@@ -13783,10 +13672,10 @@ void SpeculativeJIT::compileEnumeratorHasProperty(Node* node, SlowPathFunctionTy
 
     if (isCell(baseEdge.useKind())) {
         SpeculateCellOperand base(this, baseEdge);
-        generate(base.gpr(), base.gpr());
+        generate(JSValueRegs::payloadOnly(base.gpr()));
     } else {
         JSValueOperand base(this, baseEdge);
-        generate(base.regs(), base.regs().payloadGPR());
+        generate(base.regs());
     }
 }
 

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/interpreter/CallFrame.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/interpreter/CallFrame.cpp
@@ -247,6 +247,8 @@ SourceOrigin CallFrame::callerSourceOrigin(VM& vm)
 
 JSGlobalObject* CallFrame::globalObjectOfClosestCodeBlock(VM& vm, CallFrame* callFrame)
 {
+    // FIXME: We need to handle JSONP interpretation case in ProgramExecutable since it does not have vm.topCallFrame.
+    // rdar://83691438
     JSGlobalObject* globalObject = nullptr;
     StackVisitor::visit(callFrame, vm, [&](StackVisitor& visitor) {
         if (visitor->isWasmFrame()) {

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/jit/JITStubRoutine.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/jit/JITStubRoutine.h
@@ -33,6 +33,7 @@
 namespace JSC {
 
 class JITStubRoutineSet;
+class Structure;
 class VM;
 
 #if USE(JSVALUE64)

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/jit/Repatch.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/jit/Repatch.cpp
@@ -792,7 +792,7 @@ static InlineCacheAction tryCachePutBy(JSGlobalObject* globalObject, CodeBlock* 
                         return GiveUpOnCache;
                 }
 
-                newCase = AccessCase::createTransition(vm, codeBlock, propertyName, offset, oldStructure, newStructure, conditionSet, WTFMove(prototypeAccessChain));
+                newCase = AccessCase::createTransition(vm, codeBlock, propertyName, offset, oldStructure, newStructure, conditionSet, WTFMove(prototypeAccessChain), stubInfo);
             }
         } else if (slot.isCacheableCustom() || slot.isCacheableSetter()) {
             if (slot.isCacheableCustom()) {

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/jsc.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/jsc.cpp
@@ -2468,8 +2468,8 @@ JSC_DEFINE_HOST_FUNCTION(functionSetTimeout, (JSGlobalObject* globalObject, Call
         return throwVMTypeError(globalObject, scope, "First argument is not a JS function"_s);
 
     // FIXME: We don't look at the timeout parameter because we don't have a schedule work later API.
-    vm.deferredWorkTimer->addPendingWork(vm, callback, { });
-    vm.deferredWorkTimer->scheduleWorkSoon(callback, [callback](DeferredWorkTimer::Ticket, DeferredWorkTimer::TicketData&&) {
+    auto ticket = vm.deferredWorkTimer->addPendingWork(vm, callback, { });
+    vm.deferredWorkTimer->scheduleWorkSoon(ticket, [callback](DeferredWorkTimer::Ticket) {
         JSGlobalObject* globalObject = callback->globalObject();
         MarkedArgumentBuffer args;
         call(globalObject, callback, jsUndefined(), args, "You shouldn't see this...");

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/CommonSlowPaths.cpp
@@ -1010,42 +1010,14 @@ JSC_DEFINE_COMMON_SLOW_PATH(slow_path_enumerator_get_by_val)
     BEGIN();
     auto bytecode = pc->as<OpEnumeratorGetByVal>();
     JSValue baseValue = GET_C(bytecode.m_base).jsValue();
+    JSValue propertyName = GET(bytecode.m_propertyName).jsValue();
     auto& metadata = bytecode.metadata(codeBlock);
     auto mode = static_cast<JSPropertyNameEnumerator::Mode>(GET(bytecode.m_mode).jsValue().asUInt32());
     metadata.m_enumeratorMetadata |= static_cast<uint8_t>(mode);
-
     JSPropertyNameEnumerator* enumerator = jsCast<JSPropertyNameEnumerator*>(GET(bytecode.m_enumerator).jsValue());
     unsigned index = GET(bytecode.m_index).jsValue().asInt32();
-    switch (mode) {
-    case JSPropertyNameEnumerator::IndexedMode: {
-        if (LIKELY(baseValue.isCell()))
-            metadata.m_arrayProfile.observeStructureID(baseValue.asCell()->structureID());
-        RETURN_PROFILED(baseValue.get(globalObject, static_cast<unsigned>(index)));
-    }
-    case JSPropertyNameEnumerator::OwnStructureMode: {
-        if (LIKELY(baseValue.isCell()) && baseValue.asCell()->structureID() == enumerator->cachedStructureID()) {
-            // We'll only match the structure ID if the base is an object.
-            ASSERT(index < enumerator->endStructurePropertyIndex());
-            RETURN_PROFILED(baseValue.getObject()->getDirect(index < enumerator->cachedInlineCapacity() ? index : index - enumerator->cachedInlineCapacity() + firstOutOfLineOffset));
-        } else
-            metadata.m_enumeratorMetadata |= static_cast<uint8_t>(JSPropertyNameEnumerator::HasSeenOwnStructureModeStructureMismatch);
-        FALLTHROUGH;
-    }
 
-    case JSPropertyNameEnumerator::GenericMode: {
-        if (baseValue.isCell() && mode != JSPropertyNameEnumerator::OwnStructureMode)
-            metadata.m_arrayProfile.observeStructureID(baseValue.asCell()->structureID());
-        JSString* string = asString(GET(bytecode.m_propertyName).jsValue());
-        auto propertyName = string->toIdentifier(globalObject);
-        CHECK_EXCEPTION();
-        RETURN_PROFILED(baseValue.get(globalObject, propertyName));
-    }
-
-    default:
-        RELEASE_ASSERT_NOT_REACHED();
-        break;
-    };
-    RELEASE_ASSERT_NOT_REACHED();
+    RETURN_PROFILED(CommonSlowPaths::opEnumeratorGetByVal(globalObject, baseValue, propertyName, index, mode, enumerator, &metadata.m_arrayProfile, &metadata.m_enumeratorMetadata));
 }
 
 JSC_DEFINE_COMMON_SLOW_PATH(slow_path_enumerator_in_by_val)

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2021 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,11 +25,12 @@
 
 #pragma once
 
+#include "JSCast.h"
 #include "JSRunLoopTimer.h"
 #include "Strong.h"
 
 #include <wtf/Deque.h>
-#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
 #include <wtf/Lock.h>
 #include <wtf/Vector.h>
 
@@ -44,14 +45,26 @@ public:
     using Base = JSRunLoopTimer;
 
     struct TicketData {
+    private:
+        WTF_MAKE_FAST_ALLOCATED;
+    public:
+        TicketData(VM&, JSObject* scriptExecutionOwner, Vector<Strong<JSCell>>&& dependencies);
+
+        VM& vm();
+        JSObject* target();
+
+        void cancel();
+        bool isCancelled() const { return !scriptExecutionOwner.get(); }
+
         Vector<Strong<JSCell>> dependencies;
         Strong<JSObject> scriptExecutionOwner;
     };
 
+    using Ticket = TicketData*;
+
     void doWork(VM&) final;
 
-    using Ticket = JSObject*;
-    void addPendingWork(VM&, Ticket, Vector<Strong<JSCell>>&& dependencies);
+    Ticket addPendingWork(VM&, JSObject* target, Vector<Strong<JSCell>>&& dependencies);
     bool hasPendingWork(Ticket);
     bool hasDependancyInPendingWork(Ticket, JSCell* dependency);
     bool cancelPendingWork(Ticket);
@@ -61,7 +74,7 @@ public:
     // to make sure your memory ownership model won't leak memory when
     // this occurs. The easiest way is to make sure everything is either owned
     // by a GC'd value in dependencies or by the Task lambda.
-    using Task = Function<void(Ticket, TicketData&&)>;
+    using Task = Function<void(Ticket)>;
     void scheduleWorkSoon(Ticket, Task&&);
     void didResumeScriptExecutionOwner();
 
@@ -77,7 +90,13 @@ private:
     bool m_shouldStopRunLoopWhenAllTicketsFinish { false };
     bool m_currentlyRunningTask { false };
     Deque<std::tuple<Ticket, Task>> m_tasks WTF_GUARDED_BY_LOCK(m_taskLock);
-    HashMap<Ticket, TicketData> m_pendingTickets;
+    HashSet<std::unique_ptr<TicketData>> m_pendingTickets;
 };
+
+inline JSObject* DeferredWorkTimer::TicketData::target()
+{
+    ASSERT(!isCancelled());
+    return jsCast<JSObject*>(dependencies.last().get());
+}
 
 } // namespace JSC

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/IntlCache.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/IntlCache.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "IntlCache.h"
 
+#include "IntlDisplayNames.h"
 #include <wtf/Vector.h>
 
 namespace JSC {
@@ -53,6 +54,7 @@ Vector<UChar, 32> IntlCache::getBestDateTimePattern(const CString& locale, const
     return patternBuffer;
 }
 
+#if HAVE(ICU_U_LOCALE_DISPLAY_NAMES)
 Vector<UChar, 32> IntlCache::getFieldDisplayName(const CString& locale, UDateTimePatternField field, UDateTimePGDisplayWidth width, UErrorCode& status)
 {
     auto sharedGenerator = getSharedPatternGenerator(locale, status);
@@ -64,5 +66,6 @@ Vector<UChar, 32> IntlCache::getFieldDisplayName(const CString& locale, UDateTim
         return { };
     return buffer;
 }
+#endif
 
 } // namespace JSC

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/IntlCache.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/IntlCache.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "IntlDisplayNames.h"
 #include <unicode/udatpg.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/text/CString.h>
@@ -39,7 +40,9 @@ public:
     IntlCache() = default;
 
     Vector<UChar, 32> getBestDateTimePattern(const CString& locale, const UChar* skeleton, unsigned skeletonSize, UErrorCode&);
+#if HAVE(ICU_U_LOCALE_DISPLAY_NAMES)
     Vector<UChar, 32> getFieldDisplayName(const CString& locale, UDateTimePatternField, UDateTimePGDisplayWidth, UErrorCode&);
+#endif
 
 private:
     UDateTimePatternGenerator* getSharedPatternGenerator(const CString& locale, UErrorCode& status)

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/JSFinalizationRegistry.cpp
@@ -149,13 +149,15 @@ void JSFinalizationRegistry::finalizeUnconditionally(VM& vm)
         return !bucket.value.size();
     });
 
-    if (!vm.deferredWorkTimer->hasPendingWork(this) && (readiedCell || deadCount(locker))) {
-        vm.deferredWorkTimer->addPendingWork(vm, this, { });
-        ASSERT(vm.deferredWorkTimer->hasPendingWork(this));
-        vm.deferredWorkTimer->scheduleWorkSoon(this, [this](DeferredWorkTimer::Ticket, DeferredWorkTimer::TicketData&&) {
+    if (!m_hasAlreadyScheduledWork && (readiedCell || deadCount(locker))) {
+        auto ticket = vm.deferredWorkTimer->addPendingWork(vm, this, { });
+        ASSERT(vm.deferredWorkTimer->hasPendingWork(ticket));
+        vm.deferredWorkTimer->scheduleWorkSoon(ticket, [this](DeferredWorkTimer::Ticket) {
             JSGlobalObject* globalObject = this->globalObject();
+            this->m_hasAlreadyScheduledWork = false;
             this->runFinalizationCleanup(globalObject);
         });
+        m_hasAlreadyScheduledWork = true;
     }
 }
 
@@ -240,3 +242,4 @@ size_t JSFinalizationRegistry::deadCount(const Locker<JSCellLock>&)
 }
 
 }
+

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/JSFinalizationRegistry.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/JSFinalizationRegistry.h
@@ -106,6 +106,7 @@ private:
     // We use a separate list for no unregister values instead of a special key in the tables above because the HashMap has a tendency to reallocate under us when iterating...
     LiveRegistrations m_noUnregistrationLive;
     DeadRegistrations m_noUnregistrationDead;
+    bool m_hasAlreadyScheduledWork { false };
 };
 
 } // namespace JSC

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/StructureCache.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/StructureCache.cpp
@@ -31,6 +31,12 @@
 
 namespace JSC {
 
+void StructureCache::clear()
+{
+    Locker locker { m_lock };
+    m_structures.clear();
+}
+
 inline Structure* StructureCache::createEmptyStructure(JSGlobalObject* globalObject, JSObject* prototype, const TypeInfo& typeInfo, const ClassInfo* classInfo, IndexingType indexingType, unsigned inlineCapacity, bool makePolyProtoStructure, FunctionExecutable* executable)
 {
     RELEASE_ASSERT(!!prototype); // We use nullptr inside the HashMap for prototype to mean poly proto, so user's of this API must provide non-null prototypes.

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/StructureCache.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/runtime/StructureCache.h
@@ -48,7 +48,7 @@ public:
     {
     }
 
-    void clear() { m_structures.clear(); }
+    JS_EXPORT_PRIVATE void clear();
 
     JS_EXPORT_PRIVATE Structure* emptyObjectStructureForPrototype(JSGlobalObject*, JSObject*, unsigned inlineCapacity, bool makePolyProtoStructure = false, FunctionExecutable* = nullptr);
     JS_EXPORT_PRIVATE Structure* emptyStructureForPrototypeFromBaseStructure(JSGlobalObject*, JSObject*, Structure*);

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -146,7 +146,7 @@ void BBQPlan::work(CompilationEffort effort)
         {
             LLIntCallee& llintCallee = m_codeBlock->m_llintCallees->at(m_functionIndex).get();
             Locker locker { llintCallee.tierUpCounter().m_lock };
-            llintCallee.setReplacement(callee.copyRef());
+            llintCallee.setReplacement(callee.copyRef(), mode());
             llintCallee.tierUpCounter().m_compilationStatus = LLIntTierUpCounter::CompilationStatus::Compiled;
         }
     }

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmOMGForOSREntryPlan.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmOMGForOSREntryPlan.cpp
@@ -121,14 +121,14 @@ void OMGForOSREntryPlan::work(CompilationEffort)
             case CompilationMode::LLIntMode: {
                 LLIntCallee* llintCallee = static_cast<LLIntCallee*>(m_callee.ptr());
                 Locker locker { llintCallee->tierUpCounter().m_lock };
-                llintCallee->setOSREntryCallee(callee.copyRef());
+                llintCallee->setOSREntryCallee(callee.copyRef(), mode());
                 llintCallee->tierUpCounter().m_loopCompilationStatus = LLIntTierUpCounter::CompilationStatus::Compiled;
                 break;
             }
             case CompilationMode::BBQMode: {
                 BBQCallee* bbqCallee = static_cast<BBQCallee*>(m_callee.ptr());
                 Locker locker { bbqCallee->tierUpCount()->getLock() };
-                bbqCallee->setOSREntryCallee(callee.copyRef());
+                bbqCallee->setOSREntryCallee(callee.copyRef(), mode());
                 bbqCallee->tierUpCount()->osrEntryTriggers()[m_loopIndex] = TierUpCount::TriggerReason::CompilationDone;
                 bbqCallee->tierUpCount()->m_compilationStatusForOMGForOSREntry = TierUpCount::CompilationStatus::Compiled;
                 break;

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -131,7 +131,7 @@ void OMGPlan::work(CompilationEffort)
             if (m_codeBlock->m_llintCallees) {
                 LLIntCallee& llintCallee = m_codeBlock->m_llintCallees->at(m_functionIndex).get();
                 Locker locker { llintCallee.tierUpCounter().m_lock };
-                llintCallee.setReplacement(callee.copyRef());
+                llintCallee.setReplacement(callee.copyRef(), mode());
                 llintCallee.tierUpCounter().m_compilationStatus = LLIntTierUpCounter::CompilationStatus::Compiled;
             }
         }

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmPlan.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmPlan.cpp
@@ -139,9 +139,9 @@ void Plan::updateCallSitesToCallUs(CodeBlock& codeBlock, CodeLocationLabel<WasmE
         stageRepatch(codeBlock.m_wasmToWasmCallsites[i]);
         if (codeBlock.m_llintCallees) {
             LLIntCallee& llintCallee = codeBlock.m_llintCallees->at(i).get();
-            if (JITCallee* replacementCallee = llintCallee.replacement())
+            if (JITCallee* replacementCallee = llintCallee.replacement(codeBlock.mode()))
                 stageRepatch(replacementCallee->wasmToWasmCallsites());
-            if (OMGForOSREntryCallee* osrEntryCallee = llintCallee.osrEntryCallee())
+            if (OMGForOSREntryCallee* osrEntryCallee = llintCallee.osrEntryCallee(codeBlock.mode()))
                 stageRepatch(osrEntryCallee->wasmToWasmCallsites());
         }
         if (BBQCallee* bbqCallee = codeBlock.m_bbqCallees[i].get()) {
@@ -174,9 +174,9 @@ void Plan::updateCallSitesToCallUs(CodeBlock& codeBlock, CodeLocationLabel<WasmE
         repatchCalls(codeBlock.m_wasmToWasmCallsites[i]);
         if (codeBlock.m_llintCallees) {
             LLIntCallee& llintCallee = codeBlock.m_llintCallees->at(i).get();
-            if (JITCallee* replacementCallee = llintCallee.replacement())
+            if (JITCallee* replacementCallee = llintCallee.replacement(codeBlock.mode()))
                 repatchCalls(replacementCallee->wasmToWasmCallsites());
-            if (OMGForOSREntryCallee* osrEntryCallee = llintCallee.osrEntryCallee())
+            if (OMGForOSREntryCallee* osrEntryCallee = llintCallee.osrEntryCallee(codeBlock.mode()))
                 repatchCalls(osrEntryCallee->wasmToWasmCallsites());
         }
         if (BBQCallee* bbqCallee = codeBlock.m_bbqCallees[i].get()) {

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
@@ -29,6 +29,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include "DeferredWorkTimer.h"
 #include "JSCJSValue.h"
 
 namespace JSC {
@@ -72,7 +73,7 @@ private:
     bool m_threadedCompilationStarted { false };
     Lock m_lock;
     unsigned m_remainingCompilationRequests { 0 };
-    JSPromise* m_promise; // Raw pointer, but held by DeferredWorkTimer.
+    DeferredWorkTimer::Ticket m_ticket;
     Ref<Wasm::ModuleInformation> m_info;
     StreamingParser m_parser;
     RefPtr<LLIntPlan> m_plan;

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -115,13 +115,14 @@ std::optional<uint32_t> Table::grow(uint32_t delta, JSValue defaultValue)
     };
 
     if (auto* funcRefTable = asFuncrefTable()) {
-        if (!checkedGrow(funcRefTable->m_importableFunctions, [] (auto&) { }))
+        if (!checkedGrow(funcRefTable->m_importableFunctions, [](auto&) { }))
             return std::nullopt;
-        if (!checkedGrow(funcRefTable->m_instances, [] (auto&) { }))
+        if (!checkedGrow(funcRefTable->m_instances, [](auto&) { }))
             return std::nullopt;
     }
 
-    if (!checkedGrow(m_jsValues, [defaultValue] (WriteBarrier<Unknown>& slot) { slot.setStartingValue(defaultValue); }))
+    VM& vm = m_owner->vm();
+    if (!checkedGrow(m_jsValues, [&](WriteBarrier<Unknown>& slot) { slot.set(vm, m_owner, defaultValue); }))
         return std::nullopt;
 
     setLength(newLength);

--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
@@ -168,9 +168,9 @@ void JSWebAssembly::webAssemblyModuleValidateAsync(JSGlobalObject* globalObject,
     Vector<Strong<JSCell>> dependencies;
     dependencies.append(Strong<JSCell>(vm, globalObject));
 
-    vm.deferredWorkTimer->addPendingWork(vm, promise, WTFMove(dependencies));
-    Wasm::Module::validateAsync(&vm.wasmContext, WTFMove(source), createSharedTask<Wasm::Module::CallbackType>([promise, globalObject, &vm] (Wasm::Module::ValidationResult&& result) mutable {
-        vm.deferredWorkTimer->scheduleWorkSoon(promise, [promise, globalObject, result = WTFMove(result), &vm](DeferredWorkTimer::Ticket, DeferredWorkTimer::TicketData&&) mutable {
+    auto ticket = vm.deferredWorkTimer->addPendingWork(vm, promise, WTFMove(dependencies));
+    Wasm::Module::validateAsync(&vm.wasmContext, WTFMove(source), createSharedTask<Wasm::Module::CallbackType>([ticket, promise, globalObject, &vm] (Wasm::Module::ValidationResult&& result) mutable {
+        vm.deferredWorkTimer->scheduleWorkSoon(ticket, [promise, globalObject, result = WTFMove(result), &vm](DeferredWorkTimer::Ticket) mutable {
             auto scope = DECLARE_THROW_SCOPE(vm);
             JSValue module = JSWebAssemblyModule::createStub(vm, globalObject, globalObject->webAssemblyModuleStructure(), WTFMove(result));
             if (UNLIKELY(scope.exception())) {
@@ -199,11 +199,11 @@ static void instantiate(VM& vm, JSGlobalObject* globalObject, JSPromise* promise
     dependencies.append(Strong<JSCell>(vm, promise));
     dependencies.append(Strong<JSCell>(vm, importObject));
 
-    vm.deferredWorkTimer->addPendingWork(vm, instance, WTFMove(dependencies));
+    auto ticket = vm.deferredWorkTimer->addPendingWork(vm, instance, WTFMove(dependencies));
     // Note: This completion task may or may not get called immediately.
-    module->module().compileAsync(&vm.wasmContext, instance->memoryMode(), createSharedTask<Wasm::CodeBlock::CallbackType>([promise, instance, module, importObject, resolveKind, creationMode, &vm] (Ref<Wasm::CodeBlock>&& refCodeBlock) mutable {
+    module->module().compileAsync(&vm.wasmContext, instance->memoryMode(), createSharedTask<Wasm::CodeBlock::CallbackType>([ticket, promise, instance, module, importObject, resolveKind, creationMode, &vm] (Ref<Wasm::CodeBlock>&& refCodeBlock) mutable {
         RefPtr<Wasm::CodeBlock> codeBlock = WTFMove(refCodeBlock);
-        vm.deferredWorkTimer->scheduleWorkSoon(instance, [promise, instance, module, importObject, resolveKind, creationMode, &vm, codeBlock = WTFMove(codeBlock)](DeferredWorkTimer::Ticket, DeferredWorkTimer::TicketData&&) mutable {
+        vm.deferredWorkTimer->scheduleWorkSoon(ticket, [promise, instance, module, importObject, resolveKind, creationMode, &vm, codeBlock = WTFMove(codeBlock)](DeferredWorkTimer::Ticket) mutable {
             JSGlobalObject* globalObject = instance->globalObject();
             resolve(vm, globalObject, promise, instance, module, importObject, codeBlock.releaseNonNull(), resolveKind, creationMode);
         });
@@ -224,9 +224,9 @@ static void compileAndInstantiate(VM& vm, JSGlobalObject* globalObject, JSPromis
     Vector<Strong<JSCell>> dependencies;
     dependencies.append(Strong<JSCell>(vm, importObject));
     dependencies.append(Strong<JSCell>(vm, moduleKeyCell));
-    vm.deferredWorkTimer->addPendingWork(vm, promise, WTFMove(dependencies));
-    Wasm::Module::validateAsync(&vm.wasmContext, WTFMove(source), createSharedTask<Wasm::Module::CallbackType>([promise, importObject, moduleKeyCell, globalObject, resolveKind, creationMode, &vm] (Wasm::Module::ValidationResult&& result) mutable {
-        vm.deferredWorkTimer->scheduleWorkSoon(promise, [promise, importObject, moduleKeyCell, globalObject, result = WTFMove(result), resolveKind, creationMode, &vm](DeferredWorkTimer::Ticket, DeferredWorkTimer::TicketData&&) mutable {
+    auto ticket = vm.deferredWorkTimer->addPendingWork(vm, promise, WTFMove(dependencies));
+    Wasm::Module::validateAsync(&vm.wasmContext, WTFMove(source), createSharedTask<Wasm::Module::CallbackType>([ticket, promise, importObject, moduleKeyCell, globalObject, resolveKind, creationMode, &vm] (Wasm::Module::ValidationResult&& result) mutable {
+        vm.deferredWorkTimer->scheduleWorkSoon(ticket, [promise, importObject, moduleKeyCell, globalObject, result = WTFMove(result), resolveKind, creationMode, &vm](DeferredWorkTimer::Ticket) mutable {
             auto scope = DECLARE_THROW_SCOPE(vm);
             JSWebAssemblyModule* module = JSWebAssemblyModule::createStub(vm, globalObject, globalObject->webAssemblyModuleStructure(), WTFMove(result));
             if (UNLIKELY(scope.exception())) {
@@ -268,9 +268,9 @@ void JSWebAssembly::webAssemblyModuleInstantinateAsync(JSGlobalObject* globalObj
     Vector<Strong<JSCell>> dependencies;
     dependencies.append(Strong<JSCell>(vm, importObject));
     dependencies.append(Strong<JSCell>(vm, globalObject));
-    vm.deferredWorkTimer->addPendingWork(vm, promise, WTFMove(dependencies));
-    Wasm::Module::validateAsync(&vm.wasmContext, WTFMove(source), createSharedTask<Wasm::Module::CallbackType>([promise, importObject, globalObject, &vm] (Wasm::Module::ValidationResult&& result) mutable {
-        vm.deferredWorkTimer->scheduleWorkSoon(promise, [promise, importObject, globalObject, result = WTFMove(result), &vm](DeferredWorkTimer::Ticket, DeferredWorkTimer::TicketData&&) mutable {
+    auto ticket = vm.deferredWorkTimer->addPendingWork(vm, promise, WTFMove(dependencies));
+    Wasm::Module::validateAsync(&vm.wasmContext, WTFMove(source), createSharedTask<Wasm::Module::CallbackType>([ticket, promise, importObject, globalObject, &vm] (Wasm::Module::ValidationResult&& result) mutable {
+        vm.deferredWorkTimer->scheduleWorkSoon(ticket, [promise, importObject, globalObject, result = WTFMove(result), &vm](DeferredWorkTimer::Ticket) mutable {
             auto scope = DECLARE_THROW_SCOPE(vm);
             JSWebAssemblyModule* module = JSWebAssemblyModule::createStub(vm, globalObject, globalObject->webAssemblyModuleStructure(), WTFMove(result));
             if (UNLIKELY(scope.exception())) {

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/Assertions.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/Assertions.h
@@ -271,14 +271,14 @@ WTF_EXPORT_PRIVATE bool WTFIsDebuggerAttached(void);
 #elif !ENABLE(DEVELOPER_MODE) && !OS(DARWIN)
 #ifdef __cplusplus
 #define CRASH() std::abort()
-#define CRASH_UNDER_CONSTEXPR_CONTEXT() std::abort()
+#define CRASH_UNDER_CONSTEXPR_CONTEXT() WTFBreakpointTrapUnderConstexprContext()
 #else
 #define CRASH() abort()
-#define CRASH_UNDER_CONSTEXPR_CONTEXT() abort()
+#define CRASH_UNDER_CONSTEXPR_CONTEXT() WTFBreakpointTrapUnderConstexprContext()
 #endif // __cplusplus
 #else
 #define CRASH() WTFCrash()
-#define CRASH_UNDER_CONSTEXPR_CONTEXT() WTFCrash()
+#define CRASH_UNDER_CONSTEXPR_CONTEXT() WTFBreakpointTrapUnderConstexprContext()
 #endif
 
 #endif // !defined(CRASH)

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/CompletionHandler.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/CompletionHandler.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <utility>
 #include <wtf/Function.h>
 #include <wtf/MainThread.h>
 

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/MallocPtr.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/MallocPtr.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <utility>
 #include <wtf/FastMalloc.h>
 #include <wtf/Noncopyable.h>
 

--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/text/IntegerToStringConversion.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/text/IntegerToStringConversion.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <string>
 #include <wtf/text/LChar.h>
 
 namespace WTF {

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -178,7 +178,11 @@ ExceptionOr<Ref<FetchResponse>> FetchResponse::clone(ScriptExecutionContext& con
 
     // If loading, let's create a stream so that data is teed on both clones.
     if (isLoading() && !m_readableStreamSource) {
-        auto voidOrException = createReadableStream(*context.globalObject());
+        auto* globalObject = context.globalObject();
+        if (!globalObject)
+            return Exception { InvalidStateError, "Context is stopped"_s };
+
+        auto voidOrException = createReadableStream(*globalObject);
         if (UNLIKELY(voidOrException.hasException()))
             return voidOrException.releaseException();
     }

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
@@ -530,6 +530,9 @@ void IDBServer::getAllDatabaseNamesAndVersions(IDBConnectionIdentifier serverCon
     HashSet<String> visitedDatabasePaths;
 
     for (auto& database : m_uniqueIDBDatabaseMap.values()) {
+        if (database->identifier().origin() != origin)
+            continue;
+
         auto path = database->filePath();
         if (!path.isEmpty())
             visitedDatabasePaths.add(path);

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/webxr/XRReferenceSpaceEvent.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/webxr/XRReferenceSpaceEvent.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEBXR)
 
 #include "Event.h"
+#include <wtf/IsoMalloc.h>
 #include <wtf/Ref.h>
 #include <wtf/RefPtr.h>
 
@@ -37,6 +38,7 @@ class WebXRReferenceSpace;
 class WebXRRigidTransform;
 
 class XRReferenceSpaceEvent : public Event {
+    WTF_MAKE_ISO_ALLOCATED(XRReferenceSpaceEvent);
 public:
     struct Init : EventInit {
         RefPtr<WebXRReferenceSpace> referenceSpace;
@@ -47,7 +49,7 @@ public:
     virtual ~XRReferenceSpaceEvent();
 
     const WebXRReferenceSpace& referenceSpace() const;
-    const WebXRRigidTransform& transform() const;
+    WebXRRigidTransform* transform() const;
 
 private:
     XRReferenceSpaceEvent(const AtomString&, const Init&, IsTrusted);

--- a/modules/javafx.web/src/main/native/Source/WebCore/Modules/webxr/XRReferenceSpaceEvent.idl
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Modules/webxr/XRReferenceSpaceEvent.idl
@@ -28,7 +28,7 @@
     Conditional=WEBXR,
 ] dictionary XRReferenceSpaceEventInit : EventInit {
     required WebXRReferenceSpace referenceSpace;
-    WebXRRigidTransform transform;
+    WebXRRigidTransform? transform;
 };
 
 [
@@ -40,5 +40,5 @@
     constructor(DOMString type, XRReferenceSpaceEventInit eventInitDict);
 
     [SameObject] readonly attribute WebXRReferenceSpace referenceSpace;
-    [SameObject] readonly attribute WebXRRigidTransform transform;
+    [SameObject] readonly attribute WebXRRigidTransform? transform;
 };

--- a/modules/javafx.web/src/main/native/Source/WebCore/Sources.txt
+++ b/modules/javafx.web/src/main/native/Source/WebCore/Sources.txt
@@ -518,6 +518,7 @@ bindings/js/JSPluginElementFunctions.cpp
 bindings/js/JSPopStateEventCustom.cpp
 bindings/js/JSPromiseRejectionEventCustom.cpp
 bindings/js/JSRTCRtpSFrameTransformCustom.cpp
+bindings/js/JSRangeCustom.cpp
 bindings/js/JSReadableStreamSourceCustom.cpp
 bindings/js/JSRemoteDOMWindowBase.cpp
 bindings/js/JSRemoteDOMWindowCustom.cpp

--- a/modules/javafx.web/src/main/native/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -528,9 +528,11 @@ static bool isSimpleImage(const RenderObject& renderer)
         || (is<HTMLImageElement>(node) && downcast<HTMLImageElement>(node)->hasAttributeWithoutSynchronization(usemapAttr)))
         return false;
 
+#if ENABLE(VIDEO)
     // Exclude video and audio elements.
     if (is<HTMLMediaElement>(node))
         return false;
+#endif // ENABLE(VIDEO)
 
     return true;
 }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/JSDOMConvertCallbacks.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/JSDOMConvertCallbacks.h
@@ -45,11 +45,7 @@ template<typename T> struct Converter<IDLCallbackFunction<T>> : DefaultConverter
             return nullptr;
         }
 
-        JSDOMGlobalObject* incumbentGlobalObject = &globalObject;
-        if (auto* globalObject = JSC::CallFrame::globalObjectOfClosestCodeBlock(vm, vm.topCallFrame))
-            incumbentGlobalObject = JSC::jsCast<JSDOMGlobalObject*>(globalObject);
-
-        return T::create(JSC::asObject(value), incumbentGlobalObject);
+        return T::create(JSC::asObject(value), &callerGlobalObject(globalObject, vm.topCallFrame));
     }
 };
 
@@ -83,11 +79,7 @@ template<typename T> struct Converter<IDLCallbackInterface<T>> : DefaultConverte
             return nullptr;
         }
 
-        JSDOMGlobalObject* incumbentGlobalObject = &globalObject;
-        if (auto* globalObject = JSC::CallFrame::globalObjectOfClosestCodeBlock(vm, vm.topCallFrame))
-            incumbentGlobalObject = JSC::jsCast<JSDOMGlobalObject*>(globalObject);
-
-        return T::create(JSC::asObject(value), incumbentGlobalObject);
+        return T::create(JSC::asObject(value), &callerGlobalObject(globalObject, vm.topCallFrame));
     }
 };
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -60,6 +60,7 @@
 #include <JavaScriptCore/JSCustomSetterFunction.h>
 #include <JavaScriptCore/JSInternalPromise.h>
 #include <JavaScriptCore/StructureInlines.h>
+#include <JavaScriptCore/VMEntryScope.h>
 #include <JavaScriptCore/VMTrapsInlines.h>
 #include <JavaScriptCore/WasmStreamingCompiler.h>
 #include <JavaScriptCore/WeakGCMapInlines.h>
@@ -558,6 +559,80 @@ JSDOMGlobalObject* toJSDOMGlobalObject(ScriptExecutionContext& context, DOMWrapp
 
     ASSERT_NOT_REACHED();
     return nullptr;
+}
+
+static JSDOMGlobalObject& callerGlobalObject(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame* callFrame, bool skipFirstFrame, bool lookUpFromVMEntryScope)
+{
+    VM& vm = lexicalGlobalObject.vm();
+    if (callFrame) {
+        class GetCallerGlobalObjectFunctor {
+        public:
+            GetCallerGlobalObjectFunctor(bool skipFirstFrame)
+                : m_skipFirstFrame(skipFirstFrame)
+            { }
+
+            StackVisitor::Status operator()(StackVisitor& visitor) const
+            {
+                if (m_skipFirstFrame) {
+                    if (!m_hasSkippedFirstFrame) {
+                        m_hasSkippedFirstFrame = true;
+                        return StackVisitor::Continue;
+                    }
+                }
+
+                if (auto* codeBlock = visitor->codeBlock())
+                    m_globalObject = codeBlock->globalObject();
+                else {
+                    ASSERT(visitor->callee().rawPtr());
+                    // FIXME: Callee is not an object if the caller is Web Assembly.
+                    // Figure out what to do here. We can probably get the global object
+                    // from the top-most Wasm Instance. https://bugs.webkit.org/show_bug.cgi?id=165721
+                    if (visitor->callee().isCell() && visitor->callee().asCell()->isObject())
+                        m_globalObject = jsCast<JSObject*>(visitor->callee().asCell())->globalObject();
+                }
+                return StackVisitor::Done;
+            }
+
+            JSC::JSGlobalObject* globalObject() const { return m_globalObject; }
+
+        private:
+            bool m_skipFirstFrame { false };
+            mutable bool m_hasSkippedFirstFrame { false };
+            mutable JSC::JSGlobalObject* m_globalObject { nullptr };
+        };
+
+        GetCallerGlobalObjectFunctor iter(skipFirstFrame);
+        callFrame->iterate(vm, iter);
+        if (iter.globalObject())
+            return *jsCast<JSDOMGlobalObject*>(iter.globalObject());
+    }
+
+    // In the case of legacyActiveGlobalObjectForAccessor, it is possible that vm.topCallFrame is nullptr when the script is evaluated as JSONP.
+    // Since we put JSGlobalObject to VMEntryScope, we can retrieve the right globalObject from that.
+    // For callerGlobalObject, we do not check vm.entryScope to keep it the old behavior.
+    if (lookUpFromVMEntryScope) {
+        if (vm.entryScope) {
+            if (auto* result = vm.entryScope->globalObject())
+                return *jsCast<JSDOMGlobalObject*>(result);
+        }
+    }
+
+    // If we cannot find JSGlobalObject in caller frames, we just return the current lexicalGlobalObject.
+    return *jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject);
+}
+
+JSDOMGlobalObject& callerGlobalObject(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame* callFrame)
+{
+    constexpr bool skipFirstFrame = true;
+    constexpr bool lookUpFromVMEntryScope = false;
+    return callerGlobalObject(lexicalGlobalObject, callFrame, skipFirstFrame, lookUpFromVMEntryScope);
+}
+
+JSDOMGlobalObject& legacyActiveGlobalObjectForAccessor(JSC::JSGlobalObject& lexicalGlobalObject, JSC::CallFrame* callFrame)
+{
+    constexpr bool skipFirstFrame = false;
+    constexpr bool lookUpFromVMEntryScope = true;
+    return callerGlobalObject(lexicalGlobalObject, callFrame, skipFirstFrame, lookUpFromVMEntryScope);
 }
 
 } // namespace WebCore

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -143,6 +143,8 @@ private:
 };
 
 JSDOMGlobalObject* toJSDOMGlobalObject(ScriptExecutionContext&, DOMWrapperWorld&);
+WEBCORE_EXPORT JSDOMGlobalObject& callerGlobalObject(JSC::JSGlobalObject&, JSC::CallFrame*);
+JSDOMGlobalObject& legacyActiveGlobalObjectForAccessor(JSC::JSGlobalObject&, JSC::CallFrame*);
 
 template<class JSClass>
 JSClass* toJSDOMGlobalObject(JSC::VM& vm, JSC::JSValue value)

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/JSDOMWindowBase.cpp
@@ -284,17 +284,12 @@ JSDOMWindow* toJSDOMWindow(Frame& frame, DOMWrapperWorld& world)
 
 DOMWindow& incumbentDOMWindow(JSGlobalObject& fallbackGlobalObject, CallFrame& callFrame)
 {
-    if (auto* globalObject = CallFrame::globalObjectOfClosestCodeBlock(fallbackGlobalObject.vm(), &callFrame))
-        return asJSDOMWindow(globalObject)->wrapped();
-    return asJSDOMWindow(&fallbackGlobalObject)->wrapped();
+    return asJSDOMWindow(&callerGlobalObject(fallbackGlobalObject, &callFrame))->wrapped();
 }
 
 DOMWindow& incumbentDOMWindow(JSGlobalObject& fallbackGlobalObject)
 {
-    VM& vm = fallbackGlobalObject.vm();
-    if (auto* globalObject = CallFrame::globalObjectOfClosestCodeBlock(vm, vm.topCallFrame))
-        return asJSDOMWindow(globalObject)->wrapped();
-    return asJSDOMWindow(&fallbackGlobalObject)->wrapped();
+    return asJSDOMWindow(&callerGlobalObject(fallbackGlobalObject, fallbackGlobalObject.vm().topCallFrame))->wrapped();
 }
 
 DOMWindow& activeDOMWindow(JSGlobalObject& lexicalGlobalObject)
@@ -306,6 +301,16 @@ DOMWindow& firstDOMWindow(JSGlobalObject& lexicalGlobalObject)
 {
     VM& vm = lexicalGlobalObject.vm();
     return asJSDOMWindow(vm.deprecatedVMEntryGlobalObject(&lexicalGlobalObject))->wrapped();
+}
+
+DOMWindow& legacyActiveDOMWindowForAccessor(JSGlobalObject& fallbackGlobalObject, CallFrame& callFrame)
+{
+    return asJSDOMWindow(&legacyActiveGlobalObjectForAccessor(fallbackGlobalObject, &callFrame))->wrapped();
+}
+
+DOMWindow& legacyActiveDOMWindowForAccessor(JSGlobalObject& fallbackGlobalObject)
+{
+    return asJSDOMWindow(&legacyActiveGlobalObjectForAccessor(fallbackGlobalObject, fallbackGlobalObject.vm().topCallFrame))->wrapped();
 }
 
 Document* responsibleDocument(VM& vm, CallFrame& callFrame)

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/JSDOMWindowBase.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/JSDOMWindowBase.h
@@ -126,6 +126,9 @@ DOMWindow& incumbentDOMWindow(JSC::JSGlobalObject&);
 DOMWindow& activeDOMWindow(JSC::JSGlobalObject&);
 DOMWindow& firstDOMWindow(JSC::JSGlobalObject&);
 
+DOMWindow& legacyActiveDOMWindowForAccessor(JSC::JSGlobalObject&, JSC::CallFrame&);
+DOMWindow& legacyActiveDOMWindowForAccessor(JSC::JSGlobalObject&);
+
 // FIXME: This should probably be removed in favor of one of the other DOMWindow accessors. It is intended
 //        to provide the document specfied as the 'responsible document' in the algorithm for document.open()
 //        (https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#document-open-steps steps 4

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/JSRangeCustom.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/js/JSRangeCustom.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Igalia S.L. All rights reserved.
+ * Copyright (C) 2021 Igalia S.L. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,43 +24,18 @@
  */
 
 #include "config.h"
-#include "XRReferenceSpaceEvent.h"
+#include "JSRange.h"
 
-#if ENABLE(WEBXR)
-
-#include "WebXRReferenceSpace.h"
-#include "WebXRRigidTransform.h"
-#include <wtf/IsoMallocInlines.h>
+#include "Range.h"
 
 namespace WebCore {
 
-WTF_MAKE_ISO_ALLOCATED_IMPL(XRReferenceSpaceEvent);
-
-Ref<XRReferenceSpaceEvent> XRReferenceSpaceEvent::create(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
+template<typename Visitor>
+void JSRange::visitAdditionalChildren(Visitor& visitor)
 {
-    return adoptRef(*new XRReferenceSpaceEvent(type, initializer, isTrusted));
+    wrapped().visitNodesConcurrently(visitor);
 }
 
-XRReferenceSpaceEvent::XRReferenceSpaceEvent(const AtomString& type, const Init& initializer, IsTrusted isTrusted)
-    : Event(type, initializer, isTrusted)
-    , m_referenceSpace(initializer.referenceSpace)
-    , m_transform(initializer.transform)
-{
-    ASSERT(m_referenceSpace);
-}
-
-XRReferenceSpaceEvent::~XRReferenceSpaceEvent() = default;
-
-const WebXRReferenceSpace& XRReferenceSpaceEvent::referenceSpace() const
-{
-    return *m_referenceSpace;
-}
-
-WebXRRigidTransform* XRReferenceSpaceEvent::transform() const
-{
-    return m_transform.get();
-}
+DEFINE_VISIT_ADDITIONAL_CHILDREN(JSRange);
 
 } // namespace WebCore
-
-#endif // ENABLE(WEBXR)

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -5984,6 +5984,11 @@ sub GenerateCallWith
         AddToImplIncludes("JSDOMWindowBase.h");
         push(@callWithArgs, "incumbentDOMWindow(*$globalObject" . ($callFrameReference ? ", " . $callFrameReference : "") . ")");
     }
+    if ($codeGenerator->ExtendedAttributeContains($callWith, "LegacyActiveWindowForAccessor")) {
+        AddToImplIncludes("DOMWindow.h");
+        AddToImplIncludes("JSDOMWindowBase.h");
+        push(@callWithArgs, "legacyActiveDOMWindowForAccessor(*$globalObject" . ($callFrameReference ? ", " . $callFrameReference : "") . ")");
+    }
     if ($codeGenerator->ExtendedAttributeContains($callWith, "FirstWindow")) {
         AddToImplIncludes("DOMWindow.h");
         AddToImplIncludes("JSDOMWindowBase.h");

--- a/modules/javafx.web/src/main/native/Source/WebCore/css/StyleRuleImport.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/css/StyleRuleImport.cpp
@@ -71,7 +71,7 @@ void StyleRuleImport::setCSSStyleSheet(const String& href, const URL& baseURL, c
 
     Document* document = m_parentStyleSheet ? m_parentStyleSheet->singleOwnerDocument() : nullptr;
     m_styleSheet = StyleSheetContents::create(this, href, context);
-    if (m_parentStyleSheet->isContentOpaque() || !cachedStyleSheet->isCORSSameOrigin())
+    if ((m_parentStyleSheet && m_parentStyleSheet->isContentOpaque()) || !cachedStyleSheet->isCORSSameOrigin())
         m_styleSheet->setAsOpaque();
     m_styleSheet->parseAuthorStyleSheet(cachedStyleSheet, document ? &document->securityOrigin() : nullptr);
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/css/calc/CSSCalcOperationNode.cpp
@@ -34,6 +34,7 @@
 #include "CSSPrimitiveValue.h"
 #include "CSSUnits.h"
 #include "CalcExpressionOperation.h"
+#include "Logging.h"
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {

--- a/modules/javafx.web/src/main/native/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/css/calc/CSSCalcPrimitiveValueNode.cpp
@@ -31,6 +31,7 @@
 #include "CSSPrimitiveValueMappings.h"
 #include "CalcExpressionLength.h"
 #include "CalcExpressionNumber.h"
+#include "Logging.h"
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/InlineStyleSheetOwner.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/InlineStyleSheetOwner.cpp
@@ -241,7 +241,7 @@ bool InlineStyleSheetOwner::sheetLoaded(Element& element)
 
 void InlineStyleSheetOwner::startLoadingDynamicSheet(Element& element)
 {
-    if (m_styleScope)
+    if (m_styleScope && !m_styleScope->hasPendingSheet(element))
         m_styleScope->addPendingSheet(element);
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Range.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Range.cpp
@@ -37,6 +37,7 @@
 #include "HTMLBodyElement.h"
 #include "HTMLHtmlElement.h"
 #include "HTMLNames.h"
+#include "JSNode.h"
 #include "NodeTraversal.h"
 #include "NodeWithIndex.h"
 #include "ProcessingInstruction.h"
@@ -1097,6 +1098,12 @@ RefPtr<Range> createLiveRange(const std::optional<SimpleRange>& range)
     if (!range)
         return nullptr;
     return createLiveRange(*range);
+}
+
+void Range::visitNodesConcurrently(JSC::AbstractSlotVisitor& visitor) const
+{
+    visitor.addOpaqueRoot(root(&m_start.container()));
+    visitor.addOpaqueRoot(root(&m_end.container()));
 }
 
 } // namespace WebCore

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Range.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Range.h
@@ -115,6 +115,8 @@ public:
     String debugDescription() const;
 #endif
 
+    void visitNodesConcurrently(JSC::AbstractSlotVisitor&) const;
+
     enum ActionType : uint8_t { Delete, Extract, Clone };
 
 private:

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Range.idl
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Range.idl
@@ -22,6 +22,7 @@
     GenerateIsReachable=ReachableFromDOMWindow,
     ExportMacro=WEBCORE_EXPORT,
     Exposed=Window,
+    JSCustomMarkFunction,
     JSGenerateToNativeObject,
 ] interface Range : AbstractRange {
     [CallWith=Document] constructor();

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/CompositeEditCommand.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/CompositeEditCommand.cpp
@@ -551,12 +551,13 @@ bool CompositeEditCommand::isRemovableBlock(const Node* node)
     return false;
 }
 
-void CompositeEditCommand::insertNodeBefore(Ref<Node>&& insertChild, Node& refChild, ShouldAssumeContentIsAlwaysEditable shouldAssumeContentIsAlwaysEditable)
+bool CompositeEditCommand::insertNodeBefore(Ref<Node>&& insertChild, Node& refChild, ShouldAssumeContentIsAlwaysEditable shouldAssumeContentIsAlwaysEditable)
 {
     auto parent = makeRefPtr(refChild.parentNode());
     if (!parent || (!parent->hasEditableStyle() && parent->renderer()))
-        return;
+        return false;
     applyCommandToComposite(InsertNodeBeforeCommand::create(WTFMove(insertChild), refChild, shouldAssumeContentIsAlwaysEditable, editingAction()));
+    return true;
 }
 
 void CompositeEditCommand::insertNodeAfter(Ref<Node>&& insertChild, Node& refChild)
@@ -1748,14 +1749,16 @@ RefPtr<Node> CompositeEditCommand::splitTreeToNode(Node& start, Node& end, bool 
 
     ASSERT(adjustedEnd);
     RefPtr<Node> node;
-    for (node = &start; node && node->parentNode() != adjustedEnd; node = node->parentNode()) {
-        if (!node->parentNode() || !is<Element>(*node->parentNode()))
+    for (node = &start; node && node->parentNode() != adjustedEnd;) {
+        RefPtr parentNode = node->parentNode();
+        if (!parentNode || !is<Element>(*parentNode) || editingIgnoresContent(*parentNode))
             break;
         // Do not split a node when doing so introduces an empty node.
-        VisiblePosition positionInParent = firstPositionInNode(node->parentNode());
+        VisiblePosition positionInParent = firstPositionInNode(parentNode.get());
         VisiblePosition positionInNode = firstPositionInOrBeforeNode(node.get());
         if (positionInParent != positionInNode)
-            splitElement(downcast<Element>(*node->parentNode()), *node);
+            splitElement(downcast<Element>(*parentNode), *node);
+        node = parentNode;
     }
 
     return node;

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/CompositeEditCommand.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/CompositeEditCommand.h
@@ -154,7 +154,7 @@ protected:
     void insertNodeAfter(Ref<Node>&&, Node& refChild);
     void insertNodeAt(Ref<Node>&&, const Position&);
     void insertNodeAtTabSpanPosition(Ref<Node>&&, const Position&);
-    void insertNodeBefore(Ref<Node>&&, Node& refChild, ShouldAssumeContentIsAlwaysEditable = DoNotAssumeContentIsAlwaysEditable);
+    bool insertNodeBefore(Ref<Node>&&, Node& refChild, ShouldAssumeContentIsAlwaysEditable = DoNotAssumeContentIsAlwaysEditable);
     void insertParagraphSeparatorAtPosition(const Position&, bool useDefaultParagraphElement = false, bool pasteBlockqutoeIntoUnquotedArea = false);
     void insertParagraphSeparator(bool useDefaultParagraphElement = false, bool pasteBlockqutoeIntoUnquotedArea = false);
     void insertLineBreak();

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/CreateLinkCommand.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/CreateLinkCommand.cpp
@@ -40,7 +40,7 @@ CreateLinkCommand::CreateLinkCommand(Document& document, const String& url)
 
 void CreateLinkCommand::doApply()
 {
-    if (endingSelection().isNone())
+    if (endingSelection().isNoneOrOrphaned())
         return;
 
     auto anchorElement = HTMLAnchorElement::create(document());

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -491,11 +491,15 @@ void DeleteSelectionCommand::insertBlockPlaceholderForTableCellIfNeeded(Element&
 
 void DeleteSelectionCommand::removeNodeUpdatingStates(Node& node, ShouldAssumeContentIsAlwaysEditable shouldAssumeContentIsAlwaysEditable)
 {
-    if (&node == m_startBlock && !isEndOfBlock(VisiblePosition(firstPositionInNode(m_startBlock.get())).previous()))
+    if (&node == m_startBlock) {
+        auto prev = VisiblePosition(firstPositionInNode(m_startBlock.get())).previous();
+        if (!prev.isNull() && !isEndOfBlock(prev))
         m_needPlaceholder = true;
-    else if (&node == m_endBlock && !isStartOfBlock(VisiblePosition(lastPositionInNode(m_startBlock.get())).next()))
+    } else if (&node == m_endBlock) {
+        auto next = VisiblePosition(lastPositionInNode(m_endBlock.get())).next();
+        if (!next.isNull() && !isStartOfBlock(next))
         m_needPlaceholder = true;
-
+    }
     // FIXME: Update the endpoints of the range being deleted.
     updatePositionForNodeRemoval(m_endingPosition, node);
     updatePositionForNodeRemoval(m_leadingWhitespace, node);

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/EditingStyle.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/EditingStyle.cpp
@@ -477,8 +477,10 @@ void EditingStyle::init(Node* node, PropertiesToInclude propertiesToInclude)
     if (node && node->computedStyle()) {
         auto* renderStyle = node->computedStyle();
         removeTextFillAndStrokeColorsIfNeeded(renderStyle);
-        if (renderStyle->fontDescription().keywordSize())
-            m_mutableStyle->setProperty(CSSPropertyFontSize, computedStyleAtPosition.getFontSizeCSSValuePreferringKeyword()->cssText());
+        if (renderStyle->fontDescription().keywordSize()) {
+            if (auto cssValue = computedStyleAtPosition.getFontSizeCSSValuePreferringKeyword())
+                m_mutableStyle->setProperty(CSSPropertyFontSize, cssValue->cssText());
+        }
     }
 
     m_shouldUseFixedDefaultFontSize = computedStyleAtPosition.useFixedFontDefaultSize();

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/FrameSelection.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/FrameSelection.cpp
@@ -70,6 +70,7 @@
 #include "SimpleRange.h"
 #include "SpatialNavigation.h"
 #include "StyleProperties.h"
+#include "StyleTreeResolver.h"
 #include "TypingCommand.h"
 #include "VisibleUnits.h"
 #include <stdio.h>
@@ -1343,6 +1344,11 @@ bool FrameSelection::modify(EAlteration alter, SelectionDirection direction, Tex
 
     willBeModified(alter, direction);
 
+    auto selectionDocument = m_selection.document();
+    if (!selectionDocument)
+        return false;
+    selectionDocument->updateLayoutIgnorePendingStylesheets();
+    Style::PostResolutionCallbackDisabler disabler(*selectionDocument);
     bool reachedBoundary = false;
     bool wasRange = m_selection.isRange();
     Position originalStartPosition = m_selection.start();

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/IndentOutdentCommand.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/IndentOutdentCommand.cpp
@@ -116,8 +116,8 @@ void IndentOutdentCommand::indentIntoBlockquote(const Position& start, const Pos
         targetBlockquote = createBlockElement();
         if (outerBlock == nodeToSplitTo)
             insertNodeAt(*targetBlockquote, start);
-        else
-            insertNodeBefore(*targetBlockquote, *outerBlock);
+        else if (!insertNodeBefore(*targetBlockquote, *outerBlock))
+            return;
         startOfContents = positionInParentAfterNode(targetBlockquote.get());
     }
 
@@ -192,8 +192,13 @@ void IndentOutdentCommand::outdentParagraph()
     }
     auto placeholder = HTMLBRElement::create(document());
     insertNodeBefore(placeholder, *splitBlockquoteNode);
-    if (placeholder->isConnected())
-        moveParagraph(startOfParagraph(visibleStartOfParagraph), endOfParagraph(visibleEndOfParagraph), positionBeforeNode(placeholder.ptr()), true);
+    if (!placeholder->isConnected())
+        return;
+    auto visibleStartOfParagraphToMove = startOfParagraph(visibleStartOfParagraph);
+    auto visibleEndOfParagraphToMove = endOfParagraph(visibleEndOfParagraph);
+    if (visibleStartOfParagraphToMove.isNull() || visibleEndOfParagraphToMove.isNull())
+        return;
+    moveParagraph(visibleStartOfParagraphToMove, visibleEndOfParagraphToMove, positionBeforeNode(placeholder.ptr()), true);
 }
 
 // FIXME: We should merge this function with ApplyBlockElementCommand::formatSelection

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/InsertLineBreakCommand.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/InsertLineBreakCommand.cpp
@@ -60,7 +60,7 @@ bool InsertLineBreakCommand::shouldUseBreakElement(const Position& position)
     // the input element, and in that case we need to check the input element's
     // parent's renderer.
     auto* node = position.parentAnchoredEquivalent().deprecatedNode();
-    return node->renderer() && !node->renderer()->style().preserveNewline();
+    return node && node->renderer() && !node->renderer()->style().preserveNewline();
 }
 
 void InsertLineBreakCommand::doApply()
@@ -81,6 +81,8 @@ void InsertLineBreakCommand::doApply()
     position = positionAvoidingSpecialElementBoundary(position);
     position = positionOutsideTabSpan(position);
 
+    if (!isEditablePosition(position))
+        return;
     RefPtr<Node> nodeToInsert;
     if (shouldUseBreakElement(position))
         nodeToInsert = HTMLBRElement::create(document());

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/InsertListCommand.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/InsertListCommand.cpp
@@ -155,7 +155,7 @@ void InsertListCommand::doApply()
                 // infinite loop and because there is no more work to be done.
                 // FIXME(<rdar://problem/5983974>): The endingSelection() may be incorrect here.  Compute
                 // the new location of endOfSelection and use it as the end of the new selection.
-                if (!startOfLastParagraph.deepEquivalent().anchorNode()->isConnected())
+                    if (startOfLastParagraph.isOrphan())
                     return;
                 setEndingSelection(startOfCurrentParagraph);
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/ModifySelectionListLevel.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/ModifySelectionListLevel.cpp
@@ -91,48 +91,52 @@ static bool getStartEndListChildren(const VisibleSelection& selection, Node*& st
 
 void ModifySelectionListLevelCommand::insertSiblingNodeRangeBefore(Node* startNode, Node* endNode, Node* refNode)
 {
-    Node* node = startNode;
-    while (1) {
-        Node* next = node->nextSibling();
+    RefPtr node = startNode;
+    while (node) {
+        RefPtr next = node->nextSibling();
         removeNode(*node);
         insertNodeBefore(*node, *refNode);
 
         if (node == endNode)
-            break;
+            return;
 
         node = next;
     }
+    ASSERT_NOT_REACHED();
 }
 
 void ModifySelectionListLevelCommand::insertSiblingNodeRangeAfter(Node* startNode, Node* endNode, Node* refNode)
 {
-    Node* node = startNode;
-    while (1) {
-        Node* next = node->nextSibling();
+    RefPtr node = startNode;
+    RefPtr refChild = refNode;
+    while (node) {
+        RefPtr next = node->nextSibling();
         removeNode(*node);
-        insertNodeAfter(*node, *refNode);
+        insertNodeAfter(*node, *refChild);
 
         if (node == endNode)
-            break;
+            return;
 
-        refNode = node;
+        refChild = node;
         node = next;
     }
+    ASSERT_NOT_REACHED();
 }
 
 void ModifySelectionListLevelCommand::appendSiblingNodeRange(Node* startNode, Node* endNode, Element* newParent)
 {
-    Node* node = startNode;
-    while (1) {
-        Node* next = node->nextSibling();
+    RefPtr node = startNode;
+    while (node) {
+        RefPtr next = node->nextSibling();
         removeNode(*node);
         appendNode(*node, *newParent);
 
         if (node == endNode)
-            break;
+            return;
 
         node = next;
     }
+    ASSERT_NOT_REACHED();
 }
 
 IncreaseSelectionListLevelCommand::IncreaseSelectionListLevelCommand(Document& document, Type listType)

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -830,6 +830,8 @@ void ReplaceSelectionCommand::moveNodeOutOfAncestor(Node& node, Node& ancestor, 
     VisiblePosition lastPositionInParagraph = lastPositionInNode(&ancestor);
     if (positionAtEndOfNode == lastPositionInParagraph) {
         removeNode(node);
+        if (!ancestor.isConnected())
+            return;
         if (ancestor.nextSibling())
             insertNodeBefore(WTFMove(protectedNode), *ancestor.nextSibling());
         else

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/VisibleUnits.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/VisibleUnits.cpp
@@ -1181,7 +1181,7 @@ Node* findEndOfParagraph(Node* startNode, Node* highestRoot, Node* stayInsideBlo
         }
 
         // FIXME: This is wrong when startNode is a block. We should return a position after the block.
-        if (r->isBR() || isBlock(n))
+        if (r->isBR() || is<HTMLBRElement>(n) || isBlock(n))
             break;
 
         // FIXME: We avoid returning a position where the renderer can't accept the caret.

--- a/modules/javafx.web/src/main/native/Source/WebCore/editing/markup.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/editing/markup.cpp
@@ -318,7 +318,7 @@ private:
     }
 
     enum class NodeTraversalMode { EmitString, DoNotEmitString };
-    Node* traverseNodesForSerialization(Node* startNode, Node* pastEnd, NodeTraversalMode);
+    Node* traverseNodesForSerialization(Node& startNode, Node* pastEnd, NodeTraversalMode);
 
     bool appendNodeToPreserveMSOList(Node&);
 
@@ -625,22 +625,24 @@ Node* StyledMarkupAccumulator::serializeNodes(const Position& start, const Posit
 {
     ASSERT(start <= end);
     auto startNode = start.firstNode();
+    if (!startNode)
+        return nullptr;
     Node* pastEnd = end.computeNodeAfterPosition();
     if (!pastEnd && end.containerNode())
         pastEnd = nextSkippingChildren(*end.containerNode());
 
     if (!m_highestNodeToBeSerialized) {
-        Node* lastClosed = traverseNodesForSerialization(startNode.get(), pastEnd, NodeTraversalMode::DoNotEmitString);
+        Node* lastClosed = traverseNodesForSerialization(*startNode, pastEnd, NodeTraversalMode::DoNotEmitString);
         m_highestNodeToBeSerialized = lastClosed;
     }
 
     if (m_highestNodeToBeSerialized && m_highestNodeToBeSerialized->parentNode())
         m_wrappingStyle = EditingStyle::wrappingStyleForSerialization(*m_highestNodeToBeSerialized->parentNode(), shouldAnnotate(), m_standardFontFamilySerializationMode);
 
-    return traverseNodesForSerialization(startNode.get(), pastEnd, NodeTraversalMode::EmitString);
+    return traverseNodesForSerialization(*startNode, pastEnd, NodeTraversalMode::EmitString);
 }
 
-Node* StyledMarkupAccumulator::traverseNodesForSerialization(Node* startNode, Node* pastEnd, NodeTraversalMode traversalMode)
+Node* StyledMarkupAccumulator::traverseNodesForSerialization(Node& startNode, Node* pastEnd, NodeTraversalMode traversalMode)
 {
     const bool shouldEmit = traversalMode == NodeTraversalMode::EmitString;
 
@@ -680,7 +682,7 @@ Node* StyledMarkupAccumulator::traverseNodesForSerialization(Node* startNode, No
 
     Node* lastNode = nullptr;
     Node* next = nullptr;
-    for (auto* n = startNode; n != pastEnd; lastNode = n, n = next) {
+    for (auto* n = &startNode; n != pastEnd; lastNode = n, n = next) {
 
         Vector<Node*, 8> exitedAncestors;
         next = nullptr;

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/HTMLMediaElement.cpp
@@ -4469,7 +4469,8 @@ bool HTMLMediaElement::setupAndCallJS(const JSSetupFunction& task)
 
     auto pendingActivity = makePendingActivity(*this);
     auto& world = ensureIsolatedWorld();
-    auto& scriptController = document().frame()->script();
+    Ref protectedFrame = *document().frame();
+    auto& scriptController = protectedFrame->script();
     auto* globalObject = JSC::jsCast<JSDOMGlobalObject*>(scriptController.globalObject(world));
     auto& vm = globalObject->vm();
     JSC::JSLockHolder lock(vm);

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/ImageBitmap.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/ImageBitmap.cpp
@@ -153,7 +153,7 @@ static bool taintsOrigin(SecurityOrigin* origin, HTMLVideoElement& video)
     if (!video.hasSingleSecurityOrigin())
         return true;
 
-    if (video.player()->didPassCORSAccessCheck())
+    if (!video.player() || video.player()->didPassCORSAccessCheck())
         return false;
 
     auto url = video.currentSrc();

--- a/modules/javafx.web/src/main/native/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -292,6 +292,9 @@ void HTMLConstructionSite::mergeAttributesFromTokenIntoElement(AtomHTMLToken&& t
     if (token.attributes().isEmpty())
         return;
 
+    if (!scriptingContentIsAllowed(m_parserContentPolicy))
+        element.stripScriptingAttributes(token.attributes());
+
     for (auto& tokenAttribute : token.attributes()) {
         if (!element.elementData() || !element.findAttributeByName(tokenAttribute.name()))
             element.setAttribute(tokenAttribute.name(), tokenAttribute.value());

--- a/modules/javafx.web/src/main/native/Source/WebCore/layout/formattingContexts/FormattingQuirks.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/layout/formattingContexts/FormattingQuirks.cpp
@@ -32,6 +32,7 @@
 #include "LayoutBox.h"
 #include "LayoutBoxGeometry.h"
 #include "LayoutInitialContainingBlock.h"
+#include "LayoutState.h"
 
 namespace WebCore {
 namespace Layout {

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/DocumentLoader.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/DocumentLoader.cpp
@@ -631,7 +631,7 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
         DOCUMENTLOADER_RELEASE_LOG("willSendRequest: With no provisional document loader");
 
     bool didReceiveRedirectResponse = !redirectResponse.isNull();
-    if (!frameLoader()->checkIfFormActionAllowedByCSP(newRequest.url(), didReceiveRedirectResponse)) {
+    if (!frameLoader()->checkIfFormActionAllowedByCSP(newRequest.url(), didReceiveRedirectResponse, redirectResponse.url())) {
         DOCUMENTLOADER_RELEASE_LOG("willSendRequest: canceling - form action not allowed by CSP");
         cancelMainResourceLoad(frameLoader()->cancelledError(newRequest));
         return completionHandler(WTFMove(newRequest));
@@ -758,7 +758,7 @@ static bool checkIfCOOPValuesRequireBrowsingContextGroupSwitch(bool isInitialAbo
     return true;
 }
 
-static std::tuple<Ref<SecurityOrigin>, CrossOriginOpenerPolicy> computeResponseOriginAndCOOP(const ResourceResponse& response, const Document& document, const std::optional<NavigationAction::Requester>& requester)
+static std::tuple<Ref<SecurityOrigin>, CrossOriginOpenerPolicy> computeResponseOriginAndCOOP(const ResourceResponse& response, const Document& document, const std::optional<NavigationAction::Requester>& requester, ContentSecurityPolicy* responseCSP)
 {
     // Non-initial empty documents (about:blank) should inherit their cross-origin-opener-policy from the navigation's initiator top level document,
     // if the initiator and its top level document are same-origin, or default (unsafe-none) otherwise.
@@ -766,7 +766,9 @@ static std::tuple<Ref<SecurityOrigin>, CrossOriginOpenerPolicy> computeResponseO
     if (SecurityPolicy::shouldInheritSecurityOriginFromOwner(response.url()) && requester)
         return std::make_tuple(makeRef(requester->securityOrigin()), requester->securityOrigin().isSameOriginAs(requester->topOrigin()) ? requester->crossOriginOpenerPolicy() : CrossOriginOpenerPolicy { });
 
-    return std::make_tuple(SecurityOrigin::create(response.url()), obtainCrossOriginOpenerPolicy(response, document));
+    // If the HTTP response contains a CSP header, it may set sandbox flags, which would cause the origin to become unique.
+    auto responseOrigin = responseCSP && responseCSP->sandboxFlags() != SandboxNone ? SecurityOrigin::createUnique() : SecurityOrigin::create(response.url());
+    return std::make_tuple(WTFMove(responseOrigin), obtainCrossOriginOpenerPolicy(response, document));
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch (Step 12.5.6)
@@ -779,7 +781,7 @@ bool DocumentLoader::doCrossOriginOpenerHandlingOfResponse(const ResourceRespons
     if (!m_frame->document() || !m_frame->document()->settings().crossOriginOpenerPolicyEnabled())
         return true;
 
-    auto [responseOrigin, responseCOOP] = computeResponseOriginAndCOOP(response, *m_frame->document(), m_triggeringAction.requester());
+    auto [responseOrigin, responseCOOP] = computeResponseOriginAndCOOP(response, *m_frame->document(), m_triggeringAction.requester(), m_contentSecurityPolicy.get());
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#process-a-navigate-fetch (Step 12.5.6.2)
     // If sandboxFlags is not empty and responseCOOP's value is not "unsafe-none", then set response to an appropriate network error and break.
@@ -915,6 +917,12 @@ static URL microsoftTeamsRedirectURL()
 void DocumentLoader::responseReceived(CachedResource& resource, const ResourceResponse& response, CompletionHandler<void()>&& completionHandler)
 {
     ASSERT_UNUSED(resource, m_mainResource == &resource);
+
+    if (!response.httpHeaderField(HTTPHeaderName::ContentSecurityPolicy).isNull()) {
+        m_contentSecurityPolicy = makeUnique<ContentSecurityPolicy>(URL { response.url() }, nullptr);
+        m_contentSecurityPolicy->didReceiveHeaders(ContentSecurityPolicyResponseHeaders { response }, m_request.httpReferrer(), ContentSecurityPolicy::ReportParsingErrors::No);
+    } else
+        m_contentSecurityPolicy = nullptr;
 
 #if ENABLE(RESOURCE_LOAD_STATISTICS)
     // FIXME(218779): Remove this quirk once microsoft.com completes their login flow redesign.

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/DocumentLoader.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/DocumentLoader.h
@@ -423,6 +423,7 @@ public:
     bool lastNavigationWasAppInitiated() const { return m_lastNavigationWasAppInitiated; }
     void setLastNavigationWasAppInitiated(bool lastNavigationWasAppInitiated) { m_lastNavigationWasAppInitiated = lastNavigationWasAppInitiated; }
 
+    ContentSecurityPolicy* contentSecurityPolicy() const { return m_contentSecurityPolicy.get(); }
     std::optional<CrossOriginOpenerPolicy> crossOriginOpenerPolicy() const { return m_currentCoopEnforcementResult ? std::make_optional(m_currentCoopEnforcementResult->crossOriginOpenerPolicy) : std::nullopt; }
 
     bool isContinuingLoadAfterResponsePolicyCheck() const { return m_isContinuingLoadAfterResponsePolicyCheck; }
@@ -628,6 +629,7 @@ private:
     ShouldOpenExternalURLsPolicy m_shouldOpenExternalURLsPolicy { ShouldOpenExternalURLsPolicy::ShouldNotAllow };
 
     std::unique_ptr<ApplicationCacheHost> m_applicationCacheHost;
+    std::unique_ptr<ContentSecurityPolicy> m_contentSecurityPolicy;
 
 #if ENABLE(CONTENT_FILTERING)
     std::unique_ptr<ContentFilter> m_contentFilter;

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -681,11 +681,11 @@ bool DocumentThreadableLoader::isAllowedByContentSecurityPolicy(const URL& url, 
     case ContentSecurityPolicyEnforcement::DoNotEnforce:
         return true;
     case ContentSecurityPolicyEnforcement::EnforceChildSrcDirective:
-        return contentSecurityPolicy().allowChildContextFromSource(url, redirectResponseReceived);
+        return contentSecurityPolicy().allowChildContextFromSource(url, redirectResponseReceived, preRedirectURL);
     case ContentSecurityPolicyEnforcement::EnforceConnectSrcDirective:
         return contentSecurityPolicy().allowConnectToSource(url, redirectResponseReceived, preRedirectURL);
     case ContentSecurityPolicyEnforcement::EnforceScriptSrcDirective:
-        return contentSecurityPolicy().allowScriptFromSource(url, redirectResponseReceived);
+        return contentSecurityPolicy().allowScriptFromSource(url, redirectResponseReceived, preRedirectURL);
     }
     ASSERT_NOT_REACHED();
     return false;

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/DocumentWriter.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/DocumentWriter.cpp
@@ -33,6 +33,7 @@
 #include "ContentSecurityPolicy.h"
 #include "DOMImplementation.h"
 #include "DOMWindow.h"
+#include "DocumentLoader.h"
 #include "Frame.h"
 #include "FrameLoader.h"
 #include "FrameLoaderClient.h"
@@ -141,6 +142,12 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
     bool shouldReuseDefaultView = m_frame->loader().stateMachine().isDisplayingInitialEmptyDocument()
         && m_frame->document()->isSecureTransitionTo(url)
         && (m_frame->window() && !m_frame->window()->wasWrappedWithoutInitializedSecurityOrigin() && m_frame->window()->mayReuseForNavigation());
+
+    if (shouldReuseDefaultView) {
+        ASSERT(m_frame->loader().documentLoader());
+        if (auto* contentSecurityPolicy = m_frame->loader().documentLoader()->contentSecurityPolicy())
+            shouldReuseDefaultView = !(contentSecurityPolicy->sandboxFlags() & SandboxOrigin);
+    }
 
     // Temporarily extend the lifetime of the existing document so that FrameLoader::clear() doesn't destroy it as
     // we need to retain its ongoing set of upgraded requests in new navigation contexts per <http://www.w3.org/TR/upgrade-insecure-requests/>

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/FrameLoader.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/FrameLoader.h
@@ -241,7 +241,7 @@ public:
     void forceSandboxFlags(SandboxFlags flags) { m_forcedSandboxFlags |= flags; }
     SandboxFlags effectiveSandboxFlags() const;
 
-    bool checkIfFormActionAllowedByCSP(const URL&, bool didReceiveRedirectResponse) const;
+    bool checkIfFormActionAllowedByCSP(const URL&, bool didReceiveRedirectResponse, const URL& preRedirectURL) const;
 
     WEBCORE_EXPORT Frame* opener();
     WEBCORE_EXPORT const Frame* opener() const;

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/SubresourceLoader.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/SubresourceLoader.cpp
@@ -277,7 +277,7 @@ void SubresourceLoader::willSendRequestInternal(ResourceRequest&& newRequest, co
                 m_frame->page()->diagnosticLoggingClient().logDiagnosticMessageWithResult(DiagnosticLoggingKeys::cachedResourceRevalidationKey(), emptyString(), DiagnosticLoggingResultFail, ShouldSample::Yes);
         }
 
-        if (!m_documentLoader->cachedResourceLoader().updateRequestAfterRedirection(m_resource->type(), newRequest, options())) {
+        if (!m_documentLoader->cachedResourceLoader().updateRequestAfterRedirection(m_resource->type(), newRequest, options(), redirectResponse.url())) {
             SUBRESOURCELOADER_RELEASE_LOG("willSendRequestInternal: resource load canceled because CachedResourceLoader::updateRequestAfterRedirection (really CachedResourceLoader::canRequestAfterRedirection) said no");
             cancel();
             return completionHandler(WTFMove(newRequest));

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/cache/CachedRawResource.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/cache/CachedRawResource.cpp
@@ -167,8 +167,8 @@ void CachedRawResource::didAddClient(CachedResourceClient& c)
         auto responseProcessedHandler = [this, protectedThis = WTFMove(protectedThis), client] {
             if (!hasClient(*client))
                 return;
-            if (auto data = m_data) {
-                data->forEachSegment([&](auto& segment) {
+            if (m_data) {
+                m_data->forEachSegment([&](auto& segment) {
                     if (hasClient(*client))
                         client->dataReceived(*this, segment.data(), segment.size());
                 });

--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -156,8 +156,8 @@ public:
     void warnUnusedPreloads();
     void stopUnusedPreloadsTimer();
 
-    bool updateRequestAfterRedirection(CachedResource::Type, ResourceRequest&, const ResourceLoaderOptions&);
-    bool allowedByContentSecurityPolicy(CachedResource::Type, const URL&, const ResourceLoaderOptions&, ContentSecurityPolicy::RedirectResponseReceived) const;
+    bool updateRequestAfterRedirection(CachedResource::Type, ResourceRequest&, const ResourceLoaderOptions&, const URL& preRedirectURL);
+    bool allowedByContentSecurityPolicy(CachedResource::Type, const URL&, const ResourceLoaderOptions&, ContentSecurityPolicy::RedirectResponseReceived, const URL& preRedirectURL = URL()) const;
 
     static const ResourceLoaderOptions& defaultCachedResourceOptions();
 
@@ -197,7 +197,7 @@ private:
     ImageLoading clientDefersImage(const URL&) const;
     void reloadImagesIfNotDeferred();
 
-    bool canRequestAfterRedirection(CachedResource::Type, const URL&, const ResourceLoaderOptions&) const;
+    bool canRequestAfterRedirection(CachedResource::Type, const URL&, const ResourceLoaderOptions&, const URL& preRedirectURL) const;
     bool canRequestInContentDispositionAttachmentSandbox(CachedResource::Type, const URL&) const;
 
     HashSet<String> m_validatedURLs;

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/ClientOrigin.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/ClientOrigin.h
@@ -37,6 +37,7 @@ struct ClientOrigin {
 
     unsigned hash() const;
     bool operator==(const ClientOrigin&) const;
+    bool operator!=(const ClientOrigin& other) const { return !(*this == other); }
 
     template<class Encoder> void encode(Encoder&) const;
     template<class Decoder> static std::optional<ClientOrigin> decode(Decoder&);

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/DragController.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/DragController.cpp
@@ -961,6 +961,11 @@ bool DragController::startDrag(Frame& src, const DragState& state, OptionSet<Dra
     if (!state.source)
         return false;
 
+#if PLATFORM(GTK)
+    if (dragEvent.isTouchEvent())
+        return false;
+#endif
+
     Ref<Frame> protector(src);
     auto hitTestResult = hitTestResultForDragStart(src, *state.source, dragOrigin);
     if (!hitTestResult)

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/EventHandler.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/EventHandler.cpp
@@ -3807,9 +3807,10 @@ void EventHandler::defaultKeyboardEventHandler(KeyboardEvent& event)
             defaultTabEventHandler(event);
         else if (event.keyIdentifier() == "U+0008")
             defaultBackspaceEventHandler(event);
-        else if (event.keyIdentifier() == "PageUp" || event.keyIdentifier() == "PageDown")
-            startKeyboardScrolling(event);
-        else {
+        else if (event.keyIdentifier() == "PageUp" || event.keyIdentifier() == "PageDown") {
+            if (startKeyboardScrolling(event))
+                event.setDefaultHandled();
+        } else {
             FocusDirection direction = focusDirectionForKey(event.keyIdentifier());
             if (direction != FocusDirection::None)
                 defaultArrowEventHandler(direction, event);
@@ -4288,6 +4289,9 @@ void EventHandler::stopKeyboardScrolling()
 
 bool EventHandler::startKeyboardScrolling(KeyboardEvent& event)
 {
+    if (!m_frame.settings().eventHandlerDrivenSmoothKeyboardScrollingEnabled())
+        return false;
+
     Ref protectedFrame = m_frame;
     FrameView* view = m_frame.view();
 
@@ -4303,8 +4307,8 @@ void EventHandler::defaultArrowEventHandler(FocusDirection focusDirection, Keybo
     ASSERT(event.type() == eventNames().keydownEvent);
 
     if (!isSpatialNavigationEnabled(&m_frame)) {
-        if (m_frame.settings().eventHandlerDrivenSmoothKeyboardScrollingEnabled())
-            startKeyboardScrolling(event);
+        if (startKeyboardScrolling(event))
+            event.setDefaultHandled();
         return;
     }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/FrameView.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/FrameView.cpp
@@ -352,6 +352,11 @@ void FrameView::detachCustomScrollbars()
     m_scrollCorner = nullptr;
 }
 
+void FrameView::willBeDestroyed()
+{
+    setHasHorizontalScrollbar(false);
+    setHasVerticalScrollbar(false);
+}
 void FrameView::recalculateScrollbarOverlayStyle()
 {
     auto style = [this] {

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/FrameView.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/FrameView.h
@@ -682,6 +682,7 @@ public:
 
     String debugDescription() const final;
 
+    void willBeDestroyed() final;
     // ScrollView
     void updateScrollbarSteps() override;
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/IntersectionObserver.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/IntersectionObserver.h
@@ -122,6 +122,7 @@ private:
     Vector<WeakPtr<Element>> m_observationTargets;
     Vector<GCReachableRef<Element>> m_pendingTargets;
     Vector<Ref<IntersectionObserverEntry>> m_queuedEntries;
+    Vector<GCReachableRef<Element>> m_targetsWaitingForFirstObservation;
 };
 
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/Location.idl
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/Location.idl
@@ -43,7 +43,7 @@
     LegacyUnforgeable,
     Exposed=Window
 ] interface Location {
-    [SetterCallWith=IncumbentWindow&FirstWindow, DoNotCheckSecurityOnSetter] stringifier attribute USVString href;
+    [SetterCallWith=LegacyActiveWindowForAccessor&FirstWindow, DoNotCheckSecurityOnSetter] stringifier attribute USVString href;
 
     // FIXME: We should use IncumbentWindow once we found why https://bugs.webkit.org/show_bug.cgi?id=228943 issue occured.
     [CallWith=ActiveWindow&FirstWindow] undefined assign(USVString url);
@@ -51,13 +51,13 @@
     [CallWith=ActiveWindow] undefined reload();
 
     // URI decomposition attributes
-    [SetterCallWith=IncumbentWindow&FirstWindow] attribute USVString protocol;
-    [SetterCallWith=IncumbentWindow&FirstWindow] attribute USVString host;
-    [SetterCallWith=IncumbentWindow&FirstWindow] attribute USVString hostname;
-    [SetterCallWith=IncumbentWindow&FirstWindow] attribute USVString port;
-    [SetterCallWith=IncumbentWindow&FirstWindow] attribute USVString pathname;
-    [SetterCallWith=IncumbentWindow&FirstWindow] attribute USVString search;
-    [SetterCallWith=IncumbentWindow&FirstWindow] attribute USVString hash;
+    [SetterCallWith=LegacyActiveWindowForAccessor&FirstWindow] attribute USVString protocol;
+    [SetterCallWith=LegacyActiveWindowForAccessor&FirstWindow] attribute USVString host;
+    [SetterCallWith=LegacyActiveWindowForAccessor&FirstWindow] attribute USVString hostname;
+    [SetterCallWith=LegacyActiveWindowForAccessor&FirstWindow] attribute USVString port;
+    [SetterCallWith=LegacyActiveWindowForAccessor&FirstWindow] attribute USVString pathname;
+    [SetterCallWith=LegacyActiveWindowForAccessor&FirstWindow] attribute USVString search;
+    [SetterCallWith=LegacyActiveWindowForAccessor&FirstWindow] attribute USVString hash;
 
     readonly attribute USVString origin;
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/PerformanceNavigationTiming.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/PerformanceNavigationTiming.cpp
@@ -23,8 +23,6 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#pragma once
-
 #include "config.h"
 #include "PerformanceNavigationTiming.h"
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/PerformanceResourceTiming.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/PerformanceResourceTiming.cpp
@@ -99,6 +99,9 @@ PerformanceResourceTiming::~PerformanceResourceTiming() = default;
 
 const String& PerformanceResourceTiming::nextHopProtocol() const
 {
+    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+        return emptyString();
+
     return m_resourceTiming.networkLoadMetrics().protocol;
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -84,6 +84,7 @@ public:
     WEBCORE_EXPORT ContentSecurityPolicyResponseHeaders responseHeaders() const;
     enum ReportParsingErrors { No, Yes };
     WEBCORE_EXPORT void didReceiveHeaders(const ContentSecurityPolicyResponseHeaders&, String&& referrer, ReportParsingErrors = ReportParsingErrors::Yes);
+    void didReceiveHeaders(const ContentSecurityPolicy&, ReportParsingErrors = ReportParsingErrors::Yes);
     void didReceiveHeader(const String&, ContentSecurityPolicyHeaderType, ContentSecurityPolicy::PolicyFrom, String&& referrer, int httpStatusCode = 0);
 
     bool allowScriptWithNonce(const String& nonce, bool overrideContentSecurityPolicy = false) const;
@@ -103,19 +104,19 @@ public:
     WEBCORE_EXPORT bool overridesXFrameOptions() const;
 
     enum class RedirectResponseReceived { No, Yes };
-    WEBCORE_EXPORT bool allowScriptFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No) const;
-    bool allowImageFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No) const;
-    bool allowStyleFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No) const;
-    bool allowFontFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No) const;
+    WEBCORE_EXPORT bool allowScriptFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No, const URL& preRedirectURL = URL()) const;
+    bool allowImageFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No, const URL& preRedirectURL = URL()) const;
+    bool allowStyleFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No, const URL& preRedirectURL = URL()) const;
+    bool allowFontFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No, const URL& preRedirectURL = URL()) const;
 #if ENABLE(APPLICATION_MANIFEST)
-    bool allowManifestFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No) const;
+    bool allowManifestFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No, const URL& preRedirectURL = URL()) const;
 #endif
-    bool allowMediaFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No) const;
+    bool allowMediaFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No, const URL& preRedirectURL = URL()) const;
 
     bool allowChildFrameFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No) const;
-    WEBCORE_EXPORT bool allowChildContextFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No) const;
+    WEBCORE_EXPORT bool allowChildContextFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No, const URL& requestedURL = URL()) const;
     WEBCORE_EXPORT bool allowConnectToSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No, const URL& requestedURL = URL()) const;
-    bool allowFormAction(const URL&, RedirectResponseReceived = RedirectResponseReceived::No) const;
+    bool allowFormAction(const URL&, RedirectResponseReceived = RedirectResponseReceived::No, const URL& preRedirectURL = URL()) const;
 
     bool allowObjectFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No) const;
     bool allowBaseURI(const URL&, bool overrideContentSecurityPolicy = false) const;
@@ -177,6 +178,8 @@ public:
 
     void setDocumentURL(URL& documentURL) { m_documentURL = documentURL; }
 
+    SandboxFlags sandboxFlags() const { return m_sandboxFlags; }
+
 private:
     void logToConsole(const String& message, const String& contextURL = String(), const WTF::OrdinalNumber& contextLine = WTF::OrdinalNumber::beforeFirst(), const WTF::OrdinalNumber& contextColumn = WTF::OrdinalNumber::beforeFirst(), JSC::JSGlobalObject* = nullptr) const;
     void applyPolicyToScriptExecutionContext();
@@ -203,7 +206,7 @@ private:
     bool allPoliciesAllow(ViolatedDirectiveCallback&&, Predicate&&, Args&&...) const WARN_UNUSED_RETURN;
 
     using ResourcePredicate = const ContentSecurityPolicyDirective *(ContentSecurityPolicyDirectiveList::*)(const URL &, bool) const;
-    bool allowResourceFromSource(const URL&, RedirectResponseReceived, const char*, ResourcePredicate) const;
+    bool allowResourceFromSource(const URL&, RedirectResponseReceived, const char*, ResourcePredicate, const URL& preRedirectURL = URL()) const;
 
     using HashInEnforcedAndReportOnlyPoliciesPair = std::pair<bool, bool>;
     template<typename Predicate> HashInEnforcedAndReportOnlyPoliciesPair findHashOfContentInPolicies(Predicate&&, StringView content, OptionSet<ContentSecurityPolicyHashAlgorithm>) const WARN_UNUSED_RETURN;

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/PlatformMouseEvent.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/PlatformMouseEvent.h
@@ -91,6 +91,12 @@ const double ForceAtForceClick = 2;
         bool didActivateWebView() const { return m_didActivateWebView; }
 #endif
 
+#if PLATFORM(GTK)
+        enum class IsTouch : bool { No, Yes };
+
+        bool isTouchEvent() const { return m_isTouchEvent == IsTouch::Yes; }
+#endif
+
     protected:
         MouseButton m_button { NoButton };
         SyntheticClickType m_syntheticClickType { NoTap };
@@ -109,6 +115,8 @@ const double ForceAtForceClick = 2;
         int m_menuTypeForEvent { 0 };
 #elif PLATFORM(WIN)
         bool m_didActivateWebView { false };
+#elif PLATFORM(GTK)
+        IsTouch m_isTouchEvent { IsTouch::No };
 #endif
     };
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/SharedBuffer.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/SharedBuffer.cpp
@@ -238,7 +238,8 @@ Ref<SharedBuffer> SharedBuffer::copy() const
 
 void SharedBuffer::forEachSegment(const Function<void(const Span<const uint8_t>&)>& apply) const
 {
-    for (auto& segment : m_segments)
+    auto segments = m_segments;
+    for (auto& segment : segments)
         apply(Span { segment.segment->data(), segment.segment->size() });
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/SourcesGLib.txt
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/SourcesGLib.txt
@@ -23,6 +23,7 @@
 
 platform/audio/glib/AudioBusGLib.cpp
 
+platform/glib/ApplicationGLib.cpp
 platform/glib/FileMonitorGLib.cpp
 platform/glib/KeyedDecoderGlib.cpp
 platform/glib/KeyedEncoderGlib.cpp

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/UserAgentQuirks.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/UserAgentQuirks.cpp
@@ -169,9 +169,9 @@ String UserAgentQuirks::stringForQuirk(UserAgentQuirk quirk)
     switch (quirk) {
     case NeedsChromeBrowser:
         // Get versions from https://chromium.googlesource.com/chromium/src.git
-        return "Chrome/90.0.4419.1"_s;
+        return "Chrome/97.0.4669.2"_s;
     case NeedsFirefoxBrowser:
-        return "; rv:87.0) Gecko/20100101 Firefox/87.0"_s;
+        return "; rv:95.0) Gecko/20100101 Firefox/95.0"_s;
     case NeedsMacintoshPlatform:
         return "Macintosh; Intel Mac OS X 10_15"_s;
     case NeedsUnbrandedUserAgent:

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/Widget.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/Widget.h
@@ -180,6 +180,8 @@ public:
     // the frame rects be the same no matter what transforms are applied.
     virtual bool transformsAffectFrameRect() { return true; }
 
+    virtual void willBeDestroyed() { }
+
 #if PLATFORM(COCOA)
     NSView* getOuterView() const;
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/BifurcatedGraphicsContext.cpp
@@ -275,11 +275,13 @@ void BifurcatedGraphicsContext::drawPattern(NativeImage& nativeImage, const Floa
     m_secondaryContext.drawPattern(nativeImage, imageSize, destRect, tileRect, patternTransform, phase, spacing, options);
 }
 
+#if ENABLE(VIDEO)
 void BifurcatedGraphicsContext::paintFrameForMedia(MediaPlayer& player, const FloatRect& destination)
 {
     m_primaryContext.paintFrameForMedia(player, destination);
     m_secondaryContext.paintFrameForMedia(player, destination);
 }
+#endif // ENABLE(VIDEO)
 
 void BifurcatedGraphicsContext::scale(const FloatSize& scale)
 {

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/x11/XUniqueResource.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/x11/XUniqueResource.h
@@ -28,6 +28,8 @@
 
 #if PLATFORM(X11)
 
+#include <utility>
+
 #if USE(GLX)
 typedef unsigned long GLXPbuffer;
 typedef unsigned long GLXPixmap;

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderBlock.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderBlock.cpp
@@ -3175,6 +3175,9 @@ std::optional<LayoutUnit> RenderBlock::availableLogicalHeightForPercentageComput
         LayoutUnit contentBoxHeight = adjustContentBoxLogicalHeightForBoxSizing((LayoutUnit)styleToUse.logicalHeight().value());
         availableHeight = std::max(0_lu, constrainContentBoxLogicalHeightByMinMax(contentBoxHeight - scrollbarLogicalHeight(), std::nullopt));
     } else if (shouldComputeLogicalHeightFromAspectRatio()) {
+        // Only grid is expected to be in a state where it is calculating pref width and having unknown logical width.
+        if (isRenderGrid() && preferredLogicalWidthsDirty() && !style().logicalWidth().isFixed())
+            return availableHeight;
         availableHeight = blockSizeFromAspectRatio(horizontalBorderAndPaddingExtent(), verticalBorderAndPaddingExtent(), LayoutUnit(style().logicalAspectRatio()), style().boxSizingForAspectRatio(), logicalWidth());
     } else if (isOutOfFlowPositionedWithSpecifiedHeight) {
         // Don't allow this to affect the block' size() member variable, since this

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -2099,6 +2099,28 @@ bool RenderBlockFlow::containsFloat(RenderBox& renderer) const
     return m_floatingObjects && m_floatingObjects->set().contains<FloatingObjectHashTranslator>(renderer);
 }
 
+bool RenderBlockFlow::subtreeContainsFloat(RenderBox& renderer) const
+{
+    bool contains = m_floatingObjects && m_floatingObjects->set().contains<FloatingObjectHashTranslator>(renderer);
+    for (auto& block : childrenOfType<RenderBlock>(*this)) {
+        if (!is<RenderBlockFlow>(block))
+            continue;
+        auto& blockFlow = downcast<RenderBlockFlow>(block);
+        contains |= blockFlow.subtreeContainsFloat(renderer);
+    }
+    return contains;
+}
+bool RenderBlockFlow::subtreeContainsFloats() const
+{
+    bool contains = m_floatingObjects && !m_floatingObjects->set().isEmpty();
+    for (auto& block : childrenOfType<RenderBlock>(*this)) {
+        if (!is<RenderBlockFlow>(block))
+            continue;
+        auto& blockFlow = downcast<RenderBlockFlow>(block);
+        contains |= blockFlow.subtreeContainsFloats();
+    }
+    return contains;
+}
 void RenderBlockFlow::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle)
 {
     RenderBlock::styleDidChange(diff, oldStyle);
@@ -2868,7 +2890,7 @@ void RenderBlockFlow::markAllDescendantsWithFloatsForLayout(RenderBox* floatToRe
             continue;
         }
         auto& blockFlow = downcast<RenderBlockFlow>(block);
-        if ((floatToRemove ? blockFlow.containsFloat(*floatToRemove) : blockFlow.containsFloats()) || blockFlow.shrinkToAvoidFloats())
+        if ((floatToRemove ? blockFlow.subtreeContainsFloat(*floatToRemove) : blockFlow.subtreeContainsFloats()) || blockFlow.shrinkToAvoidFloats())
             blockFlow.markAllDescendantsWithFloatsForLayout(floatToRemove, inLayout);
     }
 }
@@ -3674,7 +3696,7 @@ void RenderBlockFlow::invalidateLineLayoutPath()
 #endif
         m_lineLayout = WTF::Monostate();
         setLineLayoutPath(path);
-        if (needsLayout())
+        if (selfNeedsLayout() || normalChildNeedsLayout())
             return;
         // FIXME: We should just kick off a subtree layout here (if needed at all) see webkit.org/b/172947.
         setNeedsLayout();

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderBlockFlow.h
@@ -278,6 +278,8 @@ public:
 
     bool containsFloats() const override { return m_floatingObjects && !m_floatingObjects->set().isEmpty(); }
     bool containsFloat(RenderBox&) const;
+    bool subtreeContainsFloats() const;
+    bool subtreeContainsFloat(RenderBox&) const;
 
     void deleteLines() override;
     void computeOverflow(LayoutUnit oldClientAfterEdge, bool recomputeFloats = false) override;

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderBox.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderBox.cpp
@@ -408,7 +408,7 @@ void RenderBox::styleDidChange(StyleDifference diff, const RenderStyle* oldStyle
     // Changing the position from/to absolute can potentially create/remove flex/grid items, as absolutely positioned
     // children of a flex/grid box are out-of-flow, and thus, not flex/grid items. This means that we need to clear
     // any override content size set by our container, because it would likely be incorrect after the style change.
-    if (isOutOfFlowPositioned() && parent() && parent()->style().isDisplayFlexibleOrGridBox())
+    if (isOutOfFlowPositioned() && parent() && parent()->style().isDisplayFlexibleBoxIncludingDeprecatedOrGridBox())
         clearOverridingContentSize();
 
 #if ENABLE(LAYOUT_FORMATTING_CONTEXT)

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderCounter.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderCounter.cpp
@@ -291,7 +291,8 @@ static CounterInsertionPoint findPlaceForCounter(RenderElement& counterOwner, co
                         previousSibling = currentCounter;
                         // We are no longer interested in previous siblings of the currentRenderer or their children
                         // as counters they may have attached cannot be the previous sibling of the counter we are placing.
-                        currentRenderer = parentOrPseudoHostElement(*currentRenderer)->renderer();
+                        auto* parent = parentOrPseudoHostElement(*currentRenderer);
+                        currentRenderer = parent ? parent->renderer() : nullptr;
                         continue;
                     }
                 } else

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderWidget.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderWidget.cpp
@@ -103,6 +103,8 @@ void RenderWidget::willBeDestroyed()
         cache->remove(this);
     }
 
+    if (renderTreeBeingDestroyed() && document().backForwardCacheState() == Document::NotInBackForwardCache && m_widget)
+        m_widget->willBeDestroyed();
     setWidget(nullptr);
 
     RenderReplaced::willBeDestroyed();

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/style/RenderStyle.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/style/RenderStyle.h
@@ -1495,6 +1495,7 @@ public:
     bool isDisplayInlineType() const { return isDisplayInlineType(display()); }
     bool isOriginalDisplayInlineType() const { return isDisplayInlineType(originalDisplay()); }
     bool isDisplayFlexibleOrGridBox() const { return isDisplayFlexibleOrGridBox(display()); }
+    bool isDisplayFlexibleBoxIncludingDeprecatedOrGridBox() const { return isDisplayFlexibleOrGridBox() || isDisplayDeprecatedFlexibleBox(display()); }
     bool isDisplayRegionType() const;
     bool isDisplayTableOrTablePart() const { return isDisplayTableOrTablePart(display()); }
     bool isOriginalDisplayListItemType() const { return isDisplayListItemType(originalDisplay()); }
@@ -1961,6 +1962,7 @@ private:
     static bool isDisplayFlexibleBox(DisplayType);
     static bool isDisplayGridBox(DisplayType);
     static bool isDisplayFlexibleOrGridBox(DisplayType);
+    static bool isDisplayDeprecatedFlexibleBox(DisplayType);
     static bool isDisplayListItemType(DisplayType);
     static bool isDisplayTableOrTablePart(DisplayType);
 
@@ -2366,6 +2368,11 @@ inline bool RenderStyle::isDisplayGridBox(DisplayType display)
 inline bool RenderStyle::isDisplayFlexibleOrGridBox(DisplayType display)
 {
     return isDisplayFlexibleBox(display) || isDisplayGridBox(display);
+}
+
+inline bool RenderStyle::isDisplayDeprecatedFlexibleBox(DisplayType display)
+{
+    return display == DisplayType::Box || display == DisplayType::InlineBox;
 }
 
 inline bool RenderStyle::isDisplayListItemType(DisplayType display)

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -317,7 +317,7 @@ void RenderTreeUpdater::updateElementRenderer(Element& element, const Style::Ele
         elementUpdateStyle->addCachedPseudoStyle(RenderStyle::clonePtr(*it.value.style));
     }
 
-    bool shouldTearDownRenderers = elementUpdate.change == Style::Change::Renderer && (element.renderer() || element.hasDisplayContents());
+    bool shouldTearDownRenderers = elementUpdate.change == Style::Change::Renderer && (element.renderer() || element.hasDisplayContents() || element.isInTopLayer());
     if (shouldTearDownRenderers) {
         if (!element.renderer()) {
             // We may be tearing down a descendant renderer cached in renderTreePosition.

--- a/modules/javafx.web/src/main/native/Source/WebCore/workers/Worker.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/workers/Worker.h
@@ -34,6 +34,7 @@
 #include "WorkerScriptLoaderClient.h"
 #include "WorkerType.h"
 #include <JavaScriptCore/RuntimeFlags.h>
+#include <wtf/Deque.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/text/AtomStringHash.h>
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/workers/service/SWClientConnection.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/workers/service/SWClientConnection.h
@@ -88,8 +88,7 @@ public:
     virtual void whenServiceWorkerIsTerminatedForTesting(ServiceWorkerIdentifier, CompletionHandler<void()>&& callback) { callback(); }
 
     WEBCORE_EXPORT void registerServiceWorkerClients();
-
-    WEBCORE_EXPORT void registerServiceWorkerClients();
+    bool isClosed() const { return m_isClosed; }
 
 protected:
     WEBCORE_EXPORT SWClientConnection();
@@ -106,6 +105,7 @@ protected:
     WEBCORE_EXPORT void notifyClientsOfControllerChange(const HashSet<DocumentIdentifier>& contextIdentifiers, ServiceWorkerData&& newController);
 
     WEBCORE_EXPORT void clearPendingJobs();
+    void setIsClosed() { m_isClosed = true; }
 
 private:
     virtual void scheduleJobInServer(const ServiceWorkerJobData&) = 0;
@@ -113,6 +113,7 @@ private:
     enum class IsJobComplete { No, Yes };
     bool postTaskForJob(ServiceWorkerJobIdentifier, IsJobComplete, Function<void(ServiceWorkerJob&)>&&);
 
+    bool m_isClosed { false };
     HashMap<ServiceWorkerJobIdentifier, DocumentOrWorkerIdentifier> m_scheduledJobSources;
 };
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -503,7 +503,7 @@ const char* ServiceWorkerContainer::activeDOMObjectName() const
 SWClientConnection& ServiceWorkerContainer::ensureSWClientConnection()
 {
     ASSERT(scriptExecutionContext());
-    if (!m_swConnection) {
+    if (!m_swConnection || m_swConnection->isClosed()) {
         auto& context = *scriptExecutionContext();
         if (is<WorkerGlobalScope>(context))
             m_swConnection = &downcast<WorkerGlobalScope>(context).swClientConnection();

--- a/modules/javafx.web/src/main/native/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/workers/service/server/SWServer.cpp
@@ -819,6 +819,11 @@ void SWServer::workerContextTerminated(SWServerWorker& worker)
     // At this point if no registrations are referencing the worker then it will be destroyed,
     // removing itself from the m_workersByID map.
     auto result = m_runningOrTerminatingWorkers.take(worker.identifier());
+    if (!result) {
+        ASSERT(worker.isNotRunning());
+        return;
+    }
+
     ASSERT_UNUSED(result, result == &worker);
 
     worker.setState(SWServerWorker::State::NotRunning);

--- a/modules/javafx.web/src/main/native/Source/WebCore/xml/XPathStep.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/xml/XPathStep.cpp
@@ -257,7 +257,7 @@ void Step::nodesInAxis(Node& context, NodeSet& nodes) const
         case ParentAxis:
             if (context.isAttributeNode()) {
                 Element* node = static_cast<Attr&>(context).ownerElement();
-                if (nodeMatches(*node, ParentAxis, m_nodeTest))
+                if (node && nodeMatches(*node, ParentAxis, m_nodeTest))
                     nodes.append(node);
             } else {
                 ContainerNode* node = context.parentNode();
@@ -269,6 +269,8 @@ void Step::nodesInAxis(Node& context, NodeSet& nodes) const
             Node* node = &context;
             if (context.isAttributeNode()) {
                 node = static_cast<Attr&>(context).ownerElement();
+                if (!node)
+                    return;
                 if (nodeMatches(*node, AncestorAxis, m_nodeTest))
                     nodes.append(node);
             }
@@ -299,6 +301,8 @@ void Step::nodesInAxis(Node& context, NodeSet& nodes) const
         case FollowingAxis:
             if (context.isAttributeNode()) {
                 Node* node = static_cast<Attr&>(context).ownerElement();
+                if (!node)
+                    return;
                 while ((node = NodeTraversal::next(*node))) {
                     if (nodeMatches(*node, FollowingAxis, m_nodeTest))
                         nodes.append(node);
@@ -318,9 +322,11 @@ void Step::nodesInAxis(Node& context, NodeSet& nodes) const
             return;
         case PrecedingAxis: {
             Node* node;
-            if (context.isAttributeNode())
+            if (context.isAttributeNode()) {
                 node = static_cast<Attr&>(context).ownerElement();
-            else
+                if (!node)
+                    return;
+            } else
                 node = &context;
             while (ContainerNode* parent = node->parentNode()) {
                 for (node = NodeTraversal::previous(*node); node != parent; node = NodeTraversal::previous(*node)) {
@@ -381,6 +387,8 @@ void Step::nodesInAxis(Node& context, NodeSet& nodes) const
             Node* node = &context;
             if (context.isAttributeNode()) {
                 node = static_cast<Attr&>(context).ownerElement();
+                if (!node)
+                    return;
                 if (nodeMatches(*node, AncestorOrSelfAxis, m_nodeTest))
                     nodes.append(node);
             }

--- a/modules/javafx.web/src/main/native/Tools/TestRunnerShared/ReftestFunctions.cpp
+++ b/modules/javafx.web/src/main/native/Tools/TestRunnerShared/ReftestFunctions.cpp
@@ -36,9 +36,12 @@ void sendTestRenderedEvent(JSGlobalContextRef context)
         return;
     auto initializer = JSObjectMake(context, nullptr, nullptr);
     setProperty(context, initializer, "bubbles", true);
-    auto event = callConstructor(context, "Event", { makeValue(context, "TestRendered"), initializer });
+    auto value = makeValue(context, "TestRendered");
+    JSValueProtect(context, value);
+    auto event = callConstructor(context, "Event", { value, initializer });
     auto documentElement = objectProperty(context, JSContextGetGlobalObject(context), { "document", "documentElement" });
     call(context, documentElement, "dispatchEvent", { event });
+    JSValueUnprotect(context, value);
 }
 
 bool hasReftestWaitAttribute(JSGlobalContextRef context)


### PR DESCRIPTION
Stabilization fixes from WebKitGTK 2.34.5

Reviewed-by: jvos, kcr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281711](https://bugs.openjdk.java.net/browse/JDK-8281711): Cherry-pick WebKit 613.1 stabilization fixes


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/773/head:pull/773` \
`$ git checkout pull/773`

Update a local copy of the PR: \
`$ git checkout pull/773` \
`$ git pull https://git.openjdk.java.net/jfx pull/773/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 773`

View PR using the GUI difftool: \
`$ git pr show -t 773`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/773.diff">https://git.openjdk.java.net/jfx/pull/773.diff</a>

</details>
