### PR TITLE
8290841: Notify menu event after a long press gesture on Android is not dispatched

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/AndroidInputDeviceRegistry.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/AndroidInputDeviceRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -79,6 +79,10 @@ public class AndroidInputDeviceRegistry extends InputDeviceRegistry {
 
     public static void dispatchKeyEventFromNative(int type, int key, char[] chars, int modifiers) {
         instance.processor.dispatchKeyEvent(type, key, chars, modifiers);
+    }
+
+    public static void dispatchMenuEventFromNative(int x, int y, int xAbs, int yAbs, boolean isKeyboardTrigger) {
+        instance.processor.dispatchMenuEvent(x, y, xAbs, yAbs, isKeyboardTrigger);
     }
 
     public static void gotKeyEventFromNative(int action, int linuxKey) {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/AndroidInputProcessor.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/AndroidInputProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -67,6 +67,20 @@ class AndroidInputProcessor {
                 return;
             }
             RunnableProcessor.runLater( () ->  view.notifyKey(type, key, chars, modifiers));
+        });
+    }
+
+    synchronized void dispatchMenuEvent(int x, int y, int xAbs, int yAbs, boolean isKeyboardTrigger) {
+        Platform.runLater(() -> {
+            MonocleWindow window = MonocleWindowManager.getInstance().getFocusedWindow();
+            if (window == null) {
+                return;
+            }
+            MonocleView view = (MonocleView) window.getView();
+            if (view == null) {
+                return;
+            }
+            RunnableProcessor.runLater(() -> view.notifyMenu(x, y, xAbs, yAbs, isKeyboardTrigger));
         });
     }
 

--- a/modules/javafx.graphics/src/main/native-glass/monocle/android/nativeBridge.c
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/android/nativeBridge.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ static jclass jScreenClass;
 
 static jmethodID monocle_gotTouchEventFromNative;
 static jmethodID monocle_dispatchKeyEventFromNative;
+static jmethodID monocle_dispatchMenuEventFromNative;
 static jmethodID monocle_repaintAll;
 static jmethodID monocle_registerDevice;
 static jmethodID screen_init;
@@ -63,6 +64,9 @@ void initializeFromJava (JNIEnv *env) {
     monocle_dispatchKeyEventFromNative = (*env)->GetStaticMethodID(
                                             env, jAndroidInputDeviceRegistryClass, "dispatchKeyEventFromNative",
                                             "(II[CI)V");
+    monocle_dispatchMenuEventFromNative = (*env)->GetStaticMethodID(
+                                             env, jAndroidInputDeviceRegistryClass, "dispatchMenuEventFromNative",
+                                             "(IIIIZ)V");
     monocle_registerDevice = (*env)->GetStaticMethodID(env, jAndroidInputDeviceRegistryClass, "registerDevice","()V");
     screen_init = (*env)->GetMethodID(env, jScreenClass,"<init>", "(JIIIIIIIIIIIIIIIFFFF)V");
     GLASS_LOG_FINE("Initializing native Android Bridge done");
@@ -137,6 +141,21 @@ void androidJfx_gotKeyEvent (int action, int keyCode, jchar* chars, int count, i
     (*javaEnv)->SetCharArrayRegion(javaEnv, jchars, 0, count, chars);
     (*javaEnv)->CallStaticVoidMethod(javaEnv, jAndroidInputDeviceRegistryClass, monocle_dispatchKeyEventFromNative,
                                      action, keyCode, jchars, mods);
+}
+
+void androidJfx_gotMenuEvent(int x, int y, int xAbs, int yAbs, bool isKeyboardTrigger) {
+    initializeFromNative();
+    if (javaEnv == NULL) {
+        GLASS_LOG_FINE("javaEnv still null, not ready to process menu events");
+        return;
+    }
+    if (deviceRegistered == 0) {
+        deviceRegistered = 1;
+        GLASS_LOG_FINE("This is the first time we have a menu event, register device now");
+        (*javaEnv)->CallStaticVoidMethod(javaEnv, jAndroidInputDeviceRegistryClass, monocle_registerDevice);
+    }
+    (*javaEnv)->CallStaticVoidMethod(javaEnv, jAndroidInputDeviceRegistryClass, monocle_dispatchMenuEventFromNative,
+                                     x, y, xAbs, yAbs, isKeyboardTrigger);
 }
 
 void androidJfx_requestGlassToRedraw() {

--- a/modules/javafx.graphics/src/main/native-glass/monocle/android/nativeBridge.h
+++ b/modules/javafx.graphics/src/main/native-glass/monocle/android/nativeBridge.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,11 +24,13 @@
  */
 #include <android/native_window_jni.h>
 #include <android/log.h>
+#include <stdbool.h>
 
 // the following functions can be invoked by native code invoked by Android Activity code
 void androidJfx_setNativeWindow(ANativeWindow* nativeWindow);
 void androidJfx_setDensity(float nativeDensity);
 void androidJfx_gotTouchEvent (int count, int* actions, int* ids, int* xs, int* ys, int primary);
+void androidJfx_gotMenuEvent(int x, int y, int xAbs, int yAbs, bool isKeyboardTrigger);
 void androidJfx_requestGlassToRedraw();
 
 #define GLASS_LOG_INFO(...)  ((void)__android_log_print(ANDROID_LOG_INFO,"GLASS", __VA_ARGS__))


### PR DESCRIPTION
This PR allows dispatching a menu event on Android to trigger a ContextMenuEvent. 

It is somehow a follow-up of [JDK-8245575](https://bugs.openjdk.java.net/browse/JDK-8245575), where the same was added for iOS.

While no test can be provided, the current changes have been tested, building and deploying on Android.