### PR TITLE
8289835: Change JavaFX release version to 20

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -24,7 +24,7 @@
 [general]
 project=openjfx
 jbs=jdk
-version=openjfx19
+version=openjfx20
 
 [repository]
 tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9]((\.\d{1,3}){0,2})-((b\d{2,3})|(ga))|[1-9]u(\d{1,3})-((b\d{2,3})|(ga))

--- a/build.properties
+++ b/build.properties
@@ -39,7 +39,7 @@
 jfx.release.suffix=-ea
 
 # UPDATE THE FOLLOWING VALUES FOR A NEW RELEASE
-jfx.release.major.version=19
+jfx.release.major.version=20
 jfx.release.minor.version=0
 jfx.release.security.version=0
 jfx.release.patch.version=0
@@ -56,8 +56,8 @@ jfx.release.patch.version=0
 
 javadoc.bottom=<small><a href="http://bugreport.java.com/bugreport/">Report a bug or suggest an enhancement</a><br> Copyright &copy; 2008, 2022, Oracle and/or its affiliates. All rights reserved.</small>
 
-javadoc.title=JavaFX 19
-javadoc.header=JavaFX&nbsp;19
+javadoc.title=JavaFX 20
+javadoc.header=JavaFX&nbsp;20
 
 ##############################################################################
 #

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/runtime/VersionInfoTest.java
@@ -89,7 +89,7 @@ public class VersionInfoTest {
         String version = VersionInfo.getVersion();
         // Need to update major version number when we develop the next
         // major release.
-        assertTrue(version.startsWith("19"));
+        assertTrue(version.startsWith("20"));
         String runtimeVersion = VersionInfo.getRuntimeVersion();
         assertTrue(runtimeVersion.startsWith(version));
     }


### PR DESCRIPTION
Bump the version number of JavaFX to 20. I will integrate this to `master` as part of forking the `jfx19` stabilization branch, which is scheduled for Thursday, July 14, 2022 at 16:00 UTC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289835](https://bugs.openjdk.org/browse/JDK-8289835): Change JavaFX release version to 20


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/820/head:pull/820` \
`$ git checkout pull/820`

Update a local copy of the PR: \
`$ git checkout pull/820` \
`$ git pull https://git.openjdk.org/jfx pull/820/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 820`

View PR using the GUI difftool: \
`$ git pr show -t 820`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/820.diff">https://git.openjdk.org/jfx/pull/820.diff</a>

</details>
