### PR TITLE
8089280: horizontal scrollbar should never become visible in TableView with constrained resize policy

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/NestedTableColumnHeader.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/NestedTableColumnHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -598,15 +598,9 @@ public class NestedTableColumnHeader extends TableColumnHeader {
             return;
         }
 
-        boolean isConstrainedResize = false;
         TableViewSkinBase tableSkin = getTableSkin();
         Callback<ResizeFeaturesBase,Boolean> columnResizePolicy = TableSkinUtils.columnResizePolicyProperty(tableSkin).get();
-        if (columnResizePolicy != null) {
-            isConstrainedResize =
-                    tableSkin instanceof TableViewSkin ? TableView.CONSTRAINED_RESIZE_POLICY.equals(columnResizePolicy) :
-                    tableSkin instanceof TreeTableViewSkin ? TreeTableView.CONSTRAINED_RESIZE_POLICY.equals(columnResizePolicy) :
-                    false;
-        }
+        boolean isConstrainedResize = TableSkinUtils.isConstrainedResizePolicy(columnResizePolicy);
 
         // RT-32547 - don't show resize cursor when in constrained resize mode
         // and there is only one column

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
@@ -690,7 +690,7 @@ public class TableColumnHeader extends Region {
 
         // RT-23486
         maxWidth += padding;
-        if (tv.getColumnResizePolicy() == TableView.CONSTRAINED_RESIZE_POLICY && tv.getWidth() > 0) {
+        if (TableSkinUtils.isConstrainedResizePolicy(tv.getColumnResizePolicy()) && tv.getWidth() > 0) {
             if (maxWidth > tc.getMaxWidth()) {
                 maxWidth = tc.getMaxWidth();
             }
@@ -785,7 +785,7 @@ public class TableColumnHeader extends Region {
 
         // RT-23486
         maxWidth += padding;
-        if (ttv.getColumnResizePolicy() == TreeTableView.CONSTRAINED_RESIZE_POLICY && ttv.getWidth() > 0) {
+        if (TableSkinUtils.isConstrainedResizePolicy(ttv.getColumnResizePolicy()) && ttv.getWidth() > 0) {
 
             if (maxWidth > tc.getMaxWidth()) {
                 maxWidth = tc.getMaxWidth();

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableSkinUtils.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableSkinUtils.java
@@ -210,7 +210,7 @@ class TableSkinUtils {
     }
 
     /** returns true if the column resize policy is constrained */
-    public static boolean isConstrainedResizePolicy(Callback<? extends ResizeFeaturesBase,Boolean> x) {
+    public static boolean isConstrainedResizePolicy(Callback<? extends ResizeFeaturesBase, Boolean> x) {
         return (x == TableView.CONSTRAINED_RESIZE_POLICY) ||
                (x == TreeTableView.CONSTRAINED_RESIZE_POLICY);
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableSkinUtils.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableSkinUtils.java
@@ -211,7 +211,7 @@ class TableSkinUtils {
 
     /** returns true if the column resize policy is constrained */
     public static boolean isConstrainedResizePolicy(Callback<? extends ResizeFeaturesBase,Boolean> x) {
-        return (x == (Object)TableView.CONSTRAINED_RESIZE_POLICY) ||
-               (x == (Object)TreeTableView.CONSTRAINED_RESIZE_POLICY);
+        return (x == TableView.CONSTRAINED_RESIZE_POLICY) ||
+               (x == TreeTableView.CONSTRAINED_RESIZE_POLICY);
     }
 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableSkinUtils.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableSkinUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -207,5 +207,11 @@ class TableSkinUtils {
             return treeTableViewSkin.tableBackingListProperty;
         }
         return null;
+    }
+
+    /** returns true if the column resize policy is constrained */
+    public static boolean isConstrainedResizePolicy(Callback<? extends ResizeFeaturesBase,Boolean> x) {
+        return (x == (Object)TableView.CONSTRAINED_RESIZE_POLICY) ||
+               (x == (Object)TreeTableView.CONSTRAINED_RESIZE_POLICY);
     }
 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
@@ -896,7 +896,7 @@ public abstract class TableViewSkinBase<M, S, C extends Control, I extends Index
     }
 
     void updateSuppressBreadthBar() {
-        Callback<ResizeFeaturesBase,Boolean> p = TableSkinUtils.columnResizePolicyProperty(this).get();
+        Callback<ResizeFeaturesBase, Boolean> p = TableSkinUtils.columnResizePolicyProperty(this).get();
         boolean suppress = TableSkinUtils.isConstrainedResizePolicy(p);
         flow.setSuppressBreadthBar(suppress);
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -336,6 +336,10 @@ public abstract class TableViewSkinBase<M, S, C extends Control, I extends Index
         });
         registerChangeListener(TableSkinUtils.placeholderProperty(this), e -> updatePlaceholderRegionVisibility());
         registerChangeListener(flow.getVbar().visibleProperty(), e -> updateContentWidth());
+        registerChangeListener(TableSkinUtils.columnResizePolicyProperty(this), (v) -> {
+            updateSuppressBreadthBar();
+        });
+        updateSuppressBreadthBar();
     }
 
 
@@ -889,6 +893,12 @@ public abstract class TableViewSkinBase<M, S, C extends Control, I extends Index
         // FIXME this isn't perfect, but it prevents RT-14885, which results in
         // undesired horizontal scrollbars when in constrained resize mode
         getSkinnable().getProperties().put("TableView.contentWidth", Math.floor(contentWidth));
+    }
+
+    protected void updateSuppressBreadthBar() {
+        Callback<ResizeFeaturesBase,Boolean> p = TableSkinUtils.columnResizePolicyProperty(this).get();
+        boolean suppress = TableSkinUtils.isConstrainedResizePolicy(p);
+        flow.setSuppressBreadthBar(suppress);
     }
 
     private void refreshView() {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -304,7 +304,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
     private boolean needBreadthBar;
     private boolean needLengthBar;
     private boolean tempVisibility = false;
-
+    private boolean suppressBreadthBar;
 
 
     /* *************************************************************************
@@ -2378,6 +2378,13 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
     }
 
     /**
+     * Suppresses the breadth bar from appearing.
+     */
+    public void setSuppressBreadthBar(boolean suppress) {
+        this.suppressBreadthBar = suppress;
+    }
+
+    /**
      * @return true if bar visibility changed
      */
     private boolean computeBarVisiblity() {
@@ -2409,8 +2416,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
                 barVisibilityChanged = true;
             }
 
-            // second conditional removed for RT-36669.
-            final boolean breadthBarVisible = (maxPrefBreadth > viewportBreadth);// || (needLengthBar && maxPrefBreadth > (viewportBreadth - lengthBarBreadth));
+            final boolean breadthBarVisible = !suppressBreadthBar && (maxPrefBreadth > viewportBreadth);
             if (breadthBarVisible ^ needBreadthBar) {
                 needBreadthBar = breadthBarVisible;
                 barVisibilityChanged = true;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -5950,7 +5950,7 @@ public class TableViewTest {
     public void testSuppressHorizontalScrollBar() {
         TableView<String> table = new TableView<>();
         for (int i = 0; i < 10; i++) {
-            final TableColumn<String,String> c = new TableColumn<>("C" + i);
+            final TableColumn<String, String> c = new TableColumn<>("C" + i);
             c.setCellValueFactory(value -> new SimpleStringProperty(value.getValue()));
             c.setMinWidth(200); // caused HSB before the fix
             table.getColumns().add(c);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -7106,7 +7106,7 @@ public class TreeTableViewTest {
 
         TreeTableView<String> table = new TreeTableView<>();
         for (int i = 0; i < 10; i++) {
-            TreeTableColumn<String,String> c = new TreeTableColumn<>("C" + i);
+            TreeTableColumn<String, String> c = new TreeTableColumn<>("C" + i);
             c.setCellValueFactory(value -> new SimpleStringProperty(value.getValue().getValue()));
             table.getColumns().add(c);
         }


### PR DESCRIPTION
Modified the tree/table view internals to suppress the horizontal (a.k.a. breadth in VirtualFlow) scroll bar when a constrained resize mode is in effect.  This change complements fixes added in [JDK-8089009](https://bugs.openjdk.org/browse/JDK-8089009) without addressing other bugs found in https://bugs.openjdk.org/browse/JDK-8292810

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8089280](https://bugs.openjdk.org/browse/JDK-8089280): horizontal scrollbar should never become visible in TableView with constrained resize policy


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/894/head:pull/894` \
`$ git checkout pull/894`

Update a local copy of the PR: \
`$ git checkout pull/894` \
`$ git pull https://git.openjdk.org/jfx pull/894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 894`

View PR using the GUI difftool: \
`$ git pr show -t 894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/894.diff">https://git.openjdk.org/jfx/pull/894.diff</a>

</details>
