### PR TITLE
8295962: Reference to State in Task.java is ambiguous when building with JDK 19

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/concurrent/Task.java
+++ b/modules/javafx.graphics/src/main/java/javafx/concurrent/Task.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -690,14 +690,14 @@ public abstract class Task<V> extends FutureTask<V> implements Worker<V>, EventT
      */
     protected abstract V call() throws Exception;
 
-    private ObjectProperty<State> state = new SimpleObjectProperty<>(this, "state", State.READY);
-    final void setState(State value) { // package access for the Service
+    private ObjectProperty<Worker.State> state = new SimpleObjectProperty<>(this, "state", Worker.State.READY);
+    final void setState(Worker.State value) { // package access for the Service
         checkThread();
-        final State s = getState();
-        if (s != State.CANCELLED) {
+        final Worker.State s = getState();
+        if (s != Worker.State.CANCELLED) {
             this.state.set(value);
             // Make sure the running flag is set
-            setRunning(value == State.SCHEDULED || value == State.RUNNING);
+            setRunning(value == Worker.State.SCHEDULED || value == Worker.State.RUNNING);
 
             // Invoke the event handlers, and then call the protected methods.
             switch (state.get()) {
@@ -729,8 +729,8 @@ public abstract class Task<V> extends FutureTask<V> implements Worker<V>, EventT
             }
         }
     }
-    @Override public final State getState() { checkThread(); return state.get(); }
-    @Override public final ReadOnlyObjectProperty<State> stateProperty() { checkThread(); return state; }
+    @Override public final Worker.State getState() { checkThread(); return state.get(); }
+    @Override public final ReadOnlyObjectProperty<Worker.State> stateProperty() { checkThread(); return state; }
 
     /**
      * The onSchedule event handler is called whenever the Task state
@@ -1025,9 +1025,9 @@ public abstract class Task<V> extends FutureTask<V> implements Worker<V>, EventT
             // state flag will not be readable immediately after this call. However,
             // that would be the case anyway since these properties are not thread-safe.
             if (isFxApplicationThread()) {
-                setState(State.CANCELLED);
+                setState(Worker.State.CANCELLED);
             } else {
-                runLater(() -> setState(State.CANCELLED));
+                runLater(() -> setState(Worker.State.CANCELLED));
             }
         }
         // return the flag
@@ -1418,8 +1418,8 @@ public abstract class Task<V> extends FutureTask<V> implements Worker<V>, EventT
             // in all cases so that developer code can be consistent.
             task.started = true;
             task.runLater(() -> {
-                task.setState(State.SCHEDULED);
-                task.setState(State.RUNNING);
+                task.setState(Worker.State.SCHEDULED);
+                task.setState(Worker.State.RUNNING);
             });
             // Go ahead and delegate to the wrapped callable
             try {
@@ -1434,7 +1434,7 @@ public abstract class Task<V> extends FutureTask<V> implements Worker<V>, EventT
                         // can assume if the result is set, it has
                         // succeeded.
                         task.updateValue(result);
-                        task.setState(State.SUCCEEDED);
+                        task.setState(Worker.State.SUCCEEDED);
                     });
                     return result;
                 } else {
@@ -1453,7 +1453,7 @@ public abstract class Task<V> extends FutureTask<V> implements Worker<V>, EventT
                 // in that circumstance.
                 task.runLater(() -> {
                     task._setException(th);
-                    task.setState(State.FAILED);
+                    task.setState(Worker.State.FAILED);
                 });
                 // Some error occurred during the call (it might be
                 // an exception (either runtime or checked), or it might

--- a/modules/javafx.graphics/src/shims/java/javafx/concurrent/TaskShim.java
+++ b/modules/javafx.graphics/src/shims/java/javafx/concurrent/TaskShim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/shims/java/javafx/concurrent/TaskShim.java
+++ b/modules/javafx.graphics/src/shims/java/javafx/concurrent/TaskShim.java
@@ -49,7 +49,7 @@ public abstract class TaskShim<V> extends Task<V> {
         super.runLater(r);
     }
 
-    public void shim_setState(State value) {
+    public void shim_setState(Worker.State value) {
         super.setState(value);
     }
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/concurrent/AbstractTask.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/concurrent/AbstractTask.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/test/java/test/javafx/concurrent/AbstractTask.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/concurrent/AbstractTask.java
@@ -26,8 +26,8 @@
 package test.javafx.concurrent;
 
 import java.util.concurrent.Semaphore;
-import javafx.concurrent.Task;
 import javafx.concurrent.TaskShim;
+import javafx.concurrent.Worker;
 
 /**
  * For testing purposes, we use this subclass of Task that will fake out the
@@ -59,7 +59,7 @@ public abstract class AbstractTask extends TaskShim<String> {
 
     // Simulates scheduling the concurrent for execution
     public void simulateSchedule() {
-        shim_setState(State.SCHEDULED);
+        shim_setState(Worker.State.SCHEDULED);
     }
 
     // For most tests, we want to pretend that we are on the FX app thread, always.

--- a/modules/javafx.graphics/src/test/java/test/javafx/concurrent/TaskCancelTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/concurrent/TaskCancelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/test/java/test/javafx/concurrent/TaskCancelTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/concurrent/TaskCancelTest.java
@@ -26,6 +26,7 @@
 package test.javafx.concurrent;
 
 import javafx.concurrent.Task;
+import javafx.concurrent.Worker;
 import test.javafx.concurrent.mocks.EpicFailTask;
 import test.javafx.concurrent.mocks.InfiniteTask;
 import test.javafx.concurrent.mocks.RunAwayTask;
@@ -57,7 +58,7 @@ public class TaskCancelTest {
      */
     @Test public void cancellingA_READY_TaskShouldChangeStateTo_CANCELLED() {
         assertTrue(task.cancel());
-        assertEquals(Task.State.CANCELLED, task.getState());
+        assertEquals(Worker.State.CANCELLED, task.getState());
         assertTrue(task.isDone());
     }
 
@@ -69,7 +70,7 @@ public class TaskCancelTest {
     @Test public void cancellingA_SCHEDULED_TaskShouldChangeStateTo_CANCELLED() {
         task.simulateSchedule();
         assertTrue(task.cancel());
-        assertEquals(Task.State.CANCELLED, task.getState());
+        assertEquals(Worker.State.CANCELLED, task.getState());
         assertTrue(task.isDone());
     }
 
@@ -90,7 +91,7 @@ public class TaskCancelTest {
         assertTrue(task.cancel());
         th.join();
 
-        assertEquals(Task.State.CANCELLED, task.getState());
+        assertEquals(Worker.State.CANCELLED, task.getState());
         // TODO why is this commented out?
 //        assertNull(task.getException());
         assertNull(task.getValue());
@@ -105,7 +106,7 @@ public class TaskCancelTest {
         Task t = new SimpleTask();
         t.run();
         assertFalse(t.cancel());
-        assertEquals(Task.State.SUCCEEDED, t.getState());
+        assertEquals(Worker.State.SUCCEEDED, t.getState());
         assertTrue(t.isDone());
     }
 
@@ -117,7 +118,7 @@ public class TaskCancelTest {
         Task t = new EpicFailTask();
         t.run();
         assertFalse(t.cancel());
-        assertEquals(Task.State.FAILED, t.getState());
+        assertEquals(Worker.State.FAILED, t.getState());
         assertTrue(t.isDone());
     }
 
@@ -136,7 +137,7 @@ public class TaskCancelTest {
         runAway.stopLooping.set(true);
         th.join();
 
-        assertEquals(Task.State.CANCELLED, runAway.getState());
+        assertEquals(Worker.State.CANCELLED, runAway.getState());
         // TODO why is this commented out?
 //        assertNull(task.getException());
         assertNull(runAway.getValue());

--- a/modules/javafx.graphics/src/test/java/test/javafx/concurrent/TaskSimpleTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/concurrent/TaskSimpleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/test/java/test/javafx/concurrent/TaskSimpleTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/concurrent/TaskSimpleTest.java
@@ -65,7 +65,7 @@ public class TaskSimpleTest {
      ***********************************************************************/
 
     @Test public void stateShouldBe_READY_ByDefault() {
-        assertEquals(Task.State.READY, task.getState());
+        assertEquals(Worker.State.READY, task.getState());
     }
 
     @Test public void workDoneShouldBe_Indeterminate_ByDefault() {


### PR DESCRIPTION
This PR replaces all occurrences of `State` with `Worker.State` in `javafx.concurrent.Task`.

The `javafx.concurrent.Task` class implements `javafx.concurrent.Worker` and extends `java.util.concurrent.FutureTask`, which in turn implements `java.util.concurrent.Future`.

`Worker` has a nested `State` enum, which is used in the implementing `Task` class without being qualified -- since `Task` is a `Worker`, we can just say `State` instead of `Worker.State`.

[JDK-8277090](https://bugs.openjdk.org/browse/JDK-8277090) added a nested `State` enum to the `java.util.concurrent.Future` interface in JDK 19, so an unqualified reference to `State` from the `Task` class is now ambiguous when using JDK 19 to build. The javadoc task fails with an error (and the only reason the javac task doesn't is that we use `--release 17`).

With this fix, a local build and test using JDK 19 passes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295962](https://bugs.openjdk.org/browse/JDK-8295962): Reference to State in Task.java is ambiguous when building with JDK 19


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Author)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/933/head:pull/933` \
`$ git checkout pull/933`

Update a local copy of the PR: \
`$ git checkout pull/933` \
`$ git pull https://git.openjdk.org/jfx pull/933/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 933`

View PR using the GUI difftool: \
`$ git pr show -t 933`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/933.diff">https://git.openjdk.org/jfx/pull/933.diff</a>

</details>
