### PR TITLE
8278426: ImagePool uses terminally deprecated System.runFinalization method

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/ImagePool.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/effect/impl/ImagePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -256,9 +256,6 @@ public class ImagePool {
         // this is to help to free up space held by those images that we no
         // longer have references to
         System.gc();
-        System.runFinalization();
-        System.gc();
-        System.runFinalization();
     }
 
     public synchronized void dispose() {


### PR DESCRIPTION
This change removes runFinalization calls in ImagePool::pruneCache method.

Finalizers are deprecated in JDK 18 and will be removed soon.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278426](https://bugs.openjdk.org/browse/JDK-8278426): ImagePool uses terminally deprecated System.runFinalization method


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/918/head:pull/918` \
`$ git checkout pull/918`

Update a local copy of the PR: \
`$ git checkout pull/918` \
`$ git pull https://git.openjdk.org/jfx pull/918/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 918`

View PR using the GUI difftool: \
`$ git pr show -t 918`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/918.diff">https://git.openjdk.org/jfx/pull/918.diff</a>

</details>
