### PR TITLE
8218826: TableRowSkinBase: horizontal layout broken if row has padding

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -243,7 +243,7 @@ public abstract class TableRowSkinBase<T,
     }
 
     /** {@inheritDoc} */
-    @Override protected void layoutChildren(double x, final double y, final double w, final double h) {
+    @Override protected void layoutChildren(double x, double y, final double w, final double h) {
         checkState();
         if (cellsMap.isEmpty()) return;
 
@@ -316,10 +316,6 @@ public abstract class TableRowSkinBase<T,
         double width;
         double height;
 
-        final double verticalPadding = snappedTopInset() + snappedBottomInset();
-        final double horizontalPadding = snappedLeftInset() + snappedRightInset();
-        final double controlHeight = control.getHeight();
-
         /**
          * RT-26743:TreeTableView: Vertical Line looks unfinished.
          * We used to not do layout on cells whose row exceeded the number
@@ -347,18 +343,18 @@ public abstract class TableRowSkinBase<T,
                 // may be variable and / or dynamic.
                 isVisible = isColumnPartiallyOrFullyVisible(tableColumn);
 
+                y = 0;
                 height = fixedCellSize;
             } else {
-                height = Math.max(controlHeight, tableCell.prefHeight(-1));
-                height = snapSizeY(height) - snapSizeY(verticalPadding);
+                height = h;
             }
+
+            width = tableCell.prefWidth(height);
 
             if (isVisible) {
                 if (fixedCellSizeEnabled && tableCell.getParent() == null) {
                     getChildren().add(tableCell);
                 }
-
-                width = tableCell.prefWidth(height) - snapSizeX(horizontalPadding);
 
                 // Added for RT-32700, and then updated for RT-34074.
                 // We change the alignment from CENTER_LEFT to TOP_LEFT if the
@@ -367,7 +363,7 @@ public abstract class TableRowSkinBase<T,
                 // What I would rather do is only change the alignment if the
                 // alignment has not been manually changed, but for now this will
                 // do.
-                final boolean centreContent = h <= 24.0;
+                final boolean centreContent = height <= 24.0;
 
                 // if the style origin is null then the property has not been
                 // set (or it has been reset to its default), which means that
@@ -392,7 +388,7 @@ public abstract class TableRowSkinBase<T,
                             disclosureNode.resize(disclosureWidth, ph);
 
                             disclosureNode.relocate(x + leftMargin,
-                                    centreContent ? (h / 2.0 - ph / 2.0) :
+                                    centreContent ? y + (h / 2.0 - ph / 2.0) :
                                             (y + tableCell.getPadding().getTop()));
                             disclosureNode.toFront();
                         }
@@ -423,16 +419,13 @@ public abstract class TableRowSkinBase<T,
                 ///////////////////////////////////////////
                 // further indentation code ends here
                 ///////////////////////////////////////////
-
                 tableCell.resize(width, height);
-                tableCell.relocate(x, snappedTopInset());
+                tableCell.relocate(x, y);
 
                 // Request layout is here as (partial) fix for RT-28684.
                 // This does not appear to impact performance...
                 tableCell.requestLayout();
             } else {
-                width = snapSizeX(tableCell.prefWidth(-1)) - snapSizeX(horizontalPadding);
-
                 if (fixedCellSizeEnabled) {
                     // we only add/remove to the scenegraph if the fixed cell
                     // length support is enabled - otherwise we keep all
@@ -562,7 +555,7 @@ public abstract class TableRowSkinBase<T,
 
     /** {@inheritDoc} */
     @Override protected double computePrefWidth(double height, double topInset, double rightInset, double bottomInset, double leftInset) {
-        double prefWidth = 0.0;
+        double prefWidth = leftInset + rightInset;
         for (R cell : cells) {
             prefWidth += cell.prefWidth(height);
         }
@@ -582,8 +575,9 @@ public abstract class TableRowSkinBase<T,
         // cells via CSS, where the desired height is less than the height
         // of the TableCells. Essentially, -fx-cell-size is given higher
         // precedence now
+        double cellSizeWithInsets = getCellSize() + topInset + bottomInset;
         if (getCellSize() < DEFAULT_CELL_SIZE) {
-            return getCellSize();
+            return cellSizeWithInsets;
         }
 
         // FIXME according to profiling, this method is slow and should
@@ -594,8 +588,10 @@ public abstract class TableRowSkinBase<T,
             final R tableCell = cells.get(i);
             prefHeight = Math.max(prefHeight, tableCell.prefHeight(-1));
         }
-        double ph = Math.max(prefHeight, Math.max(getCellSize(), getSkinnable().minHeight(-1)));
+        prefHeight += topInset + bottomInset;
 
+        double cellSizeOrMinHeight = Math.max(cellSizeWithInsets, getSkinnable().minHeight(-1));
+        double ph = Math.max(prefHeight, cellSizeOrMinHeight);
         return ph;
     }
 
@@ -613,7 +609,7 @@ public abstract class TableRowSkinBase<T,
         // of the TableCells. Essentially, -fx-cell-size is given higher
         // precedence now
         if (getCellSize() < DEFAULT_CELL_SIZE) {
-            return getCellSize();
+            return getCellSize() + topInset + bottomInset;
         }
 
         // FIXME according to profiling, this method is slow and should
@@ -624,6 +620,8 @@ public abstract class TableRowSkinBase<T,
             final R tableCell = cells.get(i);
             minHeight = Math.max(minHeight, tableCell.minHeight(-1));
         }
