### PR TITLE
8289606: CustomSecurityManagerTest fails on Mac M1

### DIFF
--- a/tests/system/src/test/java/test/robot/helloworld/CustomSecurityManagerTest.java
+++ b/tests/system/src/test/java/test/robot/helloworld/CustomSecurityManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -195,7 +195,15 @@ public class CustomSecurityManagerTest extends VisualTestBase {
                 assertFalse(propertyState);
             }
             for (int row = 0; row < 2; row++) {
-                int y = row == 0 ? 1 : screenHeight.get() - 2;
+                int h = screenHeight.get();
+                int y;
+                if (row == 0) {
+                    // avoid the top area as it might contain OS-specific UI (Macs with a notch)
+                    y = h / 3;
+                } else {
+                    y = h - 2;
+                }
+
                 for (int col = 0; col < 2; col++) {
                     int x = col == 0 ? 1 : screenWidth.get() - 2;
                     Color color = getColor(x, y);


### PR DESCRIPTION
- sampling at 1/3 of screen height instead of the very top to avoid hitting OS UI found on the newer Macs with a notch
- change applies to all platforms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289606](https://bugs.openjdk.org/browse/JDK-8289606): CustomSecurityManagerTest fails on Mac M1


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/826/head:pull/826` \
`$ git checkout pull/826`

Update a local copy of the PR: \
`$ git checkout pull/826` \
`$ git pull https://git.openjdk.org/jfx pull/826/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 826`

View PR using the GUI difftool: \
`$ git pr show -t 826`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/826.diff">https://git.openjdk.org/jfx/pull/826.diff</a>

</details>
