### PR TITLE
9073465: dispatch properly touch events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,12 +20,7 @@ testbin/
 org.eclipse.buildship*
 
 # Ignore IntelliJ files
-.idea/tasks.xml
-.idea/workspace.xml
-.idea/inspectionProfiles/**
-.idea/copyright/profiles_settings.xml
-.idea/codeStyles/**
-.idea/checkstyle-idea.xml
+.idea
 
 # Ignore the following file suffixes
 *.vcxproj.user

--- a/modules/javafx.graphics/src/main/native-glass/win/FullScreenWindow.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/FullScreenWindow.cpp
@@ -369,7 +369,7 @@ LRESULT FullScreenWindow::WindowProc(UINT msg, WPARAM wParam, LPARAM lParam)
             }
             break;
         case WM_TOUCH:
-            HandleViewTouchEvent(GetHWND(), msg, wParam, lParam);
+            HandleViewTouchEvent(GetHWND(), msg, wParam, lParam, 1);
             return 0;
         case WM_GETOBJECT: {
             LRESULT lr = HandleViewGetAccessible(GetHWND(), wParam, lParam);

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
@@ -574,7 +574,7 @@ LRESULT GlassWindow::WindowProc(UINT msg, WPARAM wParam, LPARAM lParam)
         case WM_TOUCH:
             if (IsEnabled()) {
                 if (activeTouchWindow == 0 || activeTouchWindow == GetHWND()) {
-                    if(HandleViewTouchEvent(GetHWND(), msg, wParam, lParam) > 0) {
+                    if(HandleViewTouchEvent(GetHWND(), msg, wParam, lParam, 1) > 0) {
                         activeTouchWindow = GetHWND();
                     } else {
                         activeTouchWindow = 0;
@@ -1628,7 +1628,7 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_win_WinWindow__1setVisible
             }
 
             if (activeTouchWindow == hWnd) {
-                pWindow->HandleViewTouchEvent(hWnd, 0, 0, 0);
+                pWindow->HandleViewTouchEvent(hWnd, 0, 0, 0, 0);
                 activeTouchWindow = 0;
             }
         }

--- a/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
@@ -1260,14 +1260,10 @@ static char * touchEventName(unsigned int dwFlags) {
 
 void NotifyTouchInput(
         HWND hWnd, jobject view, jclass gestureSupportCls,
-        const TOUCHINPUT* ti, unsigned count)
+        const TOUCHINPUT* ti, unsigned count, bool isDirect)
 {
 
     JNIEnv *env = GetEnv();
-
-    // Sets to 'true' if source device is a touch screen
-    // and to 'false' if source device is a touch pad/pen.
-    const bool isDirect = IsTouchEvent();
 
     jint modifiers = GetModifiers();
     env->CallStaticObjectMethod(gestureSupportCls,
@@ -1337,7 +1333,7 @@ void NotifyManipulationProcessor(
 } // namespace
 
 unsigned int ViewContainer::HandleViewTouchEvent(
-        HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
+        HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam, bool isDirect)
 {
     const UINT newCount = static_cast<UINT>(LOWORD(wParam));
     TOUCHINPUT * tempTouchInputBuf;
@@ -1463,7 +1459,7 @@ unsigned int ViewContainer::HandleViewTouchEvent(
      }
 
     if (pointsCount > 0) {
-        NotifyTouchInput(hWnd, GetView(), m_gestureSupportCls, &m_thisTouchInputBuf[0], pointsCount);
+        NotifyTouchInput(hWnd, GetView(), m_gestureSupportCls, &m_thisTouchInputBuf[0], pointsCount, isDirect);
 
         if (m_manipProc) {
             NotifyManipulationProcessor(*m_manipProc, &m_thisTouchInputBuf[0], pointsCount);

--- a/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.h
@@ -104,7 +104,7 @@ class ViewContainer {
 
         void ResetMouseTracking(HWND hwnd);
 
-        unsigned int HandleViewTouchEvent(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+        unsigned int HandleViewTouchEvent(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam, bool isDirect);
 
         void NotifyViewMoved(HWND hwnd);
         void NotifyViewSize(HWND hwnd);


### PR DESCRIPTION
Hello, Currently our team is developing an touch screen software based in javafx platform for windows. 
We are using by now ThinkPad x1 Fold and Lenovo Yogabook as target device. 
Using JavaFx16 version application works very well in both touch devices and receive correct touch events from listeners.  
After upgrade to 17+ touch events is not dispatch anymore. 

This fix was based on this thread https://stackoverflow.com/questions/69203599/javafx-no-touchevents as ref

We have modified this PR files and build from source jfx project and with that changes
both devices getting work properly again and receive touch events. 

Bug was opened as id 9073465. Maybe status is for aproval yet.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `9073465`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `9073465`.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/802/head:pull/802` \
`$ git checkout pull/802`

Update a local copy of the PR: \
`$ git checkout pull/802` \
`$ git pull https://git.openjdk.org/jfx.git pull/802/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 802`

View PR using the GUI difftool: \
`$ git pr show -t 802`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/802.diff">https://git.openjdk.org/jfx/pull/802.diff</a>

</details>
