### PR TITLE
8297042: gradle -PBUILD_SDK_FOR_TEST=false fails with gradle 7.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -609,12 +609,6 @@ ext.CROSS_TOOLS_DIR = file(crossToolsDir)
 defineProperty("BUILD_SDK_FOR_TEST", "true")
 ext.DO_BUILD_SDK_FOR_TEST = Boolean.parseBoolean(BUILD_SDK_FOR_TEST)
 
-// All "classes" and "jar" tasks and their dependencies would be disabled
-// when running with DO_BUILD_SDK_FOR_TEST=false as they're unneeded for running tests
-if (!DO_BUILD_SDK_FOR_TEST) {
-    gradle.taskGraph.useFilter({ task -> !task.name.equals("classes") && !task.name.equals("jar") })
-}
-
 // Make sure JDK_HOME/bin/java exists
 if (!file(JAVA).exists()) throw new Exception("Missing or incorrect path to 'java': '$JAVA'. Perhaps bad JDK_HOME? $JDK_HOME")
 if (!file(JAVAC).exists()) throw new Exception("Missing or incorrect path to 'javac': '$JAVAC'. Perhaps bad JDK_HOME? $JDK_HOME")


### PR DESCRIPTION
This PR fixes our `build.gradle` script so it can work with gradle 7.6.

When doing a test build with gradle 7.6 RC3:

```
$ gradle sdk
$ gradle --info -PBUILD_SDK_FOR_TEST=false test
```

We get the following error:

```
FAILURE: Build failed with an exception.

* Where:
Build file 'C:\Users\kcr\javafx\jfx-kcr\jfx\rt\build.gradle' line: 615

* What went wrong:
A problem occurred evaluating root project 'rt'.
> No signature of method: org.gradle.execution.taskgraph.DefaultTaskExecutionGraph.useFilter() is applicable for argument types: (build_32ube911nql8mvr8torfp363j$_run_closure1) values: [build_32ube911nql8mvr8torfp363j$_run_closure1@1679a7fe]
```

As noted in JBS, setting the gradle `-PBUILD_SDK_FOR_TEST=false` flag can be used when running tests to avoid a complete build of the sdk.

The fix is to remove the use of `gradle.taskGraph.useFilter`, which is not public API, but is an implementation detail that happened to "work" up until recently, but stopped working some time between gradle 7.3 and gradle 7.6. I say "work" in quotes, because there is effectively no difference in what gets run because of the dependency on the shims.

The following two GHA test runs show the problem when running with gradle 7.6 RC3 and the fix:

[test-build-gradle-7.6](https://github.com/kevinrushforth/jfx/actions/runs/3470969280) : test build run using gradle 7.6 RC3 without the fix from this PR; it fails as expected
[test-build-gradle-7.6+8297042](https://github.com/kevinrushforth/jfx/actions/runs/3470983142) : test build run using gradle 7.6 RC3 without the fix from this PR; it passes on all platforms

Additionally, the GHA test run for _this_ PR shows that it works fine with gradle 7.3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297042](https://bugs.openjdk.org/browse/JDK-8297042): gradle -PBUILD_SDK_FOR_TEST=false fails with gradle 7.6


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/949/head:pull/949` \
`$ git checkout pull/949`

Update a local copy of the PR: \
`$ git checkout pull/949` \
`$ git pull https://git.openjdk.org/jfx pull/949/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 949`

View PR using the GUI difftool: \
`$ git pr show -t 949`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/949.diff">https://git.openjdk.org/jfx/pull/949.diff</a>

</details>
