### PR TITLE
8286261: Selection of non-expanded non-leaf treeItem grows unexpectedly when adding two-level descendants

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
@@ -232,4 +232,18 @@ class ControlUtils {
         }
         return -1;
     }
+
+    public static <S> boolean isTreeItemIncludingAncestorsExpanded(TreeItem<S> item) {
+        if (item == null || !item.isExpanded()) {
+            return false;
+        }
+        TreeItem<S> ancestor = item.getParent();
+        while (ancestor != null) {
+            if (!ancestor.isExpanded()) {
+                return false;
+            }
+            ancestor = ancestor.getParent();
+        }
+        return true;
+    }
 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -2611,7 +2611,7 @@ public class TreeTableView<S> extends Control {
                         }
                     } else if (e.wasAdded()) {
                         // shuffle selection by the number of added items
-                        shift += treeItem.isExpanded() ? addedSize : 0;
+                        shift += ControlUtils.isTreeItemIncludingAncestorsExpanded(treeItem) ? addedSize : 0;
 
                         // RT-32963: We were taking the startRow from the TreeItem
                         // in which the children were added, rather than from the
@@ -2647,7 +2647,7 @@ public class TreeTableView<S> extends Control {
 
                         // shuffle selection by the number of removed items
                         // only if removed items are before the current selection.
-                        if (treeItem.isExpanded()) {
+                        if (ControlUtils.isTreeItemIncludingAncestorsExpanded(treeItem)) {
                             int lastSelectedSiblingIndex = selectedItems.stream()
                                     .map(item -> ControlUtils.getIndexOfChildWithDescendant(treeItem, item))
                                     .max(Comparator.naturalOrder())
@@ -3491,7 +3491,7 @@ public class TreeTableView<S> extends Control {
                         // get the TreeItem the event occurred on - we only need to
                         // shift if the tree item is expanded
                         TreeItem<S> eventTreeItem = e.getTreeItem();
-                        if (eventTreeItem.isExpanded()) {
+                        if (ControlUtils.isTreeItemIncludingAncestorsExpanded(eventTreeItem)) {
                             for (int i = 0; i < e.getAddedChildren().size(); i++) {
                                 // get the added item and determine the row it is in
                                 TreeItem<S> item = e.getAddedChildren().get(i);
@@ -3513,7 +3513,7 @@ public class TreeTableView<S> extends Control {
                             }
                         }
 
-                        if (e.getTreeItem().isExpanded()) {
+                        if (ControlUtils.isTreeItemIncludingAncestorsExpanded(e.getTreeItem())) {
                             int focusedSiblingRow = ControlUtils.getIndexOfChildWithDescendant(e.getTreeItem(), getFocusedItem());
                             if (e.getFrom() <= focusedSiblingRow) {
                                 // shuffle selection by the number of removed items

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeView.java
@@ -1406,7 +1406,7 @@ public class TreeView<T> extends Control {
                     // no-op
                 } else if (e.wasAdded()) {
                     // shuffle selection by the number of added items
-                    shift += treeItem.isExpanded() ? addedSize : 0;
+                    shift += ControlUtils.isTreeItemIncludingAncestorsExpanded(treeItem) ? addedSize : 0;
 
                     // RT-32963: We were taking the startRow from the TreeItem
                     // in which the children were added, rather than from the
@@ -1434,7 +1434,7 @@ public class TreeView<T> extends Control {
 
                     // shuffle selection by the number of removed items
                     // only if removed items are before the current selection.
-                    if (treeItem.isExpanded()) {
+                    if (ControlUtils.isTreeItemIncludingAncestorsExpanded(treeItem)) {
                         int lastSelectedSiblingIndex = selectedItems.stream()
                                 .map(item -> ControlUtils.getIndexOfChildWithDescendant(treeItem, item))
                                 .max(Comparator.naturalOrder())
@@ -1683,7 +1683,7 @@ public class TreeView<T> extends Control {
                         // get the TreeItem the event occurred on - we only need to
                         // shift if the tree item is expanded
                         TreeItem<T> eventTreeItem = e.getTreeItem();
-                        if (eventTreeItem.isExpanded()) {
+                        if (ControlUtils.isTreeItemIncludingAncestorsExpanded(eventTreeItem)) {
                             for (int i = 0; i < e.getAddedChildren().size(); i++) {
                                 // get the added item and determine the row it is in
                                 TreeItem<T> item = e.getAddedChildren().get(i);
@@ -1705,7 +1705,7 @@ public class TreeView<T> extends Control {
                             }
                         }
 
-                        if (e.getTreeItem().isExpanded()) {
+                        if (ControlUtils.isTreeItemIncludingAncestorsExpanded(e.getTreeItem())) {
                             int focusedSiblingRow = ControlUtils.getIndexOfChildWithDescendant(e.getTreeItem(), getFocusedItem());
                             if (e.getFrom() <= focusedSiblingRow) {
                                 // shuffle selection by the number of removed items

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
@@ -3833,6 +3833,80 @@ public class TreeViewTest {
         assertEquals("Node 1", table.getSelectionModel().getSelectedItem().getValue());
     }
 
+    // JDK-8286261
+    @Test
+    public void testAddTreeItemToCollapsedAncestorKeepsSelectedItem() {
+        TreeItem<String> rootNode = new TreeItem<>("Root");
+        rootNode.setExpanded(true);
+        TreeItem<String> level1 = new TreeItem<>("Node 0");
+        level1.setExpanded(false);
+        TreeItem<String> level2 = new TreeItem<>("Node 1");
+        level2.getChildren().add(new TreeItem<>("Node 2"));
+        level2.setExpanded(true);
+
+        rootNode.getChildren().add(level1);
+        rootNode.getChildren().add(new TreeItem<>("Node 3"));
+
+        level1.getChildren().add(level2);
+
+        TreeView<String> table = new TreeView<>(rootNode);
+        table.setShowRoot(false);
+        table.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+
+        table.getSelectionModel().select(level1);
+        assertEquals(0, table.getSelectionModel().getSelectedIndex());
+        assertEquals("Node 0", table.getSelectionModel().getSelectedItem().getValue());
+        assertEquals(0, table.getFocusModel().getFocusedIndex());
+        assertEquals("Node 0", table.getFocusModel().getFocusedItem().getValue());
+
+        // add new node at level 3, that has a collapsed ancestor
+        level2.getChildren().add(new TreeItem<>("Node 4"));
+
+        // selection and focus remain at level1
+        assertEquals(0, table.getSelectionModel().getSelectedIndex());
+        assertEquals("Node 0", table.getSelectionModel().getSelectedItem().getValue());
+        assertEquals(0, table.getFocusModel().getFocusedIndex());
+        assertEquals("Node 0", table.getFocusModel().getFocusedItem().getValue());
+    }
+
+    // JDK-8286261
+    @Test
+    public void testRemoveTreeItemFromCollapsedAncestorKeepsSelectedItem() {
+        TreeItem<String> rootNode = new TreeItem<>("Root");
+        rootNode.setExpanded(true);
+        TreeItem<String> level1 = new TreeItem<>("Node 0");
+        level1.setExpanded(false);
+        TreeItem<String> level2 = new TreeItem<>("Node 1");
+        level2.getChildren().add(new TreeItem<>("Node 2"));
+        level2.getChildren().add(new TreeItem<>("Node 3"));
+
+        level2.setExpanded(true);
+
+        rootNode.getChildren().add(level1);
+        rootNode.getChildren().add(new TreeItem<>("Node 4"));
+
+        level1.getChildren().add(level2);
+
+        TreeView<String> table = new TreeView<>(rootNode);
+        table.setShowRoot(false);
+        table.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
+
+        table.getSelectionModel().select(level1);
+        assertEquals(0, table.getSelectionModel().getSelectedIndex());
+        assertEquals("Node 0", table.getSelectionModel().getSelectedItem().getValue());
+        assertEquals(0, table.getFocusModel().getFocusedIndex());
+        assertEquals("Node 0", table.getFocusModel().getFocusedItem().getValue());
+
+        // remove Node 2 at level 3, that has a collapsed ancestor
+        level2.getChildren().remove(0);
+
+        // selection and focus remain at level1
+        assertEquals(0, table.getSelectionModel().getSelectedIndex());
+        assertEquals("Node 0", table.getSelectionModel().getSelectedItem().getValue());
+        assertEquals(0, table.getFocusModel().getFocusedIndex());
+        assertEquals("Node 0", table.getFocusModel().getFocusedItem().getValue());
+    }
+
     public static class MisbehavingOnCancelTreeCell<S> extends TreeCell<S> {
 
         @Override


### PR DESCRIPTION
This PR extends the check if a treeItem is expanded to all its ancestors, as in case one ancestor is collapsed, all its children will be hidden.

4 tests are included, two for TreeView and two for TreeTableView.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286261](https://bugs.openjdk.java.net/browse/JDK-8286261): Selection of non-expanded non-leaf treeItem grows unexpectedly when adding two-level descendants


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/791/head:pull/791` \
`$ git checkout pull/791`

Update a local copy of the PR: \
`$ git checkout pull/791` \
`$ git pull https://git.openjdk.java.net/jfx pull/791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 791`

View PR using the GUI difftool: \
`$ git pr show -t 791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/791.diff">https://git.openjdk.java.net/jfx/pull/791.diff</a>

</details>
