### PR TITLE
8286774: Replace openjdk.java.net with openjdk.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ OpenJFX is an open source project and we love to receive contributions from our 
 Bug reports
 -----------
 
-If you think you have found a bug in OpenJFX, first make sure that you are testing against the latest version - your issue may already have been fixed. If not, search our [issues list](https://bugs.openjdk.java.net/issues/?filter=39543) in the Java Bug System (JBS) in case a similar issue has already been opened. More information on where and how to report a bug can be found at [bugreport.java.com](https://bugreport.java.com/).
+If you think you have found a bug in OpenJFX, first make sure that you are testing against the latest version - your issue may already have been fixed. If not, search our [issues list](https://bugs.openjdk.org/issues/?filter=39543) in the Java Bug System (JBS) in case a similar issue has already been opened. More information on where and how to report a bug can be found at [bugreport.java.com](https://bugreport.java.com/).
 
 It is very helpful if you can prepare a reproduction of the bug. In other words, provide a small test case which we can run to confirm your bug. It makes it easier to find the problem and to fix it.
 
@@ -16,13 +16,13 @@ Feature requests
 ----------------
 
 If you find yourself wishing for a feature that doesn't exist in OpenJFX, you are probably not alone. There are bound to be others out there with similar needs. Many of the features that OpenJFX has today have been added because our users saw the need. Please be aware that
-all new feature requests, including any API changes, need prior discussion on the [openjfx-dev](https://mail.openjdk.java.net/mailman/listinfo/openjfx-dev) mailing list, even if there is already an open
-[JBS issue](https://bugs.openjdk.java.net). See the [New features / API additions](#new-features--api-additions) section below for more information.
+all new feature requests, including any API changes, need prior discussion on the [openjfx-dev](https://mail.openjdk.org/mailman/listinfo/openjfx-dev) mailing list, even if there is already an open
+[JBS issue](https://bugs.openjdk.org). See the [New features / API additions](#new-features--api-additions) section below for more information.
 
 Contributing code and documentation changes
 -------------------------------------------
 
-If you have a bug fix or new feature that you would like to contribute to OpenJFX, please talk about what you would like to do on the [openjfx-dev](https://mail.openjdk.java.net/mailman/listinfo/openjfx-dev) mailing list. It may be that somebody is already working on it, or that there are particular issues that you should know about before implementing the change.
+If you have a bug fix or new feature that you would like to contribute to OpenJFX, please talk about what you would like to do on the [openjfx-dev](https://mail.openjdk.org/mailman/listinfo/openjfx-dev) mailing list. It may be that somebody is already working on it, or that there are particular issues that you should know about before implementing the change.
 
 We enjoy working with contributors to get their code accepted. There are many approaches to fixing a problem and it is important to find the best approach before writing too much code.
 
@@ -46,11 +46,11 @@ If you are a first time contributor to OpenJFX, welcome! Please do the following
 
 * Read the code review policies
 
-    Please read the entire section below on how to submit a pull request, as well as the [OpenJFX Code Review Policies](https://wiki.openjdk.java.net/display/OpenJFX/Code+Reviews). If this is a feature request, please note the additional requirements and expectations in the [New features / API additions](#new-features--api-additions) section at the end of this guide.
+    Please read the entire section below on how to submit a pull request, as well as the [OpenJFX Code Review Policies](https://wiki.openjdk.org/display/OpenJFX/Code+Reviews). If this is a feature request, please note the additional requirements and expectations in the [New features / API additions](#new-features--api-additions) section at the end of this guide.
 
 * File a bug in JBS for every pull request
 
-    A unique [JBS](https://bugs.openjdk.java.net) bug ID is needed for every
+    A unique [JBS](https://bugs.openjdk.org) bug ID is needed for every
     pull request. If there isn't already a bug filed in JBS, then please
     file one at [bugreport.java.com](https://bugreport.java.com/).
     A developer with an active OpenJDK ID can file a bug directly in JBS.
@@ -88,7 +88,7 @@ Once your changes and tests are ready to submit for review:
     The Skara bot will then run `jcheck` on the server to verify the format
     of the PR title and check for whitespace errors. Once that passes,
     it will automatically send a Request For Review (RFR) email to the
-    [openjfx-dev](https://mail.openjdk.java.net/mailman/listinfo/openjfx-dev) mailing list.
+    [openjfx-dev](https://mail.openjdk.org/mailman/listinfo/openjfx-dev) mailing list.
     The Skara bot will also cross-link the JBS Issue and the pull request.
     See the
     [Skara project page](https://github.com/openjdk/skara#openjdk-project-skara)
@@ -115,7 +115,7 @@ Once your changes and tests are ready to submit for review:
 4. Code review
 
     All pull requests _must_ be reviewed according to the
-    [OpenJFX Code Review Policies](https://wiki.openjdk.java.net/display/OpenJFX/Code+Reviews).
+    [OpenJFX Code Review Policies](https://wiki.openjdk.org/display/OpenJFX/Code+Reviews).
     It is the responsibility of the Reviewer(s) and the Committer who
     will integrate or sponsor the change to ensure that the code review policies
     are followed, and that all concerns have been addressed.
@@ -144,7 +144,7 @@ Once your changes and tests are ready to submit for review:
     Reviewer role in the project.
 
     NOTE: A reviewer can indicate that a PR needs a
-    [CSR](https://wiki.openjdk.java.net/display/csr/Main) by
+    [CSR](https://wiki.openjdk.org/display/csr/Main) by
     entering the `/csr` command. The Skara bot will then require an approved
     CSR before the PR can be integrated.
 
@@ -178,7 +178,7 @@ The main idea is to think in terms of "stewardship" when evolving the JavaFX API
 It begins before you submit a pull request for review, and continues after the new feature is integrated.
 With that in mind, here are the needed steps to get a new feature into JavaFX.
 
-1. Discuss the proposed feature on the [openjfx-dev](https://mail.openjdk.java.net/mailman/listinfo/openjfx-dev) mailing list.
+1. Discuss the proposed feature on the [openjfx-dev](https://mail.openjdk.org/mailman/listinfo/openjfx-dev) mailing list.
 You should start with _why_ you think
 adding the API to the core of JavaFX is a good and useful addition for multiple applications (not just your own)
 and for the evolution of the JavaFX UI Toolkit. Part of this is to see whether the Project Leads and Reviewers
@@ -191,7 +191,7 @@ proceed to the API.
 
 2. Discuss the API needed to provide the feature. While this can't always be completely separated from its
 implementation, it is the public API itself that is important to nail down and get right. While we don't currently
-use the formal JEP process as is done for larger JDK features, the [JEP template](http://openjdk.java.net/jeps/2)
+use the formal JEP process as is done for larger JDK features, the [JEP template](https://openjdk.org/jeps/2)
 provides some ideas to consider when proposing an API, such as a summary of the changes, goals, motivation, testing,
 dependencies, etc. A Draft (or WIP) pull request can be useful for illustrative purposes as long as the focus is on the public API.
 If there are trade-offs to be made in the implementation, or different implementation approaches that you might take,
@@ -199,8 +199,8 @@ this is a good time to discuss it. Once this step is far enough along that there
 then it's time to focus on the implementation.
 
 3. Submit a review of your proposed implementation. As noted in the
-[New features / API additions](https://wiki.openjdk.java.net/display/OpenJFX/Code+Reviews#CodeReviews-NewFeaturesC.Newfeatures/APIadditions.)
-section of the Code Review Policies doc, we also need a [CSR](https://wiki.openjdk.java.net/display/csr/Main), which documents the API change and its approval.
+[New features / API additions](https://wiki.openjdk.org/display/OpenJFX/Code+Reviews#CodeReviews-NewFeaturesC.Newfeatures/APIadditions.)
+section of the Code Review Policies doc, we also need a [CSR](https://wiki.openjdk.org/display/csr/Main), which documents the API change and its approval.
 The CSR can be reviewed in parallel. Changes in the API that arise during the review need to be reflected in the CSR, meaning
 that the final review / approval of the CSR usually happens late in the review cycle.
 You can avoid extra work by waiting to submit the CSR until the API is agreed upon and the code review for the documentation is reasonably far along.
@@ -254,4 +254,4 @@ bash ./gradlew -PFULL_TEST=true -PUSE_ROBOT=true all test
 If you don't build WebKit (using the `-PCOMPILE_WEBKIT=true` option), you are likely to get test failures when running the web tests. See the [Web Testing](WEBKIT-MEDIA-STUBS.md) page for information on how to address this.
 
 Even more documentation on OpenJFX projects and its build system can be found on the
-[OpenJFX Wiki](https://wiki.openjdk.java.net/display/OpenJFX/).
+[OpenJFX Wiki](https://wiki.openjdk.org/display/OpenJFX/).

--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ OpenJFX is an open source, next generation client application platform for deskt
 
 OpenJFX is free software, licensed under [GPL v2 with the Classpath exception](LICENSE), just like the JDK. Anybody is welcome to contribute to this project, port it to other platforms or devices, or do anything else that a free software license allows you to do!
 
-OpenJFX is a project under the charter of the OpenJDK. The [OpenJDK Bylaws](https://openjdk.java.net/bylaws) and [License](LICENSE) govern our work. The OpenJFX project membership can be found on the [OpenJDK Census](https://openjdk.java.net/census#openjfx). We welcome patches and involvement from individual contributors or companies. If this is your first time contributing to an OpenJDK project, you will need to review the rules on [becoming a Contributor](https://openjdk.java.net/bylaws#contributor), and sign the [Oracle Contributor Agreement](https://oca.opensource.oracle.com/) (OCA).
+OpenJFX is a project under the charter of the OpenJDK. The [OpenJDK Bylaws](https://openjdk.org/bylaws) and [License](LICENSE) govern our work. The OpenJFX project membership can be found on the [OpenJDK Census](https://openjdk.org/census#openjfx). We welcome patches and involvement from individual contributors or companies. If this is your first time contributing to an OpenJDK project, you will need to review the rules on [becoming a Contributor](https://openjdk.org/bylaws#contributor), and sign the [Oracle Contributor Agreement](https://oca.opensource.oracle.com/) (OCA).
 
 ## Issue tracking
 
-If you think you have found a bug in OpenJFX, first make sure that you are testing against the latest version - your issue may already have been fixed. If not, search our [issues list](https://bugs.openjdk.java.net/issues/?filter=39543) in the Java Bug System (JBS) in case a similar issue has already been opened. More information on where and how to report a bug can be found at [bugreport.java.com](https://bugreport.java.com/).
+If you think you have found a bug in OpenJFX, first make sure that you are testing against the latest version - your issue may already have been fixed. If not, search our [issues list](https://bugs.openjdk.org/issues/?filter=39543) in the Java Bug System (JBS) in case a similar issue has already been opened. More information on where and how to report a bug can be found at [bugreport.java.com](https://bugreport.java.com/).
 
 ## Getting Started
 
-For instructions on building JavaFX, see the [Building OpenJFX](https://wiki.openjdk.java.net/display/OpenJFX/Building+OpenJFX) Wiki page.
+For instructions on building JavaFX, see the [Building OpenJFX](https://wiki.openjdk.org/display/OpenJFX/Building+OpenJFX) Wiki page.
 
 For information about downloading and using JavaFX, see the [JavaFX community site](https://openjfx.io/).
 

--- a/UPDATING-VERSION.md
+++ b/UPDATING-VERSION.md
@@ -2,7 +2,7 @@
 
 Here are the instructions for updating the JavaFX release version number
 for a feature release or security (dot-dot) release.
-See [JDK-8226365](https://bugs.openjdk.java.net/browse/JDK-8226365)
+See [JDK-8226365](https://bugs.openjdk.org/browse/JDK-8226365)
 for a recent example.
 
 ## Incrementing the feature version

--- a/apps/toys/DragDrop/src/dragdrop/DragDropWithControls.java
+++ b/apps/toys/DragDrop/src/dragdrop/DragDropWithControls.java
@@ -110,7 +110,7 @@ public class DragDropWithControls extends Application {
         new Thread(new Runnable() {
             @Override public void run() {
                 log("Loading image..");
-                image = new Image("http://openjdk.java.net/images/duke-thinking.png");
+                image = new Image("https://openjdk.org/images/duke-thinking.png");
                 log("Ready.");
                 log("");
             }

--- a/apps/toys/DragDrop/src/dragdrop/DragDropWithControlsSwing.java
+++ b/apps/toys/DragDrop/src/dragdrop/DragDropWithControlsSwing.java
@@ -120,7 +120,7 @@ public class DragDropWithControlsSwing extends Application {
         new Thread(new Runnable() {
             @Override public void run() {
                 log("Loading image..");
-                image = new Image("http://openjdk.java.net/images/duke-thinking.png");
+                image = new Image("https://openjdk.org/images/duke-thinking.png");
                 log("Ready.");
                 log("");
             }

--- a/apps/toys/Hello/src/main/java/hello/HelloProgressIndicator.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloProgressIndicator.java
@@ -116,7 +116,7 @@ public class HelloProgressIndicator extends Application {
         root.getChildren().add(pInd6);
 
         // busy indicator - indeterminate and spin are enabled by default
-        // See https://wiki.openjdk.java.net/display/OpenJFX/ProgressIndicator+User+Experience+Documentation
+        // See https://wiki.openjdk.org/display/OpenJFX/ProgressIndicator+User+Experience+Documentation
         ProgressIndicator pInd7 = new ProgressIndicator();
         pInd7.setLayoutX(300);
         pInd7.setLayoutY(250);

--- a/doc-files/release-notes-11.md
+++ b/doc-files/release-notes-11.md
@@ -21,18 +21,18 @@ The default duration that the mouse has to be pressed on a Spinner control arrow
 
   repeatDelay: The duration that the mouse has to be pressed for each successive step after the first value steps. The default is now 60 msec.
 
-See [JDK-8167096](https://bugs.openjdk.java.net/browse/JDK-8167096) for more information.
+See [JDK-8167096](https://bugs.openjdk.org/browse/JDK-8167096) for more information.
 
 
 ### Standalone javafx modules no longer have permissions by default
 
 The javafx.* modules are now loaded by the application class loader and no longer have permissions by default. Applications that want to run with a security manager enabled will need to specify a custom policy file, using "-Djava.security.policy", granting all permissions to each of the javafx.* modules.
-See [JDK-8210617](https://bugs.openjdk.java.net/browse/JDK-8210617) for more information.
+See [JDK-8210617](https://bugs.openjdk.org/browse/JDK-8210617) for more information.
 
 
 ### Switch default GTK version to 3
 
-JavaFX will now use GTK 3 by default on Linux platforms where the gtk3 library is present. Prior to JavaFX 11, the GTK 2 library was the default. This matches the default for AWT in JDK 11. See [JDK-8198654](https://bugs.openjdk.java.net/browse/JDK-8198654) for more information.
+JavaFX will now use GTK 3 by default on Linux platforms where the gtk3 library is present. Prior to JavaFX 11, the GTK 2 library was the default. This matches the default for AWT in JDK 11. See [JDK-8198654](https://bugs.openjdk.org/browse/JDK-8198654) for more information.
 
 
 ## New Features
@@ -41,13 +41,13 @@ The following notes describe some of the enhancements in JavaFX 11. See the tabl
 
 ### FX Robot API
 
-Public FX Robot API was added to support simulating user interaction such as typing keys on the keyboard and using the mouse as well as capturing graphical information. See [JDK-8090763](https://bugs.openjdk.java.net/browse/JDK-8090763) for more information.
+Public FX Robot API was added to support simulating user interaction such as typing keys on the keyboard and using the mouse as well as capturing graphical information. See [JDK-8090763](https://bugs.openjdk.org/browse/JDK-8090763) for more information.
 
 ## Removed Features and Options
 
 ### Remove support for libavcodec 53 and 55
 
-FX Media support for libavcodec 53 and 55 was removed. These libraries are not present on supported Linux platforms by default, and are no longer needed. See [JDK-8194062](https://bugs.openjdk.java.net/browse/JDK-8194062) for more information.
+FX Media support for libavcodec 53 and 55 was removed. These libraries are not present on supported Linux platforms by default, and are no longer needed. See [JDK-8194062](https://bugs.openjdk.org/browse/JDK-8194062) for more information.
 
 
 ## Known Issues
@@ -64,7 +64,7 @@ An alternative workaround is to explicitly force GTK 2 by passing the following 
     java -Djdk.gtk.version=2 ...
 ```
 
-See [JDK-8210411](https://bugs.openjdk.java.net/browse/JDK-8210411) for more information.
+See [JDK-8210411](https://bugs.openjdk.org/browse/JDK-8210411) for more information.
 
 ### Swing interop requires qualified exports when run with JDK 10
 
@@ -77,13 +77,13 @@ To run FX / Swing interop applications using JavaFX 11 with an OpenJDK 10 releas
 --add-exports=java.desktop/sun.swing=javafx.swing
 ```
 
-See [JDK-8210615](https://bugs.openjdk.java.net/browse/JDK-8210615) for more information.
+See [JDK-8210615](https://bugs.openjdk.org/browse/JDK-8210615) for more information.
 
 
 ### Swing interop fails when run with a security manager with standalone SDK
 
 FX / Swing interop applications will fail when run with a security manager enabled. An application that uses either JFXPanel or SwingNode must run without a security manager enabled.
-See [JDK-8202451](https://bugs.openjdk.java.net/browse/JDK-8202451) for more information.
+See [JDK-8202451](https://bugs.openjdk.org/browse/JDK-8202451) for more information.
 
 
 ### Swing interop fails when using a minimal jdk image created with jlink
@@ -107,115 +107,115 @@ Workaround: create your image using one of the following two methods:
         --add-modules java.desktop,javafx.swing,javafx.controls
 ```
 
-See [JDK-8210759](https://bugs.openjdk.java.net/browse/JDK-8210759) for more information.
+See [JDK-8210759](https://bugs.openjdk.org/browse/JDK-8210759) for more information.
 
 
 ## List of Fixed Bugs
 
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8203345](https://bugs.openjdk.java.net/browse/JDK-8203345)|Memory leak in VirtualFlow when screen reader is enabled|accessibility
-[JDK-8204336](https://bugs.openjdk.java.net/browse/JDK-8204336)|Platform.exit() throws ISE when a nested event loop is active|application-lifecycle
-[JDK-8089454](https://bugs.openjdk.java.net/browse/JDK-8089454)|[HTMLEditor] selection removes CENTER alignment|controls
-[JDK-8154039](https://bugs.openjdk.java.net/browse/JDK-8154039)|Memory leak when selecting a tab which is not contained in TabPane::getTabs()|controls
-[JDK-8157690](https://bugs.openjdk.java.net/browse/JDK-8157690)|[TabPane] Sorting tabs makes tab selection menu empty|controls
-[JDK-8165459](https://bugs.openjdk.java.net/browse/JDK-8165459)|HTMLEditor: clipboard toolbar buttons are disabled unexpectedly|controls
-[JDK-8185854](https://bugs.openjdk.java.net/browse/JDK-8185854)|NPE on non-editable ComboBox in TabPane with custom Skin|controls
-[JDK-8187432](https://bugs.openjdk.java.net/browse/JDK-8187432)|ListView: EditEvent on start has incorrect index|controls
-[JDK-8192800](https://bugs.openjdk.java.net/browse/JDK-8192800)|Table auto resize ignores column resize policy|controls
-[JDK-8193311](https://bugs.openjdk.java.net/browse/JDK-8193311)|[Spinner] Default button not activated on ENTER|controls
-[JDK-8193495](https://bugs.openjdk.java.net/browse/JDK-8193495)|TabPane does not update correctly tab positions in the header area after a quick remove and add operations|controls
-[JDK-8194913](https://bugs.openjdk.java.net/browse/JDK-8194913)|Focus traversal is broken if a Pane is added to a ToolBar|controls
-[JDK-8196827](https://bugs.openjdk.java.net/browse/JDK-8196827)|test.javafx.scene.control.ComboBoxTest - generates NullPointerException|controls
-[JDK-8197846](https://bugs.openjdk.java.net/browse/JDK-8197846)|ComboBox: becomes unclickable after removal and re-adding|controls
-[JDK-8197985](https://bugs.openjdk.java.net/browse/JDK-8197985)|Pressing Shift + DOWN in ListView causes Exception to be thrown|controls
-[JDK-8200285](https://bugs.openjdk.java.net/browse/JDK-8200285)|TabDragPolicy.REORDER prevents ContextMenu from showing|controls
-[JDK-8201285](https://bugs.openjdk.java.net/browse/JDK-8201285)|DateCell text color are not updated correctly when DateCell with disable = true is reused|controls
-[JDK-8208610](https://bugs.openjdk.java.net/browse/JDK-8208610)|Incorrect check for calling class in FXMLLoader::getDefaultClassLoader|fxml
-[JDK-8129582](https://bugs.openjdk.java.net/browse/JDK-8129582)|Controls slow considerably when displaying RTL-languages text on Linux|graphics
-[JDK-8195801](https://bugs.openjdk.java.net/browse/JDK-8195801)|Replace jdk.internal.misc.Unsafe with sun.misc.Unsafe in MarlinFX|graphics
-[JDK-8195802](https://bugs.openjdk.java.net/browse/JDK-8195802)|Eliminate use of jdk.internal.misc security utilities in javafx.graphics|graphics
-[JDK-8195806](https://bugs.openjdk.java.net/browse/JDK-8195806)|Eliminate dependency on sun.font.lookup in javafx.graphics|graphics
-[JDK-8195808](https://bugs.openjdk.java.net/browse/JDK-8195808)|Eliminate dependency on sun.print in javafx.graphics|graphics
-[JDK-8196617](https://bugs.openjdk.java.net/browse/JDK-8196617)|FX print tests fail with NPE in some environments|graphics
-[JDK-8198354](https://bugs.openjdk.java.net/browse/JDK-8198354)|[macOS] Corrupt Thai characters displayed in word wrapped label |graphics
-[JDK-8201231](https://bugs.openjdk.java.net/browse/JDK-8201231)|java.lang.NullPointerException at WindowStage.setPlatformEnabled|graphics
-[JDK-8202396](https://bugs.openjdk.java.net/browse/JDK-8202396)|memory leak in ios native imageloader|graphics
-[JDK-8202743](https://bugs.openjdk.java.net/browse/JDK-8202743)|Dashed Stroke randomly painted incorrectly, may freeze application|graphics
-[JDK-8203378](https://bugs.openjdk.java.net/browse/JDK-8203378)|JDK build fails to compile javafx.graphics module-info.java if FX was built with OpenJDK|graphics
-[JDK-8203801](https://bugs.openjdk.java.net/browse/JDK-8203801)|Missing Classpath exception in PrismLoaderGlue.stg file|graphics
-[JDK-8207328](https://bugs.openjdk.java.net/browse/JDK-8207328)|API docs for javafx.css.Stylesheet are inaccurate / wrong|graphics
-[JDK-8209191](https://bugs.openjdk.java.net/browse/JDK-8209191)|[macOS] Distorted complex text rendering|graphics
-[JDK-8088722](https://bugs.openjdk.java.net/browse/JDK-8088722)|GSTPlatform cannot play MP4 files with multiple audio tracks|media
-[JDK-8191446](https://bugs.openjdk.java.net/browse/JDK-8191446)|[Linux] Build and deliver the libav media stubs for openjfx build|media
-[JDK-8193313](https://bugs.openjdk.java.net/browse/JDK-8193313)|MediaPlayer Leaking Native Memory|media
-[JDK-8195803](https://bugs.openjdk.java.net/browse/JDK-8195803)|Eliminate use of sun.nio.ch.DirectBuffer in javafx.media|media
-[JDK-8198316](https://bugs.openjdk.java.net/browse/JDK-8198316)|MediaPlayer crashes when playing m3u8 files on macOS High Sierra 10.13.2|media
-[JDK-8199008](https://bugs.openjdk.java.net/browse/JDK-8199008)|[macOS, Linux] Instantiating MediaPlayer causes CPU usage to be over 100%|media
-[JDK-8199527](https://bugs.openjdk.java.net/browse/JDK-8199527)|Upgrade GStreamer to 1.14|media
-[JDK-8202393](https://bugs.openjdk.java.net/browse/JDK-8202393)|App Transport Security blocks http media on macOS with JDK build using new compilers|media
-[JDK-8191661](https://bugs.openjdk.java.net/browse/JDK-8191661)|FXCanvas on Win32 HiDPI produces wrong results|other
-[JDK-8193910](https://bugs.openjdk.java.net/browse/JDK-8193910)|Version number in cssref.html and introduction_to_fxml.html is wrong|other
-[JDK-8195799](https://bugs.openjdk.java.net/browse/JDK-8195799)|Use System logger instead of platform logger in javafx modules|other
-[JDK-8195800](https://bugs.openjdk.java.net/browse/JDK-8195800)|Eliminate dependency on sun.reflect.misc in javafx modules|other
-[JDK-8195974](https://bugs.openjdk.java.net/browse/JDK-8195974)|Replace use of java.util.logging in javafx with System logger|other
-[JDK-8196297](https://bugs.openjdk.java.net/browse/JDK-8196297)|Remove obsolete JFR logger code|other
-[JDK-8199357](https://bugs.openjdk.java.net/browse/JDK-8199357)|Remove references to applets and Java Web Start from FX|other
-[JDK-8200587](https://bugs.openjdk.java.net/browse/JDK-8200587)|Fix mistakes in FX API docs|other
-[JDK-8202036](https://bugs.openjdk.java.net/browse/JDK-8202036)|Update OpenJFX license files to match OpenJDK|other
-[JDK-8202357](https://bugs.openjdk.java.net/browse/JDK-8202357)|Extra chars in copyright header in ModuleHelper.java|other
-[JDK-8204653](https://bugs.openjdk.java.net/browse/JDK-8204653)|Fix mistakes in FX API docs|other
-[JDK-8204956](https://bugs.openjdk.java.net/browse/JDK-8204956)|Cleanup whitespace after fix for JDK-8200285|other
-[JDK-8207794](https://bugs.openjdk.java.net/browse/JDK-8207794)|FXCanvas does not update x/y of EmbeddedStageInterface when FXCanvas is reparented|other
-[JDK-8208294](https://bugs.openjdk.java.net/browse/JDK-8208294)|install native library fails when jrt protocol is used|other
-[JDK-8180151](https://bugs.openjdk.java.net/browse/JDK-8180151)|JavaFX incorrectly renders scenegraph with two 3D boxes with certain dimensions|scenegraph
-[JDK-8192056](https://bugs.openjdk.java.net/browse/JDK-8192056)|Memory leak when removing javafx.scene.shape.Sphere-objects from a group or container|scenegraph
-[JDK-8205008](https://bugs.openjdk.java.net/browse/JDK-8205008)|GeneralTransform3D transform function with single Vec3d argument wrong results|scenegraph
-[JDK-8207377](https://bugs.openjdk.java.net/browse/JDK-8207377)|Document the behavior of Robot::getPixelColor with HiDPI|scenegraph
-[JDK-8201291](https://bugs.openjdk.java.net/browse/JDK-8201291)|Clicking a JFXPanel having setFocusable(false) causes its processMouseEvent method to loop forever|swing
-[JDK-8088769](https://bugs.openjdk.java.net/browse/JDK-8088769)|Alphachannel for transparent colors is not shown in HtmlEditor|web
-[JDK-8088925](https://bugs.openjdk.java.net/browse/JDK-8088925)|Non opaque background cause NumberFormatException|web
-[JDK-8089375](https://bugs.openjdk.java.net/browse/JDK-8089375)|When WebWorker file is unaccessible, script should fail silently or post meaningful exception|web
-[JDK-8147476](https://bugs.openjdk.java.net/browse/JDK-8147476)|Rendering  issues with MathML  token elements|web
-[JDK-8193368](https://bugs.openjdk.java.net/browse/JDK-8193368)|[OS X] Remove redundant files|web
-[JDK-8193590](https://bugs.openjdk.java.net/browse/JDK-8193590)|Memory leak when using WebView with Tooltip|web
-[JDK-8194265](https://bugs.openjdk.java.net/browse/JDK-8194265)|Webengine (webkit) crash when reading files using FileReader|web
-[JDK-8194935](https://bugs.openjdk.java.net/browse/JDK-8194935)|Cherry pick GTK WebKit 2.18.5 changes|web
-[JDK-8195804](https://bugs.openjdk.java.net/browse/JDK-8195804)|Remove unused qualified export of sun.net.www from java.base to javafx.web|web
-[JDK-8196011](https://bugs.openjdk.java.net/browse/JDK-8196011)|Intermittent crash when using WebView from JFXPanel application|web
-[JDK-8196374](https://bugs.openjdk.java.net/browse/JDK-8196374)|windows x86 webview-icu isAlphaNumericString crash |web
-[JDK-8196677](https://bugs.openjdk.java.net/browse/JDK-8196677)|Cherry pick GTK WebKit 2.18.6 changes|web
-[JDK-8196968](https://bugs.openjdk.java.net/browse/JDK-8196968)|One time crash on exit in JNIEnv_::CallObjectMethod|web
-[JDK-8197987](https://bugs.openjdk.java.net/browse/JDK-8197987)|Update libxslt to version 1.1.32|web
-[JDK-8199474](https://bugs.openjdk.java.net/browse/JDK-8199474)|Update to 606.1 version of WebKit|web
-[JDK-8200418](https://bugs.openjdk.java.net/browse/JDK-8200418)|"webPage.executeCommand(""removeFormat"", null) removes the style of the body element"|web
-[JDK-8200629](https://bugs.openjdk.java.net/browse/JDK-8200629)|Update SQLite to version 3.23.0|web
-[JDK-8202277](https://bugs.openjdk.java.net/browse/JDK-8202277)|WebView image capture fails with standalone FX due to dependency on javafx.swing|web
-[JDK-8203698](https://bugs.openjdk.java.net/browse/JDK-8203698)|JavaFX WebView crashes when visiting certain web sites|web
-[JDK-8204856](https://bugs.openjdk.java.net/browse/JDK-8204856)|WebEngine document becomes null after PAGE_REPLACED event|web
-[JDK-8206899](https://bugs.openjdk.java.net/browse/JDK-8206899)|DRT crashes randomly when running 'dom/html/level2/html/AppletsCollection.html'|web
-[JDK-8206995](https://bugs.openjdk.java.net/browse/JDK-8206995)|Remove unused WebKit files|web
-[JDK-8208114](https://bugs.openjdk.java.net/browse/JDK-8208114)|Drag and drop of text contents and URL links functionalities are broken in Webview|web
-[JDK-8208622](https://bugs.openjdk.java.net/browse/JDK-8208622)|[WebView] IllegalStateException when invoking print API with html form controls|web
-[JDK-8209049](https://bugs.openjdk.java.net/browse/JDK-8209049)|Cherry pick GTK WebKit 2.20.4 changes|web
-[JDK-8163795](https://bugs.openjdk.java.net/browse/JDK-8163795)|[Windows] Remove call to StretchBlt in native GetScreenCapture method|window-toolkit
-[JDK-8191885](https://bugs.openjdk.java.net/browse/JDK-8191885)|[MacOS] JavaFX main window not resizable coming back from full screen mode in MacOS|window-toolkit
-[JDK-8196031](https://bugs.openjdk.java.net/browse/JDK-8196031)|FX Robot mouseMove fails on Windows 10 1709 with HiDPI|window-toolkit
-[JDK-8199614](https://bugs.openjdk.java.net/browse/JDK-8199614)|[macos] ImageCursor.getBestSize() throws NullPointerException|window-toolkit
-[JDK-8204635](https://bugs.openjdk.java.net/browse/JDK-8204635)|[Linux] getMouseX, getMouseY in gtk GlassRobot.cpp ignore the HiDPI scale|window-toolkit
-[JDK-8207372](https://bugs.openjdk.java.net/browse/JDK-8207372)|Robot.mouseWheel not implemented correctly on Linux, Mac|window-toolkit
+[JDK-8203345](https://bugs.openjdk.org/browse/JDK-8203345)|Memory leak in VirtualFlow when screen reader is enabled|accessibility
+[JDK-8204336](https://bugs.openjdk.org/browse/JDK-8204336)|Platform.exit() throws ISE when a nested event loop is active|application-lifecycle
+[JDK-8089454](https://bugs.openjdk.org/browse/JDK-8089454)|[HTMLEditor] selection removes CENTER alignment|controls
+[JDK-8154039](https://bugs.openjdk.org/browse/JDK-8154039)|Memory leak when selecting a tab which is not contained in TabPane::getTabs()|controls
+[JDK-8157690](https://bugs.openjdk.org/browse/JDK-8157690)|[TabPane] Sorting tabs makes tab selection menu empty|controls
+[JDK-8165459](https://bugs.openjdk.org/browse/JDK-8165459)|HTMLEditor: clipboard toolbar buttons are disabled unexpectedly|controls
+[JDK-8185854](https://bugs.openjdk.org/browse/JDK-8185854)|NPE on non-editable ComboBox in TabPane with custom Skin|controls
+[JDK-8187432](https://bugs.openjdk.org/browse/JDK-8187432)|ListView: EditEvent on start has incorrect index|controls
+[JDK-8192800](https://bugs.openjdk.org/browse/JDK-8192800)|Table auto resize ignores column resize policy|controls
+[JDK-8193311](https://bugs.openjdk.org/browse/JDK-8193311)|[Spinner] Default button not activated on ENTER|controls
+[JDK-8193495](https://bugs.openjdk.org/browse/JDK-8193495)|TabPane does not update correctly tab positions in the header area after a quick remove and add operations|controls
+[JDK-8194913](https://bugs.openjdk.org/browse/JDK-8194913)|Focus traversal is broken if a Pane is added to a ToolBar|controls
+[JDK-8196827](https://bugs.openjdk.org/browse/JDK-8196827)|test.javafx.scene.control.ComboBoxTest - generates NullPointerException|controls
+[JDK-8197846](https://bugs.openjdk.org/browse/JDK-8197846)|ComboBox: becomes unclickable after removal and re-adding|controls
+[JDK-8197985](https://bugs.openjdk.org/browse/JDK-8197985)|Pressing Shift + DOWN in ListView causes Exception to be thrown|controls
+[JDK-8200285](https://bugs.openjdk.org/browse/JDK-8200285)|TabDragPolicy.REORDER prevents ContextMenu from showing|controls
+[JDK-8201285](https://bugs.openjdk.org/browse/JDK-8201285)|DateCell text color are not updated correctly when DateCell with disable = true is reused|controls
+[JDK-8208610](https://bugs.openjdk.org/browse/JDK-8208610)|Incorrect check for calling class in FXMLLoader::getDefaultClassLoader|fxml
+[JDK-8129582](https://bugs.openjdk.org/browse/JDK-8129582)|Controls slow considerably when displaying RTL-languages text on Linux|graphics
+[JDK-8195801](https://bugs.openjdk.org/browse/JDK-8195801)|Replace jdk.internal.misc.Unsafe with sun.misc.Unsafe in MarlinFX|graphics
+[JDK-8195802](https://bugs.openjdk.org/browse/JDK-8195802)|Eliminate use of jdk.internal.misc security utilities in javafx.graphics|graphics
+[JDK-8195806](https://bugs.openjdk.org/browse/JDK-8195806)|Eliminate dependency on sun.font.lookup in javafx.graphics|graphics
+[JDK-8195808](https://bugs.openjdk.org/browse/JDK-8195808)|Eliminate dependency on sun.print in javafx.graphics|graphics
+[JDK-8196617](https://bugs.openjdk.org/browse/JDK-8196617)|FX print tests fail with NPE in some environments|graphics
+[JDK-8198354](https://bugs.openjdk.org/browse/JDK-8198354)|[macOS] Corrupt Thai characters displayed in word wrapped label |graphics
+[JDK-8201231](https://bugs.openjdk.org/browse/JDK-8201231)|java.lang.NullPointerException at WindowStage.setPlatformEnabled|graphics
+[JDK-8202396](https://bugs.openjdk.org/browse/JDK-8202396)|memory leak in ios native imageloader|graphics
+[JDK-8202743](https://bugs.openjdk.org/browse/JDK-8202743)|Dashed Stroke randomly painted incorrectly, may freeze application|graphics
+[JDK-8203378](https://bugs.openjdk.org/browse/JDK-8203378)|JDK build fails to compile javafx.graphics module-info.java if FX was built with OpenJDK|graphics
+[JDK-8203801](https://bugs.openjdk.org/browse/JDK-8203801)|Missing Classpath exception in PrismLoaderGlue.stg file|graphics
+[JDK-8207328](https://bugs.openjdk.org/browse/JDK-8207328)|API docs for javafx.css.Stylesheet are inaccurate / wrong|graphics
+[JDK-8209191](https://bugs.openjdk.org/browse/JDK-8209191)|[macOS] Distorted complex text rendering|graphics
+[JDK-8088722](https://bugs.openjdk.org/browse/JDK-8088722)|GSTPlatform cannot play MP4 files with multiple audio tracks|media
+[JDK-8191446](https://bugs.openjdk.org/browse/JDK-8191446)|[Linux] Build and deliver the libav media stubs for openjfx build|media
+[JDK-8193313](https://bugs.openjdk.org/browse/JDK-8193313)|MediaPlayer Leaking Native Memory|media
+[JDK-8195803](https://bugs.openjdk.org/browse/JDK-8195803)|Eliminate use of sun.nio.ch.DirectBuffer in javafx.media|media
+[JDK-8198316](https://bugs.openjdk.org/browse/JDK-8198316)|MediaPlayer crashes when playing m3u8 files on macOS High Sierra 10.13.2|media
+[JDK-8199008](https://bugs.openjdk.org/browse/JDK-8199008)|[macOS, Linux] Instantiating MediaPlayer causes CPU usage to be over 100%|media
+[JDK-8199527](https://bugs.openjdk.org/browse/JDK-8199527)|Upgrade GStreamer to 1.14|media
+[JDK-8202393](https://bugs.openjdk.org/browse/JDK-8202393)|App Transport Security blocks http media on macOS with JDK build using new compilers|media
+[JDK-8191661](https://bugs.openjdk.org/browse/JDK-8191661)|FXCanvas on Win32 HiDPI produces wrong results|other
+[JDK-8193910](https://bugs.openjdk.org/browse/JDK-8193910)|Version number in cssref.html and introduction_to_fxml.html is wrong|other
+[JDK-8195799](https://bugs.openjdk.org/browse/JDK-8195799)|Use System logger instead of platform logger in javafx modules|other
+[JDK-8195800](https://bugs.openjdk.org/browse/JDK-8195800)|Eliminate dependency on sun.reflect.misc in javafx modules|other
+[JDK-8195974](https://bugs.openjdk.org/browse/JDK-8195974)|Replace use of java.util.logging in javafx with System logger|other
+[JDK-8196297](https://bugs.openjdk.org/browse/JDK-8196297)|Remove obsolete JFR logger code|other
+[JDK-8199357](https://bugs.openjdk.org/browse/JDK-8199357)|Remove references to applets and Java Web Start from FX|other
+[JDK-8200587](https://bugs.openjdk.org/browse/JDK-8200587)|Fix mistakes in FX API docs|other
+[JDK-8202036](https://bugs.openjdk.org/browse/JDK-8202036)|Update OpenJFX license files to match OpenJDK|other
+[JDK-8202357](https://bugs.openjdk.org/browse/JDK-8202357)|Extra chars in copyright header in ModuleHelper.java|other
+[JDK-8204653](https://bugs.openjdk.org/browse/JDK-8204653)|Fix mistakes in FX API docs|other
+[JDK-8204956](https://bugs.openjdk.org/browse/JDK-8204956)|Cleanup whitespace after fix for JDK-8200285|other
+[JDK-8207794](https://bugs.openjdk.org/browse/JDK-8207794)|FXCanvas does not update x/y of EmbeddedStageInterface when FXCanvas is reparented|other
+[JDK-8208294](https://bugs.openjdk.org/browse/JDK-8208294)|install native library fails when jrt protocol is used|other
+[JDK-8180151](https://bugs.openjdk.org/browse/JDK-8180151)|JavaFX incorrectly renders scenegraph with two 3D boxes with certain dimensions|scenegraph
+[JDK-8192056](https://bugs.openjdk.org/browse/JDK-8192056)|Memory leak when removing javafx.scene.shape.Sphere-objects from a group or container|scenegraph
+[JDK-8205008](https://bugs.openjdk.org/browse/JDK-8205008)|GeneralTransform3D transform function with single Vec3d argument wrong results|scenegraph
+[JDK-8207377](https://bugs.openjdk.org/browse/JDK-8207377)|Document the behavior of Robot::getPixelColor with HiDPI|scenegraph
+[JDK-8201291](https://bugs.openjdk.org/browse/JDK-8201291)|Clicking a JFXPanel having setFocusable(false) causes its processMouseEvent method to loop forever|swing
+[JDK-8088769](https://bugs.openjdk.org/browse/JDK-8088769)|Alphachannel for transparent colors is not shown in HtmlEditor|web
+[JDK-8088925](https://bugs.openjdk.org/browse/JDK-8088925)|Non opaque background cause NumberFormatException|web
+[JDK-8089375](https://bugs.openjdk.org/browse/JDK-8089375)|When WebWorker file is unaccessible, script should fail silently or post meaningful exception|web
+[JDK-8147476](https://bugs.openjdk.org/browse/JDK-8147476)|Rendering  issues with MathML  token elements|web
+[JDK-8193368](https://bugs.openjdk.org/browse/JDK-8193368)|[OS X] Remove redundant files|web
+[JDK-8193590](https://bugs.openjdk.org/browse/JDK-8193590)|Memory leak when using WebView with Tooltip|web
+[JDK-8194265](https://bugs.openjdk.org/browse/JDK-8194265)|Webengine (webkit) crash when reading files using FileReader|web
+[JDK-8194935](https://bugs.openjdk.org/browse/JDK-8194935)|Cherry pick GTK WebKit 2.18.5 changes|web
+[JDK-8195804](https://bugs.openjdk.org/browse/JDK-8195804)|Remove unused qualified export of sun.net.www from java.base to javafx.web|web
+[JDK-8196011](https://bugs.openjdk.org/browse/JDK-8196011)|Intermittent crash when using WebView from JFXPanel application|web
+[JDK-8196374](https://bugs.openjdk.org/browse/JDK-8196374)|windows x86 webview-icu isAlphaNumericString crash |web
+[JDK-8196677](https://bugs.openjdk.org/browse/JDK-8196677)|Cherry pick GTK WebKit 2.18.6 changes|web
+[JDK-8196968](https://bugs.openjdk.org/browse/JDK-8196968)|One time crash on exit in JNIEnv_::CallObjectMethod|web
+[JDK-8197987](https://bugs.openjdk.org/browse/JDK-8197987)|Update libxslt to version 1.1.32|web
+[JDK-8199474](https://bugs.openjdk.org/browse/JDK-8199474)|Update to 606.1 version of WebKit|web
+[JDK-8200418](https://bugs.openjdk.org/browse/JDK-8200418)|"webPage.executeCommand(""removeFormat"", null) removes the style of the body element"|web
+[JDK-8200629](https://bugs.openjdk.org/browse/JDK-8200629)|Update SQLite to version 3.23.0|web
+[JDK-8202277](https://bugs.openjdk.org/browse/JDK-8202277)|WebView image capture fails with standalone FX due to dependency on javafx.swing|web
+[JDK-8203698](https://bugs.openjdk.org/browse/JDK-8203698)|JavaFX WebView crashes when visiting certain web sites|web
+[JDK-8204856](https://bugs.openjdk.org/browse/JDK-8204856)|WebEngine document becomes null after PAGE_REPLACED event|web
+[JDK-8206899](https://bugs.openjdk.org/browse/JDK-8206899)|DRT crashes randomly when running 'dom/html/level2/html/AppletsCollection.html'|web
+[JDK-8206995](https://bugs.openjdk.org/browse/JDK-8206995)|Remove unused WebKit files|web
+[JDK-8208114](https://bugs.openjdk.org/browse/JDK-8208114)|Drag and drop of text contents and URL links functionalities are broken in Webview|web
+[JDK-8208622](https://bugs.openjdk.org/browse/JDK-8208622)|[WebView] IllegalStateException when invoking print API with html form controls|web
+[JDK-8209049](https://bugs.openjdk.org/browse/JDK-8209049)|Cherry pick GTK WebKit 2.20.4 changes|web
+[JDK-8163795](https://bugs.openjdk.org/browse/JDK-8163795)|[Windows] Remove call to StretchBlt in native GetScreenCapture method|window-toolkit
+[JDK-8191885](https://bugs.openjdk.org/browse/JDK-8191885)|[MacOS] JavaFX main window not resizable coming back from full screen mode in MacOS|window-toolkit
+[JDK-8196031](https://bugs.openjdk.org/browse/JDK-8196031)|FX Robot mouseMove fails on Windows 10 1709 with HiDPI|window-toolkit
+[JDK-8199614](https://bugs.openjdk.org/browse/JDK-8199614)|[macos] ImageCursor.getBestSize() throws NullPointerException|window-toolkit
+[JDK-8204635](https://bugs.openjdk.org/browse/JDK-8204635)|[Linux] getMouseX, getMouseY in gtk GlassRobot.cpp ignore the HiDPI scale|window-toolkit
+[JDK-8207372](https://bugs.openjdk.org/browse/JDK-8207372)|Robot.mouseWheel not implemented correctly on Linux, Mac|window-toolkit
 
 
 ## List of Enhancements
 
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8205919](https://bugs.openjdk.java.net/browse/JDK-8205919)|Create artifacts and functionality to upload them to Maven Central|build
-[JDK-8167096](https://bugs.openjdk.java.net/browse/JDK-8167096)|Add APIs to customize step repeat timing for Spinner control|controls
-[JDK-8177380](https://bugs.openjdk.java.net/browse/JDK-8177380)|Add standard colors in ColorPicker color palette|controls
-[JDK-8186187](https://bugs.openjdk.java.net/browse/JDK-8186187)|Modify return type of public API StyleConverter.getEnumConverter()|controls
-[JDK-8204621](https://bugs.openjdk.java.net/browse/JDK-8204621)|Upgrade MarlinFX to 0.9.2|graphics
-[JDK-8090763](https://bugs.openjdk.java.net/browse/JDK-8090763)|FX Robot API|scenegraph
-[JDK-8130379](https://bugs.openjdk.java.net/browse/JDK-8130379)|Enhance the Bounds class with getCenter method|scenegraph
-[JDK-8195811](https://bugs.openjdk.java.net/browse/JDK-8195811)|Support FX Swing interop using public API|swing
-[JDK-8198654](https://bugs.openjdk.java.net/browse/JDK-8198654)|Switch FX's default GTK version to 3|window-toolkit
+[JDK-8205919](https://bugs.openjdk.org/browse/JDK-8205919)|Create artifacts and functionality to upload them to Maven Central|build
+[JDK-8167096](https://bugs.openjdk.org/browse/JDK-8167096)|Add APIs to customize step repeat timing for Spinner control|controls
+[JDK-8177380](https://bugs.openjdk.org/browse/JDK-8177380)|Add standard colors in ColorPicker color palette|controls
+[JDK-8186187](https://bugs.openjdk.org/browse/JDK-8186187)|Modify return type of public API StyleConverter.getEnumConverter()|controls
+[JDK-8204621](https://bugs.openjdk.org/browse/JDK-8204621)|Upgrade MarlinFX to 0.9.2|graphics
+[JDK-8090763](https://bugs.openjdk.org/browse/JDK-8090763)|FX Robot API|scenegraph
+[JDK-8130379](https://bugs.openjdk.org/browse/JDK-8130379)|Enhance the Bounds class with getCenter method|scenegraph
+[JDK-8195811](https://bugs.openjdk.org/browse/JDK-8195811)|Support FX Swing interop using public API|swing
+[JDK-8198654](https://bugs.openjdk.org/browse/JDK-8198654)|Switch FX's default GTK version to 3|window-toolkit

--- a/doc-files/release-notes-12.md
+++ b/doc-files/release-notes-12.md
@@ -10,59 +10,59 @@ As of JDK 11 the JavaFX modules are delivered separately from the JDK. These rel
 
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8152395](https://bugs.openjdk.java.net/browse/JDK-8152395)|[ToolBar] Overflow button of ToolBar doesn't appear when the size of the items increases|controls
-[JDK-8212102](https://bugs.openjdk.java.net/browse/JDK-8212102)|[TextField] IOOBE on paste/replace text with control characters|controls
-[JDK-8217270](https://bugs.openjdk.java.net/browse/JDK-8217270)|Broken link to cssref.html in javafx.controls package docs|controls
-[JDK-8167068](https://bugs.openjdk.java.net/browse/JDK-8167068)|GLS language errors|graphics
-[JDK-8188810](https://bugs.openjdk.java.net/browse/JDK-8188810)|Fonts are blurry on Ubuntu 16.04 and Debian 9|graphics
-[JDK-8203884](https://bugs.openjdk.java.net/browse/JDK-8203884)|Update libjpeg to version 9c|graphics
-[JDK-8207839](https://bugs.openjdk.java.net/browse/JDK-8207839)|[win] Negative glyph_id causes ArrayIndexOutOfBoundsException|graphics
-[JDK-8209764](https://bugs.openjdk.java.net/browse/JDK-8209764)|JavaFX/Monocle - Partial Screen Capture Broken|graphics
-[JDK-8209791](https://bugs.openjdk.java.net/browse/JDK-8209791)|OpenJFX build fails in PrismPrint.c due to missing JNICALL|graphics
-[JDK-8209968](https://bugs.openjdk.java.net/browse/JDK-8209968)|Image size sometimes off by 1 when scaling down images with preserveRatio true|graphics
-[JDK-8209969](https://bugs.openjdk.java.net/browse/JDK-8209969)|Monocle setBounds issue (width/height mixed)|graphics
-[JDK-8210219](https://bugs.openjdk.java.net/browse/JDK-8210219)|GlassClipboard.cpp fails to compile with newer versions of VS2017|graphics
-[JDK-8210386](https://bugs.openjdk.java.net/browse/JDK-8210386)|Clipping problems with complex affine transforms: negative scaling factors or small scaling factors|graphics
-[JDK-8212115](https://bugs.openjdk.java.net/browse/JDK-8212115)|Typo in javadoc for javafx.stage.Window|graphics
-[JDK-8214035](https://bugs.openjdk.java.net/browse/JDK-8214035)|Unable to render cmyk jpeg image|graphics
-[JDK-8214397](https://bugs.openjdk.java.net/browse/JDK-8214397)|Provide fallback to tmpdir if user home is not writable for native libs|graphics
-[JDK-8214185](https://bugs.openjdk.java.net/browse/JDK-8214185)|Upgrade GStreamer to the latest (1.14.4) version|media
-[JDK-8183399](https://bugs.openjdk.java.net/browse/JDK-8183399)|[macOSX] Scroll events finish with invalid delta values|other
-[JDK-8189926](https://bugs.openjdk.java.net/browse/JDK-8189926)|[Mac] Pulse timer should pause when idle|other
-[JDK-8211014](https://bugs.openjdk.java.net/browse/JDK-8211014)|Fix mistakes in FX API docs|other
-[JDK-8205092](https://bugs.openjdk.java.net/browse/JDK-8205092)|NullPointerException in PickResultChooser.processOffer when using viewOrder|scenegraph
-[JDK-8207837](https://bugs.openjdk.java.net/browse/JDK-8207837)|Indeterminate ProgressBar does not animate if content is added after scene is set on window|scenegraph
-[JDK-8216377](https://bugs.openjdk.java.net/browse/JDK-8216377)|JavaFX: memoryleak for initial nodes of Window|scenegraph
-[JDK-8210092](https://bugs.openjdk.java.net/browse/JDK-8210092)|Remove old javafx.swing implementation|swing
-[JDK-8207159](https://bugs.openjdk.java.net/browse/JDK-8207159)|Update ICU to version 62.1|web
-[JDK-8209457](https://bugs.openjdk.java.net/browse/JDK-8209457)|[WebView] Canvas.toDataURL with image/jpeg MIME type fails|web
-[JDK-8210218](https://bugs.openjdk.java.net/browse/JDK-8210218)|WebKit build fails with newer versions of VS 2017|web
-[JDK-8211399](https://bugs.openjdk.java.net/browse/JDK-8211399)|libxslt fails to build with glibc 2.26|web
-[JDK-8211454](https://bugs.openjdk.java.net/browse/JDK-8211454)|Update SQLite to version 3.26.0|web
-[JDK-8213541](https://bugs.openjdk.java.net/browse/JDK-8213541)|WebView does not handle HTTP response without ContentType|web
-[JDK-8213806](https://bugs.openjdk.java.net/browse/JDK-8213806)|WebView - JVM crashes for given HTML|web
-[JDK-8214119](https://bugs.openjdk.java.net/browse/JDK-8214119)|Update to 607.1 version of WebKit|web
-[JDK-8214452](https://bugs.openjdk.java.net/browse/JDK-8214452)|Update libxml2 to version 2.9.9|web
-[JDK-8215702](https://bugs.openjdk.java.net/browse/JDK-8215702)|SVG gradients are not rendered|web
-[JDK-8215799](https://bugs.openjdk.java.net/browse/JDK-8215799)|Complex text is not rendered by webkit on Windows|web
-[JDK-8216470](https://bugs.openjdk.java.net/browse/JDK-8216470)|Some methods of System.Logger are unimplemented in PlatformLogger|web
-[JDK-8218611](https://bugs.openjdk.java.net/browse/JDK-8218611)|[DRT] fast/xslt tests fails with Unsupported encoding windows-1251|web
-[JDK-8210411](https://bugs.openjdk.java.net/browse/JDK-8210411)|JavaFX crashes on Ubuntu 18.04 with Wayland|window-toolkit
-[JDK-8211280](https://bugs.openjdk.java.net/browse/JDK-8211280)|JavaFX build fails on Linux with gcc8|window-toolkit
-[JDK-8211304](https://bugs.openjdk.java.net/browse/JDK-8211304)|[macOS] Crash on focus loss from dialog on macOS 10.14 Mojave|window-toolkit
-[JDK-8218424](https://bugs.openjdk.java.net/browse/JDK-8218424)|[macOSX] mousewheel scrolling slow|window-toolkit
+[JDK-8152395](https://bugs.openjdk.org/browse/JDK-8152395)|[ToolBar] Overflow button of ToolBar doesn't appear when the size of the items increases|controls
+[JDK-8212102](https://bugs.openjdk.org/browse/JDK-8212102)|[TextField] IOOBE on paste/replace text with control characters|controls
+[JDK-8217270](https://bugs.openjdk.org/browse/JDK-8217270)|Broken link to cssref.html in javafx.controls package docs|controls
+[JDK-8167068](https://bugs.openjdk.org/browse/JDK-8167068)|GLS language errors|graphics
+[JDK-8188810](https://bugs.openjdk.org/browse/JDK-8188810)|Fonts are blurry on Ubuntu 16.04 and Debian 9|graphics
+[JDK-8203884](https://bugs.openjdk.org/browse/JDK-8203884)|Update libjpeg to version 9c|graphics
+[JDK-8207839](https://bugs.openjdk.org/browse/JDK-8207839)|[win] Negative glyph_id causes ArrayIndexOutOfBoundsException|graphics
+[JDK-8209764](https://bugs.openjdk.org/browse/JDK-8209764)|JavaFX/Monocle - Partial Screen Capture Broken|graphics
+[JDK-8209791](https://bugs.openjdk.org/browse/JDK-8209791)|OpenJFX build fails in PrismPrint.c due to missing JNICALL|graphics
+[JDK-8209968](https://bugs.openjdk.org/browse/JDK-8209968)|Image size sometimes off by 1 when scaling down images with preserveRatio true|graphics
+[JDK-8209969](https://bugs.openjdk.org/browse/JDK-8209969)|Monocle setBounds issue (width/height mixed)|graphics
+[JDK-8210219](https://bugs.openjdk.org/browse/JDK-8210219)|GlassClipboard.cpp fails to compile with newer versions of VS2017|graphics
+[JDK-8210386](https://bugs.openjdk.org/browse/JDK-8210386)|Clipping problems with complex affine transforms: negative scaling factors or small scaling factors|graphics
+[JDK-8212115](https://bugs.openjdk.org/browse/JDK-8212115)|Typo in javadoc for javafx.stage.Window|graphics
+[JDK-8214035](https://bugs.openjdk.org/browse/JDK-8214035)|Unable to render cmyk jpeg image|graphics
+[JDK-8214397](https://bugs.openjdk.org/browse/JDK-8214397)|Provide fallback to tmpdir if user home is not writable for native libs|graphics
+[JDK-8214185](https://bugs.openjdk.org/browse/JDK-8214185)|Upgrade GStreamer to the latest (1.14.4) version|media
+[JDK-8183399](https://bugs.openjdk.org/browse/JDK-8183399)|[macOSX] Scroll events finish with invalid delta values|other
+[JDK-8189926](https://bugs.openjdk.org/browse/JDK-8189926)|[Mac] Pulse timer should pause when idle|other
+[JDK-8211014](https://bugs.openjdk.org/browse/JDK-8211014)|Fix mistakes in FX API docs|other
+[JDK-8205092](https://bugs.openjdk.org/browse/JDK-8205092)|NullPointerException in PickResultChooser.processOffer when using viewOrder|scenegraph
+[JDK-8207837](https://bugs.openjdk.org/browse/JDK-8207837)|Indeterminate ProgressBar does not animate if content is added after scene is set on window|scenegraph
+[JDK-8216377](https://bugs.openjdk.org/browse/JDK-8216377)|JavaFX: memoryleak for initial nodes of Window|scenegraph
+[JDK-8210092](https://bugs.openjdk.org/browse/JDK-8210092)|Remove old javafx.swing implementation|swing
+[JDK-8207159](https://bugs.openjdk.org/browse/JDK-8207159)|Update ICU to version 62.1|web
+[JDK-8209457](https://bugs.openjdk.org/browse/JDK-8209457)|[WebView] Canvas.toDataURL with image/jpeg MIME type fails|web
+[JDK-8210218](https://bugs.openjdk.org/browse/JDK-8210218)|WebKit build fails with newer versions of VS 2017|web
+[JDK-8211399](https://bugs.openjdk.org/browse/JDK-8211399)|libxslt fails to build with glibc 2.26|web
+[JDK-8211454](https://bugs.openjdk.org/browse/JDK-8211454)|Update SQLite to version 3.26.0|web
+[JDK-8213541](https://bugs.openjdk.org/browse/JDK-8213541)|WebView does not handle HTTP response without ContentType|web
+[JDK-8213806](https://bugs.openjdk.org/browse/JDK-8213806)|WebView - JVM crashes for given HTML|web
+[JDK-8214119](https://bugs.openjdk.org/browse/JDK-8214119)|Update to 607.1 version of WebKit|web
+[JDK-8214452](https://bugs.openjdk.org/browse/JDK-8214452)|Update libxml2 to version 2.9.9|web
+[JDK-8215702](https://bugs.openjdk.org/browse/JDK-8215702)|SVG gradients are not rendered|web
+[JDK-8215799](https://bugs.openjdk.org/browse/JDK-8215799)|Complex text is not rendered by webkit on Windows|web
+[JDK-8216470](https://bugs.openjdk.org/browse/JDK-8216470)|Some methods of System.Logger are unimplemented in PlatformLogger|web
+[JDK-8218611](https://bugs.openjdk.org/browse/JDK-8218611)|[DRT] fast/xslt tests fails with Unsupported encoding windows-1251|web
+[JDK-8210411](https://bugs.openjdk.org/browse/JDK-8210411)|JavaFX crashes on Ubuntu 18.04 with Wayland|window-toolkit
+[JDK-8211280](https://bugs.openjdk.org/browse/JDK-8211280)|JavaFX build fails on Linux with gcc8|window-toolkit
+[JDK-8211304](https://bugs.openjdk.org/browse/JDK-8211304)|[macOS] Crash on focus loss from dialog on macOS 10.14 Mojave|window-toolkit
+[JDK-8218424](https://bugs.openjdk.org/browse/JDK-8218424)|[macOSX] mousewheel scrolling slow|window-toolkit
 
 
 ## List of Enhancements
 
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8207942](https://bugs.openjdk.java.net/browse/JDK-8207942)|Add new protected VirtualFlow methods for subclassing|controls
-[JDK-8210361](https://bugs.openjdk.java.net/browse/JDK-8210361)|Add images to docs for public API classes of controls and missing examples|controls
-[JDK-8204060](https://bugs.openjdk.java.net/browse/JDK-8204060)|[Canvas] Add API in GraphicsContext to control image smoothing|graphics
-[JDK-8214069](https://bugs.openjdk.java.net/browse/JDK-8214069)|Use xdg-open to get default web browser on Linux systems|graphics
-[JDK-8088418](https://bugs.openjdk.java.net/browse/JDK-8088418)|Reintroduce JFR Pulse Logger|other
-[JDK-8090930](https://bugs.openjdk.java.net/browse/JDK-8090930)|Support mouse forward/back buttons|scenegraph
-[JDK-8211249](https://bugs.openjdk.java.net/browse/JDK-8211249)|Refactor javafx.swing implementation to get rid of unneeded abstraction layer|swing
-[JDK-8148129](https://bugs.openjdk.java.net/browse/JDK-8148129)|Implement Accelerated composition for WebView|web
-[JDK-8207772](https://bugs.openjdk.java.net/browse/JDK-8207772)|File API and FileReader should be supported in WebView|web
+[JDK-8207942](https://bugs.openjdk.org/browse/JDK-8207942)|Add new protected VirtualFlow methods for subclassing|controls
+[JDK-8210361](https://bugs.openjdk.org/browse/JDK-8210361)|Add images to docs for public API classes of controls and missing examples|controls
+[JDK-8204060](https://bugs.openjdk.org/browse/JDK-8204060)|[Canvas] Add API in GraphicsContext to control image smoothing|graphics
+[JDK-8214069](https://bugs.openjdk.org/browse/JDK-8214069)|Use xdg-open to get default web browser on Linux systems|graphics
+[JDK-8088418](https://bugs.openjdk.org/browse/JDK-8088418)|Reintroduce JFR Pulse Logger|other
+[JDK-8090930](https://bugs.openjdk.org/browse/JDK-8090930)|Support mouse forward/back buttons|scenegraph
+[JDK-8211249](https://bugs.openjdk.org/browse/JDK-8211249)|Refactor javafx.swing implementation to get rid of unneeded abstraction layer|swing
+[JDK-8148129](https://bugs.openjdk.org/browse/JDK-8148129)|Implement Accelerated composition for WebView|web
+[JDK-8207772](https://bugs.openjdk.org/browse/JDK-8207772)|File API and FileReader should be supported in WebView|web

--- a/doc-files/release-notes-13.md
+++ b/doc-files/release-notes-13.md
@@ -10,71 +10,71 @@ As of JDK 11 the JavaFX modules are delivered separately from the JDK. These rel
 
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8221702](https://bugs.openjdk.java.net/browse/JDK-8221702)|Use HTTPS to download all build dependencies|build
-[JDK-8220012](https://bugs.openjdk.java.net/browse/JDK-8220012)|Accordion control holds reference to child pane after it is removed|controls
-[JDK-8209938](https://bugs.openjdk.java.net/browse/JDK-8209938)|Default and Cancel button cause memory leak|controls
-[JDK-8222222](https://bugs.openjdk.java.net/browse/JDK-8222222)|Gradients defined in CSS always use "reflect" even when "repeat" is specified|controls
-[JDK-8089986](https://bugs.openjdk.java.net/browse/JDK-8089986)|Menu beeps when mnemonics is used|controls
-[JDK-8222073](https://bugs.openjdk.java.net/browse/JDK-8222073)|Revert unintentional change to Dialog.java|controls
-[JDK-8222457](https://bugs.openjdk.java.net/browse/JDK-8222457)|TabPane doesn't respect order of TabPane.getTabs() list|controls
-[JDK-8222214](https://bugs.openjdk.java.net/browse/JDK-8222214)|TableView rows disappears when inside a pane and KEY_UP is pressed|controls
-[JDK-8197536](https://bugs.openjdk.java.net/browse/JDK-8197536)|TableView, ListView: unexpected scrolling behaviour on up/down keys|controls
-[JDK-8201539](https://bugs.openjdk.java.net/browse/JDK-8201539)|Crash in DirectWrite CreateBitmap code when running TestFX test suite|graphics
-[JDK-8222211](https://bugs.openjdk.java.net/browse/JDK-8222211)|Creating animated gif image from non FX App thread causes exception|graphics
-[JDK-8210973](https://bugs.openjdk.java.net/browse/JDK-8210973)|Focus goes to wrong Window when dismissing an Alert|graphics
-[JDK-8217492](https://bugs.openjdk.java.net/browse/JDK-8217492)|JavaFX - memory leak after the event WindowEvent.DESTROY|graphics
-[JDK-8221987](https://bugs.openjdk.java.net/browse/JDK-8221987)|NPE in javafx.graphics/javafx.stage.Window$TKBoundsConfigurator.apply|graphics
-[JDK-8226789](https://bugs.openjdk.java.net/browse/JDK-8226789)|Path rendered incorrectly when it goes outside the clipping region|graphics
-[JDK-8219008](https://bugs.openjdk.java.net/browse/JDK-8219008)|Update OpenGL Headers to version 4.6|graphics
-[JDK-8229890](https://bugs.openjdk.java.net/browse/JDK-8229890)|WritableImage update fails for empty region|graphics
-[JDK-8208076](https://bugs.openjdk.java.net/browse/JDK-8208076)|display INVISIBLE_GLYPH_ID as square box on Windows|graphics
-[JDK-8208173](https://bugs.openjdk.java.net/browse/JDK-8208173)|isComplexCharCode() returns false for U+11FF|graphics
-[JDK-8222217](https://bugs.openjdk.java.net/browse/JDK-8222217)|FX build fails on 32-bit Windows after fix for JDK-8133841|media
-[JDK-8133841](https://bugs.openjdk.java.net/browse/JDK-8133841)|Full HD video can not be played on standard 1080p screen in portrait mode|media
-[JDK-8209180](https://bugs.openjdk.java.net/browse/JDK-8209180)|Media fails to load source from custom image, with jrt: URL|media
-[JDK-8215894](https://bugs.openjdk.java.net/browse/JDK-8215894)|Provide media support for libav version 58|media
-[JDK-8222780](https://bugs.openjdk.java.net/browse/JDK-8222780)|Visual Studio does not open media vs_projects files|media
-[JDK-8213510](https://bugs.openjdk.java.net/browse/JDK-8213510)|[Windows] MediaPlayer does not play some mp3 with artwork stream in mjpeg|media
-[JDK-8211900](https://bugs.openjdk.java.net/browse/JDK-8211900)|javafx.media classes directly reference platform classes that are excluded|media
-[JDK-8218174](https://bugs.openjdk.java.net/browse/JDK-8218174)|Add missing license file for Mesa header files|other
-[JDK-8222746](https://bugs.openjdk.java.net/browse/JDK-8222746)|Cleanup third-party legal files|other
-[JDK-8221377](https://bugs.openjdk.java.net/browse/JDK-8221377)|Fix mistakes in FX API docs|other
-[JDK-8223377](https://bugs.openjdk.java.net/browse/JDK-8223377)|JavaFX can crash due to loading the wrong native libraries if system libraries are installed|other
-[JDK-8222212](https://bugs.openjdk.java.net/browse/JDK-8222212)|Memory Leak with SwingNode using Drag and Drop function|swing
-[JDK-8224636](https://bugs.openjdk.java.net/browse/JDK-8224636)|"CSS ""pointer-events"" property ""stroke"" is not respected for SVG renderings"|web
-[JDK-8219539](https://bugs.openjdk.java.net/browse/JDK-8219539)|Cherry pick GTK WebKit 2.22.6 changes|web
-[JDK-8220147](https://bugs.openjdk.java.net/browse/JDK-8220147)|Cherry pick GTK WebKit 2.22.7 changes|web
-[JDK-8227079](https://bugs.openjdk.java.net/browse/JDK-8227079)|Cherry pick GTK WebKit 2.24.3 changes|web
-[JDK-8215775](https://bugs.openjdk.java.net/browse/JDK-8215775)|Scrollbars from web pages appear to be absolute, overlapping everything|web
-[JDK-8225203](https://bugs.openjdk.java.net/browse/JDK-8225203)|Update SQLite to version 3.28.0|web
-[JDK-8219362](https://bugs.openjdk.java.net/browse/JDK-8219362)|Update to 608.1 version of WebKit|web
-[JDK-8217942](https://bugs.openjdk.java.net/browse/JDK-8217942)|Upgrade to libxslt 1.1.33|web
-[JDK-8222912](https://bugs.openjdk.java.net/browse/JDK-8222912)|Websocket client doesn't work in WebView|web
-[JDK-8221941](https://bugs.openjdk.java.net/browse/JDK-8221941)|Wrong package declaration for WCTextRunImpl.java in web module|web
-[JDK-8219734](https://bugs.openjdk.java.net/browse/JDK-8219734)|[WebView] Get rid of macOS SDK private API usage|web
-[JDK-8219917](https://bugs.openjdk.java.net/browse/JDK-8219917)|[WebView] Sub-resource integrity check fails on Windows and Linux|web
-[JDK-8227431](https://bugs.openjdk.java.net/browse/JDK-8227431)|[Windows] Fix assertion failure on X86 32-bit when enabling CLOOP based JavaScript interpreter|web
-[JDK-8230361](https://bugs.openjdk.java.net/browse/JDK-8230361)|[web] Cookies are not enabled in WebKit v608.1 |web
-[JDK-8229328](https://bugs.openjdk.java.net/browse/JDK-8229328)|[windows] PlatformFileHandle type should be JGObject rather than void 
-[JDK-8222788](https://bugs.openjdk.java.net/browse/JDK-8222788)|javafx.web build fails on XCode 10.2|web
-[JDK-8226951](https://bugs.openjdk.java.net/browse/JDK-8226951)|Backout commit for JDK-8226537 to fix the attribution|window-toolkit
-[JDK-8211302](https://bugs.openjdk.java.net/browse/JDK-8211302)|DragAndDrop no longer works with GTK3|window-toolkit
-[JDK-8226537](https://bugs.openjdk.java.net/browse/JDK-8226537)|Multi-level Stage::initOwner can crash gnome-shell or X.org server|window-toolkit
-[JDK-8226274](https://bugs.openjdk.java.net/browse/JDK-8226274)|NPE in WinWindow.notifyMoving when Stage with no Scene is shown on 2nd monitor|window-toolkit
-[JDK-8088717](https://bugs.openjdk.java.net/browse/JDK-8088717)|Win: UNDECORATED windows are not minimized with the taskbar button|window-toolkit
-[JDK-8220272](https://bugs.openjdk.java.net/browse/JDK-8220272)|Window order is not correct when Modality.WINDOW_MODAL|window-toolkit
-[JDK-8212060](https://bugs.openjdk.java.net/browse/JDK-8212060)|[GTK3] Stage sometimes shown at top-left before moving to correct position|window-toolkit
+[JDK-8221702](https://bugs.openjdk.org/browse/JDK-8221702)|Use HTTPS to download all build dependencies|build
+[JDK-8220012](https://bugs.openjdk.org/browse/JDK-8220012)|Accordion control holds reference to child pane after it is removed|controls
+[JDK-8209938](https://bugs.openjdk.org/browse/JDK-8209938)|Default and Cancel button cause memory leak|controls
+[JDK-8222222](https://bugs.openjdk.org/browse/JDK-8222222)|Gradients defined in CSS always use "reflect" even when "repeat" is specified|controls
+[JDK-8089986](https://bugs.openjdk.org/browse/JDK-8089986)|Menu beeps when mnemonics is used|controls
+[JDK-8222073](https://bugs.openjdk.org/browse/JDK-8222073)|Revert unintentional change to Dialog.java|controls
+[JDK-8222457](https://bugs.openjdk.org/browse/JDK-8222457)|TabPane doesn't respect order of TabPane.getTabs() list|controls
+[JDK-8222214](https://bugs.openjdk.org/browse/JDK-8222214)|TableView rows disappears when inside a pane and KEY_UP is pressed|controls
+[JDK-8197536](https://bugs.openjdk.org/browse/JDK-8197536)|TableView, ListView: unexpected scrolling behaviour on up/down keys|controls
+[JDK-8201539](https://bugs.openjdk.org/browse/JDK-8201539)|Crash in DirectWrite CreateBitmap code when running TestFX test suite|graphics
+[JDK-8222211](https://bugs.openjdk.org/browse/JDK-8222211)|Creating animated gif image from non FX App thread causes exception|graphics
+[JDK-8210973](https://bugs.openjdk.org/browse/JDK-8210973)|Focus goes to wrong Window when dismissing an Alert|graphics
+[JDK-8217492](https://bugs.openjdk.org/browse/JDK-8217492)|JavaFX - memory leak after the event WindowEvent.DESTROY|graphics
+[JDK-8221987](https://bugs.openjdk.org/browse/JDK-8221987)|NPE in javafx.graphics/javafx.stage.Window$TKBoundsConfigurator.apply|graphics
+[JDK-8226789](https://bugs.openjdk.org/browse/JDK-8226789)|Path rendered incorrectly when it goes outside the clipping region|graphics
+[JDK-8219008](https://bugs.openjdk.org/browse/JDK-8219008)|Update OpenGL Headers to version 4.6|graphics
+[JDK-8229890](https://bugs.openjdk.org/browse/JDK-8229890)|WritableImage update fails for empty region|graphics
+[JDK-8208076](https://bugs.openjdk.org/browse/JDK-8208076)|display INVISIBLE_GLYPH_ID as square box on Windows|graphics
+[JDK-8208173](https://bugs.openjdk.org/browse/JDK-8208173)|isComplexCharCode() returns false for U+11FF|graphics
+[JDK-8222217](https://bugs.openjdk.org/browse/JDK-8222217)|FX build fails on 32-bit Windows after fix for JDK-8133841|media
+[JDK-8133841](https://bugs.openjdk.org/browse/JDK-8133841)|Full HD video can not be played on standard 1080p screen in portrait mode|media
+[JDK-8209180](https://bugs.openjdk.org/browse/JDK-8209180)|Media fails to load source from custom image, with jrt: URL|media
+[JDK-8215894](https://bugs.openjdk.org/browse/JDK-8215894)|Provide media support for libav version 58|media
+[JDK-8222780](https://bugs.openjdk.org/browse/JDK-8222780)|Visual Studio does not open media vs_projects files|media
+[JDK-8213510](https://bugs.openjdk.org/browse/JDK-8213510)|[Windows] MediaPlayer does not play some mp3 with artwork stream in mjpeg|media
+[JDK-8211900](https://bugs.openjdk.org/browse/JDK-8211900)|javafx.media classes directly reference platform classes that are excluded|media
+[JDK-8218174](https://bugs.openjdk.org/browse/JDK-8218174)|Add missing license file for Mesa header files|other
+[JDK-8222746](https://bugs.openjdk.org/browse/JDK-8222746)|Cleanup third-party legal files|other
+[JDK-8221377](https://bugs.openjdk.org/browse/JDK-8221377)|Fix mistakes in FX API docs|other
+[JDK-8223377](https://bugs.openjdk.org/browse/JDK-8223377)|JavaFX can crash due to loading the wrong native libraries if system libraries are installed|other
+[JDK-8222212](https://bugs.openjdk.org/browse/JDK-8222212)|Memory Leak with SwingNode using Drag and Drop function|swing
+[JDK-8224636](https://bugs.openjdk.org/browse/JDK-8224636)|"CSS ""pointer-events"" property ""stroke"" is not respected for SVG renderings"|web
+[JDK-8219539](https://bugs.openjdk.org/browse/JDK-8219539)|Cherry pick GTK WebKit 2.22.6 changes|web
+[JDK-8220147](https://bugs.openjdk.org/browse/JDK-8220147)|Cherry pick GTK WebKit 2.22.7 changes|web
+[JDK-8227079](https://bugs.openjdk.org/browse/JDK-8227079)|Cherry pick GTK WebKit 2.24.3 changes|web
+[JDK-8215775](https://bugs.openjdk.org/browse/JDK-8215775)|Scrollbars from web pages appear to be absolute, overlapping everything|web
+[JDK-8225203](https://bugs.openjdk.org/browse/JDK-8225203)|Update SQLite to version 3.28.0|web
+[JDK-8219362](https://bugs.openjdk.org/browse/JDK-8219362)|Update to 608.1 version of WebKit|web
+[JDK-8217942](https://bugs.openjdk.org/browse/JDK-8217942)|Upgrade to libxslt 1.1.33|web
+[JDK-8222912](https://bugs.openjdk.org/browse/JDK-8222912)|Websocket client doesn't work in WebView|web
+[JDK-8221941](https://bugs.openjdk.org/browse/JDK-8221941)|Wrong package declaration for WCTextRunImpl.java in web module|web
+[JDK-8219734](https://bugs.openjdk.org/browse/JDK-8219734)|[WebView] Get rid of macOS SDK private API usage|web
+[JDK-8219917](https://bugs.openjdk.org/browse/JDK-8219917)|[WebView] Sub-resource integrity check fails on Windows and Linux|web
+[JDK-8227431](https://bugs.openjdk.org/browse/JDK-8227431)|[Windows] Fix assertion failure on X86 32-bit when enabling CLOOP based JavaScript interpreter|web
+[JDK-8230361](https://bugs.openjdk.org/browse/JDK-8230361)|[web] Cookies are not enabled in WebKit v608.1 |web
+[JDK-8229328](https://bugs.openjdk.org/browse/JDK-8229328)|[windows] PlatformFileHandle type should be JGObject rather than void 
+[JDK-8222788](https://bugs.openjdk.org/browse/JDK-8222788)|javafx.web build fails on XCode 10.2|web
+[JDK-8226951](https://bugs.openjdk.org/browse/JDK-8226951)|Backout commit for JDK-8226537 to fix the attribution|window-toolkit
+[JDK-8211302](https://bugs.openjdk.org/browse/JDK-8211302)|DragAndDrop no longer works with GTK3|window-toolkit
+[JDK-8226537](https://bugs.openjdk.org/browse/JDK-8226537)|Multi-level Stage::initOwner can crash gnome-shell or X.org server|window-toolkit
+[JDK-8226274](https://bugs.openjdk.org/browse/JDK-8226274)|NPE in WinWindow.notifyMoving when Stage with no Scene is shown on 2nd monitor|window-toolkit
+[JDK-8088717](https://bugs.openjdk.org/browse/JDK-8088717)|Win: UNDECORATED windows are not minimized with the taskbar button|window-toolkit
+[JDK-8220272](https://bugs.openjdk.org/browse/JDK-8220272)|Window order is not correct when Modality.WINDOW_MODAL|window-toolkit
+[JDK-8212060](https://bugs.openjdk.org/browse/JDK-8212060)|[GTK3] Stage sometimes shown at top-left before moving to correct position|window-toolkit
 
 
 ## List of Enhancements
 
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8226454](https://bugs.openjdk.java.net/browse/JDK-8226454)|Point2D and Point3D should implement Interpolatable|animation
-[JDK-8221269](https://bugs.openjdk.java.net/browse/JDK-8221269)|Extract embedded actions from JSL grammar file to Visitor class|build
-[JDK-8223760](https://bugs.openjdk.java.net/browse/JDK-8223760)|support static build for macosx|build
-[JDK-8222258](https://bugs.openjdk.java.net/browse/JDK-8222258)|Add exclusion scope for LightBase|graphics
-[JDK-8167148](https://bugs.openjdk.java.net/browse/JDK-8167148)|Add native rendering support  by supporting WritableImages backed by NIO ByteBuffers|graphics
-[JDK-8217605](https://bugs.openjdk.java.net/browse/JDK-8217605)|Add support for e-paper displays|graphics
-[JDK-8226912](https://bugs.openjdk.java.net/browse/JDK-8226912)|Color, Point2D and Point3D's fields should be made final|graphics
-[JDK-8217470](https://bugs.openjdk.java.net/browse/JDK-8217470)|Upgrade Direct3D9 shader model from 2.0 to 3.0 for 3D operations|graphics
+[JDK-8226454](https://bugs.openjdk.org/browse/JDK-8226454)|Point2D and Point3D should implement Interpolatable|animation
+[JDK-8221269](https://bugs.openjdk.org/browse/JDK-8221269)|Extract embedded actions from JSL grammar file to Visitor class|build
+[JDK-8223760](https://bugs.openjdk.org/browse/JDK-8223760)|support static build for macosx|build
+[JDK-8222258](https://bugs.openjdk.org/browse/JDK-8222258)|Add exclusion scope for LightBase|graphics
+[JDK-8167148](https://bugs.openjdk.org/browse/JDK-8167148)|Add native rendering support  by supporting WritableImages backed by NIO ByteBuffers|graphics
+[JDK-8217605](https://bugs.openjdk.org/browse/JDK-8217605)|Add support for e-paper displays|graphics
+[JDK-8226912](https://bugs.openjdk.org/browse/JDK-8226912)|Color, Point2D and Point3D's fields should be made final|graphics
+[JDK-8217470](https://bugs.openjdk.org/browse/JDK-8217470)|Upgrade Direct3D9 shader model from 2.0 to 3.0 for 3D operations|graphics

--- a/doc-files/release-notes-14.md
+++ b/doc-files/release-notes-14.md
@@ -10,65 +10,65 @@ As of JDK 11 the JavaFX modules are delivered separately from the JDK. These rel
 
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8237975](https://bugs.openjdk.java.net/browse/JDK-8237975) | Non-embedded Animations do not play backwards after being paused | animation
-[JDK-8236753](https://bugs.openjdk.java.net/browse/JDK-8236753) | Animations do not play backwards after being stopped | animation
-[JDK-8232524](https://bugs.openjdk.java.net/browse/JDK-8232524) | SynchronizedObservableMap cannot be be protected for copying/iterating | base
-[JDK-8220396](https://bugs.openjdk.java.net/browse/JDK-8220396) | Bindings class gives a lot of unneeded 'select-binding' log messages | base
-[JDK-8229472](https://bugs.openjdk.java.net/browse/JDK-8229472) | Deprecate for removal JavaBeanXxxPropertyBuilders constructors | base
-[JDK-8207774](https://bugs.openjdk.java.net/browse/JDK-8207774) | TextField: must not forward ENTER if actionHandler consumed the actionEvent | controls
-[JDK-8207759](https://bugs.openjdk.java.net/browse/JDK-8207759) | VK_ENTER not consumed by TextField when default Button exists | controls
-[JDK-8179097](https://bugs.openjdk.java.net/browse/JDK-8179097) | NPE in MenuButtonSkinBase class | controls
-[JDK-8185937](https://bugs.openjdk.java.net/browse/JDK-8185937) | Spinner with Double/Integer value factory ignores up/down arrow keys | controls
-[JDK-8233040](https://bugs.openjdk.java.net/browse/JDK-8233040) | ComboBoxPopupControl: remove eventFilter for F4 | controls
-[JDK-8232811](https://bugs.openjdk.java.net/browse/JDK-8232811) | Dialog's preferred size no longer accommodates multi-line strings | controls
-[JDK-8221334](https://bugs.openjdk.java.net/browse/JDK-8221334) | TableViewSkin: must initialize flow's cellCount in constructor | controls
-[JDK-8220722](https://bugs.openjdk.java.net/browse/JDK-8220722) | ProgressBarSkin: adds strong listener to control's width property | controls
-[JDK-8237372](https://bugs.openjdk.java.net/browse/JDK-8237372) | NullPointerException in TabPaneSkin.stopDrag | controls
-[JDK-8193445](https://bugs.openjdk.java.net/browse/JDK-8193445) | JavaFX CSS is applied redundantly leading to significant performance degradation | controls
-[JDK-8196587](https://bugs.openjdk.java.net/browse/JDK-8196587) | Remove use of deprecated finalize method from JPEGImageLoader | graphics
-[JDK-8166194](https://bugs.openjdk.java.net/browse/JDK-8166194) | JavaFX: poor printing quality for Region nodes | graphics
-[JDK-8189092](https://bugs.openjdk.java.net/browse/JDK-8189092) | ArrayIndexOutOfBoundsException on Linux in getCachedGlyph | graphics
-[JDK-8236448](https://bugs.openjdk.java.net/browse/JDK-8236448) | Remove unused and repair broken Android/Dalvik code | graphics
-[JDK-8236484](https://bugs.openjdk.java.net/browse/JDK-8236484) | Compile error in monocle dispman | graphics
-[JDK-8232687](https://bugs.openjdk.java.net/browse/JDK-8232687) | No static JNI loader for libprism-sw | graphics
-[JDK-8232943](https://bugs.openjdk.java.net/browse/JDK-8232943) | Gesture support is not initialized on iOS | graphics
-[JDK-8232929](https://bugs.openjdk.java.net/browse/JDK-8232929) | Duplicate symbols when building static libraries | graphics
-[JDK-8232210](https://bugs.openjdk.java.net/browse/JDK-8232210) | Update Mesa 3-D Headers to version 19.2.1 | graphics
-[JDK-8235151](https://bugs.openjdk.java.net/browse/JDK-8235151) | Nonexistent notifyQuit method referred from iOS GlassHelper.m | graphics
-[JDK-8235150](https://bugs.openjdk.java.net/browse/JDK-8235150) | IosApplication does not pass the required object in _leaveNestedEventLoopImpl | graphics
-[JDK-8235627](https://bugs.openjdk.java.net/browse/JDK-8235627) | Blank stages when running JavaFX app in a macOS virtual machine | graphics
-[JDK-8234916](https://bugs.openjdk.java.net/browse/JDK-8234916) | [macos 10.15] Garbled text running with native-image | graphics
-[JDK-8223296](https://bugs.openjdk.java.net/browse/JDK-8223296) | NullPointerException in GlassScene.java at line 325 | graphics
-[JDK-8236808](https://bugs.openjdk.java.net/browse/JDK-8236808) | javafx_iio can not be used in static environment | graphics
-[JDK-8088198](https://bugs.openjdk.java.net/browse/JDK-8088198) | Exception thrown from snapshot if dimensions are larger than max texture size | graphics
-[JDK-8232589](https://bugs.openjdk.java.net/browse/JDK-8232589) | Remove CoreAudio Utility Classes | media
-[JDK-8230610](https://bugs.openjdk.java.net/browse/JDK-8230610) | Upgrade GStreamer to version 1.16.1 | media
-[JDK-8230609](https://bugs.openjdk.java.net/browse/JDK-8230609) | Upgrade glib to version 2.62.2 | media
-[JDK-8233338](https://bugs.openjdk.java.net/browse/JDK-8233338) | FX javadoc headings are out of sequence | other
-[JDK-8232824](https://bugs.openjdk.java.net/browse/JDK-8232824) | Removing TabPane with strong referenced content causes memory leak from weak one | scenegraph
-[JDK-8200224](https://bugs.openjdk.java.net/browse/JDK-8200224) | First mouse press each time JFXPanel gains focus is triggered twice | swing
-[JDK-8218640](https://bugs.openjdk.java.net/browse/JDK-8218640) | Update ICU4C to version 64.2 | web
-[JDK-8233747](https://bugs.openjdk.java.net/browse/JDK-8233747) | JVM crash in com.sun.webkit.dom.DocumentImpl.createAttribute | web
-[JDK-8230492](https://bugs.openjdk.java.net/browse/JDK-8230492) | font-family not set in HTMLEditor if font name has a number in it | web
-[JDK-8236912](https://bugs.openjdk.java.net/browse/JDK-8236912) | NullPointerException when clicking in WebView with Button 4 or Button 5 | web
-[JDK-8231188](https://bugs.openjdk.java.net/browse/JDK-8231188) | Update SQLite to version 3.30.1 | web
-[JDK-8234056](https://bugs.openjdk.java.net/browse/JDK-8234056) | Upgrade to libxslt 1.1.34 | web
-[JDK-8231513](https://bugs.openjdk.java.net/browse/JDK-8231513) | JavaFX cause Keystroke Receiving prompt on MacOS 10.15 (Catalina) | window-toolkit
-[JDK-8234474](https://bugs.openjdk.java.net/browse/JDK-8234474) | [macos 10.15] Crash in file dialog in sandbox mode | window-toolkit
-[JDK-8228766](https://bugs.openjdk.java.net/browse/JDK-8228766) | Platform.startup() deadlock on mac when called from class initializer | window-toolkit
-[JDK-8227366](https://bugs.openjdk.java.net/browse/JDK-8227366) | Wrong stage gets focused after modal stage creation | window-toolkit
+[JDK-8237975](https://bugs.openjdk.org/browse/JDK-8237975) | Non-embedded Animations do not play backwards after being paused | animation
+[JDK-8236753](https://bugs.openjdk.org/browse/JDK-8236753) | Animations do not play backwards after being stopped | animation
+[JDK-8232524](https://bugs.openjdk.org/browse/JDK-8232524) | SynchronizedObservableMap cannot be be protected for copying/iterating | base
+[JDK-8220396](https://bugs.openjdk.org/browse/JDK-8220396) | Bindings class gives a lot of unneeded 'select-binding' log messages | base
+[JDK-8229472](https://bugs.openjdk.org/browse/JDK-8229472) | Deprecate for removal JavaBeanXxxPropertyBuilders constructors | base
+[JDK-8207774](https://bugs.openjdk.org/browse/JDK-8207774) | TextField: must not forward ENTER if actionHandler consumed the actionEvent | controls
+[JDK-8207759](https://bugs.openjdk.org/browse/JDK-8207759) | VK_ENTER not consumed by TextField when default Button exists | controls
+[JDK-8179097](https://bugs.openjdk.org/browse/JDK-8179097) | NPE in MenuButtonSkinBase class | controls
+[JDK-8185937](https://bugs.openjdk.org/browse/JDK-8185937) | Spinner with Double/Integer value factory ignores up/down arrow keys | controls
+[JDK-8233040](https://bugs.openjdk.org/browse/JDK-8233040) | ComboBoxPopupControl: remove eventFilter for F4 | controls
+[JDK-8232811](https://bugs.openjdk.org/browse/JDK-8232811) | Dialog's preferred size no longer accommodates multi-line strings | controls
+[JDK-8221334](https://bugs.openjdk.org/browse/JDK-8221334) | TableViewSkin: must initialize flow's cellCount in constructor | controls
+[JDK-8220722](https://bugs.openjdk.org/browse/JDK-8220722) | ProgressBarSkin: adds strong listener to control's width property | controls
+[JDK-8237372](https://bugs.openjdk.org/browse/JDK-8237372) | NullPointerException in TabPaneSkin.stopDrag | controls
+[JDK-8193445](https://bugs.openjdk.org/browse/JDK-8193445) | JavaFX CSS is applied redundantly leading to significant performance degradation | controls
+[JDK-8196587](https://bugs.openjdk.org/browse/JDK-8196587) | Remove use of deprecated finalize method from JPEGImageLoader | graphics
+[JDK-8166194](https://bugs.openjdk.org/browse/JDK-8166194) | JavaFX: poor printing quality for Region nodes | graphics
+[JDK-8189092](https://bugs.openjdk.org/browse/JDK-8189092) | ArrayIndexOutOfBoundsException on Linux in getCachedGlyph | graphics
+[JDK-8236448](https://bugs.openjdk.org/browse/JDK-8236448) | Remove unused and repair broken Android/Dalvik code | graphics
+[JDK-8236484](https://bugs.openjdk.org/browse/JDK-8236484) | Compile error in monocle dispman | graphics
+[JDK-8232687](https://bugs.openjdk.org/browse/JDK-8232687) | No static JNI loader for libprism-sw | graphics
+[JDK-8232943](https://bugs.openjdk.org/browse/JDK-8232943) | Gesture support is not initialized on iOS | graphics
+[JDK-8232929](https://bugs.openjdk.org/browse/JDK-8232929) | Duplicate symbols when building static libraries | graphics
+[JDK-8232210](https://bugs.openjdk.org/browse/JDK-8232210) | Update Mesa 3-D Headers to version 19.2.1 | graphics
+[JDK-8235151](https://bugs.openjdk.org/browse/JDK-8235151) | Nonexistent notifyQuit method referred from iOS GlassHelper.m | graphics
+[JDK-8235150](https://bugs.openjdk.org/browse/JDK-8235150) | IosApplication does not pass the required object in _leaveNestedEventLoopImpl | graphics
+[JDK-8235627](https://bugs.openjdk.org/browse/JDK-8235627) | Blank stages when running JavaFX app in a macOS virtual machine | graphics
+[JDK-8234916](https://bugs.openjdk.org/browse/JDK-8234916) | [macos 10.15] Garbled text running with native-image | graphics
+[JDK-8223296](https://bugs.openjdk.org/browse/JDK-8223296) | NullPointerException in GlassScene.java at line 325 | graphics
+[JDK-8236808](https://bugs.openjdk.org/browse/JDK-8236808) | javafx_iio can not be used in static environment | graphics
+[JDK-8088198](https://bugs.openjdk.org/browse/JDK-8088198) | Exception thrown from snapshot if dimensions are larger than max texture size | graphics
+[JDK-8232589](https://bugs.openjdk.org/browse/JDK-8232589) | Remove CoreAudio Utility Classes | media
+[JDK-8230610](https://bugs.openjdk.org/browse/JDK-8230610) | Upgrade GStreamer to version 1.16.1 | media
+[JDK-8230609](https://bugs.openjdk.org/browse/JDK-8230609) | Upgrade glib to version 2.62.2 | media
+[JDK-8233338](https://bugs.openjdk.org/browse/JDK-8233338) | FX javadoc headings are out of sequence | other
+[JDK-8232824](https://bugs.openjdk.org/browse/JDK-8232824) | Removing TabPane with strong referenced content causes memory leak from weak one | scenegraph
+[JDK-8200224](https://bugs.openjdk.org/browse/JDK-8200224) | First mouse press each time JFXPanel gains focus is triggered twice | swing
+[JDK-8218640](https://bugs.openjdk.org/browse/JDK-8218640) | Update ICU4C to version 64.2 | web
+[JDK-8233747](https://bugs.openjdk.org/browse/JDK-8233747) | JVM crash in com.sun.webkit.dom.DocumentImpl.createAttribute | web
+[JDK-8230492](https://bugs.openjdk.org/browse/JDK-8230492) | font-family not set in HTMLEditor if font name has a number in it | web
+[JDK-8236912](https://bugs.openjdk.org/browse/JDK-8236912) | NullPointerException when clicking in WebView with Button 4 or Button 5 | web
+[JDK-8231188](https://bugs.openjdk.org/browse/JDK-8231188) | Update SQLite to version 3.30.1 | web
+[JDK-8234056](https://bugs.openjdk.org/browse/JDK-8234056) | Upgrade to libxslt 1.1.34 | web
+[JDK-8231513](https://bugs.openjdk.org/browse/JDK-8231513) | JavaFX cause Keystroke Receiving prompt on MacOS 10.15 (Catalina) | window-toolkit
+[JDK-8234474](https://bugs.openjdk.org/browse/JDK-8234474) | [macos 10.15] Crash in file dialog in sandbox mode | window-toolkit
+[JDK-8228766](https://bugs.openjdk.org/browse/JDK-8228766) | Platform.startup() deadlock on mac when called from class initializer | window-toolkit
+[JDK-8227366](https://bugs.openjdk.org/browse/JDK-8227366) | Wrong stage gets focused after modal stage creation | window-toolkit
 
 ## List of Enhancements
 
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8207957](https://bugs.openjdk.java.net/browse/JDK-8207957) | TableSkinUtils should not contain actual code implementation | controls
-[JDK-8130738](https://bugs.openjdk.java.net/browse/JDK-8130738) | Add tabSize property to Text and TextFlow | graphics
-[JDK-8226850](https://bugs.openjdk.java.net/browse/JDK-8226850) | Use an EnumSet for DirtyBits instead of an ordinal-based mask | graphics
-[JDK-8092352](https://bugs.openjdk.java.net/browse/JDK-8092352) | Skip event dispatch if there are no handlers/filters | scenegraph
-[JDK-8211308](https://bugs.openjdk.java.net/browse/JDK-8211308) | Support HTTP/2 in WebView | web
-[JDK-8087980](https://bugs.openjdk.java.net/browse/JDK-8087980) | Add property to disable Monocle cursor | window-toolkit
-[JDK-8225571](https://bugs.openjdk.java.net/browse/JDK-8225571) | Port Linux glass drag source (DND) to use gtk instead of gdk | window-toolkit
+[JDK-8207957](https://bugs.openjdk.org/browse/JDK-8207957) | TableSkinUtils should not contain actual code implementation | controls
+[JDK-8130738](https://bugs.openjdk.org/browse/JDK-8130738) | Add tabSize property to Text and TextFlow | graphics
+[JDK-8226850](https://bugs.openjdk.org/browse/JDK-8226850) | Use an EnumSet for DirtyBits instead of an ordinal-based mask | graphics
+[JDK-8092352](https://bugs.openjdk.org/browse/JDK-8092352) | Skip event dispatch if there are no handlers/filters | scenegraph
+[JDK-8211308](https://bugs.openjdk.org/browse/JDK-8211308) | Support HTTP/2 in WebView | web
+[JDK-8087980](https://bugs.openjdk.org/browse/JDK-8087980) | Add property to disable Monocle cursor | window-toolkit
+[JDK-8225571](https://bugs.openjdk.org/browse/JDK-8225571) | Port Linux glass drag source (DND) to use gtk instead of gdk | window-toolkit
 
 ## List of Security fixes
 

--- a/doc-files/release-notes-15.md
+++ b/doc-files/release-notes-15.md
@@ -11,110 +11,110 @@ As of JDK 11 the JavaFX modules are delivered separately from the JDK. These rel
 
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8241582](https://bugs.openjdk.java.net/browse/JDK-8241582)|Infinite animation does not start from the end when started with a negative rate|animation
-[JDK-8240688](https://bugs.openjdk.java.net/browse/JDK-8240688)|Remove the JavaBeanXxxPropertyBuilders constructors|base
-[JDK-8196586](https://bugs.openjdk.java.net/browse/JDK-8196586)|Remove use of deprecated finalize methods from javafx property objects|base
-[JDK-8237469](https://bugs.openjdk.java.net/browse/JDK-8237469)|Inherited styles don't update when node is moved|controls
-[JDK-8236840](https://bugs.openjdk.java.net/browse/JDK-8236840)|Memory leak when switching ButtonSkin|controls
-[JDK-8237453](https://bugs.openjdk.java.net/browse/JDK-8237453)|[TabPane] Incorrect arrow key traversal through tabs after reordering|controls
-[JDK-8236839](https://bugs.openjdk.java.net/browse/JDK-8236839)|System menubar removed when other menubars are created or modified|controls
-[JDK-8236259](https://bugs.openjdk.java.net/browse/JDK-8236259)|MemoryLeak in ProgressIndicator|controls
-[JDK-8230809](https://bugs.openjdk.java.net/browse/JDK-8230809)|HTMLEditor formatting lost when selecting all (CTRL-A)|controls
-[JDK-8245499](https://bugs.openjdk.java.net/browse/JDK-8245499)|Text input controls should show handles on iOS|controls
-[JDK-8245282](https://bugs.openjdk.java.net/browse/JDK-8245282)|Button/Combo Behavior: memory leak on dispose|controls
-[JDK-8241249](https://bugs.openjdk.java.net/browse/JDK-8241249)|NPE in TabPaneSkin.perfromDrag|controls
-[JDK-8241999](https://bugs.openjdk.java.net/browse/JDK-8241999)|ChoiceBox: incorrect toggle selected for uncontained selectedItem|controls
-[JDK-8242001](https://bugs.openjdk.java.net/browse/JDK-8242001)|ChoiceBox: must update value on setting SelectionModel, part 2|controls
-[JDK-8241737](https://bugs.openjdk.java.net/browse/JDK-8241737)|TabPaneSkin memory leak on replacing selectionModel|controls
-[JDK-8242548](https://bugs.openjdk.java.net/browse/JDK-8242548)|Wrapped labeled controls using -fx-line-spacing cut text off|controls
-[JDK-8242489](https://bugs.openjdk.java.net/browse/JDK-8242489)|ChoiceBox: initially toggle not sync'ed to selection |controls
-[JDK-8242167](https://bugs.openjdk.java.net/browse/JDK-8242167)|ios keyboard handling|controls
-[JDK-8242163](https://bugs.openjdk.java.net/browse/JDK-8242163)|Android keyboard integration fails|controls
-[JDK-8089134](https://bugs.openjdk.java.net/browse/JDK-8089134)|[2D traversal, RTL] TraversalEngine only handles left/right key traversal correctly in RTL for top-level engine in ToolBar|controls
-[JDK-8089828](https://bugs.openjdk.java.net/browse/JDK-8089828)|RTL Orientation, the flag of a mnemonic is not placed under the mnemonic letter.|controls
-[JDK-8087555](https://bugs.openjdk.java.net/browse/JDK-8087555)|[ChoiceBox] uncontained value not shown|controls
-[JDK-8244110](https://bugs.openjdk.java.net/browse/JDK-8244110)|NPE in MenuButtonSkinBase change listener|controls
-[JDK-8244647](https://bugs.openjdk.java.net/browse/JDK-8244647)|Wrong first layout pass of Scrollbar controls on touch supported devices|controls
-[JDK-8244421](https://bugs.openjdk.java.net/browse/JDK-8244421)|Wrong scrollbar position on touch enabled devices|controls
-[JDK-8244657](https://bugs.openjdk.java.net/browse/JDK-8244657)|ChoiceBox/ToolBarSkin: misbehavior on switching skin|controls
-[JDK-8241455](https://bugs.openjdk.java.net/browse/JDK-8241455)|Memory leak on replacing selection/focusModel|controls
-[JDK-8241710](https://bugs.openjdk.java.net/browse/JDK-8241710)|NullPointerException while entering empty submenu with "arrow right"|controls
-[JDK-8237926](https://bugs.openjdk.java.net/browse/JDK-8237926)|Potential memory leak of model data in javafx.scene.control.ListView|controls
-[JDK-8235480](https://bugs.openjdk.java.net/browse/JDK-8235480)|Regression: [RTL] Arrow keys navigation doesn't respect TableView orientation|controls
-[JDK-8175358](https://bugs.openjdk.java.net/browse/JDK-8175358)|Memory leak when moving MenuButton into another Scene|controls
-[JDK-8198402](https://bugs.openjdk.java.net/browse/JDK-8198402)|ToggleButton.setToggleGroup causes memory leak when button is removed via ToggleGroup.getToggles() |controls
-[JDK-8246195](https://bugs.openjdk.java.net/browse/JDK-8246195)|ListViewSkin/Behavior: misbehavior on switching skin|controls
-[JDK-8245575](https://bugs.openjdk.java.net/browse/JDK-8245575)|Show the ContextMenu of input controls with long press gesture on iOS|controls
-[JDK-8244418](https://bugs.openjdk.java.net/browse/JDK-8244418)|MenuBar: IOOB exception on requestFocus on empty bar|controls
-[JDK-8176270](https://bugs.openjdk.java.net/browse/JDK-8176270)|Adding ChangeListener to TextField.selectedTextProperty causes StringOutOfBoundsException|controls
-[JDK-8227619](https://bugs.openjdk.java.net/browse/JDK-8227619)|Potential memory leak in javafx.scene.control.ListView|controls
-[JDK-8244824](https://bugs.openjdk.java.net/browse/JDK-8244824)|TableView : Incorrect German translation|controls
-[JDK-8237602](https://bugs.openjdk.java.net/browse/JDK-8237602)|TabPane doesn't respect order of TabPane.getTabs() list|controls
-[JDK-8193800](https://bugs.openjdk.java.net/browse/JDK-8193800)|TreeTableView selection changes on sorting|controls
-[JDK-8244112](https://bugs.openjdk.java.net/browse/JDK-8244112)|Skin implementations: must not violate contract of dispose |controls
-[JDK-8234959](https://bugs.openjdk.java.net/browse/JDK-8234959)|FXMLLoader does not populate ENGINE_SCOPE Bindings with FILENAME and ARGV|fxml
-[JDK-8245456](https://bugs.openjdk.java.net/browse/JDK-8245456)|MacPasteboard throws ClassCastException on static builds|graphics
-[JDK-8244735](https://bugs.openjdk.java.net/browse/JDK-8244735)|Error on iOS passing keys with unicode values greater than 255|graphics
-[JDK-8242577](https://bugs.openjdk.java.net/browse/JDK-8242577)|Cell selection fails on iOS most of the times|graphics
-[JDK-8243255](https://bugs.openjdk.java.net/browse/JDK-8243255)|Font size is large in JavaFX app with enabled Monocle on Raspberry Pi|graphics
-[JDK-8157224](https://bugs.openjdk.java.net/browse/JDK-8157224)|isNPOTSupported check is too strict|graphics
-[JDK-8240262](https://bugs.openjdk.java.net/browse/JDK-8240262)|iOS refresh rate is capped to 30 Hz|graphics
-[JDK-8240265](https://bugs.openjdk.java.net/browse/JDK-8240265)|iOS: Unnecessary logging on pinch gestures |graphics
-[JDK-8237770](https://bugs.openjdk.java.net/browse/JDK-8237770)|Error creating fragment phong shader on iOS|graphics
-[JDK-8202296](https://bugs.openjdk.java.net/browse/JDK-8202296)|Monocle MouseInput doesn't send keyboard modifiers in events.|graphics
-[JDK-8245635](https://bugs.openjdk.java.net/browse/JDK-8245635)|GlassPasteboard::getUTFs fails on iOS|graphics
-[JDK-8240264](https://bugs.openjdk.java.net/browse/JDK-8240264)|iOS: Unnecessary logging on every pulse when GL context changes|graphics
-[JDK-8201570](https://bugs.openjdk.java.net/browse/JDK-8201570)|Get two bytes for the Linux input event type, not four|graphics
-[JDK-8241370](https://bugs.openjdk.java.net/browse/JDK-8241370)|Crash in JPEGImageLoader after fix for JDK-8212034|graphics
-[JDK-8212034](https://bugs.openjdk.java.net/browse/JDK-8212034)|Potential memory leaks in jpegLoader.c in error case|graphics
-[JDK-8237782](https://bugs.openjdk.java.net/browse/JDK-8237782)|Only read advances up to the minimum of the numHorMetrics or the available font data.|graphics
-[JDK-8237833](https://bugs.openjdk.java.net/browse/JDK-8237833)|Check glyph size before adding to glyph texture cache.|graphics
-[JDK-8239107](https://bugs.openjdk.java.net/browse/JDK-8239107)|Update libjpeg to version 9d|graphics
-[JDK-8201567](https://bugs.openjdk.java.net/browse/JDK-8201567)|QuantumRenderer modifies buffer in use by JavaFX Application Thread|graphics
-[JDK-8246348](https://bugs.openjdk.java.net/browse/JDK-8246348)|Crash in libpango on Ubuntu 20.04 with some unicode chars|graphics
-[JDK-8246204](https://bugs.openjdk.java.net/browse/JDK-8246204)|No 3D support for newer Intel graphics drivers on Linux|graphics
-[JDK-8242530](https://bugs.openjdk.java.net/browse/JDK-8242530)|[macos] Some audio files miss spectrum data when another audio file plays first|media
-[JDK-8240694](https://bugs.openjdk.java.net/browse/JDK-8240694)|[macos 10.15] JavaFX Media hangs on some video files on Catalina|media
-[JDK-8236832](https://bugs.openjdk.java.net/browse/JDK-8236832)|[macos 10.15] JavaFX Application hangs on video play on Catalina|media
-[JDK-8239095](https://bugs.openjdk.java.net/browse/JDK-8239095)|Upgrade libFFI to the latest 3.3 version|media
-[JDK-8250238](https://bugs.openjdk.java.net/browse/JDK-8250238)|Media fails to load libav 58 library when using modules from maven central|media
-[JDK-8241629](https://bugs.openjdk.java.net/browse/JDK-8241629)|[macos10.15] Long startup delay playing media over https on Catalina|media
-[JDK-8214699](https://bugs.openjdk.java.net/browse/JDK-8214699)|Node.getPseudoClassStates must return the same instance on every call|scenegraph
-[JDK-8247163](https://bugs.openjdk.java.net/browse/JDK-8247163)|JFXPanel throws exception on click when no Scene is set|swing
-[JDK-8220484](https://bugs.openjdk.java.net/browse/JDK-8220484)|JFXPanel renders a slanted image with a hidpi monitor scale of 125% or 175%|swing
-[JDK-8239454](https://bugs.openjdk.java.net/browse/JDK-8239454)|LLIntData : invalid opcode returned for 16 and 32 bit wide instructions|web
-[JDK-8239109](https://bugs.openjdk.java.net/browse/JDK-8239109)|Update SQLite to version 3.31.1|web
-[JDK-8240211](https://bugs.openjdk.java.net/browse/JDK-8240211)|Stack overflow on Windows 32-bit can lead to crash|web
-[JDK-8240218](https://bugs.openjdk.java.net/browse/JDK-8240218)|IOS Webkit implementation broken|web
-[JDK-8238526](https://bugs.openjdk.java.net/browse/JDK-8238526)|Cherry pick GTK WebKit 2.26.3 changes|web
-[JDK-8223298](https://bugs.openjdk.java.net/browse/JDK-8223298)|SVG patterns are drawn wrong|web
-[JDK-8242209](https://bugs.openjdk.java.net/browse/JDK-8242209)|Increase web native thread stack size for x86 mode|web
-[JDK-8233942](https://bugs.openjdk.java.net/browse/JDK-8233942)|Update to 609.1 version of WebKit|web
-[JDK-8237889](https://bugs.openjdk.java.net/browse/JDK-8237889)|Update libxml2 to version 2.9.10|web
-[JDK-8244579](https://bugs.openjdk.java.net/browse/JDK-8244579)|Windows "User Objects" leakage with WebView|web
-[JDK-8208169](https://bugs.openjdk.java.net/browse/JDK-8208169)|can not print selected pages of web page|web
-[JDK-8191758](https://bugs.openjdk.java.net/browse/JDK-8191758)|Match WebKit's font weight rendering with JavaFX|web
-[JDK-8234471](https://bugs.openjdk.java.net/browse/JDK-8234471)|Canvas in webview displayed with wrong scale on Windows|web
-[JDK-8247963](https://bugs.openjdk.java.net/browse/JDK-8247963)|Update SQLite to version 3.32.3|web
-[JDK-8236971](https://bugs.openjdk.java.net/browse/JDK-8236971)|[macos] Gestures handled incorrectly due to missing events|window-toolkit
-[JDK-8176499](https://bugs.openjdk.java.net/browse/JDK-8176499)|Dependence on java.util.Timer freezes screen when OS time resets backwards|window-toolkit
-[JDK-8236685](https://bugs.openjdk.java.net/browse/JDK-8236685)|[macOs] Remove obsolete file dialog subclasses|window-toolkit
-[JDK-8248381](https://bugs.openjdk.java.net/browse/JDK-8248381)|Create a daemon thread for MonocleTimer|window-toolkit
-[JDK-8248490](https://bugs.openjdk.java.net/browse/JDK-8248490)|[macOS] Undecorated stage does not minimize|window-toolkit
+[JDK-8241582](https://bugs.openjdk.org/browse/JDK-8241582)|Infinite animation does not start from the end when started with a negative rate|animation
+[JDK-8240688](https://bugs.openjdk.org/browse/JDK-8240688)|Remove the JavaBeanXxxPropertyBuilders constructors|base
+[JDK-8196586](https://bugs.openjdk.org/browse/JDK-8196586)|Remove use of deprecated finalize methods from javafx property objects|base
+[JDK-8237469](https://bugs.openjdk.org/browse/JDK-8237469)|Inherited styles don't update when node is moved|controls
+[JDK-8236840](https://bugs.openjdk.org/browse/JDK-8236840)|Memory leak when switching ButtonSkin|controls
+[JDK-8237453](https://bugs.openjdk.org/browse/JDK-8237453)|[TabPane] Incorrect arrow key traversal through tabs after reordering|controls
+[JDK-8236839](https://bugs.openjdk.org/browse/JDK-8236839)|System menubar removed when other menubars are created or modified|controls
+[JDK-8236259](https://bugs.openjdk.org/browse/JDK-8236259)|MemoryLeak in ProgressIndicator|controls
+[JDK-8230809](https://bugs.openjdk.org/browse/JDK-8230809)|HTMLEditor formatting lost when selecting all (CTRL-A)|controls
+[JDK-8245499](https://bugs.openjdk.org/browse/JDK-8245499)|Text input controls should show handles on iOS|controls
+[JDK-8245282](https://bugs.openjdk.org/browse/JDK-8245282)|Button/Combo Behavior: memory leak on dispose|controls
+[JDK-8241249](https://bugs.openjdk.org/browse/JDK-8241249)|NPE in TabPaneSkin.perfromDrag|controls
+[JDK-8241999](https://bugs.openjdk.org/browse/JDK-8241999)|ChoiceBox: incorrect toggle selected for uncontained selectedItem|controls
+[JDK-8242001](https://bugs.openjdk.org/browse/JDK-8242001)|ChoiceBox: must update value on setting SelectionModel, part 2|controls
+[JDK-8241737](https://bugs.openjdk.org/browse/JDK-8241737)|TabPaneSkin memory leak on replacing selectionModel|controls
+[JDK-8242548](https://bugs.openjdk.org/browse/JDK-8242548)|Wrapped labeled controls using -fx-line-spacing cut text off|controls
+[JDK-8242489](https://bugs.openjdk.org/browse/JDK-8242489)|ChoiceBox: initially toggle not sync'ed to selection |controls
+[JDK-8242167](https://bugs.openjdk.org/browse/JDK-8242167)|ios keyboard handling|controls
+[JDK-8242163](https://bugs.openjdk.org/browse/JDK-8242163)|Android keyboard integration fails|controls
+[JDK-8089134](https://bugs.openjdk.org/browse/JDK-8089134)|[2D traversal, RTL] TraversalEngine only handles left/right key traversal correctly in RTL for top-level engine in ToolBar|controls
+[JDK-8089828](https://bugs.openjdk.org/browse/JDK-8089828)|RTL Orientation, the flag of a mnemonic is not placed under the mnemonic letter.|controls
+[JDK-8087555](https://bugs.openjdk.org/browse/JDK-8087555)|[ChoiceBox] uncontained value not shown|controls
+[JDK-8244110](https://bugs.openjdk.org/browse/JDK-8244110)|NPE in MenuButtonSkinBase change listener|controls
+[JDK-8244647](https://bugs.openjdk.org/browse/JDK-8244647)|Wrong first layout pass of Scrollbar controls on touch supported devices|controls
+[JDK-8244421](https://bugs.openjdk.org/browse/JDK-8244421)|Wrong scrollbar position on touch enabled devices|controls
+[JDK-8244657](https://bugs.openjdk.org/browse/JDK-8244657)|ChoiceBox/ToolBarSkin: misbehavior on switching skin|controls
+[JDK-8241455](https://bugs.openjdk.org/browse/JDK-8241455)|Memory leak on replacing selection/focusModel|controls
+[JDK-8241710](https://bugs.openjdk.org/browse/JDK-8241710)|NullPointerException while entering empty submenu with "arrow right"|controls
+[JDK-8237926](https://bugs.openjdk.org/browse/JDK-8237926)|Potential memory leak of model data in javafx.scene.control.ListView|controls
+[JDK-8235480](https://bugs.openjdk.org/browse/JDK-8235480)|Regression: [RTL] Arrow keys navigation doesn't respect TableView orientation|controls
+[JDK-8175358](https://bugs.openjdk.org/browse/JDK-8175358)|Memory leak when moving MenuButton into another Scene|controls
+[JDK-8198402](https://bugs.openjdk.org/browse/JDK-8198402)|ToggleButton.setToggleGroup causes memory leak when button is removed via ToggleGroup.getToggles() |controls
+[JDK-8246195](https://bugs.openjdk.org/browse/JDK-8246195)|ListViewSkin/Behavior: misbehavior on switching skin|controls
+[JDK-8245575](https://bugs.openjdk.org/browse/JDK-8245575)|Show the ContextMenu of input controls with long press gesture on iOS|controls
+[JDK-8244418](https://bugs.openjdk.org/browse/JDK-8244418)|MenuBar: IOOB exception on requestFocus on empty bar|controls
+[JDK-8176270](https://bugs.openjdk.org/browse/JDK-8176270)|Adding ChangeListener to TextField.selectedTextProperty causes StringOutOfBoundsException|controls
+[JDK-8227619](https://bugs.openjdk.org/browse/JDK-8227619)|Potential memory leak in javafx.scene.control.ListView|controls
+[JDK-8244824](https://bugs.openjdk.org/browse/JDK-8244824)|TableView : Incorrect German translation|controls
+[JDK-8237602](https://bugs.openjdk.org/browse/JDK-8237602)|TabPane doesn't respect order of TabPane.getTabs() list|controls
+[JDK-8193800](https://bugs.openjdk.org/browse/JDK-8193800)|TreeTableView selection changes on sorting|controls
+[JDK-8244112](https://bugs.openjdk.org/browse/JDK-8244112)|Skin implementations: must not violate contract of dispose |controls
+[JDK-8234959](https://bugs.openjdk.org/browse/JDK-8234959)|FXMLLoader does not populate ENGINE_SCOPE Bindings with FILENAME and ARGV|fxml
+[JDK-8245456](https://bugs.openjdk.org/browse/JDK-8245456)|MacPasteboard throws ClassCastException on static builds|graphics
+[JDK-8244735](https://bugs.openjdk.org/browse/JDK-8244735)|Error on iOS passing keys with unicode values greater than 255|graphics
+[JDK-8242577](https://bugs.openjdk.org/browse/JDK-8242577)|Cell selection fails on iOS most of the times|graphics
+[JDK-8243255](https://bugs.openjdk.org/browse/JDK-8243255)|Font size is large in JavaFX app with enabled Monocle on Raspberry Pi|graphics
+[JDK-8157224](https://bugs.openjdk.org/browse/JDK-8157224)|isNPOTSupported check is too strict|graphics
+[JDK-8240262](https://bugs.openjdk.org/browse/JDK-8240262)|iOS refresh rate is capped to 30 Hz|graphics
+[JDK-8240265](https://bugs.openjdk.org/browse/JDK-8240265)|iOS: Unnecessary logging on pinch gestures |graphics
+[JDK-8237770](https://bugs.openjdk.org/browse/JDK-8237770)|Error creating fragment phong shader on iOS|graphics
+[JDK-8202296](https://bugs.openjdk.org/browse/JDK-8202296)|Monocle MouseInput doesn't send keyboard modifiers in events.|graphics
+[JDK-8245635](https://bugs.openjdk.org/browse/JDK-8245635)|GlassPasteboard::getUTFs fails on iOS|graphics
+[JDK-8240264](https://bugs.openjdk.org/browse/JDK-8240264)|iOS: Unnecessary logging on every pulse when GL context changes|graphics
+[JDK-8201570](https://bugs.openjdk.org/browse/JDK-8201570)|Get two bytes for the Linux input event type, not four|graphics
+[JDK-8241370](https://bugs.openjdk.org/browse/JDK-8241370)|Crash in JPEGImageLoader after fix for JDK-8212034|graphics
+[JDK-8212034](https://bugs.openjdk.org/browse/JDK-8212034)|Potential memory leaks in jpegLoader.c in error case|graphics
+[JDK-8237782](https://bugs.openjdk.org/browse/JDK-8237782)|Only read advances up to the minimum of the numHorMetrics or the available font data.|graphics
+[JDK-8237833](https://bugs.openjdk.org/browse/JDK-8237833)|Check glyph size before adding to glyph texture cache.|graphics
+[JDK-8239107](https://bugs.openjdk.org/browse/JDK-8239107)|Update libjpeg to version 9d|graphics
+[JDK-8201567](https://bugs.openjdk.org/browse/JDK-8201567)|QuantumRenderer modifies buffer in use by JavaFX Application Thread|graphics
+[JDK-8246348](https://bugs.openjdk.org/browse/JDK-8246348)|Crash in libpango on Ubuntu 20.04 with some unicode chars|graphics
+[JDK-8246204](https://bugs.openjdk.org/browse/JDK-8246204)|No 3D support for newer Intel graphics drivers on Linux|graphics
+[JDK-8242530](https://bugs.openjdk.org/browse/JDK-8242530)|[macos] Some audio files miss spectrum data when another audio file plays first|media
+[JDK-8240694](https://bugs.openjdk.org/browse/JDK-8240694)|[macos 10.15] JavaFX Media hangs on some video files on Catalina|media
+[JDK-8236832](https://bugs.openjdk.org/browse/JDK-8236832)|[macos 10.15] JavaFX Application hangs on video play on Catalina|media
+[JDK-8239095](https://bugs.openjdk.org/browse/JDK-8239095)|Upgrade libFFI to the latest 3.3 version|media
+[JDK-8250238](https://bugs.openjdk.org/browse/JDK-8250238)|Media fails to load libav 58 library when using modules from maven central|media
+[JDK-8241629](https://bugs.openjdk.org/browse/JDK-8241629)|[macos10.15] Long startup delay playing media over https on Catalina|media
+[JDK-8214699](https://bugs.openjdk.org/browse/JDK-8214699)|Node.getPseudoClassStates must return the same instance on every call|scenegraph
+[JDK-8247163](https://bugs.openjdk.org/browse/JDK-8247163)|JFXPanel throws exception on click when no Scene is set|swing
+[JDK-8220484](https://bugs.openjdk.org/browse/JDK-8220484)|JFXPanel renders a slanted image with a hidpi monitor scale of 125% or 175%|swing
+[JDK-8239454](https://bugs.openjdk.org/browse/JDK-8239454)|LLIntData : invalid opcode returned for 16 and 32 bit wide instructions|web
+[JDK-8239109](https://bugs.openjdk.org/browse/JDK-8239109)|Update SQLite to version 3.31.1|web
+[JDK-8240211](https://bugs.openjdk.org/browse/JDK-8240211)|Stack overflow on Windows 32-bit can lead to crash|web
+[JDK-8240218](https://bugs.openjdk.org/browse/JDK-8240218)|IOS Webkit implementation broken|web
+[JDK-8238526](https://bugs.openjdk.org/browse/JDK-8238526)|Cherry pick GTK WebKit 2.26.3 changes|web
+[JDK-8223298](https://bugs.openjdk.org/browse/JDK-8223298)|SVG patterns are drawn wrong|web
+[JDK-8242209](https://bugs.openjdk.org/browse/JDK-8242209)|Increase web native thread stack size for x86 mode|web
+[JDK-8233942](https://bugs.openjdk.org/browse/JDK-8233942)|Update to 609.1 version of WebKit|web
+[JDK-8237889](https://bugs.openjdk.org/browse/JDK-8237889)|Update libxml2 to version 2.9.10|web
+[JDK-8244579](https://bugs.openjdk.org/browse/JDK-8244579)|Windows "User Objects" leakage with WebView|web
+[JDK-8208169](https://bugs.openjdk.org/browse/JDK-8208169)|can not print selected pages of web page|web
+[JDK-8191758](https://bugs.openjdk.org/browse/JDK-8191758)|Match WebKit's font weight rendering with JavaFX|web
+[JDK-8234471](https://bugs.openjdk.org/browse/JDK-8234471)|Canvas in webview displayed with wrong scale on Windows|web
+[JDK-8247963](https://bugs.openjdk.org/browse/JDK-8247963)|Update SQLite to version 3.32.3|web
+[JDK-8236971](https://bugs.openjdk.org/browse/JDK-8236971)|[macos] Gestures handled incorrectly due to missing events|window-toolkit
+[JDK-8176499](https://bugs.openjdk.org/browse/JDK-8176499)|Dependence on java.util.Timer freezes screen when OS time resets backwards|window-toolkit
+[JDK-8236685](https://bugs.openjdk.org/browse/JDK-8236685)|[macOs] Remove obsolete file dialog subclasses|window-toolkit
+[JDK-8248381](https://bugs.openjdk.org/browse/JDK-8248381)|Create a daemon thread for MonocleTimer|window-toolkit
+[JDK-8248490](https://bugs.openjdk.org/browse/JDK-8248490)|[macOS] Undecorated stage does not minimize|window-toolkit
 
 ## List of Enhancements
 
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8242523](https://bugs.openjdk.java.net/browse/JDK-8242523)|Update the Animation and ClipEnvelope classes|animation
-[JDK-8240692](https://bugs.openjdk.java.net/browse/JDK-8240692)|Cleanup of the javafx property objects|base
-[JDK-8244417](https://bugs.openjdk.java.net/browse/JDK-8244417)|support static build for Windows|build
-[JDK-8238080](https://bugs.openjdk.java.net/browse/JDK-8238080)|FXMLLoader: if script engines implement javax.script.Compilable compile scripts|fxml
-[JDK-8227425](https://bugs.openjdk.java.net/browse/JDK-8227425)|Add support for e-paper displays on i.MX6 devices|graphics
-[JDK-8238954](https://bugs.openjdk.java.net/browse/JDK-8238954)|Improve performance of tiled snapshot rendering |graphics
-[JDK-8238755](https://bugs.openjdk.java.net/browse/JDK-8238755)|allow to create static lib for javafx.media on linux|media
-[JDK-8208761](https://bugs.openjdk.java.net/browse/JDK-8208761)|Update constant collections to use the new immutable collections|other
-[JDK-8246357](https://bugs.openjdk.java.net/browse/JDK-8246357)|Allow static build of webkit library on linux|web
+[JDK-8242523](https://bugs.openjdk.org/browse/JDK-8242523)|Update the Animation and ClipEnvelope classes|animation
+[JDK-8240692](https://bugs.openjdk.org/browse/JDK-8240692)|Cleanup of the javafx property objects|base
+[JDK-8244417](https://bugs.openjdk.org/browse/JDK-8244417)|support static build for Windows|build
+[JDK-8238080](https://bugs.openjdk.org/browse/JDK-8238080)|FXMLLoader: if script engines implement javax.script.Compilable compile scripts|fxml
+[JDK-8227425](https://bugs.openjdk.org/browse/JDK-8227425)|Add support for e-paper displays on i.MX6 devices|graphics
+[JDK-8238954](https://bugs.openjdk.org/browse/JDK-8238954)|Improve performance of tiled snapshot rendering |graphics
+[JDK-8238755](https://bugs.openjdk.org/browse/JDK-8238755)|allow to create static lib for javafx.media on linux|media
+[JDK-8208761](https://bugs.openjdk.org/browse/JDK-8208761)|Update constant collections to use the new immutable collections|other
+[JDK-8246357](https://bugs.openjdk.org/browse/JDK-8246357)|Allow static build of webkit library on linux|web
 
 ## List of Security fixes
 

--- a/doc-files/release-notes-16.md
+++ b/doc-files/release-notes-16.md
@@ -12,7 +12,7 @@ As of JDK 11 the JavaFX modules are delivered separately from the JDK. These rel
 
 The JavaFX classes must be loaded from a set of named `javafx.*` modules on the _module path_. Loading the JavaFX classes from the classpath is not supported.
 The JavaFX runtime logs a warning at startup if the JavaFX classes are not loaded from the expected named module.
-See [JDK-8256362](https://bugs.openjdk.java.net/browse/JDK-8256362) for more information.
+See [JDK-8256362](https://bugs.openjdk.org/browse/JDK-8256362) for more information.
 
 ## Removed Features and Options
 
@@ -21,72 +21,72 @@ See [JDK-8256362](https://bugs.openjdk.java.net/browse/JDK-8256362) for more inf
 The obsolete Pisces rasterizer has been removed from JavaFX.
 The Marlin rasterizer has been the default since JDK 10, but it was possible to select either the native Pisces rasterizer or the Java-based Pisces rasterizer by setting the `prism.rasterizerorder` system property to `nativepisces` or `javapisces`, respectively.
 Those options will now be silently ignored, and the default Marlin rasterizer will always be used.
-See [JDK-8196079](https://bugs.openjdk.java.net/browse/JDK-8196079) for more information.
+See [JDK-8196079](https://bugs.openjdk.org/browse/JDK-8196079) for more information.
 
 ## List of Fixed Bugs
 
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8256362](https://bugs.openjdk.java.net/browse/JDK-8256362)|JavaFX must warn when the javafx.* modules are loaded from the classpath|application-lifecycle
-[JDK-8251352](https://bugs.openjdk.java.net/browse/JDK-8251352)|Many javafx.base classes have implicit no-arg constructors|base
-[JDK-8251946](https://bugs.openjdk.java.net/browse/JDK-8251946)|ObservableList.setAll does not conform to specification|base
-[JDK-8177945](https://bugs.openjdk.java.net/browse/JDK-8177945)|Single cell selection flickers when adding data to TableView|controls
-[JDK-8178297](https://bugs.openjdk.java.net/browse/JDK-8178297)|TableView scrolls slightly when adding new elements|controls
-[JDK-8209788](https://bugs.openjdk.java.net/browse/JDK-8209788)|Left/Right/Ctrl+A keys not working in editor of ComboBox if popup showing|controls
-[JDK-8242621](https://bugs.openjdk.java.net/browse/JDK-8242621)|TabPane: Memory leak when switching skin|controls
-[JDK-8245053](https://bugs.openjdk.java.net/browse/JDK-8245053)|Keyboard doesn't show when TextInputControl has focus|controls
-[JDK-8246202](https://bugs.openjdk.java.net/browse/JDK-8246202)|ChoiceBoxSkin: misbehavior on switching skin, part 2|controls
-[JDK-8246745](https://bugs.openjdk.java.net/browse/JDK-8246745)|ListCell/Skin: misbehavior on switching skin|controls
-[JDK-8247576](https://bugs.openjdk.java.net/browse/JDK-8247576)|Labeled/SkinBase: misbehavior on switching skin|controls
-[JDK-8251941](https://bugs.openjdk.java.net/browse/JDK-8251941)|ListCell: visual artifact when items contain null values|controls
-[JDK-8252236](https://bugs.openjdk.java.net/browse/JDK-8252236)|TabPane: must keep header of selected tab visible|controls
-[JDK-8252811](https://bugs.openjdk.java.net/browse/JDK-8252811)|The list of cells in a VirtualFlow is cleared every time the number of items changes|controls
-[JDK-8253597](https://bugs.openjdk.java.net/browse/JDK-8253597)|TreeTableView: must select leaf row on click into indentation region|controls
-[JDK-8253634](https://bugs.openjdk.java.net/browse/JDK-8253634)|TreeCell/Skin: misbehavior on switching skin|controls
-[JDK-8254964](https://bugs.openjdk.java.net/browse/JDK-8254964)|Fix default values in Spinner class|controls
-[JDK-8256821](https://bugs.openjdk.java.net/browse/JDK-8256821)|TreeViewSkin/Behavior: misbehavior on switching skin|controls
-[JDK-8199592](https://bugs.openjdk.java.net/browse/JDK-8199592)|Control labels truncated at certain DPI scaling levels|graphics
-[JDK-8211294](https://bugs.openjdk.java.net/browse/JDK-8211294)|ScrollPane content is blurry with 125% scaling|graphics
-[JDK-8248908](https://bugs.openjdk.java.net/browse/JDK-8248908)|Printer.createPageLayout() returns 0.75" margins instead of hardware margins|graphics
-[JDK-8252446](https://bugs.openjdk.java.net/browse/JDK-8252446)|Screen.getScreens() is empty sometimes|graphics
-[JDK-8254605](https://bugs.openjdk.java.net/browse/JDK-8254605)|repaint on Android broken|graphics
-[JDK-8255415](https://bugs.openjdk.java.net/browse/JDK-8255415)|Nested calls to snap methods in Region give different results|graphics
-[JDK-8256012](https://bugs.openjdk.java.net/browse/JDK-8256012)|Fix build of Monocle for Linux|graphics
-[JDK-8257719](https://bugs.openjdk.java.net/browse/JDK-8257719)|JFXPanel scene fails to render correctly on HiDPI after fix for JDK-8199592|graphics
-[JDK-8258592](https://bugs.openjdk.java.net/browse/JDK-8258592)|Control labels in Dialogs are truncated at certain DPI scaling levels|graphics
-[JDK-8248365](https://bugs.openjdk.java.net/browse/JDK-8248365)|Debug build crashes on Windows when playing media file|media
-[JDK-8252060](https://bugs.openjdk.java.net/browse/JDK-8252060)|gstreamer fails to build with gcc 10|media
-[JDK-8252107](https://bugs.openjdk.java.net/browse/JDK-8252107)|Media pipeline initialization can crash if audio or video bin state change fails|media
-[JDK-8252389](https://bugs.openjdk.java.net/browse/JDK-8252389)|Fix mistakes in FX API docs|other
-[JDK-8251353](https://bugs.openjdk.java.net/browse/JDK-8251353)|Many javafx scenegraph classes have implicit no-arg constructors|scenegraph
-[JDK-8252387](https://bugs.openjdk.java.net/browse/JDK-8252387)|Deprecate for removal css Selector and ShapeConverter constructors|scenegraph
-[JDK-8252547](https://bugs.openjdk.java.net/browse/JDK-8252547)|Correct transformations docs in Node|scenegraph
-[JDK-8231372](https://bugs.openjdk.java.net/browse/JDK-8231372)|JFXPanel fails to render if setScene called on Swing thread|swing
-[JDK-8181775](https://bugs.openjdk.java.net/browse/JDK-8181775)|JavaFX WebView does not calculate border-radius properly|web
-[JDK-8202990](https://bugs.openjdk.java.net/browse/JDK-8202990)|javafx webview css filter property with display scaling|web
-[JDK-8240969](https://bugs.openjdk.java.net/browse/JDK-8240969)|WebView does not allow to load style sheet in modularized applications|web
-[JDK-8242361](https://bugs.openjdk.java.net/browse/JDK-8242361)|JavaFX Web View crashes with Segmentation Fault, when HTML contains Data-URIs|web
-[JDK-8245284](https://bugs.openjdk.java.net/browse/JDK-8245284)|Update to 610.1 version of WebKit|web
-[JDK-8249839](https://bugs.openjdk.java.net/browse/JDK-8249839)|Cherry pick GTK WebKit 2.28.3 changes|web
-[JDK-8252062](https://bugs.openjdk.java.net/browse/JDK-8252062)|WebKit build fails with recent VS 2019 compiler|web
-[JDK-8252381](https://bugs.openjdk.java.net/browse/JDK-8252381)|Cherry pick GTK WebKit 2.28.4 changes|web
-[JDK-8253696](https://bugs.openjdk.java.net/browse/JDK-8253696)|WebEngine refuses to load local "file:///" CSS stylesheets when using JDK 15|web
-[JDK-8254049](https://bugs.openjdk.java.net/browse/JDK-8254049)|Update WebView to public suffix list 2020-04-24|web
-[JDK-8257897](https://bugs.openjdk.java.net/browse/JDK-8257897)|Fix webkit build for XCode 12|web
-[JDK-8201568](https://bugs.openjdk.java.net/browse/JDK-8201568)|zForce touchscreen input device fails when closed and immediately reopened|window-toolkit
-[JDK-8233678](https://bugs.openjdk.java.net/browse/JDK-8233678)|[macos 10.15] System menu bar does not work initially on macOS Catalina|window-toolkit
-[JDK-8237491](https://bugs.openjdk.java.net/browse/JDK-8237491)|[Linux] Undecorated stage cannot be maximized|window-toolkit
-[JDK-8241840](https://bugs.openjdk.java.net/browse/JDK-8241840)|Memoryleak: Closed focused Stages are not collected with Monocle.|window-toolkit
-[JDK-8251241](https://bugs.openjdk.java.net/browse/JDK-8251241)|macOS: iconify property doesn't change after minimize when resizable is false|window-toolkit
-[JDK-8251555](https://bugs.openjdk.java.net/browse/JDK-8251555)|Remove unused focusedWindow field in glass Window to avoid leak|window-toolkit
-[JDK-8255723](https://bugs.openjdk.java.net/browse/JDK-8255723)|Gtk glass backend should run with Gtk+ 3.8 (minimum)|window-toolkit
+[JDK-8256362](https://bugs.openjdk.org/browse/JDK-8256362)|JavaFX must warn when the javafx.* modules are loaded from the classpath|application-lifecycle
+[JDK-8251352](https://bugs.openjdk.org/browse/JDK-8251352)|Many javafx.base classes have implicit no-arg constructors|base
+[JDK-8251946](https://bugs.openjdk.org/browse/JDK-8251946)|ObservableList.setAll does not conform to specification|base
+[JDK-8177945](https://bugs.openjdk.org/browse/JDK-8177945)|Single cell selection flickers when adding data to TableView|controls
+[JDK-8178297](https://bugs.openjdk.org/browse/JDK-8178297)|TableView scrolls slightly when adding new elements|controls
+[JDK-8209788](https://bugs.openjdk.org/browse/JDK-8209788)|Left/Right/Ctrl+A keys not working in editor of ComboBox if popup showing|controls
+[JDK-8242621](https://bugs.openjdk.org/browse/JDK-8242621)|TabPane: Memory leak when switching skin|controls
+[JDK-8245053](https://bugs.openjdk.org/browse/JDK-8245053)|Keyboard doesn't show when TextInputControl has focus|controls
+[JDK-8246202](https://bugs.openjdk.org/browse/JDK-8246202)|ChoiceBoxSkin: misbehavior on switching skin, part 2|controls
+[JDK-8246745](https://bugs.openjdk.org/browse/JDK-8246745)|ListCell/Skin: misbehavior on switching skin|controls
+[JDK-8247576](https://bugs.openjdk.org/browse/JDK-8247576)|Labeled/SkinBase: misbehavior on switching skin|controls
+[JDK-8251941](https://bugs.openjdk.org/browse/JDK-8251941)|ListCell: visual artifact when items contain null values|controls
+[JDK-8252236](https://bugs.openjdk.org/browse/JDK-8252236)|TabPane: must keep header of selected tab visible|controls
+[JDK-8252811](https://bugs.openjdk.org/browse/JDK-8252811)|The list of cells in a VirtualFlow is cleared every time the number of items changes|controls
+[JDK-8253597](https://bugs.openjdk.org/browse/JDK-8253597)|TreeTableView: must select leaf row on click into indentation region|controls
+[JDK-8253634](https://bugs.openjdk.org/browse/JDK-8253634)|TreeCell/Skin: misbehavior on switching skin|controls
+[JDK-8254964](https://bugs.openjdk.org/browse/JDK-8254964)|Fix default values in Spinner class|controls
+[JDK-8256821](https://bugs.openjdk.org/browse/JDK-8256821)|TreeViewSkin/Behavior: misbehavior on switching skin|controls
+[JDK-8199592](https://bugs.openjdk.org/browse/JDK-8199592)|Control labels truncated at certain DPI scaling levels|graphics
+[JDK-8211294](https://bugs.openjdk.org/browse/JDK-8211294)|ScrollPane content is blurry with 125% scaling|graphics
+[JDK-8248908](https://bugs.openjdk.org/browse/JDK-8248908)|Printer.createPageLayout() returns 0.75" margins instead of hardware margins|graphics
+[JDK-8252446](https://bugs.openjdk.org/browse/JDK-8252446)|Screen.getScreens() is empty sometimes|graphics
+[JDK-8254605](https://bugs.openjdk.org/browse/JDK-8254605)|repaint on Android broken|graphics
+[JDK-8255415](https://bugs.openjdk.org/browse/JDK-8255415)|Nested calls to snap methods in Region give different results|graphics
+[JDK-8256012](https://bugs.openjdk.org/browse/JDK-8256012)|Fix build of Monocle for Linux|graphics
+[JDK-8257719](https://bugs.openjdk.org/browse/JDK-8257719)|JFXPanel scene fails to render correctly on HiDPI after fix for JDK-8199592|graphics
+[JDK-8258592](https://bugs.openjdk.org/browse/JDK-8258592)|Control labels in Dialogs are truncated at certain DPI scaling levels|graphics
+[JDK-8248365](https://bugs.openjdk.org/browse/JDK-8248365)|Debug build crashes on Windows when playing media file|media
+[JDK-8252060](https://bugs.openjdk.org/browse/JDK-8252060)|gstreamer fails to build with gcc 10|media
+[JDK-8252107](https://bugs.openjdk.org/browse/JDK-8252107)|Media pipeline initialization can crash if audio or video bin state change fails|media
+[JDK-8252389](https://bugs.openjdk.org/browse/JDK-8252389)|Fix mistakes in FX API docs|other
+[JDK-8251353](https://bugs.openjdk.org/browse/JDK-8251353)|Many javafx scenegraph classes have implicit no-arg constructors|scenegraph
+[JDK-8252387](https://bugs.openjdk.org/browse/JDK-8252387)|Deprecate for removal css Selector and ShapeConverter constructors|scenegraph
+[JDK-8252547](https://bugs.openjdk.org/browse/JDK-8252547)|Correct transformations docs in Node|scenegraph
+[JDK-8231372](https://bugs.openjdk.org/browse/JDK-8231372)|JFXPanel fails to render if setScene called on Swing thread|swing
+[JDK-8181775](https://bugs.openjdk.org/browse/JDK-8181775)|JavaFX WebView does not calculate border-radius properly|web
+[JDK-8202990](https://bugs.openjdk.org/browse/JDK-8202990)|javafx webview css filter property with display scaling|web
+[JDK-8240969](https://bugs.openjdk.org/browse/JDK-8240969)|WebView does not allow to load style sheet in modularized applications|web
+[JDK-8242361](https://bugs.openjdk.org/browse/JDK-8242361)|JavaFX Web View crashes with Segmentation Fault, when HTML contains Data-URIs|web
+[JDK-8245284](https://bugs.openjdk.org/browse/JDK-8245284)|Update to 610.1 version of WebKit|web
+[JDK-8249839](https://bugs.openjdk.org/browse/JDK-8249839)|Cherry pick GTK WebKit 2.28.3 changes|web
+[JDK-8252062](https://bugs.openjdk.org/browse/JDK-8252062)|WebKit build fails with recent VS 2019 compiler|web
+[JDK-8252381](https://bugs.openjdk.org/browse/JDK-8252381)|Cherry pick GTK WebKit 2.28.4 changes|web
+[JDK-8253696](https://bugs.openjdk.org/browse/JDK-8253696)|WebEngine refuses to load local "file:///" CSS stylesheets when using JDK 15|web
+[JDK-8254049](https://bugs.openjdk.org/browse/JDK-8254049)|Update WebView to public suffix list 2020-04-24|web
+[JDK-8257897](https://bugs.openjdk.org/browse/JDK-8257897)|Fix webkit build for XCode 12|web
+[JDK-8201568](https://bugs.openjdk.org/browse/JDK-8201568)|zForce touchscreen input device fails when closed and immediately reopened|window-toolkit
+[JDK-8233678](https://bugs.openjdk.org/browse/JDK-8233678)|[macos 10.15] System menu bar does not work initially on macOS Catalina|window-toolkit
+[JDK-8237491](https://bugs.openjdk.org/browse/JDK-8237491)|[Linux] Undecorated stage cannot be maximized|window-toolkit
+[JDK-8241840](https://bugs.openjdk.org/browse/JDK-8241840)|Memoryleak: Closed focused Stages are not collected with Monocle.|window-toolkit
+[JDK-8251241](https://bugs.openjdk.org/browse/JDK-8251241)|macOS: iconify property doesn't change after minimize when resizable is false|window-toolkit
+[JDK-8251555](https://bugs.openjdk.org/browse/JDK-8251555)|Remove unused focusedWindow field in glass Window to avoid leak|window-toolkit
+[JDK-8255723](https://bugs.openjdk.org/browse/JDK-8255723)|Gtk glass backend should run with Gtk+ 3.8 (minimum)|window-toolkit
 
 ## List of Enhancement
 
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8252546](https://bugs.openjdk.java.net/browse/JDK-8252546)|Move ObservableValue's equality check and lazy evaluation descriptions to @implSpec|base
-[JDK-8196079](https://bugs.openjdk.java.net/browse/JDK-8196079)|Remove obsolete Pisces rasterizer|graphics
-[JDK-8217472](https://bugs.openjdk.java.net/browse/JDK-8217472)|Add attenuation for PointLight|graphics
-[JDK-8254569](https://bugs.openjdk.java.net/browse/JDK-8254569)|Remove hard dependency on Dispman in Monocle fb rendering|graphics
-[JDK-8242861](https://bugs.openjdk.java.net/browse/JDK-8242861)|Update ImagePattern to apply SVG pattern transforms|web
+[JDK-8252546](https://bugs.openjdk.org/browse/JDK-8252546)|Move ObservableValue's equality check and lazy evaluation descriptions to @implSpec|base
+[JDK-8196079](https://bugs.openjdk.org/browse/JDK-8196079)|Remove obsolete Pisces rasterizer|graphics
+[JDK-8217472](https://bugs.openjdk.org/browse/JDK-8217472)|Add attenuation for PointLight|graphics
+[JDK-8254569](https://bugs.openjdk.org/browse/JDK-8254569)|Remove hard dependency on Dispman in Monocle fb rendering|graphics
+[JDK-8242861](https://bugs.openjdk.org/browse/JDK-8242861)|Update ImagePattern to apply SVG pattern transforms|web

--- a/doc-files/release-notes-17.md
+++ b/doc-files/release-notes-17.md
@@ -17,105 +17,105 @@ Application developers may need to adjust their IDE settings so that the IDE can
 
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8258777](https://bugs.openjdk.java.net/browse/JDK-8258777)|SkinBase: add api to un-/register invalidation-/listChange listeners|controls
-[JDK-8267554](https://bugs.openjdk.java.net/browse/JDK-8267554)|Support loading stylesheets from data-URIs|controls
-[JDK-8223717](https://bugs.openjdk.java.net/browse/JDK-8223717)|javafx printing: Support Specifying Print to File in the API|graphics
-[JDK-8234920](https://bugs.openjdk.java.net/browse/JDK-8234920)|Add SpotLight to the selection of 3D light types|graphics
-[JDK-8259718](https://bugs.openjdk.java.net/browse/JDK-8259718)|Remove the Marlin rasterizer (single-precision)|graphics
-[JDK-8267551](https://bugs.openjdk.java.net/browse/JDK-8267551)|Support loading images from inline data-URIs|graphics
-[JDK-8268120](https://bugs.openjdk.java.net/browse/JDK-8268120)|Allow hardware cursor to be used on Monocle-EGL platforms|graphics
-[JDK-8258499](https://bugs.openjdk.java.net/browse/JDK-8258499)|JavaFX: Move src.zip out of the lib directory|other
-[JDK-8252935](https://bugs.openjdk.java.net/browse/JDK-8252935)|Add treeShowing listener only when needed|scenegraph
-[JDK-8259680](https://bugs.openjdk.java.net/browse/JDK-8259680)|Need API to query states of CAPS LOCK and NUM LOCK keys|scenegraph
-[JDK-8092439](https://bugs.openjdk.java.net/browse/JDK-8092439)|[Monocle] Refactor monocle SPI to allow support for multiple screens|graphics
+[JDK-8258777](https://bugs.openjdk.org/browse/JDK-8258777)|SkinBase: add api to un-/register invalidation-/listChange listeners|controls
+[JDK-8267554](https://bugs.openjdk.org/browse/JDK-8267554)|Support loading stylesheets from data-URIs|controls
+[JDK-8223717](https://bugs.openjdk.org/browse/JDK-8223717)|javafx printing: Support Specifying Print to File in the API|graphics
+[JDK-8234920](https://bugs.openjdk.org/browse/JDK-8234920)|Add SpotLight to the selection of 3D light types|graphics
+[JDK-8259718](https://bugs.openjdk.org/browse/JDK-8259718)|Remove the Marlin rasterizer (single-precision)|graphics
+[JDK-8267551](https://bugs.openjdk.org/browse/JDK-8267551)|Support loading images from inline data-URIs|graphics
+[JDK-8268120](https://bugs.openjdk.org/browse/JDK-8268120)|Allow hardware cursor to be used on Monocle-EGL platforms|graphics
+[JDK-8258499](https://bugs.openjdk.org/browse/JDK-8258499)|JavaFX: Move src.zip out of the lib directory|other
+[JDK-8252935](https://bugs.openjdk.org/browse/JDK-8252935)|Add treeShowing listener only when needed|scenegraph
+[JDK-8259680](https://bugs.openjdk.org/browse/JDK-8259680)|Need API to query states of CAPS LOCK and NUM LOCK keys|scenegraph
+[JDK-8092439](https://bugs.openjdk.org/browse/JDK-8092439)|[Monocle] Refactor monocle SPI to allow support for multiple screens|graphics
 
 ## List of Fixed Bugs
 
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8185447](https://bugs.openjdk.java.net/browse/JDK-8185447)|The special high-contrast mode of JavaFX Controls in Japanese environment do not work.|accessibility
-[JDK-8263322](https://bugs.openjdk.java.net/browse/JDK-8263322)|Calling Application.launch on FX thread should throw IllegalStateException, but causes deadlock|application-lifecycle
-[JDK-8260468](https://bugs.openjdk.java.net/browse/JDK-8260468)|Wrong behavior of LocalDateTimeStringConverter|base
-[JDK-8260475](https://bugs.openjdk.java.net/browse/JDK-8260475)|Deprecate for removal protected access members in DateTimeStringConverter|base
-[JDK-8264770](https://bugs.openjdk.java.net/browse/JDK-8264770)|BidirectionalBinding should use InvalidationListener to prevent boxing|base
-[JDK-8267505](https://bugs.openjdk.java.net/browse/JDK-8267505)|{List,Set,Map}PropertyBase::bind should check against identity|base
-[JDK-8089589](https://bugs.openjdk.java.net/browse/JDK-8089589)|[ListView] ScrollBar content moves toward-backward during scrolling.|controls
-[JDK-8089913](https://bugs.openjdk.java.net/browse/JDK-8089913)|CSS pseudo classes missing by default for some controls|controls
-[JDK-8137323](https://bugs.openjdk.java.net/browse/JDK-8137323)|Incorrect parsing of mnemonic in controls text|controls
-[JDK-8165214](https://bugs.openjdk.java.net/browse/JDK-8165214)|ListView.EditEvent.getIndex() does not return the correct index|controls
-[JDK-8186904](https://bugs.openjdk.java.net/browse/JDK-8186904)|TableColumnHeader: resize cursor lost on right click|controls
-[JDK-8187229](https://bugs.openjdk.java.net/browse/JDK-8187229)|Tree/TableCell: cancel event must return correct editing location|controls
-[JDK-8189354](https://bugs.openjdk.java.net/browse/JDK-8189354)|Change.getRemoved() list contains incorrect selected items when a TreeItem is collapsed|controls
-[JDK-8196065](https://bugs.openjdk.java.net/browse/JDK-8196065)|ListChangeListener getRemoved() returns items that were not removed.|controls
-[JDK-8204568](https://bugs.openjdk.java.net/browse/JDK-8204568)|Relative CSS-Attributes don't work all time|controls
-[JDK-8208088](https://bugs.openjdk.java.net/browse/JDK-8208088)|Memory Leak in ControlAcceleratorSupport|controls
-[JDK-8228363](https://bugs.openjdk.java.net/browse/JDK-8228363)|ContextMenu.show with side=TOP does not work the first time in the presence of CSS|controls
-[JDK-8239138](https://bugs.openjdk.java.net/browse/JDK-8239138)|StyleManager should use a BufferedInputStream|controls
-[JDK-8244075](https://bugs.openjdk.java.net/browse/JDK-8244075)|Accelerator of ContextMenu's MenuItem is not removed when ContextMenu is removed from Scene|controls
-[JDK-8252238](https://bugs.openjdk.java.net/browse/JDK-8252238)|TableView: Editable (pseudo-editable) cells should respect the row editability|controls
-[JDK-8256283](https://bugs.openjdk.java.net/browse/JDK-8256283)|IndexOutOfBoundsException when sorting a TreeTableView|controls
-[JDK-8258663](https://bugs.openjdk.java.net/browse/JDK-8258663)|Fixed size TableCells are not removed from sene graph when column is removed|controls
-[JDK-8261460](https://bugs.openjdk.java.net/browse/JDK-8261460)|Incorrect CSS applied to ContextMenu on DialogPane|controls
-[JDK-8261840](https://bugs.openjdk.java.net/browse/JDK-8261840)|Submenus close to screen borders are no longer repositioned|controls
-[JDK-8263807](https://bugs.openjdk.java.net/browse/JDK-8263807)|Button types of a DialogPane are set twice, returns a wrong button|controls
-[JDK-8264157](https://bugs.openjdk.java.net/browse/JDK-8264157)|Items of non-editable ComboBox cannot be selected using up/down keys|controls
-[JDK-8264127](https://bugs.openjdk.java.net/browse/JDK-8264127)|ListCell editing status is true, when index changes while editing|controls
-[JDK-8264677](https://bugs.openjdk.java.net/browse/JDK-8264677)|MemoryLeak: Progressindicator leaks, when treeShowing is false|controls
-[JDK-8265206](https://bugs.openjdk.java.net/browse/JDK-8265206)|Tree-/TableCell: editing state not updated on cell re-use|controls
-[JDK-8265210](https://bugs.openjdk.java.net/browse/JDK-8265210)|TreeCell: cell editing state not updated on cell re-use|controls
-[JDK-8265669](https://bugs.openjdk.java.net/browse/JDK-8265669)|AccumCell should not be visible|controls
-[JDK-8266539](https://bugs.openjdk.java.net/browse/JDK-8266539)|[TreeView]: Change.getRemoved() contains null item when deselecting a TreeItem|controls
-[JDK-8266966](https://bugs.openjdk.java.net/browse/JDK-8266966)|Wrong CSS properties are applied to other nodes after fix for JDK-8204568|controls
-[JDK-8267094](https://bugs.openjdk.java.net/browse/JDK-8267094)|TreeCell: cancelEvent must return correct editing location|controls
-[JDK-8267392](https://bugs.openjdk.java.net/browse/JDK-8267392)|ENTER key press on editable TableView throws NPE|controls
-[JDK-8269026](https://bugs.openjdk.java.net/browse/JDK-8269026)|PasswordField doesn't render bullet character on Android|controls
-[JDK-8269136](https://bugs.openjdk.java.net/browse/JDK-8269136)|Tree/TablePosition: must not throw NPE on instantiating with null table|controls
-[JDK-8270314](https://bugs.openjdk.java.net/browse/JDK-8270314)|TreeTableCell: inconsistent naming for tableRow and tableColumn property methods|controls
-[JDK-8165749](https://bugs.openjdk.java.net/browse/JDK-8165749)|java.lang.RuntimeException: dndGesture.dragboard is null in dragDrop|graphics
-[JDK-8210199](https://bugs.openjdk.java.net/browse/JDK-8210199)|[linux / macOS] fileChooser can't handle emojis|graphics
-[JDK-8211362](https://bugs.openjdk.java.net/browse/JDK-8211362)|Restrict export of libjpeg symbols from libjavafx_iio.so|graphics
-[JDK-8217955](https://bugs.openjdk.java.net/browse/JDK-8217955)|Problems with touch input and JavaFX 11|graphics
-[JDK-8239589](https://bugs.openjdk.java.net/browse/JDK-8239589)|JavaFX UI will not repaint after reconnecting via Remote Desktop|graphics
-[JDK-8252099](https://bugs.openjdk.java.net/browse/JDK-8252099)|JavaFX does not render Myanmar script correctly|graphics
-[JDK-8258986](https://bugs.openjdk.java.net/browse/JDK-8258986)|getColor throws IOOBE when PixelReader reads the same pixel twice|graphics
-[JDK-8259046](https://bugs.openjdk.java.net/browse/JDK-8259046)|ViewPainter.ROOT_PATHS holds reference to Scene causing memory leak|graphics
-[JDK-8262396](https://bugs.openjdk.java.net/browse/JDK-8262396)|Update Mesa 3-D Headers to version 21.0.3|graphics
-[JDK-8262802](https://bugs.openjdk.java.net/browse/JDK-8262802)|Wrong context origin coordinates when using EGL and HiDPI|graphics
-[JDK-8263402](https://bugs.openjdk.java.net/browse/JDK-8263402)|MemoryLeak: Node hardreferences it's previous Parent after csslayout and getting removed from the scene|graphics
-[JDK-8267160](https://bugs.openjdk.java.net/browse/JDK-8267160)|Monocle mouse never get ENTERED state|graphics
-[JDK-8267314](https://bugs.openjdk.java.net/browse/JDK-8267314)|Loading some animated GIFs fails with ArrayIndexOutOfBoundsException: Index 4096 out of bounds for length 4096|graphics
-[JDK-8259356](https://bugs.openjdk.java.net/browse/JDK-8259356)|MediaPlayer's seek freezes video|media
-[JDK-8262365](https://bugs.openjdk.java.net/browse/JDK-8262365)|Update GStreamer to version 1.18.3|media
-[JDK-8262366](https://bugs.openjdk.java.net/browse/JDK-8262366)|Update glib to version 2.66.7|media
-[JDK-8264737](https://bugs.openjdk.java.net/browse/JDK-8264737)|JavaFX media stream stops playing after reconnecting via Remote Desktop|media
-[JDK-8266860](https://bugs.openjdk.java.net/browse/JDK-8266860)|[macos] Incorrect duration reported for HLS live streams|media
-[JDK-8267819](https://bugs.openjdk.java.net/browse/JDK-8267819)|CoInitialize/CoUninitialize should be called on same thread|media
-[JDK-8268152](https://bugs.openjdk.java.net/browse/JDK-8268152)|gstmpegaudioparse does not provides timestamps for HLS MP3 streams|media
-[JDK-8268219](https://bugs.openjdk.java.net/browse/JDK-8268219)|hlsprogressbuffer should provide PTS after GStreamer update|media
-[JDK-8269147](https://bugs.openjdk.java.net/browse/JDK-8269147)|Update GStreamer to version 1.18.4|media
-[JDK-8252783](https://bugs.openjdk.java.net/browse/JDK-8252783)|Remove the css Selector and ShapeConverter constructors|scenegraph
-[JDK-8264162](https://bugs.openjdk.java.net/browse/JDK-8264162)|PickResult.toString() is missing the closing square bracket|scenegraph
-[JDK-8264330](https://bugs.openjdk.java.net/browse/JDK-8264330)|Scene MouseHandler is referencing removed nodes|scenegraph
-[JDK-8270246](https://bugs.openjdk.java.net/browse/JDK-8270246)|Deprecate for removal implementation methods in Scene|scenegraph
-[JDK-8254836](https://bugs.openjdk.java.net/browse/JDK-8254836)|Cherry pick GTK WebKit 2.30.3 changes|web
-[JDK-8259555](https://bugs.openjdk.java.net/browse/JDK-8259555)|Webkit crashes on Apple Silicon|web
-[JDK-8259635](https://bugs.openjdk.java.net/browse/JDK-8259635)|Update to 610.2 version of WebKit|web
-[JDK-8260163](https://bugs.openjdk.java.net/browse/JDK-8260163)|IrresponsiveScriptTest.testInfiniteLoopInScript unit test fails on Windows|web
-[JDK-8260165](https://bugs.openjdk.java.net/browse/JDK-8260165)|CSSFilterTest.testCSSFilterRendering system test fails|web
-[JDK-8260245](https://bugs.openjdk.java.net/browse/JDK-8260245)|Update ICU4C to version 68.2|web
-[JDK-8260257](https://bugs.openjdk.java.net/browse/JDK-8260257)|[Linux] WebView no longer reacts to some mouse events|web
-[JDK-8263788](https://bugs.openjdk.java.net/browse/JDK-8263788)|JavaFX application freezes completely after some time when using the WebView|web
-[JDK-8264501](https://bugs.openjdk.java.net/browse/JDK-8264501)|UIWebView for iOS is deprecated|web
-[JDK-8264990](https://bugs.openjdk.java.net/browse/JDK-8264990)|WebEngine crashes with segfault when not loaded through system classloader|web
-[JDK-8269131](https://bugs.openjdk.java.net/browse/JDK-8269131)|Update libxml2 to version 2.9.12|web
-[JDK-8206253](https://bugs.openjdk.java.net/browse/JDK-8206253)|No/Wrong scroll events from touch input in window mode|window-toolkit
-[JDK-8231558](https://bugs.openjdk.java.net/browse/JDK-8231558)|[macos] Platform.exit causes assertion error on macOS 10.15 or later|window-toolkit
-[JDK-8240640](https://bugs.openjdk.java.net/browse/JDK-8240640)|[macos] Wrong focus behaviour with multiple Alerts|window-toolkit
-[JDK-8248126](https://bugs.openjdk.java.net/browse/JDK-8248126)|JavaFX ignores HiDPI scaling settings on some linux platforms|window-toolkit
-[JDK-8249737](https://bugs.openjdk.java.net/browse/JDK-8249737)|java.lang.RuntimeException: Too many touch points reported|window-toolkit
-[JDK-8258381](https://bugs.openjdk.java.net/browse/JDK-8258381)|[macos] Exception when input emoji using Chinese input method|window-toolkit
-[JDK-8263169](https://bugs.openjdk.java.net/browse/JDK-8263169)|[macOS] JavaFX windows open as tabs when system preference for documents is set|window-toolkit
-[JDK-8266743](https://bugs.openjdk.java.net/browse/JDK-8266743)|Crash on macOS 10.11 due to ignored @available 10.12 check|window-toolkit
+[JDK-8185447](https://bugs.openjdk.org/browse/JDK-8185447)|The special high-contrast mode of JavaFX Controls in Japanese environment do not work.|accessibility
+[JDK-8263322](https://bugs.openjdk.org/browse/JDK-8263322)|Calling Application.launch on FX thread should throw IllegalStateException, but causes deadlock|application-lifecycle
+[JDK-8260468](https://bugs.openjdk.org/browse/JDK-8260468)|Wrong behavior of LocalDateTimeStringConverter|base
+[JDK-8260475](https://bugs.openjdk.org/browse/JDK-8260475)|Deprecate for removal protected access members in DateTimeStringConverter|base
+[JDK-8264770](https://bugs.openjdk.org/browse/JDK-8264770)|BidirectionalBinding should use InvalidationListener to prevent boxing|base
+[JDK-8267505](https://bugs.openjdk.org/browse/JDK-8267505)|{List,Set,Map}PropertyBase::bind should check against identity|base
+[JDK-8089589](https://bugs.openjdk.org/browse/JDK-8089589)|[ListView] ScrollBar content moves toward-backward during scrolling.|controls
+[JDK-8089913](https://bugs.openjdk.org/browse/JDK-8089913)|CSS pseudo classes missing by default for some controls|controls
+[JDK-8137323](https://bugs.openjdk.org/browse/JDK-8137323)|Incorrect parsing of mnemonic in controls text|controls
+[JDK-8165214](https://bugs.openjdk.org/browse/JDK-8165214)|ListView.EditEvent.getIndex() does not return the correct index|controls
+[JDK-8186904](https://bugs.openjdk.org/browse/JDK-8186904)|TableColumnHeader: resize cursor lost on right click|controls
+[JDK-8187229](https://bugs.openjdk.org/browse/JDK-8187229)|Tree/TableCell: cancel event must return correct editing location|controls
+[JDK-8189354](https://bugs.openjdk.org/browse/JDK-8189354)|Change.getRemoved() list contains incorrect selected items when a TreeItem is collapsed|controls
+[JDK-8196065](https://bugs.openjdk.org/browse/JDK-8196065)|ListChangeListener getRemoved() returns items that were not removed.|controls
+[JDK-8204568](https://bugs.openjdk.org/browse/JDK-8204568)|Relative CSS-Attributes don't work all time|controls
+[JDK-8208088](https://bugs.openjdk.org/browse/JDK-8208088)|Memory Leak in ControlAcceleratorSupport|controls
+[JDK-8228363](https://bugs.openjdk.org/browse/JDK-8228363)|ContextMenu.show with side=TOP does not work the first time in the presence of CSS|controls
+[JDK-8239138](https://bugs.openjdk.org/browse/JDK-8239138)|StyleManager should use a BufferedInputStream|controls
+[JDK-8244075](https://bugs.openjdk.org/browse/JDK-8244075)|Accelerator of ContextMenu's MenuItem is not removed when ContextMenu is removed from Scene|controls
+[JDK-8252238](https://bugs.openjdk.org/browse/JDK-8252238)|TableView: Editable (pseudo-editable) cells should respect the row editability|controls
+[JDK-8256283](https://bugs.openjdk.org/browse/JDK-8256283)|IndexOutOfBoundsException when sorting a TreeTableView|controls
+[JDK-8258663](https://bugs.openjdk.org/browse/JDK-8258663)|Fixed size TableCells are not removed from sene graph when column is removed|controls
+[JDK-8261460](https://bugs.openjdk.org/browse/JDK-8261460)|Incorrect CSS applied to ContextMenu on DialogPane|controls
+[JDK-8261840](https://bugs.openjdk.org/browse/JDK-8261840)|Submenus close to screen borders are no longer repositioned|controls
+[JDK-8263807](https://bugs.openjdk.org/browse/JDK-8263807)|Button types of a DialogPane are set twice, returns a wrong button|controls
+[JDK-8264157](https://bugs.openjdk.org/browse/JDK-8264157)|Items of non-editable ComboBox cannot be selected using up/down keys|controls
+[JDK-8264127](https://bugs.openjdk.org/browse/JDK-8264127)|ListCell editing status is true, when index changes while editing|controls
+[JDK-8264677](https://bugs.openjdk.org/browse/JDK-8264677)|MemoryLeak: Progressindicator leaks, when treeShowing is false|controls
+[JDK-8265206](https://bugs.openjdk.org/browse/JDK-8265206)|Tree-/TableCell: editing state not updated on cell re-use|controls
+[JDK-8265210](https://bugs.openjdk.org/browse/JDK-8265210)|TreeCell: cell editing state not updated on cell re-use|controls
+[JDK-8265669](https://bugs.openjdk.org/browse/JDK-8265669)|AccumCell should not be visible|controls
+[JDK-8266539](https://bugs.openjdk.org/browse/JDK-8266539)|[TreeView]: Change.getRemoved() contains null item when deselecting a TreeItem|controls
+[JDK-8266966](https://bugs.openjdk.org/browse/JDK-8266966)|Wrong CSS properties are applied to other nodes after fix for JDK-8204568|controls
+[JDK-8267094](https://bugs.openjdk.org/browse/JDK-8267094)|TreeCell: cancelEvent must return correct editing location|controls
+[JDK-8267392](https://bugs.openjdk.org/browse/JDK-8267392)|ENTER key press on editable TableView throws NPE|controls
+[JDK-8269026](https://bugs.openjdk.org/browse/JDK-8269026)|PasswordField doesn't render bullet character on Android|controls
+[JDK-8269136](https://bugs.openjdk.org/browse/JDK-8269136)|Tree/TablePosition: must not throw NPE on instantiating with null table|controls
+[JDK-8270314](https://bugs.openjdk.org/browse/JDK-8270314)|TreeTableCell: inconsistent naming for tableRow and tableColumn property methods|controls
+[JDK-8165749](https://bugs.openjdk.org/browse/JDK-8165749)|java.lang.RuntimeException: dndGesture.dragboard is null in dragDrop|graphics
+[JDK-8210199](https://bugs.openjdk.org/browse/JDK-8210199)|[linux / macOS] fileChooser can't handle emojis|graphics
+[JDK-8211362](https://bugs.openjdk.org/browse/JDK-8211362)|Restrict export of libjpeg symbols from libjavafx_iio.so|graphics
+[JDK-8217955](https://bugs.openjdk.org/browse/JDK-8217955)|Problems with touch input and JavaFX 11|graphics
+[JDK-8239589](https://bugs.openjdk.org/browse/JDK-8239589)|JavaFX UI will not repaint after reconnecting via Remote Desktop|graphics
+[JDK-8252099](https://bugs.openjdk.org/browse/JDK-8252099)|JavaFX does not render Myanmar script correctly|graphics
+[JDK-8258986](https://bugs.openjdk.org/browse/JDK-8258986)|getColor throws IOOBE when PixelReader reads the same pixel twice|graphics
+[JDK-8259046](https://bugs.openjdk.org/browse/JDK-8259046)|ViewPainter.ROOT_PATHS holds reference to Scene causing memory leak|graphics
+[JDK-8262396](https://bugs.openjdk.org/browse/JDK-8262396)|Update Mesa 3-D Headers to version 21.0.3|graphics
+[JDK-8262802](https://bugs.openjdk.org/browse/JDK-8262802)|Wrong context origin coordinates when using EGL and HiDPI|graphics
+[JDK-8263402](https://bugs.openjdk.org/browse/JDK-8263402)|MemoryLeak: Node hardreferences it's previous Parent after csslayout and getting removed from the scene|graphics
+[JDK-8267160](https://bugs.openjdk.org/browse/JDK-8267160)|Monocle mouse never get ENTERED state|graphics
+[JDK-8267314](https://bugs.openjdk.org/browse/JDK-8267314)|Loading some animated GIFs fails with ArrayIndexOutOfBoundsException: Index 4096 out of bounds for length 4096|graphics
+[JDK-8259356](https://bugs.openjdk.org/browse/JDK-8259356)|MediaPlayer's seek freezes video|media
+[JDK-8262365](https://bugs.openjdk.org/browse/JDK-8262365)|Update GStreamer to version 1.18.3|media
+[JDK-8262366](https://bugs.openjdk.org/browse/JDK-8262366)|Update glib to version 2.66.7|media
+[JDK-8264737](https://bugs.openjdk.org/browse/JDK-8264737)|JavaFX media stream stops playing after reconnecting via Remote Desktop|media
+[JDK-8266860](https://bugs.openjdk.org/browse/JDK-8266860)|[macos] Incorrect duration reported for HLS live streams|media
+[JDK-8267819](https://bugs.openjdk.org/browse/JDK-8267819)|CoInitialize/CoUninitialize should be called on same thread|media
+[JDK-8268152](https://bugs.openjdk.org/browse/JDK-8268152)|gstmpegaudioparse does not provides timestamps for HLS MP3 streams|media
+[JDK-8268219](https://bugs.openjdk.org/browse/JDK-8268219)|hlsprogressbuffer should provide PTS after GStreamer update|media
+[JDK-8269147](https://bugs.openjdk.org/browse/JDK-8269147)|Update GStreamer to version 1.18.4|media
+[JDK-8252783](https://bugs.openjdk.org/browse/JDK-8252783)|Remove the css Selector and ShapeConverter constructors|scenegraph
+[JDK-8264162](https://bugs.openjdk.org/browse/JDK-8264162)|PickResult.toString() is missing the closing square bracket|scenegraph
+[JDK-8264330](https://bugs.openjdk.org/browse/JDK-8264330)|Scene MouseHandler is referencing removed nodes|scenegraph
+[JDK-8270246](https://bugs.openjdk.org/browse/JDK-8270246)|Deprecate for removal implementation methods in Scene|scenegraph
+[JDK-8254836](https://bugs.openjdk.org/browse/JDK-8254836)|Cherry pick GTK WebKit 2.30.3 changes|web
+[JDK-8259555](https://bugs.openjdk.org/browse/JDK-8259555)|Webkit crashes on Apple Silicon|web
+[JDK-8259635](https://bugs.openjdk.org/browse/JDK-8259635)|Update to 610.2 version of WebKit|web
+[JDK-8260163](https://bugs.openjdk.org/browse/JDK-8260163)|IrresponsiveScriptTest.testInfiniteLoopInScript unit test fails on Windows|web
+[JDK-8260165](https://bugs.openjdk.org/browse/JDK-8260165)|CSSFilterTest.testCSSFilterRendering system test fails|web
+[JDK-8260245](https://bugs.openjdk.org/browse/JDK-8260245)|Update ICU4C to version 68.2|web
+[JDK-8260257](https://bugs.openjdk.org/browse/JDK-8260257)|[Linux] WebView no longer reacts to some mouse events|web
+[JDK-8263788](https://bugs.openjdk.org/browse/JDK-8263788)|JavaFX application freezes completely after some time when using the WebView|web
+[JDK-8264501](https://bugs.openjdk.org/browse/JDK-8264501)|UIWebView for iOS is deprecated|web
+[JDK-8264990](https://bugs.openjdk.org/browse/JDK-8264990)|WebEngine crashes with segfault when not loaded through system classloader|web
+[JDK-8269131](https://bugs.openjdk.org/browse/JDK-8269131)|Update libxml2 to version 2.9.12|web
+[JDK-8206253](https://bugs.openjdk.org/browse/JDK-8206253)|No/Wrong scroll events from touch input in window mode|window-toolkit
+[JDK-8231558](https://bugs.openjdk.org/browse/JDK-8231558)|[macos] Platform.exit causes assertion error on macOS 10.15 or later|window-toolkit
+[JDK-8240640](https://bugs.openjdk.org/browse/JDK-8240640)|[macos] Wrong focus behaviour with multiple Alerts|window-toolkit
+[JDK-8248126](https://bugs.openjdk.org/browse/JDK-8248126)|JavaFX ignores HiDPI scaling settings on some linux platforms|window-toolkit
+[JDK-8249737](https://bugs.openjdk.org/browse/JDK-8249737)|java.lang.RuntimeException: Too many touch points reported|window-toolkit
+[JDK-8258381](https://bugs.openjdk.org/browse/JDK-8258381)|[macos] Exception when input emoji using Chinese input method|window-toolkit
+[JDK-8263169](https://bugs.openjdk.org/browse/JDK-8263169)|[macOS] JavaFX windows open as tabs when system preference for documents is set|window-toolkit
+[JDK-8266743](https://bugs.openjdk.org/browse/JDK-8266743)|Crash on macOS 10.11 due to ignored @available 10.12 check|window-toolkit
 
 ## List of Security fixes
 

--- a/doc-files/release-notes-18.md
+++ b/doc-files/release-notes-18.md
@@ -13,95 +13,95 @@ As of JDK 11 the JavaFX modules are delivered separately from the JDK. These rel
 The JavaFX GTK 2 library is deprecated and will be removed in a future release. The JavaFX runtime issues a warning if the GTK 2 library is requested on the command line via `java -Djdk.gtk.version=2`.
 The JavaFX runtime also issues a warning if the GTK 2 library is selected as a fallback, which happens if the GTK 3 library cannot be loaded. Application developers should avoid requesting the GTK 2 library.
 
-See [JDK-8273089](https://bugs.openjdk.java.net/browse/JDK-8273089) for more information.
+See [JDK-8273089](https://bugs.openjdk.org/browse/JDK-8273089) for more information.
 
 ## List of Enhancements
 
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8267472](https://bugs.openjdk.java.net/browse/JDK-8267472)|JavaFX modules to include version information|build
-[JDK-8172095](https://bugs.openjdk.java.net/browse/JDK-8172095)|Let Node.managed become CSS-styleable|controls
-[JDK-8234921](https://bugs.openjdk.java.net/browse/JDK-8234921)|Add DirectionalLight to the selection of 3D light types|graphics
-[JDK-8272870](https://bugs.openjdk.java.net/browse/JDK-8272870)|Add convenience factory methods for Border and Background|graphics
-[JDK-8278595](https://bugs.openjdk.java.net/browse/JDK-8278595)|Provide more information when a pipeline can't be used|graphics
-[JDK-8278860](https://bugs.openjdk.java.net/browse/JDK-8278860)|Streamline properties for Monocle|graphics
-[JDK-8273096](https://bugs.openjdk.java.net/browse/JDK-8273096)|Add support for H.265/HEVC to JavaFX Media|media
-[JDK-8214158](https://bugs.openjdk.java.net/browse/JDK-8214158)|Implement HostServices.showDocument on macOS without calling AWT|other
-[JDK-8090547](https://bugs.openjdk.java.net/browse/JDK-8090547)|Allow for transparent backgrounds in WebView|web
-[JDK-8273089](https://bugs.openjdk.java.net/browse/JDK-8273089)|Deprecate JavaFX GTK 2 library for removal|window-toolkit
+[JDK-8267472](https://bugs.openjdk.org/browse/JDK-8267472)|JavaFX modules to include version information|build
+[JDK-8172095](https://bugs.openjdk.org/browse/JDK-8172095)|Let Node.managed become CSS-styleable|controls
+[JDK-8234921](https://bugs.openjdk.org/browse/JDK-8234921)|Add DirectionalLight to the selection of 3D light types|graphics
+[JDK-8272870](https://bugs.openjdk.org/browse/JDK-8272870)|Add convenience factory methods for Border and Background|graphics
+[JDK-8278595](https://bugs.openjdk.org/browse/JDK-8278595)|Provide more information when a pipeline can't be used|graphics
+[JDK-8278860](https://bugs.openjdk.org/browse/JDK-8278860)|Streamline properties for Monocle|graphics
+[JDK-8273096](https://bugs.openjdk.org/browse/JDK-8273096)|Add support for H.265/HEVC to JavaFX Media|media
+[JDK-8214158](https://bugs.openjdk.org/browse/JDK-8214158)|Implement HostServices.showDocument on macOS without calling AWT|other
+[JDK-8090547](https://bugs.openjdk.org/browse/JDK-8090547)|Allow for transparent backgrounds in WebView|web
+[JDK-8273089](https://bugs.openjdk.org/browse/JDK-8273089)|Deprecate JavaFX GTK 2 library for removal|window-toolkit
 
 ## List of Fixed Bugs
 
 Issue key|Summary|Subcomponent
 ---------|-------|------------
-[JDK-8203463](https://bugs.openjdk.java.net/browse/JDK-8203463)|[Accessibility, Narrator] NPE in TableView|accessibility
-[JDK-8273969](https://bugs.openjdk.java.net/browse/JDK-8273969)|Memory Leak on the Runnable provided to Platform.startup|application-lifecycle
-[JDK-8270838](https://bugs.openjdk.java.net/browse/JDK-8270838)|Remove deprecated protected access members from DateTimeStringConverter|base
-[JDK-8273138](https://bugs.openjdk.java.net/browse/JDK-8273138)|BidirectionalBinding fails to observe changes of invalid properties|base
-[JDK-8273754](https://bugs.openjdk.java.net/browse/JDK-8273754)|Re-introduce Automatic-Module-Name in empty jars|build
-[JDK-8278260](https://bugs.openjdk.java.net/browse/JDK-8278260)|JavaFX shared libraries not stripped on Linux or macOS|build
-[JDK-8089398](https://bugs.openjdk.java.net/browse/JDK-8089398)|[ChoiceBox, ComboBox] throws NPE on setting value on null selectionModel|controls
-[JDK-8090158](https://bugs.openjdk.java.net/browse/JDK-8090158)|Wrong implementation of adjustValue in scrollBars|controls
-[JDK-8187474](https://bugs.openjdk.java.net/browse/JDK-8187474)|Tree-/TableCell, TreeCell: editingCell/Item not updated in cell.startEdit|controls
-[JDK-8188026](https://bugs.openjdk.java.net/browse/JDK-8188026)|TextFieldXXCell: NPE on calling startEdit|controls
-[JDK-8188027](https://bugs.openjdk.java.net/browse/JDK-8188027)|List/TableCell: must not fire event in startEdit if already editing|controls
-[JDK-8191995](https://bugs.openjdk.java.net/browse/JDK-8191995)|Regression: DatePicker must commit on focusLost|controls
-[JDK-8197991](https://bugs.openjdk.java.net/browse/JDK-8197991)|Selecting many items in a TableView is very slow|controls
-[JDK-8205915](https://bugs.openjdk.java.net/browse/JDK-8205915)|[macOS] Accelerator assigned to button in dialog fires menuItem in owning stage|controls
-[JDK-8231644](https://bugs.openjdk.java.net/browse/JDK-8231644)|TreeTableView Regression: Indentation wrong using Label as column content type|controls
-[JDK-8240506](https://bugs.openjdk.java.net/browse/JDK-8240506)|TextFieldSkin/Behavior: misbehavior on switching skin|controls
-[JDK-8244419](https://bugs.openjdk.java.net/browse/JDK-8244419)|TextAreaSkin: throws UnsupportedOperation on dispose|controls
-[JDK-8268295](https://bugs.openjdk.java.net/browse/JDK-8268295)|Tree- and TableCell sub implementations should respect the row editability|controls
-[JDK-8269081](https://bugs.openjdk.java.net/browse/JDK-8269081)|Tree/ListViewSkin: must remove flow on dispose|controls
-[JDK-8269871](https://bugs.openjdk.java.net/browse/JDK-8269871)|CellEditEvent: must not throw NPE in accessors|controls
-[JDK-8271474](https://bugs.openjdk.java.net/browse/JDK-8271474)|Tree-/TableCell: inconsistent edit event firing pattern|controls
-[JDK-8271484](https://bugs.openjdk.java.net/browse/JDK-8271484)|Tree-/TableCell: NPE when accessing edit event from startEdit|controls
-[JDK-8272118](https://bugs.openjdk.java.net/browse/JDK-8272118)|ListViewSkin et al: must not cancel edit on scrolling|controls
-[JDK-8273071](https://bugs.openjdk.java.net/browse/JDK-8273071)|SeparatorSkin: must remove child on dispose|controls
-[JDK-8273324](https://bugs.openjdk.java.net/browse/JDK-8273324)|IllegalArgumentException: fromIndex(0) > toIndex(-1) after clear and select TableCell|controls
-[JDK-8274022](https://bugs.openjdk.java.net/browse/JDK-8274022)|Additional Memory Leak in ControlAcceleratorSupport|controls
-[JDK-8274061](https://bugs.openjdk.java.net/browse/JDK-8274061)|Tree-/TableRowSkin: misbehavior on switching skin|controls
-[JDK-8274137](https://bugs.openjdk.java.net/browse/JDK-8274137)|TableView scrollbar/header misaligned when reloading data|controls
-[JDK-8274854](https://bugs.openjdk.java.net/browse/JDK-8274854)|Mnemonics for menu containing numeric text not working|controls
-[JDK-8274433](https://bugs.openjdk.java.net/browse/JDK-8274433)|All Cells: misbehavior of startEdit|controls
-[JDK-8274699](https://bugs.openjdk.java.net/browse/JDK-8274699)|Certain blend modes cannot be set from CSS|controls
-[JDK-8274669](https://bugs.openjdk.java.net/browse/JDK-8274669)|Dialog sometimes ignores max height|controls
-[JDK-8275911](https://bugs.openjdk.java.net/browse/JDK-8275911)|Keyboard doesn't show when tapping inside an iOS text input control|controls
-[JDK-8276167](https://bugs.openjdk.java.net/browse/JDK-8276167)|VirtualFlow.scrollToTop doesn't scroll to the top of the last element|controls
-[JDK-8276313](https://bugs.openjdk.java.net/browse/JDK-8276313)|ScrollPane scroll delta incorrectly depends on content height|controls
-[JDK-8276553](https://bugs.openjdk.java.net/browse/JDK-8276553)|ListView scrollTo() is broken after fix for JDK-8089589|controls
-[JDK-8281207](https://bugs.openjdk.java.net/browse/JDK-8281207)|TableView scrollTo() will not show last row for a custom cell factory.|controls
-[JDK-8232812](https://bugs.openjdk.java.net/browse/JDK-8232812)|[MacOS] Double click title bar does not restore window size|graphics
-[JDK-8236689](https://bugs.openjdk.java.net/browse/JDK-8236689)|macOS 10.15 Catalina: LCD text renders badly|graphics
-[JDK-8254956](https://bugs.openjdk.java.net/browse/JDK-8254956)|[REDO] Memoryleak: Closed focused Stages are not collected with Monocle|graphics
-[JDK-8255015](https://bugs.openjdk.java.net/browse/JDK-8255015)|Inconsistent illumination of 3D shape by PointLight|graphics
-[JDK-8269374](https://bugs.openjdk.java.net/browse/JDK-8269374)|Menu inoperable after setting stage to second monitor|graphics
-[JDK-8269638](https://bugs.openjdk.java.net/browse/JDK-8269638)|Property methods, setters, and getters in printing API should be final|graphics
-[JDK-8269639](https://bugs.openjdk.java.net/browse/JDK-8269639)|[macos] Calling stage.setY(0) twice causes wrong popups location|graphics
-[JDK-8276490](https://bugs.openjdk.java.net/browse/JDK-8276490)|Incorrect path for duplicate x and y values, when path falls outside axis bound|graphics
-[JDK-8276915](https://bugs.openjdk.java.net/browse/JDK-8276915)|Crash on iOS 15.1 in GlassRunnable::dealloc|graphics
-[JDK-8278905](https://bugs.openjdk.java.net/browse/JDK-8278905)|JavaFX: EnumConverter has a typo in the toString method|graphics
-[JDK-8279328](https://bugs.openjdk.java.net/browse/JDK-8279328)|CssParser uses default charset instead of UTF-8|graphics
-[JDK-8253351](https://bugs.openjdk.java.net/browse/JDK-8253351)|MediaPlayer does not display an mp4 if there no speakers connected to the PC's|media
-[JDK-8268718](https://bugs.openjdk.java.net/browse/JDK-8268718)|[macos] Video stops, but audio continues to play when stopTime is reached|media
-[JDK-8222455](https://bugs.openjdk.java.net/browse/JDK-8222455)|JavaFX error loading glass.dll from cache|other
-[JDK-8270839](https://bugs.openjdk.java.net/browse/JDK-8270839)|Remove deprecated implementation methods from Scene|scenegraph
-[JDK-8268849](https://bugs.openjdk.java.net/browse/JDK-8268849)|Update to 612.1 version of WebKit|web
-[JDK-8270479](https://bugs.openjdk.java.net/browse/JDK-8270479)|WebKit 612.1 build fails with Visual Studio 2017|web
-[JDK-8272329](https://bugs.openjdk.java.net/browse/JDK-8272329)|Cherry pick GTK WebKit 2.32.3 changes|web
-[JDK-8274107](https://bugs.openjdk.java.net/browse/JDK-8274107)|Cherry pick GTK WebKit 2.32.4 changes|web
-[JDK-8275138](https://bugs.openjdk.java.net/browse/JDK-8275138)|WebView: UserAgent string is empty for first request|web
-[JDK-8276847](https://bugs.openjdk.java.net/browse/JDK-8276847)|JSException: ReferenceError: Can't find variable: IntersectionObserver|web
-[JDK-8277133](https://bugs.openjdk.java.net/browse/JDK-8277133)|Dragboard contents retrieved all over again during a DND process on WebView|web
-[JDK-8277457](https://bugs.openjdk.java.net/browse/JDK-8277457)|AccessControlException: access denied ("java.net.NetPermission" "getCookieHandler")|web
-[JDK-8160597](https://bugs.openjdk.java.net/browse/JDK-8160597)|IllegalArgumentException when we initiate drag on Image|window-toolkit
-[JDK-8227371](https://bugs.openjdk.java.net/browse/JDK-8227371)|Drag&Drop while holding the CMD key does not work on macOS|window-toolkit
-[JDK-8242544](https://bugs.openjdk.java.net/browse/JDK-8242544)|CMD+ENTER key event crashes the application when invoked on dialog|window-toolkit
-[JDK-8269967](https://bugs.openjdk.java.net/browse/JDK-8269967)|JavaFX should fail fast on macOS below minimum version|window-toolkit
-[JDK-8269968](https://bugs.openjdk.java.net/browse/JDK-8269968)|[REDO] Bump minimum version of macOS for x64 to 10.12|window-toolkit
-[JDK-8271398](https://bugs.openjdk.java.net/browse/JDK-8271398)|GTK3 drag view image swaps red and blue color channels|window-toolkit
-[JDK-8274929](https://bugs.openjdk.java.net/browse/JDK-8274929)|Crash while reading specific clipboard content|window-toolkit
-[JDK-8275723](https://bugs.openjdk.java.net/browse/JDK-8275723)|Crash on macOS 12 in GlassRunnable::dealloc|window-toolkit
+[JDK-8203463](https://bugs.openjdk.org/browse/JDK-8203463)|[Accessibility, Narrator] NPE in TableView|accessibility
+[JDK-8273969](https://bugs.openjdk.org/browse/JDK-8273969)|Memory Leak on the Runnable provided to Platform.startup|application-lifecycle
+[JDK-8270838](https://bugs.openjdk.org/browse/JDK-8270838)|Remove deprecated protected access members from DateTimeStringConverter|base
+[JDK-8273138](https://bugs.openjdk.org/browse/JDK-8273138)|BidirectionalBinding fails to observe changes of invalid properties|base
+[JDK-8273754](https://bugs.openjdk.org/browse/JDK-8273754)|Re-introduce Automatic-Module-Name in empty jars|build
+[JDK-8278260](https://bugs.openjdk.org/browse/JDK-8278260)|JavaFX shared libraries not stripped on Linux or macOS|build
+[JDK-8089398](https://bugs.openjdk.org/browse/JDK-8089398)|[ChoiceBox, ComboBox] throws NPE on setting value on null selectionModel|controls
+[JDK-8090158](https://bugs.openjdk.org/browse/JDK-8090158)|Wrong implementation of adjustValue in scrollBars|controls
+[JDK-8187474](https://bugs.openjdk.org/browse/JDK-8187474)|Tree-/TableCell, TreeCell: editingCell/Item not updated in cell.startEdit|controls
+[JDK-8188026](https://bugs.openjdk.org/browse/JDK-8188026)|TextFieldXXCell: NPE on calling startEdit|controls
+[JDK-8188027](https://bugs.openjdk.org/browse/JDK-8188027)|List/TableCell: must not fire event in startEdit if already editing|controls
+[JDK-8191995](https://bugs.openjdk.org/browse/JDK-8191995)|Regression: DatePicker must commit on focusLost|controls
+[JDK-8197991](https://bugs.openjdk.org/browse/JDK-8197991)|Selecting many items in a TableView is very slow|controls
+[JDK-8205915](https://bugs.openjdk.org/browse/JDK-8205915)|[macOS] Accelerator assigned to button in dialog fires menuItem in owning stage|controls
+[JDK-8231644](https://bugs.openjdk.org/browse/JDK-8231644)|TreeTableView Regression: Indentation wrong using Label as column content type|controls
+[JDK-8240506](https://bugs.openjdk.org/browse/JDK-8240506)|TextFieldSkin/Behavior: misbehavior on switching skin|controls
+[JDK-8244419](https://bugs.openjdk.org/browse/JDK-8244419)|TextAreaSkin: throws UnsupportedOperation on dispose|controls
+[JDK-8268295](https://bugs.openjdk.org/browse/JDK-8268295)|Tree- and TableCell sub implementations should respect the row editability|controls
+[JDK-8269081](https://bugs.openjdk.org/browse/JDK-8269081)|Tree/ListViewSkin: must remove flow on dispose|controls
+[JDK-8269871](https://bugs.openjdk.org/browse/JDK-8269871)|CellEditEvent: must not throw NPE in accessors|controls
+[JDK-8271474](https://bugs.openjdk.org/browse/JDK-8271474)|Tree-/TableCell: inconsistent edit event firing pattern|controls
+[JDK-8271484](https://bugs.openjdk.org/browse/JDK-8271484)|Tree-/TableCell: NPE when accessing edit event from startEdit|controls
+[JDK-8272118](https://bugs.openjdk.org/browse/JDK-8272118)|ListViewSkin et al: must not cancel edit on scrolling|controls
+[JDK-8273071](https://bugs.openjdk.org/browse/JDK-8273071)|SeparatorSkin: must remove child on dispose|controls
+[JDK-8273324](https://bugs.openjdk.org/browse/JDK-8273324)|IllegalArgumentException: fromIndex(0) > toIndex(-1) after clear and select TableCell|controls
+[JDK-8274022](https://bugs.openjdk.org/browse/JDK-8274022)|Additional Memory Leak in ControlAcceleratorSupport|controls
+[JDK-8274061](https://bugs.openjdk.org/browse/JDK-8274061)|Tree-/TableRowSkin: misbehavior on switching skin|controls
+[JDK-8274137](https://bugs.openjdk.org/browse/JDK-8274137)|TableView scrollbar/header misaligned when reloading data|controls
+[JDK-8274854](https://bugs.openjdk.org/browse/JDK-8274854)|Mnemonics for menu containing numeric text not working|controls
+[JDK-8274433](https://bugs.openjdk.org/browse/JDK-8274433)|All Cells: misbehavior of startEdit|controls
+[JDK-8274699](https://bugs.openjdk.org/browse/JDK-8274699)|Certain blend modes cannot be set from CSS|controls
+[JDK-8274669](https://bugs.openjdk.org/browse/JDK-8274669)|Dialog sometimes ignores max height|controls
+[JDK-8275911](https://bugs.openjdk.org/browse/JDK-8275911)|Keyboard doesn't show when tapping inside an iOS text input control|controls
+[JDK-8276167](https://bugs.openjdk.org/browse/JDK-8276167)|VirtualFlow.scrollToTop doesn't scroll to the top of the last element|controls
+[JDK-8276313](https://bugs.openjdk.org/browse/JDK-8276313)|ScrollPane scroll delta incorrectly depends on content height|controls
+[JDK-8276553](https://bugs.openjdk.org/browse/JDK-8276553)|ListView scrollTo() is broken after fix for JDK-8089589|controls
+[JDK-8281207](https://bugs.openjdk.org/browse/JDK-8281207)|TableView scrollTo() will not show last row for a custom cell factory.|controls
+[JDK-8232812](https://bugs.openjdk.org/browse/JDK-8232812)|[MacOS] Double click title bar does not restore window size|graphics
+[JDK-8236689](https://bugs.openjdk.org/browse/JDK-8236689)|macOS 10.15 Catalina: LCD text renders badly|graphics
+[JDK-8254956](https://bugs.openjdk.org/browse/JDK-8254956)|[REDO] Memoryleak: Closed focused Stages are not collected with Monocle|graphics
+[JDK-8255015](https://bugs.openjdk.org/browse/JDK-8255015)|Inconsistent illumination of 3D shape by PointLight|graphics
+[JDK-8269374](https://bugs.openjdk.org/browse/JDK-8269374)|Menu inoperable after setting stage to second monitor|graphics
+[JDK-8269638](https://bugs.openjdk.org/browse/JDK-8269638)|Property methods, setters, and getters in printing API should be final|graphics
+[JDK-8269639](https://bugs.openjdk.org/browse/JDK-8269639)|[macos] Calling stage.setY(0) twice causes wrong popups location|graphics
+[JDK-8276490](https://bugs.openjdk.org/browse/JDK-8276490)|Incorrect path for duplicate x and y values, when path falls outside axis bound|graphics
+[JDK-8276915](https://bugs.openjdk.org/browse/JDK-8276915)|Crash on iOS 15.1 in GlassRunnable::dealloc|graphics
+[JDK-8278905](https://bugs.openjdk.org/browse/JDK-8278905)|JavaFX: EnumConverter has a typo in the toString method|graphics
+[JDK-8279328](https://bugs.openjdk.org/browse/JDK-8279328)|CssParser uses default charset instead of UTF-8|graphics
+[JDK-8253351](https://bugs.openjdk.org/browse/JDK-8253351)|MediaPlayer does not display an mp4 if there no speakers connected to the PC's|media
+[JDK-8268718](https://bugs.openjdk.org/browse/JDK-8268718)|[macos] Video stops, but audio continues to play when stopTime is reached|media
+[JDK-8222455](https://bugs.openjdk.org/browse/JDK-8222455)|JavaFX error loading glass.dll from cache|other
+[JDK-8270839](https://bugs.openjdk.org/browse/JDK-8270839)|Remove deprecated implementation methods from Scene|scenegraph
+[JDK-8268849](https://bugs.openjdk.org/browse/JDK-8268849)|Update to 612.1 version of WebKit|web
+[JDK-8270479](https://bugs.openjdk.org/browse/JDK-8270479)|WebKit 612.1 build fails with Visual Studio 2017|web
+[JDK-8272329](https://bugs.openjdk.org/browse/JDK-8272329)|Cherry pick GTK WebKit 2.32.3 changes|web
+[JDK-8274107](https://bugs.openjdk.org/browse/JDK-8274107)|Cherry pick GTK WebKit 2.32.4 changes|web
+[JDK-8275138](https://bugs.openjdk.org/browse/JDK-8275138)|WebView: UserAgent string is empty for first request|web
+[JDK-8276847](https://bugs.openjdk.org/browse/JDK-8276847)|JSException: ReferenceError: Can't find variable: IntersectionObserver|web
+[JDK-8277133](https://bugs.openjdk.org/browse/JDK-8277133)|Dragboard contents retrieved all over again during a DND process on WebView|web
+[JDK-8277457](https://bugs.openjdk.org/browse/JDK-8277457)|AccessControlException: access denied ("java.net.NetPermission" "getCookieHandler")|web
+[JDK-8160597](https://bugs.openjdk.org/browse/JDK-8160597)|IllegalArgumentException when we initiate drag on Image|window-toolkit
+[JDK-8227371](https://bugs.openjdk.org/browse/JDK-8227371)|Drag&Drop while holding the CMD key does not work on macOS|window-toolkit
+[JDK-8242544](https://bugs.openjdk.org/browse/JDK-8242544)|CMD+ENTER key event crashes the application when invoked on dialog|window-toolkit
+[JDK-8269967](https://bugs.openjdk.org/browse/JDK-8269967)|JavaFX should fail fast on macOS below minimum version|window-toolkit
+[JDK-8269968](https://bugs.openjdk.org/browse/JDK-8269968)|[REDO] Bump minimum version of macOS for x64 to 10.12|window-toolkit
+[JDK-8271398](https://bugs.openjdk.org/browse/JDK-8271398)|GTK3 drag view image swaps red and blue color channels|window-toolkit
+[JDK-8274929](https://bugs.openjdk.org/browse/JDK-8274929)|Crash while reading specific clipboard content|window-toolkit
+[JDK-8275723](https://bugs.openjdk.org/browse/JDK-8275723)|Crash on macOS 12 in GlassRunnable::dealloc|window-toolkit
 
 ## List of Security fixes
 

--- a/modules/javafx.base/src/main/version-info/VersionInfo.java
+++ b/modules/javafx.base/src/main/version-info/VersionInfo.java
@@ -37,7 +37,7 @@ package com.sun.javafx.runtime;
  * System Properties at the loading of the JavaFX Toolkit. The JavaFX properties
  * are javafx.version and javafx.runtime.version. Their formats follow the
  * specification of java.version and java.runtime.version respectively.
- * See http://openjdk.java.net/jeps/223 for details.
+ * See https://openjdk.org/jeps/223 for details.
  *
  * For example, an early access build of JavaFX 9 build 76 will contain
  * the following properties:
@@ -147,7 +147,7 @@ public class VersionInfo {
      * The format of the value strings of javafx.version and javafx.runtime.version
      * will follow the same pattern as java.version and java.runtime.version
      * respectively.
-     * See http://openjdk.java.net/jeps/223 for details.
+     * See https://openjdk.org/jeps/223 for details.
      */
     public static synchronized void setupSystemProperties() {
         if (System.getProperty("javafx.version") == null) {

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyEventFirer.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/KeyEventFirer.java
@@ -51,7 +51,7 @@ public class KeyEventFirer {
      * <p>
      * Beware: using this constructor on an <code>EventTarget</code> of type <code>Node</code>
      * which is not focusOwner may lead
-     * to false greens (see https://bugs.openjdk.java.net/browse/JDK-8231692).
+     * to false greens (see https://bugs.openjdk.org/browse/JDK-8231692).
      *
      * @param target the target to fire keyEvents onto, must not be null.
      * @throws NullPointerException if target is null.

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxLabelTextTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxLabelTextTest.java
@@ -52,7 +52,7 @@ import javafx.util.StringConverter;
 
 /**
  * Contains tests around the text shown in the box's label, mainly covering
- * fix for https://bugs.openjdk.java.net/browse/JDK-8087555.
+ * fix for https://bugs.openjdk.org/browse/JDK-8087555.
  *
  * <p>
  * It is parameterized in the converter

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxSelectionTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ChoiceBoxSelectionTest.java
@@ -125,7 +125,7 @@ public class ChoiceBoxSelectionTest {
     }
 
     /**
-     * Not quite https://bugs.openjdk.java.net/browse/JDK-8089398
+     * Not quite https://bugs.openjdk.org/browse/JDK-8089398
      * (the issue there is setting value while selectionModel == null)
      *
      * This here throws NPE if selectionModel is null when the skin is attached.

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboSpecialKeyTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ComboSpecialKeyTest.java
@@ -58,7 +58,7 @@ import test.com.sun.javafx.pgstub.StubToolkit;
 import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
 
 /**
- * Test for https://bugs.openjdk.java.net/browse/JDK-8233040 - F4
+ * Test for https://bugs.openjdk.org/browse/JDK-8233040 - F4
  * must not be consumed by EventFilter in ComboBoxPopupControl.
  * <p>
  * Parameterized in concrete sub of ComboBoxBase and editable.

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/DefaultCancelButtonTestBase.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/DefaultCancelButtonTestBase.java
@@ -63,7 +63,7 @@ import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
  * <li> default/cancel button
  * <li> not/consuming external handler
  * <li> handler registration before/after showing the stage: this is due to
- *   https://bugs.openjdk.java.net/browse/JDK-8231245 (Controls' behavior
+ *   https://bugs.openjdk.org/browse/JDK-8231245 (Controls' behavior
  *   depends on sequence of handler registration). The errors mostly show up
  *   when the handlers are registered after the stage is shown.
  * <li> added filter/handler/singleton handler and no handler at all

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SelectionFocusModelMemoryTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SelectionFocusModelMemoryTest.java
@@ -70,7 +70,7 @@ import javafx.stage.Stage;
 
 /**
  * Testing for potential memory leaks in xxSelectionModel and xxFocusModel (
- * https://bugs.openjdk.java.net/browse/JDK-8241455).
+ * https://bugs.openjdk.org/browse/JDK-8241455).
  * Might happen, when the concrete selection/focusModel registers strong listeners on any of the
  * control's properties.
  * <p>

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
@@ -832,7 +832,7 @@ public class TableCellTest {
      * Test that cell.cancelEdit can switch table editing off
      * even if a subclass violates its contract.
      *
-     * For details, see https://bugs.openjdk.java.net/browse/JDK-8265206
+     * For details, see https://bugs.openjdk.org/browse/JDK-8265206
      *
      */
     @Test

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
@@ -364,7 +364,7 @@ public class TextFieldTest {
     }
 
     /**
-     * Test related to https://bugs.openjdk.java.net/browse/JDK-8207759
+     * Test related to https://bugs.openjdk.org/browse/JDK-8207759
      * broken event dispatch sequence by forwardToParent.
      */
     @Test

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
@@ -1144,7 +1144,7 @@ public class TreeTableCellTest {
      * Test that cell.cancelEdit can switch table editing off
      * even if a subclass violates its contract.
      *
-     * For details, see https://bugs.openjdk.java.net/browse/JDK-8265206
+     * For details, see https://bugs.openjdk.org/browse/JDK-8265206
      *
      */
     @Test

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
@@ -3733,7 +3733,7 @@ public class TreeViewTest {
      * Test that cell.cancelEdit can switch tree editing off
      * even if a subclass violates its contract.
      *
-     * For details, see https://bugs.openjdk.java.net/browse/JDK-8265206
+     * For details, see https://bugs.openjdk.org/browse/JDK-8265206
      *
      */
     @Test

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/ListCellStartEditTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/ListCellStartEditTest.java
@@ -122,7 +122,7 @@ public class ListCellStartEditTest {
 
         if (listCell instanceof CheckBoxListCell) {
             assertNotNull(listCell.getGraphic());
-            // Ignored until https://bugs.openjdk.java.net/browse/JDK-8270042 is resolved.
+            // Ignored until https://bugs.openjdk.org/browse/JDK-8270042 is resolved.
             // Check if the checkbox is disabled when not editable.
             // assertEquals(expectedEditingState, !listCell.getGraphic().isDisabled());
         } else if (!listCell.getClass().equals(ListCell.class)) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TableCellStartEditTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TableCellStartEditTest.java
@@ -145,7 +145,7 @@ public class TableCellStartEditTest {
 
         if (tableCell instanceof CheckBoxTableCell) {
             assertNotNull(tableCell.getGraphic());
-            // Ignored until https://bugs.openjdk.java.net/browse/JDK-8270042 is resolved.
+            // Ignored until https://bugs.openjdk.org/browse/JDK-8270042 is resolved.
             // Check if the checkbox is disabled when not editable.
             // assertEquals(expectedEditingState, !tableCell.getGraphic().isDisabled());
         } else if (tableCell instanceof ProgressBarTableCell) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TreeCellStartEditTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TreeCellStartEditTest.java
@@ -123,7 +123,7 @@ public class TreeCellStartEditTest {
 
         if (treeCell instanceof CheckBoxTreeCell) {
             assertNotNull(treeCell.getGraphic());
-            // Ignored until https://bugs.openjdk.java.net/browse/JDK-8270042 is resolved.
+            // Ignored until https://bugs.openjdk.org/browse/JDK-8270042 is resolved.
             // Check if the checkbox is disabled when not editable.
             // assertEquals(expectedEditingState, !treeCell.getGraphic().isDisabled());
         } else if (!treeCell.getClass().equals(TreeCell.class)) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TreeTableCellStartEditTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/cell/TreeTableCellStartEditTest.java
@@ -146,7 +146,7 @@ public class TreeTableCellStartEditTest {
 
         if (treeTableCell instanceof CheckBoxTreeTableCell) {
             assertNotNull(treeTableCell.getGraphic());
-            // Ignored until https://bugs.openjdk.java.net/browse/JDK-8270042 is resolved.
+            // Ignored until https://bugs.openjdk.org/browse/JDK-8270042 is resolved.
             // Check if the checkbox is disabled when not editable.
             // assertEquals(expectedEditingState, !treeTableCell.getGraphic().isDisabled());
         } else if (treeTableCell instanceof ProgressBarTreeTableCell) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinDisposeContractTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinDisposeContractTest.java
@@ -40,7 +40,7 @@ import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactor
 import javafx.scene.control.Control;
 
 /**
- * Test for https://bugs.openjdk.java.net/browse/JDK-8244112:
+ * Test for https://bugs.openjdk.org/browse/JDK-8244112:
  * skin must not blow if dispose is called more than once.
  * <p>
  * This test is parameterized in the type of control.

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TabPaneSkinHeaderOrderTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TabPaneSkinHeaderOrderTest.java
@@ -45,8 +45,8 @@ import static org.junit.Assert.*;
 
 /**
  * Testing sync'ing of tab headers with tabs.
- * https://bugs.openjdk.java.net/browse/JDK-8222457
- * https://bugs.openjdk.java.net/browse/JDK-8237602
+ * https://bugs.openjdk.org/browse/JDK-8222457
+ * https://bugs.openjdk.org/browse/JDK-8237602
  *
  * All basically the same issue: the listChangeListener is not correctly
  * updating the tab headers.

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDInputDeviceRegistry.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/EPDInputDeviceRegistry.java
@@ -123,7 +123,7 @@ class EPDInputDeviceRegistry extends InputDeviceRegistry {
      * Creates a Linux input device with the given properties.
      *
      * @implNote Works around bug
-     * <a href="https://bugs.openjdk.java.net/browse/JDK-8201568">JDK-8201568</a>,
+     * <a href="https://bugs.openjdk.org/browse/JDK-8201568">JDK-8201568</a>,
      * "zForce touchscreen input device fails when closed and immediately
      * reopened," by opening the device before creating its
      * {@code LinuxInputDevice}.

--- a/tests/manual/printing/PrintPerformanceTest.java
+++ b/tests/manual/printing/PrintPerformanceTest.java
@@ -69,7 +69,7 @@ public class PrintPerformanceTest extends Application {
     }
 
     static final String instructions =
-            "This is regression test for 8150181 (see https://bugs.openjdk.java.net/browse/JDK-8150181 ).\n" +
+            "This is regression test for 8150181 (see https://bugs.openjdk.org/browse/JDK-8150181 ).\n" +
                     "Use *ONLY A VIRTUAL* printer for this test. Press print button, after this 120 pages will be printed.\n" +
                     "Printing job should take relatively small time( because we use virtual printer), " +
                     "if pages won't be printed after 60 seconds then test is failed, otherwise it is passed.";

--- a/tests/manual/printing/PrintTest.java
+++ b/tests/manual/printing/PrintTest.java
@@ -74,7 +74,7 @@ public class PrintTest extends Application {
     }
 
     static final String instructions =
-            "This is regression test for 8150076 (see https://bugs.openjdk.java.net/browse/JDK-8150076 ).\n" +
+            "This is regression test for 8150076 (see https://bugs.openjdk.org/browse/JDK-8150076 ).\n" +
                     "Press print button, after this 2 pages must be printed. When all pages are printed you will " +
                     "see \"PASSED!\" message below, otherwise test is failed.";
 

--- a/tests/manual/web/dnd/DNDWebViewTest.java
+++ b/tests/manual/web/dnd/DNDWebViewTest.java
@@ -44,7 +44,7 @@ public class DNDWebViewTest extends Application {
         final Button offlineButton = new Button("Offline test");
         final Button onlineButton = new Button("Online test");
         offlineButton.setOnAction(e -> webView.getEngine().load(getClass().getResource("drag.html").toExternalForm()));
-        onlineButton.setOnAction(e -> webView.getEngine().load("https://openjdk.java.net"));
+        onlineButton.setOnAction(e -> webView.getEngine().load("https://openjdk.org"));
 
         final Label instructions = new Label("Select a test and drag the images");
         final Label readTime = new Label("");


### PR DESCRIPTION
Simple replacement of `openjdk.java.net` with `openjdk.org` everywhere (except `ASSEMBLY_EXCEPTION`, which is a legal file copied from the mainline `jdk` repo). While doing this I also fixed a few places that were using `http` rather than `https`.
