### PR TITLE
8087673: [TableView] TableView and TreeTableView menu button overlaps columns when using a constrained resize policy.

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
@@ -33,6 +33,7 @@ import com.sun.javafx.scene.control.skin.Utils;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
+import javafx.beans.value.ChangeListener;
 import javafx.beans.value.WritableValue;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
@@ -294,6 +295,11 @@ public class TableColumnHeader extends Region {
         }
     };
 
+    private final ChangeListener<Number> cornerPaddingChangeListener = (obs, ov, nv) -> {
+        if (isLastVisibleColumn) {
+            requestLayout();
+        }
+    };
 
 
     /* *************************************************************************
@@ -372,8 +378,9 @@ public class TableColumnHeader extends Region {
             isSizeDirty = false;
         }
 
+        double cornerRegionPadding = tableHeaderRow == null ? 0d : tableHeaderRow.cornerPadding.get();
         double sortWidth = 0;
-        double w = snapSizeX(getWidth()) - (snappedLeftInset() + snappedRightInset());
+        double w = snapSizeX(getWidth()) - (snappedLeftInset() + snappedRightInset()) - cornerRegionPadding;
         double h = getHeight() - (snappedTopInset() + snappedBottomInset());
         double x = w;
 
@@ -475,8 +482,14 @@ public class TableColumnHeader extends Region {
         return tableHeaderRow;
     }
 
-    void setTableHeaderRow(TableHeaderRow thr) {
+   void setTableHeaderRow(TableHeaderRow thr) {
+        if (tableHeaderRow != null) {
+            tableHeaderRow.cornerPadding.removeListener(cornerPaddingChangeListener);
+        }
         tableHeaderRow = thr;
+        if (tableHeaderRow != null) {
+            tableHeaderRow.cornerPadding.addListener(cornerPaddingChangeListener);
+        }
         updateTableSkin();
     }
 
@@ -552,6 +565,9 @@ public class TableColumnHeader extends Region {
         }
 
         changeListenerHandler.dispose();
+        if (tableHeaderRow != null) {
+            tableHeaderRow.cornerPadding.removeListener(cornerPaddingChangeListener);
+        }
     }
 
     private boolean isSortingEnabled() {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableHeaderRow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableHeaderRow.java
@@ -680,7 +680,7 @@ public class TableHeaderRow extends StackPane {
     // for that header, to prevent the content of the latter from being partially
     // covered.
     private void updateCornerPadding() {
-        double padding = 0;
+        double padding = 0.0;
         if (cornerRegion.isVisible() && !flow.getVbar().isVisible()) {
             double x = cornerRegion.getLayoutX();
             padding = getRootHeader().getColumnHeaders().stream()
@@ -689,9 +689,9 @@ public class TableHeaderRow extends StackPane {
                     .map(header -> {
                         Bounds bounds = header.localToScene(header.getBoundsInLocal());
                         return bounds.getMinX() <= x && x < bounds.getMaxX() ?
-                             cornerRegion.getWidth() : 0d;
+                             cornerRegion.getWidth() : 0.0;
                     })
-                    .orElse(0d);
+                    .orElse(0.0);
         }
         cornerPadding.set(padding);
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableHeaderRow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableHeaderRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,14 +30,17 @@ import java.util.*;
 import javafx.beans.InvalidationListener;
 import javafx.beans.WeakInvalidationListener;
 import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.property.SimpleBooleanProperty;
-import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.StringProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.WeakChangeListener;
 import javafx.collections.ListChangeListener;
 import javafx.collections.WeakListChangeListener;
+import javafx.geometry.Bounds;
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
 import javafx.geometry.Side;
@@ -46,9 +49,7 @@ import javafx.scene.control.CheckMenuItem;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Control;
 import javafx.scene.control.Label;
-import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableColumnBase;
-import javafx.scene.layout.Border;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
@@ -108,6 +109,7 @@ public class TableHeaderRow extends StackPane {
      * when clicked shows a PopupMenu consisting of all leaf columns.
      */
     private Pane cornerRegion;
