### PR TITLE
8293214: Add support for Linux/LoongArch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,3 @@ For information about downloading and using JavaFX, see the [JavaFX community si
 ## Contributing
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
-

--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ For information about downloading and using JavaFX, see the [JavaFX community si
 ## Contributing
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our code of conduct, and the process for submitting pull requests to us.
+

--- a/build.gradle
+++ b/build.gradle
@@ -310,7 +310,7 @@ if (IS_WINDOWS && OS_ARCH != "x86" && OS_ARCH != "amd64") {
     fail("Unknown and unsupported build architecture: $OS_ARCH")
 } else if (IS_MAC && OS_ARCH != "x86_64" && OS_ARCH != "aarch64") {
     fail("Unknown and unsupported build architecture: $OS_ARCH")
-} else if (IS_LINUX && OS_ARCH != "i386" && OS_ARCH != "amd64" && OS_ARCH != "aarch64" && OS_ARCH != "loongarch64") {
+} else if (IS_LINUX && OS_ARCH != "i386" && OS_ARCH != "amd64" && !IS_AARCH64 && !IS_LOONGARCH64) {
     fail("Unknown and unsupported build architecture: $OS_ARCH")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -291,8 +291,10 @@ ext.MODULESOURCEPATH = "modulesourcepath.args"
 // this build running on a Mac, Windows, or Linux machine? 32 or 64 bit?
 ext.OS_NAME = System.getProperty("os.name").toLowerCase()
 ext.OS_ARCH = System.getProperty("os.arch")
+ext.ARCH_NAME = "x64"
 ext.IS_64 = OS_ARCH.toLowerCase().contains("64")
 ext.IS_AARCH64 = OS_ARCH.toLowerCase().contains("aarch64")
+ext.IS_LOONGARCH64 = OS_ARCH.toLowerCase().contains("loongarch64")
 ext.IS_MAC = OS_NAME.contains("mac") || OS_NAME.contains("darwin")
 ext.IS_WINDOWS = OS_NAME.contains("windows")
 ext.IS_LINUX = OS_NAME.contains("linux")
@@ -308,10 +310,21 @@ if (IS_WINDOWS && OS_ARCH != "x86" && OS_ARCH != "amd64") {
     fail("Unknown and unsupported build architecture: $OS_ARCH")
 } else if (IS_MAC && OS_ARCH != "x86_64" && OS_ARCH != "aarch64") {
     fail("Unknown and unsupported build architecture: $OS_ARCH")
-} else if (IS_LINUX && OS_ARCH != "i386" && OS_ARCH != "amd64" && OS_ARCH != "aarch64") {
+} else if (IS_LINUX && OS_ARCH != "i386" && OS_ARCH != "amd64" && OS_ARCH != "aarch64" && OS_ARCH != "loongarch64") {
     fail("Unknown and unsupported build architecture: $OS_ARCH")
 }
 
+if (IS_64) {
+    if (IS_AARCH64) {
+        ARCH_NAME = "aarch64"
+    } else if (IS_LOONGARCH64) {
+        ARCH_NAME = "loongarch64"
+    } else {
+        ARCH_NAME = "x64"
+    }
+} else {
+    ARCH_NAME = "x32"
+}
 
 // Get the JDK_HOME automatically based on the version of Java used to execute gradle. Or, if specified,
 // use a user supplied JDK_HOME, STUB_RUNTIME, JAVAC, all of which may be specified
@@ -2923,7 +2936,7 @@ project(":media") {
                     args("JAVA_HOME=${JDK_HOME}", "GENERATED_HEADERS_DIR=${generatedHeadersDir}",
                          "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=jfxmedia",
                          "COMPILE_PARFAIT=${compileParfait}",
-                         IS_64 ? IS_AARCH64 ? "ARCH=aarch64" : "ARCH=x64" : "ARCH=x32",
+                         "ARCH=${ARCH_NAME}",
                         "CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}")
 
                     if (t.name == "win") {
@@ -2950,7 +2963,7 @@ project(":media") {
                     exec {
                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/gstreamer-lite")
                         args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=gstreamer-lite",
-                             IS_64 ? IS_AARCH64 ? "ARCH=aarch64" : "ARCH=x64" : "ARCH=x32", "CC=${mediaProperties.compiler}",
+                             "ARCH=${ARCH_NAME}", "CC=${mediaProperties.compiler}",
                              "AR=${mediaProperties.ar}", "LINKER=${mediaProperties.linker}")
 
                         if (t.name == "win") {
@@ -2968,7 +2981,7 @@ project(":media") {
                     exec {
                         commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/${projectDir}/fxplugins")
                         args("OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}", "BASE_NAME=fxplugins",
-                             IS_64 ? IS_AARCH64 ? "ARCH=aarch64" : "ARCH=x64" : "ARCH=x32",
+                             "ARCH=${ARCH_NAME}",
                              "CC=${mediaProperties.compiler}", "AR=${mediaProperties.ar}", "LINKER=${mediaProperties.linker}")
 
                         if (t.name == "win") {
@@ -3278,7 +3291,7 @@ project(":media") {
                                         args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
                                              "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
                                              "BASE_NAME=avplugin", "VERSION=${version}", "LIBAV_DIR=${libavDir}",
-                                             "SUFFIX=", IS_64 ? IS_AARCH64 ? "ARCH=aarch64" : "ARCH=x64" : "ARCH=x32",
+                                             "SUFFIX=", "ARCH=${ARCH_NAME}",
                                              "STATIC=${IS_STATIC_BUILD}")
                                     }
                                 }
@@ -3294,7 +3307,7 @@ project(":media") {
                                              "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
                                              "BASE_NAME=avplugin", "VERSION=${version}", "LIBAV_DIR=${libavDir}",
                                              "SUFFIX=-ffmpeg",
-                                             IS_64 ? IS_AARCH64 ? "ARCH=aarch64" : "ARCH=x64" : "ARCH=x32")
+                                             "ARCH=${ARCH_NAME}")
                                     }
                                 }
                             }
@@ -3309,7 +3322,7 @@ project(":media") {
                                              "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
                                              "BASE_NAME=avplugin", "VERSION=${version}", "LIBAV_DIR=${libavDir}",
                                              "SUFFIX=-ffmpeg",
-                                             IS_64 ? IS_AARCH64 ? "ARCH=aarch64" : "ARCH=x64" : "ARCH=x32")
+                                             "ARCH=${ARCH_NAME}")
                                     }
                                 }
                             }
