### PR TITLE
8290037: Bindings should clean up after themselves when their weak listeners go out of scope

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/ConcurrentListenerAccess.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/ConcurrentListenerAccess.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.binding;
+
+/**
+ * Marker interface for {@link javafx.beans.value.ObservableValue}s which support
+ * concurrent modification of their listeners.
+ */
+public interface ConcurrentListenerAccess {
+
+}

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/ListenerRemover.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/ListenerRemover.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.binding;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Objects;
+
+import javafx.beans.InvalidationListener;
+import javafx.beans.Observable;
+import javafx.beans.WeakListener;
+
+/**
+ * This class is used for cleaning up weak listener stubs registered by the
+ * various *PropertyBase classes.
+ *
+ * A Cleaner is not used here as calling {@link Observable#removeListener(InvalidationListener)}
+ * cannot be guaranteed to be executed very quick and not to block (as per Cleaner requirements).
+ */
+public class ListenerRemover {
+
+    public static final ReferenceQueue<?> QUEUE = new ReferenceQueue<>();
+
+    /**
+     * When ref becomes weakly reachable, remove weakListener from target.
+     *
+     * @param <T> the type of reference
+     * @param <L> the listener type
+     * @param ref an object to monitor for weak reachability, cannot be {@code null}
+     * @param weakListener a listener implementing {@link WeakListener} and {@link InvalidationListener}, cannot be {@code null}
+     * @param target an {@link Observable} from which to remove the listener, cannot be {@code null}
+     * @return a {@link WeakReference}, never {@code null}
+     */
+    public static final <T, L extends InvalidationListener & WeakListener> WeakReference<T> whenWeaklyReachable(T ref, L weakListener, Observable target) {
+        return new TrackingWeakReference<>(
+            Objects.requireNonNull(ref, "ref"),
+            Objects.requireNonNull(weakListener, "weakListener"),
+            Objects.requireNonNull(target, "target")
+        );
+    }
+
+    private static class TrackingWeakReference<T> extends WeakReference<T> {
+        final InvalidationListener weakListener;
+        final Observable target;
+
+        public TrackingWeakReference(T referent, InvalidationListener weakListener, Observable target) {
+            super(referent, queue());
+
+            this.weakListener = weakListener;
+            this.target = target;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static final <T> ReferenceQueue<T> queue() {
+        return (ReferenceQueue<T>)QUEUE;
+    }
+
+    static {
+        AccessController.doPrivileged(
+            new PrivilegedAction<Object>() {
+                @Override
+                public Object run() {
+
+                    /*
+                     * The thread must be a member of a thread group
+                     * which will not get GCed before VM exit.
+                     * Make its parent the top-level thread group.
+                     */
+
+                    ThreadGroup tg = Thread.currentThread().getThreadGroup();
+
+                    for (ThreadGroup tgn = tg;
+                         tgn != null;
+                         tg = tgn, tgn = tg.getParent());
+
+                    Thread t = new Thread(tg, ListenerRemover::run, "Listener Stub Disposer");
+
+                    t.setContextClassLoader(null);
+                    t.setDaemon(true);
+                    t.setPriority(Thread.MAX_PRIORITY);
+                    t.start();
+
+                    return null;
+                }
+            }
+        );
+    }
+
+    private static void run() {
+        while (true) {
+            try {
+                TrackingWeakReference<?> ref = (TrackingWeakReference<?>) QUEUE.remove();
+
+                ref.target.removeListener(ref.weakListener);
+            } catch (Exception e) {
+                System.out.println("Exception while removing weak listener stub: " + e);
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/ListenerRemover.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/ListenerRemover.java
@@ -44,7 +44,7 @@ import javafx.beans.WeakListener;
  */
 public class ListenerRemover {
 
-    public static final ReferenceQueue<?> QUEUE = new ReferenceQueue<>();
+    private static final ReferenceQueue<?> QUEUE = new ReferenceQueue<>();
 
     /**
      * When ref becomes weakly reachable, remove weakListener from target.


### PR DESCRIPTION
This is an initial (incomplete) implementation of 8290037 for evaluation.

If the approach is agreed, I will modify the rest of the `*PropertyBase` classes which use weak listeners, and add some tests.

I didn't use `Cleaner` because cleaning up a listener may block.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion openjfx19 to be approved (needs to be created)
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Integration blocker
&nbsp;⚠️ Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with the updated jcheck configuration)

### Issue
 * [JDK-8290037](https://bugs.openjdk.org/browse/JDK-8290037): Bindings should clean up after themselves when their weak listeners go out of scope


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/827/head:pull/827` \
`$ git checkout pull/827`

Update a local copy of the PR: \
`$ git checkout pull/827` \
`$ git pull https://git.openjdk.org/jfx.git pull/827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 827`

View PR using the GUI difftool: \
`$ git pr show -t 827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/827.diff">https://git.openjdk.org/jfx/pull/827.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/827#issuecomment-1184548233)