### PR TITLE
8292678 Openjfx: all projects to use JUnit5 (Eclipse)

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -5,6 +5,6 @@
   <classpathentry kind="src" exported="true" path="/swt"/>
   <classpathentry kind="src" exported="true" path="/swing"/>
   <classpathentry kind="src" exported="true" path="/media"/>
-  <classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
+  <classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
   <classpathentry kind="output" path="bin"/>
 </classpath>

--- a/modules/javafx.base/.classpath
+++ b/modules/javafx.base/.classpath
@@ -15,11 +15,6 @@
 			<attribute name="add-reads" value="javafx.base=java.management:javafx.base=jdk.management"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
 		<attributes>
 			<attribute name="test" value="true"/>

--- a/modules/javafx.fxml/.classpath
+++ b/modules/javafx.fxml/.classpath
@@ -35,7 +35,7 @@
 			<attribute name="add-exports" value="javafx.base/com.sun.javafx.collections=javafx.fxml"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4">
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/modules/javafx.graphics/.classpath
+++ b/modules/javafx.graphics/.classpath
@@ -33,7 +33,7 @@
 			<attribute name="add-exports" value="javafx.base/com.sun.javafx.property=javafx.graphics:javafx.base/test.util.memory=javafx.graphics"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4">
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/modules/javafx.swing/.classpath
+++ b/modules/javafx.swing/.classpath
@@ -21,6 +21,6 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/modules/javafx.swt/.classpath
+++ b/modules/javafx.swt/.classpath
@@ -19,7 +19,7 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4">
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/modules/javafx.web/.classpath
+++ b/modules/javafx.web/.classpath
@@ -45,7 +45,7 @@
 			<attribute name="add-exports" value="javafx.base/com.sun.javafx=javafx.web"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4">
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
 		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>

--- a/tests/.classpath
+++ b/tests/.classpath
@@ -17,11 +17,6 @@
 			<attribute name="add-exports" value="java.desktop/sun.awt.datatransfer=ALL-UNNAMED"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
 			<attributes>
 			<attribute name="test" value="true"/>

--- a/tests/system/.classpath
+++ b/tests/system/.classpath
@@ -54,11 +54,6 @@
 			<attribute name="add-exports" value="java.desktop/sun.awt.datatransfer=ALL-UNNAMED"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4">
-		<attributes>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
 			<attributes>
 			<attribute name="test" value="true"/>


### PR DESCRIPTION
This change affects eclipse projects only - all eclipse projects are configured to use JUnit5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8292678](https://bugs.openjdk.org/browse/JDK-8292678): Openjfx: all projects to use JUnit5 (Eclipse)


### Reviewers
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/883/head:pull/883` \
`$ git checkout pull/883`

Update a local copy of the PR: \
`$ git checkout pull/883` \
`$ git pull https://git.openjdk.org/jfx pull/883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 883`

View PR using the GUI difftool: \
`$ git pr show -t 883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/883.diff">https://git.openjdk.org/jfx/pull/883.diff</a>

</details>
