### PR TITLE
8291630: Update attribution in webkit.md file

### DIFF
--- a/modules/javafx.web/src/main/legal/webkit.md
+++ b/modules/javafx.web/src/main/legal/webkit.md
@@ -36,6 +36,178 @@ Apache 2.0, and BSD-style licenses.
 #### LGPL 2.1 License
 ```
 
+Copyright (C) 1999-2004 Harri Porten (porten@kde.org)
+Copyright (C) 2000-2003 Peter Kelly (pmk@post.com)
+Copyright (C) 2002-2022 Apple Inc. All rights reserved.
+Copyright (C) 2007 Cameron Zwarich (cwzwarich@uwaterloo.ca)
+Copyright (C) 2006-2007 Maks Orlovich
+Copyright (C) 2005-2008 Eric Seidel <eric@webkit.org>
+Copyright (C) 2010-2021 Igalia, S.L.
+Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
+Copyright (C) 2009 Acision BV. All rights reserved.
+Copyright (C) 2006 Bjoern Graf (bjoern.graf@gmail.com)
+Copyright (C) 2010 Zoltan Herczeg (zherczeg@inf.u-szeged.hu)
+Copyright (C) 2012 Mathias Bynens (mathias@qiwi.be)
+Copyright (C) 2005-2007 Alexey Proskuryakov (ap@nypop.com)
+Copyright (C) 2002-2021 Apple Inc.
+Copyright (C) 2008-2009 Torch Mobile, Inc. All rights reserved.
+Copyright (C) 2010-2011 Torch Mobile (Beijing) Co. Ltd. All rights reserved.
+Copyright (C) 2007 Eric Seidel (eric@webkit.org)
+Copyright (C) 2008-2021 Google Inc. All rights reserved.
+Copyright (C) 2007-2009 Torch Mobile, Inc.
+Copyright (C) 2010 &yet, LLC. (nate@andyet.net)
+Copyright 2006-2008 the V8 project authors. All rights reserved.
+Copyright (C) 2010-2011 Research In Motion Limited. All rights reserved.
+Copyright (C) 2015-2016 Canon Inc. All rights reserved.
+Copyright (C) 2006-2021 Apple, Inc.
+Copyright (C) 2010 Peter Varga (pvarga@inf.u-szeged.hu), University of Szeged
+Copyright (C) 2015 Jordan Harband (ljharb@gmail.com)
+Copyright (C) 2015 Yusuke Suzuki <utatane.tea@gmail.com>.
+Copyright (C) 2021 Igalia S.L. All rights reserved.
+Copyright (C) 2021 Igalia, S.L. All rights reserved.
+Copyright (C) 2017-2021 Sony Interactive Entertainment Inc.
+Copyright (C) 2004-2019 Nikolas Zimmermann <zimmermann@kde.org>
+Copyright (C) 2006 Anders Carlsson <andersca@mac.com>
+Copyright (C) 2006-2007 Samuel Weinig <sam@webkit.org>
+Copyright (C) 2005-2007 Alexey Proskuryakov <ap@webkit.org>
+Copyright (C) 2008-2009 Cameron McCormack <cam@mcc.id.au>
+Copyright (C) Research In Motion Limited 2009-2012. All rights reserved.
+Copyright (C) 2008-2013 Nokia Corporation and/or its subsidiary(-ies)
+Copyright (C) 2011 Patrick Gansterer <paroga@webkit.org>
+Copyright (C) 2009-2012 Ericsson AB. All rights reserved.
+Copyright (C) 2018-2019 Metrological Group B.V.
+Copyright (C) 2008 David Levin <levin@chromium.org>
+Copyright (C) 2011, Benjamin Poulain <ikipou@gmail.com>
+Copyright (C) 2012 University of Szeged. All rights reserved.
+Copyright (C) 2009-2022 Igalia S.L.
+Copyright (C) 2009-2011 Nokia Corporation and/or its subsidiary(-ies).
+Copyright (C) 2010-2012 Patrick Gansterer <paroga@paroga.com>
+Copyright (C) 2015 Yusuke Suzuki<utatane.tea@gmail.com>. All rights reserved.
+Copyright (C) 2000-2001 Dawit Alemayehu <adawit@kde.org>
+Copyright (C) 2006-2019 Apple Inc. All rights reserved
+Copyright (C) 1999-2003 Lars Knoll (knoll@kde.org)
+Copyright (C) 2006 Andrew Wellington (proton@wiretapped.net)
+Copyright (C) 2006 Lars Knoll <lars@trolltech.com>
+Copyright (C) 2006 George Staikos <staikos@kde.org>
+Copyright (C) 2005-2006 Alexey Proskuryakov <ap@nypop.com>
+Copyright (C) 2007-2008 Alp Toker <alp@atoker.com>
+Copyright (C) 2009 Gustavo Noronha Silva <gns@gnome.org>
+Copyright (C) 2000 Daniel Molkentin (molkentin@kde.org)
+Copyright (C) 2000 Stefan Schimanski (schimmi@kde.org)
+Copyright (C) 2011-2020 Igalia S.L
+Copyright (C) 2008 Nuanti Ltd.
+Copyright (C) 2008 Apple Ltd.
+Copyright (C) 2009 Jan Alonzo
+Copyright (C) 2012-2013 Samsung Electronics
+Copyright (C) 2012-2014 Samsung Electronics. All rights reserved.
+Copyright (C) 2009-2011 Google, Inc. All rights reserved.
+Copyright (C) 2013 Michael Pruett <michael@68k.org>
+Copyright (C) 2006 Jon Shier (jshier@iastate.edu)
+Copyright (C) 2003-2021 Apple Inc. All rights reseved.
+Copyright (C) 2006 Alexey Proskuryakov (ap@webkit.org)
+Copyright (C) 2009 Google Inc. All rights reseved.
+Copyright (C) 2004-2006 Nikolas Zimmermann <wildfox@kde.org>
+Copyright (C) 2007-2012 Google Inc.
+Copyright (C) 2004 Zack Rusin <zack@kde.org>
+Copyright (C) 2007 Nicholas Shanks <webkit@nickshanks.com>
+Copyright (C) 2011 Sencha, Inc. All rights reserved.
+Copyright (C) 2011-2018 Adobe Systems Incorporated. All rights reserved.
+Copyright (C) 2004-2010 Rob Buis <buis@kde.org>
+Copyright (C) 2003-2021 Apple Inc. All right reserved.
+Copyright (C) 2006-2007 Samuel Weinig (sam@webkit.org)
+Copyright (C) 2004-2005 Allan Sandfeld Jensen (kde@carewolf.com)
+Copyright (C) 2008-2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
+Copyright (C) 2012-2013 Intel Corporation. All rights reserved.
+Copyright (C) 2009-2010  Torch Mobile (Beijing) Co. Ltd. All rights reserved.
+Copyright (C) 2011 Andreas Kling (kling@webkit.org)
+Copyright (C) 2007-2008 David Smith (catfish.man@gmail.com)
+Copyright (C) 2006-2007 Nicholas Shanks (webkit@nickshanks.com)
+Copyright (C) 2011, Code Aurora Forum. All rights reserved.
+Copyright (C) 2011 Rik Cabanier (cabanier@adobe.com)
+Copyright (C) 2011-2012 Motorola Mobility, Inc. All rights reserved.
+Copyright (C) 2014 Yusuke Suzuki <utatane.tea@gmail.com>
+Copyright (C) 1999-2002 Waldo Bastian (bastian@kde.org)
+Copyright (C) 2010 Andras Becsi (abecsi@inf.u-szeged.hu), University of Szeged
+Copyright (C) 2001 Tobias Anton (anton@stud.fbi.fh-darmstadt.de)
+Copyright (C) 2006 Samuel Weinig (sam.weinig@gmail.com)
+Copyright (C) 2009-2012 Google, Inc.
+Copyright (C) 2008 David Smith <catfish.man@gmail.com>
+Copyright (C) 2006-2007 Rob Buis
+Copyright (C) 2004-2022 Apple, Inc. All rights reserved.
+Copyright (C) 2014 Yoav Weiss (yoav@yoav.ws)
+Copyright (C) 2015 Akamai Technologies Inc. All rights reserved.
+Copyright (C) 2000 Frederik Holljen (frederik.holljen@hig.no)
+Copyright (C) 2011 Motorola Mobility. All rights reserved.
+Copyright (C) 2009 Jakub Wieczorek <faw217@gmail.com>
+Copyright (C) 2009 Michelangelo De Simone <micdesim@gmail.com>
+Copyright (C) 2012 Motorola Mobility Inc.
+Copyright (C) 2006-2010 Apple Inc. All rights reserve
+Copyright (C) 2009 Rob Buis (rwlbuis@gmail.com)
+Copyright (C) 2003-2017 Inc. All rights reserved.
+Copyright (C) 2003-2013 Apple Inc. ALl rights reserved.
+Copyright (C) 1997 Martin Jones (mjones@kde.org)
+Copyright (C) 2010-2011 Nokia Inc. All rights reserved.
+Copyright (C) 2002 Cyrus Patel <cyp@fb14.uni-mainz.de>
+Copyright (C) 1998-1999 Lars Knoll (knoll@mpi-hd.mpg.de)
+Copyright (C) 2000-2003 Dirk Mueller (mueller@kde.org)
+Copyright (C) 2000-2001 Dirk Mueller <mueller@kde.org>
+Copyright (C) 2009 Torch Mobile Inc. http://www.torchmobile.com/
+Copyright (C) 2010 Rob Buis <rwlbuis@gmail.com>
+Copyright (C) 2011 Cosmin Truta <ctruta@gmail.com>
+Copyright (C) 2011-2012 University of Szeged
+Copyright (C) 2011-2012 Renata Hodovan <reni@webkit.org>
+Copyright (C) 2012, Samsung Electronics. All rights reserved.
+Copyright (C) 1998-1999 Torben Weis <weis@kde.org>
+Copyright (C) 2000 Simon Hausmann <hausmann@kde.org>
+Copyright (C) 2009 Antonio Gomes <tonikitoo@webkit.org>
+Copyright (C) 2010 Andras Becsi <abecsi@inf.u-szeged.hu>, University of Szeged
+Copyright (C) 2012, Google Inc. All rights reserved.
+Copyright (C) 1999 Antti Koivisto (koivisto@kde.org)
+Copyright (C) 2006 Graham Dennis (graham.dennis@gmail.com)
+Copyright (C) 2007-2008 Holger Hans Peter Freyther
+Copyright (C) 2011 Brent Fulgham
+Copyright (C) 2006 Michael Emmel mike.emmel@gmail.com
+Copyright (C) 2007 Pioneer Research Center USA, Inc.
+Copyright (C) 2010-2011 Brent Fulgham <bfulgham@webkit.org>
+Copyright (C) 2010 Tieto Corporation.
+Copyright (C) 2008 Alex Mathews <possessedpenguinbob@gmail.com>
+Copyright (C) 2008-2011 Dirk Schulze <krit@webkit.org>
+Copyright (C) 2010 Zoltan Herczeg <zherczeg@webkit.org>
+Copyright (C) 2010 Renata Hodovan <reni@inf.u-szeged.hu>
+Copyright (C) 2011 Gabor Loki <loki@webkit.org>
+Copyright (C) Apple Inc. 2017-2021 All rights reserved.
+Copyright (C) 2012 Adobe Systems Incorporated
+Copyright (C) 2012-2013 Company 100, Inc.
+Copyright (C) 2012-2013 basysKom GmbH
+Copyright (C) 2012 Digia Plc. and/or its subsidiary(-ies)
+Copyright (C) 2013 Company 100 Inc.
+Copyright (C) 2007-2009 Torch Mobile Inc.
+Copyright (C) 2020 WikiMedia Inc. All rights reserved.
+Copyright (C) 2013 ChangSeok Oh <shivamidow@gmail.com>
+Copyright (C) 2013 Adobe Systems Inc. All right reserved.
+Copyright (C) 2003-2013,  Apple Inc. All rights reserved.
+Copyright (C) 1999 Lars Knoll <knoll@kde.org>
+Copyright (C) 1999 Antti Koivisto <koivisto@kde.org>
+Copyright (C) 2006 Allan Sandfeld Jensen <kde@carewolf.com>
+Copyright (C) 2019 Adobe. All rights reserved.
+Copyright (C) 2010 Daniel Bates (dbates@intudata.com)
+Copyright (C) 2011 Robert Hogan <robert@roberthogan.net>
+Copyright (C) 2009 Kenneth Rohde Christiansen
+Copyright (C) 2020 Noam Rosenthal (noam@webkit.org)
+Copyright (C) 2009 Jeff Schiller <codedread@gmail.com>
+Copyright (C) 2005-2006 Alexander Kellett <lypanov@kde.org>
+Copyright (C) 2005-2006 Oliver Hunt <ojh16@student.canterbury.ac.nz>
+Copyright (C) 2012 Zoltan Herczeg <zherczeg@webkit.org>.
+Copyright (C) 2011 Torch Mobile (Beijing) CO. Ltd. All rights reserved.
+Copyright (C) Research In Motion Limited 2010-11. All rights reserved.
+Copyright (C) 2011 Leo Yang <leoyang@webkit.org>
+Copyright (C) 2005-2006 Oliver Hunt <oliver@nerget.com>
+Copyright (C) 2002-2003 The Karbon Developers
+Copyright (C) 2007-2008 Julien Chaffraix <jchaffraix@webkit.org>
+Copyright (C) 2012 Intel Corporation
+Copyright (C) 1984-2006
+Copyright (C) 2000 Peter Kelly <pmk@post.com>
+
                   GNU LESSER GENERAL PUBLIC LICENSE
                        Version 2.1, February 1999
 
@@ -553,9 +725,379 @@ Copyright (C) 2012 Google Inc. All rights reserved.
 Copyright (C) 2017 Yusuke Suzuki <utatane.tea@gmail.com>. All rights reserved.
 Copyright (C) 2017 Mozilla Foundation. All rights reserved.
 
-This Source Code Form is subject to the terms of the Mozilla Public
-License, v. 2.0. If a copy of the MPL was not distributed with this
-file, You can obtain one at http://mozilla.org/MPL/2.0/.
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.
 
 ```
 
