### PR TITLE
8289384: Fix warnings: method does not override the inherited method since it is private to a different package

### DIFF
--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/charts/area/curvefitted/CurveFittedAreaChart.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/charts/area/curvefitted/CurveFittedAreaChart.java
@@ -1,5 +1,5 @@
  /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -50,9 +50,10 @@ public class CurveFittedAreaChart extends AreaChart<Number, Number> {
     public CurveFittedAreaChart(NumberAxis xAxis, NumberAxis yAxis) {
         super(xAxis, yAxis);
     }
+
     @Override protected void layoutPlotChildren() {
         super.layoutPlotChildren();
-        for (int index = 0; index < getDataSize(); index++) {
+        for (int index = 0; index < getDataSizePrivate(); index++) {
             final XYChart.Series<Number, Number> series = getData().get(index);
             final Group seriesGroup = (Group)series.getNode();
             final Path seriesLine = (Path)seriesGroup.getChildren().get(1);
@@ -61,7 +62,7 @@ public class CurveFittedAreaChart extends AreaChart<Number, Number> {
         }
     }
 
-    private int getDataSize() {
+    private int getDataSizePrivate() {
         final ObservableList<XYChart.Series<Number, Number>> data = getData();
         return (data != null) ? data.size() : 0;
     }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlHelper.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,7 +59,7 @@ public class ControlHelper extends RegionHelper {
         return controlAccessor.skinClassNameProperty(control);
     }
 
-    void superProcessCSSImpl(Node node) {
+    private void superProcessCSSImpl(Node node) {
         super.processCSSImpl(node);
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -937,7 +937,7 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
      * text to display is an expensive operation. Package private ONLY FOR THE
      * SAKE OF TESTING.
      */
-    void updateDisplayedText() {
+    void updateDisplayedTextPrivate() {
         updateDisplayedText(-1, -1);
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ProgressIndicatorSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ProgressIndicatorSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -177,7 +177,7 @@ public class ProgressIndicatorSkin extends SkinBase<ProgressIndicator> {
         }
     };
 
-    Paint getProgressColor() {
+    Paint getProgressColorPrivate() {
         return progressColor.get();
     }
 

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/LabeledSkinBaseShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/LabeledSkinBaseShim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@ public class LabeledSkinBaseShim {
     }
 
     public static void updateDisplayedText(LabeledSkinBase b) {
-        b.updateDisplayedText();
+        b.updateDisplayedTextPrivate();
     }
 
     public static boolean get_invalidText(LabeledSkinBase b) {

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/ProgressIndicatorSkinShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/ProgressIndicatorSkinShim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ import javafx.scene.paint.Paint;
 public class ProgressIndicatorSkinShim {
 
     public static Paint getProgressColor(ProgressIndicatorSkin ps) {
-        return ps.getProgressColor();
+        return ps.getProgressColorPrivate();
     }
 
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/ParentHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/ParentHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -89,7 +89,7 @@ public class ParentHelper extends NodeHelper {
         return parentAccessor.doComputeContains(node, localX, localY);
     }
 
-    void superProcessCSSImpl(Node node) {
+    private void superProcessCSSImpl(Node node) {
         super.processCSSImpl(node);
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/ps/BaseShaderGraphics.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/ps/BaseShaderGraphics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ public abstract class BaseShaderGraphics
         this.context = context;
     }
 
-    BaseShaderContext getContext() {
+    BaseShaderContext getBaseShaderContext() {
         return context;
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/ps/CachingShapeRep.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/ps/CachingShapeRep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -508,7 +508,7 @@ class CachingShapeRepState {
         }
 
         BaseShaderGraphics bsg = (BaseShaderGraphics)g;
-        BaseShaderContext context = bsg.getContext();
+        BaseShaderContext context = bsg.getBaseShaderContext();
         if (doUpdateMask || texData.cacheEntry == null) {
             // need to create a new mask texture, or reuse an existing one
             if (xformBounds == null) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/text/TextFlow.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/text/TextFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -404,8 +404,8 @@ public class TextFlow extends Pane {
                     if (baseline == BASELINE_OFFSET_SAME_AS_HEIGHT) {
                         baseline = node.getLayoutBounds().getHeight();
                     }
-                    double width = computeChildPrefAreaWidth(node, null);
-                    double height = computeChildPrefAreaHeight(node, null);
+                    double width = computeChildPrefAreaWidthPrivate(node, null);
+                    double height = computeChildPrefAreaHeightPrivate(node, null);
                     spans[i] = new EmbeddedSpan(node, baseline, width, height);
                 }
             }
@@ -619,7 +619,7 @@ public class TextFlow extends Pane {
         return a <= b ? a : b;
     }
 
-    double computeChildPrefAreaWidth(Node child, Insets margin) {
+    private double computeChildPrefAreaWidthPrivate(Node child, Insets margin) {
         return computeChildPrefAreaWidth(child, margin, -1);
     }
 
@@ -637,7 +637,7 @@ public class TextFlow extends Pane {
         return left + snapSizeX(boundedSize(child.minWidth(alt), child.prefWidth(alt), child.maxWidth(alt))) + right;
     }
 
-    double computeChildPrefAreaHeight(Node child, Insets margin) {
+    private double computeChildPrefAreaHeightPrivate(Node child, Insets margin) {
         return computeChildPrefAreaHeight(child, margin, -1);
     }
 

--- a/modules/javafx.swt/src/main/java/javafx/embed/swt/CustomTransfer.java
+++ b/modules/javafx.swt/src/main/java/javafx/embed/swt/CustomTransfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ class CustomTransfer extends ByteArrayTransfer {
         return new int [] {registerType(name)};
     }
 
-    boolean checkByteArray(Object object) {
+    private boolean checkByteArrayPrivate(Object object) {
         return (object != null && object instanceof byte[] && ((byte[])object).length > 0);
     }
 
@@ -86,7 +86,7 @@ class CustomTransfer extends ByteArrayTransfer {
     }
 
     boolean checkCustom(Object object) {
-        return checkByteArray(object) || checkByteBuffer(object);
+        return checkByteArrayPrivate(object) || checkByteBuffer(object);
     }
 
     protected boolean validate(Object object) {


### PR DESCRIPTION
The fix includes:
- renaming of offending methods to avoid confusion
- explicitly declaring the offending methods as private

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8289384](https://bugs.openjdk.org/browse/JDK-8289384): Fix warnings: method does not override the inherited method since it is private to a different package


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/824/head:pull/824` \
`$ git checkout pull/824`

Update a local copy of the PR: \
`$ git checkout pull/824` \
`$ git pull https://git.openjdk.org/jfx pull/824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 824`

View PR using the GUI difftool: \
`$ git pr show -t 824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/824.diff">https://git.openjdk.org/jfx/pull/824.diff</a>

</details>
