### PR TITLE
8296618: Skip failing test SwingNodeDnDMemoryLeakTest until JDK-8285503 is fixed

### DIFF
--- a/tests/system/src/test/java/test/javafx/embed/swing/SwingNodeDnDMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/SwingNodeDnDMemoryLeakTest.java
@@ -41,6 +41,7 @@ import javax.swing.JLabel;
 
 import test.util.Util;
 import static test.util.Util.TIMEOUT;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.BeforeClass;
 import org.junit.AfterClass;
@@ -71,6 +72,7 @@ public class SwingNodeDnDMemoryLeakTest {
         Platform.exit();
     }
 
+    @Ignore("JDK-8296618")
     @Test
     public void testSwingNodeMemoryLeak() {
         Util.runAndWait(() -> {


### PR DESCRIPTION
Fixes [JDK-8296618](https://bugs.openjdk.org/browse/JDK-8296618)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296618](https://bugs.openjdk.org/browse/JDK-8296618): Skip failing test SwingNodeDnDMemoryLeakTest until JDK-8285503 is fixed


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/942/head:pull/942` \
`$ git checkout pull/942`

Update a local copy of the PR: \
`$ git checkout pull/942` \
`$ git pull https://git.openjdk.org/jfx pull/942/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 942`

View PR using the GUI difftool: \
`$ git pr show -t 942`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/942.diff">https://git.openjdk.org/jfx/pull/942.diff</a>

</details>
