### PR TITLE
8289611: MouseLocationOnScreenTest sometimes fails on Mac M1

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,8 @@ public class MouseLocationOnScreenTest {
     public void testMouseLocation() throws Exception {
 
         Screen screen = Screen.getPrimary();
-        Rectangle2D bounds = screen.getBounds();
+        // using visual bounds prevents hitting the camera notch area on newer Macs
+        Rectangle2D bounds = screen.getVisualBounds();
         int x1 = (int) bounds.getMinX();
         int x2 = (int) (x1 + bounds.getWidth() - 1);
         int y1 = (int) bounds.getMinY();


### PR DESCRIPTION
- using Screen.getVisualBounds() instead of Screen.getBounds()

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289611](https://bugs.openjdk.org/browse/JDK-8289611): MouseLocationOnScreenTest sometimes fails on Mac M1


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/828/head:pull/828` \
`$ git checkout pull/828`

Update a local copy of the PR: \
`$ git checkout pull/828` \
`$ git pull https://git.openjdk.org/jfx pull/828/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 828`

View PR using the GUI difftool: \
`$ git pr show -t 828`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/828.diff">https://git.openjdk.org/jfx/pull/828.diff</a>

</details>
