### PR TITLE
8285217: [Android] Window's screen is not updated after native screen was disposed

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Screen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Screen.java
@@ -382,15 +382,16 @@ public final class Screen {
             eventHandler.handleSettingsChanged();
         }
 
-        // Update the screen for each window to match the new instance.
+        // Update the screen for each window to match the new instance,
+        // also when such screen was disposed and a new one is available.
         // Note that if a window has moved to another screen, the window
         // will be notified separately of that from native code and the
         // new screen will be updated there
         List<Window> windows = Window.getWindows();
         for (Window w : windows) {
-            Screen oldScreen = w.getScreen();
+            long oldNativeScreen = w.getScreen().getNativeScreen();
             for (Screen newScreen : screens) {
-                if (oldScreen.getNativeScreen() == newScreen.getNativeScreen()) {
+                if (oldNativeScreen == newScreen.getNativeScreen() || oldNativeScreen == 0) {
                     w.setScreen(newScreen);
                     break;
                 }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Screen.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Screen.java
@@ -382,16 +382,15 @@ public final class Screen {
             eventHandler.handleSettingsChanged();
         }
 
-        // Update the screen for each window to match the new instance,
-        // also when such screen was disposed and a new one is available.
+        // Update the screen for each window to match the new instance.
         // Note that if a window has moved to another screen, the window
         // will be notified separately of that from native code and the
         // new screen will be updated there
         List<Window> windows = Window.getWindows();
         for (Window w : windows) {
-            long oldNativeScreen = w.getScreen().getNativeScreen();
+            Screen oldScreen = w.getScreen();
             for (Screen newScreen : screens) {
-                if (oldNativeScreen == newScreen.getNativeScreen() || oldNativeScreen == 0) {
+                if (oldScreen.getNativeScreen() == newScreen.getNativeScreen()) {
                     w.setScreen(newScreen);
                     break;
                 }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleWindow.java
@@ -264,6 +264,11 @@ final class MonocleWindow extends Window {
         return true;
     }
 
+    @Override
+    protected void notifyMoveToAnotherScreen(Screen screen) {
+        super.notifyMoveToAnotherScreen(screen);
+    }
+
     void setFullScreen(boolean fullscreen) {
         NativeScreen screen = NativePlatformFactory.getNativePlatform().getScreen();
         int x = getX();

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleWindowManager.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleWindowManager.java
@@ -173,19 +173,18 @@ final class MonocleWindowManager {
         }
     }
 
-    static void repaintFromNative () {
-        Platform.runLater(new Runnable () {
-
-            @Override
-            public void run() {
-                Screen.notifySettingsChanged();
-                MonocleWindow focusedWindow = instance.getFocusedWindow();
-                if (focusedWindow != null) {
-                    focusedWindow.setFullScreen(true);
+    static void repaintFromNative(Screen screen) {
+        Platform.runLater(() -> {
+            Screen.notifySettingsChanged();
+            MonocleWindow focusedWindow = instance.getFocusedWindow();
+            if (focusedWindow != null) {
+                if (screen != null && screen.getNativeScreen() != focusedWindow.getScreen().getNativeScreen()) {
+                    focusedWindow.notifyMoveToAnotherScreen(screen);
                 }
-                instance.repaintAll();
-                Toolkit.getToolkit().requestNextPulse();
+                focusedWindow.setFullScreen(true);
             }
+            instance.repaintAll();
+            Toolkit.getToolkit().requestNextPulse();
         });
     }
 

--- a/modules/javafx.graphics/src/main/native-glass/monocle/android/nativeBridge.c
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/android/nativeBridge.c
@@ -161,8 +161,8 @@ void androidJfx_requestGlassToRedraw() {
         GLASS_LOG_WARNING("we can't do this yet, no androidWindow\n");
         return;
     }
-    int32_t width = ANativeWindow_getWidth(androidWindow);
-    int32_t height = ANativeWindow_getHeight(androidWindow);
+    int32_t width = ANativeWindow_getWidth(androidWindow) / androidDensity;
+    int32_t height = ANativeWindow_getHeight(androidWindow) / androidDensity;
     jobject screen = (*javaEnv)->NewObject(javaEnv, jScreenClass, screen_init,
         (jlong) androidWindow, 24,
         0, 0, (jint) width, (jint) height,

--- a/modules/javafx.graphics/src/main/native-glass/monocle/android/nativeBridge.c
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/android/nativeBridge.c
@@ -168,7 +168,7 @@ void androidJfx_requestGlassToRedraw() {
         0, 0, (jint) width, (jint) height,
         0, 0, (jint) width, (jint) height,
         0, 0, (jint) width, (jint) height,
-        100, 100, (jfloat) 1, (jfloat) 1, androidDensity, androidDensity);
+        SCREEN_DPI, SCREEN_DPI, (jfloat) 1, (jfloat) 1, androidDensity, androidDensity);
     (*javaEnv)->CallStaticVoidMethod(javaEnv, jMonocleWindowManagerClass, monocle_repaintAll, screen);
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/monocle/android/nativeBridge.c
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/android/nativeBridge.c
@@ -33,11 +33,13 @@ JavaVM *jVM = NULL;
 
 static jclass jAndroidInputDeviceRegistryClass;
 static jclass jMonocleWindowManagerClass;
+static jclass jScreenClass;
 
 static jmethodID monocle_gotTouchEventFromNative;
 static jmethodID monocle_dispatchKeyEventFromNative;
 static jmethodID monocle_repaintAll;
 static jmethodID monocle_registerDevice;
+static jmethodID screen_init;
 
 ANativeWindow* androidWindow = NULL;
 jfloat androidDensity = 0.f;
@@ -51,9 +53,10 @@ void initializeFromJava (JNIEnv *env) {
                                                  (*env)->FindClass(env, "com/sun/glass/ui/monocle/MonocleWindowManager"));
     jAndroidInputDeviceRegistryClass = (*env)->NewGlobalRef(env,
                                                  (*env)->FindClass(env, "com/sun/glass/ui/monocle/AndroidInputDeviceRegistry"));
+    jScreenClass = (*env)->NewGlobalRef(env, (*env)->FindClass(env, "com/sun/glass/ui/Screen"));
     monocle_repaintAll = (*env)->GetStaticMethodID(
                                             env, jMonocleWindowManagerClass, "repaintFromNative",
-                                            "()V");
+                                            "(Lcom/sun/glass/ui/Screen;)V");
     monocle_gotTouchEventFromNative = (*env)->GetStaticMethodID(
                                             env, jAndroidInputDeviceRegistryClass, "gotTouchEventFromNative",
                                             "(I[I[I[I[II)V");
@@ -61,6 +64,7 @@ void initializeFromJava (JNIEnv *env) {
                                             env, jAndroidInputDeviceRegistryClass, "dispatchKeyEventFromNative",
                                             "(II[CI)V");
     monocle_registerDevice = (*env)->GetStaticMethodID(env, jAndroidInputDeviceRegistryClass, "registerDevice","()V");
+    screen_init = (*env)->GetMethodID(env, jScreenClass,"<init>", "(JIIIIIIIIIIIIIIIFFFF)V");
     GLASS_LOG_FINE("Initializing native Android Bridge done");
 }
 
@@ -153,7 +157,19 @@ void androidJfx_requestGlassToRedraw() {
         GLASS_LOG_WARNING("we can't do this yet, no monocle_repaintAll\n");
         return;
     }
-    (*javaEnv)->CallStaticVoidMethod(javaEnv, jMonocleWindowManagerClass, monocle_repaintAll);
+    if (androidWindow == NULL) {
+        GLASS_LOG_WARNING("we can't do this yet, no androidWindow\n");
+        return;
+    }
+    int32_t width = ANativeWindow_getWidth(androidWindow);
+    int32_t height = ANativeWindow_getHeight(androidWindow);
+    jobject screen = (*javaEnv)->NewObject(javaEnv, jScreenClass, screen_init,
+        (jlong) androidWindow, 24,
+        0, 0, (jint) width, (jint) height,
+        0, 0, (jint) width, (jint) height,
+        0, 0, (jint) width, (jint) height,
+        100, 100, (jfloat) 1, (jfloat) 1, androidDensity, androidDensity);
+    (*javaEnv)->CallStaticVoidMethod(javaEnv, jMonocleWindowManagerClass, monocle_repaintAll, screen);
 }
 
 /* ===== called from Java ===== */

--- a/modules/javafx.graphics/src/main/native-glass/monocle/android/nativeBridge.h
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/android/nativeBridge.h
@@ -36,6 +36,8 @@ void androidJfx_requestGlassToRedraw();
 #define GLASS_LOG_FINEST(...)  ((void)__android_log_print(ANDROID_LOG_INFO,"GLASS", __VA_ARGS__))
 #define GLASS_LOG_WARNING(...)  ((void)__android_log_print(ANDROID_LOG_INFO,"GLASS", __VA_ARGS__))
 
+static const jint SCREEN_DPI = 100;
+
 ANativeWindow* android_getNativeWindow(JNIEnv *env);
 jfloat android_getDensity(JNIEnv *env);
 


### PR DESCRIPTION
This PR updates the screen for each window even for the case where the old screen has been disposed but there is a new screen instance found for such window.

This is the case of Android, where the lifecycle of the application allows destroying the native screen when the app goes to the background, and providing a new native screen, in case it comes back to the foreground. Before this PR, the screen for the window wasn't updated after returning from the background, and if orientation changes happened, the dimensions were wrong.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8285217](https://bugs.openjdk.java.net/browse/JDK-8285217): [Android] Window's screen is not updated after native screen was disposed


### Reviewers
 * [Johan Vos](https://openjdk.java.net/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/778/head:pull/778` \
`$ git checkout pull/778`

Update a local copy of the PR: \
`$ git checkout pull/778` \
`$ git pull https://git.openjdk.java.net/jfx pull/778/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 778`

View PR using the GUI difftool: \
`$ git pr show -t 778`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/778.diff">https://git.openjdk.java.net/jfx/pull/778.diff</a>

</details>
