### PR TITLE
8087557: [Win] [Accessibility, Dialogs] Alert Dialog content is not fully read by Screen Reader

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/DialogPane.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/DialogPane.java
@@ -53,6 +53,7 @@ import javafx.css.StyleableProperty;
 import javafx.css.StyleableStringProperty;
 import javafx.event.ActionEvent;
 import javafx.geometry.Pos;
+import javafx.scene.AccessibleRole;
 import javafx.scene.Node;
 import javafx.scene.control.ButtonBar.ButtonData;
 import javafx.scene.image.Image;
@@ -209,6 +210,7 @@ public class DialogPane extends Pane {
      */
     public DialogPane() {
         getStyleClass().add("dialog-pane");
+        setAccessibleRole(AccessibleRole.DIALOG);
 
         headerTextPanel = new GridPane();
         getChildren().add(headerTextPanel);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/DialogTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/DialogTest.java
@@ -25,13 +25,13 @@
 package test.javafx.scene.control;
 
 import com.sun.javafx.tk.Toolkit;
+import javafx.scene.AccessibleRole;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Dialog;
 import javafx.scene.layout.StackPane;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 
 /** Tests for the {@link Dialog} class. */
@@ -78,6 +78,11 @@ public class DialogTest {
         assertDialogPaneHeightEquals(minHeight);
 
         assertEquals(minHeight, dialog.getDialogPane().getMinHeight(), 0);
+    }
+
+    @Test
+    public void testAccessibleRole() {
+        assertEquals(AccessibleRole.DIALOG, dialog.getDialogPane().getAccessibleRole());
     }
 
     @Test

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacAccessible.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacAccessible.java
@@ -1299,6 +1299,7 @@ final class MacAccessible extends Accessible {
                         case PAGE_ITEM: result = "page"; break;
                         case TAB_ITEM: result = "tab"; break;
                         case LIST_VIEW: result = "list"; break;
+                        case DIALOG: result = "dialog"; break;
                         default:
                             MacRole macRole = getRole(role);
                             MacSubrole subRole = MacSubrole.getRole(role);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinAccessible.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinAccessible.java
@@ -105,6 +105,7 @@ final class WinAccessible extends Accessible {
     private static final int UIA_ToggleToggleStatePropertyId     = 30086;
     private static final int UIA_AriaRolePropertyId              = 30101;
     private static final int UIA_ProviderDescriptionPropertyId   = 30107;
+    private static final int UIA_IsDialogPropertyId              = 30174;
 
     /* Control Pattern Identifiers */
     private static final int UIA_InvokePatternId                 = 10000;
@@ -795,6 +796,7 @@ final class WinAccessible extends Accessible {
                     switch (role) {
                         case TITLED_PANE: description = "title pane"; break;
                         case PAGE_ITEM: description = "page"; break;
+                        case DIALOG: description = "dialog"; break;
                         default:
                     }
                 }
@@ -834,6 +836,12 @@ final class WinAccessible extends Accessible {
                 variant.boolVal = focus != null ? focus : false;
                 break;
             }
+            case UIA_IsDialogPropertyId: {
+                AccessibleRole role = (AccessibleRole) getAttribute(ROLE);
+                variant = new WinVariant();
+                variant.vt = WinVariant.VT_BOOL;
+                variant.boolVal = (role == AccessibleRole.DIALOG);
+            } break;
             case UIA_IsContentElementPropertyId:
             case UIA_IsControlElementPropertyId: {
                 //TODO how to handle ControlElement versus ContentElement

--- a/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleRole.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleRole.java
@@ -822,4 +822,16 @@ public enum AccessibleRole {
      * </ul>
      */
     TREE_VIEW,
+
+    /**
+     * Dialog role.
+     * <p>
+     * Attributes:
+     * <ul>
+     * <li> {@link AccessibleAttribute#TEXT} </li>
+     * <li> {@link AccessibleAttribute#ROLE_DESCRIPTION} </li>
+     * <li> {@link AccessibleAttribute#CHILDREN} </li>
+     * </ul>
+     */
+    DIALOG
 }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleRole.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleRole.java
@@ -832,6 +832,8 @@ public enum AccessibleRole {
      * <li> {@link AccessibleAttribute#ROLE_DESCRIPTION} </li>
      * <li> {@link AccessibleAttribute#CHILDREN} </li>
      * </ul>
+     *
+     * @since 20
      */
     DIALOG
 }

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -6522,7 +6522,13 @@ public class Scene implements EventTarget {
                             }
                             return getRoot();//not sure
                         }
-                        case ROLE: return AccessibleRole.PARENT;
+                        case ROLE: {
+                            if (getRoot() != null && getRoot().getAccessibleRole() == AccessibleRole.DIALOG) {
+                                return AccessibleRole.DIALOG;
+                            } else {
+                                return AccessibleRole.PARENT;
+                            }
+                        }
                         case SCENE: return Scene.this;
                         case FOCUS_NODE: {
                             if (transientFocusContainer != null) {


### PR DESCRIPTION
Accessibility is not implemented for JavaFX dialogs. This change is to implement the accessibility on windows platform.
Without this fix : On Windows platform, content of Dialog are not read by Windows Narrator or JAWS.
With this fix:
1. Windows narrator reads the dialog correctly
2. JAWS fails to read the header text. : This will be handled separately 
3. Behavior of VoiceOver on MacOS remains unchanged : This will be handled separately.

Verification:
1. Run HelloAlert toy app, with fix.
2. Start Windows Narrator
3. Click on the different buttons to show different Dialogs
=> Observe that Narrator reads all the content correctly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8087557](https://bugs.openjdk.org/browse/JDK-8087557): [Win] [Accessibility, Dialogs] Alert Dialog content is not fully read by Screen Reader
 * [JDK-8292658](https://bugs.openjdk.org/browse/JDK-8292658): [Win] [Accessibility, Dialogs] Alert Dialog content is not fully read by Screen Reader (**CSR**)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/873/head:pull/873` \
`$ git checkout pull/873`

Update a local copy of the PR: \
`$ git checkout pull/873` \
`$ git pull https://git.openjdk.org/jfx pull/873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 873`

View PR using the GUI difftool: \
`$ git pr show -t 873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/873.diff">https://git.openjdk.org/jfx/pull/873.diff</a>

</details>
