### PR TITLE
8285725: Wrong link to JBS in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ OpenJFX is a project under the charter of the OpenJDK. The [OpenJDK Bylaws](http
 
 ## Issue tracking
 
-If you think you have found a bug in OpenJFX, first make sure that you are testing against the latest version - your issue may already have been fixed. If not, search our [issues list](https://bugs.openjdk.java.net) in the Java Bug System (JBS) in case a similar issue has already been opened. More information on where and how to report a bug can be found at [bugreport.java.com](https://bugreport.java.com/).
+If you think you have found a bug in OpenJFX, first make sure that you are testing against the latest version - your issue may already have been fixed. If not, search our [issues list](https://bugs.openjdk.java.net/issues/?filter=39543) in the Java Bug System (JBS) in case a similar issue has already been opened. More information on where and how to report a bug can be found at [bugreport.java.com](https://bugreport.java.com/).
 
 ## Getting Started
 


### PR DESCRIPTION
Updated the README link to match the CONTRIBUTING link.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8285725](https://bugs.openjdk.java.net/browse/JDK-8285725): Wrong link to JBS in README.md


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/788/head:pull/788` \
`$ git checkout pull/788`

Update a local copy of the PR: \
`$ git checkout pull/788` \
`$ git pull https://git.openjdk.java.net/jfx pull/788/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 788`

View PR using the GUI difftool: \
`$ git pr show -t 788`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/788.diff">https://git.openjdk.java.net/jfx/pull/788.diff</a>

</details>
