### PR TITLE
Update GlyphCache.java

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/GlyphCache.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/GlyphCache.java
@@ -239,6 +239,7 @@ public class GlyphCache {
     }
 
     private GlyphData getCachedGlyph(int glyphCode, int subPixel) {
+        if (glyphCode <= 0) {return null;}
         int segIndex = glyphCode >>> SEGSHIFT;
         int subIndex = glyphCode & SEGMASK;
         segIndex |= (subPixel << SUBPIXEL_SHIFT);


### PR DESCRIPTION
When I used BlueJ, I found a problem with Chinese display. /javafx.graphics/com/sun/javafx/font/CompositeGlyphMapper.java#getGlyphCode may return a negative number when no font library is specified in Linux,and this could cause java.lang.ArrayIndexOutOfBoundsException error.So javafx.graphics/com/sun/prism/impl/GlyphCache.java#getCachedGlyph  shou check the glyphCode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed (1 review required, with at least 1 reviewer)

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/796/head:pull/796` \
`$ git checkout pull/796`

Update a local copy of the PR: \
`$ git checkout pull/796` \
`$ git pull https://git.openjdk.java.net/jfx pull/796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 796`

View PR using the GUI difftool: \
`$ git pr show -t 796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/796.diff">https://git.openjdk.java.net/jfx/pull/796.diff</a>

</details>
