### PR TITLE
8290530: Bump minimum JDK version for JavaFX to JDK 17

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,11 +231,11 @@ Please also follow these formatting guidelines:
 
 ### Building and testing
 
-JDK 11 (at a minimum) is required to build OpenJFX. You must have the JDK
+JDK 17 (at a minimum) is required to build OpenJFX. You must have the JDK
 installed on your system
 with the environment variable `JAVA_HOME` referencing the path to Java home for
 your JDK installation. By default, tests use the same runtime as `JAVA_HOME`.
-Currently OpenJFX will build and run on JDK 11 through JDK 18. JDK 17 is recommended.
+Currently OpenJFX will build and run on JDK 17 through JDK 18.
 
 It is possible to develop in any major Java IDE (Eclipse, IntelliJ, NetBeans). IDEs can automatically configure projects based on Gradle setup.
 

--- a/build.gradle
+++ b/build.gradle
@@ -365,6 +365,9 @@ if (BUILD_CLOSED) {
 defineProperty("GRADLE_VERSION_CHECK", "true")
 ext.IS_GRADLE_VERSION_CHECK = Boolean.parseBoolean(GRADLE_VERSION_CHECK)
 
+// JAVA_TARGET_VERSION specifies the minimum compile and runtime Java version that we will target when building the JavaFX classes
+ext.JAVA_TARGET_VERSION = Integer.parseInt(jfxJdkTargetVersion)
+
 // JFX_DEPS_URL specifies the optional location of an alternate local repository
 defineProperty("JFX_DEPS_URL", "")
 
@@ -627,8 +630,8 @@ try {
             defineProperty("jdkBuildNumber", jdkVersionInfo[1])
 
             // Define global properties based on the version of Java
-            def status = compareJdkVersion(jdkVersion, "12")
-            ext.jdk12OrLater = (status >= 0)
+//            def status = compareJdkVersion(jdkVersion, "18")
+//            ext.jdk18OrLater = (status >= 0)
         }
     }
 } finally {
@@ -1340,6 +1343,7 @@ logger.quiet("jdk version: ${jdkVersion}")
 logger.quiet("jdk build number: ${jdkBuildNumber}")
 logger.quiet("minimum jdk version: ${jfxBuildJdkVersionMin}")
 logger.quiet("minimum jdk build number: ${jfxBuildJdkBuildnumMin}")
+logger.quiet("Java target version: ${JAVA_TARGET_VERSION}")
 
 if (IS_LINUX) {
     logger.quiet("GCC version: ${jfxBuildLinuxGccVersion}")
@@ -1954,7 +1958,11 @@ allprojects {
     // All of our projects are java projects
 
     apply plugin: "java"
-    sourceCompatibility = 11
+
+    // Set sourceCompatibility to the target release of Java. Most modules
+    // set compiler.options.release (to the same target version), which will
+    // override this setting, but it is needed for those modules that can't.
+    sourceCompatibility = JAVA_TARGET_VERSION
 
     // By default all of our projects require junit for testing so we can just
     // setup this dependency here.
@@ -2625,6 +2633,12 @@ project(":controls") {
 }
 
 project(":swing") {
+
+    // We need to skip setting compiler.options.release for this module,
+    // since javafx.swing requires jdk.unsupoprted.desktop, which is
+    // excluded by "--release NN". This will fall back to using
+    // "-source NN -target NN" for this module.
+    project.ext.skipJavaCompilerOptionRelease = true
 
     tasks.all {
         if (!COMPILE_SWING) it.enabled = false
@@ -3486,9 +3500,7 @@ project(":web") {
         dependsOn webArchiveJar
         def testResourceDir = file("$buildDir/testing/resources")
         jvmArgs "-DWEB_ARCHIVE_JAR_TEST_DIR=$testResourceDir"
-        if (jdk12OrLater) {
-            systemProperty 'java.security.manager', 'allow'
-        }
+        systemProperty 'java.security.manager', 'allow'
     }
 
     task compileJavaDOMBinding()
@@ -3697,6 +3709,12 @@ project(":systemTests") {
         sourceSets.testscriptapp2
     ]
 
+    // We need to skip setting compiler.options.release for system tests,
+    // since the tests export an internal package from java.desktop, which
+    // is disallowed by "--release NN". This will fall back to using
+    // "-source NN -target NN" for the system tests.
+    project.ext.skipJavaCompilerOptionRelease = true
+
     project.ext.buildModule = false
     project.ext.moduleRuntime = false
     project.ext.moduleName = "systemTests"
@@ -3866,9 +3884,7 @@ project(":systemTests") {
             systemProperty "ClipShapeTest.numTests", rootProject.getProperty("ClipShapeTest.numTests")
         }
 
-        if (jdk12OrLater) {
-            systemProperty 'java.security.manager', 'allow'
-        }
+        systemProperty 'java.security.manager', 'allow'
 
         if (!IS_USE_ROBOT) {
             // Disable all robot-based visual tests
@@ -3903,6 +3919,15 @@ allprojects {
         } else if (compile.options.hasProperty("incremental")) {
             compile.options.incremental = IS_INCREMENTAL
         }
+
+        if (project.hasProperty('skipJavaCompilerOptionRelease') &&
+                project.ext.skipJavaCompilerOptionRelease) {
+
+            logger.info "Using 'javac -source/-target' for ${compile}"
+        } else {
+            compile.options.release = JAVA_TARGET_VERSION
+        }
+
         compile.options.debug = true // we always generate debugging info in the class files
         compile.options.debugOptions.debugLevel = IS_DEBUG_JAVA ? "source,lines,vars" : "source,lines"
         compile.options.fork = true

--- a/build.gradle
+++ b/build.gradle
@@ -630,6 +630,10 @@ try {
             defineProperty("jdkBuildNumber", jdkVersionInfo[1])
 
             // Define global properties based on the version of Java
+            // For example, we could define a "jdk18OrLater" property as
+            // follows that could then be used implement conditional build
+            // logic based on whether we were running on JDK 18 or later,
+            // should the need arise.
 //            def status = compareJdkVersion(jdkVersion, "18")
 //            ext.jdk18OrLater = (status >= 0)
         }

--- a/build.gradle
+++ b/build.gradle
@@ -631,7 +631,7 @@ try {
 
             // Define global properties based on the version of Java
             // For example, we could define a "jdk18OrLater" property as
-            // follows that could then be used implement conditional build
+            // follows that could then be used to implement conditional build
             // logic based on whether we were running on JDK 18 or later,
             // should the need arise.
 //            def status = compareJdkVersion(jdkVersion, "18")

--- a/build.gradle
+++ b/build.gradle
@@ -2639,7 +2639,7 @@ project(":controls") {
 project(":swing") {
 
     // We need to skip setting compiler.options.release for this module,
-    // since javafx.swing requires jdk.unsupoprted.desktop, which is
+    // since javafx.swing requires jdk.unsupported.desktop, which is
     // excluded by "--release NN". This will fall back to using
     // "-source NN -target NN" for this module.
     project.ext.skipJavaCompilerOptionRelease = true

--- a/build.properties
+++ b/build.properties
@@ -70,13 +70,18 @@ javadoc.header=JavaFX&nbsp;20
 # jfx.build.jdk.buildnum.min should be set to the lowest version that
 # supports building FX (which must be <= jfx.build.jdk.buildnum)
 #
+# jfx.jdk.target.version is set to the minimum runtime version that
+# JavaFX will run on. This is passed to javac as the value of "--release",
+# so it also defines the language features that can be used.
+#
 ##############################################################################
 
 # JDK
 jfx.build.jdk.version=18.0.1
 jfx.build.jdk.buildnum=10
-jfx.build.jdk.version.min=11
-jfx.build.jdk.buildnum.min=28
+jfx.build.jdk.version.min=17
+jfx.build.jdk.buildnum.min=35
+jfx.jdk.target.version=17
 
 # The jfx.gradle.version property defines the version of gradle that is
 # used in the build. It must match the version number in
@@ -85,7 +90,7 @@ jfx.build.jdk.buildnum.min=28
 # The jfx.gradle.version.min property defines the minimum version of gradle
 # that is supported. It must be <= jfx.gradle.version.
 jfx.gradle.version=7.3
-jfx.gradle.version.min=6.3
+jfx.gradle.version.min=7.3
 
 # Toolchains
 jfx.build.linux.gcc.version=gcc11.2.0-OL6.4+1.0


### PR DESCRIPTION
This PR bumps the minimum JDK version needed to build and run JavaFX to JDK 17, starting with JavaFX 20.

As discussed in [this thread](https://mail.openjdk.org/pipermail/openjfx-dev/2022-July/034874.html) on the `openjfx-dev` mailing list, this means that we can start using language features and APIs available from JDK 12 through 17. However, this is not an open invitation to globally refactor data classes into records, or change all multi-line Strings into text blocks. Rather we will be able to start using recent JDK capabilities in new code where it makes sense to do so.

The changes are as follows:

1. Added a new `jfx.jdk.target.version` property in `build.properties` to define the minimum JDK version, and set it to 17.
2. Bumped the minimum version of the boot JDK to 17 and the minimum version of gradle to 7.3.
3. Use the recent gradle feature to implement the minimum JDK version using `--release NN` instead of `-source NN -target NN` where possible (everywhere except when building the `javafx.swing` module and the system tests).
4. Update `CONTRIBUTING.md` to say that JDK 17 is the minimum.

Because this change has behavioral compatibility impact, it will need a CSR and a release note.

/reviewers 2
/csr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8290530](https://bugs.openjdk.org/browse/JDK-8290530): Bump minimum JDK version for JavaFX to JDK 17
 * [JDK-8291052](https://bugs.openjdk.org/browse/JDK-8291052): Bump minimum JDK version for JavaFX to JDK 17 (**CSR**)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/850/head:pull/850` \
`$ git checkout pull/850`

Update a local copy of the PR: \
`$ git checkout pull/850` \
`$ git pull https://git.openjdk.org/jfx pull/850/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 850`

View PR using the GUI difftool: \
`$ git pr show -t 850`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/850.diff">https://git.openjdk.org/jfx/pull/850.diff</a>

</details>
