### PR TITLE
8296409: Stop additional change listeners being added

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuButtonSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/MenuButtonSkinBase.java
@@ -144,23 +144,14 @@ public class MenuButtonSkinBase<C extends MenuButton> extends SkinBase<C> {
         };
         control.getItems().addListener(itemsChangedListener);
 
-        if (getSkinnable().getScene() != null) {
-            ControlAcceleratorSupport.addAcceleratorsIntoScene(getSkinnable().getItems(), getSkinnable());
-        }
+        ControlAcceleratorSupport.addAcceleratorsIntoScene(getSkinnable().getItems(), getSkinnable());
 
         List<Mnemonic> mnemonics = new ArrayList<>();
         sceneChangeListener = (scene, oldValue, newValue) -> {
             if (oldValue != null) {
-                ControlAcceleratorSupport.removeAcceleratorsFromScene(getSkinnable().getItems(), oldValue);
-
                 // We only need to remove the mnemonics from the old scene,
                 // they will be added to the new one as soon as the popup becomes visible again.
                 removeMnemonicsFromScene(mnemonics, oldValue);
-            }
-
-            // FIXME: null skinnable should not happen
-            if (getSkinnable() != null && getSkinnable().getScene() != null) {
-                ControlAcceleratorSupport.addAcceleratorsIntoScene(getSkinnable().getItems(), getSkinnable());
             }
         };
         control.sceneProperty().addListener(sceneChangeListener);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlAcceleratorSupportTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlAcceleratorSupportTest.java
@@ -27,6 +27,7 @@ package test.javafx.scene.control;
 
 import javafx.scene.control.MenuBar;
 import javafx.scene.control.Menu;
+import javafx.scene.control.MenuButton;
 import javafx.scene.control.MenuItem;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.StackPane;
@@ -114,5 +115,20 @@ public class ControlAcceleratorSupportTest {
 
             checker.assertCollectable(menuItem);
         });
+    }
+
+    @Test
+    public void testMemoryButtonSkinDoesntAddAdditionalListeners() {
+        // JDK-8296409
+        MenuItem menuItem = new MenuItem("Menu Item");
+        MenuButton menuButton = new MenuButton("Menu Button", null, menuItem);
+        StackPane root = new StackPane(menuButton);
+        StageLoader sl = new StageLoader(root);
+        assertEquals(1, getListenerCount(menuItem.acceleratorProperty()));
+        root.getChildren().remove(menuButton);
+        assertEquals(0, getListenerCount(menuItem.acceleratorProperty()));
+        root.getChildren().add(menuButton);
+        assertEquals(1, getListenerCount(menuItem.acceleratorProperty()));
+        sl.dispose();
     }
 }


### PR DESCRIPTION
When menu buttons are added and removed from the scene, an accelerator change listener is added to each menu item in the menu. There is nothing stopping the same change listener being added multiple times.

MenuButtonSkinBase calls the ControlAcceleratorSupport.addAcceleratorsIntoScene(getSkinnable().getItems(), getSkinnable()); method each time the button is added to the scene, but that method itself also registers a listener to call itself. Each time the button is added to the scene, the method is called at least twice.

When it's removed from the scene, the remove accelerator method is also called twice, but only the first call removes a change listener attached to the accelerator because the first call removes the entry from the hashmap changeListenerMap. The second call finds nothing in the map, and doesn't remove the additional instance.

This pull request just removes the redundant code in the MenuButtonSkinBase.