### PR TITLE
8286552: TextFormatter: UpdateValue/UpdateText is called, when no ValueConverter is set

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TextFormatter.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TextFormatter.java
@@ -37,7 +37,7 @@ import java.util.function.UnaryOperator;
  * A Formatter describes a format of a {@code TextInputControl} text by using two distinct mechanisms:
  * <ul>
  *     <li>A filter ({@link #getFilter()}) that can intercept and modify user input. This helps to keep the text
- *     in the desired format. A default text supplier can be used to provide the initial text.</li>
+ *     in the desired format. A default text supplier can be used to provide the intial text.</li>
  *     <li>A value converter ({@link #getValueConverter()}) and value ({@link #valueProperty()})
  *     can be used to provide special format that represents a value of type {@code V}.
  *     If the control is editable and the text is changed by the user, the value is then updated to correspond to the text.
@@ -199,7 +199,7 @@ public class TextFormatter<V> {
     }
 
     void updateValue(String text) {
-        if (valueConverter != null &&!value.isBound()) {
+        if (valueConverter != null && !value.isBound()) {
             try {
                 V v = valueConverter.fromString(text);
                 setValue(v);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TextFormatter.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TextFormatter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@ import java.util.function.UnaryOperator;
  * A Formatter describes a format of a {@code TextInputControl} text by using two distinct mechanisms:
  * <ul>
  *     <li>A filter ({@link #getFilter()}) that can intercept and modify user input. This helps to keep the text
- *     in the desired format. A default text supplier can be used to provide the intial text.</li>
+ *     in the desired format. A default text supplier can be used to provide the initial text.</li>
  *     <li>A value converter ({@link #getValueConverter()}) and value ({@link #valueProperty()})
  *     can be used to provide special format that represents a value of type {@code V}.
  *     If the control is editable and the text is changed by the user, the value is then updated to correspond to the text.
@@ -199,7 +199,7 @@ public class TextFormatter<V> {
     }
 
     void updateValue(String text) {
-        if (!value.isBound()) {
+        if (valueConverter != null &&!value.isBound()) {
             try {
                 V v = valueConverter.fromString(text);
                 setValue(v);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,6 +61,7 @@ import javafx.scene.input.KeyCodeCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
+import javafx.util.converter.IntegerStringConverter;
 import test.com.sun.javafx.pgstub.StubToolkit;
 import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
@@ -472,6 +473,80 @@ public class TextFieldTest {
         assertEquals("x aayyy", txtField.getText());
         assertEquals(4, txtField.getSelection().getStart());
         assertEquals(4, txtField.getSelection().getEnd());
+    }
+
+    @Test
+    public void testTextFormatterWithFilter() {
+        txtField.setText("abc");
+        txtField.setTextFormatter(new TextFormatter<>(this::upperCase));
+        assertEquals("abc", txtField.getText());
+
+        // Set text again to trigger the text formatter filter.
+        txtField.setText("abc");
+        assertEquals("ABC", txtField.getText());
+    }
+
+    @Test
+    public void testTextFormatterWithConverter() {
+        txtField.setText("200");
+        txtField.setTextFormatter(new TextFormatter<>(new IntegerStringConverter() {
+            @Override
+            public Integer fromString(String value) {
+                // Converter to integer and add 100.
+                return super.fromString(value) + 100;
+            }
+        }));
+        // No default value -> text is cleared.
+        assertEquals("", txtField.getText());
+
+        txtField.setText("500");
+        assertEquals("600", txtField.getText());
+    }
+
+    @Test
+    public void testTextFormatterWithConverterAndDefaultValue() {
+        txtField.setText("200");
+        txtField.setTextFormatter(new TextFormatter<>(new IntegerStringConverter() {
+            @Override
+            public Integer fromString(String value) {
+                // Converter to integer and add 100.
+                return super.fromString(value) + 100;
+            }
+        }, 1000));
+        // Default value is set as text.
+        assertEquals("1000", txtField.getText());
+
+        txtField.setText("500");
+        assertEquals("600", txtField.getText());
+    }
+
+    @Test
+    public void testTextFormatterWithConverterAndFilter() {
+        txtField.setText("200");
+        txtField.setTextFormatter(new TextFormatter<>(new IntegerStringConverter() {
+            @Override
+            public Integer fromString(String value) {
+                // Converter to integer and add 100.
+                return super.fromString(value) + 100;
+            }
+        }, 1000, change -> {
+            change.setText(change.getText().replace("3", ""));
+            return change;
+        }));
+        // Default value is set as text.
+        assertEquals("1000", txtField.getText());
+
+        txtField.setText("500");
+        assertEquals("600", txtField.getText());
+
+        // 3 is removed, therefore we get 100. The value converter above will then add 100 (=200).
+        txtField.setText("1300");
+        assertEquals("200", txtField.getText());
+    }
+
+    private Change upperCase(Change change) {
+        change.setText(change.getText().toUpperCase());
+        return change;
     }
 
     private Change noDigits(Change change) {


### PR DESCRIPTION
A common reason for using the `TextFormatter` is the need for a `filter`.
Therefore, the following constructor is typically used:
`public TextFormatter(@NamedArg("filter") UnaryOperator<Change> filter) { ... }`

With that, no `valueConverter` is set in the `TextFormatter`.

When a `TextField` will commit his value, `TextFormatter.updateValue(...)` is called.
Since `valueConverter` is null, an NPE is thrown and catched inside it and `TextFormatter.updateText()` is called  (which will call `TextInputControl.updateText(...)`), which won't do anything either since `valueConverter` is still not set (=null).

A minor improvement here is to just skip `TextFormatter.updateValue(...)` and therefore `TextFormatter.updateText()` (-> `TextInputControl.updateText(...)`), since this methods won't do anything without a `valueConverter`.
With that change, no exception (NPE) is thrown and catched, and therefore also exception breakpoints are not called (can be annoying ;)).
This will also slightly increase the performance, as throwing exceptions is a (minor) bottleneck.

Added tests for all `TextFormatter` functionalities, which pass before and after.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Issue
 * [JDK-8286552](https://bugs.openjdk.java.net/browse/JDK-8286552): TextFormatter: UpdateValue/UpdateText is called, when no ValueConverter is set


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/794/head:pull/794` \
`$ git checkout pull/794`

Update a local copy of the PR: \
`$ git checkout pull/794` \
`$ git pull https://git.openjdk.java.net/jfx pull/794/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 794`

View PR using the GUI difftool: \
`$ git pr show -t 794`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/794.diff">https://git.openjdk.java.net/jfx/pull/794.diff</a>

</details>
