### PR TITLE
8283318: Videos with unusual sizes cannot be played on windows

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/dshowwrapper.cpp
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/dshowwrapper/dshowwrapper.cpp
@@ -2100,11 +2100,11 @@ static gboolean dshowwrapper_load_decoder_h264(GstStructure *s, GstDShowWrapper 
         // Enable dynamic format change for MP4 via ReceiveConnection().
         // HLS works fine using QueryAccept without buffer size changes and
         // breaks if dynamic format is enabled, so for now we will use it only
-        // for MP4. It seems we only need it for portrait video or anything
-        // bigger then 1920x1080, so we will enable it only for such resolution.
-        // See JDK-8133841.
-        if ((width < height) || (width > 1920 && height > 1080))
-            outputFormat.bEnableDynamicFormatChanges = 1;
+        // for MP4. It seems we need it for portrait video, anything that has
+        // width > 1920 and/or height > 1080 or any not standard resolutions
+        // such as 1706x854.
+        // See JDK-8133841 and JDK-8283318.
+        outputFormat.bEnableDynamicFormatChanges = 1;
 
         decoder->width = width;
         decoder->height = height;


### PR DESCRIPTION
Fixed by removing check which enables dynamic format change, since it requires for portrait videos, not standard resolutions and anything that has width > 1920 or/and height > 1080.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8283318](https://bugs.openjdk.java.net/browse/JDK-8283318): Videos with unusual sizes cannot be played on windows


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/775/head:pull/775` \
`$ git checkout pull/775`

Update a local copy of the PR: \
`$ git checkout pull/775` \
`$ git pull https://git.openjdk.java.net/jfx pull/775/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 775`

View PR using the GUI difftool: \
`$ git pr show -t 775`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/775.diff">https://git.openjdk.java.net/jfx/pull/775.diff</a>

</details>
