### PR TITLE
8293839: Documentation memory consistency effects of runLater

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -153,8 +153,8 @@ public final class Platform {
      *
      * <p>
      * Memory consistency effects: Actions in a thread prior to submitting a
-     * runnable to this method <i>happen-before</i> actions performed by
-     * the runnable in the JavaFX Application Thread.
+     * {@code runnable} to this method <i>happen-before</i> actions performed
+     * by the runnable in the JavaFX Application Thread.
      * </p>
      *
      * @param runnable the Runnable whose run method will be executed on the

--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -153,7 +153,7 @@ public final class Platform {
      *
      * <p>
      * Memory consistency effects: Actions in a thread prior to submitting a
-     * runnable to this method <i>happen-before</i> actions performed by 
+     * runnable to this method <i>happen-before</i> actions performed by
      * the runnable in the JavaFX Application Thread.
      * </p>
      *

--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -151,6 +151,12 @@ public final class Platform {
      * {@link #startup(Runnable)} once.
      * </p>
      *
+     * <p>
+     * Memory consistency effects: Actions in a thread prior to submitting a
+     * runnable to this method <i>happen-before</i> actions performed by 
+     * the runnable in the JavaFX Application Thread.
+     * </p>
+     *
      * @param runnable the Runnable whose run method will be executed on the
      * JavaFX Application Thread
      *


### PR DESCRIPTION
Prior to this change it was not clear from the documentation if callers of Platform#runLater must perform
any synchronisation to have writes of the calling thread be visible in the JavaFX Application
Thread. It is important to document either if callers can rely on runLater to do such synchronisation
internally, or to document is users CAN NOT rely on runLater for this.

This change documents that actions in a thread prior to submitting a runnable to
Platform#runLater happen-before actions performed by the runnable in the JavaFX
Application Thread.

runLater inherits the memory consistency effects of InvokeLaterDispatcher in most cases. 
InvokeLaterDispatcher uses BlockingDeque internally. This change documents this
in the same way as it is documented by BlockingDeque.

Other implementations of runLater should have similar memory consistency effects.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293839](https://bugs.openjdk.org/browse/JDK-8293839): Documentation memory consistency effects of runLater


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/872/head:pull/872` \
`$ git checkout pull/872`

Update a local copy of the PR: \
`$ git checkout pull/872` \
`$ git pull https://git.openjdk.org/jfx pull/872/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 872`

View PR using the GUI difftool: \
`$ git pr show -t 872`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/872.diff">https://git.openjdk.org/jfx/pull/872.diff</a>

</details>
