### PR TITLE
8290274: DRT 27 tests fail due to xml not well formed error on window

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/xml/parser/XMLDocumentParser.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/xml/parser/XMLDocumentParser.cpp
@@ -182,7 +182,10 @@ void XMLDocumentParser::end()
     // I don't believe XMLDocumentParserQt needs doEnd called in the fragment case.
     ASSERT(!m_parsingFragment);
 
+    // doEnd() call not needed for JAVA platform, as it is making XMLDocumentParserLibxml2 xml not well-formed error
+#if !PLATFORM(JAVA)
     doEnd();
+#endif
 
     // doEnd() call above can detach the parser and null out its document.
     // In that case, we just bail out.


### PR DESCRIPTION
Issue: xml not well-formed error occurs at XML document parser.
Issue: doEnd() call not needed for JAVA platform, as it is making XMLDocumentParserLibxml2 xml not well-formed error.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8290274](https://bugs.openjdk.org/browse/JDK-8290274): DRT 27 tests fail due to xml not well formed error on window


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/866/head:pull/866` \
`$ git checkout pull/866`

Update a local copy of the PR: \
`$ git checkout pull/866` \
`$ git pull https://git.openjdk.org/jfx.git pull/866/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 866`

View PR using the GUI difftool: \
`$ git pr show -t 866`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/866.diff">https://git.openjdk.org/jfx/pull/866.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/866#issuecomment-1210462685)