### PR TITLE
8291853: [CSS] ClassCastException in CssStyleHelper calculateValue

### DIFF
--- a/modules/javafx.controls/src/main/resources/com/sun/javafx/scene/control/skin/modena/modena.css
+++ b/modules/javafx.controls/src/main/resources/com/sun/javafx/scene/control/skin/modena/modena.css
@@ -357,6 +357,9 @@ is being used to size a border should also be in pixels.
     /** Focus line for keyboard focus traversal on cell based controls */
     -fx-cell-focus-inner-border: derive(-fx-selection-bar,30%);
 
+    /* Cell border color is initialized here to avoid a race condition during initialization */
+    -fx-table-cell-border-color: transparent;
+
     /* The colors to use in Pagination */
     -fx-page-bullet-border: #acacac;
     -fx-page-indicator-hover-border: #accee5;
@@ -377,9 +380,6 @@ is being used to size a border should also be in pixels.
      **************************************************************************/
 
     -fx-background-color: -fx-background;
-
-    /* avoid race condition during initialization */
-    -fx-table-cell-border-color: transparent;
 }
 
 /* Make popups transparent */

--- a/modules/javafx.controls/src/main/resources/com/sun/javafx/scene/control/skin/modena/modena.css
+++ b/modules/javafx.controls/src/main/resources/com/sun/javafx/scene/control/skin/modena/modena.css
@@ -377,6 +377,9 @@ is being used to size a border should also be in pixels.
      **************************************************************************/
 
     -fx-background-color: -fx-background;
+
+    /* avoid race condition during initialization */
+    -fx-table-cell-border-color: transparent;
 }
 
 /* Make popups transparent */


### PR DESCRIPTION
A race condition exists where a derived color depends on another derived color which has not been yet defined or processed.  The only side effect of this condition is a ClassCastException - the color eventually gets resolved.

Solution: initialize the derived color to transparent earlier to suppress the exception.

This was also a test bug https://bugs.openjdk.org/browse/JDK-8198604

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291853](https://bugs.openjdk.org/browse/JDK-8291853): [CSS] ClassCastException in CssStyleHelper calculateValue


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/947/head:pull/947` \
`$ git checkout pull/947`

Update a local copy of the PR: \
`$ git checkout pull/947` \
`$ git pull https://git.openjdk.org/jfx pull/947/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 947`

View PR using the GUI difftool: \
`$ git pr show -t 947`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/947.diff">https://git.openjdk.org/jfx/pull/947.diff</a>

</details>
