### PR TITLE
8279214: Memory leak in Scene after dragging a cell

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -3668,6 +3668,7 @@ public class Scene implements EventTarget {
                     ? currentEventTargets.get(0) : null;
             pdrEventTarget.clear();
             pdrEventTargets.clear();
+            fullPDRTmpTargetWrapper.clear();
         }
 
         public void enterFullPDR(EventTarget gestureSource) {


### PR DESCRIPTION
This PR fixes a memory leak in dnd code in the `MouseHandler` of a `Scene`.
The memory leak occurs after calling `startFullDrag()`. The `fullPDRTmpTargetWrapper` is then populated but never cleared.
Fix is to call `clear()` on the `fullPDRTmpTargetWrapper`, very similar to https://github.com/openjdk/jfx/pull/448 ([JDK-8264330](https://bugs.openjdk.java.net/browse/JDK-8264330)).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8279214](https://bugs.openjdk.org/browse/JDK-8279214): Memory leak in Scene after dragging a cell


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Author)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/899/head:pull/899` \
`$ git checkout pull/899`

Update a local copy of the PR: \
`$ git checkout pull/899` \
`$ git pull https://git.openjdk.org/jfx pull/899/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 899`

View PR using the GUI difftool: \
`$ git pr show -t 899`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/899.diff">https://git.openjdk.org/jfx/pull/899.diff</a>

</details>
