### PR TITLE
8293795: [Accessibility] [Win] [Narrator] Exceptions when deleting text with continous key press in TextArea and TextField

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTextRangeProvider.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTextRangeProvider.java
@@ -232,8 +232,7 @@ class WinTextRangeProvider {
         }
 
         /* Always ensure range consistency */
-        start = Math.max(0, Math.min(start, length));
-        end = Math.max(start, Math.min(end, length));
+        validateRange(text);
     }
 
     private long FindAttribute(int attributeId, WinVariant val, boolean backward) {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTextRangeProvider.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTextRangeProvider.java
@@ -91,8 +91,7 @@ class WinTextRangeProvider {
         peer = 0L;
     }
 
-    private void validateRange() {
-        String text = (String)getAttribute(TEXT);
+    private void validateRange(String text) {
         if (text == null) {
             start = end = 0;
             return;
@@ -161,7 +160,7 @@ class WinTextRangeProvider {
         if (text == null) return;
         int length = text.length();
         if (length == 0) return;
-        validateRange();
+        validateRange(text);
 
         switch (unit) {
             case TextUnit_Character: {
@@ -320,7 +319,7 @@ class WinTextRangeProvider {
         String text = (String)getAttribute(TEXT);
         if (text == null) return null;
         int length = text.length();
-        validateRange();
+        validateRange(text);
 
         /* Narrator will not focus an empty text control if the bounds are NULL */
         if (length == 0) return new double[0];
@@ -363,7 +362,7 @@ class WinTextRangeProvider {
     private String GetText(int maxLength) {
         String text = (String)getAttribute(TEXT);
         if (text == null) return null;
-        validateRange();
+        validateRange(text);
         int endOffset = maxLength != -1 ? Math.min(end, start + maxLength) : end;
 //        System.out.println("+GetText [" + text.substring(start, endOffset)+"]");
         return text.substring(start, endOffset);
@@ -468,7 +467,7 @@ class WinTextRangeProvider {
         }
 
         /* Always ensure range consistency */
-        validateRange();
+        validateRange(text);
         return actualCount;
     }
 
@@ -477,7 +476,7 @@ class WinTextRangeProvider {
         String text = (String)getAttribute(TEXT);
         if (text == null) return 0;
         int length = text.length();
-        validateRange();
+        validateRange(text);
 
         int actualCount = 0;
         int offset = endpoint == TextPatternRangeEndpoint_Start ? start : end;
@@ -573,7 +572,7 @@ class WinTextRangeProvider {
         }
 
         /* Always ensure range consistency */
-        validateRange();
+        validateRange(text);
         return actualCount;
     }
 
@@ -593,7 +592,7 @@ class WinTextRangeProvider {
         }
 
         /* Always ensure range consistency */
-        validateRange();
+        validateRange(text);
     }
 
     private void Select() {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTextRangeProvider.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTextRangeProvider.java
@@ -91,6 +91,18 @@ class WinTextRangeProvider {
         peer = 0L;
     }
 
+    private void validateRange() {
+        String text = (String)getAttribute(TEXT);
+        if (text == null) {
+            start = end = 0;
+            return;
+        }
+
+        int length = text.length();
+        start = Math.max(0, Math.min(start, length));
+        end = Math.max(start, Math.min(end, length));
+    }
+
     void setRange(int start, int end) {
         this.start = start;
         this.end = end;
@@ -105,7 +117,7 @@ class WinTextRangeProvider {
     }
 
     @Override public String toString() {
-        return "Range(start: "+start+", end: "+end+", id: " + id + ")";
+        return "Range(start: " + start + ", end: " + end + ", id: " + id + ")";
     }
 
     private Object getAttribute(AccessibleAttribute attribute, Object... parameters) {
@@ -149,6 +161,7 @@ class WinTextRangeProvider {
         if (text == null) return;
         int length = text.length();
         if (length == 0) return;
+        validateRange();
 
         switch (unit) {
             case TextUnit_Character: {
@@ -177,7 +190,6 @@ class WinTextRangeProvider {
                 break;
             }
             case TextUnit_Line: {
-                if (start > length) start = length;
                 Integer lineIndex = (Integer)getAttribute(LINE_FOR_OFFSET, start);
                 Integer lineStart = (Integer)getAttribute(LINE_START, lineIndex);
                 Integer lineEnd = (Integer)getAttribute(LINE_END, lineIndex);
@@ -308,6 +320,7 @@ class WinTextRangeProvider {
         String text = (String)getAttribute(TEXT);
         if (text == null) return null;
         int length = text.length();
+        validateRange();
 
         /* Narrator will not focus an empty text control if the bounds are NULL */
         if (length == 0) return new double[0];
@@ -350,6 +363,7 @@ class WinTextRangeProvider {
     private String GetText(int maxLength) {
         String text = (String)getAttribute(TEXT);
         if (text == null) return null;
+        validateRange();
         int endOffset = maxLength != -1 ? Math.min(end, start + maxLength) : end;
 //        System.out.println("+GetText [" + text.substring(start, endOffset)+"]");
         return text.substring(start, endOffset);
@@ -454,8 +468,7 @@ class WinTextRangeProvider {
         }
 
         /* Always ensure range consistency */
-        start = Math.max(0, Math.min(start, length));
-        end = Math.max(start, Math.min(end, length));
+        validateRange();
         return actualCount;
     }
 
@@ -464,6 +477,7 @@ class WinTextRangeProvider {
         String text = (String)getAttribute(TEXT);
         if (text == null) return 0;
         int length = text.length();
+        validateRange();
 
         int actualCount = 0;
         int offset = endpoint == TextPatternRangeEndpoint_Start ? start : end;
@@ -559,8 +573,7 @@ class WinTextRangeProvider {
         }
 
         /* Always ensure range consistency */
-        start = Math.max(0, Math.min(start, length));
-        end = Math.max(start, Math.min(end, length));
+        validateRange();
         return actualCount;
     }
 
@@ -580,8 +593,7 @@ class WinTextRangeProvider {
         }
 
         /* Always ensure range consistency */
-        start = Math.max(0, Math.min(start, length));
-        end = Math.max(start, Math.min(end, length));
+        validateRange();
     }
 
     private void Select() {


### PR DESCRIPTION
This is a follow up bug-fix to [JDK-8284281](https://bugs.openjdk.org/browse/JDK-8284281)

Issue:
When Narrator is running,
Following scenarios with TextField or TextArea cause IllegalArgumentException  or NPE

1. Move cursor to beginning of line, Press and hold DELETE key
2. Move cursor to beginning of line, Press and hold CTRL + DELETE key
3. Move cursor to end of line, Press and hold BACKSPACE key
4. Move cursor to end of line, Press and hold CTRL + BACKSPACE key

Fix:
Two variable `start` and `end` in  `WinTextRangeProvider` should be validated against text length
1. Added a method `validateRange()`, and is called several from methods which access text based on `start` and `end` variables
2. Partially reverted fix of [JDK-8284281](https://bugs.openjdk.org/browse/JDK-8284281) : 
    - removed https://github.com/openjdk/jfx/blob/35675c8d27d54a26059b182614e18152794dbcec/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinTextRangeProvider.java#L180
    - and used `validateRange()` instead to be symmetrical.

Verification:
To observe the issue.

1. Run any program with TextField and/or TextArea
2. Launch Windows Narrator
3. Run the exception causing scenarios several times:

- Move cursor to beginning of line, Press and hold DELETE key
- Move cursor to beginning of line, Press and hold CTRL + DELETE key
- Move cursor to end of line, Press and hold BACKSPACE key
- Move cursor to end of line, Press and hold CTRL + BACKSPACE key

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8293795](https://bugs.openjdk.org/browse/JDK-8293795): [Accessibility] [Win] [Narrator] Exceptions when deleting text with continous key press in TextArea and TextField


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Hima Bindu Meda](https://openjdk.org/census#hmeda) (@HimaBinduMeda - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/907/head:pull/907` \
`$ git checkout pull/907`

Update a local copy of the PR: \
`$ git checkout pull/907` \
`$ git pull https://git.openjdk.org/jfx pull/907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 907`

View PR using the GUI difftool: \
`$ git pr show -t 907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/907.diff">https://git.openjdk.org/jfx/pull/907.diff</a>

</details>