+    final DoubleProperty cornerPadding = new SimpleDoubleProperty();
 
     /**
      * PopupMenu shown to users to allow for them to hide/show columns in the
@@ -155,6 +157,8 @@ public class TableHeaderRow extends StackPane {
         }
     };
 
+    private final ChangeListener<Boolean> cornerPaddingListener = (obs, ov, nv) -> updateCornerPadding();
+
     private final WeakInvalidationListener weakTableWidthListener =
             new WeakInvalidationListener(tableWidthListener);
 
@@ -169,6 +173,9 @@ public class TableHeaderRow extends StackPane {
 
     private final WeakInvalidationListener weakColumnTextListener =
             new WeakInvalidationListener(columnTextListener);
+
+    private final WeakChangeListener<Boolean> weakCornerPaddingListener =
+            new WeakChangeListener<>(cornerPaddingListener);
 
 
 
@@ -261,6 +268,8 @@ public class TableHeaderRow extends StackPane {
             columnPopupMenu.show(cornerRegion, Side.BOTTOM, 0, 0);
             me.consume();
         });
+        cornerRegion.visibleProperty().addListener(weakCornerPaddingListener);
+        flow.getVbar().visibleProperty().addListener(weakCornerPaddingListener);
 
         // the actual header
         // the region that is anchored above the vertical scrollbar
@@ -381,8 +390,10 @@ public class TableHeaderRow extends StackPane {
             filler.resizeRelocate(x + headerWidth, snappedTopInset(), fillerWidth, prefHeight);
         }
 
-        // position the top-right rectangle (which sits above the scrollbar)
+        // position the top-right rectangle (which sits above the scrollbar if visible, or adds padding to the
+        // header of the last visible column if not)
         cornerRegion.resizeRelocate(tableWidth - cornerWidth, snappedTopInset(), cornerWidth, prefHeight);
+        updateCornerPadding();
     }
 
     /** {@inheritDoc} */
@@ -662,4 +673,27 @@ public class TableHeaderRow extends StackPane {
 
         return false;
     }
