### PR TITLE
8279297: Remove Shape::setMode method

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/shape/ShapeHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/shape/ShapeHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,10 +109,6 @@ public abstract class ShapeHelper extends NodeHelper {
         return shapeAccessor.getMode(shape);
     }
 
-    public static void setMode(Shape shape, NGShape.Mode mode) {
-        shapeAccessor.setMode(shape, mode);
-    }
-
     public static void setShapeChangeListener(Shape shape, Runnable listener) {
         shapeAccessor.setShapeChangeListener(shape, listener);
     }
@@ -133,7 +129,6 @@ public abstract class ShapeHelper extends NodeHelper {
         Paint doCssGetFillInitialValue(Shape shape);
         Paint doCssGetStrokeInitialValue(Shape shape);
         NGShape.Mode getMode(Shape shape);
-        void setMode(Shape shape, NGShape.Mode mode);
         void setShapeChangeListener(Shape shape, Runnable listener);
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/shape/Shape.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/shape/Shape.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -160,11 +160,6 @@ public abstract class Shape extends Node {
             @Override
             public NGShape.Mode getMode(Shape shape) {
                 return shape.getMode();
-            }
-
-            @Override
-            public void setMode(Shape shape, NGShape.Mode mode) {
-                shape.setMode(mode);
             }
 
             @Override
@@ -400,10 +395,6 @@ public abstract class Shape extends Node {
 
     NGShape.Mode getMode() {
         return mode;
-    }
-
-    void setMode(NGShape.Mode mode) {
-        mode = mode;
     }
 
     private NGShape.Mode mode = NGShape.Mode.FILL;


### PR DESCRIPTION
- removed unused method

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279297](https://bugs.openjdk.org/browse/JDK-8279297): Remove Shape::setMode method


### Reviewers
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/814/head:pull/814` \
`$ git checkout pull/814`

Update a local copy of the PR: \
`$ git checkout pull/814` \
`$ git pull https://git.openjdk.org/jfx pull/814/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 814`

View PR using the GUI difftool: \
`$ git pr show -t 814`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/814.diff">https://git.openjdk.org/jfx/pull/814.diff</a>

</details>
