### PR TITLE
8187145: (Tree)TableView with null selectionModel: throws NPE on sorting

### DIFF
--- a/apps/.classpath
+++ b/apps/.classpath
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/base"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/controls"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/fxml"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/graphics"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/media"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/swing"/>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/apps/.settings/org.eclipse.core.resources.prefs
+++ b/apps/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/apps/samples/.classpath
+++ b/apps/samples/.classpath
@@ -1,27 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-    <classpathentry kind="src" path="3DViewer/src/main/java"/>
-    <classpathentry kind="src" path="3DViewer/src/test/java"/>
-    <classpathentry kind="src" path="3DViewer/src/main/resources"/>
-    <classpathentry kind="src" path="3DViewer/src/test/resources"/>
-    <classpathentry kind="src" path="Ensemble8/src/app/java"/>
-    <classpathentry kind="src" path="Ensemble8/src/app/resources"/>
-    <classpathentry kind="src" path="Ensemble8/src/samples/java"/>
-    <classpathentry kind="src" path="Ensemble8/src/samples/resources"/>
-    <classpathentry kind="src" path="Ensemble8/src/compiletime/java"/>
-    <classpathentry kind="src" path="Ensemble8/src/generated/java"/>
-    <classpathentry kind="src" path="Ensemble8/src/generated/resources"/>
-    <classpathentry kind="lib" path="Ensemble8/lib/lucene-core-7.7.3.jar"/>
-    <classpathentry kind="lib" path="Ensemble8/lib/lucene-grouping-7.7.3.jar"/>
-    <classpathentry kind="lib" path="Ensemble8/lib/lucene-queryparser-7.7.3.jar"/>
-    <classpathentry kind="src" path="MandelbrotSet/src"/>
-    <classpathentry kind="src" path="Modena/src/main/java"/>
-    <classpathentry kind="src" path="Modena/src/main/resources"/>
-    <classpathentry combineaccessrules="false" kind="src" path="/rt">
-    <attributes>
-        <attribute name="optional" value="true"/>
-        </attributes>
-    </classpathentry>
-    <classpathentry kind="output" path="bin"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="3DViewer/src/main/java"/>
+	<classpathentry kind="src" path="3DViewer/src/test/java"/>
+	<classpathentry kind="src" path="3DViewer/src/main/resources"/>
+	<classpathentry kind="src" path="3DViewer/src/test/resources"/>
+	<classpathentry kind="src" path="Ensemble8/src/app/java"/>
+	<classpathentry kind="src" path="Ensemble8/src/app/resources"/>
+	<classpathentry kind="src" path="Ensemble8/src/samples/java"/>
+	<classpathentry kind="src" path="Ensemble8/src/samples/resources"/>
+	<classpathentry kind="src" path="Ensemble8/src/compiletime/java"/>
+	<classpathentry kind="src" path="Ensemble8/src/generated/java"/>
+	<classpathentry kind="src" path="Ensemble8/src/generated/resources"/>
+	<classpathentry kind="lib" path="Ensemble8/lib/lucene-core-7.7.3.jar"/>
+	<classpathentry kind="lib" path="Ensemble8/lib/lucene-grouping-7.7.3.jar"/>
+	<classpathentry kind="lib" path="Ensemble8/lib/lucene-queryparser-7.7.3.jar"/>
+	<classpathentry kind="src" path="MandelbrotSet/src"/>
+	<classpathentry kind="src" path="Modena/src/main/java"/>
+	<classpathentry kind="src" path="Modena/src/main/resources"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/web"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/media"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/base"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/controls"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/graphics"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/fxml"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/swing"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/apps/samples/.settings/org.eclipse.core.resources.prefs
+++ b/apps/samples/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/apps/toys/.classpath
+++ b/apps/toys/.classpath
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-    <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
-    <classpathentry kind="src" path="FX8-3DFeatures/src"/>
-    <classpathentry kind="src" path="Hello/src/main/java"/>
-    <classpathentry combineaccessrules="false" kind="src" path="/rt">
-    <attributes>
-        <attribute name="optional" value="true"/>
-        </attributes>
-    </classpathentry>
-    <classpathentry kind="output" path="bin"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="FX8-3DFeatures/src"/>
+	<classpathentry kind="src" path="Hello/src/main/java"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/web"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/graphics"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/controls"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/base"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/fxml"/>
+	<classpathentry combineaccessrules="false" kind="src" path="/media"/>
+	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/apps/toys/.settings/org.eclipse.core.resources.prefs
+++ b/apps/toys/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/apps/toys/ColorCube/.classpath
+++ b/apps/toys/ColorCube/.classpath
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry combineaccessrules="false" kind="src" path="/graphics">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry combineaccessrules="false" kind="src" path="/controls">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry combineaccessrules="false" kind="src" path="/base">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry combineaccessrules="false" kind="src" path="/swing">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="bin"/>
+</classpath>

