### PR TITLE
8290331 Binding value left null when immediately revalidated in invalidation listener

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/beans/binding/ObjectBinding.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/binding/ObjectBinding.java
@@ -180,7 +180,10 @@ public abstract class ObjectBinding<T> extends ObjectExpression<T> implements
             valid = false;
             onInvalidating();
             ExpressionHelper.fireValueChangedEvent(helper);
-            value = null;  // clear cached value to avoid hard reference to stale data
+
+            if (!valid) {  // if still invalid after calling listeners...
+                value = null;  // clear cached value to avoid hard reference to stale data
+            }
         }
     }
 

--- a/modules/javafx.base/src/main/java/javafx/beans/binding/ObjectBinding.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/binding/ObjectBinding.java
@@ -181,8 +181,13 @@ public abstract class ObjectBinding<T> extends ObjectExpression<T> implements
             onInvalidating();
             ExpressionHelper.fireValueChangedEvent(helper);
 
-            if (!valid) {  // if still invalid after calling listeners...
-                value = null;  // clear cached value to avoid hard reference to stale data
+            /*
+             * Cached value should be cleared to avoid a strong reference to stale data,
+             * but only if this binding didn't become valid after firing the event:
+             */
+
+            if (!valid) {
+                value = null;
             }
         }
     }

--- a/modules/javafx.base/src/test/java/test/javafx/beans/value/LazyObjectBindingTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/value/LazyObjectBindingTest.java
@@ -52,6 +52,24 @@ public class LazyObjectBindingTest {
         assertFalse(binding.isValid());
     }
 
+    @Test
+    void invalidationWhichBecomesValidDuringCallbacksShouldReturnCorrectValue() {
+        LazyObjectBindingStub<String> binding = new LazyObjectBindingStub<>() {
+            @Override
+            protected String computeValue() {
+                return "A";
+            }
+        };
+
+        binding.addListener(obs -> {
+            assertEquals("A", binding.get());
+        });
+
+        binding.invalidate();  // becomes valid again immediately
+
+        assertEquals("A", binding.get());
+    }
+
     @Nested
     class WhenObservedWithInvalidationListener {
         private InvalidationListener invalidationListener = obs -> {};


### PR DESCRIPTION
I introduced a bug with the fluent bindings PR which affects all ObjectBindings.

This is the code that fails:

        SimpleObjectProperty<Boolean> condition = new SimpleObjectProperty<>(true);
        ObservableValue<String> binding = condition.map(Object::toString);

        binding.addListener(o -> { binding.getValue(); });

        condition.set(false);

        assertEquals(false, binding.getValue());  // returns null (!)

This PR fixes this problem and adds a test case to cover it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8290331](https://bugs.openjdk.org/browse/JDK-8290331): Binding value left null when immediately revalidated in invalidation listener


### Reviewers
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Author)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/829/head:pull/829` \
`$ git checkout pull/829`

Update a local copy of the PR: \
`$ git checkout pull/829` \
`$ git pull https://git.openjdk.org/jfx pull/829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 829`

View PR using the GUI difftool: \
`$ git pr show -t 829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/829.diff">https://git.openjdk.org/jfx/pull/829.diff</a>

</details>
