### PR TITLE
8290393: Code sample in javadoc of ObservableValue flatMap is incorrect

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/beans/value/ObservableValue.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/value/ObservableValue.java
@@ -223,16 +223,16 @@ public interface ObservableValue<T> extends Observable {
      *
      * // Assuming the listView is currently shown to the user, then:
      *
-     * isShowing().getValue();  // Returns true
+     * isShowing.getValue();  // Returns true
      *
      * listView.getScene().getWindow().hide();
-     * isShowing().getValue();  // Returns false
+     * isShowing.getValue();  // Returns false
      *
      * listView.getScene().getWindow().show();
-     * isShowing().getValue();  // Returns true
+     * isShowing.getValue();  // Returns true
      *
      * listView.getParent().getChildren().remove(listView);
-     * isShowing().getValue();  // Returns false
+     * isShowing.getValue();  // Returns false
      * }</pre>
      * Changes in any of the values of: the scene of {@code listView}, the window of that scene, or
      * the showing of that window, will update the boolean value {@code isShowing}.


### PR DESCRIPTION
Fix small error in flatmap docs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290393](https://bugs.openjdk.org/browse/JDK-8290393): Code sample in javadoc of ObservableValue flatMap is incorrect


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/831/head:pull/831` \
`$ git checkout pull/831`

Update a local copy of the PR: \
`$ git checkout pull/831` \
`$ git pull https://git.openjdk.org/jfx pull/831/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 831`

View PR using the GUI difftool: \
`$ git pr show -t 831`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/831.diff">https://git.openjdk.org/jfx/pull/831.diff</a>

</details>
