### PR TITLE
8289396: Fix warnings: Null pointer access: The variable instance can only be null at this location

### DIFF
--- a/modules/javafx.graphics/src/test/java/test/javafx/css/RuleTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/RuleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -162,17 +162,6 @@ public class RuleTest {
         Rule instance = null;
         long expResult = 0l;
         long result = RuleShim.applies(instance, node, null);
-        assertEquals(expResult, result);
-        fail("The test case is a prototype.");
-    }
-
-    @Ignore("JDK-8234154")
-    @Test
-    public void testToString() {
-        System.out.println("toString");
-        Rule instance = null;
-        String expResult = "";
-        String result = instance.toString();
         assertEquals(expResult, result);
         fail("The test case is a prototype.");
     }


### PR DESCRIPTION
- removed meaningless test case

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289396](https://bugs.openjdk.org/browse/JDK-8289396): Fix warnings: Null pointer access: The variable instance can only be null at this location


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/813/head:pull/813` \
`$ git checkout pull/813`

Update a local copy of the PR: \
`$ git checkout pull/813` \
`$ git pull https://git.openjdk.org/jfx pull/813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 813`

View PR using the GUI difftool: \
`$ git pr show -t 813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/813.diff">https://git.openjdk.org/jfx/pull/813.diff</a>

</details>
