### PR TITLE
8295327: JavaFX - IllegalArgumentException when printing with margins equal to 0

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/print/J2DPrinterJob.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/j2d/print/J2DPrinterJob.java
@@ -512,10 +512,10 @@ public class J2DPrinterJob implements PrinterJobImpl {
                 bm = pWid - mpaX - mpaW;
                 break;
             }
-            if (Math.abs(lm) < 0.01) lm = 0;
-            if (Math.abs(rm) < 0.01) rm = 0;
-            if (Math.abs(tm) < 0.01) tm = 0;
-            if (Math.abs(bm) < 0.01) bm = 0;
+            if (lm < 0.01) lm = 0;
+            if (rm < 0.01) rm = 0;
+            if (tm < 0.01) tm = 0;
+            if (bm < 0.01) bm = 0;
             newLayout = fxPrinter.createPageLayout(paper, orient,
                                                    lm, rm, tm, bm);
         }


### PR DESCRIPTION
If floating point error caused a small negative value in the conversions needed from ISO to US measurements, then this will cause the IAE reported. 
The code doing the rounding should not have used Math.abs()

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295327](https://bugs.openjdk.org/browse/JDK-8295327): JavaFX - IllegalArgumentException when printing with margins equal to 0


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/934/head:pull/934` \
`$ git checkout pull/934`

Update a local copy of the PR: \
`$ git checkout pull/934` \
`$ git pull https://git.openjdk.org/jfx pull/934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 934`

View PR using the GUI difftool: \
`$ git pr show -t 934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/934.diff">https://git.openjdk.org/jfx/pull/934.diff</a>

</details>
