### PR TITLE
8296589: PixelBufferDrawTest fails on some systems

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/PixelBufferDrawTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/PixelBufferDrawTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -186,10 +186,11 @@ public class PixelBufferDrawTest {
     }
 
     private void compareColor(Color exp, Color act) {
-        Assert.assertEquals(exp.getRed(), act.getRed(), 0.005);
-        Assert.assertEquals(exp.getBlue(), act.getBlue(), 0.005);
-        Assert.assertEquals(exp.getGreen(), act.getGreen(), 0.005);
-        Assert.assertEquals(exp.getOpacity(), act.getOpacity(), 0.005);
+        final double COMPARE_DELTA = 0.01;
+        Assert.assertEquals(exp.getRed(), act.getRed(), COMPARE_DELTA);
+        Assert.assertEquals(exp.getBlue(), act.getBlue(), COMPARE_DELTA);
+        Assert.assertEquals(exp.getGreen(), act.getGreen(), COMPARE_DELTA);
+        Assert.assertEquals(exp.getOpacity(), act.getOpacity(), COMPARE_DELTA);
     }
 
     private void verifyColor(Color color1, Color color2) {


### PR DESCRIPTION
Issue happening on some hardware due to slightly different pixel values being returned.

Increased tolerance of asserts in compareColor function to allow these tests to pass (0.01 delta is still tighter than other similar tests which use 0.07).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296589](https://bugs.openjdk.org/browse/JDK-8296589): PixelBufferDrawTest fails on some systems


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/944/head:pull/944` \
`$ git checkout pull/944`

Update a local copy of the PR: \
`$ git checkout pull/944` \
`$ git pull https://git.openjdk.org/jfx pull/944/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 944`

View PR using the GUI difftool: \
`$ git pr show -t 944`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/944.diff">https://git.openjdk.org/jfx/pull/944.diff</a>

</details>
