### PR TITLE
8089009: TableView with CONSTRAINED_RESIZE_POLICY incorrectly displays a horizontal scroll bar.

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableUtil.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableUtil.java
@@ -223,7 +223,7 @@ class TableUtil {
             colWidth += col.getWidth();
         }
 
-        if (Math.abs(colWidth - tableWidth) > 1) {
+        if (Math.abs(colWidth - tableWidth) > 0) {
             isShrinking = colWidth > tableWidth;
             target = tableWidth;
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableUtil.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableUtil.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2016, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableUtil.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableUtil.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableUtil.java
@@ -38,6 +38,11 @@ import javafx.collections.ObservableList;
  */
 class TableUtil {
 
+    /**
+     * Constant to consider floating-point arithmetic precision.
+      */
+    private static final double EPSILON = .0000001;
+
     private TableUtil() {
         // no-op
     }
@@ -223,7 +228,7 @@ class TableUtil {
             colWidth += col.getWidth();
         }
 
-        if (Math.abs(colWidth - tableWidth) > 0) {
+        if (Math.abs(colWidth - tableWidth) > EPSILON) {
             isShrinking = colWidth > tableWidth;
             target = tableWidth;
 
@@ -248,7 +253,7 @@ class TableUtil {
                     // finishes early due to a series of "fixed" entries at the end.
                     // In this case, lowerBound == upperBound, for all subsequent terms.
                     double newSize;
-                    if (Math.abs(totalLowerBound - totalUpperBound) < .0000001) {
+                    if (Math.abs(totalLowerBound - totalUpperBound) < EPSILON) {
                         newSize = lowerBound;
                     } else {
                         double f = (target - totalLowerBound) / (totalUpperBound - totalLowerBound);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -5819,26 +5819,26 @@ public class TableViewTest {
 
         ScrollBar horizontalBar = VirtualFlowTestUtils.getVirtualFlowHorizontalScrollbar(table);
         assertNotNull(horizontalBar);
-        assertEquals(false, horizontalBar.isVisible());
-        assertTrue(table.getWidth() == initialWidth);
+        assertEquals(initialWidth, table.getWidth(), 0);
+        assertFalse(horizontalBar.isVisible());
 
         // Reduce table width by 10px
-        table.setMinWidth(initialWidth-10);
+        table.setMinWidth(initialWidth - 10);
         Toolkit.getToolkit().firePulse();
-        assertTrue(table.getWidth() == initialWidth-10);
-        assertEquals(false, horizontalBar.isVisible());
+        assertEquals(initialWidth - 10, table.getWidth(), 0);
+        assertFalse(horizontalBar.isVisible());
 
         // Reset table width
         table.setMinWidth(initialWidth);
         Toolkit.getToolkit().firePulse();
-        assertTrue(table.getWidth() == initialWidth);
-        assertEquals(false, horizontalBar.isVisible());
+        assertEquals(initialWidth, table.getWidth(), 0);
+        assertFalse(horizontalBar.isVisible());
 
         // Reduce table width by 1px
-        table.setMinWidth(initialWidth-1);
+        table.setMinWidth(initialWidth - 1);
         Toolkit.getToolkit().firePulse();
-        assertTrue(table.getWidth() == initialWidth-1);
-        assertEquals(false, horizontalBar.isVisible());
+        assertEquals(initialWidth - 1, table.getWidth(), 0);
+        assertFalse(horizontalBar.isVisible());
 
         sl.dispose();
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -5795,4 +5795,52 @@ public class TableViewTest {
         assertEquals(1, anchor.getRow());
         assertEquals(column, anchor.getTableColumn());
     }
+
+    // see JDK-8089009
+    @Test public void testHScrollBarVisibilityForConstrainedTable() {
+        TableColumn firstNameCol = new TableColumn("First Name");
+        firstNameCol.setCellValueFactory(new PropertyValueFactory<Person, String>("firstName"));
+
+        TableColumn lastNameCol = new TableColumn("Last Name");
+        lastNameCol.setCellValueFactory(new PropertyValueFactory<Person, String>("lastName"));
+
+        TableColumn emailCol = new TableColumn("Email");
+        emailCol.setCellValueFactory(new PropertyValueFactory<Person, String>("email"));
+
+        final double initialWidth = 500;
+        TableView<Person> table = new TableView<>(personTestData);
+        table.setMinWidth(initialWidth);
+        table.getColumns().addAll(firstNameCol, lastNameCol, emailCol);
+        table.setItems(personTestData);
+        table.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+
+        StageLoader sl = new StageLoader(table);
+        Toolkit.getToolkit().firePulse();
+
+        ScrollBar horizontalBar = VirtualFlowTestUtils.getVirtualFlowHorizontalScrollbar(table);
+        assertNotNull(horizontalBar);
+        assertEquals(false, horizontalBar.isVisible());
+        assertTrue(table.getWidth() == initialWidth);
+
+        // Reduce table width by 10px
+        table.setMinWidth(initialWidth-10);
+        Toolkit.getToolkit().firePulse();
+        assertTrue(table.getWidth() == initialWidth-10);
+        assertEquals(false, horizontalBar.isVisible());
+
+        // Reset table width
+        table.setMinWidth(initialWidth);
+        Toolkit.getToolkit().firePulse();
+        assertTrue(table.getWidth() == initialWidth);
+        assertEquals(false, horizontalBar.isVisible());
+
+        // Reduce table width by 1px
+        table.setMinWidth(initialWidth-1);
+        Toolkit.getToolkit().firePulse();
+        assertTrue(table.getWidth() == initialWidth-1);
+        assertEquals(false, horizontalBar.isVisible());
+
+        sl.dispose();
+    }
+
 }


### PR DESCRIPTION
**Issue:**
When the `TableView` is set with built-in `CONSTRAINED_RESIZE_POLICY`, the horizontal scroll bar keeps flickering when the `TableView` width is reduced.

**Cause:**
The table columns widths are recalculated only if the difference of the `TableView` width and the total columns width is greater than 1px. Because of this improper calculations, if the `TableView` width is reduced by 1px, the columns widths are not updated. Which results to computing for horizontal scroll bar visibility in `VirtualFlow` to improper results and let the horizontal scroll bar to be visible. 

Where as if the `TableView` width is reduced by more than 1px, the calculations are done correctly and the horizontal scroll bar visibility is turned off. Because of this behaviour, it looks like the horizontal scroll bar is flickering when the `TableView` width is reduced (let’s say by dragging).

To confirm this behaviour, please find the below example that showcases the issue:
When the tableView width is reduced/increased by 1px, the column widths are recalculated only after every alternate 1px change. Whereas if the tableView width is reduced/increased by more than 1px (say 10px), the column widths are calculated correctly.

```
import javafx.application.Application;
import javafx.beans.property.SimpleStringProperty;
import javafx.beans.property.StringProperty;
import javafx.collections.FXCollections;
import javafx.collections.ObservableList;
import javafx.geometry.Insets;
import javafx.scene.Group;
import javafx.scene.Scene;
import javafx.scene.control.*;
import javafx.scene.layout.HBox;
import javafx.scene.layout.VBox;
import javafx.stage.Stage;

public class ConstrainedResizePolicyIssueDemo extends Application {
    @Override
    public void start(Stage primaryStage) throws Exception {
        TableColumn<Person, String> fnCol = new TableColumn<>("First Name");
        fnCol.setMinWidth(100);
        fnCol.setCellValueFactory(param -> param.getValue().firstNameProperty());

        TableColumn<Person, String> priceCol = new TableColumn<>("Price");
        priceCol.setMinWidth(100);
        priceCol.setMaxWidth(150);
        priceCol.setCellValueFactory(param -> param.getValue().priceProperty());

        TableColumn<Person, String> totalCol = new TableColumn<>("Total");
        totalCol.setMinWidth(100);
        totalCol.setMaxWidth(150);
        totalCol.setCellValueFactory(param -> param.getValue().totalProperty());

        ObservableList<Person> persons = FXCollections.observableArrayList();
        persons.add(new Person("Harry", "200.00", "210.00"));
        persons.add(new Person("Jacob", "260.00", "260.00"));

        TableView<Person> tableView = new TableView<>();
        tableView.getColumns().addAll(fnCol, priceCol, totalCol);
        tableView.setItems(persons);
        tableView.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
        tableView.setMinWidth(500);
        tableView.maxWidthProperty().bind(tableView.minWidthProperty());

        Button button1 = new Button("Reduce 1px");
        button1.setOnAction(e -> tableView.setMinWidth(tableView.getMinWidth() - 1));
        Button button2 = new Button("Reduce 10px");
        button2.setOnAction(e -> tableView.setMinWidth(tableView.getMinWidth() - 10));
        Button button3 = new Button("Reset");
        button3.setOnAction(e -> tableView.setMinWidth(500));
        Button button4 = new Button("Increase 1px");
        button4.setOnAction(e -> tableView.setMinWidth(tableView.getMinWidth() + 1));
        Button button5 = new Button("Increase 10px");
        button5.setOnAction(e -> tableView.setMinWidth(tableView.getMinWidth() + 10));

        HBox row = new HBox(button1, button2, button3, button4, button5);
        row.setSpacing(10);
        TextArea output = new TextArea();

        addWidthListeners(tableView, output);
        VBox root = new VBox(row, new Group(tableView), output);
        root.setSpacing(10);
        root.setPadding(new Insets(10));

        Scene scene = new Scene(root);
        primaryStage.setScene(scene);
        primaryStage.setTitle("Constrained Resize Policy Issue TableView");
        primaryStage.show();
    }

    private void addWidthListeners(TableView<Person> tableView, TextArea output) {
        tableView.widthProperty().addListener((obs, old, val) -> {
            String str = "Table width changed :: " + val + "\n";
            output.setText(output.getText() + str);
            output.positionCaret(output.getText().length());
        });
        tableView.getColumns().forEach(column -> {
            column.widthProperty().addListener((obs, old, width) -> {
                String str = " ---> " + column.getText() + " : width changed to : " + column.getWidth()+"\n";
                output.setText(output.getText() + str);
                output.positionCaret(output.getText().length());
            });
        });
    }

    class Person {
        private StringProperty firstName = new SimpleStringProperty();
        private StringProperty price = new SimpleStringProperty();
        private StringProperty total = new SimpleStringProperty();

        public Person(String fn, String price, String total) {
            setFirstName(fn);
            setPrice(price);
            setTotal(total);
        }

        public StringProperty firstNameProperty() {
            return firstName;
        }

        public void setFirstName(String firstName) {
            this.firstName.set(firstName);
        }

        public StringProperty priceProperty() {
            return price;
        }

        public void setPrice(String price) {
            this.price.set(price);
        }

        public StringProperty totalProperty() {
            return total;
        }

        public void setTotal(String total) {
            this.total.set(total);
        }
    }
}
```

**Fix:**
On investigating the code, it is noticed that there is an explicit line of code to check if the difference in widths is greater than 1px. I think this should be greater than 0px. Because we need to recompute the columns widths even if the width is increased by 1px.

The part of the code that need to be updated is in TableUtil.java -> constrainedResize(..) method -> line 226

`if (Math.abs(colWidth - tableWidth) > 1) {`

If I update the value 1 to 0, the issue is fixed and the horizontal scroll bar visibility is computed correctly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8089009](https://bugs.openjdk.org/browse/JDK-8089009): TableView with CONSTRAINED_RESIZE_POLICY incorrectly displays a horizontal scroll bar.


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Author)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/848/head:pull/848` \
`$ git checkout pull/848`

Update a local copy of the PR: \
`$ git checkout pull/848` \
`$ git pull https://git.openjdk.org/jfx pull/848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 848`

View PR using the GUI difftool: \
`$ git pr show -t 848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/848.diff">https://git.openjdk.org/jfx/pull/848.diff</a>

</details>
