### PR TITLE
8290348: TreeTableView jumping to top

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -3072,7 +3072,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
     private boolean recalculating = false;
 
     private void recalculateAndImproveEstimatedSize(int improve) {
-        if (recalculating)  return;
+        if (recalculating) return;
         recalculating = true;
         int itemCount = getCellCount();
         int cacheCount = itemSizeCache.size();

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -3074,43 +3074,46 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
     private void recalculateAndImproveEstimatedSize(int improve) {
         if (recalculating) return;
         recalculating = true;
-        int itemCount = getCellCount();
-        int cacheCount = itemSizeCache.size();
-        boolean keepRatio = ((cacheCount > 0) && !Double.isInfinite(this.absoluteOffset));
+        try {
+            int itemCount = getCellCount();
+            int cacheCount = itemSizeCache.size();
+            boolean keepRatio = ((cacheCount > 0) && !Double.isInfinite(this.absoluteOffset));
 
-        int oldIndex = computeCurrentIndex();
-        double oldOffset = computeViewportOffset(getPosition());
-        int added = 0;
-        while ((itemCount > itemSizeCache.size()) && (added < improve)) {
-            getOrCreateCellSize(itemSizeCache.size());
-            added++;
-        }
-        cacheCount = itemSizeCache.size();
-        int cnt = 0;
-        double tot = 0d;
-        for (int i = 0; (i < itemCount && i < cacheCount); i++) {
-            Double il = itemSizeCache.get(i);
-            if (il != null) {
-                tot = tot + il;
-                cnt++;
+            int oldIndex = computeCurrentIndex();
+            double oldOffset = computeViewportOffset(getPosition());
+            int added = 0;
+            while ((itemCount > itemSizeCache.size()) && (added < improve)) {
+                getOrCreateCellSize(itemSizeCache.size());
+                added++;
             }
-        }
-        this.estimatedSize = cnt == 0 ? 1d : tot * itemCount / cnt;
-        double estSize = estimatedSize / itemCount;
-
-        if (keepRatio) {
-            double newOffset = 0;
-            for (int i = 0; i < oldIndex; i++) {
-                double h = getCellSize(i);
-                if (h < 0) {
-                    h = estSize;
+            cacheCount = itemSizeCache.size();
+            int cnt = 0;
+            double tot = 0d;
+            for (int i = 0; (i < itemCount && i < cacheCount); i++) {
+                Double il = itemSizeCache.get(i);
+                if (il != null) {
+                    tot = tot + il;
+                    cnt++;
                 }
-                newOffset += h;
             }
-            this.absoluteOffset = newOffset + oldOffset;
-            adjustPosition();
+            this.estimatedSize = cnt == 0 ? 1d : tot * itemCount / cnt;
+            double estSize = estimatedSize / itemCount;
+
+            if (keepRatio) {
+                double newOffset = 0;
+                for (int i = 0; i < oldIndex; i++) {
+                    double h = getCellSize(i);
+                    if (h < 0) {
+                        h = estSize;
+                    }
+                    newOffset += h;
+                }
+                this.absoluteOffset = newOffset + oldOffset;
+                adjustPosition();
+            }
+        } finally {
+            recalculating = false;
         }
-        recalculating = false;
     }
 
     private void resetSizeEstimates() {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -3069,11 +3069,14 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
         recalculateAndImproveEstimatedSize(DEFAULT_IMPROVEMENT);
     }
 
+    private boolean recalculating = false;
+
     private void recalculateAndImproveEstimatedSize(int improve) {
+        if (recalculating)  return;
+        recalculating = true;
         int itemCount = getCellCount();
         int cacheCount = itemSizeCache.size();
         boolean keepRatio = ((cacheCount > 0) && !Double.isInfinite(this.absoluteOffset));
-        double estSize = estimatedSize / itemCount;
 
         int oldIndex = computeCurrentIndex();
         double oldOffset = computeViewportOffset(getPosition());
@@ -3107,7 +3110,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             this.absoluteOffset = newOffset + oldOffset;
             adjustPosition();
         }
-
+        recalculating = false;
     }
 
     private void resetSizeEstimates() {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -3096,7 +3096,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             }
         }
         this.estimatedSize = cnt == 0 ? 1d : tot * itemCount / cnt;
-        estSize = estimatedSize / itemCount;
+        double estSize = estimatedSize / itemCount;
 
         if (keepRatio) {
             double newOffset = 0;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
@@ -3928,6 +3928,7 @@ public class TreeViewTest {
         rootNode.getChildren().addAll(generateChildren(1));
         TreeView<String> treeView = new TreeView<>(rootNode);
         treeView.scrollTo(100);
+        IndexedCell expandedCell = VirtualFlowTestUtils.getCell(treeView, 100);
         Toolkit.getToolkit().firePulse();
         rootNode.getChildren().get(1).setExpanded(false);
         Toolkit.getToolkit().firePulse();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
@@ -3907,6 +3907,34 @@ public class TreeViewTest {
         assertEquals("Node 0", table.getFocusModel().getFocusedItem().getValue());
     }
 
+    private List<TreeItem<String>> generateChildren(int lvl) {
+        List<TreeItem<String>> children = new ArrayList<>();
+        for (int idx = 0; idx < 10; idx++) {
+            TreeItem<String> child = new TreeItem<>("Child lvl. " + lvl + " idx. " + idx);
+            child.setExpanded(true);
+            if (lvl <= 2) {
+                child.getChildren().addAll(generateChildren(lvl + 1));
+            }
+            children.add(child);
+        }
+        return children;
+    }
+
+    // JDK-8290348
+    @Test
+    public void testCheckPositionAfterCollapsed() {
+        TreeItem<String> rootNode = new TreeItem<>("Root");
+        rootNode.setExpanded(true);
+        rootNode.getChildren().addAll(generateChildren(1));
+        TreeView<String> treeView = new TreeView<>(rootNode);
+        treeView.scrollTo(100);
+        Toolkit.getToolkit().firePulse();
+        rootNode.getChildren().get(1).setExpanded(false);
+        Toolkit.getToolkit().firePulse();
+        IndexedCell scrolledCell = VirtualFlowTestUtils.getCell(treeView, 100);
+        assertTrue(scrolledCell.isVisible());
+    }
+
     public static class MisbehavingOnCancelTreeCell<S> extends TreeCell<S> {
 
         @Override


### PR DESCRIPTION
Do not recalculate total estimated size recursively.

In the (unlikely) event that the recalculation triggers a new recalculation (e.g. when the height of a Cell is changed), do not start this recalculation.
The cache and cache size may become inconsistent if a recursive calculation is started.
This fixes JDK-8290348

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8290348](https://bugs.openjdk.org/browse/JDK-8290348): TreeTableView jumping to top


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/836/head:pull/836` \
`$ git checkout pull/836`

Update a local copy of the PR: \
`$ git checkout pull/836` \
`$ git pull https://git.openjdk.org/jfx pull/836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 836`

View PR using the GUI difftool: \
`$ git pr show -t 836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/836.diff">https://git.openjdk.org/jfx/pull/836.diff</a>

</details>
