### PR TITLE
8289388: Fix warnings: method is overriding a synchronized method without being synchronized

### DIFF
--- a/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/newimpl/FXDnDInteropN.java
+++ b/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/newimpl/FXDnDInteropN.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -184,7 +184,8 @@ public class FXDnDInteropN {
             if (c != null) recognizers.put(c, this);
         }
 
-        @Override public void setComponent(Component c) {
+        @Override
+        public synchronized void setComponent(Component c) {
             final Component old = getComponent();
             if (old != null) recognizers.remove(old);
             super.setComponent(c);

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/PrismImage.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/prism/PrismImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,7 +61,7 @@ abstract class PrismImage extends WCImage {
     }
 
     @Override
-    public void deref() {
+    public synchronized void deref() {
         super.deref();
         if (!hasRefs()) {
             dispose();

--- a/modules/javafx.web/src/main/java/com/sun/webkit/Timer.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/Timer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -164,7 +164,7 @@ final class SeparateThreadTimer extends Timer implements Runnable {
     }
 
     @Override
-    public void notifyTick() {
+    public synchronized void notifyTick() {
         assert false;
     }
 }


### PR DESCRIPTION
Fixes warnings generated by the latest Eclipse: 
method is overriding a synchronized method without being synchronized

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289388](https://bugs.openjdk.org/browse/JDK-8289388): Fix warnings: method is overriding a synchronized method without being synchronized


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/819/head:pull/819` \
`$ git checkout pull/819`

Update a local copy of the PR: \
`$ git checkout pull/819` \
`$ git pull https://git.openjdk.org/jfx pull/819/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 819`

View PR using the GUI difftool: \
`$ git pr show -t 819`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/819.diff">https://git.openjdk.org/jfx/pull/819.diff</a>

</details>
