### PR TITLE
8292549: GitHub actions: intermittent build failure on macOS while downloading ant

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -151,9 +151,10 @@ jobs:
       BOOT_JDK_VERSION: "18.0.2"
       BOOT_JDK_FILENAME: "jdk-18.0.2_macos-x64_bin.tar.gz"
       BOOT_JDK_URL: "https://download.oracle.com/java/18/archive/jdk-18.0.2_macos-x64_bin.tar.gz"
-      ANT_DIR: "apache-ant-1.10.5"
-      ANT_FILENAME: "apache-ant-1.10.5.tar.gz"
-      ANT_URL: "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz"
+      # Disabled due to timeout downloading ant; use ant installed on system
+      #ANT_DIR: "apache-ant-1.10.5"
+      #ANT_FILENAME: "apache-ant-1.10.5.tar.gz"
+      #ANT_URL: "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.gz"
 
     steps:
       - name: Checkout the source
@@ -165,9 +166,10 @@ jobs:
         run: |
           set -x
           echo "NOT NEEDED: brew install make"
-          mkdir -p "${HOME}/build-tools"
-          wget -O "${HOME}/build-tools/${ANT_FILENAME}" "${ANT_URL}"
-          tar -zxf "${HOME}/build-tools/${ANT_FILENAME}" -C "${HOME}/build-tools"
+          echo "NOT NEEDED: wget ... ant"
+          #mkdir -p "${HOME}/build-tools"
+          #wget -O "${HOME}/build-tools/${ANT_FILENAME}" "${ANT_URL}"
+          #tar -zxf "${HOME}/build-tools/${ANT_FILENAME}" -C "${HOME}/build-tools"
 
 # FIXME: enable cache for boot JDK
 #      - name: Restore boot JDK from cache
@@ -191,9 +193,10 @@ jobs:
           set -x
           export JAVA_HOME="${HOME}/bootjdk/jdk-${BOOT_JDK_VERSION}.jdk/Contents/Home"
           echo "JAVA_HOME=${JAVA_HOME}" >> "${GITHUB_ENV}"
-          export ANT_HOME="${HOME}/build-tools/${ANT_DIR}"
-          echo "ANT_HOME=${ANT_HOME}" >> "${GITHUB_ENV}"
-          export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+          #export ANT_HOME="${HOME}/build-tools/${ANT_DIR}"
+          #echo "ANT_HOME=${ANT_HOME}" >> "${GITHUB_ENV}"
+          #export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+          export PATH="$JAVA_HOME/bin:$PATH"
           env | sort
           which java
           java -version
@@ -206,7 +209,8 @@ jobs:
         working-directory: jfx
         run: |
           set -x
-          export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+          #export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+          export PATH="$JAVA_HOME/bin:$PATH"
           bash gradlew -version
           bash gradlew --info all
 
@@ -214,7 +218,8 @@ jobs:
         working-directory: jfx
         run: |
           set -x
-          export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+          #export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
+          export PATH="$JAVA_HOME/bin:$PATH"
           bash gradlew --info --continue -PBUILD_SDK_FOR_TEST=false test -x :web:test
 
 


### PR DESCRIPTION
Use the system version of `ant` on macOS platforms rather than downloading it from apache.org.

As noted in the bug report, we are seeing frequent GitHub Actions (GHA) failures on macOS due to a timeout while attempting to download apache ant 1.10.5.

The JavaFX build uses `ant` to build the apps (so `gradle apps` requires it). The installed version of ant on the macOS 11 systems that we use is ant 1.10.12, which works fine to build the apps. Given that the GHA builds are just a sanity test used as a help to reviewers and contributors, and that we already relax the requirement to specify the exact versions for a few other platform tools, there is no real downside to doing this.

This PR only touches the GHA build script for the macOS job, so the GHA test run is sufficient to test it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292549](https://bugs.openjdk.org/browse/JDK-8292549): GitHub actions: intermittent build failure on macOS while downloading ant


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Author)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/879/head:pull/879` \
`$ git checkout pull/879`

Update a local copy of the PR: \
`$ git checkout pull/879` \
`$ git pull https://git.openjdk.org/jfx pull/879/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 879`

View PR using the GUI difftool: \
`$ git pr show -t 879`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/879.diff">https://git.openjdk.org/jfx/pull/879.diff</a>

</details>
