### PR TITLE
8265835: Exception in Quantum due to null platformWindow

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassScene.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassScene.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -335,13 +335,15 @@ abstract class GlassScene implements TKScene {
 
     protected Color getClearColor() {
         WindowStage windowStage = stage instanceof WindowStage ? (WindowStage)stage : null;
-        if (windowStage != null && windowStage.getPlatformWindow().isTransparentWindow()) {
+        if (windowStage != null && windowStage.getPlatformWindow() != null &&
+                windowStage.getPlatformWindow().isTransparentWindow()) {
             return (Color.TRANSPARENT);
         } else {
             if (fillPaint == null) {
                 return Color.WHITE;
             } else if (fillPaint.isOpaque() ||
-                    (windowStage != null && windowStage.getPlatformWindow().isUnifiedWindow())) {
+                    (windowStage != null && windowStage.getPlatformWindow() != null &&
+                    windowStage.getPlatformWindow().isUnifiedWindow())) {
                 //For bare windows the transparent fill is allowed
                 if (fillPaint.getType() == Paint.Type.COLOR) {
                     return (Color)fillPaint;


### PR DESCRIPTION
Reproduction code was not provided, I wasn't able to reproduce the circumstances in which the issue occurs. On our side it seems like `WindowStage.getPlatformWindow()` will not return null, however it is also difficult to reject the possibility that some custom user code might trigger an edge-case where a null will be returned.

Adding these checks is not an intrusive change to our code, it is in fact an extra null-check added to already existing checks, but it might prevent the exception from appearing in the future.

I checked other places in our code using `WindowStage.getPlatformWindow()` and none require a null check.