### PR TITLE
8289171: Blank final field 'dialog' may not have been initialized in scene.control.Dialog:521

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/Dialog.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/Dialog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -249,7 +249,7 @@ public class Dialog<R> implements EventTarget {
      *
      **************************************************************************/
 
-    final FXDialog dialog;
+    final FXDialog dialog = new HeavyweightDialog(this);
 
     private boolean isClosing;
 
@@ -265,7 +265,6 @@ public class Dialog<R> implements EventTarget {
      * Creates a dialog without a specified owner.
      */
     public Dialog() {
-        this.dialog = new HeavyweightDialog(this);
         setDialogPane(new DialogPane());
         initModality(Modality.APPLICATION_MODAL);
     }


### PR DESCRIPTION
- changed initialization sequence

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289171](https://bugs.openjdk.org/browse/JDK-8289171): Blank final field 'dialog' may not have been initialized in scene.control.Dialog:521


### Reviewers
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/815/head:pull/815` \
`$ git checkout pull/815`

Update a local copy of the PR: \
`$ git checkout pull/815` \
`$ git pull https://git.openjdk.org/jfx pull/815/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 815`

View PR using the GUI difftool: \
`$ git pr show -t 815`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/815.diff">https://git.openjdk.org/jfx/pull/815.diff</a>

</details>
