### PR TITLE
8285034: Skip ServiceTest.testManyServicesRunConcurrently on Windows

### DIFF
--- a/modules/javafx.graphics/src/test/java/test/javafx/concurrent/ServiceTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/concurrent/ServiceTest.java
@@ -25,6 +25,7 @@
 
 package test.javafx.concurrent;
 
+import com.sun.javafx.PlatformUtil;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import test.javafx.concurrent.mocks.SimpleTask;
@@ -46,6 +47,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 /**
  */
@@ -174,6 +176,10 @@ public class ServiceTest {
     // and several micro / milliseconds to get setup and execute. So 2 seconds should be more
     // than enough time.
     @Test(timeout = 2000) public void testManyServicesRunConcurrently() throws Exception {
+        if (PlatformUtil.isWindows()) {
+            assumeTrue(Boolean.getBoolean("unstable.test")); // JDK-8284552
+        }
+
         final CountDownLatch latch = new CountDownLatch(32);
         for (int i=0; i<32; i++) {
             Service<Void> s = new ServiceShim<Void>() {


### PR DESCRIPTION
The test ServiceTest.testManyServicesRunConcurrently fails intermittently on Windows platform with a time out error.
Test needs to be skipped until fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285034](https://bugs.openjdk.java.net/browse/JDK-8285034): Skip ServiceTest.testManyServicesRunConcurrently on Windows


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/783/head:pull/783` \
`$ git checkout pull/783`

Update a local copy of the PR: \
`$ git checkout pull/783` \
`$ git pull https://git.openjdk.java.net/jfx pull/783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 783`

View PR using the GUI difftool: \
`$ git pr show -t 783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/783.diff">https://git.openjdk.java.net/jfx/pull/783.diff</a>

</details>
