### PR TITLE
8289587: IllegalArgumentException: Color.rgb's red parameter (-16776961) expects color values 0-255

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/ColorChooserJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/ColorChooserJava.cpp
@@ -44,14 +44,15 @@ ColorChooserJava::ColorChooserJava(JGObject& webPage, ColorChooserClient* client
         "(Lcom/sun/webkit/WebPage;IIIJ)Lcom/sun/webkit/ColorChooser;");
     ASSERT(mid);
 
+    auto [r, g, b, a] = color.toSRGBALossy<uint8_t>();
 
     m_colorChooserRef = JGObject(env->CallStaticObjectMethod(
         PG_GetColorChooserClass(env),
         mid,
         (jobject) webPage,
-        color.red,
-        color.green,
-        color.blue,
+        r,
+        g,
+        b,
         ptr_to_jlong(this)));
 
     ASSERT(m_colorChooserClient);
@@ -69,12 +70,14 @@ void ColorChooserJava::reattachColorChooser(const Color& color)
         "(III)V");
     ASSERT(mid);
 
+    auto [r, g, b, a] = color.toSRGBALossy<uint8_t>();
+
     env->CallVoidMethod(
         m_colorChooserRef,
         mid,
-        color.red,
-        color.green,
-        color.blue);
+        r,
+        g,
+        b);
     WTF::CheckAndClearException(env);
 }
 

--- a/tests/system/src/test/addExports
+++ b/tests/system/src/test/addExports
@@ -26,6 +26,8 @@
 --add-exports javafx.graphics/com.sun.javafx.tk=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.prism.impl=ALL-UNNAMED
 #
+--add-exports=javafx.controls/com.sun.javafx.scene.control=ALL-UNNAMED
+#
 --add-exports javafx.web/com.sun.webkit=ALL-UNNAMED
 # compilation additions
 --add-exports=javafx.graphics/com.sun.glass.events=ALL-UNNAMED

