### PR TITLE
WIP: 8292922: [Linux] No more drag events when new Stage is created in drag handler

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.h
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.h
@@ -192,6 +192,7 @@ protected:
     bool is_iconified;
     bool is_maximized;
     bool is_mouse_entered;
+    bool is_focusable;
 
     /*
      * sm_grab_window points to WindowContext holding a mouse grab.
@@ -211,6 +212,15 @@ protected:
      * should be reported during this drag.
      */
     static WindowContext* sm_mouse_drag_window;
+
+    /*
+     * sm_deferred_focusable_windows is a set of windows that were
+     * created and set as focusable while another window was doing a
+     * mouse drag. In order to not disrupt the drag, the setting of the
+     * window(s) as focusable is deferred until the drag is finished.
+     */
+    static std::set<WindowContext*> sm_deferred_focusable_windows;
+
 public:
     bool isEnabled();
     bool hasIME();


### PR DESCRIPTION
This is a Draft pull request with an initial fix for:

[JDK-8292922](https://bugs.openjdk.org/browse/JDK-8292922): [Linux] No more drag events when new Stage is created in drag handler

The fix is two-fold:

1. Defer any request to set focusability to true while drag is active, and process those requests when drag is released. This means that newly created windows won't interrupt the in-process drag operation
2. Check for focusability before requesting focus in three places where this check was missing, `process_focus`, `set_visible`, and `request_focus`.

It needs to be more thoroughly tested, but my testing thus far shows that it fixes the bug without introducing any regressions. I left in several debug print statements that I will remove before taking this PR out of Draft mode (I won't have time to get back to this for a few weeks).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/905/head:pull/905` \
`$ git checkout pull/905`

Update a local copy of the PR: \
`$ git checkout pull/905` \
`$ git pull https://git.openjdk.org/jfx pull/905/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 905`

View PR using the GUI difftool: \
`$ git pr show -t 905`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/905.diff">https://git.openjdk.org/jfx/pull/905.diff</a>

</details>
