### PR TITLE
JDK-8295236: Update JavaDoc in javafx.geometry.Point3D

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/geometry/Point3D.java
+++ b/modules/javafx.graphics/src/main/java/javafx/geometry/Point3D.java
@@ -410,12 +410,12 @@ public class Point3D implements Interpolatable<Point3D> {
     }
 
     /**
-     * Determines whether this Point3D is equal to a given object.
+     * Indicates whether some other object is "equal to" this one.
      * Two instances of Point3D are equal if the return values of their
      * {@code getX}, {@code getY}, and {@code getZ} methods are equal.
-     * @param obj an object to be compared with this Point3D.
-     * @return true if the object to be compared is an instance of Point3D and
-     * has the same values; false otherwise.
+     *
+     * @param obj the reference object with which to compare
+     * @return true if this Point3D is the same as the obj argument; false otherwise
      */
     @Override
     public boolean equals(Object obj) {

--- a/modules/javafx.graphics/src/main/java/javafx/geometry/Point3D.java
+++ b/modules/javafx.graphics/src/main/java/javafx/geometry/Point3D.java
@@ -410,8 +410,8 @@ public class Point3D implements Interpolatable<Point3D> {
     }
 
     /**
-     * Determines whether this Point3D is equal to a given object. 
-     * Two instances of Point3D are equal if the return values of their 
+     * Determines whether this Point3D is equal to a given object.
+     * Two instances of Point3D are equal if the return values of their
      * {@code getX}, {@code getY}, and {@code getZ} methods are equal.
      * @param obj an object to be compared with this Point3D.
      * @return true if the object to be compared is an instance of Point3D and

--- a/modules/javafx.graphics/src/main/java/javafx/geometry/Point3D.java
+++ b/modules/javafx.graphics/src/main/java/javafx/geometry/Point3D.java
@@ -410,10 +410,14 @@ public class Point3D implements Interpolatable<Point3D> {
     }
 
     /**
-     * Returns a hash code value for the point.
-     * @return a hash code value for the point.
+     * Determines whether or not two objects are equal. Two instances of {@code Point3D}
+     * are equal if the values of their x, y, and z properties are equal.
+     * @param obj an object to be compared with this {@code Point3D}.
+     * @return true if the object to be compared is an instance of Point3D and
+     * has the same values; false otherwise.
      */
-    @Override public boolean equals(Object obj) {
+    @Override
+    public boolean equals(Object obj) {
         if (obj == this) return true;
         if (obj instanceof Point3D) {
             Point3D other = (Point3D) obj;
@@ -425,7 +429,8 @@ public class Point3D implements Interpolatable<Point3D> {
      * Returns a hash code for this {@code Point3D} object.
      * @return a hash code for this {@code Point3D} object.
      */
-    @Override public int hashCode() {
+    @Override
+    public int hashCode() {
         if (hash == 0) {
             long bits = 7L;
             bits = 31L * bits + Double.doubleToLongBits(getX());
@@ -443,7 +448,8 @@ public class Point3D implements Interpolatable<Point3D> {
      * implementations.
      * The returned string might be empty but cannot be {@code null}.
      */
-    @Override public String toString() {
+    @Override
+    public String toString() {
         return "Point3D [x = " + getX() + ", y = " + getY() + ", z = " + getZ() + "]";
     }
 }

--- a/modules/javafx.graphics/src/main/java/javafx/geometry/Point3D.java
+++ b/modules/javafx.graphics/src/main/java/javafx/geometry/Point3D.java
@@ -410,9 +410,10 @@ public class Point3D implements Interpolatable<Point3D> {
     }
 
     /**
-     * Determines whether or not two objects are equal. Two instances of {@code Point3D}
-     * are equal if the values of their x, y, and z properties are equal.
-     * @param obj an object to be compared with this {@code Point3D}.
+     * Determines whether this Point3D is equal to a given object. 
+     * Two instances of Point3D are equal if the return values of their 
+     * {@code getX}, {@code getY}, and {@code getZ} methods are equal.
+     * @param obj an object to be compared with this Point3D.
      * @return true if the object to be compared is an instance of Point3D and
      * has the same values; false otherwise.
      */
@@ -429,8 +430,7 @@ public class Point3D implements Interpolatable<Point3D> {
      * Returns a hash code for this {@code Point3D} object.
      * @return a hash code for this {@code Point3D} object.
      */
-    @Override
-    public int hashCode() {
+    @Override public int hashCode() {
         if (hash == 0) {
             long bits = 7L;
             bits = 31L * bits + Double.doubleToLongBits(getX());
@@ -448,8 +448,7 @@ public class Point3D implements Interpolatable<Point3D> {
      * implementations.
      * The returned string might be empty but cannot be {@code null}.
      */
-    @Override
-    public String toString() {
+    @Override public String toString() {
         return "Point3D [x = " + getX() + ", y = " + getY() + ", z = " + getZ() + "]";
     }
 }

--- a/modules/javafx.graphics/src/main/java/javafx/geometry/Point3D.java
+++ b/modules/javafx.graphics/src/main/java/javafx/geometry/Point3D.java
@@ -411,11 +411,11 @@ public class Point3D implements Interpolatable<Point3D> {
 
     /**
      * Indicates whether some other object is "equal to" this one.
-     * Two instances of Point3D are equal if the return values of their
+     * Two instances of {@code Point3D} are equal if the return values of their
      * {@code getX}, {@code getY}, and {@code getZ} methods are equal.
      *
-     * @param obj the reference object with which to compare
-     * @return true if this Point3D is the same as the obj argument; false otherwise
+     * @param {@code obj} the reference object with which to compare
+     * @return {@code true} if this {@code Point3D} is the same as the {@code obj} argument; {@code false} otherwise
      */
     @Override
     public boolean equals(Object obj) {

--- a/modules/javafx.graphics/src/main/java/javafx/geometry/Point3D.java
+++ b/modules/javafx.graphics/src/main/java/javafx/geometry/Point3D.java
@@ -414,7 +414,7 @@ public class Point3D implements Interpolatable<Point3D> {
      * Two instances of {@code Point3D} are equal if the return values of their
      * {@code getX}, {@code getY}, and {@code getZ} methods are equal.
      *
-     * @param {@code obj} the reference object with which to compare
+     * @param obj the reference object with which to compare
      * @return {@code true} if this {@code Point3D} is the same as the {@code obj} argument; {@code false} otherwise
      */
     @Override


### PR DESCRIPTION
The JavaDoc for equals had a copy/paste error. I normalized the text based on the JavaDoc for method java.awt.Point#equals. ~~I also changed formatting in the method signatures of equals(), hashCode() and toString().~~

For good measure, some kind of copy/paste detection should probably be added to the many automated checks. For the entire OpenJDK project.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295236](https://bugs.openjdk.org/browse/JDK-8295236): Update JavaDoc in javafx.geometry.Point3D


### Reviewers
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/913/head:pull/913` \
`$ git checkout pull/913`

Update a local copy of the PR: \
`$ git checkout pull/913` \
`$ git pull https://git.openjdk.org/jfx pull/913/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 913`

View PR using the GUI difftool: \
`$ git pr show -t 913`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/913.diff">https://git.openjdk.org/jfx/pull/913.diff</a>

</details>