--- a/tests/system/src/test/java/test/javafx/scene/web/ColorChooserTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/ColorChooserTest.java
@@ -38,136 +38,132 @@ import javafx.scene.paint.Color;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
 import javafx.stage.Window;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import test.util.Util;
 
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 public class ColorChooserTest {
     private static final CountDownLatch launchLatch = new CountDownLatch(1);
 
-    static ColorChooserTestApp colorChooserTestApp;
+    static volatile Stage stage;
+    static volatile ColorChooserTestApp colorChooserTestApp;
 
-    private WebView webView;
-    private Scene scene;
-    private int counter;
-    private final List<String> colors = List.of("#ff3300", "#3367ff", "#cc072d");
+    @Test
+    public void testColorChooser() {
+        colorChooserTestApp.startTest();
+    }
+
+    @BeforeAll
+    public static void setupOnce() {
+        new Thread(() -> Application.launch(ColorChooserTestApp.class, (String[]) null)).start();
+        Assertions.assertTrue(Util.await(launchLatch), "Timeout waiting for FX runtime to start");
+    }
+
+    @AfterAll
+    public static void tearDownOnce() {
+        Platform.runLater(stage::hide);
+        Platform.exit();
+    }
 
     public static class ColorChooserTestApp extends Application {
-        Stage primaryStage = null;
+
+        private WebView webView;
+        private Scene scene;
+        private int counter;
+        private final List<String> colors = List.of("#ff3300", "#3367ff", "#cc072d");
 
         @Override
         public void init() {
-            ColorChooserTest.colorChooserTestApp = this;
+            colorChooserTestApp = this;
         }
 
         @Override
         public void start(Stage primaryStage) throws Exception {
             Platform.setImplicitExit(false);
-            this.primaryStage = primaryStage;
-            launchLatch.countDown();
-        }
-    }
+            stage = primaryStage;
 
-    @BeforeClass
-    public static void setupOnce() {
-        // Start the Test Application
-        new Thread(() -> Application.launch(ColorChooserTestApp.class, (String[])null)).start();
-
-        assertTrue("Timeout waiting for FX runtime to start", Util.await(launchLatch));
-    }
-
-    @AfterClass
-    public static void tearDownOnce() {
-        Platform.exit();
-    }
-
-    @Before
-    public void setupTestObjects() {
-        Platform.runLater(() -> {
             webView = new WebView();
             scene = new Scene(webView);
-            colorChooserTestApp.primaryStage.setScene(scene);
-            colorChooserTestApp.primaryStage.setAlwaysOnTop(true);
-            colorChooserTestApp.primaryStage.setWidth(300);
-            colorChooserTestApp.primaryStage.setHeight(300);
-            colorChooserTestApp.primaryStage.show();
-        });
-    }
-
-    @Test public void testColorChooser() {
-        final CountDownLatch webViewStateLatch = new CountDownLatch(2);
-
-        Util.runAndWait(() -> {
-            assertNotNull(webView);
-            Window.getWindows().addListener((ListChangeListener<Window>) change -> {
-                while (change.next()) {
-                    if (change.wasAdded()) {
-                        change.getAddedSubList().stream()
-                                .filter(w -> w.getScene().getRoot() instanceof CustomColorDialog)
-                                .findFirst()
-                                .map(w -> (CustomColorDialog) w.getScene().getRoot())
-                                .ifPresent(dialog -> {
-                                    assertEquals(dialog.getCurrentColor(), Color.web(colors.get(counter - 1)));
-                                    dialog.setCustomColor(Color.web(colors.get(counter)));
-                                    HBox box = (HBox) dialog.lookup("#buttons-hbox");
-                                    Button ok = (Button) box.getChildren().get(0);
-                                    Platform.runLater(() -> {
-                                        ok.fire();
-                                        webViewStateLatch.countDown();
-                                    });
-                                });
-                    }
-                }
-            });
-            webView.getEngine().setOnAlert(event -> {
-                assertNotNull(event.getData());
-                assertEquals(event.getData(), "color: " + colors.get(counter++));
-            });
-            webView.getEngine().loadContent("<head>" +
-                    "<script>" +
-                    "   function logColor(event) {" +
-                    "        var color = document.querySelector(\"#color\");\n" +
-                    "        alert(\"color: \" + color.value);" +
-                    "   }\n" +
-                    "   setTimeout(\n" +
-                    "     () => {\n" +
-                    "        var color = document.querySelector(\"#color\");\n" +
-                    "        color.addEventListener(\"change\", logColor, false);" +
-                    "        alert(\"color: \" + color.value);" +
-                    "     }, 100);" +
-                    "</script>" +
-                    "</head>" +
-                    "<body>" +
-                    "   <input id=\"color\" type=\"color\" value=\"" + colors.get(0) + "\">" +
-                    "</body>");
-        });
-
-        Util.sleep(100);
-        Util.runAndWait(() -> webView.requestFocus());
-        for (int i = 0; i < 2; i++) {
-            // the first time, it creates the dialog (fwkCreateAndShowColorChooser),
-            // the second time, it reuses it (fwkShowColorChooser)
-            Util.sleep(100);
-            Util.runAndWait(() -> {
-                webView.fireEvent(new MouseEvent(MouseEvent.MOUSE_PRESSED, 30,
-                        15, (int) (scene.getWindow().getX() + scene.getX() + 30),
-                        (int) (scene.getWindow().getY() + scene.getY() + 15), MouseButton.PRIMARY, 1,
-                        false, false, false, false, true, false, false, true, false, false, null));
-                webView.fireEvent(new MouseEvent(MouseEvent.MOUSE_RELEASED, 30,
-                        15, (int) (scene.getWindow().getX() + scene.getX() + 30),
-                        (int) (scene.getWindow().getY() + scene.getY() + 15), MouseButton.PRIMARY, 1,
-                        false, false, false, false, false, false, false, true, false, false, null));
-            });
+            stage.setScene(scene);
+            stage.setAlwaysOnTop(true);
+            stage.setWidth(300);
+            stage.setHeight(300);
+            stage.setOnShown(e -> launchLatch.countDown());
+            stage.show();
         }
-        assertTrue("Timeout when waiting for color chooser ", Util.await(webViewStateLatch));
+
+        public void startTest() {
+            final CountDownLatch webViewStateLatch = new CountDownLatch(2);
+
+            Util.runAndWait(() -> {
+                Assertions.assertNotNull(webView);
+                Window.getWindows().addListener((ListChangeListener<Window>) change -> {
+                    while (change.next()) {
+                        if (change.wasAdded()) {
+                            change.getAddedSubList().stream()
+                                    .filter(w -> w.getScene().getRoot() instanceof CustomColorDialog)
+                                    .findFirst()
+                                    .map(w -> (CustomColorDialog) w.getScene().getRoot())
+                                    .ifPresent(dialog -> {
+                                        Assertions.assertEquals(dialog.getCurrentColor(), Color.web(colors.get(counter - 1)));
+                                        dialog.setCustomColor(Color.web(colors.get(counter)));
+                                        HBox box = (HBox) dialog.lookup("#buttons-hbox");
+                                        Button ok = (Button) box.getChildren().get(0);
+                                        Platform.runLater(() -> {
+                                            ok.fire();
+                                            webViewStateLatch.countDown();
+                                        });
+                                    });
+                        }
+                    }
+                });
+                webView.getEngine().setOnAlert(event -> {
+                    Assertions.assertNotNull(event.getData());
+                    Assertions.assertEquals(event.getData(), "color: " + colors.get(counter++));
+                });
+                webView.getEngine().loadContent("<head>" +
+                        "<script>" +
+                        "   function logColor(event) {" +
+                        "        var color = document.querySelector(\"#color\");\n" +
+                        "        alert(\"color: \" + color.value);" +
+                        "   }\n" +
+                        "   setTimeout(\n" +
+                        "     () => {\n" +
+                        "        var color = document.querySelector(\"#color\");\n" +
+                        "        color.addEventListener(\"change\", logColor, false);" +
+                        "        alert(\"color: \" + color.value);" +
+                        "     }, 100);" +
+                        "</script>" +
+                        "</head>" +
+                        "<body>" +
+                        "   <input id=\"color\" type=\"color\" value=\"" + colors.get(0) + "\">" +
+                        "</body>");
+            });
+
+            Util.sleep(100);
+            Util.runAndWait(() -> webView.requestFocus());
+            for (int i = 0; i < 2; i++) {
+                // the first time, it creates the dialog (fwkCreateAndShowColorChooser),
+                // the second time, it reuses it (fwkShowColorChooser)
+                Util.sleep(100);
+                Util.runAndWait(() -> {
+                    webView.fireEvent(new MouseEvent(MouseEvent.MOUSE_PRESSED, 30,
+                            15, (int) (stage.getX() + scene.getX() + 30),
+                            (int) (stage.getY() + scene.getY() + 15), MouseButton.PRIMARY, 1,
+                            false, false, false, false, true, false, false, true, false, false, null));
+                    webView.fireEvent(new MouseEvent(MouseEvent.MOUSE_RELEASED, 30,
+                            15, (int) (stage.getX() + scene.getX() + 30),
+                            (int) (stage.getY() + scene.getY() + 15), MouseButton.PRIMARY, 1,
+                            false, false, false, false, false, false, false, true, false, false, null));
+                });
+            }
+            Assertions.assertTrue(Util.await(webViewStateLatch), "Timeout when waiting for color chooser");
+        }
     }
+
 }

