### PR TITLE
8293883: Add tests/.classpath (Eclipse)

### DIFF
--- a/tests/.classpath
+++ b/tests/.classpath
@@ -11,6 +11,7 @@
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" path="manual/controls"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
 		<attributes>
 			<attribute name="module" value="true"/>
@@ -18,7 +19,7 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/5">
-			<attributes>
+		<attributes>
 			<attribute name="test" value="true"/>
 		</attributes>
 	</classpathentry>

--- a/tests/.classpath
+++ b/tests/.classpath
@@ -12,6 +12,13 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="src" path="manual/controls"/>
+	<classpathentry kind="src" path="manual/dnd"/>
+	<classpathentry kind="src" path="manual/events"/>
+	<classpathentry kind="src" path="manual/graphics"/>
+	<classpathentry kind="src" path="manual/swing"/>
+	<classpathentry kind="src" path="manual/text"/>
+	<classpathentry kind="src" path="manual/UI"/>
+	<classpathentry kind="src" path="performance/3DLighting"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
 		<attributes>
 			<attribute name="module" value="true"/>


### PR DESCRIPTION
Adding a tests/.classpath file to include tests/manual/controls source folder so Eclipse could see/execute manual tests there.

Also, I would rather move the sources there to a specific package (test.manual ?) instead of a default package. Any objections?
edit: won't be done as a part of this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8293883](https://bugs.openjdk.org/browse/JDK-8293883): Add tests/.classpath (Eclipse)


### Reviewers
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/901/head:pull/901` \
`$ git checkout pull/901`

Update a local copy of the PR: \
`$ git checkout pull/901` \
`$ git pull https://git.openjdk.org/jfx pull/901/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 901`

View PR using the GUI difftool: \
`$ git pr show -t 901`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/901.diff">https://git.openjdk.org/jfx/pull/901.diff</a>

</details>
