### PR TITLE
8290527: Bump macOS GitHub actions to macOS 11

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -140,7 +140,7 @@ jobs:
   macos_x64_build:
     name: macOS x64
     needs: validation
-    runs-on: "macos-10.15"
+    runs-on: "macos-11"
 
     env:
       # FIXME: read this information from a property file
@@ -199,7 +199,7 @@ jobs:
           java -version
           which ant
           ant -version
-          sudo xcode-select --switch /Applications/Xcode_11.3.1.app/Contents/Developer
+          sudo xcode-select --switch /Applications/Xcode_12.4.app/Contents/Developer
           xcodebuild -version
 
       - name: Build JavaFX artifacts


### PR DESCRIPTION
Use macOS 11 / Xcode 12.4 for GitHub actions runs.

As noted in the JBS bug, macOS 10.15 has been deprecated as a GitHub Actions platform, and will be removed completely on August 30th. See https://github.com/actions/virtual-environments#available-environments and actions/virtual-environments#5583 for context.

This PR also switches to using XCode 12.4, which matches our production builds.

As you can see from the GHA run, the tests pass after this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290527](https://bugs.openjdk.org/browse/JDK-8290527): Bump macOS GitHub actions to macOS 11


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/844/head:pull/844` \
`$ git checkout pull/844`

Update a local copy of the PR: \
`$ git checkout pull/844` \
`$ git pull https://git.openjdk.org/jfx pull/844/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 844`

View PR using the GUI difftool: \
`$ git pr show -t 844`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/844.diff">https://git.openjdk.org/jfx/pull/844.diff</a>

</details>
