### PR TITLE
8090522: Allow support for disabling stage iconification (minimization)

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -374,6 +374,12 @@ public abstract class Toolkit {
 
     public abstract TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl, @SuppressWarnings("removal") AccessControlContext acc);
 
+    public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle,
+        boolean primary, Modality modality, TKStage owner, boolean rtl, boolean minimizable, boolean closable,
+        AccessControlContext acc){
+        return createTKStage(peerWindow, securityDialog, stageStyle, primary, modality, owner, rtl, acc);
+    }
+
     public abstract TKStage createTKPopupStage(Window peerWindow, StageStyle popupStyle, TKStage owner, @SuppressWarnings("removal") AccessControlContext acc);
     public abstract TKStage createTKEmbeddedStage(HostInterface host, @SuppressWarnings("removal") AccessControlContext acc);
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
@@ -603,6 +603,20 @@ public final class QuantumToolkit extends Toolkit {
         return stage;
     }
 
+    @Override public TKStage createTKStage(Window peerWindow, boolean securityDialog, StageStyle stageStyle, boolean primary, Modality modality, TKStage owner, boolean rtl, boolean minimizable, boolean closable, AccessControlContext acc) {
+        assertToolkitRunning();
+        WindowStage stage = new WindowStage(peerWindow, securityDialog, stageStyle, modality, owner);
+        stage.setSecurityContext(acc);
+        if (primary) {
+            stage.setIsPrimary();
+        }
+        stage.setRTL(rtl);
+        stage.setClosable(closable);
+        stage.setMinimizable(minimizable);
+        stage.init(systemMenu);
+        return stage;
+    }
+
     @Override public boolean canStartNestedEventLoop() {
         return inPulse == 0;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
@@ -68,6 +68,8 @@ class WindowStage extends GlassStage {
 
     private OverlayWarning warning = null;
     private boolean rtl = false;
+    private boolean minimizable = true;
+    private boolean closable = true;
     private boolean transparent = false;
     private boolean isPrimaryStage = false;
     private boolean isPopupStage = false;
@@ -167,6 +169,14 @@ class WindowStage extends GlassStage {
                         if (ownerWindow != null || modality != Modality.NONE) {
                             windowMask &=
                                 ~(Window.MINIMIZABLE | Window.MAXIMIZABLE);
+                        }
+                        if (!closable)
+                        {
+                            windowMask &= ~(Window.CLOSABLE);
+                        }
+                        if (!minimizable)
+                        {
+                            windowMask &= ~(Window.MINIMIZABLE);
                         }
                         resizable = true;
                         break;
@@ -930,6 +940,14 @@ class WindowStage extends GlassStage {
 
     @Override public void setRTL(boolean b) {
         rtl = b;
+    }
+
+    public void setClosable(boolean closable) {
+        this.closable = closable;
+    }
+
+    public void setMinimizable(boolean minimizable) {
+        this.minimizable = minimizable;
     }
 
 }

--- a/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
@@ -490,6 +490,62 @@ public class Stage extends Window {
         this.style = style;
     }
 
+    private boolean closable = true;
+
+    /**
+     * Specifies if this stage should be closable.
+     *
+     * @param closable closable state value
+     *
+     * @throws IllegalStateException if this property is set after the stage
+     * has ever been made visible.
+     *
+     * @defaultValue true
+     */
+    public void initClosable(boolean closable) {
+        if (hasBeenVisible) {
+            throw new IllegalStateException("Cannot set style once stage has been set visible");
+        }
+        this.closable = closable;
+    }
+
+    /**
+     * Retrieves the closable state of this stage.
+     *
+     * @return the stage closable state
+     */
+    public boolean isClosable() {
+        return closable;
+    }
+
+    private boolean minimizable = true;
+
+    /**
+     * Specifies if this stage should be minimizable.
+     *
+     * @param minimizable minimizable state value
+     *
+     * @throws IllegalStateException if this property is set after the stage
+     * has ever been made visible.
+     *
+     * @defaultValue true
+     */
+    public void initMinimizable(boolean minimizable) {
+        if (hasBeenVisible) {
+            throw new IllegalStateException("Cannot set style once stage has been set visible");
+        }
+        this.minimizable = minimizable;
+    }
+
+    /**
+     * Retrieves the minimizable state of this stage.
+     *
+     * @return the stage minimizable state
+     */
+    public boolean isMinimizable() {
+        return minimizable;
+    }
+
     /**
      * Retrieves the style attribute for this stage.
      *
@@ -1161,7 +1217,7 @@ public class Stage extends Window {
                 }
             }
             setPeer(toolkit.createTKStage(this, isSecurityDialog(),
-                    stageStyle, isPrimary(), getModality(), tkStage, rtl, acc));
+                    stageStyle, isPrimary(), getModality(), tkStage, rtl, minimizable, closable, acc));
             getPeer().setMinimumSize((int) Math.ceil(getMinWidth()),
                     (int) Math.ceil(getMinHeight()));
             getPeer().setMaximumSize((int) Math.floor(getMaxWidth()),

--- a/modules/javafx.graphics/src/test/java/test/javafx/stage/StageMutabilityTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/stage/StageMutabilityTest.java
@@ -175,6 +175,110 @@ public class StageMutabilityTest {
         assertEquals(Modality.NONE, stage.getModality());
     }
 
+    @Test public void testClosableSet() {
+        Stage stage = new Stage();
+        assertTrue(stage.isClosable());
+        stage.initClosable(true);
+        assertTrue(stage.isClosable());
+        stage.initClosable(false);
+        assertFalse(stage.isClosable());
+    }
+
+    @Test public void testClosableSetWhileVisible() {
+        Stage stage = new Stage();
+        assertTrue(stage.isClosable());
+        stage.show();
+        assertTrue(stage.isClosable());
+        try {
+            stage.initClosable(true);
+            // Error if we get here we didn't get the expected exception
+            assertTrue(false);
+        } catch (IllegalStateException ex) {
+        }
+        assertTrue(stage.isClosable());
+        try {
+            stage.initClosable(false);
+            // Error if we get here we didn't get the expected exception
+            assertTrue(false);
+        } catch (IllegalStateException ex) {
+        }
+        assertTrue(stage.isClosable());
+    }
+
+    @Test public void testClosableSetAfterVisible() {
+        Stage stage = new Stage();
+        assertTrue(stage.isClosable());
+        stage.show();
+        stage.hide();
+        assertTrue(stage.isClosable());
+        try {
+            stage.initClosable(true);
+            // Error if we get here we didn't get the expected exception
+            assertTrue(false);
+        } catch (IllegalStateException ex) {
+        }
+        assertTrue(stage.isClosable());
+        try {
+            stage.initClosable(false);
+            // Error if we get here we didn't get the expected exception
+            assertTrue(false);
+        } catch (IllegalStateException ex) {
+        }
+        assertTrue(stage.isClosable());
+    }
+
+    @Test public void testMinimizableSet() {
+        Stage stage = new Stage();
+        assertTrue(stage.isMinimizable());
+        stage.initMinimizable(true);
+        assertTrue(stage.isMinimizable());
+        stage.initMinimizable(false);
+        assertFalse(stage.isMinimizable());
+    }
+
+    @Test public void testMinimizableSetWhileVisible() {
+        Stage stage = new Stage();
+        assertTrue(stage.isMinimizable());
+        stage.show();
+        assertTrue(stage.isMinimizable());
+        try {
+            stage.initMinimizable(true);
+            // Error if we get here we didn't get the expected exception
+            assertTrue(false);
+        } catch (IllegalStateException ex) {
+        }
+        assertTrue(stage.isMinimizable());
+        try {
+            stage.initMinimizable(false);
+            // Error if we get here we didn't get the expected exception
+            assertTrue(false);
+        } catch (IllegalStateException ex) {
+        }
+        assertTrue(stage.isMinimizable());
+    }
+
+    @Test public void testMinimizableSetAfterVisible() {
+        Stage stage = new Stage();
+        assertTrue(stage.isMinimizable());
+        stage.show();
+        stage.hide();
+        assertTrue(stage.isMinimizable());
+        try {
+            stage.initMinimizable(true);
+            // Error if we get here we didn't get the expected exception
+            assertTrue(false);
+        } catch (IllegalStateException ex) {
+        }
+        assertTrue(stage.isMinimizable());
+        try {
+            stage.initMinimizable(false);
+            // Error if we get here we didn't get the expected exception
+            assertTrue(false);
+        } catch (IllegalStateException ex) {
+        }
+        assertTrue(stage.isMinimizable());
+    }
+
 // TODO: Add more Modality test below:
 //    /**
 //     * Tests that setting the value of style on a visible Stage throws an exception


### PR DESCRIPTION
`Stage` minimalizing (iconified state) cannot be disabled for the user. The same for `Stage` closable state.
PR adds these features without breaking backward compatibility.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion openjfx19 to be approved (needs to be created)
- [ ] Change must be properly reviewed (3 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 2 [Authors](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8090522](https://bugs.openjdk.org/browse/JDK-8090522): Allow support for disabling stage iconification (minimization)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/798/head:pull/798` \
`$ git checkout pull/798`

Update a local copy of the PR: \
`$ git checkout pull/798` \
`$ git pull https://git.openjdk.org/jfx.git pull/798/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 798`

View PR using the GUI difftool: \
`$ git pr show -t 798`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/798.diff">https://git.openjdk.org/jfx/pull/798.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/798#issuecomment-1131648627)