### PR TITLE
8284281: [Accessibility] [Win] [Narrator] Exceptions with TextArea & TextField when deleted last char

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTextRangeProvider.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTextRangeProvider.java
@@ -114,7 +114,7 @@ class WinTextRangeProvider {
 
     private boolean isWordStart(BreakIterator bi, String text, int offset) {
         if (offset == 0) return true;
-        if (offset == text.length()) return true;
+        if (offset >= text.length()) return true;
         if (offset == BreakIterator.DONE) return true;
         return bi.isBoundary(offset) && Character.isLetterOrDigit(text.charAt(offset));
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTextRangeProvider.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTextRangeProvider.java
@@ -177,6 +177,7 @@ class WinTextRangeProvider {
                 break;
             }
             case TextUnit_Line: {
+                if (start > length) start = length;
                 Integer lineIndex = (Integer)getAttribute(LINE_FOR_OFFSET, start);
                 Integer lineStart = (Integer)getAttribute(LINE_START, lineIndex);
                 Integer lineEnd = (Integer)getAttribute(LINE_END, lineIndex);

--- a/modules/javafx.graphics/src/main/java/javafx/scene/text/Text.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/text/Text.java
@@ -1986,8 +1986,8 @@ public class Text extends Shape {
             }
             case LINE_FOR_OFFSET: {
                 int offset = (Integer)parameters[0];
+                if (offset > getTextInternal().length()) return null;
                 TextLine[] lines = getTextLayout().getLines();
-                if (offset > getTextInternal().length()) return lines.length;
                 int lineIndex = 0;
                 for (int i = 1; i < lines.length; i++) {
                     TextLine line = lines[i];

--- a/modules/javafx.graphics/src/main/java/javafx/scene/text/Text.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/text/Text.java
@@ -1986,8 +1986,8 @@ public class Text extends Shape {
             }
             case LINE_FOR_OFFSET: {
                 int offset = (Integer)parameters[0];
-                if (offset > getTextInternal().length()) return null;
                 TextLine[] lines = getTextLayout().getLines();
+                if (offset > getTextInternal().length()) return lines.length;
                 int lineIndex = 0;
                 for (int i = 1; i < lines.length; i++) {
                     TextLine line = lines[i];


### PR DESCRIPTION
Issue:
When Narrator is running, 
1. Deleting last character from `TextField` throws `IllegalArgumentException`, and 
2. Deleting last character from `TextArea` throws `NPE`.

Fix:
When character is deleted, we receive an offset larger by one than the current text length. This scenario needs to be handled correctly.
The change in `Text.java` fixes the NPE with TextArea, and,
The change in `WinTextRangeProvider.java` fixes the IllegalArgumentException with TextField.

To observe the issue.
1. Run any program with TextField and/or TextArea
3. Launch Windows Narrator
4. Delete the last character from TextField / TextArea
5. Observe the related Exception

/contributor add kcr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8284281](https://bugs.openjdk.org/browse/JDK-8284281): [Accessibility] [Win] [Narrator] Exceptions with TextArea & TextField when deleted last char


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Contributors
 * Kevin Rushforth `<kcr@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/884/head:pull/884` \
`$ git checkout pull/884`

Update a local copy of the PR: \
`$ git checkout pull/884` \
`$ git pull https://git.openjdk.org/jfx pull/884/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 884`

View PR using the GUI difftool: \
`$ git pr show -t 884`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/884.diff">https://git.openjdk.org/jfx/pull/884.diff</a>

</details>
