### PR TITLE
8289605: Robot capture tests fail intermittently on Mac M1

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,6 +61,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Assume;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -137,6 +138,15 @@ public class RobotTest {
     private enum KeyAction {
         PRESSED,
         TYPED
+    }
+
+    @Before
+    public void before() {
+        double x = stage.getX() + stage.getWidth();
+        double y = stage.getY() + stage.getHeight();
+        Util.runAndWait(() -> {
+            robot.mouseMove(x,y);
+        });
     }
 
     @Test

--- a/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionBackgroundImageUITest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionBackgroundImageUITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionBackgroundImageUITest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionBackgroundImageUITest.java
@@ -24,21 +24,33 @@
 
 package test.robot.javafx.scene.layout;
 
-import test.robot.javafx.scene.layout.RegionUITestBase;
-import javafx.geometry.Bounds;
-import javafx.scene.paint.Color;
-import org.junit.Ignore;
-import org.junit.Test;
-import com.sun.javafx.PlatformUtil;
 import static org.junit.Assume.assumeTrue;
 
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.sun.javafx.PlatformUtil;
+
+import javafx.geometry.Bounds;
+import javafx.scene.paint.Color;
+
+/**************************************************************************
+ *                                                                        *
+ * Tests for aligned background images. The test image in use is chosen   *
+ * to align naturally with the edge of the test region.                   *
+ *                                                                        *
+ *************************************************************************/
 public class RegionBackgroundImageUITest extends RegionUITestBase {
-    /**************************************************************************
-     *                                                                        *
-     * Tests for aligned background images. The test image in use is chosen   *
-     * to align naturally with the edge of the test region.                   *
-     *                                                                        *
-     *************************************************************************/
+
+    @Before
+    public void before() {
+        double x = stage.getX() + stage.getWidth();
+        double y = stage.getY() + stage.getHeight();
+        runAndWait(() -> {
+            getRobot().mouseMove(x,y);
+        });
+    }
 
     @Test(timeout = 20000)
     public void alignedImage() {


### PR DESCRIPTION
- moving mouse pointer to stage lower right corner in order to avoid interference with the Robot screen capture.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289605](https://bugs.openjdk.org/browse/JDK-8289605): Robot capture tests fail intermittently on Mac M1


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/854/head:pull/854` \
`$ git checkout pull/854`

Update a local copy of the PR: \
`$ git checkout pull/854` \
`$ git pull https://git.openjdk.org/jfx pull/854/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 854`

View PR using the GUI difftool: \
`$ git pr show -t 854`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/854.diff">https://git.openjdk.org/jfx/pull/854.diff</a>

</details>
