### PR TITLE
8289390: Fix warnings: type parameter E is hiding the type E

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/collections/FXCollections.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/FXCollections.java
@@ -1051,7 +1051,7 @@ public class FXCollections {
         }
 
         @Override
-        public <T> T[] toArray(T[] a) {
+        public <X> X[] toArray(X[] a) {
             synchronized(mutex) {
                 return backingList.toArray(a);
             }
@@ -1335,7 +1335,7 @@ public class FXCollections {
         }
 
         @Override
-        public <T> T[] toArray(T[] a) {
+        public <X> X[] toArray(X[] a) {
             return list.toArray(a);
         }
 
@@ -1631,7 +1631,7 @@ public class FXCollections {
         }
 
         @Override
-        public <E> E[] toArray(E[] a) {
+        public <X> X[] toArray(X[] a) {
             if (a.length > 0)
                 a[0] = null;
             return a;
@@ -1817,7 +1817,7 @@ public class FXCollections {
         }
 
         @Override
-        public <E> E[] toArray(E[] a) {
+        public <X> X[] toArray(X[] a) {
             synchronized(mutex) {
                 return backingSet.toArray(a);
             }


### PR DESCRIPTION
- trivial change removes 4 eclipse warnings

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289390](https://bugs.openjdk.org/browse/JDK-8289390): Fix warnings: type parameter E is hiding the type E


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/812/head:pull/812` \
`$ git checkout pull/812`

Update a local copy of the PR: \
`$ git checkout pull/812` \
`$ git pull https://git.openjdk.org/jfx pull/812/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 812`

View PR using the GUI difftool: \
`$ git pr show -t 812`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/812.diff">https://git.openjdk.org/jfx/pull/812.diff</a>

</details>