+
+        minHeight += topInset + bottomInset;
         return minHeight;
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableRowSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableRowSkinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,10 +30,11 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
 import javafx.scene.control.IndexedCell;
-import javafx.scene.control.TableColumn;
-import javafx.scene.control.TableRow;
-import javafx.scene.control.TableView;
-import javafx.scene.control.cell.PropertyValueFactory;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeTableColumn;
+import javafx.scene.control.TreeTableRow;
+import javafx.scene.control.TreeTableView;
+import javafx.scene.control.cell.TreeItemPropertyValueFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,40 +44,43 @@ import test.com.sun.javafx.scene.control.test.Person;
 
 import static org.junit.Assert.assertEquals;
 
-public class TableRowSkinTest {
+public class TreeTableRowSkinTest {
 
-    private TableView<Person> tableView;
+    private TreeTableView<Person> treeTableView;
     private StageLoader stageLoader;
 
     @Before
     public void before() {
-        tableView = new TableView<>();
+        treeTableView = new TreeTableView<>();
 
-        TableColumn<Person, String> firstNameCol = new TableColumn<>("Firstname");
-        firstNameCol.setCellValueFactory(new PropertyValueFactory<>("firstName"));
-        TableColumn<Person, String> lastNameCol = new TableColumn<>("Lastname");
-        lastNameCol.setCellValueFactory(new PropertyValueFactory<>("lastName"));
-        TableColumn<Person, String> emailCol = new TableColumn<>("Email");
-        emailCol.setCellValueFactory(new PropertyValueFactory<>("email"));
-        TableColumn<Person, Integer> ageCol = new TableColumn<>("Age");
-        ageCol.setCellValueFactory(new PropertyValueFactory<>("age"));
+        TreeTableColumn<Person, String> firstNameCol = new TreeTableColumn<>("Firstname");
+        firstNameCol.setCellValueFactory(new TreeItemPropertyValueFactory<>("firstName"));
+        TreeTableColumn<Person, String> lastNameCol = new TreeTableColumn<>("Lastname");
+        lastNameCol.setCellValueFactory(new TreeItemPropertyValueFactory<>("lastName"));
+        TreeTableColumn<Person, String> emailCol = new TreeTableColumn<>("Email");
+        emailCol.setCellValueFactory(new TreeItemPropertyValueFactory<>("email"));
+        TreeTableColumn<Person, Integer> ageCol = new TreeTableColumn<>("Age");
+        ageCol.setCellValueFactory(new TreeItemPropertyValueFactory<>("age"));
 
-        tableView.getColumns().addAll(firstNameCol, lastNameCol, emailCol, ageCol);
+        treeTableView.getColumns().addAll(firstNameCol, lastNameCol, emailCol, ageCol);
 
-        ObservableList<Person> items = FXCollections.observableArrayList(
-                new Person("firstName1", "lastName1", "email1@javafx.com", 1),
-                new Person("firstName2", "lastName2", "email2@javafx.com", 2),
-                new Person("firstName3", "lastName3", "email3@javafx.com", 3),
-                new Person("firstName4", "lastName4", "email4@javafx.com", 4)
+        ObservableList<TreeItem<Person>> items = FXCollections.observableArrayList(
+                new TreeItem<>(new Person("firstName1", "lastName1", "email1@javafx.com", 1)),
+                new TreeItem<>(new Person("firstName2", "lastName2", "email2@javafx.com", 2)),
+                new TreeItem<>(new Person("firstName3", "lastName3", "email3@javafx.com", 3)),
+                new TreeItem<>(new Person("firstName4", "lastName4", "email4@javafx.com", 4))
         );
 
-        tableView.setItems(items);
+        TreeItem<Person> root = new TreeItem<>();
+        root.getChildren().addAll(items);
+        treeTableView.setRoot(root);
+        treeTableView.setShowRoot(false);
 
-        stageLoader = new StageLoader(tableView);
+        stageLoader = new StageLoader(treeTableView);
     }
 
     @Test
-    public void tableRowShouldHonorPadding() {
+    public void treeTableRowShouldHonorPadding() {
         int top = 10;
         int right = 20;
         int bottom = 30;
@@ -85,7 +89,7 @@ public class TableRowSkinTest {
         int horizontalPadding = left + right;
         int verticalPadding = top + bottom;
 
-        IndexedCell cell = VirtualFlowTestUtils.getCell(tableView, 0);
+        IndexedCell cell = VirtualFlowTestUtils.getCell(treeTableView, 0);
 
         double minWidth = cell.minWidth(-1);
         double prefWidth = cell.prefWidth(-1);
@@ -97,16 +101,16 @@ public class TableRowSkinTest {
         double maxHeight = cell.maxHeight(-1);
         double height = cell.getHeight();
 
-        tableView.setRowFactory(tableView -> {
-            TableRow<Person> row = new TableRow<>();
+        treeTableView.setRowFactory(treeTableView -> {
+            TreeTableRow<Person> row = new TreeTableRow<>();
             row.setPadding(new Insets(top, right, bottom, left));
             return row;
         });
 
-        tableView.refresh();
+        treeTableView.refresh();
         Toolkit.getToolkit().firePulse();
 
-        cell = VirtualFlowTestUtils.getCell(tableView, 0);
+        cell = VirtualFlowTestUtils.getCell(treeTableView, 0);
 
         assertEquals(minWidth + horizontalPadding, cell.minWidth(-1), 0);
         assertEquals(prefWidth + horizontalPadding, cell.prefWidth(-1), 0);
@@ -120,7 +124,7 @@ public class TableRowSkinTest {
     }
 
     @Test
-    public void tableRowWithCellSizeShouldHonorPadding() {
+    public void treeTableRowWithCellSizeShouldHonorPadding() {
         int top = 10;
         int right = 20;
         int bottom = 30;
@@ -130,7 +134,7 @@ public class TableRowSkinTest {
         int verticalPadding = top + bottom;
         int verticalPaddingWithCellSize = top + bottom + 10;
 
-        IndexedCell cell = VirtualFlowTestUtils.getCell(tableView, 0);
+        IndexedCell cell = VirtualFlowTestUtils.getCell(treeTableView, 0);
 
         double minWidth = cell.minWidth(-1);
         double prefWidth = cell.prefWidth(-1);
@@ -142,17 +146,17 @@ public class TableRowSkinTest {
         double maxHeight = cell.maxHeight(-1);
         double height = cell.getHeight();
 
-        tableView.setRowFactory(tableView -> {
-            TableRow<Person> row = new TableRow<>();
+        treeTableView.setRowFactory(treeTableView -> {
+            TreeTableRow<Person> row = new TreeTableRow<>();
             row.setStyle("-fx-cell-size: 34px");
             row.setPadding(new Insets(top, right, bottom, left));
             return row;
         });
 
-        tableView.refresh();
+        treeTableView.refresh();
         Toolkit.getToolkit().firePulse();
 
-        cell = VirtualFlowTestUtils.getCell(tableView, 0);
+        cell = VirtualFlowTestUtils.getCell(treeTableView, 0);
 
         assertEquals(minWidth + horizontalPadding, cell.minWidth(-1), 0);
         assertEquals(prefWidth + horizontalPadding, cell.prefWidth(-1), 0);
@@ -167,7 +171,7 @@ public class TableRowSkinTest {
     }
 
     @Test
-    public void tableRowWithFixedSizeShouldIgnoreVerticalPadding() {
+    public void treeTableRowWithFixedCellSizeShouldIgnoreVerticalPadding() {
         int top = 10;
         int right = 20;
         int bottom = 30;
@@ -175,9 +179,9 @@ public class TableRowSkinTest {
 
         int horizontalPadding = left + right;
 
-        tableView.setFixedCellSize(24);
+        treeTableView.setFixedCellSize(24);
 
-        IndexedCell cell = VirtualFlowTestUtils.getCell(tableView, 0);
+        IndexedCell cell = VirtualFlowTestUtils.getCell(treeTableView, 0);
 
         double minWidth = cell.minWidth(-1);
         double prefWidth = cell.prefWidth(-1);
@@ -189,16 +193,16 @@ public class TableRowSkinTest {
         double maxHeight = cell.maxHeight(-1);
         double height = cell.getHeight();
 
-        tableView.setRowFactory(tableView -> {
-            TableRow<Person> row = new TableRow<>();
+        treeTableView.setRowFactory(treeTableView -> {
+            TreeTableRow<Person> row = new TreeTableRow<>();
             row.setPadding(new Insets(top, right, bottom, left));
             return row;
         });
 
-        tableView.refresh();
+        treeTableView.refresh();
         Toolkit.getToolkit().firePulse();
 
-        cell = VirtualFlowTestUtils.getCell(tableView, 0);
+        cell = VirtualFlowTestUtils.getCell(treeTableView, 0);
 
         assertEquals(minWidth + horizontalPadding, cell.minWidth(-1), 0);
         assertEquals(prefWidth + horizontalPadding, cell.prefWidth(-1), 0);
@@ -213,7 +217,7 @@ public class TableRowSkinTest {
 
     @Test
     public void removedColumnsShouldRemoveCorrespondingCellsInRowFixedCellSize() {
-        tableView.setFixedCellSize(24);
+        treeTableView.setFixedCellSize(24);
         removedColumnsShouldRemoveCorrespondingCellsInRowImpl();
     }
 
@@ -224,7 +228,7 @@ public class TableRowSkinTest {
 
     @Test
     public void invisibleColumnsShouldRemoveCorrespondingCellsInRowFixedCellSize() {
-        tableView.setFixedCellSize(24);
+        treeTableView.setFixedCellSize(24);
         invisibleColumnsShouldRemoveCorrespondingCellsInRowImpl();
     }
 
@@ -240,25 +244,27 @@ public class TableRowSkinTest {
 
     private void invisibleColumnsShouldRemoveCorrespondingCellsInRowImpl() {
         // Set the last 2 columns invisible.
-        tableView.getColumns().get(tableView.getColumns().size() - 1).setVisible(false);
-        tableView.getColumns().get(tableView.getColumns().size() - 2).setVisible(false);
+        treeTableView.getColumns().get(treeTableView.getColumns().size() - 1).setVisible(false);
+        treeTableView.getColumns().get(treeTableView.getColumns().size() - 2).setVisible(false);
 
         Toolkit.getToolkit().firePulse();
 
         // We set 2 columns to invisible, so the cell count should be decremented by 2 as well.
-        assertEquals(tableView.getColumns().size() - 2,
-                VirtualFlowTestUtils.getCell(tableView, 0).getChildrenUnmodifiable().size());
+        // Note: TreeTableView has an additional children - the disclosure node - therefore we subtract 1 here.
+        assertEquals(treeTableView.getColumns().size() - 2,
+                VirtualFlowTestUtils.getCell(treeTableView, 0).getChildrenUnmodifiable().size() - 1);
     }
 
     private void removedColumnsShouldRemoveCorrespondingCellsInRowImpl() {
         // Remove the last 2 columns.
-        tableView.getColumns().remove(tableView.getColumns().size() - 2, tableView.getColumns().size());
+        treeTableView.getColumns().remove(treeTableView.getColumns().size() - 2, treeTableView.getColumns().size());
 
         Toolkit.getToolkit().firePulse();
 
         // We removed 2 columns, so the cell count should be decremented by 2 as well.
-        assertEquals(tableView.getColumns().size(),
-                VirtualFlowTestUtils.getCell(tableView, 0).getChildrenUnmodifiable().size());
+        // Note: TreeTableView has an additional children - the disclosure node - therefore we subtract 1 here.
+        assertEquals(treeTableView.getColumns().size(),
+                VirtualFlowTestUtils.getCell(treeTableView, 0).getChildrenUnmodifiable().size() - 1);
     }
 
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableRowSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableRowSkinTest.java
@@ -35,21 +35,21 @@ import javafx.scene.control.TreeTableColumn;
 import javafx.scene.control.TreeTableRow;
 import javafx.scene.control.TreeTableView;
 import javafx.scene.control.cell.TreeItemPropertyValueFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
 import test.com.sun.javafx.scene.control.test.Person;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TreeTableRowSkinTest {
 
     private TreeTableView<Person> treeTableView;
     private StageLoader stageLoader;
 
-    @Before
+    @BeforeEach
     public void before() {
         treeTableView = new TreeTableView<>();
 
@@ -237,7 +237,7 @@ public class TreeTableRowSkinTest {
         invisibleColumnsShouldRemoveCorrespondingCellsInRowImpl();
     }
 
-    @After
+    @AfterEach
     public void after() {
         stageLoader.dispose();
     }


### PR DESCRIPTION
This PR fixes a problem, where the layout is broken when a `(Tree)TableRow` has padding.
As also mentioned in the ticket, the `layoutChildren` method in `TableRowSkinBase` is implemented wrong.

The `layoutChildren` method is responsible for layouting all the `(Tree)TableCells`. 
When the row has padding, it is subtracted on every `(Tree)TableCell` - which is wrong.

Instead the `x` and `y` from `layoutChildren` should be used. (E.g. if `x` is 10 (=padding left+right = 10), then only the first cell should start at 10 and the other cells follow as usual)
Also the `compute...` methods needs to add the padding as well.

**Example:**
_Row padding left right 0:_ 
[Cell1][Cell2][Cell3]
_Row padding left right 10:_ 
[    10    ][Cell1][Cell2][Cell3][    10    ] (`compute...` method also needs to account the padding)
_Same for top bottom._

When a `fixedCellSize` is set, the padding is currently ignored (also after this PR).
Therefore, `y` in the `layoutChildren` method is set to 0 for `fixedCellSize`.

This may can be discussed in the mailing list (Could be a follow up). To support padding also when a `fixedCellSize` is set, the `compute...` methods needs to also add the padding when a `fixedCellSize` is set (in the `if` clauses) and the `VirtualFlow` needs to add the padding to every row instead of using the `fixedCellSize` directly (probably at the cost of performance).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8218826](https://bugs.openjdk.org/browse/JDK-8218826): TableRowSkinBase: horizontal layout broken if row has padding


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/800/head:pull/800` \
`$ git checkout pull/800`

Update a local copy of the PR: \
`$ git checkout pull/800` \
`$ git pull https://git.openjdk.org/jfx pull/800/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 800`

View PR using the GUI difftool: \
`$ git pr show -t 800`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/800.diff">https://git.openjdk.org/jfx/pull/800.diff</a>

</details>
