### PR TITLE
8292391: Add support for optional signing of native libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5022,6 +5022,9 @@ compileTargets { t ->
         def doStrip = targetProperties.containsKey('strip') && IS_RELEASE
         def strip = doStrip ? targetProperties.strip : null
         def stripArgs = doStrip ? targetProperties.stripArgs : null
+        def doSign = rootProject.hasProperty('codeSignCmd') && IS_RELEASE
+        def signCmd = doSign ? rootProject.ext.codeSignCmd : null
+        def signArgs = doSign ? rootProject.ext.codeSignArgs : null
         def useLipo = targetProperties.containsKey('useLipo') ? targetProperties.useLipo : false
         def modLibDest = targetProperties.modLibDest
         def moduleNativeDirName = "${platformPrefix}module-$modLibDest"
@@ -5115,6 +5118,23 @@ compileTargets { t ->
                     }
                 }
             }
+            if (doSign) {
+                doLast {
+                    def inputFiles = fileTree(dir: destDirName)
+                    inputFiles.include("*.dll")
+                    inputFiles.include("*.dylib")
+                    inputFiles.include("*.so")
+                    // FIXME: if we ever need to sign on Windows platforms, we must
+                    // exclude the Microsoft DLLs (VS2017DLLNames and WinSDKDLLNames)
+
+                    inputFiles.each { file ->
+                        exec {
+                            def cmd = [ signCmd, signArgs, file ].flatten()
+                            commandLine(cmd)
+                        }
+                    }
+                }
+            }
         }
 
         def buildModuleMediaTask = task("buildModuleMedia$t.capital", type: Copy, dependsOn: [mediaProject.assemble, prepOpenJfxStubs]) {
@@ -5169,6 +5189,23 @@ compileTargets { t ->
                     }
                 }
             }
+            if (doSign && IS_COMPILE_MEDIA) {
+                doLast {
+                    def inputFiles = fileTree(dir: destDirName)
+                    inputFiles.include("*.dll")
+                    inputFiles.include("*.dylib")
+                    inputFiles.include("*.so")
+                    // FIXME: if we ever need to sign on Windows platforms, we must
+                    // exclude the Microsoft DLLs (VS2017DLLNames and WinSDKDLLNames)
+
+                    inputFiles.each { file ->
+                        exec {
+                            def cmd = [ signCmd, signArgs, file ].flatten()
+                            commandLine(cmd)
+                        }
+                    }
+                }
+            }
         }
 
         def buildModuleWeb = task("buildModuleWeb$t.capital", type: Copy, dependsOn: [webProject.assemble, prepOpenJfxStubs]) {
@@ -5196,6 +5233,23 @@ compileTargets { t ->
                     inputFiles.each { file ->
                         exec {
                             def cmd = [ strip, stripArgs, file ].flatten()
+                            commandLine(cmd)
+                        }
+                    }
+                }
+            }
+            if (doSign && IS_COMPILE_WEBKIT) {
+                doLast {
+                    def inputFiles = fileTree(dir: destDirName)
+                    inputFiles.include("*.dll")
+                    inputFiles.include("*.dylib")
+                    inputFiles.include("*.so")
+                    // FIXME: if we ever need to sign on Windows platforms, we must
+                    // exclude the Microsoft DLLs (VS2017DLLNames and WinSDKDLLNames)
+
+                    inputFiles.each { file ->
+                        exec {
+                            def cmd = [ signCmd, signArgs, file ].flatten()
                             commandLine(cmd)
                         }
                     }


### PR DESCRIPTION
This PR enables an optional signing step inserted into the build right after the step to strip binaries that was added by [JDK-8278260](https://bugs.openjdk.org/browse/JDK-8278260). As is the case with the `strip` step, the optional signing is only ever enabled for production builds when running with `gradle -PCONF=Release`.

This is an optional step, meaning that `codeSignCmd` and `codeSignArgs` need to be provided by scripts external to the repo in order to enable it. By default, they are not defined, so the additional logic added by this PR will do nothing.

NOTE: as with the fix for [JDK-8278260](https://bugs.openjdk.org/browse/JDK-8278260), this PR adds three copies of the build logic. I filed [JDK-8292506](https://bugs.openjdk.org/browse/JDK-8292506) to refactor both of them (strip and sign), and to look for other duplication as well.
