### PR TITLE
8088420: JavaFX WebView memory leak via EventListener

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/PlatformJava.cmake
+++ b/modules/javafx.web/src/main/native/Source/WebCore/PlatformJava.cmake
@@ -82,6 +82,7 @@ add_definitions(-DSTATICALLY_LINKED_WITH_WTF)
 list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     bindings/java/JavaDOMUtils.h
     bindings/java/JavaEventListener.h
+    bindings/java/EventListenerManager.h
     bindings/java/JavaNodeFilterCondition.h
     bridge/jni/jsc/BridgeUtils.h
     dom/DOMStringList.h

--- a/modules/javafx.web/src/main/native/Source/WebCore/SourcesJava.txt
+++ b/modules/javafx.web/src/main/native/Source/WebCore/SourcesJava.txt
@@ -109,6 +109,7 @@ platform/network/java/URLLoader.cpp
 
 bindings/java/JavaDOMUtils.cpp
 bindings/java/JavaEventListener.cpp
+bindings/java/EventListenerManager.cpp
 
 page/java/DragControllerJava.cpp
 page/java/EventHandlerJava.cpp

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.cpp
@@ -53,8 +53,7 @@ void EventListenerManager::unregisterListener(JavaEventListener *listener)
              it->second = nullptr;
              listenerJObjectMap.erase(it); // remove from list
          }
-
-         if (it->second && it->second->use_count() > 1)
+         else if (it->second && it->second->use_count() > 1)
              it->second->dref();
      }
 }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.cpp
@@ -64,7 +64,7 @@ void EventListenerManager::unregisterListener(JavaEventListener *ptr)
      }
 }
 
