### PR TITLE
8290990: Clear .root style class from a root node that is removed from a Scene/SubScene

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -1223,6 +1223,7 @@ public class Scene implements EventTarget {
 
                     if (oldRoot != null) {
                         oldRoot.setScenes(null, null);
+                        oldRoot.getStyleClass().remove("root");
                     }
                     oldRoot = _value;
                     _value.getStyleClass().add(0, "root");

--- a/modules/javafx.graphics/src/main/java/javafx/scene/SubScene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/SubScene.java
@@ -316,6 +316,7 @@ public class SubScene extends Node {
                     if (oldRoot != null) {
                         StyleManager.getInstance().forget(SubScene.this);
                         oldRoot.setScenes(null, null);
+                        oldRoot.getStyleClass().remove("root");
                     }
                     oldRoot = _value;
                     _value.getStyleClass().add(0, "root");

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/SceneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/SceneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -220,6 +220,17 @@ public class SceneTest {
         assertNull(g.getScene());
         assertEquals(g2, scene.getRoot());
         assertEquals(scene, g2.getScene());
+    }
+
+    @Test
+    public void testRootStyleClassIsClearedWhenRootNodeIsRemovedFromScene() {
+        Scene scene = new Scene(new Group());
+        Group g = new Group();
+        assertFalse(g.getStyleClass().contains("root"));
+        scene.setRoot(g);
+        assertTrue(g.getStyleClass().contains("root"));
+        scene.setRoot(new Group());
+        assertFalse(g.getStyleClass().contains("root"));
     }
 
     @Test

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/SubSceneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/SubSceneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ import javafx.scene.SubScene;
 import javafx.scene.SubSceneShim;
 import javafx.scene.layout.Pane;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import org.junit.Test;
 import static org.junit.Assert.assertTrue;
@@ -129,6 +130,17 @@ public class SubSceneTest {
         assertNull(NodeShim.getSubScene(g));
         assertEquals(g2, subScene.getRoot());
         assertEquals(subScene, NodeShim.getSubScene(g2));
+    }
+
+    @Test
+    public void testRootStyleClassIsClearedWhenRootNodeIsRemovedFromSubScene() {
+        SubScene scene = new SubScene(new Group(), 10, 10);
+        Group g = new Group();
+        assertFalse(g.getStyleClass().contains("root"));
+        scene.setRoot(g);
+        assertTrue(g.getStyleClass().contains("root"));
+        scene.setRoot(new Group());
+        assertFalse(g.getStyleClass().contains("root"));
     }
 
     @Test


### PR DESCRIPTION
When a node is set as the root node of a `Scene` or `SubScene`, the "root" style class is automatically added to the node, but not cleared when the node is later removed from the scene.

This can lead to an incorrectly set "root" style class when the removed node is inserted in the scene graph below the root node, or to duplicate "root" style class entries when the removed node is again set as the root node of the scene.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8290990](https://bugs.openjdk.org/browse/JDK-8290990): Clear .root style class from a root node that is removed from a Scene/SubScene


### Reviewers
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Author)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/849/head:pull/849` \
`$ git checkout pull/849`

Update a local copy of the PR: \
`$ git checkout pull/849` \
`$ git pull https://git.openjdk.org/jfx pull/849/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 849`

View PR using the GUI difftool: \
`$ git pr show -t 849`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/849.diff">https://git.openjdk.org/jfx/pull/849.diff</a>

</details>
