### PR TITLE
8293375: add_definitions USE_SYSTEM_MALLOC when USE_SYSTEM_MALLOC is ON

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/PlatformJava.cmake
+++ b/modules/javafx.web/src/main/native/Source/WebCore/PlatformJava.cmake
@@ -78,6 +78,10 @@ list(APPEND WebCore_LIBRARIES
 
 add_definitions(-DSTATICALLY_LINKED_WITH_JavaScriptCore)
 add_definitions(-DSTATICALLY_LINKED_WITH_WTF)
+if (USE_SYSTEM_MALLOC)
+    message(STATUS "Using system malloc")
+    add_definitions(-DUSE_SYSTEM_MALLOC)
+endif ()
 
 list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     bindings/java/JavaDOMUtils.h


### PR DESCRIPTION
Hi,

jfx web failed to build when `USE_SYSTEM_MALLOC` is `ON`:

```
jfx/modules/javafx.web/build/linux/Release/WTF/Headers/wtf/Platform.h:58,
jfx/modules/javafx.web/build/linux/Release/WTF/Headers/wtf/Assertions.h:28,
jfx/modules/javafx.web/src/main/native/Source/WebCore/platform/java/WebKitLogging.h:31,
jfx/modules/javafx.web/src/main/native/Source/WebCore/platform/java/WebKitLogging.cpp:28,
jfx/modules/javafx.web/build/linux/Release/WebCore/DerivedSources/unified-sources/UnifiedSource-3c72abbe-47.cpp:1:
jfx/modules/javafx.web/build/linux/Release/WTF/Headers/wtf/PlatformUse.h:351:10: fatal error: bmalloc/BPlatform.h: No such file or directory
  #include <bmalloc/BPlatform.h>
           ^~~~~~~~~~~~~~~~~~~~~
 compilation terminated.
```

After commit `6f28d912024495278c4c35ab054bc2aab480b3e4`:

```
diff --git a/modules/javafx.web/src/main/native/Source/WTF/wtf/PlatformUse.h b/modules/javafx.web/src/main/native/Source/WTF/wtf/PlatformUse.h
index 70c047813f..d30291697a 100644
--- a/modules/javafx.web/src/main/native/Source/WTF/wtf/PlatformUse.h
+++ b/modules/javafx.web/src/main/native/Source/WTF/wtf/PlatformUse.h

...

 #if PLATFORM(IOS_FAMILY)
 #define USE_SANDBOX_EXTENSIONS_FOR_CACHE_AND_TEMP_DIRECTORY_ACCESS 1
 #endif
+
+#if !defined(USE_LIBPAS_JIT_HEAP) && !USE(SYSTEM_MALLOC)
+#include <bmalloc/BPlatform.h>
+#if BENABLE(LIBPAS)
+#if PLATFORM(MAC) && CPU(ARM64)
+#define USE_LIBPAS_JIT_HEAP 1
+#endif
+#endif
+#endif
+
```

Please review my patch.

Thanks,
Leslie Zhai

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8293375](https://bugs.openjdk.org/browse/JDK-8293375): add_definitions USE_SYSTEM_MALLOC when USE_SYSTEM_MALLOC is ON


### Reviewers
 * [Jay Bhaskar](https://openjdk.org/census#jbhaskar) (@jaybhaskar - Author)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/892/head:pull/892` \
`$ git checkout pull/892`

Update a local copy of the PR: \
`$ git checkout pull/892` \
`$ git pull https://git.openjdk.org/jfx pull/892/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 892`

View PR using the GUI difftool: \
`$ git pr show -t 892`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/892.diff">https://git.openjdk.org/jfx/pull/892.diff</a>

</details>