--- a/tests/system/src/test/java/test/javafx/scene/web/ColorChooserTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/ColorChooserTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.web;
+
+import com.sun.javafx.scene.control.CustomColorDialog;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.collections.ListChangeListener;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.layout.HBox;
+import javafx.scene.paint.Color;
+import javafx.scene.web.WebView;
+import javafx.stage.Stage;
+import javafx.stage.Window;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import test.util.Util;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class ColorChooserTest {
+    private static final CountDownLatch launchLatch = new CountDownLatch(1);
+
+    static ColorChooserTestApp colorChooserTestApp;
+
+    private WebView webView;
+    private Scene scene;
+    private int counter;
+    private final List<String> colors = List.of("#ff3300", "#3367ff", "#cc072d");
+
+    public static class ColorChooserTestApp extends Application {
+        Stage primaryStage = null;
+
+        @Override
+        public void init() {
+            ColorChooserTest.colorChooserTestApp = this;
+        }
+
+        @Override
+        public void start(Stage primaryStage) throws Exception {
+            Platform.setImplicitExit(false);
+            this.primaryStage = primaryStage;
+            launchLatch.countDown();
+        }
+    }
+
+    @BeforeClass
+    public static void setupOnce() {
+        // Start the Test Application
+        new Thread(() -> Application.launch(ColorChooserTestApp.class, (String[])null)).start();
+
+        assertTrue("Timeout waiting for FX runtime to start", Util.await(launchLatch));
+    }
+
+    @AfterClass
+    public static void tearDownOnce() {
+        Platform.exit();
+    }
+
+    @Before
+    public void setupTestObjects() {
+        Platform.runLater(() -> {
+            webView = new WebView();
+            scene = new Scene(webView);
+            colorChooserTestApp.primaryStage.setScene(scene);
+            colorChooserTestApp.primaryStage.setAlwaysOnTop(true);
+            colorChooserTestApp.primaryStage.setWidth(300);
+            colorChooserTestApp.primaryStage.setHeight(300);
+            colorChooserTestApp.primaryStage.show();
+        });
+    }
+
+    @Test public void testColorChooser() {
+        final CountDownLatch webViewStateLatch = new CountDownLatch(2);
+
+        Util.runAndWait(() -> {
+            assertNotNull(webView);
+            Window.getWindows().addListener((ListChangeListener<Window>) change -> {
+                while (change.next()) {
+                    if (change.wasAdded()) {
+                        change.getAddedSubList().stream()
+                                .filter(w -> w.getScene().getRoot() instanceof CustomColorDialog)
+                                .findFirst()
+                                .map(w -> (CustomColorDialog) w.getScene().getRoot())
+                                .ifPresent(dialog -> {
+                                    assertEquals(dialog.getCurrentColor(), Color.web(colors.get(counter - 1)));
+                                    dialog.setCustomColor(Color.web(colors.get(counter)));
+                                    HBox box = (HBox) dialog.lookup("#buttons-hbox");
+                                    Button ok = (Button) box.getChildren().get(0);
+                                    Platform.runLater(() -> {
+                                        ok.fire();
+                                        webViewStateLatch.countDown();
+                                    });
+                                });
+                    }
+                }
+            });
+            webView.getEngine().setOnAlert(event -> {
+                assertNotNull(event.getData());
+                assertEquals(event.getData(), "color: " + colors.get(counter++));
+            });
+            webView.getEngine().loadContent("<head>" +
+                    "<script>" +
+                    "   function logColor(event) {" +
+                    "        var color = document.querySelector(\"#color\");\n" +
+                    "        alert(\"color: \" + color.value);" +
+                    "   }\n" +
+                    "   setTimeout(\n" +
+                    "     () => {\n" +
+                    "        var color = document.querySelector(\"#color\");\n" +
+                    "        color.addEventListener(\"change\", logColor, false);" +
+                    "        alert(\"color: \" + color.value);" +
+                    "     }, 100);" +
+                    "</script>" +
+                    "</head>" +
+                    "<body>" +
+                    "   <input id=\"color\" type=\"color\" value=\"" + colors.get(0) + "\">" +
+                    "</body>");
+        });
+
+        Util.sleep(100);
+        Util.runAndWait(() -> webView.requestFocus());
+        for (int i = 0; i < 2; i++) {
+            // the first time, it creates the dialog (fwkCreateAndShowColorChooser),
+            // the second time, it reuses it (fwkShowColorChooser)
+            Util.sleep(100);
+            Util.runAndWait(() -> {
+                webView.fireEvent(new MouseEvent(MouseEvent.MOUSE_PRESSED, 30,
+                        15, (int) (scene.getWindow().getX() + scene.getX() + 30),
+                        (int) (scene.getWindow().getY() + scene.getY() + 15), MouseButton.PRIMARY, 1,
+                        false, false, false, false, true, false, false, true, false, false, null));
+                webView.fireEvent(new MouseEvent(MouseEvent.MOUSE_RELEASED, 30,
+                        15, (int) (scene.getWindow().getX() + scene.getX() + 30),
+                        (int) (scene.getWindow().getY() + scene.getY() + 15), MouseButton.PRIMARY, 1,
+                        false, false, false, false, false, false, false, true, false, false, null));
+            });
+        }
+        assertTrue("Timeout when waiting for color chooser ", Util.await(webViewStateLatch));
+    }
+}


### PR DESCRIPTION
This PR solves an IAE exception that happens when invoking a ColorChooser control within a WebView, by getting the r, g, b values from the Color before calling the colorChooser.

A system test is included, to verify that there is no exception and the two native functions that are modified produce the expected color components.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8289587](https://bugs.openjdk.org/browse/JDK-8289587): IllegalArgumentException: Color.rgb's red parameter (-16776961) expects color values 0-255


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/809/head:pull/809` \
`$ git checkout pull/809`

Update a local copy of the PR: \
`$ git checkout pull/809` \
`$ git pull https://git.openjdk.org/jfx pull/809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 809`

View PR using the GUI difftool: \
`$ git pr show -t 809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/809.diff">https://git.openjdk.org/jfx/pull/809.diff</a>

</details>