-jobject EventListenerManager::get_listener(JavaEventListener *ptr)
+JGObject EventListenerManager::get_listener(JavaEventListener *ptr)
 {
     std::map<JavaEventListener*, JavaObjectWrapperHandler*>::iterator it;
     it = listener_lists.find(ptr);

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+#include "EventListenerManager.h"
+#include "JavaEventListener.h"
+#include "DOMWindow.h"
+
+namespace WebCore {
+
+EventListenerManager& EventListenerManager::get_instance()
+{
+    static NeverDestroyed<EventListenerManager> sharedManager;
+    return sharedManager;
+}
+
+EventListenerManager::EventListenerManager() { }
+
+void EventListenerManager::registerListener(JavaEventListener *ptr, const JLObject &listener)
+{
+    JavaObjectWrapperHandler *temp_ref = new JavaObjectWrapperHandler(listener);
+    std::pair<JavaEventListener*, JavaObjectWrapperHandler*> entry{ ptr, temp_ref };
+    listener_lists.insert(entry);
+}
+
+void EventListenerManager::unregisterListener(JavaEventListener *ptr)
+{
+     std::map<JavaEventListener*, JavaObjectWrapperHandler*>::iterator it;
+     it = listener_lists.find(ptr);
+     JNIEnv *env = nullptr;
+     env = JavaScriptCore_GetJavaEnv();
+
+     if (it != listener_lists.end()) {
+         if (it->second && it->second->use_count() == 1) {
+              delete it->second;
+              it->second = nullptr;
+         }
+
+         if (it->second && it->second->use_count() > 1)
+             it->second->dref();
+     }
+}
+
+jobject EventListenerManager::get_listener(JavaEventListener *ptr)
+{
+     std::map<JavaEventListener*, JavaObjectWrapperHandler*>::iterator it;
+     it = listener_lists.find(ptr);
+     if (it != listener_lists.end())
+         return it->second->get_listener();
+
+     return nullptr;
+}
+
+void EventListenerManager::registerDOMWindow(DOMWindow* window, JavaEventListener *ptr)
+{
+    std::map<JavaEventListener*, JavaObjectWrapperHandler*>::iterator it;
+    it = listener_lists.find(ptr);
+    if (it != listener_lists.end())
+        it->second->ref();
+
+    std::pair<JavaEventListener*, DOMWindow*> entry{ ptr, window};
+    windowHasEvent.insert(entry);
+}
+
+void EventListenerManager::unregisterDOMWindow(DOMWindow* window)
+{
+     std::multimap<JavaEventListener*, DOMWindow*>::iterator win_it;
+     for (win_it = windowHasEvent.begin(); win_it != windowHasEvent.end(); win_it++) {
+         // de register associated event listeners with window
+         if( window == win_it->second) {
+             unregisterListener(win_it->first);
+         }
+     }
+}
+
+} // namespace WebCore
+

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.cpp
@@ -23,7 +23,6 @@
  * questions.
  */
 
-
 #include "EventListenerManager.h"
 #include "JavaEventListener.h"
 #include "DOMWindow.h"
@@ -54,8 +53,8 @@ void EventListenerManager::unregisterListener(JavaEventListener *ptr)
 
      if (it != listener_lists.end()) {
          if (it->second && it->second->use_count() == 1) {
-              delete it->second;
-              it->second = nullptr;
+             delete it->second;
+             it->second = nullptr;
          }
 
          if (it->second && it->second->use_count() > 1)
@@ -65,12 +64,12 @@ void EventListenerManager::unregisterListener(JavaEventListener *ptr)
 
 jobject EventListenerManager::get_listener(JavaEventListener *ptr)
 {
-     std::map<JavaEventListener*, JavaObjectWrapperHandler*>::iterator it;
-     it = listener_lists.find(ptr);
-     if (it != listener_lists.end())
-         return it->second->get_listener();
+    std::map<JavaEventListener*, JavaObjectWrapperHandler*>::iterator it;
+    it = listener_lists.find(ptr);
+    if (it != listener_lists.end())
+        return it->second->get_listener();
 
-     return nullptr;
+    return nullptr;
 }
 
 void EventListenerManager::registerDOMWindow(DOMWindow* window, JavaEventListener *ptr)
@@ -86,14 +85,13 @@ void EventListenerManager::registerDOMWindow(DOMWindow* window, JavaEventListene
 
 void EventListenerManager::unregisterDOMWindow(DOMWindow* window)
 {
-     std::multimap<JavaEventListener*, DOMWindow*>::iterator win_it;
-     for (win_it = windowHasEvent.begin(); win_it != windowHasEvent.end(); win_it++) {
-         // de register associated event listeners with window
-         if( window == win_it->second) {
-             unregisterListener(win_it->first);
-         }
-     }
+    std::multimap<JavaEventListener*, DOMWindow*>::iterator win_it;
+    for (win_it = windowHasEvent.begin(); win_it != windowHasEvent.end(); win_it++) {
+        // de register associated event listeners with window
+        if(window == win_it->second) {
+            unregisterListener(win_it->first);
+        }
+    }
 }
 
 } // namespace WebCore
-

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.cpp
@@ -26,7 +26,6 @@
 #include "EventListenerManager.h"
 #include "JavaEventListener.h"
 #include "DOMWindow.h"
-#include <stdio.h>
 
 namespace WebCore {
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.cpp
@@ -35,8 +35,6 @@ EventListenerManager& EventListenerManager::get_instance()
     return sharedManager;
 }
 
-EventListenerManager::EventListenerManager() { }
-
 void EventListenerManager::registerListener(JavaEventListener *ptr, const JLObject &listener)
 {
     JavaObjectWrapperHandler *temp_ref = new JavaObjectWrapperHandler(listener);
@@ -48,8 +46,6 @@ void EventListenerManager::unregisterListener(JavaEventListener *ptr)
 {
      std::map<JavaEventListener*, JavaObjectWrapperHandler*>::iterator it;
      it = listener_lists.find(ptr);
-     JNIEnv *env = nullptr;
-     env = JavaScriptCore_GetJavaEnv();
 
      if (it != listener_lists.end()) {
          if (it->second && it->second->use_count() == 1) {
@@ -109,9 +105,11 @@ void EventListenerManager::resetDOMWindow(DOMWindow* window)
             isReferringToOtherListener = true;
     }
 
-    for (win_it = windowHasEvent.begin(); win_it != windowHasEvent.end() && !isReferringToOtherListener; win_it++) {
-        if (window == win_it->second)
-           windowHasEvent.erase(win_it->first);
+    if (!isReferringToOtherListener) {
+        for (win_it = windowHasEvent.begin(); win_it != windowHasEvent.end(); win_it++) {
+            if (window == win_it->second)
+                windowHasEvent.erase(win_it->first);
+        }
     }
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.h
@@ -45,22 +45,21 @@ class JavaObjectWrapperHandler;
 
 
 class JavaObjectWrapperHandler {
-    jobject handler_;
+    JGObject handler_;
     unsigned int ref_count = 0;
 public:
     JavaObjectWrapperHandler(const JLObject& handler) {
         JNIEnv *env = nullptr;
         env = JavaScriptCore_GetJavaEnv();
-        handler_ = env->NewGlobalRef(handler);
+        handler_ = handler;
     }
 
     ~JavaObjectWrapperHandler() {
         JNIEnv *env = nullptr;
         env = JavaScriptCore_GetJavaEnv();
         env->DeleteGlobalRef(handler_);
-        handler_ = NULL;
     }
-    jobject get_listener() { return handler_; }
+    JGObject get_listener() { return handler_; }
     void ref() { ++ref_count; }
     void dref() { --ref_count; }
     unsigned int use_count() { return ref_count;}
@@ -78,7 +77,7 @@ public:
     void registerDOMWindow(DOMWindow*, JavaEventListener *ptr);
     void unregisterDOMWindow(DOMWindow*);
     void resetDOMWindow(DOMWindow*);
-    jobject get_listener(JavaEventListener *ptr);
+    JGObject get_listener(JavaEventListener *ptr);
 
 private:
     EventListenerManager();

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.h
@@ -49,15 +49,11 @@ class JavaObjectWrapperHandler {
     unsigned int ref_count = 0;
 public:
     JavaObjectWrapperHandler(const JLObject& handler) {
-        JNIEnv *env = nullptr;
-        env = JavaScriptCore_GetJavaEnv();
         handler_ = handler;
     }
 
     ~JavaObjectWrapperHandler() {
-        JNIEnv *env = nullptr;
-        env = JavaScriptCore_GetJavaEnv();
-        env->DeleteGlobalRef(handler_);
+        handler_.clear();
     }
     JGObject get_listener() { return handler_; }
     void ref() { ++ref_count; }

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.h
@@ -33,7 +33,7 @@
 
 #include<map>
 #include <wtf/NeverDestroyed.h>
-#include<iterator>
+#include <iterator>
 #include <wtf/java/JavaRef.h>
 #include <jni.h>
 
@@ -66,6 +66,7 @@ class EventListenerManager {
     friend class NeverDestroyed<EventListenerManager>;
     std::map<JavaEventListener*, JavaObjectWrapperHandler*> listener_lists;
     std::multimap<JavaEventListener*, DOMWindow*> windowHasEvent;
+    EventListenerManager() = default;
 public:
     static EventListenerManager& get_instance();
     void registerListener(JavaEventListener *ptr, const JLObject &listener);
@@ -74,9 +75,6 @@ public:
     void unregisterDOMWindow(DOMWindow*);
     void resetDOMWindow(DOMWindow*);
     JGObject get_listener(JavaEventListener *ptr);
-
-private:
-    EventListenerManager();
 };
 
 } // namespace WebCore

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.h
@@ -31,7 +31,7 @@
 
 #include "config.h"
 
-#include<map>
+#include <map>
 #include <wtf/NeverDestroyed.h>
 #include <iterator>
 #include <wtf/java/JavaRef.h>

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#pragma once
+
+#ifndef EVENT_LISTENER_MANAGER_H
+#define VENT_LISTENER_MANAGER_H
+
+
+#include "config.h"
+
+#include<map>
+#include <wtf/NeverDestroyed.h>
+#include<iterator>
+#include <wtf/java/JavaRef.h>
+#include <jni.h>
+
+namespace WebCore {
+
+class DOMWindow;
+class JavaEventListener;
+class JavaObjectWrapperHandler;
+
+
+class JavaObjectWrapperHandler {
+    jobject handler_;
+    unsigned int ref_count = 0;
+public:
+    JavaObjectWrapperHandler(const JLObject& handler) {
+        JNIEnv *env = nullptr;
+        env = JavaScriptCore_GetJavaEnv();
+        handler_ = env->NewGlobalRef(handler);
+    }
+
+    ~JavaObjectWrapperHandler() {
+        JNIEnv *env = nullptr;
+        env = JavaScriptCore_GetJavaEnv();
+        env->DeleteGlobalRef(handler_);
+        handler_ = NULL;
+    }
+    jobject get_listener() { return handler_; }
+    void ref() { ++ref_count; }
+    void dref() { --ref_count; }
+    unsigned int use_count() { return ref_count;}
+};
+
+class EventListenerManager {
+    WTF_MAKE_NONCOPYABLE(EventListenerManager);
+    friend class NeverDestroyed<EventListenerManager>;
+    std::map<JavaEventListener*, JavaObjectWrapperHandler*> listener_lists;
+    std::multimap<JavaEventListener*, DOMWindow*> windowHasEvent;
+public:
+    static EventListenerManager& get_instance();
+    void registerListener(JavaEventListener *ptr, const JLObject &listener);
+    void unregisterListener(JavaEventListener *ptr) ;
+    void registerDOMWindow(DOMWindow*, JavaEventListener *ptr);
+    void unregisterDOMWindow(DOMWindow*);
+    jobject get_listener(JavaEventListener *ptr);
+
+private:
+    EventListenerManager();
+};
+
+} // namespace WebCore
+
+#endif // EVENT_LISTENER_MANAGER_H
+

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.h
@@ -26,7 +26,7 @@
 #pragma once
 
 #ifndef EVENT_LISTENER_MANAGER_H
-#define VENT_LISTENER_MANAGER_H
+#define EVENT_LISTENER_MANAGER_H
 
 
 #include "config.h"
@@ -86,4 +86,3 @@ private:
 } // namespace WebCore
 
 #endif // EVENT_LISTENER_MANAGER_H
-

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.h
@@ -41,40 +41,43 @@ namespace WebCore {
 
 class DOMWindow;
 class JavaEventListener;
-class JavaObjectWrapperHandler;
 
 
-class JavaObjectWrapperHandler {
-    JGObject handler_;
+class ListenerJObjectWrapper {
+    JGObject listenerObj;
     unsigned int ref_count = 0;
 public:
-    JavaObjectWrapperHandler(const JLObject& handler) {
-        handler_ = handler;
+    ListenerJObjectWrapper(const JLObject& listenerObj) {
+        this->listenerObj = listenerObj;
     }
 
-    ~JavaObjectWrapperHandler() {
-        handler_.clear();
+    ~ListenerJObjectWrapper() {
+        listenerObj.clear();
     }
-    JGObject get_listener() { return handler_; }
+    JGObject getListenerJObject() { return listenerObj; }
     void ref() { ++ref_count; }
     void dref() { --ref_count; }
     unsigned int use_count() { return ref_count;}
 };
 
 class EventListenerManager {
-    WTF_MAKE_NONCOPYABLE(EventListenerManager);
-    friend class NeverDestroyed<EventListenerManager>;
-    std::map<JavaEventListener*, JavaObjectWrapperHandler*> listener_lists;
-    std::multimap<JavaEventListener*, DOMWindow*> windowHasEvent;
     EventListenerManager() = default;
+    WTF_MAKE_NONCOPYABLE(EventListenerManager);
+
+    std::map<JavaEventListener*, ListenerJObjectWrapper*> listenerJObjectMap;
+    std::multimap<JavaEventListener*, DOMWindow*> listenerDOMWindowMultiMap;
+
+    friend class NeverDestroyed<EventListenerManager>;
+
 public:
     static EventListenerManager& get_instance();
-    void registerListener(JavaEventListener *ptr, const JLObject &listener);
-    void unregisterListener(JavaEventListener *ptr) ;
-    void registerDOMWindow(DOMWindow*, JavaEventListener *ptr);
+
+    void registerListener(JavaEventListener *listener, const JLObject &listenerJObj);
+    void unregisterListener(JavaEventListener *listener) ;
+    JGObject getListenerJObject(JavaEventListener *listener);
+
+    void registerDOMWindow(DOMWindow*, JavaEventListener *listener);
     void unregisterDOMWindow(DOMWindow*);
-    void resetDOMWindow(DOMWindow*);
-    JGObject get_listener(JavaEventListener *ptr);
 };
 
 } // namespace WebCore

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/EventListenerManager.h
@@ -77,6 +77,7 @@ public:
     void unregisterListener(JavaEventListener *ptr) ;
     void registerDOMWindow(DOMWindow*, JavaEventListener *ptr);
     void unregisterDOMWindow(DOMWindow*);
+    void resetDOMWindow(DOMWindow*);
     jobject get_listener(JavaEventListener *ptr);
 
 private:

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/JavaEventListener.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/JavaEventListener.cpp
@@ -47,7 +47,7 @@ bool JavaEventListener::operator==(const EventListener& other) const
     const JavaEventListener* jother = other.isJavaEventListener()
                                         ? static_cast<const JavaEventListener*>(&other)
                                         : nullptr;
-    return jother && ( this == jother);
+    return jother && (this == jother);
 }
 
 void JavaEventListener::handleEvent(ScriptExecutionContext& context, Event& event)

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/JavaEventListener.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/JavaEventListener.cpp
@@ -65,7 +65,7 @@ void JavaEventListener::handleEvent(ScriptExecutionContext& context, Event& even
 
     event.ref();
     env->CallVoidMethod(
-        EventListenerManager::get_instance().get_listener(this),
+        EventListenerManager::get_instance().getListenerJObject(this),
         midFwkHandleEvent,
         ptr_to_jlong(&event));
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/JavaEventListener.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/JavaEventListener.cpp
@@ -47,7 +47,7 @@ bool JavaEventListener::operator==(const EventListener& other) const
     const JavaEventListener* jother = other.isJavaEventListener()
                                         ? static_cast<const JavaEventListener*>(&other)
                                         : nullptr;
-    return jother && (this == jother);
+    return this == jother;
 }
 
 void JavaEventListener::handleEvent(ScriptExecutionContext& context, Event& event)

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/JavaEventListener.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/JavaEventListener.cpp
@@ -47,7 +47,7 @@ bool JavaEventListener::operator==(const EventListener& other) const
     const JavaEventListener* jother = other.isJavaEventListener()
                                         ? static_cast<const JavaEventListener*>(&other)
                                         : nullptr;
-    return jother && isJavaEquals(m_joListener, jother->m_joListener);
+    return jother && ( this == jother);
 }
 
 void JavaEventListener::handleEvent(ScriptExecutionContext& context, Event& event)
@@ -65,7 +65,7 @@ void JavaEventListener::handleEvent(ScriptExecutionContext& context, Event& even
 
     event.ref();
     env->CallVoidMethod(
-        m_joListener,
+        EventListenerManager::get_instance().get_listener(this),
         midFwkHandleEvent,
         ptr_to_jlong(&event));
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/JavaEventListener.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/JavaEventListener.h
@@ -27,11 +27,8 @@
 
 #include "Event.h"
 #include "EventListener.h"
-#include "Node.h"
-
-#if PLATFORM(JAVA)
 #include "EventListenerManager.h"
-#endif
+#include "Node.h"
 
 #include <wtf/Vector.h>
 #include <wtf/java/JavaRef.h>

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/JavaEventListener.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/JavaEventListener.h
@@ -29,6 +29,10 @@
 #include "EventListener.h"
 #include "Node.h"
 
+#if PLATFORM(JAVA)
+#include "EventListenerManager.h"
+#endif
+
 #include <wtf/Vector.h>
 #include <wtf/java/JavaRef.h>
 
@@ -38,17 +42,15 @@ class JavaEventListener final : public EventListener {
 public:
     JavaEventListener(const JLObject &listener)
         : EventListener(NativeEventListenerType)
-        , m_joListener(listener)
     {
         relaxAdoptionRequirement();
+        EventListenerManager::get_instance().registerListener(this, listener);
     }
 
-    ~JavaEventListener() override;
+    virtual ~JavaEventListener() override;
 
     bool operator == (const EventListener&) const override;
     void handleEvent(ScriptExecutionContext& context, Event& event) override;
-
-    JGObject m_joListener;
     static ScriptExecutionContext* scriptExecutionContext();
     bool isJavaEventListener() const override { return true; }
 private:

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/EventTarget.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/EventTarget.cpp
@@ -56,6 +56,11 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
 
+#if PLATFORM(JAVA)
+#include "EventListenerManager.h"
+#include "JavaEventListener.h"
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(EventTarget);
@@ -149,6 +154,9 @@ bool EventTarget::removeEventListener(const AtomString& eventType, EventListener
     InspectorInstrumentation::willRemoveEventListener(*this, eventType, listener, options.capture);
 
     if (data->eventListenerMap.remove(eventType, listener, options.capture)) {
+#if PLATFORM(JAVA)
+        EventListenerManager::get_instance().unregisterListener(static_cast<JavaEventListener *> (&listener));
+#endif
         if (eventNames().isWheelEventType(eventType))
             invalidateEventListenerRegions();
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.cpp
@@ -90,6 +90,11 @@
 #include "ContentChangeObserver.h"
 #endif
 
+#if PLATFORM(JAVA)
+#include "JavaEventListener.h"
+#include "EventListenerManager.h"
+#endif
+
 namespace WebCore {
 
 WTF_MAKE_ISO_ALLOCATED_IMPL(Node);
@@ -2141,6 +2146,10 @@ static inline bool tryAddEventListener(Node* targetNode, const AtomString& event
     if (!targetNode->EventTarget::addEventListener(eventType, listener.copyRef(), options))
         return false;
 
+#if PLATFORM(JAVA)
+        EventListenerManager::get_instance().registerDOMWindow(targetNode->document().domWindow(),
+        static_cast<JavaEventListener *> (&listener.copyRef().get()));
+#endif
     targetNode->document().addListenerTypeIfNeeded(eventType);
     if (eventNames().isWheelEventType(eventType))
         targetNode->document().didAddWheelEventHandler(*targetNode);

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.cpp
@@ -2148,7 +2148,7 @@ static inline bool tryAddEventListener(Node* targetNode, const AtomString& event
 
 #if PLATFORM(JAVA)
         EventListenerManager::get_instance().registerDOMWindow(targetNode->document().domWindow(),
-            static_cast<JavaEventListener *> (&listener.copyRef().get()));
+           static_cast<JavaEventListener *> (&listener.copyRef().get()));
 #endif
     targetNode->document().addListenerTypeIfNeeded(eventType);
     if (eventNames().isWheelEventType(eventType))

--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/Node.cpp
@@ -2148,7 +2148,7 @@ static inline bool tryAddEventListener(Node* targetNode, const AtomString& event
 
 #if PLATFORM(JAVA)
         EventListenerManager::get_instance().registerDOMWindow(targetNode->document().domWindow(),
-        static_cast<JavaEventListener *> (&listener.copyRef().get()));
+            static_cast<JavaEventListener *> (&listener.copyRef().get()));
 #endif
     targetNode->document().addListenerTypeIfNeeded(eventType);
     if (eventNames().isWheelEventType(eventType))

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/DOMWindow.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/DOMWindow.cpp
@@ -149,6 +149,10 @@
 #include "PointerLockController.h"
 #endif
 
+#if PLATFORM(JAVA)
+#include "EventListenerManager.h"
+#endif
+
 namespace WebCore {
 using namespace Inspector;
 
@@ -443,6 +447,10 @@ DOMWindow::~DOMWindow()
 #endif
 
     removeLanguageChangeObserver(this);
+
+#if PLATFORM(JAVA)
+    EventListenerManager::get_instance().unregisterDOMWindow(this);
+#endif
 }
 
 RefPtr<MediaQueryList> DOMWindow::matchMedia(const String& media)

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/DOMWindow.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/DOMWindow.cpp
@@ -450,7 +450,6 @@ DOMWindow::~DOMWindow()
 
 #if PLATFORM(JAVA)
     EventListenerManager::get_instance().unregisterDOMWindow(this);
-    EventListenerManager::get_instance().resetDOMWindow(this);
 #endif
 }
 

--- a/modules/javafx.web/src/main/native/Source/WebCore/page/DOMWindow.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/page/DOMWindow.cpp
@@ -450,6 +450,7 @@ DOMWindow::~DOMWindow()
 
 #if PLATFORM(JAVA)
     EventListenerManager::get_instance().unregisterDOMWindow(this);
+    EventListenerManager::get_instance().resetDOMWindow(this);
 #endif
 }
 

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/EventListenerLeakTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/EventListenerLeakTest.java
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 package test.javafx.scene.web;
 
 import com.sun.javafx.application.PlatformImpl;
@@ -641,4 +642,3 @@ public class EventListenerLeakTest {
         assertEquals("Click count", 1, listeners1.get(0).getClickCount());
     }
 }
-

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/EventListenerLeakTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/EventListenerLeakTest.java
@@ -107,11 +107,6 @@ public class EventListenerLeakTest {
                 startupLatch.await(15, TimeUnit.SECONDS));
     }
 
-    @AfterClass
-    public static void cleanupOnce() {
-        Platform.exit();
-    }
-
     /**
      * Executes a job on FX app thread, and waits until it is complete.
      *

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/EventListenerLeakTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/EventListenerLeakTest.java
@@ -1,0 +1,644 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.javafx.scene.web;
+
+import com.sun.javafx.application.PlatformImpl;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import javafx.application.Platform;
+import javafx.beans.value.ChangeListener;
+import javafx.concurrent.Worker;
+import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.w3c.dom.events.Event;
+import org.w3c.dom.events.EventListener;
+import org.w3c.dom.events.EventTarget;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
+// NOTE: We cannot use TestBase since we need multiple WebView instances, and
+// greater control over the lifecycle.
+public class EventListenerLeakTest {
+
+    // List of WeakReferences to EventListener objects to count which are active
+    // NOTE: this must be reset for each test
+    static List<WeakReference<?>> listenerRefs;
+
+    // Save WeakReferences to WebView objects to later check that it is released
+    // NOTE: this must be reset for each test
+    static List<WeakReference<?>> webViewRefs;
+
+    // WebView instances for testing
+    WebView webView1;
+    WebView webView2;
+
+    // List of DOM nodes for testing
+    List<EventTarget> domNodes1;
+    List<EventTarget> domNodes2;
+
+    static class MyListener implements EventListener {
+
+        private final AtomicInteger clickCount = new AtomicInteger(0);
+
+        private MyListener() {
+        }
+
+        int getClickCount() {
+            return clickCount.get();
+        }
+
+        static MyListener create() {
+            MyListener listener = new MyListener();
+            listenerRefs.add(new WeakReference<>(listener));
+            return listener;
+        }
+
+        @Override
+        public void handleEvent(Event evt) {
+            clickCount.incrementAndGet();
+        }
+    }
+
+    @BeforeClass
+    public static void setupOnce() throws Exception {
+        final CountDownLatch startupLatch = new CountDownLatch(1);
+
+        PlatformImpl.startup(() -> {
+            startupLatch.countDown();
+        });
+
+        assertTrue("Timeout waiting for FX runtime to start",
+                startupLatch.await(15, TimeUnit.SECONDS));
+    }
+
+    @AfterClass
+    public static void cleanupOnce() {
+        Platform.exit();
+    }
+
+    /**
+     * Executes a job on FX app thread, and waits until it is complete.
+     *
+     * Must be called on the test thread.
+     */
+    void submit(Runnable job) {
+        final FutureTask<Void> future = new FutureTask<>(job, null);
+        Platform.runLater(future);
+        try {
+            // block until job is complete
+            future.get();
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            // rethrow any assertion errors as is
+            if (cause instanceof AssertionError) {
+                throw (AssertionError) e.getCause();
+            } else if (cause instanceof RuntimeException) {
+                throw (RuntimeException) cause;
+            }
+            // any other exception should be considered a test error
+            throw new AssertionError(cause);
+        } catch (InterruptedException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Loads HTML content from a String. This method does not return until
+     * loading is finished.
+     *
+     * Must be called on the test thread.
+     */
+    protected void loadContent(final WebView webView, final String content) {
+        final CountDownLatch loadLatch = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            final AtomicReference<ChangeListener<Worker.State>> stateListener
+                    = new AtomicReference<>();
+            stateListener.set((obs, oldState, newState) -> {
+                WebEngine engine = webView.getEngine();
+                if (newState == Worker.State.SUCCEEDED) {
+                    // Remove ChangeListener so we don't hold reference to the EventListener
+                    engine.getLoadWorker().stateProperty()
+                            .removeListener(stateListener.get());
+                    stateListener.set(null);
+                    loadLatch.countDown();
+                }
+            });
+
+            webView.getEngine().getLoadWorker().stateProperty()
+                    .addListener(stateListener.get());
+            webView.getEngine().loadContent(content, "text/html");
+        });
+
+        try {
+            assertTrue("Timeout waiting for content to load",
+                    loadLatch.await(5, TimeUnit.SECONDS));
+        } catch (InterruptedException ex) {
+            throw new RuntimeException("Unexpected exception", ex);
+        }
+    }
+
+    /**
+     * Gets the list of DOM anchor nodes.
+     *
+     * Must be called on the FX app thread
+     */
+    private List<EventTarget> getDomNodes(WebView webView) {
+        final List<EventTarget> nodes = new ArrayList<>();
+        Document doc = webView.getEngine().getDocument();
+        assertNotNull("Document", doc);
+
+        NodeList nodeList = doc.getElementsByTagName("a");
+        assertNotNull("DOM nodes", nodeList);
+        for (int i = 0; i < nodeList.getLength(); i++) {
+            EventTarget node = (EventTarget) nodeList.item(i);
+            nodes.add(node);
+        }
+        return nodes;
+    }
+
+    // Must be called on the event thread
+    void click(WebView webView, int link) {
+        webView.getEngine().executeScript("document.getElementById(\"link"
+                + link + "\").click()");
+    }
+
+    void assertNumActive(String msg, List<WeakReference<?>> refs, int exCount)
+            throws InterruptedException {
+
+        int count = -1;
+
+        for (int i = 0; i < 10; i++) {
+            System.gc();
+
+            count = (int) refs.stream()
+                    .filter(e -> e.get() != null)
+                    .count();
+
+            if (exCount == 0 && count == 0) {
+                break;
+            }
+
+            Thread.sleep(250);
+        }
+
+        assertEquals("Active references (" + msg + ")", exCount, count);
+    }
+
+    @Before
+    public void initEach() {
+        listenerRefs = new ArrayList<>();
+        webViewRefs = new ArrayList<>();
+
+        submit(() -> {
+            webView1 = new WebView();
+            webViewRefs.add(new WeakReference<>(webView1));
+            webView2 = new WebView();
+            webViewRefs.add(new WeakReference<>(webView2));
+        });
+    }
+
+// ---------------------------------------------------------------
+    private static final String HTML =
+            "<body><html>" +
+            "Link: <a id=\"link0\" href=click>click me 0</a><br>" +
+            "Link: <a id=\"link1\" href=click>click me 1</a><br>" +
+            "Link: <a id=\"link2\" href=click>click me 2</a><br>" +
+            "Link: <a id=\"link3\" href=click>click me 3</a><br>" +
+            "</html></body>";
+
+    private static final String HTML2 =
+            "<body><html>" +
+            "Link: <a id=\"link0\" href=click>click me 0</a><br>" +
+             "</html></body>";
+
+    private static final int NUM_DOM_NODES = 4;
+
+    /**
+     * Test that the listener remains active without a strong reference to
+     * either the listener or the DOM node when the WebView is active.
+     */
+    @Test
+    public void oneWebViewSingleListenerNoRelease() throws Exception {
+        webView2 = null; // unused
+
+        // Load HTML content and get list of DOM nodes
+        loadContent(webView1, HTML);
+
+        final List<MyListener> listeners = new ArrayList<>();
+        submit(() -> {
+            domNodes1 = getDomNodes(webView1);
+            assertEquals(NUM_DOM_NODES, domNodes1.size());
+
+            // Create listener and attach to DOM node 0
+            listeners.add(MyListener.create());
+            domNodes1.get(0).addEventListener("click", listeners.get(0), false);
+
+            // Send click event
+            click(webView1, 0);
+        });
+
+        Thread.sleep(100);
+
+        // Verify that the event is delivered to the listener
+        assertEquals("Click count", 1, listeners.get(0).getClickCount());
+
+        // Clear strong reference to listener and the DOM nodes
+        listeners.clear();
+        domNodes1.clear();
+
+        // Verify that listener is still strongly held since we didn't release it
+        assertNumActive("MyListener", listenerRefs, 1);
+    }
+
+    /**
+     * Test that there is no leak when a listener is explicitly released.
+     */
+    @Test
+    public void oneWebViewSingleListenerExplicitRelease() throws Exception {
+        webView2 = null; // unused
+
+        // Load HTML content and get list of DOM nodes
+        loadContent(webView1, HTML);
+
+        final List<WeakReference<MyListener>> listeners = new ArrayList<>();
+        submit(() -> {
+            domNodes1 = getDomNodes(webView1);
+            assertEquals(NUM_DOM_NODES, domNodes1.size());
+
+            // Create listener and attach to DOM node 0
+            MyListener myListener = MyListener.create();
+            listeners.add(new WeakReference<>(myListener));
+            domNodes1.get(0).addEventListener("click", listeners.get(0).get(), false);
+
+            // Send clilck event
+            click(webView1, 0);
+        });
+
+        // Verify that listener has not been released
+        assertNumActive("MyListener", listenerRefs, 1);
+
+        Thread.sleep(100);
+
+        // Verify that the event is delivered to the listener
+        assertNotNull(listeners.get(0).get());
+        assertEquals("Click count", 1, listeners.get(0).get().getClickCount());
+
+        submit(() -> {
+            // Remove event listener
+            assertNotNull(listeners.get(0).get());
+            domNodes1.get(0).removeEventListener("click", listeners.get(0).get(), false);
+        });
+
+        // Release strong reference to DOM nodes
+//        listeners.clear();
+        domNodes1.clear();
+
+        // Verify that listener has been released
+        assertNumActive("MyListener", listenerRefs, 0);
+    }
+
+    /**
+     * Test that there is no leak when a listener is explicitly released.
+     */
+    @Test
+    public void oneWebViewMultipleListenersExplicitRelease() throws Exception {
+        webView2 = null; // unused
+
+        // Load HTML content and get list of DOM nodes
+        loadContent(webView1, HTML);
+
+        final List<WeakReference<MyListener>> listeners = new ArrayList<>();
+        submit(() -> {
+            domNodes1 = getDomNodes(webView1);
+            assertEquals(NUM_DOM_NODES, domNodes1.size());
+
+            // Create listeners and attach to DOM node 0
+            MyListener listenerA = MyListener.create();
+            MyListener listenerB = MyListener.create();
+
+            listeners.add(new WeakReference<>(listenerA));
+            listeners.add(new WeakReference<>(listenerB));
+            listeners.add(new WeakReference<>(listenerA));
+
+            for (int i = 0; i < 3; i++) {
+                domNodes1.get(i).addEventListener("click", listeners.get(i).get(), false);
+            }
+        });
+
+        // Confirm that listeners(0) == listeners(2)
+        assertSame(listeners.get(0).get(), listeners.get(2).get());
+
+        // Verify that neither listener has been released
+        assertNumActive("MyListener", listenerRefs, 2);
+        assertNotNull(listeners.get(0).get());
+        assertNotNull(listeners.get(1).get());
+        assertNotNull(listeners.get(2).get());
+
+        submit(() -> {
+            // Send clilck events
+            click(webView1, 0);
+            click(webView1, 1);
+            click(webView1, 2);
+        });
+
+        // Verify that the events are delivered to the listeners (0 and 2 are same)
+        Thread.sleep(100);
+        assertEquals("Click count", 2, listeners.get(0).get().getClickCount());
+        assertEquals("Click count", 1, listeners.get(1).get().getClickCount());
+        assertEquals("Click count", 2, listeners.get(2).get().getClickCount());
+
+        submit(() -> {
+            // Remove shared event listener from dom node 0
+            assertNotNull(listeners.get(0).get());
+            domNodes1.get(0).removeEventListener("click", listeners.get(0).get(), false);
+            domNodes1.set(0, null);
+        });
+
+        // Verify that neither listener has been released
+        assertNumActive("MyListener", listenerRefs, 2);
+        assertNotNull(listeners.get(0).get());
+        assertNotNull(listeners.get(1).get());
+        assertNotNull(listeners.get(2).get());
+
+        submit(() -> {
+            // Send clilck events again
+            click(webView1, 0);
+            click(webView1, 1);
+            click(webView1, 2);
+        });
+
+        // Verify that one more event is delivered to each listener (0 and 2 are same)
+        Thread.sleep(100);
+        assertEquals("Click count", 3, listeners.get(0).get().getClickCount());
+        assertEquals("Click count", 2, listeners.get(1).get().getClickCount());
+        assertEquals("Click count", 3, listeners.get(2).get().getClickCount());
+
+        submit(() -> {
+            // Remove event listener from dom node 1
+            assertNotNull(listeners.get(1).get());
+            domNodes1.get(1).removeEventListener("click", listeners.get(1).get(), false);
+            domNodes1.set(1, null);
+        });
+
+        // Verify that only listener 1 has been released
+        assertNumActive("MyListener", listenerRefs, 1);
+        assertNotNull(listeners.get(0).get());
+        assertNull(listeners.get(1).get());
+        assertNotNull(listeners.get(2).get());
+
+        submit(() -> {
+            // Send clilck events again
+            click(webView1, 0);
+            click(webView1, 1);
+            click(webView1, 2);
+        });
+
+        // Verify that one more event is delivered to active listener (0 and 2 are same)
+        Thread.sleep(100);
+        assertEquals("Click count", 4, listeners.get(0).get().getClickCount());
+        assertEquals("Click count", 4, listeners.get(2).get().getClickCount());
+
+
+        submit(() -> {
+            // Remove event listener from dom node 2
+            assertNotNull(listeners.get(2).get());
+            domNodes1.get(2).removeEventListener("click", listeners.get(2).get(), false);
+            domNodes1.set(2, null);
+        });
+
+        // Verify that all listners have been released
+        assertNumActive("MyListener", listenerRefs, 0);
+        assertNull(listeners.get(0).get());
+        assertNull(listeners.get(1).get());
+        assertNull(listeners.get(2).get());
+
+        submit(() -> {
+            // Send clilck events again
+            click(webView1, 0);
+            click(webView1, 1);
+            click(webView1, 2);
+        });
+
+        // One last test of ref count after sending the clicks
+        assertNumActive("MyListener", listenerRefs, 0);
+    }
+
+    /**
+     * Test that a listener is implicitly released when the WebView is.
+     */
+    @Test
+    public void oneWebViewSingleListenerImplicitRelease() throws Exception {
+        webView2 = null; // unused
+
+        // Load HTML content and get list of DOM nodes
+        loadContent(webView1, HTML);
+
+        final List<MyListener> listeners = new ArrayList<>();
+        submit(() -> {
+            domNodes1 = getDomNodes(webView1);
+            assertEquals(NUM_DOM_NODES, domNodes1.size());
+
+            // Create listener and attach to DOM node 0
+            listeners.add(MyListener.create());
+            domNodes1.get(0).addEventListener("click", listeners.get(0), false);
+        });
+
+        // Save for later
+        WeakReference<MyListener> ref = new WeakReference<>(listeners.get(0));
+
+        // Clear strong reference to listener and the DOM nodes
+        listeners.clear();
+        domNodes1.clear();
+
+        // Verify that listener is still strongly held
+        assertNumActive("listeners", listenerRefs, 1);
+
+        submit(() -> {
+            // Send click event
+            click(webView1, 0);
+        });
+
+        Thread.sleep(100);
+
+        // Retrieve the listener from the weak ref and check that the event
+        // was delivered even though we held no reference to the event or
+        // the DOM node.
+        listeners.add(ref.get());
+        assertNotNull(listeners.get(0));
+
+        // Verify that the event is delivered to the listener
+        assertEquals("Click count", 1, listeners.get(0).getClickCount());
+
+        // Clear strong reference to listener and WebView
+        listeners.clear();
+        webView1 = null;
+
+        // Verify that there is no strong reference to the WebView
+        assertNumActive("WebView", webViewRefs, 0);
+
+        // Verify that no listeners are strongly held
+        assertNumActive("MyListener", listenerRefs, 0);
+    }
+
+    /**
+     * Test that there is no leak when a listener is explicitly released in
+     * one WebView, and that the listener attached to the other WebView is
+     * still active.
+     */
+    @Test
+    public void twoWebViewSingleListenerExplicitRelease() throws Exception {
+        // Load HTML content and get list of DOM nodes
+        loadContent(webView1, HTML);
+        loadContent(webView2, HTML);
+
+        final List<MyListener> listeners1 = new ArrayList<>();
+        final List<MyListener> listeners2 = new ArrayList<>();
+        submit(() -> {
+            domNodes1 = getDomNodes(webView1);
+            assertEquals(NUM_DOM_NODES, domNodes1.size());
+            domNodes2 = getDomNodes(webView2);
+            assertEquals(NUM_DOM_NODES, domNodes2.size());
+
+            // Create listener for each WebView and attach to DOM node 0
+            listeners1.add(MyListener.create());
+            domNodes1.get(0).addEventListener("click", listeners1.get(0), false);
+
+            listeners2.add(MyListener.create());
+            domNodes2.get(0).addEventListener("click", listeners2.get(0), false);
+
+            // Send clilck event to node 0 in webview1
+            click(webView1, 0);
+        });
+
+        // Verify that the event is delivered to the right listener
+        Thread.sleep(100);
+        assertEquals("Click count", 1, listeners1.get(0).getClickCount());
+        assertEquals("Click count", 0, listeners2.get(0).getClickCount());
+
+        submit(() -> {
+            // Now click the other WebView's node
+            click(webView2, 0);
+        });
+
+        // Verify that the event is delivered to the right listener
+        Thread.sleep(100);
+        assertEquals("Click count", 1, listeners1.get(0).getClickCount());
+        assertEquals("Click count", 1, listeners2.get(0).getClickCount());
+
+        submit(() -> {
+            // Remove event listener from first WebView
+            domNodes1.get(0).removeEventListener("click", listeners1.get(0), false);
+        });
+
+        submit(() -> {
+            // Now click both WebView's node
+            click(webView1, 0);
+            click(webView2, 0);
+        });
+
+        // Verify that the event is delivered to the right listener
+        assertEquals("Click count", 1, listeners1.get(0).getClickCount());
+        assertEquals("Click count", 2, listeners2.get(0).getClickCount());
+
+        // Release strong reference to listener and the DOM nodes
+        listeners1.clear();
+        domNodes1.clear();
+
+        // Verify that only one listener has been released
+        assertNumActive("MyListener", listenerRefs, 1);
+
+        submit(() -> {
+            // Remove event listener from second WebView
+            domNodes2.get(0).removeEventListener("click", listeners2.get(0), false);
+        });
+
+        submit(() -> {
+            // Now click the second WebView's node again
+            click(webView2, 0);
+        });
+
+        // Verify that no more events are delivered
+        Thread.sleep(100);
+        assertEquals("Click count", 2, listeners2.get(0).getClickCount());
+
+        // Release strong reference to listener and the DOM nodes
+        listeners2.clear();
+        domNodes2.clear();
+
+        // Verify that no listeners are strongly held
+        assertNumActive("MyListener", listenerRefs, 0);
+    }
+
+    /**
+     * Test checks listener is not released in
+     * WebView , in case WebView load new content.
+     */
+    @Test
+    public void TestStrongRefNewContentLoad() throws Exception {
+        // Load HTML content and get list of DOM nodes
+        loadContent(webView1, HTML);
+
+        final List<MyListener> listeners1 = new ArrayList<>();
+        submit(() -> {
+            domNodes1 = getDomNodes(webView1);
+
+            listeners1.add(MyListener.create());
+            domNodes1.get(0).addEventListener("click", listeners1.get(0), false);
+
+            // Send clilck event to node 0 in webview1
+            click(webView1, 0);
+        });
+
+        // Verify that the event is delivered to the right listener
+        Thread.sleep(100);
+        assertEquals("Click count", 1, listeners1.get(0).getClickCount());
+
+        // load new content
+        loadContent(webView1, HTML2);
+
+        // Verify that all listeners have not been released
+        Thread.sleep(100);
+        submit(() -> {
+            // Send click event
+            click(webView1, 0);
+        });
+
+        assertEquals("Click count", 1, listeners1.get(0).getClickCount());
+    }
+}
+

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/EventListenerLeakTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/EventListenerLeakTest.java
@@ -727,11 +727,13 @@ public class EventListenerLeakTest {
             click(webView1, 2);
         });
 
-        // add events listeners again
+        // Verify that the events are delivered to the listeners (0 and 2 are same)
+        Thread.sleep(100);
+        assertEquals("Click count", 6, listeners.get(1).get().getClickCount() + listeners.get(0).get().getClickCount());
+
+        // remove events listeners again
         submit(() -> {
             domNodes1 = getDomNodes(webView1);
-            assertEquals(NUM_DOM_NODES, domNodes1.size());
-
             // Create another listeners
             MyListener listener = MyListener.create();
             listeners.add(new WeakReference<>(listener));
@@ -740,6 +742,17 @@ public class EventListenerLeakTest {
                 domNodes1.get(i).removeEventListener("click", listeners.get(1).get(), false);
             }
         });
+
+        submit(() -> {
+            // Send clilck events
+            click(webView1, 0);
+            click(webView1, 1);
+            click(webView1, 2);
+        });
+
+        // Verify that the events count should not be increased
+        Thread.sleep(100);
+        assertEquals("Click count", 6, listeners.get(1).get().getClickCount() + listeners.get(0).get().getClickCount());
 
         // Release strong reference to listener and the DOM nodes
         listeners.clear();

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/EventListenerLeakTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/EventListenerLeakTest.java
@@ -604,7 +604,7 @@ public class EventListenerLeakTest {
      * This is why the count remains at 1 (from the first click on the original page).
      */
     @Test
-    public void TestStrongRefNewContentLoad() throws Exception {
+    public void testStrongRefNewContentLoad() throws Exception {
         webView2 = null;
         // Load HTML content and get list of DOM nodes
         loadContent(webView1, HTML);
@@ -727,7 +727,7 @@ public class EventListenerLeakTest {
             click(webView1, 2);
         });
 
-        // Verify that the events are delivered to the listeners (0 and 2 are same)
+        // Verify that the events are delivered to the listeners (0, 1 and 2 are same)
         Thread.sleep(100);
         assertEquals("Click count", 6, listeners.get(1).get().getClickCount() + listeners.get(0).get().getClickCount());
 
@@ -956,7 +956,7 @@ public class EventListenerLeakTest {
         Thread.sleep(100);
         // Verify that the event is delivered to the listener
         assertEquals("Click count", 1, listeners.get(0).getClickCount());
-        assertEquals("Click count", 1, listeners.get(0).getClickCount());
+        assertEquals("Click count", 1, listeners.get(1).getClickCount());
 
         submit(() -> {
             // Remove event listener

--- a/tests/manual/web/EventListenerLeak.java
+++ b/tests/manual/web/EventListenerLeak.java
@@ -1,0 +1,281 @@
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.concurrent.Worker;
+import javafx.geometry.Insets;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+import javafx.scene.control.Label;
+import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
+import javafx.stage.Stage;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.events.Event;
+import org.w3c.dom.events.EventListener;
+import org.w3c.dom.events.EventTarget;
+
+public class EventListenerLeak extends Application {
+
+    /**
+     * List of WeakReferences to EventListener objects so we can count which
+     * ones are active.
+     */
+    static List<WeakReference<EventListener>> weakRefs = new ArrayList<>();
+
+    /**
+     * Listener shared by all WebView instances.
+     */
+    static WeakReference<EventListener> sharedListener = null;
+
+    /**
+     * Count of number of active listeners.
+     * Must be updated in the FX app thread
+     */
+    static IntegerProperty activeListenerCount = new SimpleIntegerProperty(0);
+
+    /**
+     * EventListener class use to test for leaks and correct
+     * delivery of events.
+     */
+    static class MyEventListener implements EventListener {
+        private final String id;
+
+        MyEventListener(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public void handleEvent(Event event) {
+            System.out.println("[" + id + "] click");
+        }
+    }
+
+    /**
+     * Encapsulates a WebView instance and controls
+     * to remove a listner or the entire webview
+     */
+    static class LeakTestPanel extends VBox {
+        private static int count = 0;
+
+        private String name;
+        private WebView webView = null;
+        private List<WeakReference<EventListener>> myListeners = new ArrayList<>();
+        private List<EventTarget> domNodes = new ArrayList<>();
+
+        LeakTestPanel() {
+            ++count;
+            name = "WebView #" + count;
+
+            createContent();
+            setupListeners();
+        }
+
+        private static final String HTML =
+                "<body><html>" +
+                        "Link: <a href=click>click me A</a><br>" +
+                        "Link: <a href=click>click me B</a><br>" +
+                        "Link: <a href=click>click me C</a><br>" +
+                        "Link: <a href=click>click me SHARED</a><br>" +
+                        "</html></body>";
+        private static final int NUM_DOM_NODES = 4;
+
+        private void createContent() {
+            this.setSpacing(5);
+            this.setPadding(new Insets(5));
+            this.setPrefSize(350, 300);
+
+            webView = new WebView();
+
+            VBox controlBox = new VBox();
+            controlBox.setSpacing(5);
+            controlBox.setPadding(new Insets(5));
+
+            Button removeWebViewButton = new Button("Remove " + name);
+            removeWebViewButton.setOnAction(e -> {
+                if (webView != null) {
+                    System.out.println("Removing " + name);
+                    this.getChildren().remove(1);
+                    domNodes.clear();
+                    webView = null;
+                }
+                updateActiveListenerCount();
+            });
+
+            Label listenerStatusLabel = new Label("DOM Event Listeners: " + NUM_DOM_NODES + " active");
+
+            Button removeListenerButton = new Button("Remove listener");
+            removeListenerButton.setOnAction(e -> {
+                if (domNodes.isEmpty()) {
+                    System.out.println("No more listeners to remove");
+                } else {
+                    EventTarget node = domNodes.remove(0);
+                    EventListener listener = myListeners.remove(0).get();
+                    if (node != null && listener != null) {
+                        System.out.println("Removing listener");
+                        node.removeEventListener("click", listener, false);
+                    } else {
+                        System.err.println("*** Unable to remove listener");
+                    }
+                    listenerStatusLabel.setText("DOM Event Listeners: " + domNodes.size() + " active, " + (NUM_DOM_NODES - domNodes.size()) + " inactive");
+                }
+                updateActiveListenerCount();
+            });
+            controlBox.getChildren().addAll(removeWebViewButton, removeListenerButton, listenerStatusLabel);
+
+            this.getChildren().addAll(controlBox, webView);
+        }
+
+        void setupListeners() {
+            final List<ChangeListener<Worker.State>> stateListeners =
+                    new ArrayList<>();
+            stateListeners.add((obs, oldState, newState) -> {
+                WebEngine engine = webView.getEngine();
+                if (newState == Worker.State.SUCCEEDED) {
+                    Document doc = engine.getDocument();
+                    if (doc != null) {
+                        NodeList nodeList = doc.getElementsByTagName("a");
+                        if (nodeList != null) {
+                            // Adding an EventListener creates a JNI
+                            // global reference, which needs to be released
+                            // either when the listener is removed or when
+                            // the WebView does out of scope
+                            for (int i = 0; i < nodeList.getLength(); i++) {
+                                EventListener listener;
+                                if (i < 2) {
+                                    // Create a new listener
+                                    listener = new MyEventListener("" + name + " listener " + i);
+                                    weakRefs.add(new WeakReference<>(listener));
+                                } else if (i == 2) {
+                                    // Reuse exising listener
+                                    listener = myListeners.get(0).get();
+                                } else {
+                                    // Create or use a listener shared by
+                                    // all WebView instances
+                                    if (sharedListener == null) {
+                                        // Create a new listener
+                                        listener = new MyEventListener("Shared Listener");
+                                        weakRefs.add(new WeakReference<>(listener));
+                                        sharedListener = (new WeakReference<>(listener));
+                                    } else {
+                                        listener = sharedListener.get();
+                                    }
+                                }
+                                myListeners.add(new WeakReference<>(listener));
+
+                                EventTarget node = (EventTarget) nodeList.item(i);
+                                domNodes.add(node);
+                                System.err.println("" + node.getClass() + "::addEventListener");
+                                node.addEventListener("click", listener, false);
+                            }
+                        }
+                    }
+
+                    // Remove ChangeListener so we don't hold reference to the EventListener
+                    engine.getLoadWorker().stateProperty()
+                            .removeListener(stateListeners.get(0));
+                    stateListeners.clear();
+                    updateActiveListenerCount();
+                }
+            });
+            webView.getEngine().getLoadWorker().stateProperty().addListener(stateListeners.get(0));
+            webView.getEngine().loadContent(HTML);
+            webView.setPrefSize(300, 200);
+        }
+
+    }
+
+    static void updateActiveListenerCount() {
+        System.gc();
+        System.gc();
+
+        int count = 0;
+        for (WeakReference<EventListener> ref : weakRefs) {
+            if (ref.get() != null) {
+                count++;
+            }
+        }
+
+        final int newCount = count;
+        Platform.runLater(() -> {
+            if (newCount != activeListenerCount.get()) {
+                activeListenerCount.set(newCount);
+                System.err.println("Active MyEventListeners: " + newCount);
+            }
+        });
+    }
+
+    @Override
+    public void start(Stage stage) {
+        stage.setTitle("JavaFXEventListenerLeak");
+
+        BorderPane root = new BorderPane();
+        root.setPadding(new Insets(5));
+        Scene scene = new Scene(root);
+
+        VBox instructions = new VBox(
+                new Label(" This test is for EventListener memory leak manual testing "),
+                new Label("Issue: calling eventtarget.removeEventListener doesn't remove the Eventlistener"),
+                new Label(" "),
+                new Label(" STEPS:"),
+                new Label("  1. In one panel, remove the WebView."),
+                new Label("  2.  In the other panel, remove the listeners one at a time, making \n" +
+                        "\t sure that the removed link is not active, and the other links are. \n" +
+                        "\t The count should not change when the first of the three listeners \n" +
+                        "\tis removed (because that listener is still in use),\n" +
+                        "\t but then should decrease when the second and third are removed.\n"),
+                new Label("  3. The count of number of listeners should go to 0 after doing both of the above."));
+
+
+        root.setTop(instructions);
+
+        // Create content panel with 2 WebView leak test panels
+        HBox contentPanel = new HBox();
+        contentPanel.setSpacing(5);
+        contentPanel.setPadding(new Insets(5));
+
+        LeakTestPanel leakTest1 = new LeakTestPanel();
+        LeakTestPanel leakTest2 = new LeakTestPanel();
+        contentPanel.getChildren().addAll(leakTest1, leakTest2);
+
+        root.setCenter(contentPanel);
+
+        // Add status line
+        Label activeListenerLabel = new Label();
+        activeListenerLabel.textProperty().bind(activeListenerCount.asString("Active Listener Count: %d"));
+        root.setBottom(activeListenerLabel);
+
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    public static void main(String[] args) {
+
+        // NOTE: this timer is probably not needed
+        Thread thr = new Thread(() -> {
+            while (true) {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException ex) {
+                }
+
+                updateActiveListenerCount();
+            }
+        });
+        thr.setDaemon(true);
+        thr.start();
+
+        Application.launch(args);
+    }
+}

--- a/tests/manual/web/EventListenerLeak.java
+++ b/tests/manual/web/EventListenerLeak.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.beans.property.IntegerProperty;
@@ -262,7 +287,6 @@ public class EventListenerLeak extends Application {
 
     public static void main(String[] args) {
 
-        // NOTE: this timer is probably not needed
         Thread thr = new Thread(() -> {
             while (true) {
                 try {


### PR DESCRIPTION
This PR is new implementation of JavaEvent listener memory management.
Issue  [JDK-8088420](https://bugs.openjdk.java.net/browse/JDK-8088420?filter=-1)

1. Calling remove event listener does not free jni global references.
2. When WebView goes out of scope (disposed from app) , its Event Listeners are not being garbage collected.

Solution:
1.  Detached the jni global reference from JavaEventListener.
2. Create scoped ref counted wrapper class JavaObjectWrapperHandler for jni global reference.
3. Create unique  JavaObjectWrapperHandler object for each JavaEventListener.
4. EventListenerManager is a singleton class , which stores the JavaObjectWrapperHandler mapped with JavaEventListener.
5. EventListenerManager also stores the JavaEventListener mapped with DOMWindow.
6. When Event listener explicitly removed , JavaEventListener is being forwarded to EventListenerManager to clear the listener.
7. When WebView goes out of scope, EventListenerManager will de-registered all the event listeners based on the ref counts attached with WebView DOMWindow.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer), 1 [Author](https://openjdk.java.net/bylaws#author))

### Issue
 * [JDK-8088420](https://bugs.openjdk.java.net/browse/JDK-8088420): JavaFX WebView memory leak via EventListener


### Reviewers
 * [Kevin Rushforth](https://openjdk.java.net/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.java.net/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/799/head:pull/799` \
`$ git checkout pull/799`

Update a local copy of the PR: \
`$ git checkout pull/799` \
`$ git pull https://git.openjdk.java.net/jfx pull/799/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 799`

View PR using the GUI difftool: \
`$ git pr show -t 799`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/799.diff">https://git.openjdk.java.net/jfx/pull/799.diff</a>

</details>
