### PR TITLE
8285503: SwingNodeDnDMemoryLeakTest::testSwingNodeMemoryLeak fails sometimes

### DIFF
--- a/tests/system/src/test/java/test/javafx/embed/swing/SwingNodeDnDMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/SwingNodeDnDMemoryLeakTest.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.assertTrue;
 
 public class SwingNodeDnDMemoryLeakTest {
 
-    final static int TOTAL_SWINGNODE = 5;
+    final static int TOTAL_SWINGNODE = 10;
     static CountDownLatch launchLatch;
     final static int GC_ATTEMPTS = 10;
     ArrayList<WeakReference<SwingNode>> weakRefArrSN =

--- a/tests/system/src/test/java/test/javafx/embed/swing/SwingNodeDnDMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/SwingNodeDnDMemoryLeakTest.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.assertTrue;
 
 public class SwingNodeDnDMemoryLeakTest {
 
-    final static int TOTAL_SWINGNODE = 10;
+    final static int TOTAL_SWINGNODE = 5;
     static CountDownLatch launchLatch;
     final static int GC_ATTEMPTS = 10;
     ArrayList<WeakReference<SwingNode>> weakRefArrSN =
@@ -127,7 +127,7 @@ public class SwingNodeDnDMemoryLeakTest {
                 break;
             }
             try {
-                Thread.sleep(250);
+                Thread.sleep(500);
             } catch (InterruptedException e) {
                 System.err.println("InterruptedException occurred during Thread.sleep()");
             }


### PR DESCRIPTION
Root cause: The test unreliability comes from the 250ms sleep between `System.gc()` calls.
Other system tests such as `TabPaneHeaderLeakTest`, `AccordionTitlePaneLeakTest` and `ShapeViewOrderLeakTest` etc sleep for 500ms between `System.gc()` calls.

Fix:
- Increased the sleep time to 500ms between `System.gc()` calls.

Testing: This test used to fail on my macBook all the time if ran as part of a full system test run. I executed full test runs 5 times with this change and no failure was observed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285503](https://bugs.openjdk.org/browse/JDK-8285503): SwingNodeDnDMemoryLeakTest::testSwingNodeMemoryLeak fails sometimes


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/946/head:pull/946` \
`$ git checkout pull/946`

Update a local copy of the PR: \
`$ git checkout pull/946` \
`$ git pull https://git.openjdk.org/jfx pull/946/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 946`

View PR using the GUI difftool: \
`$ git pr show -t 946`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/946.diff">https://git.openjdk.org/jfx/pull/946.diff</a>

</details>
