### PR TITLE
8222210: JFXPanel popups open at wrong coordinates when using multiple hidpi monitors

### DIFF
--- a/modules/javafx.graphics/src/main/java/module-info.java
+++ b/modules/javafx.graphics/src/main/java/module-info.java
@@ -68,6 +68,7 @@ module javafx.graphics {
 
     exports com.sun.glass.ui to
         javafx.media,
+        javafx.swing,
         javafx.web;
     exports com.sun.glass.utils to
         javafx.media,

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
@@ -451,8 +451,8 @@ public class JFXPanel extends JComponent {
             popupTrigger = e.isPopupTrigger();
         }
         Point2D onScreen = convertSwingToFxPixel(getGraphicsConfiguration(), e.getXOnScreen(), e.getYOnScreen());
-        int fxXOnScreen = (int)Math.floor(onScreen.getX());
-        int fxYOnScreen = (int)Math.floor(onScreen.getY());
+        int fxXOnScreen = (int)Math.round(onScreen.getX());
+        int fxYOnScreen = (int)Math.round(onScreen.getY());
 
         if(e.getID() == MouseEvent.MOUSE_WHEEL) {
             scenePeer.scrollEvent(AbstractEvents.MOUSEEVENT_VERTICAL_WHEEL,
@@ -646,8 +646,8 @@ public class JFXPanel extends JComponent {
             if (isShowing()) {
                 Point p = getLocationOnScreen();
                 Point2D fxcoord = convertSwingToFxPixel(getGraphicsConfiguration(), p.x, p.y);
-                screenX = (int)Math.floor(fxcoord.getX());
-                screenY = (int)Math.floor(fxcoord.getY());
+                screenX = (int)Math.round(fxcoord.getX());
+                screenY = (int)Math.round(fxcoord.getY());
                 return true;
             }
         }

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
@@ -62,7 +62,7 @@ import javax.swing.JComponent;
 import javax.swing.SwingUtilities;
 
 import javafx.application.Platform;
-import javafx.geometry.Dimension2D;
+import javafx.geometry.Point2D;
 import javafx.scene.Scene;
 import com.sun.glass.ui.Screen;
 
@@ -382,27 +382,27 @@ public class JFXPanel extends JComponent {
         return null;
     }
 
-    private Dimension2D convertSwingToFxPixel(GraphicsConfiguration g, float wx, float wy) {
-        float newx, newy;
-        Screen screen = findScreen(getGraphicsConfiguration());
+    private Point2D convertSwingToFxPixel(GraphicsConfiguration g, double wx, double wy) {
+        double newx, newy;
+        Screen screen = findScreen(g);
         if (screen != null) {
             AffineTransform awtScales = getGraphicsConfiguration().getDefaultTransform();
             float pScaleX = screen.getPlatformScaleX();
             float pScaleY = screen.getPlatformScaleY();
-            float sx = screen.getX();
-            float sy = screen.getY();
-            float awtScaleX = (float)awtScales.getScaleX();
-            float awtScaleY = (float)awtScales.getScaleY();
+            int sx = screen.getX();
+            int sy = screen.getY();
+            double awtScaleX = awtScales.getScaleX();
+            double awtScaleY = awtScales.getScaleY();
 
-            float px = screen.getPlatformX();
-            float py = screen.getPlatformY();
+            int px = screen.getPlatformX();
+            int py = screen.getPlatformY();
             newx = sx + (wx - px) * awtScaleX / pScaleX;
             newy = sy + (wy - py) * awtScaleY / pScaleY;
         } else {
             newx = wx;
             newy = wy;
         }
-        return new Dimension2D(newx, newy);
+        return new Point2D(newx, newy);
     }
 
     private void sendMouseEventToFX(MouseEvent e) {
@@ -450,9 +450,9 @@ public class JFXPanel extends JComponent {
         if (e.getID() == MouseEvent.MOUSE_PRESSED || e.getID() == MouseEvent.MOUSE_RELEASED) {
             popupTrigger = e.isPopupTrigger();
         }
-        Dimension2D onScreen = convertSwingToFxPixel(getGraphicsConfiguration(), e.getXOnScreen(), e.getYOnScreen());
-        int fxXOnScreen = (int) onScreen.getWidth();
-        int fxYOnScreen = (int) onScreen.getHeight();
+        Point2D onScreen = convertSwingToFxPixel(getGraphicsConfiguration(), e.getXOnScreen(), e.getYOnScreen());
+        int fxXOnScreen = (int)Math.floor(onScreen.getX());
+        int fxYOnScreen = (int)Math.floor(onScreen.getY());
 
         if(e.getID() == MouseEvent.MOUSE_WHEEL) {
             scenePeer.scrollEvent(AbstractEvents.MOUSEEVENT_VERTICAL_WHEEL,
@@ -645,9 +645,9 @@ public class JFXPanel extends JComponent {
         synchronized (getTreeLock()) {
             if (isShowing()) {
                 Point p = getLocationOnScreen();
-                Dimension2D fxcoord = convertSwingToFxPixel(getGraphicsConfiguration(), p.x, p.y);
-                screenX = (int)fxcoord.getWidth();
-                screenY = (int)fxcoord.getHeight();
+                Point2D fxcoord = convertSwingToFxPixel(getGraphicsConfiguration(), p.x, p.y);
+                screenX = (int)Math.floor(fxcoord.getX());
+                screenY = (int)Math.floor(fxcoord.getY());
                 return true;
             }
         }

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
@@ -372,28 +372,32 @@ public class JFXPanel extends JComponent {
         Rectangle awtBounds = graphicsConfiguration.getBounds();
         AffineTransform awtScales = graphicsConfiguration.getDefaultTransform();
         for (Screen screen : Screen.getScreens()) {
-            if ((Math.abs(screen.getPlatformX() - awtBounds.getX() * awtScales.getScaleX()) < 0.001) &&
-                    (Math.abs(screen.getPlatformY() - awtBounds.getY() * awtScales.getScaleY()) < 0.001) &&
-                    (Math.abs(screen.getPlatformWidth() - awtBounds.getWidth()) < 0.001) &&
-                    (Math.abs(screen.getPlatformHeight() - awtBounds.getHeight()) < 0.001)) {
+            if ((Math.abs(screen.getPlatformX() - awtBounds.getX()) < 2.) &&
+                    (Math.abs(screen.getPlatformY() - awtBounds.getY()) < 2.) &&
+                    (Math.abs(screen.getPlatformWidth() - awtScales.getScaleX() * awtBounds.getWidth()) < 2.) &&
+                    (Math.abs(screen.getPlatformHeight() - awtScales.getScaleY() * awtBounds.getHeight()) < 2.)) {
                 return screen;
             }
         }
         return null;
     }
 
-    private Dimension2D getSwingToFxPixel(GraphicsConfiguration g, float wx, float wy) {
+    private Dimension2D convertSwingToFxPixel(GraphicsConfiguration g, float wx, float wy) {
         float newx, newy;
         Screen screen = findScreen(getGraphicsConfiguration());
         if (screen != null) {
+            AffineTransform awtScales = getGraphicsConfiguration().getDefaultTransform();
             float pScaleX = screen.getPlatformScaleX();
             float pScaleY = screen.getPlatformScaleY();
             float sx = screen.getX();
             float sy = screen.getY();
+            float awtScaleX = (float)awtScales.getScaleX();
+            float awtScaleY = (float)awtScales.getScaleY();
+
             float px = screen.getPlatformX();
             float py = screen.getPlatformY();
-            newx = sx + (wx - px) / pScaleX;
-            newy = sy + (wy - py) / pScaleY;
+            newx = sx + (wx - px) * awtScaleX / pScaleX;
+            newy = sy + (wy - py) * awtScaleY / pScaleY;
         } else {
             newx = wx;
             newy = wy;
@@ -446,7 +450,7 @@ public class JFXPanel extends JComponent {
         if (e.getID() == MouseEvent.MOUSE_PRESSED || e.getID() == MouseEvent.MOUSE_RELEASED) {
             popupTrigger = e.isPopupTrigger();
         }
-        Dimension2D onScreen = getSwingToFxPixel(getGraphicsConfiguration(), e.getXOnScreen(), e.getYOnScreen());
+        Dimension2D onScreen = convertSwingToFxPixel(getGraphicsConfiguration(), e.getXOnScreen(), e.getYOnScreen());
         int fxXOnScreen = (int) onScreen.getWidth();
         int fxYOnScreen = (int) onScreen.getHeight();
 
@@ -641,7 +645,7 @@ public class JFXPanel extends JComponent {
         synchronized (getTreeLock()) {
             if (isShowing()) {
                 Point p = getLocationOnScreen();
-                Dimension2D fxcoord = getSwingToFxPixel(getGraphicsConfiguration(), p.x, p.y);
+                Dimension2D fxcoord = convertSwingToFxPixel(getGraphicsConfiguration(), p.x, p.y);
                 screenX = (int)fxcoord.getWidth();
                 screenY = (int)fxcoord.getHeight();
                 return true;


### PR DESCRIPTION
The root problem is actually broader than stated in the JBS issue. This PR now translates screencoordinates from absolute coordinates into coordinates that take the platformScale into account. 
The whole process is complicated by the fact that throughout our code, we use e.g. `x` and `y` without clearly stating if those are absolute, logical, screen or rendering coordinates. 
I believe the most consistent approach is to have the different entry points (e.g. a Glass Window or a JFXPanel) to deal with platformScale before passing screen coordinates. This is already done in the Glass approach, and this PR does the same in JFXPanel. That means some code is duplicated, but since this is only about 12 lines, and said code lives in 2 different modules, I think it's not worth the hassle of moving that into e.g. the base module.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8222210](https://bugs.openjdk.org/browse/JDK-8222210): JFXPanel popups open at wrong coordinates when using multiple hidpi monitors


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/924/head:pull/924` \
`$ git checkout pull/924`

Update a local copy of the PR: \
`$ git checkout pull/924` \
`$ git pull https://git.openjdk.org/jfx pull/924/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 924`

View PR using the GUI difftool: \
`$ git pr show -t 924`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/924.diff">https://git.openjdk.org/jfx/pull/924.diff</a>

</details>
