### PR TITLE
8279514: NPE on clearing value of IntegerSpinnerValueFactory

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SpinnerValueFactory.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SpinnerValueFactory.java
@@ -272,6 +272,8 @@ public abstract class SpinnerValueFactory<T> {
             });
 
             valueProperty().addListener((o, oldValue, newValue) -> {
+                if (newValue == null) return;
+
                 // when the value is set, we need to react to ensure it is a
                 // valid value (and if not, blow up appropriately)
                 int newIndex = -1;
@@ -468,6 +470,8 @@ public abstract class SpinnerValueFactory<T> {
             setConverter(new IntegerStringConverter());
 
             valueProperty().addListener((o, oldValue, newValue) -> {
+                if (newValue == null) return;
+
                 // when the value is set, we need to react to ensure it is a
                 // valid value (and if not, blow up appropriately)
                 if (newValue < getMin()) {
@@ -957,6 +961,8 @@ public abstract class SpinnerValueFactory<T> {
             });
 
             valueProperty().addListener((o, oldValue, newValue) -> {
+                if (newValue == null) return;
+
                 // when the value is set, we need to react to ensure it is a
                 // valid value (and if not, blow up appropriately)
                 if (getMin() != null && newValue.isBefore(getMin())) {
@@ -1213,6 +1219,8 @@ public abstract class SpinnerValueFactory<T> {
             });
 
             valueProperty().addListener((o, oldValue, newValue) -> {
+                if (newValue == null) return;
+
                 // when the value is set, we need to react to ensure it is a
                 // valid value (and if not, blow up appropriately)
                 if (getMin() != null && newValue.isBefore(getMin())) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
@@ -28,6 +28,7 @@ import static junit.framework.Assert.*;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -122,8 +123,20 @@ public class SpinnerTest {
                 LocalTime.MIN, LocalTime.MAX,
                 LocalTime.now(), 1, ChronoUnit.HOURS);
         localTimeValueFactory = localTimeSpinner.getValueFactory();
+
+        Thread.currentThread().setUncaughtExceptionHandler((thread, throwable) -> {
+            if (throwable instanceof RuntimeException) {
+                throw (RuntimeException)throwable;
+            } else {
+                Thread.currentThread().getThreadGroup().uncaughtException(thread, throwable);
+            }
+        });
     }
 
+    @After
+    public void tearDown() {
+        Thread.currentThread().setUncaughtExceptionHandler(null);
+    }
 
     /***************************************************************************
      *                                                                         *
@@ -1478,5 +1491,30 @@ public class SpinnerTest {
         } finally {
             stage.hide();
         }
+    }
+
+    @Test public void testSetValueNull_IntegerSpinner() {
+        intValueFactory.setValue(null);
+        assertEquals(null, intSpinner.getValue());
+    }
+
+    @Test public void testSetValueNull_DoubleSpinner() {
+        dblValueFactory.setValue(null);
+        assertEquals(null, dblSpinner.getValue());
+    }
+
+    @Test public void testSetValueNull_ListSpinner() {
+        listValueFactory.setValue(null);
+        assertEquals(null, listSpinner.getValue());
+    }
+
+    @Test public void testSetValueNull_LocalDateSpinner() {
+        localDateValueFactory.setValue(null);
+        assertEquals(null, localDateSpinner.getValue());
+    }
+
+    @Test public void testSetValueNull_LocalTimeSpinner() {
+        localTimeValueFactory.setValue(null);
+        assertEquals(null, localTimeSpinner.getValue());
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
@@ -1495,26 +1495,26 @@ public class SpinnerTest {
 
     @Test public void testSetValueNull_IntegerSpinner() {
         intValueFactory.setValue(null);
-        assertEquals(null, intSpinner.getValue());
+        assertNull(intSpinner.getValue());
     }
 
     @Test public void testSetValueNull_DoubleSpinner() {
         dblValueFactory.setValue(null);
-        assertEquals(null, dblSpinner.getValue());
+        assertNull(dblSpinner.getValue());
     }
 
     @Test public void testSetValueNull_ListSpinner() {
         listValueFactory.setValue(null);
-        assertEquals(null, listSpinner.getValue());
+        assertNull(listSpinner.getValue());
     }
 
     @Test public void testSetValueNull_LocalDateSpinner() {
         localDateValueFactory.setValue(null);
-        assertEquals(null, localDateSpinner.getValue());
+        assertNull(localDateSpinner.getValue());
     }
 
     @Test public void testSetValueNull_LocalTimeSpinner() {
         localTimeValueFactory.setValue(null);
-        assertEquals(null, localTimeSpinner.getValue());
+        assertNull(localTimeSpinner.getValue());
     }
 }


### PR DESCRIPTION
A null check has been added to below SpinnerValueFactory classes in valueProperty() ChangeListeners-
- `IntegerSpinnerValueFactory`
- `LocalDateSpinnerValueFactory`
- `LocalTimeSpinnerValueFactory`
- `ListSpinnerValueFactory`

Added 5 tests that detect NPE for above 4 Spinner factories.
Only `DoubleSpinnerValueFactory` already had a valid null check - so the test for it passes before and after.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279514](https://bugs.openjdk.org/browse/JDK-8279514): NPE on clearing value of IntegerSpinnerValueFactory


### Reviewers
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/865/head:pull/865` \
`$ git checkout pull/865`

Update a local copy of the PR: \
`$ git checkout pull/865` \
`$ git pull https://git.openjdk.org/jfx pull/865/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 865`

View PR using the GUI difftool: \
`$ git pr show -t 865`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/865.diff">https://git.openjdk.org/jfx/pull/865.diff</a>

</details>
