### PR TITLE
8286867: Update #getGlyphCode return a negative number

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/GlyphCache.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/GlyphCache.java
@@ -239,7 +239,7 @@ public class GlyphCache {
     }
 
     private GlyphData getCachedGlyph(int glyphCode, int subPixel) {
-        if (glyphCode <= 0) {return null;}
+        if (glyphCode < 0) {return null;}
 
         int segIndex = glyphCode >>> SEGSHIFT;
         int subIndex = glyphCode & SEGMASK;

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/GlyphCache.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/GlyphCache.java
@@ -239,6 +239,8 @@ public class GlyphCache {
     }
 
     private GlyphData getCachedGlyph(int glyphCode, int subPixel) {
+        if (glyphCode <= 0) {return null;}
+
         int segIndex = glyphCode >>> SEGSHIFT;
         int subIndex = glyphCode & SEGMASK;
         segIndex |= (subPixel << SUBPIXEL_SHIFT);


### PR DESCRIPTION
When I used BlueJ, I found a problem with Chinese display. /javafx.graphics/com/sun/javafx/font/CompositeGlyphMapper.java#getGlyphCode may return a negative number when no font library is specified in Linux,and this could cause java.lang.ArrayIndexOutOfBoundsException error.So javafx.graphics/com/sun/prism/impl/GlyphCache.java#getCachedGlyph  shou check the glyphCode.
The crash demo like this:
`import javafx.application.Application;
import javafx.scene.Scene;
import javafx.scene.control.Menu;
import javafx.scene.control.MenuBar;
import javafx.scene.control.MenuItem;
import javafx.scene.layout.BorderPane;
import javafx.stage.Stage;

public class MenuExample extends Application {
    public static void main(String[] args) {  
    launch(args);  
        }  
  
    @Override  
    public void start(Stage primaryStage) throws Exception {
        BorderPane root = new BorderPane();
        Scene scene = new Scene(root,200,300);
        MenuBar menubar = new MenuBar();
        Menu FileMenu = new Menu("文本");
        MenuItem filemenu1=new MenuItem("新建");
        MenuItem filemenu2=new MenuItem("Save");  
        MenuItem filemenu3=new MenuItem("Exit");  
        Menu EditMenu=new Menu("Edit");  
        MenuItem EditMenu1=new MenuItem("Cut");  
        MenuItem EditMenu2=new MenuItem("Copy");  
        MenuItem EditMenu3=new MenuItem("Paste");  
        EditMenu.getItems().addAll(EditMenu1,EditMenu2,EditMenu3);  
        root.setTop(menubar);  
        FileMenu.getItems().addAll(filemenu1,filemenu2,filemenu3);  
        menubar.getMenus().addAll(FileMenu,EditMenu);  
        primaryStage.setScene(scene);  
        primaryStage.setTitle("TEST");
        primaryStage.show();  
          
    }     
}  `

the error:
`java.lang.ArrayIndexOutOfBoundsException: Index -25 out of bounds for length 32
        at com.sun.prism.impl.GlyphCache.getCachedGlyph(GlyphCache.java:332)
        at com.sun.prism.impl.GlyphCache.render(GlyphCache.java:148)
        at com.sun.prism.impl.ps.BaseShaderGraphics.drawString(BaseShaderGraphics.java:2101)
        at com.sun.javafx.sg.prism.NGText.renderText(NGText.java:312)
        at com.sun.javafx.sg.prism.NGText.renderContent2D(NGText.java:270)
        at com.sun.javafx.sg.prism.NGShape.renderContent(NGShape.java:261)
        at com.sun.javafx.sg.prism.NGNode.doRender(NGNode.java:2072)
        at com.sun.javafx.sg.prism.NGNode.render(NGNode.java:1964)
        at com.sun.javafx.sg.prism.NGGroup.renderContent(NGGroup.java:270)
        at com.sun.javafx.sg.prism.NGRegion.renderContent(NGRegion.java:578)
        at com.sun.javafx.sg.prism.NGNode.doRender(NGNode.java:2072)
        at com.sun.javafx.sg.prism.NGNode.render(NGNode.java:1964)
        at com.sun.javafx.sg.prism.NGGroup.renderContent(NGGroup.java:270)
        at com.sun.javafx.sg.prism.NGRegion.renderContent(NGRegion.java:578)
        at com.sun.javafx.sg.prism.NGNode.doRender(NGNode.java:2072)
        at com.sun.javafx.sg.prism.NGNode.render(NGNode.java:1964)
        at com.sun.javafx.sg.prism.NGGroup.renderContent(NGGroup.java:270)
        at com.sun.javafx.sg.prism.NGRegion.renderContent(NGRegion.java:578)
        at com.sun.javafx.sg.prism.NGNode.doRender(NGNode.java:2072)
        at com.sun.javafx.sg.prism.NGNode.render(NGNode.java:1964)
        at com.sun.javafx.sg.prism.NGGroup.renderContent(NGGroup.java:270)
        at com.sun.javafx.sg.prism.NGRegion.renderContent(NGRegion.java:578)
        at com.sun.javafx.sg.prism.NGNode.doRender(NGNode.java:2072)
        at com.sun.javafx.sg.prism.NGNode.render(NGNode.java:1964)
        at com.sun.javafx.sg.prism.NGGroup.renderContent(NGGroup.java:270)
        at com.sun.javafx.sg.prism.NGRegion.renderContent(NGRegion.java:578)
        at com.sun.javafx.sg.prism.NGNode.doRender(NGNode.java:2072)
        at com.sun.javafx.sg.prism.NGNode.render(NGNode.java:1964)
        at com.sun.javafx.tk.quantum.ViewPainter.doPaint(ViewPainter.java:479)
        at com.sun.javafx.tk.quantum.ViewPainter.paintImpl(ViewPainter.java:328)
        at com.sun.javafx.tk.quantum.PresentingPainter.run(PresentingPainter.java:91)
`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8286867](https://bugs.openjdk.org/browse/JDK-8286867)

### Issue
 * [JDK-8286867](https://bugs.openjdk.org/browse/JDK-8286867): CompositeGlyphMapper.java#getGlyphCode  return a negative number ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/795/head:pull/795` \
`$ git checkout pull/795`

Update a local copy of the PR: \
`$ git checkout pull/795` \
`$ git pull https://git.openjdk.org/jfx.git pull/795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 795`

View PR using the GUI difftool: \
`$ git pr show -t 795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/795.diff">https://git.openjdk.org/jfx/pull/795.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/795#issuecomment-1130560176)