### PR TITLE
8289751: Multiple unit test failures after JDK-8251483

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import javafx.beans.property.SimpleStringProperty;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import com.sun.javafx.tk.Toolkit;
@@ -367,6 +368,7 @@ public class TableCellTest {
      * The item of the {@link TableRow} should not be null, when the {@link TableCell} is not empty.
      * See also: JDK-8251483
      */
+    @Ignore("Fails currently but will be enabled again in JDK-8289357")
     @Test
     public void testRowItemIsNotNullForNonEmptyCell() {
         TableColumn<String, String> tableColumn = new TableColumn<>();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
@@ -708,6 +708,7 @@ public class TreeTableCellTest {
      * The item of the {@link TreeTableRow} should not be null, when the {@link TreeTableCell} is not empty.
      * See also: JDK-8251483
      */
+    @Ignore("Fails currently but will be enabled again in JDK-8289357")
     @Test
     public void testRowItemIsNotNullForNonEmptyCell() {
         TreeTableColumn<String, String> treeTableColumn = new TreeTableColumn<>();


### PR DESCRIPTION
As also discussed in the ticket, we need to disable/ignore this two tests for now.

With the fix for [JDK-8251483](https://bugs.openjdk.org/browse/JDK-8251483) the table row item is never null in a non empty table cell.
In the meantime with [JDK-8251480](https://bugs.openjdk.org/browse/JDK-8251480) and [JDK-8285197](https://bugs.openjdk.org/browse/JDK-8285197) we changed the table column header autosizing to be more complete by adding the table row to the setup.
Unfortunately we don't set the table view for the table row, therefore it can not know the underlying item (he knows the index but not where he can get the corresponding data for that index) -> table row item can be null in a non empty table cell (again).

This will be fixed in https://github.com/openjdk/jfx/pull/805 (and the tests can be reenabled)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289751](https://bugs.openjdk.org/browse/JDK-8289751): Multiple unit test failures after JDK-8251483


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/811/head:pull/811` \
`$ git checkout pull/811`

Update a local copy of the PR: \
`$ git checkout pull/811` \
`$ git pull https://git.openjdk.org/jfx pull/811/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 811`

View PR using the GUI difftool: \
`$ git pr show -t 811`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/811.diff">https://git.openjdk.org/jfx/pull/811.diff</a>

</details>