--- a/apps/toys/ColorCube/.project
+++ b/apps/toys/ColorCube/.project
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>ColorCube</name>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/apps/toys/ColorCube/.settings/org.eclipse.core.resources.prefs
+++ b/apps/toys/ColorCube/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/buildSrc/.classpath
+++ b/buildSrc/.classpath
@@ -1,13 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-  <classpathentry kind="src" path="build/generated-src/antlr"/>
-  <classpathentry kind="src" path="src/main/java"/>
-  <classpathentry kind="src" path="src/test/java"/>
-  <classpathentry kind="lib" exported="true" path="../build/libs/ant-1.8.2.jar"/>
-  <classpathentry kind="lib" exported="true" path="../build/libs/antlr-3.1.3.jar"/>
-  <classpathentry kind="lib" exported="true" path="../build/libs/antlr-runtime-3.1.3.jar"/>
-  <classpathentry kind="lib" exported="true" path="../build/libs/stringtemplate-3.2.jar"/>
-  <classpathentry kind="lib" exported="true" path="../build/libs/swt-debug.jar"/>
   <classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
   <classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
   <classpathentry kind="output" path="bin"/>

--- a/buildSrc/.settings/org.eclipse.core.resources.prefs
+++ b/buildSrc/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/CellBehaviorBase.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/CellBehaviorBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -271,15 +271,21 @@ public abstract class CellBehaviorBase<T extends Cell> extends BehaviorBase<T> {
 
     protected void simpleSelect(MouseButton button, int clickCount, boolean shortcutDown) {
         final int index = getIndex();
-        MultipleSelectionModel<?> sm = getSelectionModel();
-        boolean isAlreadySelected = sm.isSelected(index);
+        boolean isAlreadySelected;
 
-        if (isAlreadySelected && shortcutDown) {
-            sm.clearSelection(index);
-            getFocusModel().focus(index);
+        MultipleSelectionModel<?> sm = getSelectionModel();
+        if (sm == null) {
             isAlreadySelected = false;
         } else {
-            sm.clearAndSelect(index);
+            isAlreadySelected = sm.isSelected(index);
+
+            if (isAlreadySelected && shortcutDown) {
+                sm.clearSelection(index);
+                getFocusModel().focus(index);
+                isAlreadySelected = false;
+            } else {
+                sm.clearAndSelect(index);
+            }
         }
 
         handleClicks(button, clickCount, isAlreadySelected);
@@ -300,6 +306,10 @@ public abstract class CellBehaviorBase<T extends Cell> extends BehaviorBase<T> {
     }
 
     void selectRows(int focusedIndex, int index) {
+        if (getSelectionModel() == null) {
+            return;
+        }
+
         final boolean asc = focusedIndex < index;
 
         // and then determine all row and columns which must be selected

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableCellBehaviorBase.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableCellBehaviorBase.java
@@ -208,7 +208,7 @@ public abstract class TableCellBehaviorBase<S, T, TC extends TableColumnBase<S, 
             final int row = getNode().getIndex();
             final TableColumnBase<S,T> column = getTableColumn();
             isAlreadySelected = sm.isSelected(row, column);
-    
+
             if (isAlreadySelected && shortcutDown) {
                 sm.clearSelection(row, column);
                 getFocusModel().focus(row, (TC) column);

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableCellBehaviorBase.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableCellBehaviorBase.java
@@ -223,6 +223,7 @@ public abstract class TableCellBehaviorBase<S, T, TC extends TableColumnBase<S, 
     }
 
     private int getColumn() {
+        // this method will not be called if selection model is null
         if (getSelectionModel().isCellSelectionEnabled()) {
             TableColumnBase<S,T> tc = getTableColumn();
             return getVisibleLeafIndex(tc);

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableCellBehaviorBase.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableCellBehaviorBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,17 +200,23 @@ public abstract class TableCellBehaviorBase<S, T, TC extends TableColumnBase<S, 
 
     protected void simpleSelect(MouseButton button, int clickCount, boolean shortcutDown) {
         final TableSelectionModel<S> sm = getSelectionModel();
-        final int row = getNode().getIndex();
-        final TableColumnBase<S,T> column = getTableColumn();
-        boolean isAlreadySelected = sm.isSelected(row, column);
+        boolean isAlreadySelected;
 
-        if (isAlreadySelected && shortcutDown) {
-            sm.clearSelection(row, column);
-            getFocusModel().focus(row, (TC) column);
+        if (sm == null) {
             isAlreadySelected = false;
         } else {
-            // we check if cell selection is enabled to fix RT-33897
-            sm.clearAndSelect(row, column);
+            final int row = getNode().getIndex();
+            final TableColumnBase<S,T> column = getTableColumn();
+            isAlreadySelected = sm.isSelected(row, column);
+    
+            if (isAlreadySelected && shortcutDown) {
+                sm.clearSelection(row, column);
+                getFocusModel().focus(row, (TC) column);
+                isAlreadySelected = false;
+            } else {
+                // we check if cell selection is enabled to fix RT-33897
+                sm.clearAndSelect(row, column);
+            }
         }
 
         handleClicks(button, clickCount, isAlreadySelected);

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableViewBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TableViewBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package com.sun.javafx.scene.control.behavior;
 
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.WeakChangeListener;
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableColumnBase;
@@ -114,7 +115,12 @@ public class TableViewBehavior<T> extends TableViewBehaviorBase<TableView<T>, T,
 
     /** {@inheritDoc}  */
     @Override protected ObservableList<TablePosition> getSelectedCells() {
-        return getNode().getSelectionModel().getSelectedCells();
+        TableViewSelectionModel<T> sm = getNode().getSelectionModel();
+        if (sm == null) {
+            return FXCollections.emptyObservableList();
+        } else {
+            return sm.getSelectedCells();
+        }
     }
 
     /** {@inheritDoc}  */

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TreeTableViewBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TreeTableViewBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import static javafx.scene.input.KeyCode.*;
 
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.WeakChangeListener;
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.control.TableColumnBase;
 import javafx.scene.control.TableFocusModel;
@@ -38,6 +39,7 @@ import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeTableColumn;
 import javafx.scene.control.TreeTablePosition;
 import javafx.scene.control.TreeTableView;
+import javafx.scene.control.TreeTableView.TreeTableViewSelectionModel;
 import com.sun.javafx.scene.control.inputmap.InputMap;
 import javafx.util.Callback;
 
@@ -121,7 +123,12 @@ public class TreeTableViewBehavior<T> extends TableViewBehaviorBase<TreeTableVie
 
     /** {@inheritDoc}  */
     @Override protected ObservableList<TreeTablePosition<T,?>> getSelectedCells() {
-        return getNode().getSelectionModel().getSelectedCells();
+        TreeTableViewSelectionModel<T> sm = getNode().getSelectionModel();
+        if (sm == null) {
+            return FXCollections.observableArrayList();
+        } else {
+            return sm.getSelectedCells();
+        }
     }
 
     /** {@inheritDoc}  */
@@ -187,7 +194,8 @@ public class TreeTableViewBehavior<T> extends TableViewBehaviorBase<TreeTableVie
      * on whether we are in row or cell selection.
      */
     private void rightArrowPressed() {
-        if (getNode().getSelectionModel().isCellSelectionEnabled()) {
+        TreeTableViewSelectionModel<T> sm = getNode().getSelectionModel();
+        if ((sm != null) && sm.isCellSelectionEnabled()) {
             if (isRTL()) {
                 selectLeftCell();
             } else {
@@ -199,7 +207,8 @@ public class TreeTableViewBehavior<T> extends TableViewBehaviorBase<TreeTableVie
     }
 
     private void leftArrowPressed() {
-        if (getNode().getSelectionModel().isCellSelectionEnabled()) {
+        TreeTableViewSelectionModel<T> sm = getNode().getSelectionModel();
+        if ((sm != null) && sm.isCellSelectionEnabled()) {
             if (isRTL()) {
                 selectRightCell();
             } else {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
@@ -1567,20 +1567,26 @@ public class TableView<S> extends Control {
             return;
         }
 
-        final List<TablePosition> prevState = new ArrayList<>(getSelectionModel().getSelectedCells());
-        final int itemCount = prevState.size();
+        TableViewSelectionModel<S> selectionModel = getSelectionModel();
+        final List<TablePosition> prevState = selectionModel == null ?
+                null :
+                new ArrayList<>(selectionModel.getSelectedCells());
 
         // we set makeAtomic to true here, so that we don't fire intermediate
         // sort events - instead we send a single permutation event at the end
         // of this method.
-        getSelectionModel().startAtomic();
+        if (selectionModel != null) {
+            selectionModel.startAtomic();
+        }
 
         // get the sort policy and run it
         Callback<TableView<S>, Boolean> sortPolicy = getSortPolicy();
         if (sortPolicy == null) return;
         Boolean success = sortPolicy.call(this);
 
-        getSelectionModel().stopAtomic();
+        if (selectionModel != null) {
+            selectionModel.stopAtomic();
+        }
 
         if (success == null || ! success) {
             // the sort was a failure. Need to backout if possible
@@ -1593,15 +1599,16 @@ public class TableView<S> extends Control {
             // selection model that the items list has 'permutated' to a new ordering
 
             // FIXME we should support alternative selection model implementations!
-            if (getSelectionModel() instanceof TableViewArrayListSelectionModel) {
-                final TableViewArrayListSelectionModel<S> sm = (TableViewArrayListSelectionModel<S>) getSelectionModel();
+            if (selectionModel instanceof TableViewArrayListSelectionModel) {
+                final TableViewArrayListSelectionModel<S> sm = (TableViewArrayListSelectionModel<S>)selectionModel;
                 final ObservableList<TablePosition<S,?>> newState = (ObservableList<TablePosition<S,?>>)(Object)sm.getSelectedCells();
 
                 List<TablePosition<S, ?>> removed = new ArrayList<>();
-                for (int i = 0; i < itemCount; i++) {
-                    TablePosition<S, ?> prevItem = prevState.get(i);
-                    if (!newState.contains(prevItem)) {
-                        removed.add(prevItem);
+                if(prevState != null) {
+                    for (TablePosition<S, ?> prevItem: prevState) {
+                        if (!newState.contains(prevItem)) {
+                            removed.add(prevItem);
+                        }
                     }
                 }
 
@@ -1611,6 +1618,7 @@ public class TableView<S> extends Control {
                     // TablePosition's changing (which may reside in the same list
                     // position before and after the sort). Therefore, we need to fire
                     // a single add/remove event to cover the added and removed positions.
+                    int itemCount = prevState == null ? 0 : prevState.size();
                     ListChangeListener.Change<TablePosition<S, ?>> c = new NonIterableChange.GenericAddRemoveChange<>(0, itemCount, removed, newState);
                     sm.fireCustomSelectedCellsListChangeEvent(c);
                 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -1078,7 +1078,12 @@ public class TreeTableView<S> extends Control {
 
                     oldValue = get();
 
-                    if (oldValue != null) {
+                    if (oldValue == null) {
+                        // show no focused rows with a null selection model
+                        if (getFocusModel() != null) {
+                            getFocusModel().setFocusedIndex(-1);
+                        }
+                    } else {
                         oldValue.cellSelectionEnabledProperty().addListener(weakCellSelectionModelInvalidationListener);
                         // fake invalidation to ensure updated pseudo-class states
                         weakCellSelectionModelInvalidationListener.invalidated(oldValue.cellSelectionEnabledProperty());

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkin.java
@@ -147,27 +147,26 @@ public class TableRowSkin<T> extends TableRowSkinBase<T, TableRow<T>, TableCell<
     @Override protected Object queryAccessibleAttribute(AccessibleAttribute attribute, Object... parameters) {
         switch (attribute) {
             case SELECTED_ITEMS: {
-                if (getTableView().getSelectionModel() == null) {
-                    return null;
-                }
-
-                // FIXME this could be optimised to iterate over cellsMap only
-                // (selectedCells could be big, cellsMap is much smaller)
-                List<Node> selection = new ArrayList<>();
-                int index = getSkinnable().getIndex();
-                for (TablePosition<T,?> pos : getTableView().getSelectionModel().getSelectedCells()) {
-                    if (pos.getRow() == index) {
-                        TableColumn<T,?> column = pos.getTableColumn();
-                        if (column == null) {
-                            /* This is the row-based case */
-                            column = getTableView().getVisibleLeafColumn(0);
+                if (getTableView().getSelectionModel() != null) {
+                    // FIXME this could be optimised to iterate over cellsMap only
+                    // (selectedCells could be big, cellsMap is much smaller)
+                    List<Node> selection = new ArrayList<>();
+                    int index = getSkinnable().getIndex();
+                    for (TablePosition<T,?> pos : getTableView().getSelectionModel().getSelectedCells()) {
+                        if (pos.getRow() == index) {
+                            TableColumn<T,?> column = pos.getTableColumn();
+                            if (column == null) {
+                                /* This is the row-based case */
+                                column = getTableView().getVisibleLeafColumn(0);
+                            }
+                            TableCell<T,?> cell = cellsMap.get(column).get();
+                            if (cell != null) selection.add(cell);
                         }
-                        TableCell<T,?> cell = cellsMap.get(column).get();
-                        if (cell != null) selection.add(cell);
+                        return FXCollections.observableArrayList(selection);
                     }
-                    return FXCollections.observableArrayList(selection);
                 }
             }
+            // fall through
             case CELL_AT_ROW_COLUMN: {
                 int colIndex = (Integer)parameters[1];
                 TableColumn<T,?> column = getTableView().getVisibleLeafColumn(colIndex);
@@ -176,6 +175,7 @@ public class TableRowSkin<T> extends TableRowSkinBase<T, TableRow<T>, TableCell<
                 }
                 return null;
             }
+            // fall through
             case FOCUS_ITEM: {
                 TableViewFocusModel<T> fm = getTableView().getFocusModel();
                 TablePosition<T,?> focusedCell = fm.getFocusedCell();
@@ -189,6 +189,7 @@ public class TableRowSkin<T> extends TableRowSkinBase<T, TableRow<T>, TableCell<
                 }
                 return null;
             }
+            // fall through
             default: return super.queryAccessibleAttribute(attribute, parameters);
         }
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -147,6 +147,10 @@ public class TableRowSkin<T> extends TableRowSkinBase<T, TableRow<T>, TableCell<
     @Override protected Object queryAccessibleAttribute(AccessibleAttribute attribute, Object... parameters) {
         switch (attribute) {
             case SELECTED_ITEMS: {
+                if (getTableView().getSelectionModel() == null) {
+                    return null;
+                }
+
                 // FIXME this could be optimised to iterate over cellsMap only
                 // (selectedCells could be big, cellsMap is much smaller)
                 List<Node> selection = new ArrayList<>();

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,9 +152,11 @@ public class TableViewSkin<T> extends TableViewSkinBase<T, T, TableView<T>, Tabl
             case SELECTED_ITEMS: {
                 List<Node> selection = new ArrayList<>();
                 TableViewSelectionModel<T> sm = getSkinnable().getSelectionModel();
-                for (TablePosition<T,?> pos : sm.getSelectedCells()) {
-                    TableRow<T> row = flow.getPrivateCell(pos.getRow());
-                    if (row != null) selection.add(row);
+                if (sm != null) {
+                    for (TablePosition<T,?> pos : sm.getSelectedCells()) {
+                        TableRow<T> row = flow.getPrivateCell(pos.getRow());
+                        if (row != null) selection.add(row);
+                    }
                 }
                 return FXCollections.observableArrayList(selection);
             }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -805,6 +805,10 @@ public abstract class TableViewSkinBase<M, S, C extends Control, I extends Index
 
     private boolean isLeadIndex(boolean isFocusDriven, int index) {
         final TableSelectionModel<S> sm = getSelectionModel();
+        if (sm == null) {
+            return false;
+        }
+
         final FocusModel<M> fm = getFocusModel();
 
         return (isFocusDriven && fm.getFocusedIndex() == index)

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableRowSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableRowSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -455,23 +455,26 @@ public class TreeTableRowSkin<T> extends TableRowSkinBase<TreeItem<T>, TreeTable
         final TreeTableView<T> treeTableView = getSkinnable().getTreeTableView();
         switch (attribute) {
             case SELECTED_ITEMS: {
-                // FIXME this could be optimised to iterate over cellsMap only
-                // (selectedCells could be big, cellsMap is much smaller)
-                List<Node> selection = new ArrayList<>();
-                int index = getSkinnable().getIndex();
-                for (TreeTablePosition<T,?> pos : treeTableView.getSelectionModel().getSelectedCells()) {
-                    if (pos.getRow() == index) {
-                        TreeTableColumn<T,?> column = pos.getTableColumn();
-                        if (column == null) {
-                            /* This is the row-based case */
-                            column = treeTableView.getVisibleLeafColumn(0);
+                if (treeTableView.getSelectionModel() != null) {
+                    // FIXME this could be optimised to iterate over cellsMap only
+                    // (selectedCells could be big, cellsMap is much smaller)
+                    List<Node> selection = new ArrayList<>();
+                    int index = getSkinnable().getIndex();
+                    for (TreeTablePosition<T,?> pos : treeTableView.getSelectionModel().getSelectedCells()) {
+                        if (pos.getRow() == index) {
+                            TreeTableColumn<T,?> column = pos.getTableColumn();
+                            if (column == null) {
+                                /* This is the row-based case */
+                                column = treeTableView.getVisibleLeafColumn(0);
+                            }
+                            TreeTableCell<T,?> cell = cellsMap.get(column).get();
+                            if (cell != null) selection.add(cell);
                         }
-                        TreeTableCell<T,?> cell = cellsMap.get(column).get();
-                        if (cell != null) selection.add(cell);
+                        return FXCollections.observableArrayList(selection);
                     }
-                    return FXCollections.observableArrayList(selection);
                 }
             }
+            // fall through
             case CELL_AT_ROW_COLUMN: {
                 int colIndex = (Integer)parameters[1];
                 TreeTableColumn<T,?> column = treeTableView.getVisibleLeafColumn(colIndex);
@@ -480,6 +483,7 @@ public class TreeTableRowSkin<T> extends TableRowSkinBase<TreeItem<T>, TreeTable
                 }
                 return null;
             }
+            // fall through
             case FOCUS_ITEM: {
                 TreeTableView.TreeTableViewFocusModel<T> fm = treeTableView.getFocusModel();
                 TreeTablePosition<T,?> focusedCell = fm.getFocusedCell();
@@ -493,6 +497,7 @@ public class TreeTableRowSkin<T> extends TableRowSkinBase<TreeItem<T>, TreeTable
                 }
                 return null;
             }
+            // fall through
             default: return super.queryAccessibleAttribute(attribute, parameters);
         }
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeTableViewSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -218,9 +218,11 @@ public class TreeTableViewSkin<T> extends TableViewSkinBase<T, TreeItem<T>, Tree
             case SELECTED_ITEMS: {
                 List<Node> selection = new ArrayList<>();
                 TreeTableView.TreeTableViewSelectionModel<T> sm = getSkinnable().getSelectionModel();
-                for (TreeTablePosition<T,?> pos : sm.getSelectedCells()) {
-                    TreeTableRow<T> row = flow.getPrivateCell(pos.getRow());
-                    if (row != null) selection.add(row);
+                if (sm != null) {
+                    for (TreeTablePosition<T,?> pos : sm.getSelectedCells()) {
+                        TreeTableRow<T> row = flow.getPrivateCell(pos.getRow());
+                        if (row != null) selection.add(row);
+                    }
                 }
                 return FXCollections.observableArrayList(selection);
             }

--- a/modules/javafx.graphics/.classpath
+++ b/modules/javafx.graphics/.classpath
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src/main/java"/>
+	<classpathentry kind="src" path="build/gensrc/jsl-prism"/>
+	<classpathentry kind="src" path="build/gensrc/jsl-decora"/>
 	<classpathentry kind="src" output="testbin" path="src/shims/java">
 		<attributes>
 			<attribute name="test" value="true"/>


### PR DESCRIPTION
Setting a null selection model in TableView and TreeTableView produce NPE on sorting (and probably in some other situations) because the check for null is not done in several parts of the code. Setting a null selection model is a valid way to disable selection in a (tree)table.

There is also a similar issue with ListView [JDK-8279640](https://bugs.openjdk.org/browse/JDK-8279640).

changes:
- added check for null selection model where it was missing
- clearing focused row index on setting null selection model in TreeTableView

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8187145](https://bugs.openjdk.org/browse/JDK-8187145): (Tree)TableView with null selectionModel: throws NPE on sorting


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/864/head:pull/864` \
`$ git checkout pull/864`

Update a local copy of the PR: \
`$ git checkout pull/864` \
`$ git pull https://git.openjdk.org/jfx pull/864/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 864`

View PR using the GUI difftool: \
`$ git pr show -t 864`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/864.diff">https://git.openjdk.org/jfx/pull/864.diff</a>

</details>
