### PR TITLE
8293444: Creating ScrollPane with same content component causes memory leak

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ScrollPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ScrollPaneSkin.java
@@ -36,10 +36,12 @@ import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
+import javafx.beans.WeakInvalidationListener;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.DoublePropertyBase;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
+import javafx.beans.value.WeakChangeListener;
 import javafx.event.EventDispatcher;
 import javafx.event.EventHandler;
 import javafx.geometry.BoundingBox;
@@ -185,6 +187,7 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
         }
     };
 
+    private final WeakInvalidationListener weakNodeListener = new WeakInvalidationListener(nodeListener);
 
     /*
     ** The content of the ScrollPane has just changed bounds, check scrollBar positions.
@@ -242,7 +245,7 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
         }
     };
 
-
+    private final WeakChangeListener<Bounds> weakBoundsChangeListener = new WeakChangeListener(boundsChangeListener);
 
     /* *************************************************************************
      *                                                                         *
@@ -274,8 +277,8 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
         registerChangeListener(control.contentProperty(), e -> {
             if (scrollNode != getSkinnable().getContent()) {
                 if (scrollNode != null) {
-                    scrollNode.layoutBoundsProperty().removeListener(nodeListener);
-                    scrollNode.layoutBoundsProperty().removeListener(boundsChangeListener);
+                    scrollNode.layoutBoundsProperty().removeListener(weakNodeListener);
+                    scrollNode.layoutBoundsProperty().removeListener(weakBoundsChangeListener);
                     viewContent.getChildren().remove(scrollNode);
                 }
                 scrollNode = getSkinnable().getContent();
@@ -283,8 +286,8 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
                     nodeWidth = snapSizeX(scrollNode.getLayoutBounds().getWidth());
                     nodeHeight = snapSizeY(scrollNode.getLayoutBounds().getHeight());
                     viewContent.getChildren().setAll(scrollNode);
-                    scrollNode.layoutBoundsProperty().addListener(nodeListener);
-                    scrollNode.layoutBoundsProperty().addListener(boundsChangeListener);
+                    scrollNode.layoutBoundsProperty().addListener(weakNodeListener);
+                    scrollNode.layoutBoundsProperty().addListener(weakBoundsChangeListener);
                 }
             }
             getSkinnable().requestLayout();
@@ -635,8 +638,8 @@ public class ScrollPaneSkin extends SkinBase<ScrollPane> {
         ParentHelper.setTraversalEngine(getSkinnable(), traversalEngine);
 
         if (scrollNode != null) {
-            scrollNode.layoutBoundsProperty().addListener(nodeListener);
-            scrollNode.layoutBoundsProperty().addListener(boundsChangeListener);
+            scrollNode.layoutBoundsProperty().addListener(weakNodeListener);
+            scrollNode.layoutBoundsProperty().addListener(weakBoundsChangeListener);
         }
 
         viewRect = new StackPane() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/ScrollPaneSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/ScrollPaneSkinTest.java
@@ -26,9 +26,7 @@
 package test.javafx.scene.control.skin;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -62,6 +60,7 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.shape.Rectangle;
 import javafx.stage.Stage;
+import test.util.memory.JMemoryBuddy;
 
 
 public class ScrollPaneSkinTest {
@@ -903,7 +902,7 @@ public class ScrollPaneSkinTest {
 
         int ct = 0;
         for (WeakReference<ScrollPane> ref : refs) {
-            attemptGC(ref);
+            JMemoryBuddy.checkCollectable(ref);
             if (ref.get() != null) {
                 ct++;
             }
@@ -911,21 +910,5 @@ public class ScrollPaneSkinTest {
 
         // one instance is still held by the 'content' label
         assertTrue("uncollected objects=" + ct, ct <= 1);
-    }
-
-    // this should be in common test utils
-    private static void attemptGC(WeakReference<?> ref) {
-        for (int i = 0; i < 10; i++) {
-            System.gc();
-
-            if (ref.get() == null) {
-                break;
-            }
-            try {
-                Thread.sleep(50);
-            } catch (InterruptedException e) {
-                fail("InterruptedException occurred during Thread.sleep()");
-            }
-        }
     }
 }


### PR DESCRIPTION
Using Weak*Listeners eliminates the memory leak.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8293444](https://bugs.openjdk.org/browse/JDK-8293444): Creating ScrollPane with same content component causes memory leak


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/900/head:pull/900` \
`$ git checkout pull/900`

Update a local copy of the PR: \
`$ git checkout pull/900` \
`$ git pull https://git.openjdk.org/jfx pull/900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 900`

View PR using the GUI difftool: \
`$ git pr show -t 900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/900.diff">https://git.openjdk.org/jfx/pull/900.diff</a>

</details>
