### PR TITLE
8285475: Create release notes for 18.0.1

### DIFF
--- a/doc-files/release-notes-18.0.1.md
+++ b/doc-files/release-notes-18.0.1.md
@@ -1,0 +1,17 @@
+# Release Notes for JavaFX 18.0.1
+
+## Introduction
+
+The following notes describe important changes and information about this release. In some cases, the descriptions provide links to additional detailed information about an issue or a change.
+
+These notes document the JavaFX 18.0.1 update release. As such, they complement
+the [JavaFX 18 Release Notes](https://github.com/openjdk/jfx/blob/jfx18/doc-files/release-notes-18.md).
+
+## List of Fixed Bugs
+
+Issue key|Summary|Subcomponent
+---------|-------|------------
+[JDK-8278980](https://bugs.openjdk.java.net/browse/JDK-8278980)|Update WebKit to 613.1|web
+[JDK-8281459](https://bugs.openjdk.java.net/browse/JDK-8281459)|WebKit 613.1 build broken on M1|web
+[JDK-8281711](https://bugs.openjdk.java.net/browse/JDK-8281711)|Cherry-pick WebKit 613.1 stabilization fixes|web
+[JDK-8282099](https://bugs.openjdk.java.net/browse/JDK-8282099)|Cherry-pick WebKit 613.1 stabilization fixes (2)|web

--- a/doc-files/release-notes-18.0.1.md
+++ b/doc-files/release-notes-18.0.1.md
@@ -15,3 +15,10 @@ Issue key|Summary|Subcomponent
 [JDK-8281459](https://bugs.openjdk.java.net/browse/JDK-8281459)|WebKit 613.1 build broken on M1|web
 [JDK-8281711](https://bugs.openjdk.java.net/browse/JDK-8281711)|Cherry-pick WebKit 613.1 stabilization fixes|web
 [JDK-8282099](https://bugs.openjdk.java.net/browse/JDK-8282099)|Cherry-pick WebKit 613.1 stabilization fixes (2)|web
+
+## List of Security fixes
+
+Issue key|Summary|Subcomponent
+---------|-------|------------
+JDK-8276371 (not public) | Better long buffering | web
+JDK-8277465 (not public) | Additional fix for JDK-8276371 | web


### PR DESCRIPTION
Add release notes for JavaFX 18.0.1 to the repository

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285475](https://bugs.openjdk.java.net/browse/JDK-8285475): Create release notes for 18.0.1


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/785/head:pull/785` \
`$ git checkout pull/785`

Update a local copy of the PR: \
`$ git checkout pull/785` \
`$ git pull https://git.openjdk.java.net/jfx pull/785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 785`

View PR using the GUI difftool: \
`$ git pr show -t 785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/785.diff">https://git.openjdk.java.net/jfx/pull/785.diff</a>

</details>