+
+    // When the corner region is visible, and the vertical scrollbar is not,
+    // in case the corner region is over the header of the last
+    // visible column, if any, we have to consider its width as extra padding
+    // for that header, to prevent the content of the latter from being partially
+    // covered.
+    private void updateCornerPadding() {
+        double padding = 0;
+        if (cornerRegion.isVisible() && !flow.getVbar().isVisible()) {
+            double x = cornerRegion.getLayoutX();
+            padding = getRootHeader().getColumnHeaders().stream()
+                    .filter(header -> header.isLastVisibleColumn)
+                    .findFirst()
+                    .map(header -> {
+                        Bounds bounds = header.localToScene(header.getBoundsInLocal());
+                        return bounds.getMinX() <= x && x < bounds.getMaxX() ?
+                             cornerRegion.getWidth() : 0d;
+                    })
+                    .orElse(0d);
+        }
+        cornerPadding.set(padding);
+    }
+
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -5878,6 +5878,8 @@ public class TableViewTest {
         assertTrue(corner.isVisible());
         double cornerMinX = corner.localToScene(corner.getLayoutBounds()).getMinX();
 
+        // Verify that the slider's thumb is fully visible, and it is not overlapped
+        // by the corner region
         assertTrue(thumbMaxX < cornerMinX);
 
         sl.dispose();
@@ -5927,8 +5929,12 @@ public class TableViewTest {
         assertTrue(corner.isVisible());
         double cornerMinX = corner.localToScene(corner.getLayoutBounds()).getMinX();
 
+        // Verify that the corner region is over the last visible column header
         assertTrue(headerMinX < cornerMinX);
         assertTrue(cornerMinX < headerMaxX);
+
+        // Verify that the arrow is fully visible, and it is not overlapped
+        // by the corner region
         assertTrue(arrowMaxX < cornerMinX);
 
         sl.dispose();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -46,6 +46,8 @@ import javafx.collections.ObservableSet;
 import javafx.collections.SetChangeListener;
 import javafx.css.PseudoClass;
 import javafx.scene.Node;
+import javafx.scene.control.Slider;
+import javafx.scene.layout.Region;
 import test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils;
 import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
 import test.com.sun.javafx.scene.control.infrastructure.KeyModifier;
@@ -5848,4 +5850,87 @@ public class TableViewTest {
         sl.dispose();
     }
 
+    // See JDK-8087673
+    @Test
+    public void testTableMenuButtonDoesNotOverlapColumnHeaderGraphic() {
+        TableView<String> table = new TableView<>();
+        table.setColumnResizePolicy(TableView.CONSTRAINED_RESIZE_POLICY);
+        table.setTableMenuButtonVisible(true);
+        TableColumn<String, String> column = new TableColumn<>();
+        Slider slider = new Slider();
+        slider.setValue(100);
+        column.setGraphic(slider);
+        table.getColumns().add(column);
+
+        StageLoader sl = new StageLoader(table);
+
+        Toolkit.getToolkit().firePulse();
+
+        ScrollBar vbar = VirtualFlowTestUtils.getVirtualFlowVerticalScrollbar(table);
+        assertFalse(vbar.isVisible());
+
+        StackPane thumb = (StackPane) slider.lookup(".thumb");
+        assertNotNull(thumb);
+        double thumbMaxX = thumb.localToScene(thumb.getLayoutBounds()).getMaxX();
+
+        StackPane corner = (StackPane) table.lookup(".show-hide-columns-button");
+        assertNotNull(corner);
+        assertTrue(corner.isVisible());
+        double cornerMinX = corner.localToScene(corner.getLayoutBounds()).getMinX();
+
+        assertTrue(thumbMaxX < cornerMinX);
+
+        sl.dispose();
+    }
+
+    // See JDK-8087673
+    @Test
+    public void testTableMenuButtonDoesNotOverlapLastColumnHeader() {
+        TableView<String> table = new TableView<>();
+        table.setTableMenuButtonVisible(true);
+        for (int i = 0; i < 10; i++) {
+            final TableColumn<String, String> column = new TableColumn<>(i + "          ");
+            column.setCellValueFactory(value -> new SimpleStringProperty(value.getValue()));
+            table.getColumns().add(column);
+        }
+        for (int i = 0; i < 10; i++) {
+            table.getItems().add(Integer.toString(i));
+        }
+
+        StageLoader sl = new StageLoader(new Scene(table, 300, 300));
+
+        TableColumn<String, ?> lastColumn = table.getColumns().get(9);
+        lastColumn.setSortType(DESCENDING);
+        table.getSortOrder().setAll(lastColumn);
+        Toolkit.getToolkit().firePulse();
+
+        TableColumnHeader lastColumnHeader = VirtualFlowTestUtils.getTableColumnHeader(table, lastColumn);
+        assertNotNull(lastColumnHeader);
+
+        Region arrow = (Region) lastColumnHeader.lookup(".arrow");
+        assertNotNull(arrow);
+
+        ScrollBar vbar = VirtualFlowTestUtils.getVirtualFlowVerticalScrollbar(table);
+        assertFalse(vbar.isVisible());
+        ScrollBar hbar = VirtualFlowTestUtils.getVirtualFlowHorizontalScrollbar(table);
+        assertTrue(hbar.isVisible());
+
+        table.scrollToColumnIndex(9);
+
+        double headerMinX = lastColumnHeader.localToScene(lastColumnHeader.getLayoutBounds()).getMinX();
+        double headerMaxX = lastColumnHeader.localToScene(lastColumnHeader.getLayoutBounds()).getMaxX();
+
+        double arrowMaxX = arrow.localToScene(arrow.getLayoutBounds()).getMaxX();
+
+        StackPane corner = (StackPane) table.lookup(".show-hide-columns-button");
+        assertNotNull(corner);
+        assertTrue(corner.isVisible());
+        double cornerMinX = corner.localToScene(corner.getLayoutBounds()).getMinX();
+
+        assertTrue(headerMinX < cornerMinX);
+        assertTrue(cornerMinX < headerMaxX);
+        assertTrue(arrowMaxX < cornerMinX);
+
+        sl.dispose();
+    }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -48,6 +48,7 @@ import javafx.css.PseudoClass;
 import javafx.scene.Node;
 import javafx.scene.control.Slider;
 import javafx.scene.layout.Region;
+import org.junit.After;
 import test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils;
 import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
 import test.com.sun.javafx.scene.control.infrastructure.KeyModifier;
@@ -122,6 +123,8 @@ public class TableViewTest {
     private TableView.TableViewSelectionModel sm;
     private TableView.TableViewFocusModel<String> fm;
 
+    private StageLoader stageLoader;
+
     private ObservableList<Person> personTestData;
 
     @Before public void setup() {
@@ -137,6 +140,12 @@ public class TableViewTest {
                 new Person("Michael", "Brown", "michael.brown@example.com"));
     }
 
+    @After
+    public void cleanup() {
+        if (stageLoader != null) {
+            stageLoader.dispose();
+        }
+    }
 
     /*********************************************************************
      * Tests for the constructors                                        *
@@ -5862,7 +5871,7 @@ public class TableViewTest {
         column.setGraphic(slider);
         table.getColumns().add(column);
 
-        StageLoader sl = new StageLoader(table);
+        stageLoader = new StageLoader(table);
 
         Toolkit.getToolkit().firePulse();
 
@@ -5881,8 +5890,6 @@ public class TableViewTest {
         // Verify that the slider's thumb is fully visible, and it is not overlapped
         // by the corner region
         assertTrue(thumbMaxX < cornerMinX);
-
-        sl.dispose();
     }
 
     // See JDK-8087673
@@ -5899,7 +5906,7 @@ public class TableViewTest {
             table.getItems().add(Integer.toString(i));
         }
 
-        StageLoader sl = new StageLoader(new Scene(table, 300, 300));
+        stageLoader = new StageLoader(new Scene(table, 300, 300));
 
         TableColumn<String, ?> lastColumn = table.getColumns().get(9);
         lastColumn.setSortType(DESCENDING);
@@ -5936,7 +5943,5 @@ public class TableViewTest {
         // Verify that the arrow is fully visible, and it is not overlapped
         // by the corner region
         assertTrue(arrowMaxX < cornerMinX);
-
-        sl.dispose();
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -44,9 +44,13 @@ import java.util.stream.Collectors;
 import com.sun.javafx.scene.control.behavior.TreeTableCellBehavior;
 import javafx.beans.property.ReadOnlyIntegerWrapper;
 import javafx.collections.transformation.FilteredList;
+import javafx.scene.control.ScrollBar;
 import javafx.scene.control.SelectionModel;
+import javafx.scene.control.Slider;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
+import javafx.scene.control.skin.TableColumnHeader;
+import javafx.scene.layout.Region;
 import test.javafx.collections.MockListObserver;
 import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
 import test.com.sun.javafx.scene.control.infrastructure.KeyModifier;
@@ -6986,5 +6990,94 @@ public class TreeTableViewTest {
         assertEquals("Node 0", table.getSelectionModel().getSelectedItem().getValue());
         assertEquals(0, table.getFocusModel().getFocusedIndex());
         assertEquals("Node 0", table.getFocusModel().getFocusedItem().getValue());
+    }
+
+    // See JDK-8087673
+    @Test
+    public void testTreeTableMenuButtonDoesNotOverlapColumnHeaderGraphic() {
+        TreeTableView<String> table = new TreeTableView<>();
+        table.setColumnResizePolicy(TreeTableView.CONSTRAINED_RESIZE_POLICY);
+        table.setTableMenuButtonVisible(true);
+        TreeTableColumn<String, String> column = new TreeTableColumn<>();
+        Slider slider = new Slider();
+        slider.setValue(100);
+        column.setGraphic(slider);
+        table.getColumns().add(column);
+
+        StageLoader sl = new StageLoader(table);
+
+        Toolkit.getToolkit().firePulse();
+
+        ScrollBar vbar = VirtualFlowTestUtils.getVirtualFlowVerticalScrollbar(table);
+        assertFalse(vbar.isVisible());
+
+        StackPane thumb = (StackPane) slider.lookup(".thumb");
+        assertNotNull(thumb);
+        double thumbMaxX = thumb.localToScene(thumb.getLayoutBounds()).getMaxX();
+
+        StackPane corner = (StackPane) table.lookup(".show-hide-columns-button");
+        assertNotNull(corner);
+        assertTrue(corner.isVisible());
+        double cornerMinX = corner.localToScene(corner.getLayoutBounds()).getMinX();
+
+        assertTrue(thumbMaxX < cornerMinX);
+
+        sl.dispose();
+    }
+
+    // See JDK-8087673
+    @Test
+    public void testTableMenuButtonDoesNotOverlapLastColumnHeader() {
+        TreeTableView<String> table = new TreeTableView<>();
+        table.setTableMenuButtonVisible(true);
+        for (int i = 0; i < 10; i++) {
+            TreeTableColumn<String, String> column = new TreeTableColumn<>(i + "          ");
+            column.setCellValueFactory(value -> new SimpleStringProperty(value.getValue().getValue()));
+            table.getColumns().add(column);
+        }
+
+        TreeItem<String> root = new TreeItem<>();
+        root.setExpanded(true);
+        for (int i = 0; i < 10; i++) {
+            root.getChildren().add(new TreeItem<>(Integer.toString(i)));
+        }
+        table.setRoot(root);
+        table.setShowRoot(false);
+
+        StageLoader sl = new StageLoader(new Scene(table, 300, 300));
+
+        TreeTableColumn<String, ?> lastColumn = table.getColumns().get(9);
+        lastColumn.setSortType(TreeTableColumn.SortType.DESCENDING);
+        table.getSortOrder().setAll(lastColumn);
+        Toolkit.getToolkit().firePulse();
+
+        TableColumnHeader lastColumnHeader = VirtualFlowTestUtils.getTableColumnHeader(table, lastColumn);
+        assertNotNull(lastColumnHeader);
+
+        Region arrow = (Region) lastColumnHeader.lookup(".arrow");
+        assertNotNull(arrow);
+
+        ScrollBar vbar = VirtualFlowTestUtils.getVirtualFlowVerticalScrollbar(table);
+        assertFalse(vbar.isVisible());
+        ScrollBar hbar = VirtualFlowTestUtils.getVirtualFlowHorizontalScrollbar(table);
+        assertTrue(hbar.isVisible());
+
+        table.scrollToColumnIndex(9);
+
+        double headerMinX = lastColumnHeader.localToScene(lastColumnHeader.getLayoutBounds()).getMinX();
+        double headerMaxX = lastColumnHeader.localToScene(lastColumnHeader.getLayoutBounds()).getMaxX();
+
+        double arrowMaxX = arrow.localToScene(arrow.getLayoutBounds()).getMaxX();
+
+        StackPane corner = (StackPane) table.lookup(".show-hide-columns-button");
+        assertNotNull(corner);
+        assertTrue(corner.isVisible());
+        double cornerMinX = corner.localToScene(corner.getLayoutBounds()).getMinX();
+
+        assertTrue(headerMinX < cornerMinX);
+        assertTrue(cornerMinX < headerMaxX);
+        assertTrue(arrowMaxX < cornerMinX);
+
+        sl.dispose();
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -7020,6 +7020,8 @@ public class TreeTableViewTest {
         assertTrue(corner.isVisible());
         double cornerMinX = corner.localToScene(corner.getLayoutBounds()).getMinX();
 
+        // Verify that the slider's thumb is fully visible, and it is not overlapped
+        // by the corner region
         assertTrue(thumbMaxX < cornerMinX);
 
         sl.dispose();
@@ -7074,8 +7076,12 @@ public class TreeTableViewTest {
         assertTrue(corner.isVisible());
         double cornerMinX = corner.localToScene(corner.getLayoutBounds()).getMinX();
 
+        // Verify that the corner region is over the last visible column header
         assertTrue(headerMinX < cornerMinX);
         assertTrue(cornerMinX < headerMaxX);
+
+        // Verify that the arrow is fully visible, and it is not overlapped
+        // by the corner region
         assertTrue(arrowMaxX < cornerMinX);
 
         sl.dispose();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -51,6 +51,7 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.skin.TableColumnHeader;
 import javafx.scene.layout.Region;
+import org.junit.After;
 import test.javafx.collections.MockListObserver;
 import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
 import test.com.sun.javafx.scene.control.infrastructure.KeyModifier;
@@ -126,6 +127,7 @@ public class TreeTableViewTest {
     private TreeTableView.TreeTableViewSelectionModel sm;
     private TreeTableViewFocusModel<String> fm;
 
+    private StageLoader stageLoader;
 
     // sample data #1
     private TreeItem<String> root;
@@ -185,6 +187,13 @@ public class TreeTableViewTest {
             judyMayer,
             gregorySmith
         );
+    }
+
+    @After
+    public void cleanup() {
+        if (stageLoader != null) {
+            stageLoader.dispose();
+        }
     }
 
     private void installChildren() {
@@ -7004,7 +7013,7 @@ public class TreeTableViewTest {
         column.setGraphic(slider);
         table.getColumns().add(column);
 
-        StageLoader sl = new StageLoader(table);
+        stageLoader = new StageLoader(table);
 
         Toolkit.getToolkit().firePulse();
 
@@ -7023,8 +7032,6 @@ public class TreeTableViewTest {
         // Verify that the slider's thumb is fully visible, and it is not overlapped
         // by the corner region
         assertTrue(thumbMaxX < cornerMinX);
-
-        sl.dispose();
     }
 
     // See JDK-8087673
@@ -7046,7 +7053,7 @@ public class TreeTableViewTest {
         table.setRoot(root);
         table.setShowRoot(false);
 
-        StageLoader sl = new StageLoader(new Scene(table, 300, 300));
+        stageLoader = new StageLoader(new Scene(table, 300, 300));
 
         TreeTableColumn<String, ?> lastColumn = table.getColumns().get(9);
         lastColumn.setSortType(TreeTableColumn.SortType.DESCENDING);
@@ -7083,7 +7090,5 @@ public class TreeTableViewTest {
         // Verify that the arrow is fully visible, and it is not overlapped
         // by the corner region
         assertTrue(arrowMaxX < cornerMinX);
-
-        sl.dispose();
     }
 }


### PR DESCRIPTION
The corner region is currently laid out with this assumption:

        // position the top-right rectangle (which sits above the scrollbar)

However, the vertical scrollbar is not always visible. Therefore, when that is the case, the corner region is laid out on top of the table column headers, overlapping any of their graphic or text content. In case of the last visible column header, it is not always possible to scroll horizontally to see the full content, either because of a constrained resize policy or because there is no more space left after the last column.

This PR fixes this issue by considering as padding for the last visible column header the presence of the corner region over it, only when the vertical scrollbar is not visible and the corner region is.

A couple of tests have been added to both TableViewTest and TreeTableViewTest.

Test 1: Before and after the changes :

<img width="312" alt="image" src="https://user-images.githubusercontent.com/2043230/187190928-efc29e38-8de2-4daf-8eff-a218d6fae181.png">
<img width="312" alt="image" src="https://user-images.githubusercontent.com/2043230/187190991-deaa88b3-2f52-48bc-b3ec-107a5151f7b5.png">

Test 2:  Before (sort arrow is there, but not visible) and after the changes:
<img width="412" alt="image" src="https://user-images.githubusercontent.com/2043230/187191310-fb348d8c-84fc-4254-a1a5-91811bf09b79.png">
<img width="412" alt="image" src="https://user-images.githubusercontent.com/2043230/187191358-0d4937cb-b3b4-4530-9489-ff8cbf0c8443.png">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8087673](https://bugs.openjdk.org/browse/JDK-8087673): [TableView] TableView and TreeTableView menu button overlaps columns when using a constrained resize policy.


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Author)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/886/head:pull/886` \
`$ git checkout pull/886`

Update a local copy of the PR: \
`$ git checkout pull/886` \
`$ git pull https://git.openjdk.org/jfx pull/886/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 886`

View PR using the GUI difftool: \
`$ git pr show -t 886`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/886.diff">https://git.openjdk.org/jfx/pull/886.diff</a>

</details>