@@ -569,17 +1111,406 @@ Source/WTF/wtf/Int128.h
 
 Copyright 2017 The Abseil Authors.
 
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-     https://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+
+```
+
+#### MIT License
+```
+
+---------------------------------
+The below license applies to the following files:
+Source/JavaScriptCore/Scripts/jsmin.py
+
+Copyright (c) 2013 Dave St.Germain
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+---------------------------------
+The below license applies to the following files:
+Source/WTF/wtf/Brigand.h
+
+Copyright (c) 2015 Edouard Alligand and Joel Falcou
+
+Boost Software License - Version 1.0 - August 17th, 2003
+
+Permission is hereby granted, free of charge, to any person or organization
+obtaining a copy of the software and accompanying documentation covered by
+this license (the "Software") to use, reproduce, display, distribute,
+execute, and transmit the Software, and to prepare derivative works of the
+Software, and to permit third-parties to whom the Software is furnished to
+do so, all subject to the following:
+
+The copyright notices in the Software and this entire statement, including
+the above license grant, this restriction and the following disclaimer,
+must be included in all copies of the Software, in whole or in part, and
+all derivative works of the Software, unless such copies or derivative
+works are solely in the form of machine-executable object code generated by
+a source language processor.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
+SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
+FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+This file contains a standalone version of Edouard Alligand and Joel Falcou's
+Brigand library, which can be found at https://github.com/edouarda/brigand
+
+---------------------------------
+The below license applies to the following files:
+Source/WTF/wtf/CryptographicallyRandomNumber.cpp
+
+Copyright (c) 1996, David Mazieres <dm@uun.org>
+Copyright (c) 2008, Damien Miller <djm@openbsd.org>
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---------------------------------
+The below license applies to the following files:
+Source/WebCore/xml/XSLTExtensions.cpp
+
+Copyright (C) 2001-2002 Thomas Broyer, Charlie Bozeman and Daniel Veillard.
+Copyright (C) 2007 Alexey Proskuryakov <ap@webkit.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is fur-
+nished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FIT-
+NESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CON-
+NECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name of the authors shall not
+be used in advertising or otherwise to promote the sale, use or other deal-
+ings in this Software without prior written authorization from him.
+
+---------------------------------
+The below license applies to the following files:
+Source/bmalloc/bmalloc/CryptoRandom.cpp
+
+Copyright (c) 1996, David Mazieres <dm@uun.org>
+Copyright (c) 2008, Damien Miller <djm@openbsd.org>
+Copyright (C) 2017 Apple Inc. All rights reserved.
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---------------------------------
+The below license applies to the following files:
+Source/WTF/wtf/RobinHoodHashTable.h
+
+Copyright 2018 The Rust Project Developers.
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+---------------------------------
+The below license applies to some files in the following directories:
+Source/JavaScriptCore/disassembler/zydis/Zydis
+
+Copyright (c) 2014-2021 Florian Bernd
+Copyright (c) 2014-2021 Joel Höner
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+```
+
+#### Sun Microsystems License
+```
+---------------------------------
+The below license applies to the following files:
+Source/JavaScriptCore/runtime/MathCommon.cpp
+
+Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+
+Developed at SunSoft, a Sun Microsystems, Inc. business.
+Permission to use, copy, modify, and distribute this
+software is freely granted, provided that this notice
+is preserved.
 
 ```
 
@@ -800,13 +1731,12 @@ Copyright (C) 2019 the V8 project authors. All rights reserved.
 Copyright (C) 2007-2009 Torch Mobile, Inc.
 Copyright (C) 2011 University of Szeged. All rights reserved.
 Copyright (C) 2008-2009 Torch Mobile Inc. All rights reserved. (http://www.torchmobile.com/)
-Copyright (c) 2005-2007, Google Inc. All rights reserved.
+Copyright (C) 2005-2007, Google Inc. All rights reserved.
 Copyright (C) 2014 Raspberry Pi Foundation. All rights reserved.
 Copyright (C) 2010-2012 Research In Motion Limited. All rights reserved.
 Copyright (C) 2012-2013 Samsung Electronics. All rights reserved.
 Copyright (C) 2017 Yusuke Suzuki <utatane.tea@gmail.com>. All rights reserved.
 Copyright (C) 2021 Red Hat Inc.
-Copyright (c) 2018-2022 Apple Inc. All rights reserved.
 Copyright (C) 2015 Electronic Arts, Inc. All rights reserved.
 Copyright (C) 2009-2013 Google, Inc. All rights reserved.
 Copyright (C) 2016 Konstantin Tokavev <annulen@yandex.ru>
@@ -839,7 +1769,6 @@ Copyright (C) 2010 Torch Mobile (Beijing) Co. Ltd. All rights reserved.
 Copyright (C) 2008-2009 Dirk Schulze <krit@webkit.org>
 Copyright (C) 2009 Torch Mobile, Inc. http://www.torchmobile.com/
 Copyright (C) 2014 Cable Television Labs Inc. All rights reserved.
-Copyright (c) 2011 Google Inc. All rights reserved.
 Copyright (C) Research In Motion Limited 2009-2011. All rights reserved.
 Copyright (C) 2006 Eric Seidel (eric@webkit.org)
 Copyright (C) 2006 Alexey Proskuryakov (ap@webkit.org)
@@ -863,7 +1792,7 @@ Copyright (C) 2006-2007 Nikolas Zimmermann <zimmermann@kde.org>
 Copyright (C) 2020 Cloudinary Inc. All rights reserved.
 Copyright (C) 2012 Company 100 Inc.
 Copyright (C) 2006 Rob Buis <buis@kde.org>
-Copyright (C) 2020 Sony Interactive Entertainment Inc. All Rights reserved.
+Copyright (C) 2020 Sony Interactive Entertainment Inc. All rights reserved.
 Copyright (C) 2010 Sencha, Inc. All rights reserved.
 Copyright (C) 2013 Digia Plc. and/or its subsidiary(-ies).
 Copyright (C) 2012 ChangSeok Oh <shivamidow@gmail.com>
@@ -1127,16 +2056,13 @@ Source/cmake
 
 Copyright (C) 2003-2022 Apple Inc. All rights reserved.
 Copyright (C) 2017-2022 Sony Interactive Entertainment Inc.
-Copyright (c) 2014-2021 Apple Inc. All rights reserved.
-Copyright (c) 2014 University of Washington. All rights reserved.
-Copyright (c) 2009 Google Inc. All rights reserved.
+Copyright (C) 2014 University of Washington. All rights reserved.
+Copyright (C) 2009-2019 Google Inc. All rights reserved.
 Copyright (C) 2020 Igalia S. L.
 Copyright (C) 2015 Canon Inc. All rights reserved.
 Copyright (C) 2019-2021 Alexey Shvayka <shvaikalesh@gmail.com>.
 Copyright (C) 2014-2022 Igalia S.L.
 Copyright (C) 2014-2017 Yusuke Suzuki <utatane.tea@gmail.com>
-Copyright (C) 2010-2019 Google Inc. All rights reserved.
-Copyright (C) 2014 University of Washington. All rights reserved.
 Copyright (C) 2013-2014 University of Szeged. All rights reserved.
 Copyright (C) 2013 Digia Plc. and/or its subsidiary(-ies)
 Copyright (C) 2017-2019 Oleksandr Skachkov <gskachkov@gmail.com>.
@@ -1170,11 +2096,10 @@ Copyright (C) 2018 Akamai Technologies Inc. All rights reserved.
 Copyright 2010, The Android Open Source Project
 Copyright (C) 2012-2013 Samsung Electronics. All rights reserved.
 Copyright (C) 2013 Intel Corporation. All rights reserved.
-Copyright (c) 2011, Google Inc. All rights reserved.
+Copyright (C) 2011, Google Inc. All rights reserved.
 Copyright (C) 2006 Alexey Proskuryakov
 Copyright (C) 2010-2013 Nokia Corporation and/or its subsidiary(-ies)
 Copyright (C) 2013 Company 100, Inc. All rights reserved.
-Copyright (c) 2022 Igalia S.L.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
@@ -1477,8 +2402,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The below license applies to some files in the following directories:
 Source/JavaScriptCore/disassembler/udis86
 
-Copyright (c) 2002-2013 Vivek Thampi
-Copyright (c) 2002-2009
+Copyright (C) 2002-2013 Vivek Thampi
+Copyright (C) 2002-2009
 
 All rights reserved.
 
@@ -1672,7 +2597,7 @@ Source/JavaScriptCore/runtime
 Copyright (C) 2017 Caio Lima <ticaiolima@gmail.com>
 Copyright (C) 2017-2021 Apple Inc. All rights reserved.
 Copyright 2017 the V8 project authors. All rights reserved.
-Copyright (c) 2014 the Dart project authors. Please see the AUTHORS file [1]
+Copyright (C) 2014 the Dart project authors. Please see the AUTHORS file [1]
 Copyright 2009 The Go Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -2992,7 +3917,6 @@ Source/WebCore/css
 
 Copyright (C) 2009 Apple Inc. All rights reserved.
 Copyright (C) 2009 Google Inc.
-Copyright (C) 2011 Oracle Corp.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
@@ -3298,7 +4222,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The below license applies to some files in the following directories:
 Source/WebCore/html
 
-Copyright (c) 2012 Motorola Mobility, Inc. All rights reserved.
+Copyright (C) 2012 Motorola Mobility, Inc. All rights reserved.
 Copyright (C) 2014-2020 Apple Inc. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -3394,9 +4318,9 @@ SUCH DAMAGE.
 The below license applies to some files in the following directories:
 Source/WebCore/html/canvas
 
-Copyright (c) 2010-2012, Google Inc. All rights reserved.
-Copyright (c) 2016 Apple Inc. All rights reserved.
-Copyright (c) 2017, Apple, Inc. All rights reserved.
+Copyright (C) 2010-2012, Google Inc. All rights reserved.
+Copyright (C) 2016 Apple Inc. All rights reserved.
+Copyright (C) 2017, Apple, Inc. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -4203,7 +5127,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The below license applies to some files in the following directories:
 Source/bmalloc/libpas
 
-Copyright (c) 2018-2021 Apple Inc. All rights reserved.
+Copyright (C) 2018-2021 Apple Inc. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
@@ -4385,11 +5309,10 @@ Source/bmalloc/libpas/src/libpas
 Source/bmalloc/libpas/src/test
 
 Copyright (C) 2003-2022 Apple Inc. All rights reserved.
-Copyright (c) 2011 Google Inc. All rights reserved.
+Copyright (C) 2009-2013 Google Inc. All rights reserved.
 Copyright (C) 2008 Cameron Zwarich <cwzwarich@uwaterloo.ca>
 Copyright (C) 2012 Igalia, S.L.
 Copyright (C) 2008 Matt Lilek <webkit@mattlilek.com>
-Copyright (C) 2009-2013 Google Inc. All rights reserved.
 Copyright (C) 2011-2012 Research In Motion Limited. All rights reserved.
 Copyright (C) 2008 Cameron Zwarich (cwzwarich@uwaterloo.ca)
 Copyright (C) 2008 Collabora, Ltd. All rights reserved.
@@ -4402,7 +5325,6 @@ Copyright (C) 2016-2017 Yusuke Suzuki <utatane.tea@gmail.com>
 Copyright (C) 2018 Igalia S.L.
 Copyright (C) 2005-2021 Apple, Inc. All rights reserved.
 Copyright (C) 2016 Konstantin Tokavev <annulen@yandex.ru>
-Copyright (C) 2019 Oracle and/or its affiliates. All rights reserved.
 Copyright (C) 2009 Torch Mobile Inc. All rights reserved.
 Copyright (C) 2006 Samuel Weinig <sam.weinig@gmail.com>
 Copyright (C) 2009 Cameron McCormack <cam@mcc.id.au>
@@ -4531,7 +5453,7 @@ The below license applies to some files in the following directories:
 Source/JavaScriptCore/b3
 
 Copyright (C) 2016 Apple Inc. All rights reserved.
-Copyright (c) 2003-2014 University of Illinois at Urbana-Champaign.
+Copyright (C) 2003-2014 University of Illinois at Urbana-Champaign.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
@@ -4656,8 +5578,7 @@ Source/WebCore/workers
 
 Copyright (C) 2004-2022 Apple Inc. All rights reserved.
 Copyright (C) 2008-2021 Google Inc. All rights reserved.
-Copyright (c) 2008-2013 Google Inc. All rights reserved.
-Copyright (c) 2008-2012, Google Inc. All rights reserved.
+Copyright (C) 2008-2012, Google Inc. All rights reserved.
 Copyright (C) 2012 Research In Motion Limited. All rights reserved.
 Copyright (C) 2007-2009 Torch Mobile, Inc.
 Copyright (C) 2008 Cameron Zwarich <cwzwarich@uwaterloo.ca>
@@ -4666,7 +5587,6 @@ Copyright (C) Research In Motion Limited 2011. All rights reserved.
 Copyright (C) 2013-2022 Igalia S.L.
 Copyright (C) 2013-2014 Igalia, S.L. All rights reserved.
 Copyright (C) 2010. 2012 Google Inc. All rights reserved.
-Copyright (c) 2013-2021 Apple Inc. All rights reserved.
 Copyright (C) 2012 Samsung Electronics. All rights reserved.
 Copyright (C) 2013, Opera Software ASA. All rights reserved.
 Copyright (C) 2013 Cable Television Labs, Inc.
@@ -4676,12 +5596,10 @@ Copyright (C) 2019 Microsoft Corporation. All rights reserved.
 Copyright (C) 2015 Roopesh Chander (roop@roopc.net)
 Copyright (C) 2012 Intel Inc. All rights reserved.
 Copyright (C) 2020 WikiMedia Foundation. All Rights Reserve.
-Copyright (c) 2016 Igalia S.L.
 Copyright (C) 2011-2015 Ericsson AB. All rights reserved.
 Copyright (C) 2013 Nokia Corporation and/or its subsidiary(-ies).
-Copyright (c) 2021 Apple Inc.
+Copyright (C) 2021 Apple Inc.
 Copyright (C) 2012 Intel Corporation. All rights reserved.
-Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
 Copyright (C) 2015, Apple Inc. All rights reserved.
 Copyright (C) 2013 Igalia S.L. All rights reserved.
 
@@ -5068,7 +5986,7 @@ The below license applies to some files in the following directories:
 Source/WebCore/PAL/pal/text
 
 Copyright (C) 2011 Daniel Bates (dbates@intudata.com). All rights reserved.
-Copyright (c) 2012 Google, inc. All rights reserved.
+Copyright (C) 2012 Google, inc. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
@@ -5099,7 +6017,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The below license applies to some files in the following directories:
 Source/WebCore/bindings/js
 
-Copyright (c) 2015, Canon Inc. All rights reserved.
+Copyright (C) 2015, Canon Inc. All rights reserved.
 Copyright (C) 2018-2020 Apple Inc. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -5223,7 +6141,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The below license applies to some files in the following directories:
 Source/WebCore/html
 
-Copyright (c) 2011 Code Aurora Forum. All rights reserved.
+Copyright (C) 2011 Code Aurora Forum. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
@@ -5256,7 +6174,7 @@ The below license applies to some files in the following directories:
 Source/WebCore/html/track
 Source/WebCore/rendering
 
-Copyright (c) 2013-2014, Opera Software ASA. All rights reserved.
+Copyright (C) 2013-2014, Opera Software ASA. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
@@ -5613,7 +6531,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The below license applies to some files in the following directories:
 Source/WebGPU/WebGPU
 
-Copyright (c) 2019, "WebGPU native" developers
+Copyright (C) 2019, "WebGPU native" developers
 
 All rights reserved.
 
@@ -5694,8 +6612,8 @@ COPYING file in the source distribution for details.
 The below license applies to some files in the following directories:
 Source/cmake
 
-Copyright (c) 2014, Pablo Fernandez Alcantarilla, Jesus Nuevo
-Copyright (c) 2019, Igalia S.L.
+Copyright (C) 2014, Pablo Fernandez Alcantarilla, Jesus Nuevo
+Copyright (C) 2019, Igalia S.L.
 
 Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
@@ -5726,7 +6644,7 @@ WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH 
 The below license applies to some files in the following directories:
 Source/cmake
 
-Copyright (c) 2013 Igalia S.L.
+Copyright (C) 2013 Igalia S.L.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -5763,7 +6681,7 @@ ATSPI_LIBRARIES - containg the AT-SPI library
 The below license applies to some files in the following directories:
 Source/cmake
 
-Copyright (c) 2020 Sony Interactive Entertainment Inc.
+Copyright (C) 2020 Sony Interactive Entertainment Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -5800,8 +6718,8 @@ Dawn_LIBRARIES - containg the Dawn library
 The below license applies to some files in the following directories:
 Source/cmake
 
-Copyright (c) 2012, Intel Corporation
-Copyright (c) 2019 Sony Interactive Entertainment Inc.
+Copyright (C) 2012, Intel Corporation
+Copyright (C) 2019 Sony Interactive Entertainment Inc.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
@@ -5897,181 +6815,5 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
-
-```
-#### MIT License
-```
-
----------------------------------
-The below license applies to the following files:
-Source/JavaScriptCore/Scripts/jsmin.py
-
-Copyright (c) 2013 Dave St.Germain
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
----------------------------------
-The below license applies to the following files:
-Source/WTF/wtf/Brigand.h
-
-Copyright (c) 2015 Edouard Alligand and Joel Falcou
-
-Boost Software License - Version 1.0 - August 17th, 2003
-
-Permission is hereby granted, free of charge, to any person or organization
-obtaining a copy of the software and accompanying documentation covered by
-this license (the "Software") to use, reproduce, display, distribute,
-execute, and transmit the Software, and to prepare derivative works of the
-Software, and to permit third-parties to whom the Software is furnished to
-do so, all subject to the following:
-
-The copyright notices in the Software and this entire statement, including
-the above license grant, this restriction and the following disclaimer,
-must be included in all copies of the Software, in whole or in part, and
-all derivative works of the Software, unless such copies or derivative
-works are solely in the form of machine-executable object code generated by
-a source language processor.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
-SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
-FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
-ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-
-This file contains a standalone version of Edouard Alligand and Joel Falcou's
-Brigand library, which can be found at https://github.com/edouarda/brigand
-
----------------------------------
-The below license applies to the following files:
-Source/WTF/wtf/CryptographicallyRandomNumber.cpp
-
-Copyright (c) 1996, David Mazieres <dm@uun.org>
-Copyright (c) 2008, Damien Miller <djm@openbsd.org>
-
-Permission to use, copy, modify, and distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
----------------------------------
-The below license applies to the following files:
-Source/WebCore/xml/XSLTExtensions.cpp
-
-Copyright (C) 2001-2002 Thomas Broyer, Charlie Bozeman and Daniel Veillard.
-Copyright (C) 2007 Alexey Proskuryakov <ap@webkit.org>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is fur-
-nished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FIT-
-NESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
-AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
-IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CON-
-NECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-Except as contained in this notice, the name of the authors shall not
-be used in advertising or otherwise to promote the sale, use or other deal-
-ings in this Software without prior written authorization from him.
-
----------------------------------
-The below license applies to the following files:
-Source/bmalloc/bmalloc/CryptoRandom.cpp
-
-Copyright (c) 1996, David Mazieres <dm@uun.org>
-Copyright (c) 2008, Damien Miller <djm@openbsd.org>
-Copyright (C) 2017 Apple Inc. All rights reserved.
-
-Permission to use, copy, modify, and distribute this software for any
-purpose with or without fee is hereby granted, provided that the above
-copyright notice and this permission notice appear in all copies.
-
-THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
-WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
-ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
-OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-
-
----------------------------------
-The below license applies to the following files:
-Source/WTF/wtf/RobinHoodHashTable.h
-
-Copyright 2018 The Rust Project Developers.
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-
-
-```
-
-#### Sun Microsystems License
-```
----------------------------------
-The below license applies to the following files:
-Source/JavaScriptCore/runtime/MathCommon.cpp
-
-Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
-
-Developed at SunSoft, a Sun Microsystems, Inc. business.
-Permission to use, copy, modify, and distribute this
-software is freely granted, provided that this notice
-is preserved.
 
 ```


### PR DESCRIPTION
We need to update the attribution in `webkit.md` to reflect the latest WebKit sources and a few missed items.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291630](https://bugs.openjdk.org/browse/JDK-8291630): Update attribution in webkit.md file


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/868/head:pull/868` \
`$ git checkout pull/868`

Update a local copy of the PR: \
`$ git checkout pull/868` \
`$ git pull https://git.openjdk.org/jfx pull/868/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 868`

View PR using the GUI difftool: \
`$ git pr show -t 868`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/868.diff">https://git.openjdk.org/jfx/pull/868.diff</a>

</details>
