### PR TITLE
Update JavaDoc in javafx.geometry.Point3D

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/geometry/Point3D.java
+++ b/modules/javafx.graphics/src/main/java/javafx/geometry/Point3D.java
@@ -410,10 +410,12 @@ public class Point3D implements Interpolatable<Point3D> {
     }
 
     /**
-     * Returns a hash code value for the point.
-     * @return a hash code value for the point.
+     * Determines whether or not two objects are equal. Two instances of {@code Point3D} are equal if the values of their x, y, and z properties are equal.
+     * @param obj an object to be compared with this {@code Point3D}.
+     * @return true if the object to be compared is an instance of Point3D and has the same values; false otherwise.
      */
-    @Override public boolean equals(Object obj) {
+    @Override 
+    public boolean equals(Object obj) {
         if (obj == this) return true;
         if (obj instanceof Point3D) {
             Point3D other = (Point3D) obj;
@@ -425,7 +427,8 @@ public class Point3D implements Interpolatable<Point3D> {
      * Returns a hash code for this {@code Point3D} object.
      * @return a hash code for this {@code Point3D} object.
      */
-    @Override public int hashCode() {
+    @Override 
+    public int hashCode() {
         if (hash == 0) {
             long bits = 7L;
             bits = 31L * bits + Double.doubleToLongBits(getX());
@@ -443,7 +446,8 @@ public class Point3D implements Interpolatable<Point3D> {
      * implementations.
      * The returned string might be empty but cannot be {@code null}.
      */
-    @Override public String toString() {
+    @Override 
+    public String toString() {
         return "Point3D [x = " + getX() + ", y = " + getY() + ", z = " + getZ() + "]";
     }
 }


### PR DESCRIPTION
The JavaDoc for equals had a copy/paste error. I normalized the text based on the JavaDoc for method java.awt.Point#equals. I also changed formatting in the method signatures of equals(), hashCode() and toString().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/912/head:pull/912` \
`$ git checkout pull/912`

Update a local copy of the PR: \
`$ git checkout pull/912` \
`$ git pull https://git.openjdk.org/jfx pull/912/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 912`

View PR using the GUI difftool: \
`$ git pr show -t 912`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/912.diff">https://git.openjdk.org/jfx/pull/912.diff</a>

</details>