@@ -3319,7 +3332,7 @@ project(":media") {
                                 commandLine ("make", "${makeJobsFlag}", "-C", "${nativeSrcDir}/gstreamer/projects/linux/avplugin")
                                 args("CC=${mediaProperties.compiler}", "LINKER=${mediaProperties.linker}",
                                      "OUTPUT_DIR=${nativeOutputDir}", "BUILD_TYPE=${buildType}",
-                                     "BASE_NAME=avplugin", IS_64 ? IS_AARCH64 ? "ARCH=aarch64" : "ARCH=x64" : "ARCH=x32")
+                                     "BASE_NAME=avplugin", "ARCH=${ARCH_NAME}")
                             }
                         }
                     }
@@ -3565,6 +3578,8 @@ project(":web") {
                         if (IS_64) {
                             if (IS_AARCH64) {
                                 cmakeArgs = "$cmakeArgs -DCMAKE_SYSTEM_PROCESSOR=aarch64"
+                            } else if (IS_LOONGARCH64) {
+                                cmakeArgs = "$cmakeArgs -DCMAKE_SYSTEM_PROCESSOR=loongarch64"
                             } else {
                                 cmakeArgs = "$cmakeArgs -DCMAKE_SYSTEM_PROCESSOR=x86_64"
                             }

--- a/modules/javafx.media/src/main/native/gstreamer/projects/linux/avplugin/Makefile
+++ b/modules/javafx.media/src/main/native/gstreamer/projects/linux/avplugin/Makefile
@@ -33,7 +33,7 @@ CFLAGS = -fPIC                   \
          -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_48 \
          -ffunction-sections -fdata-sections
 
-ifeq (,$(findstring $(ARCH), aarch64 loongarch64))
+ifneq (,$(findstring $(ARCH), x64 x32))
     CFLAGS += -msse2
 endif
 

--- a/modules/javafx.media/src/main/native/gstreamer/projects/linux/avplugin/Makefile
+++ b/modules/javafx.media/src/main/native/gstreamer/projects/linux/avplugin/Makefile
@@ -33,7 +33,7 @@ CFLAGS = -fPIC                   \
          -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_48 \
          -ffunction-sections -fdata-sections
 
-ifneq ($(ARCH), aarch64)
+ifeq (,$(findstring $(ARCH), aarch64 loongarch64))
     CFLAGS += -msse2
 endif
 

--- a/modules/javafx.media/src/main/native/gstreamer/projects/linux/fxplugins/Makefile
+++ b/modules/javafx.media/src/main/native/gstreamer/projects/linux/fxplugins/Makefile
@@ -35,7 +35,7 @@ CFLAGS = -fPIC                   \
          -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_48 \
          -ffunction-sections -fdata-sections
 
-ifneq ($(ARCH), aarch64)
+ifeq (,$(findstring $(ARCH), aarch64 loongarch64))
     CFLAGS += -msse2
 endif
 

--- a/modules/javafx.media/src/main/native/gstreamer/projects/linux/fxplugins/Makefile
+++ b/modules/javafx.media/src/main/native/gstreamer/projects/linux/fxplugins/Makefile
@@ -35,7 +35,7 @@ CFLAGS = -fPIC                   \
          -DGLIB_VERSION_MAX_ALLOWED=GLIB_VERSION_2_48 \
          -ffunction-sections -fdata-sections
 
-ifeq (,$(findstring $(ARCH), aarch64 loongarch64))
+ifneq (,$(findstring $(ARCH), x64 x32))
     CFLAGS += -msse2
 endif
 

--- a/modules/javafx.media/src/main/native/jfxmedia/projects/linux/Makefile
+++ b/modules/javafx.media/src/main/native/jfxmedia/projects/linux/Makefile
@@ -72,7 +72,7 @@ ifdef HOST_COMPILE
                   -fstack-protector \
                   -Werror=trampolines \
 	          -DGSTREAMER_LITE
-        ifeq (,$(findstring $(ARCH), aarch64 loongarch64))
+        ifneq (,$(findstring $(ARCH), x64 x32))
             CFLAGS += -msse2
         endif
 

--- a/modules/javafx.media/src/main/native/jfxmedia/projects/linux/Makefile
+++ b/modules/javafx.media/src/main/native/jfxmedia/projects/linux/Makefile
@@ -72,7 +72,7 @@ ifdef HOST_COMPILE
                   -fstack-protector \
                   -Werror=trampolines \
 	          -DGSTREAMER_LITE
-        ifneq ($(ARCH), aarch64)
+        ifeq (,$(findstring $(ARCH), aarch64 loongarch64))
             CFLAGS += -msse2
         endif
 


### PR DESCRIPTION
LoongArch is a new RISC ISA. This issue proposes adding support for Linux/LoongArch64. Upstream WebKit for LoongArch64 support is not ready, but the OpenJFX part is simple and ready. When the LoongArch64 supported Webkit is updated to OpenJFX, it is supposed to work.

Testing:
- [x] base, controls, fxml, graphics and web tests, {Release,Debug}, {with WebKit,without Webkit} on Linux/x64
- [x] base, controls, fxml, graphics and web tests, {Release,Debug}, {with WebKit,without Webkit} on Linux/aarch64
- [x] base, controls, fxml and graphics tests, {Release,Debug}, without WebKit on Linux/loongarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (3 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 2 [Authors](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8293214](https://bugs.openjdk.org/browse/JDK-8293214): Add support for Linux/LoongArch64


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/888/head:pull/888` \
`$ git checkout pull/888`

Update a local copy of the PR: \
`$ git checkout pull/888` \
`$ git pull https://git.openjdk.org/jfx pull/888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 888`

View PR using the GUI difftool: \
`$ git pr show -t 888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/888.diff">https://git.openjdk.org/jfx/pull/888.diff</a>

</details>
