### PR TITLE
8291087: Wrong position of focus of screen reader on Windows with screen scale > 1

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinAccessible.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinAccessible.java
@@ -41,6 +41,8 @@ import javafx.scene.Scene;
 import javafx.scene.input.KeyCombination;
 import com.sun.glass.ui.Accessible;
 import com.sun.glass.ui.View;
+import com.sun.javafx.stage.WindowHelper;
+import com.sun.javafx.tk.TKStage;
 import static javafx.scene.AccessibleAttribute.*;
 
 /*
@@ -877,6 +879,18 @@ final class WinAccessible extends Accessible {
         return variant;
     }
 
+    float[] getPlatformScales() {
+        float[] scales = new float[] { 1.0f, 1.0f };
+        Scene scene = (Scene)getAttribute(SCENE);
+        if (scene == null || scene.getWindow() == null) return scales;
+        TKStage tkStage = WindowHelper.getPeer(scene.getWindow());
+        if (tkStage == null) return scales;
+
+        scales[0] = tkStage.getPlatformScaleX();
+        scales[1] = tkStage.getPlatformScaleY();
+        return scales;
+    }
+
     /***********************************************/
     /*       IRawElementProviderFragment           */
     /***********************************************/
@@ -887,8 +901,16 @@ final class WinAccessible extends Accessible {
 
         Bounds bounds = (Bounds)getAttribute(BOUNDS);
         if (bounds != null) {
-            return new float[] {(float)bounds.getMinX(), (float)bounds.getMinY(),
-                                (float)bounds.getWidth(), (float)bounds.getHeight()};
+            float[] scales = getPlatformScales();
+            float scaleX = scales[0];
+            float scaleY = scales[1];
+
+            float minX = (float) bounds.getMinX() * scaleX;
+            float minY = (float) bounds.getMinY() * scaleY;
+            float width = (float) bounds.getWidth() * scaleX;
+            float height = (float) bounds.getHeight() * scaleY;
+
+            return new float[] { minX, minY, width, height };
         }
         return null;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTextRangeProvider.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTextRangeProvider.java
@@ -322,14 +322,18 @@ class WinTextRangeProvider {
         }
         Bounds[] bounds = (Bounds[])getAttribute(BOUNDS_FOR_RANGE, start, endOffset);
         if (bounds != null) {
+            float[] scales = accessible.getPlatformScales();
+            float scaleX = scales[0];
+            float scaleY = scales[1];
+
             double[] result = new double[bounds.length * 4];
             int index = 0;
             for (int i = 0; i < bounds.length; i++) {
                 Bounds b = bounds[i];
-                result[index++] = b.getMinX();
-                result[index++] = b.getMinY();
-                result[index++] = b.getWidth();
-                result[index++] = b.getHeight();
+                result[index++] = b.getMinX() * scaleX;
+                result[index++] = b.getMinY() * scaleY;
+                result[index++] = b.getWidth() * scaleX;
+                result[index++] = b.getHeight() * scaleY;
             }
             return result;
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTextRangeProvider.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTextRangeProvider.java
@@ -322,18 +322,20 @@ class WinTextRangeProvider {
         }
         Bounds[] bounds = (Bounds[])getAttribute(BOUNDS_FOR_RANGE, start, endOffset);
         if (bounds != null) {
-            float[] scales = accessible.getPlatformScales();
-            float scaleX = scales[0];
-            float scaleY = scales[1];
-
             double[] result = new double[bounds.length * 4];
             int index = 0;
             for (int i = 0; i < bounds.length; i++) {
                 Bounds b = bounds[i];
-                result[index++] = b.getMinX() * scaleX;
-                result[index++] = b.getMinY() * scaleY;
-                result[index++] = b.getWidth() * scaleX;
-                result[index++] = b.getHeight() * scaleY;
+                float[] platformBounds = accessible.getPlatformBounds(
+                        (float) b.getMinX(),
+                        (float) b.getMinY(),
+                        (float) b.getWidth(),
+                        (float) b.getHeight());
+
+                result[index++] = platformBounds[0];
+                result[index++] = platformBounds[1];
+                result[index++] = platformBounds[2];
+                result[index++] = platformBounds[3];
             }
             return result;
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
@@ -55,7 +55,7 @@ import java.util.Locale;
 import java.util.ResourceBundle;
 import static com.sun.javafx.FXPermissions.*;
 
-class WindowStage extends GlassStage {
+public class WindowStage extends GlassStage {
 
     protected Window platformWindow;
 
@@ -223,7 +223,7 @@ class WindowStage extends GlassStage {
         }
     }
 
-    final Window getPlatformWindow() {
+    public final Window getPlatformWindow() {
         return platformWindow;
     }
 


### PR DESCRIPTION
When using the Windows Narrator screen reader on a Hi-DPI screen, the visible focus is drawn in the wrong location and with the wrong size. This happens because the the JavaFX Windows accessibility code that returns the screen bounds of the requested UI element does not take the screen scale into account.

The fix is to adjust the bounds by the screen scale before returning it.

You can test it on a Windows machine with scaling set to >= 125% as follows:
1. Turn on Windows Narrator
2. Run any JavaFX program with at least UI controls, for example, `hello.HelloTextField` in `apps/toys/Hello`
3. TAB between the controls

Without the fix, Narrator shows the focus indicator in the wrong position and is too small. With the fix, it is correct. While testing this, I discovered an unrelated (and preexisting) bug where the focus indicator for a TextField or TextArea whose content is larger that the control (and is displayed with scroll bars) is not clipped to the visible area. This happens regardless of screen scale. I will file a follow-up bug for this.

Note that this bug is specific to Windows. It does not occur on macOS, which works correctly on a retina or non-retina display.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8291087](https://bugs.openjdk.org/browse/JDK-8291087): Wrong position of focus of screen reader on Windows with screen scale > 1


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/853/head:pull/853` \
`$ git checkout pull/853`

Update a local copy of the PR: \
`$ git checkout pull/853` \
`$ git pull https://git.openjdk.org/jfx pull/853/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 853`

View PR using the GUI difftool: \
`$ git pr show -t 853`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/853.diff">https://git.openjdk.org/jfx/pull/853.diff</a>

</details>
