### PR TITLE
8276056: Control.skin.setSkin(Skin) fails to call dispose() on discarded Skin

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/Control.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/Control.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -236,19 +236,6 @@ public abstract class Control extends Region implements Skinnable {
         // only needed because invalidated() does not currently take
         // a reference to the old value.
         private Skin<?> oldValue;
-
-        @Override
-        //This code is basically a kind of optimization that prevents a Skin that is equal but not instance equal.
-        //Although it's not kosher from the property perspective (bindings won't pass through set), it should not do any harm.
-        //But it should be evaluated in the future.
-        public void set(Skin<?> v) {
-            if (v == null
-                ? oldValue == null
-                : oldValue != null && v.getClass().equals(oldValue.getClass()))
-                return;
-
-            super.set(v);
-        }
 
         @Override protected void invalidated() {
             Skin<?> skin = get();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinMemoryLeakTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinMemoryLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,6 +76,40 @@ public class SkinMemoryLeakTest {
     private Control control;
 
 //--------- tests
+
+    /**
+     * default skin -> set another instance of default skin
+     */
+    @Test
+    public void testMemoryLeakSameSkinClass() {
+        installDefaultSkin(control);
+        Skin<?> skin = control.getSkin();
+        installDefaultSkin(control);
+
+        WeakReference<?> weakRef = new WeakReference<>(skin);
+        skin = null;
+        attemptGC(weakRef);
+        assertNull("Unused Skin must be gc'ed", weakRef.get());
+    }
+
+    @Test
+    public void testControlChildrenSameSkinClass() {
+        installDefaultSkin(control);
+        int childCount = control.getChildrenUnmodifiable().size();
+        installDefaultSkin(control);
+        assertEquals("Old skin should dispose children when a new skin is set",
+                childCount, control.getChildrenUnmodifiable().size());
+    }
+
+    @Test
+    public void testSetSkinOfSameClass() {
+        installDefaultSkin(control);
+        Skin<?> oldSkin = control.getSkin();
+        installDefaultSkin(control);
+        Skin<?> newSkin = control.getSkin();
+
+        assertNotEquals("New skin was not set", oldSkin, newSkin);
+    }
 
     /**
      * default skin -> set alternative


### PR DESCRIPTION
For some reason the `skinProperty` did not allow to set a new skin which is the same class as the previous one.
This leads to multiple issues:
1. When creating a new skin (same class as previous), the skin will likely install some children and listener but is then rejected when setting it due to the `skinProperty` class constraint
-> Control is in a weird state as the current skin was not disposed since it is still set, although we already and 'set' a new skin
2. A skin of the same class can behave differently, so it is not really valid to reject a skin just because it is the same class as the previous
-> Just imagine we have the following skin class
```
class MyCustomButtonSkin extends ButtonSkin {
    public MyCustomButtonSkin(Button button, boolean someFlag) { super(button); ... }
}
```
Now if we would change the skin of the Button two times like this:
```
button.setSkin(new MyCustomButtonSkin(button, true));
button.setSkin(new MyCustomButtonSkin(button, false));
```
The second time the skin will be rejected as it is the same class, although I may changed the skin behaviour, in this case demonstrated by a boolean flag for showing purposes.