### PR TITLE
8284676: TreeTableView loses sort ordering when applied on empty table

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -582,10 +582,12 @@ public class TreeTableView<S> extends Control {
         @Override public Boolean call(TreeTableView table) {
             try {
                 TreeItem rootItem = table.getRoot();
-                if (rootItem == null || rootItem.getChildren().isEmpty()) return false;
+                if (rootItem == null) return false;
 
                 TreeSortMode sortMode = table.getSortMode();
                 if (sortMode == null) return false;
+
+                if (rootItem.getChildren().isEmpty()) return true;
 
                 rootItem.lastSortMode = sortMode;
                 rootItem.lastComparator = table.getComparator();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -786,6 +786,18 @@ public class TreeTableViewTest {
         });
     }
 
+    @Test public void testSetSortOrderretainsWhenRootHasNoChildren() {
+        TreeTableView<String> ttv = new TreeTableView<>();
+        TreeItem<String> root = new TreeItem<>("root");
+        root.setExpanded(true);
+        ttv.setRoot(root);
+        assertEquals(0, ttv.getSortOrder().size());
+
+        TreeTableColumn<String, String> ttc = new TreeTableColumn<>("Column");
+        ttv.getSortOrder().add(ttc);
+        assertEquals(1, ttv.getSortOrder().size());
+    }
+
     @Test public void testNPEWhenRootItemIsNull() {
         TreeTableView<String> ttv = new TreeTableView<>();
         ControlTestUtils.runWithExceptionHandler(() -> {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -786,7 +786,7 @@ public class TreeTableViewTest {
         });
     }
 
-    @Test public void testSetSortOrderretainsWhenRootHasNoChildren() {
+    @Test public void testSetSortOrderRetainsWhenRootHasNoChildren() {
         TreeTableView<String> ttv = new TreeTableView<>();
         TreeItem<String> root = new TreeItem<>("root");
         root.setExpanded(true);


### PR DESCRIPTION
Issue: In a TreeTableView if root item has no children then TreeTableView does not retain if a sort order is set.

Cause: This is a regression of fix for [JDK-8256283](https://bugs.openjdk.org/browse/JDK-8256283), which returned false from `SortPolicy.call()` function if root item has no children. This function is called from `TreeTableView.sort()` line #1863. When the returned value is false then line #1885 gets executed, which removes the sort order that was added.

Fix: The fix for [JDK-8256283](https://bugs.openjdk.org/browse/JDK-8256283) is modified to return true instead. Added a test that fails without and passes with fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8284676](https://bugs.openjdk.org/browse/JDK-8284676): TreeTableView loses sort ordering when applied on empty table


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Jose Pereda](https://openjdk.org/census#jpereda) (@jperedadnr - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/825/head:pull/825` \
`$ git checkout pull/825`

Update a local copy of the PR: \
`$ git checkout pull/825` \
`$ git pull https://git.openjdk.org/jfx pull/825/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 825`

View PR using the GUI difftool: \
`$ git pr show -t 825`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/825.diff">https://git.openjdk.org/jfx/pull/825.diff</a>

</details>
