### PR TITLE
8291625: DialogPane without header nor headerText nor graphic node adds padding to the left of the content pane

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/DialogPane.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/DialogPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1118,16 +1118,15 @@ public class DialogPane extends Pane {
             headerLabel.setMaxHeight(Double.MAX_VALUE);
             headerTextPanel.add(headerLabel, 0, 0);
 
-            // on the right of the header is a graphic, if one is specified
+            // to the right of the header, if any, or to the left of the content area otherwise,
+            // there is a graphic, if one is specified
             graphicContainer.getChildren().clear();
-
-            if (! graphicContainer.getStyleClass().contains("graphic-container")) { //$NON-NLS-1$)
-                graphicContainer.getStyleClass().add("graphic-container"); //$NON-NLS-1$
-            }
+            graphicContainer.getStyleClass().clear();
 
             final Node graphic = getGraphic();
             if (graphic != null) {
                 graphicContainer.getChildren().add(graphic);
+                graphicContainer.getStyleClass().add("graphic-container"); //$NON-NLS-1$
             }
             headerTextPanel.add(graphicContainer, 1, 0);
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/DialogPaneTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/DialogPaneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package test.javafx.scene.control;
 
 import javafx.collections.ObservableList;
 import javafx.css.PseudoClass;
+import javafx.geometry.Bounds;
 import javafx.geometry.Insets;
 import javafx.scene.Node;
 import javafx.scene.control.ButtonBar;
@@ -34,7 +35,9 @@ import javafx.scene.control.ButtonType;
 import javafx.scene.control.DialogPane;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.StackPane;
+import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Font;
 import org.junit.After;
 import org.junit.Before;
@@ -57,6 +60,41 @@ public class DialogPaneTest {
     @After
     public void after() {
         sl.dispose();
+    }
+
+    @Test
+    public void test_noGraphic_noHeader() {
+        // Since DialogPane is not set in a Dialog, PseudoClass is activated manually
+        dialogPane.pseudoClassStateChanged(PseudoClass.getPseudoClass("no-header"), true);
+        // add empty headerText to call updateHeaderArea
+        dialogPane.setHeaderText("");
+        BorderPane pane = new BorderPane();
+        dialogPane.setContent(pane);
+        dialogPane.applyCss();
+        dialogPane.layout();
+
+        Bounds paneBounds = pane.localToScene(pane.getLayoutBounds());
+        assertEquals(0, paneBounds.getMinX(), 0.0);
+        assertEquals(0, paneBounds.getMinY(), 0.0);
+    }
+
+    @Test
+    public void test_graphic_noHeader() {
+        // Since DialogPane is not set in a Dialog, PseudoClass is activated manually
+        dialogPane.pseudoClassStateChanged(PseudoClass.getPseudoClass("no-header"), true);
+        Rectangle graphic = new Rectangle(10, 10);
+        dialogPane.setGraphic(graphic);
+        BorderPane pane = new BorderPane();
+        dialogPane.setContent(pane);
+        dialogPane.applyCss();
+        dialogPane.layout();
+
+        final StackPane graphicContainer = (StackPane) graphic.getParent();
+        final Insets padding = graphicContainer.getPadding();
+
+        Bounds paneBounds = pane.localToScene(pane.getLayoutBounds());
+        assertEquals(padding.getLeft() + graphic.getWidth() + padding.getRight(), paneBounds.getMinX(), 0.0);
+        assertEquals(0, paneBounds.getMinY(), 0.0);
     }
 
     @Test


### PR DESCRIPTION
This PR fixes an issue when there is a DialogPane that has no header and no graphic is set, by adding the `graphic-container` styleclass only when there is a non-null graphic applied, preventing the padding that otherwise the graphic container will keep.

Two tests have been added, to verify that the padding is 0 when there is no graphic (this test fails without this PR) and to verify that the padding is correct when there is a graphic to the left of the content area.

As part of this PR or as possible follow-up, it could be also discussed that the right/bottom padding of the graphic container shouldn't be 0 when there is no header and the graphic is laid out to the left of the content area.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291625](https://bugs.openjdk.org/browse/JDK-8291625): DialogPane without header nor headerText nor graphic node adds padding to the left of the content pane


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/859/head:pull/859` \
`$ git checkout pull/859`

Update a local copy of the PR: \
`$ git checkout pull/859` \
`$ git pull https://git.openjdk.org/jfx pull/859/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 859`

View PR using the GUI difftool: \
`$ git pr show -t 859`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/859.diff">https://git.openjdk.org/jfx/pull/859.diff</a>

</details>
