### PR TITLE
8285360: [TestBug] Cleanup a few ignored javafx.controls unit tests

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellTest.java
@@ -384,10 +384,12 @@ public class CellTest {
         cell.startEdit();
         cell.requestFocus();
         Toolkit.getToolkit().firePulse();
+        assertTrue(cell.isEditing());
 
         other.requestFocus();
         Toolkit.getToolkit().firePulse();
 
         assertFalse(cell.isEditing());
+        stage.hide();
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellTest.java
@@ -25,10 +25,13 @@
 
 package test.javafx.scene.control;
 
+import com.sun.javafx.tk.Toolkit;
+
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.scene.Group;
 import javafx.scene.Scene;
+import javafx.stage.Stage;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -45,7 +48,6 @@ import javafx.scene.control.TreeTableCellShim;
 import javafx.scene.control.TreeTableRow;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -367,19 +369,24 @@ public class CellTest {
         assertEquals("editable", cell.editableProperty().getName());
     }
 
-    // When the cell was focused, but is no longer focused, we should cancel editing
-    // Check for focused pseudoClass state change?
-    @Ignore(value = "I'm not sure how to test this, since I need a scene & such to move focus around")
     @Test public void loseFocusWhileEditing() {
         Button other = new Button();
         Group root = new Group(other, cell);
         Scene scene = new Scene(root);
 
+        Stage stage = new Stage();
+        stage.setScene(scene);
+        stage.show();
+        stage.requestFocus();
+        Toolkit.getToolkit().firePulse();
+
         CellShim.updateItem(cell, "Apples", false);
         cell.startEdit();
         cell.requestFocus();
+        Toolkit.getToolkit().firePulse();
 
         other.requestFocus();
+        Toolkit.getToolkit().firePulse();
 
         assertFalse(cell.isEditing());
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/DateCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/DateCellTest.java
@@ -331,10 +331,12 @@ public class DateCellTest {
         cell.startEdit();
         cell.requestFocus();
         Toolkit.getToolkit().firePulse();
+        assertTrue(cell.isEditing());
 
         other.requestFocus();
         Toolkit.getToolkit().firePulse();
 
         assertFalse(cell.isEditing());
+        stage.hide();
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/DateCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/DateCellTest.java
@@ -27,6 +27,8 @@ package test.javafx.scene.control;
 
 import java.time.LocalDate;
 
+import com.sun.javafx.tk.Toolkit;
+
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.scene.Group;
@@ -34,9 +36,9 @@ import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.CellShim;
 import javafx.scene.control.DateCell;
+import javafx.stage.Stage;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils;
@@ -314,19 +316,24 @@ public class DateCellTest {
         assertEquals("editable", cell.editableProperty().getName());
     }
 
-    // When the cell was focused, but is no longer focused, we should cancel editing
-    // Check for focused pseudoClass state change?
-    @Ignore(value = "I'm not sure how to test this, since I need a scene & such to move focus around")
     @Test public void loseFocusWhileEditing() {
         Button other = new Button();
         Group root = new Group(other, cell);
         Scene scene = new Scene(root);
 
+        Stage stage = new Stage();
+        stage.setScene(scene);
+        stage.show();
+        stage.requestFocus();
+        Toolkit.getToolkit().firePulse();
+
         CellShim.updateItem(cell, today, false);
         cell.startEdit();
         cell.requestFocus();
+        Toolkit.getToolkit().firePulse();
 
         other.requestFocus();
+        Toolkit.getToolkit().firePulse();
 
         assertFalse(cell.isEditing());
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/PaginationTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/PaginationTest.java
@@ -48,7 +48,6 @@ import javafx.stage.Stage;
 import javafx.util.Callback;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import test.com.sun.javafx.pgstub.StubToolkit;
@@ -180,7 +179,7 @@ public class PaginationTest {
         assertEquals(2, pagination.getCurrentPageIndex());
     }
 
-    @Ignore @Test public void setCurrentPageIndexAndNavigateWithMouse() {
+    @Test public void setCurrentPageIndexAndNavigateWithMouse() {
         pagination.setPageCount(25);
         pagination.setPageFactory(pageIndex -> {
             Node n = createPage(pageIndex);
@@ -201,6 +200,8 @@ public class PaginationTest {
 
         SceneHelper.processMouseEvent(scene,
             MouseEventGenerator.generateMouseEvent(MouseEvent.MOUSE_PRESSED, xval+170, yval+380));
+        SceneHelper.processMouseEvent(scene,
+            MouseEventGenerator.generateMouseEvent(MouseEvent.MOUSE_RELEASED, xval+170, yval+380));
         tk.firePulse();
 
         assertEquals(3, pagination.getCurrentPageIndex());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/PaginationTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/PaginationTest.java
@@ -47,6 +47,7 @@ import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import javafx.util.Callback;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -71,6 +72,10 @@ public class PaginationTest {
         scene = new Scene(root);
         stage = new Stage();
         stage.setScene(scene);
+    }
+
+    @After public void tearDown() {
+        stage.hide();
     }
 
     /*********************************************************************

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/PopupControlTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/PopupControlTest.java
@@ -117,12 +117,6 @@ public class PopupControlTest {
         assertEquals("Hello Goodbye", popup.getStyleClass().toString());
     }
 
-    @org.junit.Ignore("getStyle should not return null per Node#setStyle")
-    @Test public void styleSetNullGetNull() {
-        popup.setStyle(null);
-        assertNull(popup.getStyle());
-    }
-
     // See Node#setStyle
     @Test public void styleSetNullGetEmptyString() {
         popup.setStyle(null);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/RadioMenuItemTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/RadioMenuItemTest.java
@@ -43,7 +43,6 @@ import static org.junit.Assert.*;
 
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -234,14 +233,6 @@ public class RadioMenuItemTest {
     @Test public void getUnspecifiedToggleGroupProperty2() {
         RadioMenuItem rmi2 = new RadioMenuItem("", null);
         assertNotNull(rmi2.toggleGroupProperty());
-    }
-
-    // calling toggleGroupProperty does not ensure the value of toggleGroup
-    // to be non null
-    @Ignore
-    @Test public void unsetToggleGroupButNotNull() {
-        rmi.toggleGroupProperty();
-        assertNotNull(rmi.getToggleGroup());
     }
 
     @Test public void toggleGroupCanBeBound() {


### PR DESCRIPTION
This PR is to cleanup a few `javafx.controls` unit tests that were ignored. 

Here is the list of targeted unit test classes- 
- Ignored tests re-enabled and fixed - `DateCellTest`, `CellTest`, `PaginationTest`
- Ignored tests removed -  `RadioMenuItemTest`, `PopupControlTest`

Results of `javafx.controls` unit tests-
**Before this PR :** 
Total tests - 8610
Failures - 0
Ignored - 246

**After this PR :** 
Total tests - 8608
Failures - 0
Ignored - 235

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285360](https://bugs.openjdk.java.net/browse/JDK-8285360): [TestBug] Cleanup a few ignored javafx.controls unit tests


### Reviewers
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/780/head:pull/780` \
`$ git checkout pull/780`

Update a local copy of the PR: \
`$ git checkout pull/780` \
`$ git pull https://git.openjdk.java.net/jfx pull/780/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 780`

View PR using the GUI difftool: \
`$ git pr show -t 780`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/780.diff">https://git.openjdk.java.net/jfx/pull/780.diff</a>

</details>
