### PR TITLE
8291502: Mouse or touch presses on a non-focusable region don't clear the focusVisible flag of the current focus owner

### DIFF
--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/MouseEventFirer.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/MouseEventFirer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,6 +59,9 @@ public final class MouseEventFirer {
 
     public MouseEventFirer(EventTarget target) {
         this.target = target;
+
+        // Use the alternative creation path for MouseEvent by default, see JDK-8253769
+        this.alternative = true;
 
         // Force the target node onto a stage so that it is accessible
         if (target instanceof Node) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -4115,7 +4115,7 @@ public class Scene implements EventTarget {
 
         private void requestFocus(Node node, boolean focusVisible) {
             if (node == null) {
-                setFocusOwner(null, focusVisible);
+                setFocusOwner(null, false);
             } else if (node.isCanReceiveFocus()) {
                 if (node != getFocusOwner()) {
                     setFocusOwner(node, focusVisible);


### PR DESCRIPTION
The `focusVisible` flag is only set on a node when it acquires input focus using a keyboard interaction, and it is cleared by mouse and touch interactions.

It is not necessary for a node to lose input focus in order to lose `focusVisible`. Currently, clicking on a region of the scene that does not contain a focusable node does not clear the `focusVisible` flag.

Detecting clicks or touches that should clear `focusVisible` can be achieved by adding an event filter for `MOUSE_PRESSED` and `TOUCH_PRESSED` to the `Scene`.

There is an additional noteworthy change with this PR:
Adding event filters to `Scene` causes many tests to fail due to a bug in `MouseEventFirer` that was identified in [8253769](https://bugs.openjdk.org/browse/JDK-8253769). Previously, mouse events generated by `MouseEventFirer` skipped a code path that causes test failures due to incorrect coordinates. With the added event filters, the code path for mouse events is slightly different, exposing the incorrect coordinates and causing tests to fail.
This problem can be solved by making the "alternative" `MouseEvent` generation path the default path.

Note: Since this is a follow-up fix for [8268225](https://bugs.openjdk.org/browse/JDK-8268225), I'm targeting this fix for `jfx19`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8291502](https://bugs.openjdk.org/browse/JDK-8291502): Mouse or touch presses on a non-focusable region don't clear the focusVisible flag of the current focus owner


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/852/head:pull/852` \
`$ git checkout pull/852`

Update a local copy of the PR: \
`$ git checkout pull/852` \
`$ git pull https://git.openjdk.org/jfx pull/852/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 852`

View PR using the GUI difftool: \
`$ git pr show -t 852`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/852.diff">https://git.openjdk.org/jfx/pull/852.diff</a>

</details>
