### PR TITLE
8277756: DatePicker listener might not be added when using second constructor

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/DatePicker.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/DatePicker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,15 @@ public class DatePicker extends ComboBoxBase<LocalDate> {
      */
     public DatePicker() {
         this(null);
+    }
 
+    /**
+     * Creates a DatePicker instance and sets the
+     * {@link #valueProperty() value} to the given date.
+     *
+     * @param localDate to be set as the currently selected date in the DatePicker. Can be null.
+     */
+    public DatePicker(LocalDate localDate) {
         valueProperty().addListener(observable -> {
             LocalDate date = getValue();
             Chronology chrono = getChronology();
@@ -115,7 +123,7 @@ public class DatePicker extends ComboBoxBase<LocalDate> {
                 lastValidDate = date;
             } else {
                 System.err.println("Restoring value to " +
-                            ((lastValidDate == null) ? "null" : getConverter().toString(lastValidDate)));
+                        ((lastValidDate == null) ? "null" : getConverter().toString(lastValidDate)));
                 setValue(lastValidDate);
             }
         });
@@ -132,6 +140,17 @@ public class DatePicker extends ComboBoxBase<LocalDate> {
                 setChronology(lastValidChronology);
             }
         });
+
+        setValue(localDate);
+        getStyleClass().add(DEFAULT_STYLE_CLASS);
+        setAccessibleRole(AccessibleRole.DATE_PICKER);
+        setEditable(true);
+
+        focusedProperty().addListener(o -> {
+            if (!isFocused()) {
+                commitValue();
+            }
+        });
     }
 
     private boolean validateDate(Chronology chrono, LocalDate date) {
@@ -144,25 +163,6 @@ public class DatePicker extends ComboBoxBase<LocalDate> {
             System.err.println(ex);
             return false;
         }
-    }
-
-    /**
-     * Creates a DatePicker instance and sets the
-     * {@link #valueProperty() value} to the given date.
-     *
-     * @param localDate to be set as the currently selected date in the DatePicker. Can be null.
-     */
-    public DatePicker(LocalDate localDate) {
-        setValue(localDate);
-        getStyleClass().add(DEFAULT_STYLE_CLASS);
-        setAccessibleRole(AccessibleRole.DATE_PICKER);
-        setEditable(true);
-
-        focusedProperty().addListener(o -> {
-            if (!isFocused()) {
-                commitValue();
-            }
-        });
     }
 
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/DatePickerTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/DatePickerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,12 @@
 
 package test.javafx.scene.control;
 
+import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.chrono.*;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.ValueRange;
 import java.util.*;
 
 import javafx.scene.control.Button;
@@ -621,6 +625,30 @@ public class DatePickerTest {
     }
 
     @Test
+    public void testInvalidChronologyIsRestored() {
+        datePicker = new DatePicker(LocalDate.of(1998, 1, 23));
+        datePicker.setChronology(IsoChronology.INSTANCE);
+
+        assertEquals(IsoChronology.INSTANCE, datePicker.getChronology());
+
+        // This should restore the old set chronology (Iso) as the chronology is invalid.
+        datePicker.setChronology(new InvalidChronology());
+        assertEquals(IsoChronology.INSTANCE, datePicker.getChronology());
+    }
+
+    @Test
+    public void testInvalidValueIsRestored() {
+        datePicker = new DatePicker(null);
+        assertNull(datePicker.getValue());
+
+        datePicker.setChronology(new InvalidChronology());
+        // This should restore the old set value (null) as the chronology is invalid.
+        datePicker.setValue(LocalDate.of(1998, 1, 23));
+
+        assertNull(datePicker.getValue());
+    }
+
+    @Test
     public void testCommitValue() {
         datePicker.setEditable(true);
         datePicker.getEditor().setText("11/24/2021");
@@ -707,6 +735,53 @@ public class DatePickerTest {
         assertEquals("11/24/2021", datePicker.getEditor().getText());
 
         stageLoader.dispose();
+    }
+
+    private class InvalidChronology extends AbstractChronology {
+        @Override
+        public String getId() {
+            return null;
+        }
+        @Override
+        public String getCalendarType() {
+            return null;
+        }
+        @Override
+        public ChronoLocalDate date(int prolepticYear, int month, int dayOfMonth) {
+            return null;
+        }
+        @Override
+        public ChronoLocalDate dateYearDay(int prolepticYear, int dayOfYear) {
+            return null;
+        }
+        @Override
+        public ChronoLocalDate dateEpochDay(long epochDay) {
+            return null;
+        }
+        @Override
+        public ChronoLocalDate date(TemporalAccessor temporal) {
+            throw new DateTimeException("Invalid");
+        }
+        @Override
+        public boolean isLeapYear(long prolepticYear) {
+            return false;
+        }
+        @Override
+        public int prolepticYear(Era era, int yearOfEra) {
+            return 0;
+        }
+        @Override
+        public Era eraOf(int eraValue) {
+            return null;
+        }
+        @Override
+        public List<Era> eras() {
+            return null;
+        }
+        @Override
+        public ValueRange range(ChronoField field) {
+            return null;
+        }
     }
 
 }


### PR DESCRIPTION
The `valueProperty()` and `chronologyProperty()` listener are now added in the second constructor of `DatePicker` 
(`public DatePicker(LocalDate localDate)`) instead of the first one (`public DatePicker()`).
Therefore, both listener are now added no matter which constructor is used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277756](https://bugs.openjdk.java.net/browse/JDK-8277756): DatePicker listener might not be added when using second constructor


### Reviewers
 * [Ajit Ghaisas](https://openjdk.java.net/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jfx pull/801/head:pull/801` \
`$ git checkout pull/801`

Update a local copy of the PR: \
`$ git checkout pull/801` \
`$ git pull https://git.openjdk.java.net/jfx pull/801/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 801`

View PR using the GUI difftool: \
`$ git pr show -t 801`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jfx/pull/801.diff">https://git.openjdk.java.net/jfx/pull/801.diff</a>

</details>
