### PR TITLE
8296592: Skip failing test StraightLineTest on Linux

### DIFF
--- a/tests/system/src/test/java/test/javafx/scene/web/StraightLineTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/StraightLineTest.java
@@ -27,6 +27,7 @@ package test.javafx.scene.web;
 
 import com.sun.webkit.WebPage;
 import com.sun.webkit.WebPageShim;
+import com.sun.javafx.PlatformUtil;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -50,6 +51,7 @@ import static javafx.concurrent.Worker.State.SUCCEEDED;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeFalse;
 
 public class StraightLineTest {
     private static final CountDownLatch launchLatch = new CountDownLatch(1);
@@ -110,6 +112,9 @@ public class StraightLineTest {
     }
 
     @Test public void testLine() {
+        // JDK-8296590
+        assumeFalse(PlatformUtil.isLinux());
+
         final CountDownLatch webViewStateLatch = new CountDownLatch(1);
 
         Util.runAndWait(() -> {


### PR DESCRIPTION
Skip `StraightLineTest` on Linux until [JDK-8296590](https://bugs.openjdk.org/browse/JDK-8296590) is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296592](https://bugs.openjdk.org/browse/JDK-8296592): Skip failing test StraightLineTest on Linux


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Author)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/943/head:pull/943` \
`$ git checkout pull/943`

Update a local copy of the PR: \
`$ git checkout pull/943` \
`$ git pull https://git.openjdk.org/jfx pull/943/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 943`

View PR using the GUI difftool: \
`$ git pr show -t 943`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/943.diff">https://git.openjdk.org/jfx/pull/943.diff</a>

</details>
