### PR TITLE
JDK-8293171: Minor typographical errors in JavaDoc javafx.scene.control.ScrollPane.java

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ScrollPane.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ScrollPane.java
@@ -291,7 +291,7 @@ public class ScrollPane extends Control {
         return hmin;
     }
     /**
-     * The minimum allowable {@link #hvalueProperty vvalue} for this ScrollPane.
+     * The minimum allowable {@link #vvalueProperty vvalue} for this ScrollPane.
      * Default value is 0.
      */
     private DoubleProperty vmin;
@@ -331,7 +331,7 @@ public class ScrollPane extends Control {
         return hmax;
     }
     /**
-     * The maximum allowable {@link #hvalueProperty vvalue} for this ScrollPane.
+     * The maximum allowable {@link #vvalueProperty vvalue} for this ScrollPane.
      * Default value is 1.
      */
     private DoubleProperty vmax;


### PR DESCRIPTION
Fix two typos in the JavaDoc. The links for the vertical property link to the horizontal property.

It's my first commit, so please comment if I haven't followed the commit protocol per expectations.

Note, I no longer have a handle to the JBS title for record 9073896. The record is not available to me: https://bugs.java.com/bugdatabase/view_bug.do?bug_id=9073896

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293171](https://bugs.openjdk.org/browse/JDK-8293171): Minor typographical errors in JavaDoc javafx.scene.control.ScrollPane.java


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Author)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/887/head:pull/887` \
`$ git checkout pull/887`

Update a local copy of the PR: \
`$ git checkout pull/887` \
`$ git pull https://git.openjdk.org/jfx pull/887/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 887`

View PR using the GUI difftool: \
`$ git pr show -t 887`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/887.diff">https://git.openjdk.org/jfx/pull/887.diff</a>

</details>
