### PR TITLE
8293971: Loading new Media from resources can sometimes fail when loading from FXML

### DIFF
--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/locator/Locator.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/locator/Locator.java
@@ -422,7 +422,8 @@ public class Locator {
                             InputStream stream = getInputStream(uri);
                             stream.close();
                             isConnected = true;
-                            contentType = MediaUtils.filenameToContentType(uri); // We need to provide at least something
+                            // Try to get the content type based on extension
+                            contentType = MediaUtils.filenameToContentType(uri);
                         }
 
                         if (isConnected) {

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/locator/Locator.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/locator/Locator.java
@@ -422,7 +422,7 @@ public class Locator {
                             InputStream stream = getInputStream(uri);
                             stream.close();
                             isConnected = true;
-                            contentType = MediaUtils.filenameToContentType(uri.getPath()); // We need to provide at least something
+                            contentType = MediaUtils.filenameToContentType(uri); // We need to provide at least something
                         }
 
                         if (isConnected) {
@@ -438,7 +438,7 @@ public class Locator {
                             } else {
                                 if (contentType == null || !MediaManager.canPlayContentType(contentType)) {
                                     // Try content based on file name.
-                                    contentType = MediaUtils.filenameToContentType(uri.getPath());
+                                    contentType = MediaUtils.filenameToContentType(uri);
 
                                     if (Locator.DEFAULT_CONTENT_TYPE.equals(contentType)) {
                                         // Try content based on file signature.
@@ -469,7 +469,7 @@ public class Locator {
             }
             else {
                 // in case of iPod files we can be sure all files are supported
-                contentType = MediaUtils.filenameToContentType(uri.getPath());
+                contentType = MediaUtils.filenameToContentType(uri);
             }
 
             if (Logger.canLog(Logger.WARNING)) {

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/MediaUtils.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/MediaUtils.java
@@ -30,6 +30,9 @@ import com.sun.media.jfxmedia.MediaException;
 import com.sun.media.jfxmedia.events.MediaErrorListener;
 import com.sun.media.jfxmedia.locator.Locator;
 import com.sun.media.jfxmedia.logging.Logger;
+
+import java.net.URI;
+import java.nio.file.Path;
 import java.util.List;
 import java.lang.ref.WeakReference;
 import java.util.ListIterator;
@@ -140,9 +143,15 @@ public class MediaUtils {
                 && (buf[1] & 0xff) == 0x44
                 && (buf[2] & 0xff) == 0x33) { // "ID3"
             contentType = CONTENT_TYPE_MPA;
+        // MP3 header - 4 bytes
+        // AAAAAAAA AAABBCCX XXXXXXXX XXXXXXXX
+        // A - Sync bits (all bits are set)
+        // B - MPEG Audio version ID (01 - reserved, rest is valid)
+        // C - Layer description (00 - reserved, rest is valid)
+        // X - Most bits combination is valid, so nothing to check
         } else if ((buf[0] & 0xff) == 0xff && (buf[1] & 0xe0) == 0xe0 && // sync
-                (buf[2] & 0x18) != 0x08 && // not reserved version
-                (buf[3] & 0x06) != 0x00) { // not reserved layer
+                (buf[1] & 0x18) != 0x08 && // not reserved version
+                (buf[1] & 0x06) != 0x00) { // not reserved layer
             contentType = CONTENT_TYPE_MPA;
         } else if ((((buf[4] & 0xff) << 24)
                 | ((buf[5] & 0xff) << 16)
@@ -175,17 +184,18 @@ public class MediaUtils {
     /**
      * Returns the content type given the file name.
      *
-     * @param filename
+     * @param uri
      * @return content type
      */
-    public static String filenameToContentType(String filename) {
-        if (filename == null) {
+    public static String filenameToContentType(URI uri) {
+        String fileName = MediaUtils.getFilenameFromURI(uri);
+        if (fileName == null) {
             return Locator.DEFAULT_CONTENT_TYPE;
         }
 
-        int dotIndex = filename.lastIndexOf(".");
+        int dotIndex = fileName.lastIndexOf(".");
         if (dotIndex != -1) {
-            String extension = filename.toLowerCase().substring(dotIndex + 1);
+            String extension = fileName.toLowerCase().substring(dotIndex + 1);
 
             switch (extension) {
                 case FILE_TYPE_AIF:
@@ -214,6 +224,37 @@ public class MediaUtils {
         }
 
         return Locator.DEFAULT_CONTENT_TYPE;
+    }
+
+    /**
+     * Returns the file name given the uri. Supports special case for JAR URIs.
+     *
+     * @param uri
+     * @return file name or null if file name cannot be extracted
+     */
+    public static String getFilenameFromURI(URI uri) {
+        if (uri.getScheme() == null) {
+            return null;
+        }
+
+        String scheme = uri.getScheme().toLowerCase();
+        if (scheme.equals("jar")) {
+            // Split to get entry
+            // jar:<url>!/{entry}
+            String[] jarURI = uri.toASCIIString().split("!/");
+            if (jarURI.length != 2) {
+                return null;
+            }
+            Path entry = Path.of(jarURI[1]);
+            Path fileName = entry.getFileName();
+            if (fileName != null) {
+                return fileName.toString();
+            }
+        } else {
+            return uri.getPath();
+        }
+
+        return null;
     }
 
     /**

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/MediaUtils.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmediaimpl/MediaUtils.java
@@ -182,7 +182,7 @@ public class MediaUtils {
         return contentType;
     }
     /**
-     * Returns the content type given the file name.
+     * Returns the content type given the uri.
      *
      * @param uri
      * @return content type
@@ -238,7 +238,7 @@ public class MediaUtils {
         }
 
         String scheme = uri.getScheme().toLowerCase();
-        if (scheme.equals("jar")) {
+        if ("jar".equals(scheme)) {
             // Split to get entry
             // jar:<url>!/{entry}
             String[] jarURI = uri.toASCIIString().split("!/");


### PR DESCRIPTION
There was two problems:
 - uri.getPath() was returning null for jar URI, since it is not a standard URI and thus we did not detect file type based on extension.
 - Our signature detection for MP3 had a bug and did not detect MP3 correctly. See comments in code.
 
Fixed by adding function to extract file name from jar URI and also signature detection was fixed for MP3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8293971](https://bugs.openjdk.org/browse/JDK-8293971): Loading new Media from resources can sometimes fail when loading from FXML


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Author)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/902/head:pull/902` \
`$ git checkout pull/902`

Update a local copy of the PR: \
`$ git checkout pull/902` \
`$ git pull https://git.openjdk.org/jfx pull/902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 902`

View PR using the GUI difftool: \
`$ git pr show -t 902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/902.diff">https://git.openjdk.org/jfx/pull/902.diff</a>

</details>
