### PR TITLE
8206430: Use consistent pattern for startup in FX system tests

### DIFF
--- a/tests/system/src/test/java/test/com/sun/glass/ui/DefaultExceptionHandlerTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/DefaultExceptionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,14 +25,18 @@
 
 package test.com.sun.glass.ui;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.stage.Stage;
+
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import test.util.Util;
 
 public class DefaultExceptionHandlerTest {
 
@@ -60,8 +64,13 @@ public class DefaultExceptionHandlerTest {
             System.out.println("Exception caught: " + e);
             System.out.flush();
         });
-        new Thread(() -> Application.launch(TestApp.class)).start();
-        startupLatch.await();
+
+        Util.launch(startupLatch, 10, TestApp.class);
+    }
+
+    @AfterClass
+    public static void teardownOnce() {
+        Platform.exit();
     }
 
     @Test
@@ -80,5 +89,4 @@ public class DefaultExceptionHandlerTest {
             throw new RuntimeException("Test FAILED: unexpected exception is caught: " + exception);
         }
     }
-
 }

--- a/tests/system/src/test/java/test/com/sun/glass/ui/DefaultExceptionHandlerTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/DefaultExceptionHandlerTest.java
@@ -70,7 +70,7 @@ public class DefaultExceptionHandlerTest {
 
     @AfterClass
     public static void teardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/com/sun/glass/ui/DefaultExceptionHandlerTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/DefaultExceptionHandlerTest.java
@@ -65,7 +65,7 @@ public class DefaultExceptionHandlerTest {
             System.out.flush();
         });
 
-        Util.launch(startupLatch, 10, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/com/sun/glass/ui/ExceptionHandlerTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/ExceptionHandlerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,18 @@
 
 package test.com.sun.glass.ui;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.stage.Stage;
 
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import test.util.Util;
 
 public class ExceptionHandlerTest {
 
@@ -61,8 +64,12 @@ public class ExceptionHandlerTest {
 
     @BeforeClass
     public static void setup() throws Exception {
-        new Thread(() -> Application.launch(TestApp.class)).start();
-        startupLatch.await();
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
+
+    @AfterClass
+    public static void shutdown() {
+        Platform.exit();
     }
 
     @Test
@@ -81,5 +88,4 @@ public class ExceptionHandlerTest {
             throw new RuntimeException("Test FAILED: unexpected exception is caught: " + exception);
         }
     }
-
 }

--- a/tests/system/src/test/java/test/com/sun/glass/ui/ExceptionHandlerTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/ExceptionHandlerTest.java
@@ -69,7 +69,7 @@ public class ExceptionHandlerTest {
 
     @AfterClass
     public static void shutdown() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/com/sun/glass/ui/ExceptionHandlerTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/ExceptionHandlerTest.java
@@ -64,7 +64,7 @@ public class ExceptionHandlerTest {
 
     @BeforeClass
     public static void setup() throws Exception {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/com/sun/glass/ui/monocle/headless/HeadlessGeometry1Test.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/monocle/headless/HeadlessGeometry1Test.java
@@ -66,7 +66,7 @@ public class HeadlessGeometry1Test {
         System.setProperty("prism.order", "sw");
         System.setProperty("headless.geometry", "150x250");
 
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
         Assert.assertEquals(0, startupLatch.getCount());
     }
 

--- a/tests/system/src/test/java/test/com/sun/glass/ui/monocle/headless/HeadlessGeometry1Test.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/monocle/headless/HeadlessGeometry1Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,15 @@
 package test.com.sun.glass.ui.monocle.headless;
 
 import com.sun.glass.ui.Screen;
+
+import test.util.Util;
+
 import javafx.application.Application;
+import javafx.application.Platform;
 import javafx.stage.Stage;
-import junit.framework.Assert;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -59,9 +65,14 @@ public class HeadlessGeometry1Test {
         System.setProperty("monocle.platform", "Headless");
         System.setProperty("prism.order", "sw");
         System.setProperty("headless.geometry", "150x250");
-        new Thread(() -> Application.launch(TestApp.class)).start();
-        startupLatch.await(5, TimeUnit.SECONDS);
+
+        Util.launch(startupLatch, 15, TestApp.class);
         Assert.assertEquals(0, startupLatch.getCount());
+    }
+
+    @AfterClass
+    public static void shutdown() {
+        Util.shutdown();
     }
 
     @Test
@@ -70,5 +81,4 @@ public class HeadlessGeometry1Test {
         Assert.assertEquals(250, height);
         Assert.assertEquals(32, depth);
     }
-
 }

--- a/tests/system/src/test/java/test/com/sun/glass/ui/monocle/headless/HeadlessGeometry2Test.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/monocle/headless/HeadlessGeometry2Test.java
@@ -65,7 +65,7 @@ public class HeadlessGeometry2Test {
         System.setProperty("prism.order", "sw");
         System.setProperty("headless.geometry", "150x250-16");
 
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
         Assert.assertEquals(0, startupLatch.getCount());
     }
 

--- a/tests/system/src/test/java/test/com/sun/glass/ui/monocle/headless/HeadlessGeometry2Test.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/monocle/headless/HeadlessGeometry2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,20 @@
 
 package test.com.sun.glass.ui.monocle.headless;
 
-import com.sun.glass.ui.Screen;
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
+import javafx.application.Platform;
 import javafx.stage.Stage;
-import junit.framework.Assert;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import com.sun.glass.ui.Screen;
+
+import test.util.Util;
 
 public class HeadlessGeometry2Test {
 
@@ -59,9 +64,14 @@ public class HeadlessGeometry2Test {
         System.setProperty("monocle.platform", "Headless");
         System.setProperty("prism.order", "sw");
         System.setProperty("headless.geometry", "150x250-16");
-        new Thread(() -> Application.launch(TestApp.class)).start();
-        startupLatch.await(5, TimeUnit.SECONDS);
+
+        Util.launch(startupLatch, 15, TestApp.class);
         Assert.assertEquals(0, startupLatch.getCount());
+    }
+
+    @AfterClass
+    public static void shutdown() {
+        Util.shutdown();
     }
 
     @Test
@@ -70,5 +80,4 @@ public class HeadlessGeometry2Test {
         Assert.assertEquals(250, height);
         Assert.assertEquals(16, depth);
     }
-
 }

--- a/tests/system/src/test/java/test/com/sun/javafx/application/HostServicesTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/application/HostServicesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,20 +25,22 @@
 
 package test.com.sun.javafx.application;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.lang.reflect.Method;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.HostServices;
 import javafx.application.Platform;
 import javafx.stage.Stage;
-import junit.framework.AssertionFailedError;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-import static test.util.Util.TIMEOUT;
+import test.util.Util;
 
 /**
  * Unit tests for Platform runLater.
@@ -65,23 +67,12 @@ public class HostServicesTest {
 
     @BeforeClass
     public static void setupOnce() {
-        // Start the Application
-        new Thread(() -> Application.launch(MyApp.class, (String[]) null)).start();
-
-        try {
-            if (!launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS)) {
-                throw new AssertionFailedError("Timeout waiting for Application to launch");
-            }
-        } catch (InterruptedException ex) {
-            AssertionFailedError err = new AssertionFailedError("Unexpected exception");
-            err.initCause(ex);
-            throw err;
-        }
+        Util.launch(launchLatch, 10, MyApp.class);
     }
 
     @AfterClass
     public static void teardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/com/sun/javafx/application/HostServicesTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/application/HostServicesTest.java
@@ -67,7 +67,7 @@ public class HostServicesTest {
 
     @BeforeClass
     public static void setupOnce() {
-        Util.launch(launchLatch, 10, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/com/sun/javafx/application/InitializeJavaFXStartupBase.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/application/InitializeJavaFXStartupBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,19 +25,16 @@
 
 package test.com.sun.javafx.application;
 
-import javafx.application.Platform;
-
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import static org.junit.Assert.assertTrue;
+
+import test.util.Util;
 
 public class InitializeJavaFXStartupBase extends InitializeJavaFXBase {
 
     public static void initializeStartup() throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
-        Platform.startup(() -> {
+        Util.startup(latch, () -> {
             latch.countDown();
         });
-        assertTrue(latch.await(5, TimeUnit.SECONDS));
     }
 }

--- a/tests/system/src/test/java/test/com/sun/javafx/application/PlatformExitCommon.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/application/PlatformExitCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,16 +25,17 @@
 
 package test.com.sun.javafx.application;
 
-import com.sun.javafx.application.PlatformImplShim;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import javafx.application.Platform;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import test.util.Util;
-
 import static org.junit.Assert.assertEquals;
-import static test.util.Util.TIMEOUT;
+
+import java.util.concurrent.CountDownLatch;
+
+import javafx.application.Platform;
+
+import org.junit.BeforeClass;
+
+import com.sun.javafx.application.PlatformImplShim;
+
+import test.util.Util;
 
 /**
  * Tests calling Platform.exit() after starting the FX runtime
@@ -50,9 +51,7 @@ public class PlatformExitCommon {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        Platform.startup(startupLatch::countDown);
-        Assert.assertTrue("Timeout waiting for FX runtime to start",
-                startupLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
+        Util.startup(startupLatch, startupLatch::countDown);
     }
 
     protected void doTestPlatformExit(boolean again) {

--- a/tests/system/src/test/java/test/com/sun/javafx/application/RunLaterTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/application/RunLaterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,20 +25,20 @@
 
 package test.com.sun.javafx.application;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.stage.Stage;
-import junit.framework.AssertionFailedError;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import test.util.Util;
 
-import static org.junit.Assert.*;
-import static test.util.Util.TIMEOUT;
+import test.util.Util;
 
 /**
  * Unit tests for Platform runLater.
@@ -60,23 +60,12 @@ public class RunLaterTest {
 
     @BeforeClass
     public static void setupOnce() {
-        // Start the Application
-        new Thread(() -> Application.launch(MyApp.class, (String[])null)).start();
-
-        try {
-            if (!launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS)) {
-                throw new AssertionFailedError("Timeout waiting for Application to launch");
-            }
-        } catch (InterruptedException ex) {
-            AssertionFailedError err = new AssertionFailedError("Unexpected exception");
-            err.initCause(ex);
-            throw err;
-        }
+        Util.launch(launchLatch, 10, MyApp.class);
     }
 
     @AfterClass
     public static void teardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     private AtomicInteger seqNum = new AtomicInteger(0);

--- a/tests/system/src/test/java/test/com/sun/javafx/application/RunLaterTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/application/RunLaterTest.java
@@ -60,7 +60,7 @@ public class RunLaterTest {
 
     @BeforeClass
     public static void setupOnce() {
-        Util.launch(launchLatch, 10, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/com/sun/javafx/font/freetype/PangoTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/font/freetype/PangoTest.java
@@ -83,7 +83,7 @@ public class PangoTest {
 
     @BeforeClass
     public static void setupOnce() throws Exception {
-        Util.launch(launchLatch, 10, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 

--- a/tests/system/src/test/java/test/com/sun/javafx/font/freetype/PangoTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/font/freetype/PangoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,13 @@
 
 package test.com.sun.javafx.font.freetype;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static test.util.Util.TIMEOUT;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -36,14 +41,11 @@ import javafx.scene.text.Text;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
 
-import org.junit.Test;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
-import junit.framework.AssertionFailedError;
-import static test.util.Util.TIMEOUT;
-
-import static org.junit.Assert.*;
+import test.util.Util;
 
 /**
  * Test program for UTF16 to UTF8 conversion and Pango
@@ -81,16 +83,13 @@ public class PangoTest {
 
     @BeforeClass
     public static void setupOnce() throws Exception {
-        // Start the Application
-        new Thread(() -> Application.launch(MyApp.class, (String[]) null)).start();
-        assertTrue("Timeout waiting for Application to launch",
-                launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
+        Util.launch(launchLatch, 10, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 
     @AfterClass
     public static void teardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     private void addTextToPane(Text text) throws Exception {

--- a/tests/system/src/test/java/test/com/sun/javafx/iio/LoadCorruptJPEGTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/iio/LoadCorruptJPEGTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,31 +24,30 @@
  */
 package test.com.sun.javafx.iio;
 
-import javafx.application.Application;
-import javafx.application.Platform;
-import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
-import javafx.scene.layout.HBox;
-import javafx.scene.Scene;
-import javafx.stage.Stage;
+import static org.junit.Assert.fail;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.net.URL;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+import javafx.scene.layout.HBox;
+import javafx.stage.Stage;
 
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertTrue;
 
 import test.util.Util;
 
 public class LoadCorruptJPEGTest {
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static HBox root;
     static volatile Scene scene;
     static volatile Stage stage;
@@ -87,18 +86,12 @@ public class LoadCorruptJPEGTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        assertTrue("Timeout waiting for FX runtime to start",
-                startupLatch.await(15, TimeUnit.SECONDS));
+        Util.launch(startupLatch, 15, TestApp.class);
     }
 
     @AfterClass
     public static void exit() {
-        Util.runAndWait(() -> {
-            stage.hide();
-        });
-        Platform.exit();
+        Util.shutdown(stage);
     }
 
     @After

--- a/tests/system/src/test/java/test/com/sun/javafx/iio/LoadCorruptJPEGTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/iio/LoadCorruptJPEGTest.java
@@ -86,7 +86,7 @@ public class LoadCorruptJPEGTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/com/sun/javafx/sg/prism/RT36296Test.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/sg/prism/RT36296Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,25 +24,27 @@
 
 package test.com.sun.javafx.sg.prism;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.geometry.Rectangle2D;
-import javafx.stage.Stage;
 import javafx.scene.Group;
 import javafx.scene.Scene;
 import javafx.scene.SnapshotParameters;
 import javafx.scene.control.Label;
 import javafx.scene.image.WritableImage;
-import junit.framework.AssertionFailedError;
+import javafx.stage.Stage;
+
 import org.junit.AfterClass;
-import static org.junit.Assert.assertEquals;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static test.util.Util.TIMEOUT;
+
+import test.util.Util;
 
 public class RT36296Test {
     CountDownLatch latch = new CountDownLatch(1);
@@ -67,25 +69,13 @@ public class RT36296Test {
 
     @BeforeClass
     public static void setupOnce() {
-        // Start the Application
-        new Thread(() -> Application.launch(MyApp.class, (String[])null)).start();
-
-        try {
-            if (!launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS)) {
-                throw new AssertionFailedError("Timeout waiting for Application to launch");
-            }
-        } catch (InterruptedException ex) {
-            AssertionFailedError err = new AssertionFailedError("Unexpected exception");
-            err.initCause(ex);
-            throw err;
-        }
-
+        Util.launch(launchLatch, 10, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 
     @AfterClass
     public static void teardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Test(timeout = 15000)

--- a/tests/system/src/test/java/test/com/sun/javafx/sg/prism/RT36296Test.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/sg/prism/RT36296Test.java
@@ -69,7 +69,7 @@ public class RT36296Test {
 
     @BeforeClass
     public static void setupOnce() {
-        Util.launch(launchLatch, 10, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 

--- a/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/CloseWindowTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/CloseWindowTest.java
@@ -74,10 +74,7 @@ public class CloseWindowTest {
 
     @AfterClass
     public static void shutdown() {
-        Platform.runLater(() -> {
-            Util.hide(primaryStage);
-            Platform.exit();
-        });
+        Util.shutdown(primaryStage);
     }
 
     @Test

--- a/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/CloseWindowTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/CloseWindowTest.java
@@ -69,7 +69,7 @@ public class CloseWindowTest {
 
     @BeforeClass
     public static void setup() throws Exception {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/CloseWindowTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/CloseWindowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package test.com.sun.javafx.tk.quantum;
 
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Group;
@@ -33,11 +35,10 @@ import javafx.stage.Modality;
 import javafx.stage.Stage;
 
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.concurrent.CountDownLatch;
+import test.util.Util;
 
 public class CloseWindowTest {
 
@@ -68,13 +69,15 @@ public class CloseWindowTest {
 
     @BeforeClass
     public static void setup() throws Exception {
-        new Thread(() -> Application.launch(TestApp.class)).start();
-        startupLatch.await();
+        Util.launch(startupLatch, 15, TestApp.class);
     }
 
     @AfterClass
     public static void shutdown() {
-        Platform.runLater(primaryStage::hide);
+        Platform.runLater(() -> {
+            Util.hide(primaryStage);
+            Platform.exit();
+        });
     }
 
     @Test

--- a/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/ViewPainterLeakTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/ViewPainterLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@ package test.com.sun.javafx.tk.quantum;
 
 import java.lang.ref.WeakReference;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -37,17 +37,17 @@ import javafx.scene.text.Text;
 import javafx.scene.text.TextFlow;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import test.util.Util;
 import test.util.memory.JMemoryBuddy;
 
-import static org.junit.Assert.*;
-
 public class ViewPainterLeakTest {
 
-    private static CountDownLatch startupLatch;
+    private static CountDownLatch startupLatch = new CountDownLatch(1);
     private static Stage stage;
     private static ScrollPane scrollPane;
     private static WeakReference<Scene> sceneRef;
@@ -83,15 +83,12 @@ public class ViewPainterLeakTest {
 
     @BeforeClass
     public static void setupOnce() throws Exception {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
-        assertTrue("Timeout waiting for FX runtime to start",
-                startupLatch.await(15, TimeUnit.SECONDS));
+        Util.launch(startupLatch, 15, TestApp.class);
     }
 
     @AfterClass
     public static void teardown() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/ViewPainterLeakTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/ViewPainterLeakTest.java
@@ -83,7 +83,7 @@ public class ViewPainterLeakTest {
 
     @BeforeClass
     public static void setupOnce() throws Exception {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/WindowSceneInitDisposeTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/WindowSceneInitDisposeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,19 +25,19 @@
 
 package test.com.sun.javafx.tk.quantum;
 
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Group;
 import javafx.scene.Scene;
-import javafx.stage.Modality;
 import javafx.stage.Stage;
 
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.concurrent.CountDownLatch;
+import test.util.Util;
 
 public class WindowSceneInitDisposeTest {
 
@@ -68,13 +68,12 @@ public class WindowSceneInitDisposeTest {
 
     @BeforeClass
     public static void setup() throws Exception {
-        new Thread(() -> Application.launch(TestApp.class)).start();
-        startupLatch.await();
+        Util.launch(startupLatch, 15, TestApp.class);
     }
 
     @AfterClass
     public static void shutdown() {
-        Platform.runLater(primaryStage::hide);
+        Util.shutdown(primaryStage);
     }
 
     @Test

--- a/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/WindowSceneInitDisposeTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/WindowSceneInitDisposeTest.java
@@ -68,7 +68,7 @@ public class WindowSceneInitDisposeTest {
 
     @BeforeClass
     public static void setup() throws Exception {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/com/sun/marlin/ClipShapeTest.java
+++ b/tests/system/src/test/java/test/com/sun/marlin/ClipShapeTest.java
@@ -24,6 +24,8 @@
  */
 package test.com.sun.marlin;
 
+import static org.junit.Assert.assertEquals;
+
 import java.awt.BasicStroke;
 import java.awt.Shape;
 import java.awt.geom.CubicCurve2D;
@@ -39,12 +41,17 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
+
+import javax.imageio.IIOImage;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
 
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -70,21 +77,13 @@ import javafx.scene.shape.StrokeLineCap;
 import javafx.scene.shape.StrokeLineJoin;
 import javafx.scene.text.Text;
 import javafx.stage.Stage;
-import javax.imageio.IIOImage;
-import javax.imageio.ImageIO;
-import javax.imageio.ImageWriteParam;
-import javax.imageio.ImageWriter;
-import javax.imageio.stream.ImageOutputStream;
 
-import junit.framework.AssertionFailedError;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static test.util.Util.TIMEOUT;
+import test.util.Util;
 
 /**
  * @test
@@ -975,11 +974,7 @@ NbPixels [All Test setups][n: 30] sum: 232 avg: 7.733 [1 | 27]
 
     @BeforeClass
     public static void setupOnce() throws Exception {
-        // Start the Application
-        new Thread(() -> Application.launch(MyApp.class, (String[]) null)).start();
-
-        assertTrue("Timeout waiting for Application to launch",
-                launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
+        Util.launch(launchLatch, 10, MyApp.class);
 
         assertEquals(0, launchLatch.getCount());
     }

--- a/tests/system/src/test/java/test/com/sun/marlin/ClipShapeTest.java
+++ b/tests/system/src/test/java/test/com/sun/marlin/ClipShapeTest.java
@@ -974,7 +974,7 @@ NbPixels [All Test setups][n: 30] sum: 232 avg: 7.733 [1 | 27]
 
     @BeforeClass
     public static void setupOnce() throws Exception {
-        Util.launch(launchLatch, 10, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
 
         assertEquals(0, launchLatch.getCount());
     }

--- a/tests/system/src/test/java/test/com/sun/marlin/ClipShapeTest.java
+++ b/tests/system/src/test/java/test/com/sun/marlin/ClipShapeTest.java
@@ -979,6 +979,11 @@ NbPixels [All Test setups][n: 30] sum: 232 avg: 7.733 [1 | 27]
         assertEquals(0, launchLatch.getCount());
     }
 
+    @AfterClass
+    public static void teardownOnce() {
+        Util.shutdown();
+    }
+
     private void checkMarlin() {
         if (!isMarlin.get()) {
             throw new RuntimeException("Marlin renderer not used at runtime !");
@@ -986,11 +991,6 @@ NbPixels [All Test setups][n: 30] sum: 232 avg: 7.733 [1 | 27]
         if (!isClipRuntime.get()) {
             throw new RuntimeException("Marlin clipping not enabled at runtime !");
         }
-    }
-
-    @AfterClass
-    public static void teardownOnce() {
-        Platform.exit();
     }
 
     @Test(timeout = 600000)

--- a/tests/system/src/test/java/test/com/sun/marlin/DashedRectTest.java
+++ b/tests/system/src/test/java/test/com/sun/marlin/DashedRectTest.java
@@ -24,8 +24,10 @@
  */
 package test.com.sun.marlin;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -44,16 +46,11 @@ import javafx.scene.shape.Path;
 import javafx.scene.shape.VLineTo;
 import javafx.stage.Stage;
 
-import junit.framework.AssertionFailedError;
 import org.junit.AfterClass;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import test.util.Util;
-import static test.util.Util.TIMEOUT;
 
 /**
  * Simple Dashed Rect rendering test
@@ -106,12 +103,7 @@ public class DashedRectTest {
 
     @BeforeClass
     public static void setupOnce() throws Exception {
-        // Start the Application
-        new Thread(() -> Application.launch(MyApp.class, (String[]) null)).start();
-
-        assertTrue("Timeout waiting for Application to launch",
-                launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
-
+        Util.launch(launchLatch, 10, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 

--- a/tests/system/src/test/java/test/com/sun/marlin/DashedRectTest.java
+++ b/tests/system/src/test/java/test/com/sun/marlin/DashedRectTest.java
@@ -102,7 +102,7 @@ public class DashedRectTest {
 
     @BeforeClass
     public static void setupOnce() throws Exception {
-        Util.launch(launchLatch, 10, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 

--- a/tests/system/src/test/java/test/com/sun/marlin/DashedRectTest.java
+++ b/tests/system/src/test/java/test/com/sun/marlin/DashedRectTest.java
@@ -30,7 +30,6 @@ import static org.junit.Assert.fail;
 import java.util.concurrent.CountDownLatch;
 
 import javafx.application.Application;
-import javafx.application.Platform;
 import javafx.collections.ObservableList;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Group;
@@ -109,7 +108,7 @@ public class DashedRectTest {
 
     @AfterClass
     public static void teardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Test(timeout = 10000)

--- a/tests/system/src/test/java/test/com/sun/marlin/HugePolygonClipTest.java
+++ b/tests/system/src/test/java/test/com/sun/marlin/HugePolygonClipTest.java
@@ -24,6 +24,9 @@
  */
 package test.com.sun.marlin;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -31,10 +34,14 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+
+import javax.imageio.IIOImage;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
 
 import javafx.application.Application;
-import javafx.application.Platform;
 import javafx.embed.swing.SwingFXUtils;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Group;
@@ -47,22 +54,12 @@ import javafx.scene.shape.Polygon;
 import javafx.scene.transform.Translate;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
-import javax.imageio.IIOImage;
-import javax.imageio.ImageIO;
-import javax.imageio.ImageWriteParam;
-import javax.imageio.ImageWriter;
-import javax.imageio.stream.ImageOutputStream;
 
-import junit.framework.AssertionFailedError;
 import org.junit.AfterClass;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import test.util.Util;
-import static test.util.Util.TIMEOUT;
 
 /**
  * Clip rendering test
@@ -134,18 +131,13 @@ public class HugePolygonClipTest {
 
     @BeforeClass
     public static void setupOnce() throws Exception {
-        // Start the Application
-        new Thread(() -> Application.launch(MyApp.class, (String[]) null)).start();
-
-        assertTrue("Timeout waiting for Application to launch",
-                launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
-
+        Util.launch(launchLatch, 10, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 
     @AfterClass
     public static void teardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Test(timeout = 10000)

--- a/tests/system/src/test/java/test/com/sun/marlin/HugePolygonClipTest.java
+++ b/tests/system/src/test/java/test/com/sun/marlin/HugePolygonClipTest.java
@@ -131,7 +131,7 @@ public class HugePolygonClipTest {
 
     @BeforeClass
     public static void setupOnce() throws Exception {
-        Util.launch(launchLatch, 10, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 

--- a/tests/system/src/test/java/test/com/sun/marlin/QPathTest.java
+++ b/tests/system/src/test/java/test/com/sun/marlin/QPathTest.java
@@ -25,9 +25,10 @@
 
 package test.com.sun.marlin;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
@@ -48,15 +49,12 @@ import javafx.scene.shape.SVGPath;
 import javafx.stage.Stage;
 import javafx.util.Duration;
 
-import junit.framework.AssertionFailedError;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static test.util.Util.TIMEOUT;
+import test.util.Util;
 
 /**
  * @test
@@ -141,18 +139,13 @@ public class QPathTest {
 
     @BeforeClass
     public static void setupOnce() throws Exception {
-        // Start the Application
-        new Thread(() -> Application.launch(MyApp.class, (String[]) null)).start();
-
-        assertTrue("Timeout waiting for Application to launch",
-                launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
-
+        Util.launch(launchLatch, 10, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 
     @AfterClass
     public static void teardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Test(timeout = 15000)

--- a/tests/system/src/test/java/test/com/sun/marlin/QPathTest.java
+++ b/tests/system/src/test/java/test/com/sun/marlin/QPathTest.java
@@ -139,7 +139,7 @@ public class QPathTest {
 
     @BeforeClass
     public static void setupOnce() throws Exception {
-        Util.launch(launchLatch, 10, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 

--- a/tests/system/src/test/java/test/com/sun/marlin/ScaleClipTest.java
+++ b/tests/system/src/test/java/test/com/sun/marlin/ScaleClipTest.java
@@ -100,7 +100,7 @@ public class ScaleClipTest {
 
     @BeforeClass
     public static void setupOnce() throws Exception {
-        Util.launch(launchLatch, 10, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
         assertEquals(0, launchLatch.getCount());
 
         System.out.println("ScaleClipTest: size = " + SIZE);

--- a/tests/system/src/test/java/test/com/sun/marlin/ScaleClipTest.java
+++ b/tests/system/src/test/java/test/com/sun/marlin/ScaleClipTest.java
@@ -24,14 +24,14 @@
  */
 package test.com.sun.marlin;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
 import java.awt.Color;
-import java.io.File;
-import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import javafx.application.Application;
-import javafx.application.Platform;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Group;
 import javafx.scene.Scene;
@@ -45,15 +45,12 @@ import javafx.scene.shape.StrokeLineCap;
 import javafx.scene.shape.StrokeLineJoin;
 import javafx.scene.transform.Transform;
 import javafx.stage.Stage;
-import junit.framework.AssertionFailedError;
+
 import org.junit.AfterClass;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import test.util.Util;
-import static test.util.Util.TIMEOUT;
 
 /**
  * Scaled Line Clipping rendering test
@@ -103,12 +100,7 @@ public class ScaleClipTest {
 
     @BeforeClass
     public static void setupOnce() throws Exception {
-        // Start the Application
-        new Thread(() -> Application.launch(MyApp.class, (String[]) null)).start();
-
-        assertTrue("Timeout waiting for Application to launch",
-                launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
-
+        Util.launch(launchLatch, 10, MyApp.class);
         assertEquals(0, launchLatch.getCount());
 
         System.out.println("ScaleClipTest: size = " + SIZE);
@@ -116,7 +108,7 @@ public class ScaleClipTest {
 
     @AfterClass
     public static void teardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Test(timeout = 10000)

--- a/tests/system/src/test/java/test/com/sun/prism/impl/PNTMeshVertexBufferLengthTest.java
+++ b/tests/system/src/test/java/test/com/sun/prism/impl/PNTMeshVertexBufferLengthTest.java
@@ -262,7 +262,7 @@ public class PNTMeshVertexBufferLengthTest {
 
     @BeforeClass
     public static void setupOnce() {
-        Util.launch(launchLatch, 10, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 

--- a/tests/system/src/test/java/test/com/sun/prism/impl/PNTMeshVertexBufferLengthTest.java
+++ b/tests/system/src/test/java/test/com/sun/prism/impl/PNTMeshVertexBufferLengthTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,12 +25,13 @@
 
 package test.com.sun.prism.impl;
 
-import com.sun.javafx.sg.prism.NGTriangleMesh;
-import com.sun.javafx.sg.prism.NGTriangleMeshShim;
-import com.sun.prism.impl.BaseMesh;
-import com.sun.prism.impl.BaseMeshShim;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.ConditionalFeature;
 import javafx.application.Platform;
@@ -44,18 +45,17 @@ import javafx.scene.shape.VertexFormat;
 import javafx.scene.transform.Rotate;
 import javafx.stage.Stage;
 
-import junit.framework.AssertionFailedError;
 import org.junit.AfterClass;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import test.util.Util;
 
-import static test.util.Util.TIMEOUT;
+import com.sun.javafx.sg.prism.NGTriangleMesh;
+import com.sun.javafx.sg.prism.NGTriangleMeshShim;
+import com.sun.prism.impl.BaseMesh;
+import com.sun.prism.impl.BaseMeshShim;
+
+import test.util.Util;
 
 /**
  * @test @bug 8178804
@@ -262,25 +262,13 @@ public class PNTMeshVertexBufferLengthTest {
 
     @BeforeClass
     public static void setupOnce() {
-        // Start the Application
-        new Thread(() -> Application.launch(MyApp.class, (String[]) null)).start();
-
-        try {
-            if (!launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS)) {
-                throw new AssertionFailedError("Timeout waiting for Application to launch");
-            }
-        } catch (InterruptedException ex) {
-            AssertionFailedError err = new AssertionFailedError("Unexpected exception");
-            err.initCause(ex);
-            throw err;
-        }
-
+        Util.launch(launchLatch, 10, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 
     @AfterClass
     public static void teardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Before

--- a/tests/system/src/test/java/test/com/sun/prism/impl/ps/ShapeCacheTest.java
+++ b/tests/system/src/test/java/test/com/sun/prism/impl/ps/ShapeCacheTest.java
@@ -90,7 +90,7 @@ public class ShapeCacheTest {
 
     @BeforeClass
     public static void setupOnce() {
-        Util.launch(launchLatch, 10, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 

--- a/tests/system/src/test/java/test/com/sun/prism/impl/ps/ShapeCacheTest.java
+++ b/tests/system/src/test/java/test/com/sun/prism/impl/ps/ShapeCacheTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,10 @@
 
 package test.com.sun.prism.impl.ps;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.geometry.Rectangle2D;
@@ -43,12 +45,12 @@ import javafx.scene.shape.MoveTo;
 import javafx.scene.shape.Path;
 import javafx.scene.transform.Affine;
 import javafx.stage.Stage;
-import junit.framework.AssertionFailedError;
+
 import org.junit.AfterClass;
-import static org.junit.Assert.assertEquals;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static test.util.Util.TIMEOUT;
+
+import test.util.Util;
 
 /**
  * @test
@@ -88,25 +90,13 @@ public class ShapeCacheTest {
 
     @BeforeClass
     public static void setupOnce() {
-        // Start the Application
-        new Thread(() -> Application.launch(MyApp.class, (String[]) null)).start();
-
-        try {
-            if (!launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS)) {
-                throw new AssertionFailedError("Timeout waiting for Application to launch");
-            }
-        } catch (InterruptedException ex) {
-            AssertionFailedError err = new AssertionFailedError("Unexpected exception");
-            err.initCause(ex);
-            throw err;
-        }
-
+        Util.launch(launchLatch, 10, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 
     @AfterClass
     public static void teardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     static Image snapshot(Node p, double sx, double sy) {

--- a/tests/system/src/test/java/test/javafx/accessibility/virtualflow/VirtualFlowMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/accessibility/virtualflow/VirtualFlowMemoryLeakTest.java
@@ -141,7 +141,7 @@ public class VirtualFlowMemoryLeakTest {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 10, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/accessibility/virtualflow/VirtualFlowMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/accessibility/virtualflow/VirtualFlowMemoryLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,21 +26,12 @@
 package test.javafx.accessibility.virtualflow;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
 import java.lang.ref.WeakReference;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-
-import com.sun.javafx.PlatformUtil;
-
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -55,12 +46,19 @@ import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TableView.TableViewSelectionModel;
 import javafx.stage.Stage;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.sun.javafx.PlatformUtil;
+
 import test.util.Util;
 import test.util.memory.JMemoryBuddy;
 
 public class VirtualFlowMemoryLeakTest {
 
-    private static CountDownLatch startupLatch;
+    private static CountDownLatch startupLatch = new CountDownLatch(1);
     private static CountDownLatch screenReaderLatch = new CountDownLatch(1);
 
     public static class TestApp extends Application {
@@ -143,20 +141,12 @@ public class VirtualFlowMemoryLeakTest {
 
     @BeforeClass
     public static void initFX() {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
-        try {
-            if (!startupLatch.await(10, SECONDS)) {
-                fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (final InterruptedException ex) {
-            fail("Unexpected exception: " + ex);
-        }
+        Util.launch(startupLatch, 10, TestApp.class);
     }
 
     @AfterClass
     public static void teardown() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/embed/swing/JFXPanelTest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/JFXPanelTest.java
@@ -69,7 +69,7 @@ public class JFXPanelTest {
 
     @BeforeClass
     public static void doSetupOnce() throws Exception {
-        Util.launch(launchLatch, 5, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
         Assert.assertEquals(0, launchLatch.getCount());
     }
 

--- a/tests/system/src/test/java/test/javafx/embed/swing/JFXPanelTest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/JFXPanelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,32 +24,29 @@
  */
 package test.javafx.embed.swing;
 
-import com.sun.javafx.PlatformUtil;
-import org.junit.Assume;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Test;
-import junit.framework.AssertionFailedError;
-
-import javax.swing.JFrame;
-import javax.swing.JMenu;
-import javax.swing.JMenuItem;
-import javax.swing.JMenuBar;
-import javax.swing.JPanel;
-import javax.swing.SwingUtilities;
-import javafx.application.Application;
-import javafx.application.Platform;
-import javafx.embed.swing.JFXPanel;
-import javafx.stage.Stage;
-import javafx.scene.Group;
-import javafx.scene.Scene;
 import java.awt.Dimension;
-import java.awt.event.InputEvent;
 import java.awt.event.MouseEvent;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.embed.swing.JFXPanel;
+import javafx.scene.Group;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import test.util.Util;
 
 public class JFXPanelTest {
     // Used to launch the application before running any test
@@ -72,19 +69,13 @@ public class JFXPanelTest {
 
     @BeforeClass
     public static void doSetupOnce() throws Exception {
-        // Start the Application
-        new Thread(() -> Application.launch(MyApp.class, (String[]) null)).start();
-
-        if (!launchLatch.await(5000, TimeUnit.MILLISECONDS)) {
-            throw new AssertionFailedError("Timeout waiting for Application to launch");
-        }
-
+        Util.launch(launchLatch, 5, MyApp.class);
         Assert.assertEquals(0, launchLatch.getCount());
     }
 
     @AfterClass
     public static void doTeardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @After

--- a/tests/system/src/test/java/test/javafx/embed/swing/SwingFXUtilsTest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/SwingFXUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,13 @@
 
 package test.javafx.embed.swing;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.awt.image.BufferedImage;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.embed.swing.SwingFXUtils;
@@ -35,13 +39,12 @@ import javafx.scene.image.Image;
 import javafx.scene.image.PixelFormat;
 import javafx.scene.image.PixelReader;
 import javafx.stage.Stage;
-import junit.framework.AssertionFailedError;
+
 import org.junit.AfterClass;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import test.util.Util;
 
 public class SwingFXUtilsTest {
     static final boolean verbose = false;
@@ -64,25 +67,13 @@ public class SwingFXUtilsTest {
 
     @BeforeClass
     public static void doSetupOnce() {
-        // Start the Application
-        new Thread(() -> Application.launch(MyApp.class, (String[]) null)).start();
-
-        try {
-            if (!launchLatch.await(5000, TimeUnit.MILLISECONDS)) {
-                throw new AssertionFailedError("Timeout waiting for Application to launch");
-            }
-        } catch (InterruptedException ex) {
-            AssertionFailedError err = new AssertionFailedError("Unexpected exception");
-            err.initCause(ex);
-            throw err;
-        }
-
+        Util.launch(launchLatch, 5, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 
     @AfterClass
     public static void doTeardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/embed/swing/SwingFXUtilsTest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/SwingFXUtilsTest.java
@@ -67,7 +67,7 @@ public class SwingFXUtilsTest {
 
     @BeforeClass
     public static void doSetupOnce() {
-        Util.launch(launchLatch, 5, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 

--- a/tests/system/src/test/java/test/javafx/embed/swing/SwingNodeDnDMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/SwingNodeDnDMemoryLeakTest.java
@@ -56,7 +56,7 @@ public class SwingNodeDnDMemoryLeakTest {
 
     @BeforeClass
     public static void setupOnce() throws Exception {
-        Util.launch(launchLatch, 10, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/embed/swing/SwingNodeDnDMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/SwingNodeDnDMemoryLeakTest.java
@@ -25,50 +25,43 @@
 
 package test.javafx.embed.swing;
 
-import javafx.application.Application;
-import javafx.application.Platform;
-import javafx.embed.swing.SwingNode;
-import javafx.scene.Scene;
-import javafx.scene.layout.BorderPane;
-import javafx.stage.Stage;
+import static org.junit.Assert.assertEquals;
 
 import java.awt.dnd.DropTarget;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+
 import javax.swing.JLabel;
 
-import test.util.Util;
-import static test.util.Util.TIMEOUT;
-import org.junit.Test;
-import org.junit.BeforeClass;
+import javafx.application.Application;
+import javafx.embed.swing.SwingNode;
+import javafx.scene.Scene;
+import javafx.scene.layout.BorderPane;
+import javafx.stage.Stage;
+
 import org.junit.AfterClass;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import test.util.Util;
 
 public class SwingNodeDnDMemoryLeakTest {
 
     final static int TOTAL_SWINGNODE = 10;
-    static CountDownLatch launchLatch;
+    static CountDownLatch launchLatch = new CountDownLatch(1);
     final static int GC_ATTEMPTS = 10;
     ArrayList<WeakReference<SwingNode>> weakRefArrSN =
                                       new ArrayList(TOTAL_SWINGNODE);
 
     @BeforeClass
     public static void setupOnce() throws Exception {
-        launchLatch = new CountDownLatch(1);
-        // Start the Application
-        new Thread(() -> Application.launch(SwingNodeDnDMemoryLeakTest.MyApp.class,
-                                            (String[])null)).start();
-
-        assertTrue("Timeout waiting for Application to launch",
-                    launchLatch.await(10, TimeUnit.SECONDS));
+        Util.launch(launchLatch, 10, MyApp.class);
     }
 
     @AfterClass
     public static void teardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/embed/swing/SwingNodeMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/SwingNodeMemoryLeakTest.java
@@ -25,34 +25,33 @@
 
 package test.javafx.embed.swing;
 
-import com.sun.javafx.PlatformUtil;
-import javafx.application.Application;
-import javafx.application.Platform;
-import javafx.embed.swing.SwingNode;
-import javafx.scene.Scene;
-import javafx.scene.layout.BorderPane;
-import javafx.scene.layout.HBox;
-import javafx.stage.Stage;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
-import javax.swing.JLabel;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+
+import javax.swing.JLabel;
+
+import javafx.application.Application;
+import javafx.embed.swing.SwingNode;
+import javafx.scene.Scene;
+import javafx.scene.layout.BorderPane;
+import javafx.stage.Stage;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.sun.javafx.PlatformUtil;
 
 import test.util.Util;
-import static test.util.Util.TIMEOUT;
-import junit.framework.AssertionFailedError;
-import org.junit.Test;
-import org.junit.BeforeClass;
-import org.junit.AfterClass;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assume.assumeTrue;
 
 public class SwingNodeMemoryLeakTest {
 
     final static int TOTAL_SWINGNODE = 10;
-    static CountDownLatch launchLatch;
+    static CountDownLatch launchLatch = new CountDownLatch(1);
     final static int GC_ATTEMPTS = 10;
     ArrayList<WeakReference<SwingNode>> weakRefArrSN =
                                       new ArrayList(TOTAL_SWINGNODE);
@@ -61,25 +60,12 @@ public class SwingNodeMemoryLeakTest {
 
     @BeforeClass
     public static void setupOnce() {
-        launchLatch = new CountDownLatch(1);
-        // Start the Application
-        new Thread(() -> Application.launch(SwingNodeMemoryLeakTest.MyApp.class, (String[])null)).start();
-
-        try {
-            if (!launchLatch.await(5 * TIMEOUT, TimeUnit.MILLISECONDS)) {
-                throw new AssertionFailedError("Timeout waiting for Application to launch ("+
-                    (5 * TIMEOUT) + " seconds)");
-            }
-        } catch (InterruptedException ex) {
-            AssertionFailedError err = new AssertionFailedError("Unexpected exception");
-            err.initCause(ex);
-            throw err;
-        }
+        Util.launch(launchLatch, 50, MyApp.class);
     }
 
     @AfterClass
     public static void teardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/embed/swing/SwingNodeScaleTest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/SwingNodeScaleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,25 +25,31 @@
 
 package test.javafx.embed.swing;
 
+import java.awt.Dimension;
+import java.awt.GridBagLayout;
+import java.awt.Rectangle;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.util.concurrent.CountDownLatch;
+
+import javax.swing.JButton;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.embed.swing.SwingNode;
 import javafx.scene.Scene;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
+
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.AfterClass;
 import org.junit.Test;
-import junit.framework.AssertionFailedError;
-import javax.swing.*;
-import java.awt.*;
-import java.awt.event.FocusAdapter;
-import java.awt.event.FocusEvent;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
-import static test.util.Util.TIMEOUT;
+import test.util.Util;
 
 public class SwingNodeScaleTest {
     static CountDownLatch launchLatch;
@@ -57,24 +63,13 @@ public class SwingNodeScaleTest {
         System.setProperty("glass.gtk.uiScale", "2");
         launchLatch = new CountDownLatch(1);
         request = new Dimension(150, 100);
-        // Start the Application
-        new Thread(() -> Application.launch(SwingNodeScaleTest.MyApp.class, (String[])null)).start();
 
-        try {
-            if (!launchLatch.await(5 * TIMEOUT, TimeUnit.MILLISECONDS)) {
-                throw new AssertionFailedError("Timeout waiting for Application to launch ("+
-                    (5 * TIMEOUT) + " seconds)");
-            }
-        } catch (InterruptedException ex) {
-            AssertionFailedError err = new AssertionFailedError("Unexpected exception");
-            err.initCause(ex);
-            throw err;
-        }
+        Util.launch(launchLatch, 50, MyApp.class);
     }
 
     @AfterClass
     public static void teardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/scene/CssStyleHelperTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/CssStyleHelperTest.java
@@ -79,7 +79,7 @@ public class CssStyleHelperTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/CssStyleHelperTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/CssStyleHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,28 +25,30 @@
 
 package test.javafx.scene;
 
-import javafx.application.Application;
-import javafx.application.Platform;
-import javafx.scene.Scene;
-import javafx.scene.control.Label;
-import javafx.scene.control.Button;
-import javafx.scene.control.CheckBox;
-import javafx.scene.layout.StackPane;
-import javafx.stage.Stage;
+import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import junit.framework.Assert;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.Label;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import test.util.Util;
-import static org.junit.Assert.assertTrue;
 
 public class CssStyleHelperTest {
 
-    private static CountDownLatch startupLatch;
+    private static CountDownLatch startupLatch = new CountDownLatch(1);
     private static StackPane root;
     private static Stage stage;
     private static Label label1;
@@ -77,10 +79,7 @@ public class CssStyleHelperTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
-        assertTrue("Timeout waiting for FX runtime to start",
-                   startupLatch.await(15, TimeUnit.SECONDS));
+        Util.launch(startupLatch, 15, TestApp.class);
     }
 
     @Test
@@ -104,7 +103,7 @@ public class CssStyleHelperTest {
     @AfterClass
     public static void teardownOnce() {
         Platform.runLater(() -> {
-            stage.hide();
+            Util.hide(stage);
             Platform.exit();
         });
     }

--- a/tests/system/src/test/java/test/javafx/scene/CssStyleHelperTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/CssStyleHelperTest.java
@@ -82,6 +82,11 @@ public class CssStyleHelperTest {
         Util.launch(startupLatch, 15, TestApp.class);
     }
 
+    @AfterClass
+    public static void teardownOnce() {
+        Util.shutdown(stage);
+    }
+
     @Test
     public void testCssIsCorrectlyAppliedToLabelOnStageHideAndShow() throws Exception {
         // sanity
@@ -98,13 +103,5 @@ public class CssStyleHelperTest {
 
         Assert.assertNull("Label1 should have no background", label1.getBackground());
         Assert.assertNull("Label2 should have no background", label2.getBackground());
-    }
-
-    @AfterClass
-    public static void teardownOnce() {
-        Platform.runLater(() -> {
-            Util.hide(stage);
-            Platform.exit();
-        });
     }
 }

--- a/tests/system/src/test/java/test/javafx/scene/ImageCursorGetBestSizeTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/ImageCursorGetBestSizeTest.java
@@ -64,7 +64,7 @@ public class ImageCursorGetBestSizeTest {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/ImageCursorGetBestSizeTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/ImageCursorGetBestSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,22 +26,24 @@
 package test.javafx.scene;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Group;
-import javafx.scene.Scene;
 import javafx.scene.ImageCursor;
+import javafx.scene.Scene;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import test.util.Util;
 
 public class ImageCursorGetBestSizeTest {
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static Stage stage;
 
     private static final double INIT_SIZE = 100.d;
@@ -62,16 +64,12 @@ public class ImageCursorGetBestSizeTest {
 
     @BeforeClass
     public static void initFX() {
-        startupLatch = new CountDownLatch(1);
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
 
-        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
-        try {
-            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
-                Assert.fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            Assert.fail("Unexpected exception: " + ex);
-        }
+    @AfterClass
+    public static void teardown() {
+        Util.shutdown(stage);
     }
 
     @Test(timeout = 20000)
@@ -79,11 +77,5 @@ public class ImageCursorGetBestSizeTest {
         Util.runAndWait(() -> {
             Assert.assertNotNull(ImageCursor.getBestSize(10, 20));
         });
-    }
-
-    @AfterClass
-    public static void teardown() {
-        Platform.runLater(stage::hide);
-        Platform.exit();
     }
 }

--- a/tests/system/src/test/java/test/javafx/scene/InitialNodesMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/InitialNodesMemoryLeakTest.java
@@ -71,7 +71,7 @@ public class InitialNodesMemoryLeakTest {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/InitialNodesMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/InitialNodesMemoryLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,9 @@
 
 package test.javafx.scene;
 
+import java.lang.ref.WeakReference;
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Group;
@@ -32,22 +35,17 @@ import javafx.scene.Scene;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
 
-import junit.framework.Assert;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import test.util.Util;
-import static org.junit.Assert.fail;
-import test.util.memory.JMemoryBuddy;
 
-import java.lang.ref.WeakReference;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import test.util.Util;
+import test.util.memory.JMemoryBuddy;
 
 
 public class InitialNodesMemoryLeakTest {
 
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static WeakReference<Group> groupWRef;
     static Stage stage;
 
@@ -73,27 +71,16 @@ public class InitialNodesMemoryLeakTest {
 
     @BeforeClass
     public static void initFX() {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(InitialNodesMemoryLeakTest.TestApp.class, (String[])null)).start();
-        try {
-            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
-                fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            fail("Unexpected exception: " + ex);
-        }
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
+
+    @AfterClass
+    public static void teardownOnce() {
+        Util.shutdown(stage);
     }
 
     @Test
     public void testRootNodeMemoryLeak() throws Exception {
         JMemoryBuddy.assertCollectable(groupWRef);
-    }
-
-    @AfterClass
-    public static void teardownOnce() {
-        Platform.runLater(() -> {
-            stage.hide();
-            Platform.exit();
-        });
     }
 }

--- a/tests/system/src/test/java/test/javafx/scene/NewSceneSizeTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/NewSceneSizeTest.java
@@ -78,7 +78,7 @@ public class NewSceneSizeTest {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/NewSceneSizeTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/NewSceneSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,16 +34,16 @@ import javafx.scene.Scene;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
-import junit.framework.Assert;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static org.junit.Assert.fail;
+import junit.framework.Assert;
+import test.util.Util;
 
 public class NewSceneSizeTest {
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static volatile Stage stage;
 
     private static double scaleX, scaleY;
@@ -78,15 +78,12 @@ public class NewSceneSizeTest {
 
     @BeforeClass
     public static void initFX() {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        try {
-            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
-                fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            fail("Unexpected exception: " + ex);
-        }
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        Util.shutdown(stage);
     }
 
     @Test
@@ -138,11 +135,5 @@ public class NewSceneSizeTest {
             Assert.assertEquals("Wrong scene " + i + " height", h[i],
                                     childStage[i].getScene().getHeight(), 0.1);
         }
-    }
-
-    @AfterClass
-    public static void teardown() {
-        Platform.runLater(stage::hide);
-        Platform.exit();
     }
 }

--- a/tests/system/src/test/java/test/javafx/scene/NodeTreeShowingTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/NodeTreeShowingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,12 @@
 
 package test.javafx.scene;
 
+import static org.junit.Assert.assertTrue;
+
+import java.util.Random;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicLong;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -32,17 +38,12 @@ import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import test.util.Util;
-
-import java.util.Random;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-
-import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for regressions in performance of manipulating Nodes in a very large
@@ -67,7 +68,7 @@ import static org.junit.Assert.assertTrue;
 
 public class NodeTreeShowingTest {
 
-    private static CountDownLatch startupLatch;
+    private static CountDownLatch startupLatch = new CountDownLatch(1);
     private static Stage stage;
     private static BorderPane rootPane;
 
@@ -87,10 +88,12 @@ public class NodeTreeShowingTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(NodeTreeShowingTest.TestApp.class, (String[]) null)).start();
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
 
-        assertTrue("Timeout waiting for FX runtime to start", startupLatch.await(15, TimeUnit.SECONDS));
+    @AfterClass
+    public static void teardownOnce() {
+        Util.shutdown(stage);
     }
 
     private StackPane createNodesRecursively(int count, int level) {
@@ -158,13 +161,5 @@ public class NodeTreeShowingTest {
         // NOTE : 800 mSec is not a benchmark value
         // It is good enough to catch the regression in performance, if any
         assertTrue("Time to add/remove " + loopCount + " nodes in a large Scene is more than 800 mSec (" + bestMillis.get() + ")", bestMillis.get() <= 800);
-    }
-
-    @AfterClass
-    public static void teardownOnce() {
-        Platform.runLater(() -> {
-            stage.hide();
-            Platform.exit();
-        });
     }
 }

--- a/tests/system/src/test/java/test/javafx/scene/NodeTreeShowingTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/NodeTreeShowingTest.java
@@ -88,7 +88,7 @@ public class NodeTreeShowingTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/QuadraticCssTimeTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/QuadraticCssTimeTest.java
@@ -83,7 +83,7 @@ public class QuadraticCssTimeTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/QuadraticCssTimeTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/QuadraticCssTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,25 +25,25 @@
 
 package test.javafx.scene;
 
+import static org.junit.Assert.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.geometry.Insets;
 import javafx.scene.Scene;
-import javafx.scene.layout.HBox;
 import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
 import javafx.scene.text.Text;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import test.util.Util;
-import junit.framework.Assert;
-import org.junit.Test;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+import test.util.Util;
 
 /**
  * This test is based on the test case reported in JDK-8209830
@@ -63,7 +63,7 @@ import static org.junit.Assert.assertTrue;
 
 public class QuadraticCssTimeTest {
 
-    private static CountDownLatch startupLatch;
+    private static CountDownLatch startupLatch = new CountDownLatch(1);
     private static Stage stage;
     private static BorderPane rootPane;
 
@@ -83,10 +83,12 @@ public class QuadraticCssTimeTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(QuadraticCssTimeTest.TestApp.class, (String[]) null)).start();
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
 
-        assertTrue("Timeout waiting for FX runtime to start", startupLatch.await(15, TimeUnit.SECONDS));
+    @AfterClass
+    public static void teardownOnce() {
+        Util.shutdown(stage);
     }
 
     @Test
@@ -112,14 +114,6 @@ public class QuadraticCssTimeTest {
             // NOTE : 800 mSec is not a benchmark value
             // It is good enough to catch the regression in performance, if any
             assertTrue("Time to add 500 Nodes is more than 800 mSec", (endTime - startTime) < 800);
-        });
-    }
-
-    @AfterClass
-    public static void teardownOnce() {
-        Platform.runLater(() -> {
-            stage.hide();
-            Platform.exit();
         });
     }
 }

--- a/tests/system/src/test/java/test/javafx/scene/RestoreSceneSizeTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/RestoreSceneSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,11 @@
  */
 package test.javafx.scene;
 
-import com.sun.javafx.PlatformUtil;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
@@ -32,19 +36,18 @@ import javafx.scene.Scene;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import com.sun.javafx.PlatformUtil;
 
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import test.util.Util;
 
 public class RestoreSceneSizeTest {
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static Stage stage;
 
     private static final int WIDTH = 234;
@@ -82,15 +85,12 @@ public class RestoreSceneSizeTest {
 
     @BeforeClass
     public static void initFX() {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        try {
-            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
-                fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            fail("Unexpected exception: " + ex);
-        }
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        Util.shutdown(stage);
     }
 
     @Test
@@ -126,11 +126,5 @@ public class RestoreSceneSizeTest {
 
         Assert.assertEquals("Scene got wrong width", w, stage.getScene().getWidth(), 0.1);
         Assert.assertEquals("Scene got wrong height", h, stage.getScene().getHeight(), 0.1);
-    }
-
-    @AfterClass
-    public static void teardown() {
-        Platform.runLater(stage::hide);
-        Platform.exit();
     }
 }

--- a/tests/system/src/test/java/test/javafx/scene/RestoreSceneSizeTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/RestoreSceneSizeTest.java
@@ -85,7 +85,7 @@ public class RestoreSceneSizeTest {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/SnapshotCommon.java
+++ b/tests/system/src/test/java/test/javafx/scene/SnapshotCommon.java
@@ -109,7 +109,7 @@ public class SnapshotCommon {
     }
 
     static void doSetupOnce() {
-        Util.launch(launchLatch, 10, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 

--- a/tests/system/src/test/java/test/javafx/scene/SnapshotCommon.java
+++ b/tests/system/src/test/java/test/javafx/scene/SnapshotCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,14 @@
 
 package test.javafx.scene;
 
-import test.util.Util;
-import javafx.scene.image.WritableImage;
-import javafx.stage.Stage;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static test.util.Util.TIMEOUT;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Group;
@@ -37,13 +40,14 @@ import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.SnapshotParameters;
 import javafx.scene.SnapshotResult;
+import javafx.scene.image.WritableImage;
 import javafx.scene.paint.Color;
+import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.util.Callback;
-import junit.framework.AssertionFailedError;
 
-import static org.junit.Assert.*;
-import static test.util.Util.TIMEOUT;
+import junit.framework.AssertionFailedError;
+import test.util.Util;
 
 /**
  * Common base class for testing snapshot.
@@ -105,24 +109,12 @@ public class SnapshotCommon {
     }
 
     static void doSetupOnce() {
-        // Start the Application
-        new Thread(() -> Application.launch(MyApp.class, (String[])null)).start();
-
-        try {
-            if (!launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS)) {
-                throw new AssertionFailedError("Timeout waiting for Application to launch");
-            }
-        } catch (InterruptedException ex) {
-            AssertionFailedError err = new AssertionFailedError("Unexpected exception");
-            err.initCause(ex);
-            throw err;
-        }
-
+        Util.launch(launchLatch, 10, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 
     static void doTeardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     protected void runDeferredSnapshotWait(final Node node,

--- a/tests/system/src/test/java/test/javafx/scene/StyleMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/StyleMemoryLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,23 +25,24 @@
 
 package test.javafx.scene;
 
-import javafx.application.Platform;
-import javafx.scene.Group;
-import javafx.scene.control.Button;
-import javafx.scene.Scene;
-import javafx.stage.Stage;
-import junit.framework.Assert;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import test.util.Util;
-import test.util.memory.JMemoryBuddy;
+import static org.junit.Assert.assertTrue;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertTrue;
+import javafx.application.Platform;
+import javafx.scene.Group;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.stage.Stage;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import test.util.Util;
+import test.util.memory.JMemoryBuddy;
 
 
 public class StyleMemoryLeakTest {
@@ -49,11 +50,16 @@ public class StyleMemoryLeakTest {
     @BeforeClass
     public static void initFX() throws Exception {
         CountDownLatch startupLatch = new CountDownLatch(1);
-        Platform.startup(() -> {
-            Platform.setImplicitExit(false);
+        Platform.setImplicitExit(false);
+
+        Util.startup(startupLatch, () -> {
             startupLatch.countDown();
         });
-        assertTrue("Timeout waiting for FX runtime to start", startupLatch.await(15, TimeUnit.SECONDS));
+    }
+
+    @AfterClass
+    public static void teardownOnce() {
+        Util.shutdown();
     }
 
     @Test
@@ -88,10 +94,5 @@ public class StyleMemoryLeakTest {
             checker.assertCollectable(stage.get());
             checker.setAsReferenced(toBeRemoved);
         });
-    }
-
-    @AfterClass
-    public static void teardownOnce() {
-        Platform.exit();
     }
 }

--- a/tests/system/src/test/java/test/javafx/scene/UIRenderDialogTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/UIRenderDialogTest.java
@@ -100,7 +100,7 @@ public class UIRenderDialogTest {
         System.setProperty("glass.win.uiScale", String.valueOf(scale));
         System.setProperty("glass.gtk.uiScale", String.valueOf(scale));
 
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/UIRenderDialogTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/UIRenderDialogTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,11 @@
  */
 package test.javafx.scene;
 
-import com.sun.javafx.PlatformUtil;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.geometry.Insets;
@@ -40,19 +44,18 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.text.Text;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
-import junit.framework.Assert;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import com.sun.javafx.PlatformUtil;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import junit.framework.Assert;
+import test.util.Util;
 
 public class UIRenderDialogTest {
-    private static CountDownLatch startupLatch;
+    private static CountDownLatch startupLatch = new CountDownLatch(1);
     private static volatile Stage stage;
     private static volatile Alert alert;
     private static final double scale = 1.75;
@@ -96,10 +99,18 @@ public class UIRenderDialogTest {
     public static void setupOnce() throws Exception {
         System.setProperty("glass.win.uiScale", String.valueOf(scale));
         System.setProperty("glass.gtk.uiScale", String.valueOf(scale));
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        assertTrue("Timeout waiting for FX runtime to start",
-                startupLatch.await(15, TimeUnit.SECONDS));
+
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        Platform.runLater(() -> {
+            if (alert != null) {
+                alert.hide();
+            }
+        });
+        Util.shutdown(stage);
     }
 
     @Test
@@ -116,16 +127,5 @@ public class UIRenderDialogTest {
             CheckBox box = (CheckBox) node;
             Assert.assertEquals("Wrong text", "Check", ((Text) box.lookup(".text")).getText());
         }
-    }
-
-    @AfterClass
-    public static void teardown() {
-        Platform.runLater(() -> {
-            if (alert != null) {
-                alert.hide();
-            }
-            stage.hide();
-        });
-        Platform.exit();
     }
 }

--- a/tests/system/src/test/java/test/javafx/scene/UIRenderSceneTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/UIRenderSceneTest.java
@@ -80,7 +80,7 @@ public class UIRenderSceneTest {
         System.setProperty("glass.win.uiScale", String.valueOf(scale));
         System.setProperty("glass.gtk.uiScale", String.valueOf(scale));
 
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/UIRenderSceneTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/UIRenderSceneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,10 @@
  */
 package test.javafx.scene;
 
-import com.sun.javafx.PlatformUtil;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.geometry.Insets;
@@ -36,20 +39,18 @@ import javafx.scene.layout.HBox;
 import javafx.scene.text.Text;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
-import junit.framework.Assert;
+
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import com.sun.javafx.PlatformUtil;
 
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import test.util.Util;
 
 public class UIRenderSceneTest {
-    private static CountDownLatch startupLatch;
+    private static CountDownLatch startupLatch = new CountDownLatch(1);
     private static volatile Stage stage;
     private static final double scale = 1.75;
 
@@ -78,10 +79,13 @@ public class UIRenderSceneTest {
     public static void setupOnce() throws Exception {
         System.setProperty("glass.win.uiScale", String.valueOf(scale));
         System.setProperty("glass.gtk.uiScale", String.valueOf(scale));
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        assertTrue("Timeout waiting for FX runtime to start",
-                startupLatch.await(15, TimeUnit.SECONDS));
+
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        Util.shutdown(stage);
     }
 
     @Test
@@ -95,11 +99,5 @@ public class UIRenderSceneTest {
             CheckBox box = (CheckBox) node;
             Assert.assertEquals("Wrong text", "Check", ((Text) box.lookup(".text")).getText());
         }
-    }
-
-    @AfterClass
-    public static void teardown() {
-        Platform.runLater(stage::hide);
-        Platform.exit();
     }
 }

--- a/tests/system/src/test/java/test/javafx/scene/UIRenderSnapToPixelTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/UIRenderSnapToPixelTest.java
@@ -58,7 +58,7 @@ public class UIRenderSnapToPixelTest {
         System.setProperty("glass.win.uiScale", String.valueOf(scale));
         System.setProperty("glass.gtk.uiScale", String.valueOf(scale));
 
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/UIRenderSnapToPixelTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/UIRenderSnapToPixelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,10 @@
  */
 package test.javafx.scene;
 
-import com.sun.javafx.PlatformUtil;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Node;
@@ -34,20 +37,19 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
-import junit.framework.Assert;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import com.sun.javafx.PlatformUtil;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import junit.framework.Assert;
+import test.util.Util;
 
 public class UIRenderSnapToPixelTest {
     private static final double scale = 1.25;
-    private static CountDownLatch startupLatch;
+    private static CountDownLatch startupLatch = new CountDownLatch(1);
     private static volatile Stage stage;
     private static final double epsilon = 0.00001;
 
@@ -55,15 +57,13 @@ public class UIRenderSnapToPixelTest {
     public static void setupOnce() throws Exception {
         System.setProperty("glass.win.uiScale", String.valueOf(scale));
         System.setProperty("glass.gtk.uiScale", String.valueOf(scale));
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
-        assertTrue("Timeout waiting for FX runtime to start", startupLatch.await(15, TimeUnit.SECONDS));
+
+        Util.launch(startupLatch, 15, TestApp.class);
     }
 
     @AfterClass
     public static void teardown() {
-        Platform.runLater(stage::hide);
-        Platform.exit();
+        Util.shutdown(stage);
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/scene/control/AccordionTitlePaneLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/AccordionTitlePaneLeakTest.java
@@ -25,6 +25,9 @@
 
 package test.javafx.scene.control;
 
+import java.lang.ref.WeakReference;
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -33,16 +36,12 @@ import javafx.scene.control.TitledPane;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
-import test.util.Util;
-
-import java.lang.ref.WeakReference;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import junit.framework.Assert;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import test.util.Util;
 
 public class AccordionTitlePaneLeakTest {
 
@@ -68,14 +67,13 @@ public class AccordionTitlePaneLeakTest {
     @BeforeClass
     public static void initFX() throws Exception {
         startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        Assert.assertTrue("Timeout waiting for FX runtime to start", startupLatch.await(15, TimeUnit.SECONDS));
+        Util.launch(startupLatch, 15, TestApp.class);
     }
 
     @AfterClass
     public static void teardownOnce() {
         Platform.runLater(() -> {
-            stage.hide();
+            Util.hide(stage);
             Platform.exit();
         });
     }

--- a/tests/system/src/test/java/test/javafx/scene/control/AccordionTitlePaneLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/AccordionTitlePaneLeakTest.java
@@ -72,10 +72,7 @@ public class AccordionTitlePaneLeakTest {
 
     @AfterClass
     public static void teardownOnce() {
-        Platform.runLater(() -> {
-            Util.hide(stage);
-            Platform.exit();
-        });
+        Util.shutdown(stage);
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/scene/control/AccordionTitlePaneLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/AccordionTitlePaneLeakTest.java
@@ -67,7 +67,7 @@ public class AccordionTitlePaneLeakTest {
     @BeforeClass
     public static void initFX() throws Exception {
         startupLatch = new CountDownLatch(1);
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/control/MenuButtonSkinBaseNPETest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/MenuButtonSkinBaseNPETest.java
@@ -92,7 +92,7 @@ public class MenuButtonSkinBaseNPETest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/control/MenuButtonSkinBaseNPETest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/MenuButtonSkinBaseNPETest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,27 +25,27 @@
 
 package test.javafx.scene.control;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
-import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuBar;
 import javafx.scene.control.MenuItem;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import test.util.Util;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 public class MenuButtonSkinBaseNPETest {
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static Menu menu;
     static MenuBar menuBar;
 
@@ -92,14 +92,11 @@ public class MenuButtonSkinBaseNPETest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        Assert.assertTrue("Timeout waiting for FX runtime to start",
-                startupLatch.await(15, TimeUnit.SECONDS));
+        Util.launch(startupLatch, 15, TestApp.class);
     }
 
     @AfterClass
     public static void tearDown() {
-        Platform.exit();
+        Util.shutdown();
     }
 }

--- a/tests/system/src/test/java/test/javafx/scene/control/ProgressIndicatorLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/ProgressIndicatorLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,28 +25,25 @@
 
 package test.javafx.scene.control;
 
-import javafx.application.Application;
-import javafx.application.Platform;
-import javafx.scene.Node;
-import javafx.scene.Group;
-import javafx.scene.Scene;
-import javafx.scene.control.ProgressIndicator;
-import javafx.scene.control.skin.ProgressIndicatorSkin;
-import javafx.stage.Stage;
-import javafx.stage.WindowEvent;
+import static org.junit.Assert.assertTrue;
 
-import java.lang.ref.WeakReference;
-import java.util.LinkedList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import junit.framework.Assert;
+import javafx.application.Platform;
+import javafx.scene.Group;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.ProgressIndicator;
+import javafx.scene.control.skin.ProgressIndicatorSkin;
+import javafx.stage.Stage;
+
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.assertTrue;
-import static test.util.Util.TIMEOUT;
+
 import test.util.Util;
 import test.util.memory.JMemoryBuddy;
 
@@ -56,9 +53,12 @@ public class ProgressIndicatorLeakTest {
     public static void initFX() throws Exception {
         CountDownLatch startupLatch = new CountDownLatch(1);
         Platform.setImplicitExit(false);
-        Platform.startup(startupLatch::countDown);
-        Assert.assertTrue("Timeout waiting for FX runtime to start",
-                startupLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
+        Util.startup(startupLatch, startupLatch::countDown);
+    }
+
+    @AfterClass
+    public static void teardownOnce() {
+        Util.shutdown();
     }
 
     @Test
@@ -119,13 +119,6 @@ public class ProgressIndicatorLeakTest {
             });
 
             checker.assertCollectable(stage.get());
-        });
-    }
-
-    @AfterClass
-    public static void teardownOnce() {
-        Platform.runLater(() -> {
-            Platform.exit();
         });
     }
 }

--- a/tests/system/src/test/java/test/javafx/scene/control/TabPaneHeaderLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/TabPaneHeaderLeakTest.java
@@ -77,7 +77,7 @@ public class TabPaneHeaderLeakTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/control/TabPaneHeaderLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/TabPaneHeaderLeakTest.java
@@ -25,6 +25,9 @@
 
 package test.javafx.scene.control;
 
+import java.lang.ref.WeakReference;
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -34,20 +37,16 @@ import javafx.scene.control.TextField;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 
-import java.lang.ref.WeakReference;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import junit.framework.Assert;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import junit.framework.Assert;
 import test.util.Util;
-import static org.junit.Assert.assertTrue;
 
 public class TabPaneHeaderLeakTest {
 
-    private static CountDownLatch startupLatch;
+    private static CountDownLatch startupLatch = new CountDownLatch(1);
     private static StackPane root;
     private static Stage stage;
     private static TabPane tabPane;
@@ -78,10 +77,12 @@ public class TabPaneHeaderLeakTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
-        assertTrue("Timeout waiting for FX runtime to start",
-                   startupLatch.await(15, TimeUnit.SECONDS));
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
+
+    @AfterClass
+    public static void teardownOnce() {
+        Util.shutdown(stage);
     }
 
     @Test
@@ -102,13 +103,5 @@ public class TabPaneHeaderLeakTest {
         // Ensure that Tab and TextField are GCed.
         Assert.assertNull("Couldn't collect Tab", tabWeakRef.get());
         Assert.assertNull("Couldn't collect TextField", textFieldWeakRef.get());
-    }
-
-    @AfterClass
-    public static void teardownOnce() {
-        Platform.runLater(() -> {
-            stage.hide();
-            Platform.exit();
-        });
     }
 }

--- a/tests/system/src/test/java/test/javafx/scene/image/WritableImageFromBufferTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/image/WritableImageFromBufferTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,16 +34,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.IntBuffer;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
 
 import javafx.application.Application;
-import javafx.application.Platform;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Scene;
 import javafx.scene.image.ImageView;
@@ -53,6 +45,13 @@ import javafx.scene.image.WritableImage;
 import javafx.scene.layout.StackPane;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
 import test.util.Util;
 
 /**
@@ -63,7 +62,7 @@ import test.util.Util;
  */
 public class WritableImageFromBufferTest {
 
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
 
     private static final int IMG_WIDTH = 600;
     private static final int IMG_HEIGHT = 400;
@@ -153,15 +152,11 @@ public class WritableImageFromBufferTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        Assert.assertTrue("Timeout waiting for FX runtime to start",
-                startupLatch.await(15, TimeUnit.SECONDS));
+        Util.launch(startupLatch, 15, TestApp.class);
     }
 
     @AfterClass
     public static void tearDown() {
-        Platform.exit();
+        Util.shutdown();
     }
-
 }

--- a/tests/system/src/test/java/test/javafx/scene/image/WritableImageFromBufferTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/image/WritableImageFromBufferTest.java
@@ -152,7 +152,7 @@ public class WritableImageFromBufferTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/input/ClipboardTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/input/ClipboardTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,32 +24,33 @@
  */
 package test.javafx.scene.input;
 
-import com.sun.javafx.PlatformUtil;
-import javafx.application.Platform;
-import javafx.scene.input.Clipboard;
-import javafx.scene.input.ClipboardContent;
-import javafx.scene.input.DataFormat;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
-import test.util.Util;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assume.assumeTrue;
 
 import java.awt.Toolkit;
 import java.awt.datatransfer.DataFlavor;
 import java.awt.datatransfer.StringSelection;
 import java.awt.datatransfer.Transferable;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+
+import javafx.scene.input.Clipboard;
+import javafx.scene.input.ClipboardContent;
+import javafx.scene.input.DataFormat;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.sun.javafx.PlatformUtil;
 
 import sun.awt.datatransfer.ClipboardTransferable;
 import sun.awt.datatransfer.SunClipboard;
-
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
+import test.util.Util;
 
 
 public class ClipboardTest {
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static Clipboard clipboard;
 
 
@@ -68,18 +69,15 @@ public class ClipboardTest {
 
     @BeforeClass
     public static void initFX() {
-        startupLatch = new CountDownLatch(1);
-        Platform.startup(() -> {
+        Util.startup(startupLatch, () -> {
             clipboard = Clipboard.getSystemClipboard();
             startupLatch.countDown();
         });
-        try {
-            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
-                fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            fail("Unexpected exception: " + ex);
-        }
+    }
+
+    @AfterClass
+    public static void teardown() {
+        Util.shutdown();
     }
 
     @Test
@@ -136,11 +134,6 @@ public class ClipboardTest {
             boolean hasString = clipboard.hasString();
             assertFalse(hasString);
         });
-    }
-
-    @AfterClass
-    public static void teardown() {
-        Platform.exit();
     }
 
     private static final class CustomClipboard extends SunClipboard {

--- a/tests/system/src/test/java/test/javafx/scene/lighting3D/DirectionalLightTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/lighting3D/DirectionalLightTest.java
@@ -26,22 +26,21 @@
 package test.javafx.scene.lighting3D;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
-
-import javafx.application.Application;
 import javafx.application.ConditionalFeature;
 import javafx.application.Platform;
 import javafx.geometry.Point3D;
 import javafx.scene.DirectionalLight;
 import javafx.scene.paint.Color;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
 import test.util.Util;
 
 public class DirectionalLightTest extends LightingTest {
@@ -58,8 +57,13 @@ public class DirectionalLightTest extends LightingTest {
     public static void initFX() throws Exception {
         startupLatch = new CountDownLatch(1);
         LightingTest.light = LIGHT;
-        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
-        assertTrue("Timeout waiting for FX runtime to start", startupLatch.await(15, TimeUnit.SECONDS));
+
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
+
+    @AfterClass
+    public static void exit() {
+        Platform.exit();
     }
 
     @Before

--- a/tests/system/src/test/java/test/javafx/scene/lighting3D/DirectionalLightTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/lighting3D/DirectionalLightTest.java
@@ -63,7 +63,7 @@ public class DirectionalLightTest extends LightingTest {
 
     @AfterClass
     public static void exit() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Before

--- a/tests/system/src/test/java/test/javafx/scene/lighting3D/DirectionalLightTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/lighting3D/DirectionalLightTest.java
@@ -36,7 +36,6 @@ import javafx.geometry.Point3D;
 import javafx.scene.DirectionalLight;
 import javafx.scene.paint.Color;
 
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -59,11 +58,6 @@ public class DirectionalLightTest extends LightingTest {
         LightingTest.light = LIGHT;
 
         Util.launch(startupLatch, TestApp.class);
-    }
-
-    @AfterClass
-    public static void exit() {
-        Util.shutdown();
     }
 
     @Before

--- a/tests/system/src/test/java/test/javafx/scene/lighting3D/DirectionalLightTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/lighting3D/DirectionalLightTest.java
@@ -58,7 +58,7 @@ public class DirectionalLightTest extends LightingTest {
         startupLatch = new CountDownLatch(1);
         LightingTest.light = LIGHT;
 
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/lighting3D/LightingTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/lighting3D/LightingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,6 @@ package test.javafx.scene.lighting3D;
 
 import java.util.concurrent.CountDownLatch;
 
-import org.junit.AfterClass;
-
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Group;
@@ -38,6 +36,10 @@ import javafx.scene.image.WritableImage;
 import javafx.scene.shape.Box;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
+
+import org.junit.AfterClass;
+
+import test.util.Util;
 
 // Since there appears to be a bug in snapshot with subscene, we are taking a snapshot of the scene and not
 // the box, so the center of the box will be at the top left, (0, 0), of the image, and the light is
@@ -93,9 +95,6 @@ public abstract class LightingTest {
 
     @AfterClass
     public static void teardown() {
-        Platform.runLater(() -> {
-            stage.hide();
-            Platform.exit();
-        });
+        Util.shutdown(stage);
     }
 }

--- a/tests/system/src/test/java/test/javafx/scene/lighting3D/PointLightAttenuationTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/lighting3D/PointLightAttenuationTest.java
@@ -60,7 +60,7 @@ public class PointLightAttenuationTest extends LightingTest {
         startupLatch = new CountDownLatch(1);
         LightingTest.light = LIGHT;
 
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @Before

--- a/tests/system/src/test/java/test/javafx/scene/lighting3D/PointLightAttenuationTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/lighting3D/PointLightAttenuationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,21 +26,19 @@
 package test.javafx.scene.lighting3D;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+
+import javafx.application.ConditionalFeature;
+import javafx.application.Platform;
+import javafx.scene.PointLight;
+import javafx.scene.paint.Color;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import javafx.application.Application;
-import javafx.application.ConditionalFeature;
-import javafx.application.Platform;
-import javafx.scene.PointLight;
-import javafx.scene.paint.Color;
 import test.util.Util;
 
 public class PointLightAttenuationTest extends LightingTest {
@@ -61,8 +59,8 @@ public class PointLightAttenuationTest extends LightingTest {
     public static void initFX() throws Exception {
         startupLatch = new CountDownLatch(1);
         LightingTest.light = LIGHT;
-        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
-        assertTrue("Timeout waiting for FX runtime to start", startupLatch.await(15, TimeUnit.SECONDS));
+
+        Util.launch(startupLatch, 15, TestApp.class);
     }
 
     @Before

--- a/tests/system/src/test/java/test/javafx/scene/lighting3D/SpotLightAttenuationTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/lighting3D/SpotLightAttenuationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,21 +26,19 @@
 package test.javafx.scene.lighting3D;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+
+import javafx.application.ConditionalFeature;
+import javafx.application.Platform;
+import javafx.scene.SpotLight;
+import javafx.scene.paint.Color;
 
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import javafx.application.Application;
-import javafx.application.ConditionalFeature;
-import javafx.application.Platform;
-import javafx.scene.SpotLight;
-import javafx.scene.paint.Color;
 import test.util.Util;
 
 public class SpotLightAttenuationTest extends LightingTest {
@@ -64,8 +62,8 @@ public class SpotLightAttenuationTest extends LightingTest {
     public static void initFX() throws Exception {
         startupLatch = new CountDownLatch(1);
         LightingTest.light = LIGHT;
-        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
-        assertTrue("Timeout waiting for FX runtime to start", startupLatch.await(15, TimeUnit.SECONDS));
+
+        Util.launch(startupLatch, 15, TestApp.class);
     }
 
     @Before

--- a/tests/system/src/test/java/test/javafx/scene/lighting3D/SpotLightAttenuationTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/lighting3D/SpotLightAttenuationTest.java
@@ -63,7 +63,7 @@ public class SpotLightAttenuationTest extends LightingTest {
         startupLatch = new CountDownLatch(1);
         LightingTest.light = LIGHT;
 
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @Before

--- a/tests/system/src/test/java/test/javafx/scene/shape/ShapeViewOrderLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/shape/ShapeViewOrderLeakTest.java
@@ -25,6 +25,9 @@
 
 package test.javafx.scene.shape;
 
+import java.lang.ref.WeakReference;
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Group;
@@ -35,20 +38,16 @@ import javafx.scene.shape.Rectangle;
 import javafx.scene.shape.Shape;
 import javafx.stage.Stage;
 
-import java.lang.ref.WeakReference;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import junit.framework.Assert;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import junit.framework.Assert;
 import test.util.Util;
-import static org.junit.Assert.assertTrue;
 
 public class ShapeViewOrderLeakTest {
 
-    private static CountDownLatch startupLatch;
+    private static CountDownLatch startupLatch = new CountDownLatch(1);
     private static StackPane root;
     private static Stage stage;
     private static Group group;
@@ -80,10 +79,12 @@ public class ShapeViewOrderLeakTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
-        assertTrue("Timeout waiting for FX runtime to start",
-                   startupLatch.await(15, TimeUnit.SECONDS));
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
+
+    @AfterClass
+    public static void teardownOnce() {
+        Util.shutdown(stage);
     }
 
     @Test
@@ -102,13 +103,5 @@ public class ShapeViewOrderLeakTest {
         }
         // Ensure that Shape is GCed.
         Assert.assertNull("Couldn't collect Shape", shapeWeakRef.get());
-    }
-
-    @AfterClass
-    public static void teardownOnce() {
-        Platform.runLater(() -> {
-            stage.hide();
-            Platform.exit();
-        });
     }
 }

--- a/tests/system/src/test/java/test/javafx/scene/shape/ShapeViewOrderLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/shape/ShapeViewOrderLeakTest.java
@@ -79,7 +79,7 @@ public class ShapeViewOrderLeakTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/web/CSSFilterTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/CSSFilterTest.java
@@ -105,7 +105,7 @@ public class CSSFilterTest {
 
     @BeforeClass
     public static void setupOnce() {
-        Util.launch(launchLatch, 10, CSSFilterTestApp.class);
+        Util.launch(launchLatch, CSSFilterTestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/web/CSSFilterTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/CSSFilterTest.java
@@ -25,7 +25,13 @@
 
 package test.javafx.scene.web;
 
+import static javafx.concurrent.Worker.State.SUCCEEDED;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -34,17 +40,14 @@ import javafx.scene.image.WritableImage;
 import javafx.scene.paint.Color;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
+
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
-import test.util.Util;
 
-import static javafx.concurrent.Worker.State.SUCCEEDED;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import test.util.Util;
 
 public class CSSFilterTest {
     private static final CountDownLatch launchLatch = new CountDownLatch(1);
@@ -102,10 +105,7 @@ public class CSSFilterTest {
 
     @BeforeClass
     public static void setupOnce() {
-        // Start the Test Application
-        new Thread(() -> Application.launch(CSSFilterTestApp.class, (String[])null)).start();
-
-        assertTrue("Timeout waiting for FX runtime to start", Util.await(launchLatch));
+        Util.launch(launchLatch, 10, CSSFilterTestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/web/CSSFilterTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/CSSFilterTest.java
@@ -110,7 +110,7 @@ public class CSSFilterTest {
 
     @AfterClass
     public static void tearDownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Before

--- a/tests/system/src/test/java/test/javafx/scene/web/CanvasTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/CanvasTest.java
@@ -68,8 +68,7 @@ public class CanvasTest {
 
     @BeforeClass
     public static void setupOnce() {
-        // Start the Test Application
-        new Thread(() -> Application.launch(CanvasTestApp.class, (String[])null)).start();
+        Util.launch(launchLatch, 10, CanvasTestApp.class);
 
         assertTrue("Timeout waiting for FX runtime to start", Util.await(launchLatch));
     }

--- a/tests/system/src/test/java/test/javafx/scene/web/CanvasTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/CanvasTest.java
@@ -25,22 +25,25 @@
 
 package test.javafx.scene.web;
 
+import static javafx.concurrent.Worker.State.SUCCEEDED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
+
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import test.util.Util;
 
-import static javafx.concurrent.Worker.State.SUCCEEDED;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import test.util.Util;
 
 public class CanvasTest {
     private static final CountDownLatch launchLatch = new CountDownLatch(1);
@@ -75,7 +78,7 @@ public class CanvasTest {
 
     @AfterClass
     public static void tearDownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Before

--- a/tests/system/src/test/java/test/javafx/scene/web/CanvasTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/CanvasTest.java
@@ -71,7 +71,7 @@ public class CanvasTest {
 
     @BeforeClass
     public static void setupOnce() {
-        Util.launch(launchLatch, 10, CanvasTestApp.class);
+        Util.launch(launchLatch, CanvasTestApp.class);
 
         assertTrue("Timeout waiting for FX runtime to start", Util.await(launchLatch));
     }

--- a/tests/system/src/test/java/test/javafx/scene/web/ColorChooserTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/ColorChooserTest.java
@@ -25,7 +25,9 @@
 
 package test.javafx.scene.web;
 
-import com.sun.javafx.scene.control.CustomColorDialog;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.collections.ListChangeListener;
@@ -38,14 +40,15 @@ import javafx.scene.paint.Color;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
 import javafx.stage.Window;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import test.util.Util;
 
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
+import com.sun.javafx.scene.control.CustomColorDialog;
+
+import test.util.Util;
 
 public class ColorChooserTest {
     private static final CountDownLatch launchLatch = new CountDownLatch(1);
@@ -60,14 +63,15 @@ public class ColorChooserTest {
 
     @BeforeAll
     public static void setupOnce() {
-        new Thread(() -> Application.launch(ColorChooserTestApp.class, (String[]) null)).start();
-        Assertions.assertTrue(Util.await(launchLatch), "Timeout waiting for FX runtime to start");
+        Util.launch(launchLatch, 10, ColorChooserTestApp.class);
     }
 
     @AfterAll
     public static void tearDownOnce() {
-        Platform.runLater(stage::hide);
-        Platform.exit();
+        Platform.runLater(() -> {
+            Util.hide(stage);
+            Platform.exit();
+        });
     }
 
     public static class ColorChooserTestApp extends Application {

--- a/tests/system/src/test/java/test/javafx/scene/web/ColorChooserTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/ColorChooserTest.java
@@ -63,7 +63,7 @@ public class ColorChooserTest {
 
     @BeforeAll
     public static void setupOnce() {
-        Util.launch(launchLatch, 10, ColorChooserTestApp.class);
+        Util.launch(launchLatch, ColorChooserTestApp.class);
     }
 
     @AfterAll

--- a/tests/system/src/test/java/test/javafx/scene/web/ColorChooserTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/ColorChooserTest.java
@@ -68,10 +68,7 @@ public class ColorChooserTest {
 
     @AfterAll
     public static void tearDownOnce() {
-        Platform.runLater(() -> {
-            Util.hide(stage);
-            Platform.exit();
-        });
+        Util.shutdown(stage);
     }
 
     public static class ColorChooserTestApp extends Application {

--- a/tests/system/src/test/java/test/javafx/scene/web/HTMLEditorTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/HTMLEditorTest.java
@@ -96,7 +96,7 @@ public class HTMLEditorTest {
 
     @BeforeClass
     public static void setupOnce() {
-        Util.launch(launchLatch, 10, HTMLEditorTestApp.class);
+        Util.launch(launchLatch, HTMLEditorTestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/web/HTMLEditorTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/HTMLEditorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,35 +25,38 @@
 
 package test.javafx.scene.web;
 
-import com.sun.javafx.PlatformUtil;
-import java.util.concurrent.atomic.AtomicReference;
+import static javafx.concurrent.Worker.State.SUCCEEDED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.event.Event;
+import javafx.scene.Node;
+import javafx.scene.Scene;
 import javafx.scene.control.ComboBox;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
-import javafx.scene.Node;
-import javafx.scene.Scene;
 import javafx.scene.text.Font;
 import javafx.scene.web.HTMLEditor;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
+
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import com.sun.javafx.PlatformUtil;
+
 import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
 import test.com.sun.javafx.scene.control.infrastructure.KeyModifier;
 import test.util.Util;
-
-import static javafx.concurrent.Worker.State.SUCCEEDED;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 public class HTMLEditorTest {
     private static final CountDownLatch launchLatch = new CountDownLatch(1);
@@ -74,6 +77,12 @@ public class HTMLEditorTest {
 
         @Override
         public void init() {
+            // Used by selectFontFamilysWithSpace() for JDK-8230492
+            Font.loadFont(
+                HTMLEditorTest.class.getResource("WebKit_Layout_Tests_2.ttf").toExternalForm(),
+                10
+            );
+
             HTMLEditorTest.htmlEditorTestApp = this;
         }
 
@@ -87,22 +96,12 @@ public class HTMLEditorTest {
 
     @BeforeClass
     public static void setupOnce() {
-        // Start the Test Application
-        new Thread(() -> Application.launch(HTMLEditorTestApp.class,
-            (String[]) null)).start();
-
-        // Used by selectFontFamilysWithSpace() for JDK-8230492
-        Font.loadFont(
-            HTMLEditorTest.class.getResource("WebKit_Layout_Tests_2.ttf").toExternalForm(),
-            10
-        );
-
-        assertTrue("Timeout waiting for FX runtime to start", Util.await(launchLatch));
+        Util.launch(launchLatch, 10, HTMLEditorTestApp.class);
     }
 
     @AfterClass
     public static void tearDownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Before

--- a/tests/system/src/test/java/test/javafx/scene/web/PageFillTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/PageFillTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,13 @@
 
 package test.javafx.scene.web;
 
-import com.sun.webkit.WebPage;
-import com.sun.webkit.WebPageShim;
+import static javafx.concurrent.Worker.State.SUCCEEDED;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -36,18 +41,16 @@ import javafx.scene.paint.Color;
 import javafx.scene.web.WebEngineShim;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
+
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import com.sun.webkit.WebPage;
+import com.sun.webkit.WebPageShim;
+
 import test.util.Util;
-
-import java.util.concurrent.CountDownLatch;
-
-import static javafx.concurrent.Worker.State.SUCCEEDED;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class PageFillTest {
     private static final CountDownLatch launchLatch = new CountDownLatch(1);
@@ -105,15 +108,12 @@ public class PageFillTest {
 
     @BeforeClass
     public static void setupOnce() {
-        // Start the Test Application
-        new Thread(() -> Application.launch(PageFillTestApp.class, (String[])null)).start();
-
-        assertTrue("Timeout waiting for FX runtime to start", Util.await(launchLatch));
+        Util.launch(launchLatch, 10, PageFillTestApp.class);
     }
 
     @AfterClass
     public static void tearDownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Before

--- a/tests/system/src/test/java/test/javafx/scene/web/PageFillTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/PageFillTest.java
@@ -108,7 +108,7 @@ public class PageFillTest {
 
     @BeforeClass
     public static void setupOnce() {
-        Util.launch(launchLatch, 10, PageFillTestApp.class);
+        Util.launch(launchLatch, PageFillTestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/web/SVGTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/SVGTest.java
@@ -74,7 +74,7 @@ public class SVGTest {
 
     @BeforeClass
     public static void setupOnce() {
-        Util.launch(launchLatch, 10, SVGTestApp.class);
+        Util.launch(launchLatch, SVGTestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/web/SVGTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/SVGTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,13 @@
 
 package test.javafx.scene.web;
 
+import static javafx.concurrent.Worker.State.SUCCEEDED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -34,16 +40,13 @@ import javafx.scene.image.WritableImage;
 import javafx.scene.paint.Color;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
+
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import test.util.Util;
 
-import static javafx.concurrent.Worker.State.SUCCEEDED;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import test.util.Util;
 
 public class SVGTest {
     private static final CountDownLatch launchLatch = new CountDownLatch(1);
@@ -71,15 +74,12 @@ public class SVGTest {
 
     @BeforeClass
     public static void setupOnce() {
-        // Start the Test Application
-        new Thread(() -> Application.launch(SVGTestApp.class, (String[])null)).start();
-
-        assertTrue("Timeout waiting for FX runtime to start", Util.await(launchLatch));
+        Util.launch(launchLatch, 10, SVGTestApp.class);
     }
 
     @AfterClass
     public static void tearDownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Before

--- a/tests/system/src/test/java/test/javafx/scene/web/StraightLineTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/StraightLineTest.java
@@ -25,33 +25,31 @@
 
 package test.javafx.scene.web;
 
-import com.sun.webkit.WebPage;
-import com.sun.webkit.WebPageShim;
-import com.sun.javafx.PlatformUtil;
+import static javafx.concurrent.Worker.State.SUCCEEDED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
+
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.image.PixelReader;
 import javafx.scene.image.WritableImage;
 import javafx.scene.paint.Color;
-import javafx.scene.web.WebEngineShim;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
-import java.io.*;
+
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import com.sun.javafx.PlatformUtil;
+
 import test.util.Util;
-
-import java.util.concurrent.CountDownLatch;
-import static org.junit.Assert.assertEquals;
-
-import static javafx.concurrent.Worker.State.SUCCEEDED;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeFalse;
 
 public class StraightLineTest {
     private static final CountDownLatch launchLatch = new CountDownLatch(1);
@@ -90,15 +88,12 @@ public class StraightLineTest {
 
     @BeforeClass
     public static void setupOnce() {
-        // Start the Test Application
-        new Thread(() -> Application.launch(StraightLineTestApp.class, (String[])null)).start();
-
-        assertTrue("Timeout waiting for FX runtime to start", Util.await(launchLatch));
+        Util.launch(launchLatch, 10, StraightLineTestApp.class);
     }
 
     @AfterClass
     public static void tearDownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Before

--- a/tests/system/src/test/java/test/javafx/scene/web/StraightLineTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/StraightLineTest.java
@@ -88,7 +88,7 @@ public class StraightLineTest {
 
     @BeforeClass
     public static void setupOnce() {
-        Util.launch(launchLatch, 10, StraightLineTestApp.class);
+        Util.launch(launchLatch, StraightLineTestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/web/WebIObserverTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/WebIObserverTest.java
@@ -71,7 +71,7 @@ public class WebIObserverTest {
 
     @BeforeClass
     public static void setupOnce() {
-        Util.launch(launchLatch, 10, WebIObserverTestApp.class);
+        Util.launch(launchLatch, WebIObserverTestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/web/WebIObserverTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/WebIObserverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,24 +25,26 @@
 
 package test.javafx.scene.web;
 
+import static javafx.concurrent.Worker.State.SUCCEEDED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
+
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import test.util.Util;
-
-import java.net.URL;
-import java.util.concurrent.CountDownLatch;
-
-import static javafx.concurrent.Worker.State.SUCCEEDED;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 public class WebIObserverTest {
     private static final CountDownLatch launchLatch = new CountDownLatch(1);
@@ -69,14 +71,12 @@ public class WebIObserverTest {
 
     @BeforeClass
     public static void setupOnce() {
-        new Thread(() -> Application.launch(WebIObserverTestApp.class, (String[])null)).start();
-
-        assertTrue("Timeout waiting for FX runtime to start", Util.await(launchLatch));
+        Util.launch(launchLatch, 10, WebIObserverTestApp.class);
     }
 
     @AfterClass
     public static void tearDownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Before

--- a/tests/system/src/test/java/test/javafx/scene/web/WebPageTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/WebPageTest.java
@@ -75,7 +75,7 @@ public class WebPageTest {
 
     @BeforeClass
     public static void setupOnce() {
-        Util.launch(launchLatch, 10, WebPageTestApp.class);
+        Util.launch(launchLatch, WebPageTestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/scene/web/WebPageTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/WebPageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,26 +25,29 @@
 
 package test.javafx.scene.web;
 
+import static javafx.concurrent.Worker.State.SUCCEEDED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.web.WebEngineShim;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
+
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import test.util.Util;
 
 import com.sun.webkit.WebPage;
 import com.sun.webkit.WebPageShim;
 
-import static javafx.concurrent.Worker.State.SUCCEEDED;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import test.util.Util;
 
 public class WebPageTest {
     private static final CountDownLatch launchLatch = new CountDownLatch(1);
@@ -72,15 +75,12 @@ public class WebPageTest {
 
     @BeforeClass
     public static void setupOnce() {
-        // Start the Test Application
-        new Thread(() -> Application.launch(WebPageTestApp.class, (String[])null)).start();
-
-        assertTrue("Timeout waiting for FX runtime to start", Util.await(launchLatch));
+        Util.launch(launchLatch, 10, WebPageTestApp.class);
     }
 
     @AfterClass
     public static void tearDownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Before

--- a/tests/system/src/test/java/test/javafx/stage/ChildStageLocationTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/ChildStageLocationTest.java
@@ -50,7 +50,7 @@ import org.junit.Test;
 import test.util.Util;
 
 public class ChildStageLocationTest {
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static Timer timer;
     static Runnable runNext;
     static volatile Stage stage;
@@ -65,8 +65,7 @@ public class ChildStageLocationTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        startupLatch = new CountDownLatch(1);
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/stage/ChildStageLocationTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/ChildStageLocationTest.java
@@ -71,7 +71,7 @@ public class ChildStageLocationTest {
 
     @AfterClass
     public static void teardown() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/stage/ChildStageLocationTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/ChildStageLocationTest.java
@@ -25,10 +25,11 @@
 
 package test.javafx.stage;
 
-import java.util.TimerTask;
+import static org.junit.Assume.assumeTrue;
+
 import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -39,14 +40,14 @@ import javafx.scene.Scene;
 import javafx.scene.control.Label;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
-
 import javafx.stage.Window;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static junit.framework.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import test.util.Util;
 
 public class ChildStageLocationTest {
     static CountDownLatch startupLatch;
@@ -56,22 +57,21 @@ public class ChildStageLocationTest {
     static volatile Stage childStage;
     static double x, y;
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         initFX();
         new ChildStageLocationTest().testLocation();
+        teardown();
     }
 
     @BeforeClass
-    public static void initFX() {
+    public static void initFX() throws Exception {
         startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        try {
-            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
-                fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            fail("Unexpected exception: " + ex);
-        }
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        Platform.exit();
     }
 
     @Test
@@ -82,15 +82,15 @@ public class ChildStageLocationTest {
         double minX = bounds.getMinX() + (bounds.getWidth() - window.getWidth())/2 - 50;
         double minY = bounds.getMinY() + (bounds.getHeight() - window.getHeight())/3 - 100;
         System.out.println("Primary stage location: " + stage.getX() + " " + stage.getY());
-        assertTrue("Primary stage X location should be >" + minX, stage.getX() > minX);
-        assertTrue("Primary stage Y location should be >" + minY, stage.getY() > minY);
+        Assert.assertTrue("Primary stage X location should be >" + minX, stage.getX() > minX);
+        Assert.assertTrue("Primary stage Y location should be >" + minY, stage.getY() > minY);
 
         window = childStage.getScene().getWindow();
         minX = bounds.getMinX() + (bounds.getWidth() - window.getWidth())/2 - 50;
         minY = bounds.getMinY() + (bounds.getHeight() - window.getHeight())/3 - 100;
         System.out.println("Child stage location: " + childStage.getX() + " " + childStage.getY());
-        assertTrue("Child stage X location should be >" + minX, childStage.getX() > minX);
-        assertTrue("Child stage Y location should be >" + minY, childStage.getY() > minY);
+        Assert.assertTrue("Child stage X location should be >" + minX, childStage.getX() > minX);
+        Assert.assertTrue("Child stage Y location should be >" + minY, childStage.getY() > minY);
     }
 
     public static class TestApp extends Application implements ChangeListener {
@@ -104,6 +104,7 @@ public class ChildStageLocationTest {
             stage.heightProperty().addListener(this);
             ChildStageLocationTest.stage = stage;
             runNext = () -> {
+                // FIX unsynchronized access from multiple threads
                 runNext = () -> {};
                 Platform.runLater(this::createChildStage);
             };
@@ -136,5 +137,4 @@ public class ChildStageLocationTest {
             childStage.showAndWait();
         }
     }
-
 }

--- a/tests/system/src/test/java/test/javafx/stage/DeiconifiedWithChildTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/DeiconifiedWithChildTest.java
@@ -76,6 +76,11 @@ public class DeiconifiedWithChildTest {
         Util.launch(startupLatch, 15, TestApp.class);
     }
 
+    @AfterClass
+    public static void teardown() {
+        Util.shutdown(childStage, stage);
+    }
+
     @Test
     public void testDeiconifiedPosition() throws Exception {
         Thread.sleep(200);
@@ -92,14 +97,5 @@ public class DeiconifiedWithChildTest {
         Thread.sleep(200);
         Assert.assertEquals("Child window was moved", x, childStage.getX(), 0.1);
         Assert.assertEquals("Child window was moved", y, childStage.getY(), 0.1);
-    }
-
-    @AfterClass
-    public static void teardown() {
-        Platform.runLater(() -> {
-            Util.hide(childStage);
-            Util.hide(stage);
-            Platform.exit();
-        });
     }
 }

--- a/tests/system/src/test/java/test/javafx/stage/DeiconifiedWithChildTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/DeiconifiedWithChildTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,24 +24,24 @@
  */
 package test.javafx.stage;
 
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.fail;
+import test.util.Util;
 
 public class DeiconifiedWithChildTest {
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static Stage stage;
     static Stage childStage;
 
@@ -73,15 +73,7 @@ public class DeiconifiedWithChildTest {
 
     @BeforeClass
     public static void initFX() {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        try {
-            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
-                fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            fail("Unexpected exception: " + ex);
-        }
+        Util.launch(startupLatch, 15, TestApp.class);
     }
 
     @Test
@@ -104,8 +96,10 @@ public class DeiconifiedWithChildTest {
 
     @AfterClass
     public static void teardown() {
-        Platform.runLater(childStage::hide);
-        Platform.runLater(stage::hide);
-        Platform.exit();
+        Platform.runLater(() -> {
+            Util.hide(childStage);
+            Util.hide(stage);
+            Platform.exit();
+        });
     }
 }

--- a/tests/system/src/test/java/test/javafx/stage/DeiconifiedWithChildTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/DeiconifiedWithChildTest.java
@@ -73,7 +73,7 @@ public class DeiconifiedWithChildTest {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/stage/FocusedWindowTestBase.java
+++ b/tests/system/src/test/java/test/javafx/stage/FocusedWindowTestBase.java
@@ -25,28 +25,26 @@
 
 package test.javafx.stage;
 
+import java.lang.ref.WeakReference;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.control.TextField;
 import javafx.stage.Stage;
 
-import java.lang.ref.WeakReference;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
 
-import junit.framework.Assert;
 import test.util.Util;
 
 public abstract class FocusedWindowTestBase {
 
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
 
     public static void initFXBase() throws Exception {
-        startupLatch = new CountDownLatch(1);
-        Platform.startup(startupLatch::countDown);
         Platform.setImplicitExit(false);
-        Assert.assertTrue("Timeout waiting for FX runtime to start",
-                startupLatch.await(15, TimeUnit.MILLISECONDS));
+        Util.startup(startupLatch, startupLatch::countDown);
     }
 
     WeakReference<Stage> closedFocusedStageWeak = null;

--- a/tests/system/src/test/java/test/javafx/stage/InitialSizeTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/InitialSizeTest.java
@@ -60,7 +60,7 @@ public class InitialSizeTest {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/stage/InitialSizeTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/InitialSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,25 +24,24 @@
  */
 package test.javafx.stage;
 
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Group;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import test.util.Util;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.fail;
-
 public class InitialSizeTest {
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static Stage stage;
     private static final double INIT_SIZE = 200.d;
 
@@ -61,15 +60,12 @@ public class InitialSizeTest {
 
     @BeforeClass
     public static void initFX() {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
-        try {
-            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
-                fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            fail("Unexpected exception: " + ex);
-        }
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        Util.shutdown(stage);
     }
 
     @Test
@@ -78,11 +74,5 @@ public class InitialSizeTest {
         Assert.assertTrue(stage.isShowing());
         Assert.assertEquals("Stage height", INIT_SIZE, stage.getHeight(), .1d);
         Assert.assertEquals("Stage width", INIT_SIZE, stage.getWidth(), .1d);
-    }
-
-    @AfterClass
-    public static void teardown() {
-        Platform.runLater(stage::hide);
-        Platform.exit();
     }
 }

--- a/tests/system/src/test/java/test/javafx/stage/MakeResizableAndResizeTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/MakeResizableAndResizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,10 +28,9 @@ package test.javafx.stage;
 import java.io.FileNotFoundException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.util.TimerTask;
 import java.util.Timer;
+import java.util.TimerTask;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -44,40 +43,42 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
 import javafx.stage.Stage;
 
+import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static junit.framework.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import test.util.Util;
 
 public class MakeResizableAndResizeTest {
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static Timer timer;
     static Runnable runNext;
     static volatile Alert alert;
 
     public static void main(String[] args) {
         initFX();
-        new MakeResizableAndResizeTest().testSize();
+        try {
+            new MakeResizableAndResizeTest().testSize();
+        } finally {
+            shutdown();
+        }
     }
 
     @BeforeClass
     public static void initFX() {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        try {
-            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
-                fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            fail("Unexpected exception: " + ex);
-        }
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
+
+    @AfterClass
+    public static void shutdown() {
+        Util.shutdown();
     }
 
     @Test
     public void testSize() {
-        assertTrue("Wrong window width", alert.getWidth() >= alert.getDialogPane().getWidth());
-        assertTrue("Wrong window height", alert.getHeight() >= alert.getDialogPane().getHeight());
+        Assert.assertTrue("Wrong window width", alert.getWidth() >= alert.getDialogPane().getWidth());
+        Assert.assertTrue("Wrong window height", alert.getHeight() >= alert.getDialogPane().getHeight());
     }
 
     public static class TestApp extends Application implements ChangeListener {

--- a/tests/system/src/test/java/test/javafx/stage/MakeResizableAndResizeTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/MakeResizableAndResizeTest.java
@@ -67,7 +67,7 @@ public class MakeResizableAndResizeTest {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/stage/MaximizeUndecorated.java
+++ b/tests/system/src/test/java/test/javafx/stage/MaximizeUndecorated.java
@@ -67,7 +67,7 @@ public class MaximizeUndecorated {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/stage/MaximizeUndecorated.java
+++ b/tests/system/src/test/java/test/javafx/stage/MaximizeUndecorated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,10 @@
  */
 package test.javafx.stage;
 
-import com.sun.javafx.PlatformUtil;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Group;
@@ -32,20 +35,18 @@ import javafx.scene.Scene;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.WindowEvent;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import com.sun.javafx.PlatformUtil;
+
 import test.util.Util;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.fail;
-import static org.junit.Assume.*;
-
 public class MaximizeUndecorated {
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static Stage stage;
     static final int POS = 500;
 
@@ -66,15 +67,12 @@ public class MaximizeUndecorated {
 
     @BeforeClass
     public static void initFX() {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
-        try {
-            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
-                fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            fail("Unexpected exception: " + ex);
-        }
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        Util.shutdown(stage);
     }
 
     @Test
@@ -85,11 +83,5 @@ public class MaximizeUndecorated {
 
         boolean movedToTopCorner = stage.getY() != POS && stage.getX() != POS;
         Assert.assertTrue("Stage has moved to desktop top corner", movedToTopCorner);
-    }
-
-    @AfterClass
-    public static void teardown() {
-        Platform.runLater(stage::hide);
-        Platform.exit();
     }
 }

--- a/tests/system/src/test/java/test/javafx/stage/MultipleScreensTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/MultipleScreensTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,11 @@
 
 package test.javafx.stage;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
+
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import javafx.application.Application;
+
 import javafx.application.Platform;
 import javafx.collections.ObservableList;
 import javafx.geometry.Rectangle2D;
@@ -36,15 +38,14 @@ import javafx.scene.Scene;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import test.util.Util;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
+import test.util.Util;
 
 public class MultipleScreensTest {
     static CountDownLatch startupLatch = new CountDownLatch(1);
@@ -54,15 +55,10 @@ public class MultipleScreensTest {
 
     Stage stage;
 
-    private static void waitForLatch(CountDownLatch latch, int seconds, String msg) throws Exception {
-        assertTrue("Timeout: " + msg, latch.await(seconds, TimeUnit.SECONDS));
-    }
-
     @BeforeClass
     public static void initFX() throws Exception {
         Platform.setImplicitExit(false);
-        Platform.startup(startupLatch::countDown);
-        waitForLatch(startupLatch, 10, "FX runtime failed to start");
+        Util.startup(startupLatch, startupLatch::countDown);
 
         // Get primary screen and list of all screens, skip tests if there is only one
         primaryScreen = Screen.getPrimary();
@@ -81,7 +77,7 @@ public class MultipleScreensTest {
 
     @AfterClass
     public static void exitFX() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Before
@@ -120,7 +116,7 @@ public class MultipleScreensTest {
             stage.show();
         });
 
-        waitForLatch(shownLatch, 5, "Stage failed to show");
+        Util.waitForLatch(shownLatch, 5, "Stage failed to show");
     }
 
     @Test(timeout = 15000)

--- a/tests/system/src/test/java/test/javafx/stage/NestedEventLoopPlatformExitTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/NestedEventLoopPlatformExitTest.java
@@ -63,7 +63,7 @@ public class NestedEventLoopPlatformExitTest {
 
     @BeforeClass
     public static void initFX() throws InterruptedException {
-        Util.launch(launchLatch, 15, TestApp.class);
+        Util.launch(launchLatch, TestApp.class);
     }
 
     // Verify that Platform.exit can be called while the NestedEventLoop is

--- a/tests/system/src/test/java/test/javafx/stage/NestedEventLoopPlatformExitTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/NestedEventLoopPlatformExitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,16 +26,19 @@
 package test.javafx.stage;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Group;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
+
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import test.util.Util;
 
 public class NestedEventLoopPlatformExitTest {
@@ -60,9 +63,12 @@ public class NestedEventLoopPlatformExitTest {
 
     @BeforeClass
     public static void initFX() throws InterruptedException {
-        // Start the Application
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        Assert.assertTrue (launchLatch.await(15, TimeUnit.SECONDS));
+        Util.launch(launchLatch, 15, TestApp.class);
+    }
+
+    @AfterClass
+    public static void shutdown() {
+        Util.shutdown();
     }
 
     // Verify that Platform.exit can be called while the NestedEventLoop is

--- a/tests/system/src/test/java/test/javafx/stage/NestedEventLoopPlatformExitTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/NestedEventLoopPlatformExitTest.java
@@ -66,11 +66,6 @@ public class NestedEventLoopPlatformExitTest {
         Util.launch(launchLatch, 15, TestApp.class);
     }
 
-    @AfterClass
-    public static void shutdown() {
-        Util.shutdown();
-    }
-
     // Verify that Platform.exit can be called while the NestedEventLoop is
     // running
     @Test(timeout = 20000)

--- a/tests/system/src/test/java/test/javafx/stage/NestedEventLoopTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/NestedEventLoopTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,39 +25,26 @@
 
 package test.javafx.stage;
 
-import java.util.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 
-import javafx.animation.KeyFrame;
-import javafx.animation.Timeline;
 import javafx.application.Application;
 import javafx.application.Platform;
-import javafx.print.PrinterJob;
 import javafx.scene.Group;
 import javafx.scene.Scene;
-import javafx.scene.control.Alert;
 import javafx.scene.paint.Color;
-import javafx.scene.shape.Rectangle;
 import javafx.stage.Stage;
-import javafx.util.Duration;
-import junit.framework.AssertionFailedError;
-import org.junit.After;
+
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
-import test.util.Util;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
-import static test.util.Util.TIMEOUT;
+import test.util.Util;
 
 /**
  * Test program for nested event loop functionality.
@@ -97,23 +84,12 @@ public class NestedEventLoopTest {
 
     @BeforeClass
     public static void setupOnce() {
-        // Start the Application
-        new Thread(() -> Application.launch(MyApp.class, (String[])null)).start();
-
-        try {
-            if (!launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS)) {
-                throw new AssertionFailedError("Timeout waiting for Application to launch");
-            }
-        } catch (InterruptedException ex) {
-            AssertionFailedError err = new AssertionFailedError("Unexpected exception");
-            err.initCause(ex);
-            throw err;
-        }
+        Util.launch(launchLatch, 10, MyApp.class);
     }
 
     @AfterClass
     public static void teardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     // Verify that we cannot enter a nested event loop on a thread other than

--- a/tests/system/src/test/java/test/javafx/stage/NestedEventLoopTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/NestedEventLoopTest.java
@@ -84,7 +84,7 @@ public class NestedEventLoopTest {
 
     @BeforeClass
     public static void setupOnce() {
-        Util.launch(launchLatch, 10, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/stage/RestoreStagePositionTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/RestoreStagePositionTest.java
@@ -79,7 +79,7 @@ public class RestoreStagePositionTest {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/stage/RestoreStagePositionTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/RestoreStagePositionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,11 @@
  */
 package test.javafx.stage;
 
-import com.sun.javafx.PlatformUtil;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
@@ -32,19 +36,18 @@ import javafx.scene.Scene;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import com.sun.javafx.PlatformUtil;
 
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import test.util.Util;
 
 public class RestoreStagePositionTest {
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static Stage stage;
 
     public static void main(String[] args) throws Exception {
@@ -76,17 +79,13 @@ public class RestoreStagePositionTest {
 
     @BeforeClass
     public static void initFX() {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        try {
-            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
-                fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            fail("Unexpected exception: " + ex);
-        }
+        Util.launch(startupLatch, 15, TestApp.class);
     }
 
+    @AfterClass
+    public static void teardown() {
+        Util.shutdown(stage);
+    }
 
     @Test
     public void testUfullscreenPosition() throws Exception {
@@ -162,11 +161,5 @@ public class RestoreStagePositionTest {
 
         Assert.assertEquals("Window was moved", x, stage.getX(), 0.1);
         Assert.assertEquals("Window was moved", y, stage.getY(), 0.1);
-    }
-
-    @AfterClass
-    public static void teardown() {
-        Platform.runLater(stage::hide);
-        Platform.exit();
     }
 }

--- a/tests/system/src/test/java/test/javafx/stage/ScreenTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/ScreenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,29 +25,28 @@
 
 package test.javafx.stage;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assume.assumeTrue;
+
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+
 import javafx.application.Platform;
 import javafx.collections.ListChangeListener.Change;
 import javafx.collections.ObservableList;
 import javafx.stage.Screen;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import test.util.Util;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
+import test.util.Util;
 
 public class ScreenTest {
     static CountDownLatch startupLatch = new CountDownLatch(1);
     static ObservableList<Screen> screens;
     static volatile boolean screensListenerCalled = false;
     static volatile boolean screensSizeIsZero = false;
-
-    private static void waitForLatch(CountDownLatch latch, int seconds, String msg) throws Exception {
-        assertTrue("Timeout: " + msg, latch.await(seconds, TimeUnit.SECONDS));
-    }
 
     /* This test for JDK-8252446 adds a listener on the ObservableList of
      * screens as the first thing in the platform startup runnable. Even
@@ -59,7 +58,7 @@ public class ScreenTest {
     @BeforeClass
     public static void initFX() throws Exception {
         Platform.setImplicitExit(false);
-        Platform.startup(() -> {
+        Util.startup(startupLatch, () -> {
             screens = Screen.getScreens();
             screens.addListener((Change<?> change) -> {
                 final int size = screens.size();
@@ -71,12 +70,11 @@ public class ScreenTest {
             });
             Platform.runLater(startupLatch::countDown);
         });
-        waitForLatch(startupLatch, 10, "FX runtime failed to start");
     }
 
     @AfterClass
     public static void exitFX() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Test
@@ -99,5 +97,4 @@ public class ScreenTest {
         assumeTrue(screensListenerCalled);
         assertFalse("Screens list is empty in listener", screensSizeIsZero);
     }
-
 }

--- a/tests/system/src/test/java/test/javafx/stage/ShowAndWaitTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/ShowAndWaitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,14 @@
 
 package test.javafx.stage;
 
-import javafx.stage.StageShim;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeNotNull;
+import static test.util.Util.TIMEOUT;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -33,6 +40,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
 import javafx.application.Application;
@@ -48,7 +56,7 @@ import javafx.stage.Stage;
 import javafx.stage.StageShim;
 import javafx.stage.Window;
 import javafx.util.Duration;
-import junit.framework.AssertionFailedError;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -57,11 +65,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-import test.util.Util;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
-import static test.util.Util.TIMEOUT;
+import junit.framework.AssertionFailedError;
+import test.util.Util;
 
 /**
  * Test program for showAndWait functionality.
@@ -126,23 +132,12 @@ public class ShowAndWaitTest {
 
     @BeforeClass
     public static void setupOnce() {
-        // Start the Application
-        new Thread(() -> Application.launch(MyApp.class, (String[])null)).start();
-
-        try {
-            if (!launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS)) {
-                throw new AssertionFailedError("Timeout waiting for Application to launch");
-            }
-        } catch (InterruptedException ex) {
-            AssertionFailedError err = new AssertionFailedError("Unexpected exception");
-            err.initCause(ex);
-            throw err;
-        }
+        Util.launch(launchLatch, 10, MyApp.class);
     }
 
     @AfterClass
     public static void teardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     // Modality of the secondary stage(s) for a particular tests

--- a/tests/system/src/test/java/test/javafx/stage/ShowAndWaitTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/ShowAndWaitTest.java
@@ -132,7 +132,7 @@ public class ShowAndWaitTest {
 
     @BeforeClass
     public static void setupOnce() {
-        Util.launch(launchLatch, 10, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/stage/StageAtTopPositionTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/StageAtTopPositionTest.java
@@ -79,8 +79,8 @@ public class StageAtTopPositionTest {
     }
 
     @BeforeClass
-    public static void initFX() throws Exception {
-        Util.launch(startupLatch, 15, TestApp.class);
+    public static void initFX() {
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/javafx/stage/StageAtTopPositionTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/StageAtTopPositionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,11 @@
 
 package test.javafx.stage;
 
-import com.sun.javafx.PlatformUtil;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
@@ -34,20 +38,18 @@ import javafx.scene.layout.VBox;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import com.sun.javafx.PlatformUtil;
 
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeTrue;
+import test.util.Util;
 
 public class StageAtTopPositionTest {
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static Stage stage;
 
     public static void main(String[] args) throws Exception {
@@ -78,10 +80,12 @@ public class StageAtTopPositionTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        assertTrue("Timeout waiting for FX runtime to start",
-                   startupLatch.await(15, TimeUnit.SECONDS));
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        Util.shutdown(stage);
     }
 
     @Test
@@ -114,11 +118,5 @@ public class StageAtTopPositionTest {
         stage.xProperty().removeListener(listenerY);
 
         Assert.assertEquals("Window was moved twice", minY, stage.getY(), 0.1);
-    }
-
-    @AfterClass
-    public static void teardown() {
-        Platform.runLater(stage::hide);
-        Platform.exit();
     }
 }

--- a/tests/system/src/test/java/test/memoryleak/JSCallbackMemoryTest.java
+++ b/tests/system/src/test/java/test/memoryleak/JSCallbackMemoryTest.java
@@ -25,27 +25,32 @@
 
 package test.memoryleak;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
 import java.lang.ref.WeakReference;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Platform;
 import javafx.concurrent.Worker;
-import javafx.scene.paint.Color;
 import javafx.scene.Scene;
+import javafx.scene.paint.Color;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
-import junit.framework.AssertionFailedError;
-import netscape.javascript.JSObject;
+
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import test.util.Util;
 
-import static org.junit.Assert.*;
-import static test.util.Util.TIMEOUT;
+import junit.framework.AssertionFailedError;
+import netscape.javascript.JSObject;
+import test.util.Util;
 
 public class JSCallbackMemoryTest {
 
@@ -184,13 +189,9 @@ public class JSCallbackMemoryTest {
     public static void doSetupOnce() throws Exception {
 
         Platform.setImplicitExit(false);
-        Platform.startup(() -> {
+        Util.startup(launchLatch, () -> {
             launchLatch.countDown();
         });
-
-        if (!launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS)) {
-            fail("Timeout waiting for Platform to start");
-        }
 
         Util.runAndWait(() -> {
             primarystage = new Stage();
@@ -209,7 +210,7 @@ public class JSCallbackMemoryTest {
 
     @AfterClass
     public static void doTeardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @After

--- a/tests/system/src/test/java/test/renderlock/RenderLockCommon.java
+++ b/tests/system/src/test/java/test/renderlock/RenderLockCommon.java
@@ -121,7 +121,10 @@ public class RenderLockCommon {
 
     @AfterClass
     public static void doTeardownOnce() {
-        Util.shutdown();
+        // see doSetupOnce() assumeTrue condition
+        if (myApp != null) {
+            Util.shutdown();
+        }
     }
 
     // ========================== TEST CASES ==========================

--- a/tests/system/src/test/java/test/renderlock/RenderLockCommon.java
+++ b/tests/system/src/test/java/test/renderlock/RenderLockCommon.java
@@ -115,7 +115,7 @@ public class RenderLockCommon {
         // focusLost event with the lock held
         assumeTrue(PlatformUtil.isMac() || PlatformUtil.isWindows());
 
-        Util.launch(launchLatch, 10, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 

--- a/tests/system/src/test/java/test/renderlock/RenderLockCommon.java
+++ b/tests/system/src/test/java/test/renderlock/RenderLockCommon.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,18 @@
 
 package test.renderlock;
 
-import com.sun.javafx.PlatformUtil;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+import static test.util.Util.TIMEOUT;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+
 import javafx.animation.FillTransition;
 import javafx.animation.Timeline;
 import javafx.application.Application;
@@ -43,14 +51,13 @@ import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
 import javafx.stage.Stage;
 import javafx.util.Duration;
-import junit.framework.AssertionFailedError;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import test.util.Util;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.*;
-import static test.util.Util.TIMEOUT;
+import com.sun.javafx.PlatformUtil;
+
+import test.util.Util;
 
 /**
  * Common base class for testing snapshot.
@@ -108,19 +115,13 @@ public class RenderLockCommon {
         // focusLost event with the lock held
         assumeTrue(PlatformUtil.isMac() || PlatformUtil.isWindows());
 
-        // Start the Application
-        new Thread(() -> Application.launch(MyApp.class, (String[])null)).start();
-
-        if (!launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS)) {
-            fail("Timeout waiting for Application to launch");
-        }
-
+        Util.launch(launchLatch, 10, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 
     @AfterClass
     public static void doTeardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     // ========================== TEST CASES ==========================

--- a/tests/system/src/test/java/test/robot/javafx/application/KeyLockedTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/application/KeyLockedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,22 +25,26 @@
 
 package test.robot.javafx.application;
 
-import com.sun.javafx.PlatformUtil;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import javafx.application.Platform;
 import javafx.scene.input.KeyCode;
 import javafx.scene.robot.Robot;
-import test.util.Util;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
-import static org.junit.Assume.assumeTrue;
+import com.sun.javafx.PlatformUtil;
+
+import test.util.Util;
 
 /**
  * Test program for Platform::isKeyLocked.
@@ -54,9 +58,7 @@ public class KeyLockedTest {
     @BeforeClass
     public static void initFX() throws Exception {
         Platform.setImplicitExit(false);
-        Platform.startup(startupLatch::countDown);
-        assertTrue("Timeout waiting for FX runtime to start",
-                startupLatch.await(15, TimeUnit.SECONDS));
+        Util.startup(startupLatch, startupLatch::countDown);
 
         if (PlatformUtil.isWindows()) {
             Util.runAndWait(() -> robot = new Robot());
@@ -77,7 +79,7 @@ public class KeyLockedTest {
                 });
             });
         }
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Test(expected = IllegalStateException.class)

--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodeBase.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodeBase.java
@@ -70,7 +70,7 @@ public class SwingNodeBase {
         robot.setAutoDelay(100);
 
         // Start the Application
-        Util.launch(launchLatch, 10, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
 
         CountDownLatch paintLatch = new CountDownLatch(1);
         SwingUtilities.invokeAndWait(()->{

--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodeBase.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/SwingNodeBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,31 +25,30 @@
 
 package test.robot.javafx.embed.swing;
 
-import javafx.application.Application;
-import javafx.application.Platform;
-import javafx.embed.swing.SwingNode;
-import javafx.scene.Scene;
-import javafx.scene.layout.VBox;
-import javafx.stage.Stage;
-import junit.framework.AssertionFailedError;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import test.util.Util;
-
-import javax.swing.JDialog;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.SwingUtilities;
 import java.awt.AWTException;
 import java.awt.Frame;
 import java.awt.Robot;
 import java.awt.event.InputEvent;
 import java.lang.reflect.InvocationTargetException;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
-import static test.util.Util.TIMEOUT;
+import javax.swing.JDialog;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.embed.swing.SwingNode;
+import javafx.scene.Scene;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+
+import test.util.Util;
 
 public class SwingNodeBase {
     public static final int BASE_LOCATION = 200;
@@ -71,17 +70,7 @@ public class SwingNodeBase {
         robot.setAutoDelay(100);
 
         // Start the Application
-        new Thread(() -> Application.launch(MyApp.class, (String[])null)).start();
-
-        try {
-            if (!launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS)) {
-                throw new AssertionFailedError("Timeout waiting for Application to launch");
-            }
-        } catch (InterruptedException ex) {
-            AssertionFailedError err = new AssertionFailedError("Unexpected exception");
-            err.initCause(ex);
-            throw err;
-        }
+        Util.launch(launchLatch, 10, MyApp.class);
 
         CountDownLatch paintLatch = new CountDownLatch(1);
         SwingUtilities.invokeAndWait(()->{
@@ -93,9 +82,7 @@ public class SwingNodeBase {
 
     @AfterClass
     public static void teardownOnce() {
-        Platform.runLater(() -> {
-            Platform.exit();
-        });
+        Util.shutdown();
     }
 
     public static void runWaitSleep(Runnable run) {

--- a/tests/system/src/test/java/test/robot/javafx/scene/AfterModalClosedTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/AfterModalClosedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,11 @@
  */
 package test.robot.javafx.scene;
 
-import com.sun.javafx.PlatformUtil;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -34,16 +38,15 @@ import javafx.scene.robot.Robot;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import com.sun.javafx.PlatformUtil;
 
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+import test.util.Util;
 
 public class AfterModalClosedTest {
     static CountDownLatch startupLatch;
@@ -78,16 +81,17 @@ public class AfterModalClosedTest {
     }
 
     @BeforeClass
-    public static void initFX() {
+    public static void initFX() throws InterruptedException {
         startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        try {
-            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
-                fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            fail("Unexpected exception: " + ex);
-        }
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        Platform.runLater(() -> {
+            Util.hide(stage);
+            Platform.exit();
+        });
     }
 
     @Test
@@ -122,11 +126,5 @@ public class AfterModalClosedTest {
         });
         resizeLatch.await(5, TimeUnit.SECONDS);
         Assert.assertTrue("Window is not resized", w && h);
-    }
-
-    @AfterClass
-    public static void teardown() {
-        Platform.runLater(stage::hide);
-        Platform.exit();
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/AfterModalClosedTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/AfterModalClosedTest.java
@@ -49,7 +49,7 @@ import com.sun.javafx.PlatformUtil;
 import test.util.Util;
 
 public class AfterModalClosedTest {
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static volatile Stage stage;
     private Robot robot;
     private int x, y;
@@ -82,8 +82,7 @@ public class AfterModalClosedTest {
 
     @BeforeClass
     public static void initFX() throws InterruptedException {
-        startupLatch = new CountDownLatch(1);
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/scene/AfterModalClosedTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/AfterModalClosedTest.java
@@ -88,10 +88,7 @@ public class AfterModalClosedTest {
 
     @AfterClass
     public static void teardown() {
-        Platform.runLater(() -> {
-            Util.hide(stage);
-            Platform.exit();
-        });
+        Util.shutdown(stage);
     }
 
     @Test

--- a/tests/system/src/test/java/test/robot/javafx/scene/ColorPickerTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ColorPickerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -171,16 +171,15 @@ public class ColorPickerTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        waitForLatch(startupLatch, 10, "FX runtime failed to start.");
+        Util.launch(startupLatch, 10, TestApp.class);
     }
 
     @AfterClass
     public static void exit() {
         Platform.runLater(() -> {
-            stage.hide();
+            Util.hide(stage);
+            Platform.exit();
         });
-        Platform.exit();
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/ColorPickerTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ColorPickerTest.java
@@ -176,10 +176,7 @@ public class ColorPickerTest {
 
     @AfterClass
     public static void exit() {
-        Platform.runLater(() -> {
-            Util.hide(stage);
-            Platform.exit();
-        });
+        Util.shutdown(stage);
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/ColorPickerTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ColorPickerTest.java
@@ -171,7 +171,7 @@ public class ColorPickerTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        Util.launch(startupLatch, 10, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/scene/ColorPickerTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ColorPickerTest.java
@@ -77,7 +77,7 @@ public class ColorPickerTest {
         mouseClick(colorPicker.getLayoutX() + colorPicker.getWidth() - 15,
                     colorPicker.getLayoutY() + colorPicker.getHeight() / 2);
         Thread.sleep(400); // ColorPicker takes some time to display the color palette.
-        waitForLatch(onShownLatch, 10, "Failed to show color palette.");
+        Util.waitForLatch(onShownLatch, 10, "Failed to show color palette.");
     }
 
     private void clickColorPickerPalette(int yFactor) throws Exception {
@@ -85,7 +85,7 @@ public class ColorPickerTest {
         mouseClick(colorPicker.getLayoutX() + colorPicker.getWidth() / 2,
                     colorPicker.getLayoutY() + colorPicker.getHeight() * yFactor);
         Thread.sleep(400);
-        waitForLatch(onActionLatch, 10, "Failed to receive onAction callback.");
+        Util.waitForLatch(onActionLatch, 10, "Failed to receive onAction callback.");
     }
 
     // This test is for verifying a specific behavior.
@@ -110,7 +110,7 @@ public class ColorPickerTest {
             colorPicker.show();
             root.getChildren().add(colorPicker);
         });
-        waitForLatch(onShownLatch, 10, "Failed to show color palette.");
+        Util.waitForLatch(onShownLatch, 10, "Failed to show color palette.");
         Thread.sleep(400); // ColorPicker takes some time to display the color palette.
         // 2.
         Assert.assertEquals("ColorPicker palette should be shown once.", 1, onShownCount);
@@ -193,9 +193,5 @@ public class ColorPickerTest {
             stage.setAlwaysOnTop(true);
             stage.show();
         }
-    }
-
-    public static void waitForLatch(CountDownLatch latch, int seconds, String msg) throws Exception {
-        Assert.assertTrue("Timeout: " + msg, latch.await(seconds, TimeUnit.SECONDS));
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/ComboBoxTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ComboBoxTest.java
@@ -187,10 +187,7 @@ public class ComboBoxTest {
 
     @AfterClass
     public static void exit() {
-        Platform.runLater(() -> {
-            Util.hide(stage);
-            Platform.exit();
-        });
+        Util.shutdown(stage);
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/ComboBoxTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ComboBoxTest.java
@@ -25,7 +25,6 @@
 package test.robot.javafx.scene;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -101,7 +100,7 @@ public class ComboBoxTest {
 
         for (int i = 0; i < ITEM_COUNT; i++) {
             Thread.sleep(300); // ComboBox is removed and added back. Time for layout.
-            waitForLatch(showLatch, 10, "Failed to show ComboBox popup list. " + i);
+            Util.waitForLatch(showLatch, 10, "Failed to show ComboBox popup list. " + i);
             showLatch = new CountDownLatch(1);
             selectedLatch = new CountDownLatch(1);
             final int k = i;
@@ -109,7 +108,7 @@ public class ComboBoxTest {
             mouseClick(comboBox.getLayoutX() + comboBox.getWidth() / 2,
                         comboBox.getLayoutY() + comboBox.getHeight() * (k + 1.2f));
 
-            waitForLatch(selectedLatch, 10, "Failed to select " + i + "th choice.");
+            Util.waitForLatch(selectedLatch, 10, "Failed to select " + i + "th choice.");
         }
         Assert.assertEquals("ComboBox popup list should have been displayed " +
             (ITEM_COUNT + 1) + " times.", (ITEM_COUNT + 1), onShownCount);
@@ -146,13 +145,13 @@ public class ComboBoxTest {
                     comboBox.getLayoutY() + comboBox.getHeight() / 2);
 
             Thread.sleep(200); // ComboBox takes some time to display the popup list.
-            waitForLatch(showLatch, 10, "Failed to show ComboBox popup list. " + i);
+            Util.waitForLatch(showLatch, 10, "Failed to show ComboBox popup list. " + i);
             final int k = i;
             // Select a choice.
             mouseClick(comboBox.getLayoutX() + comboBox.getWidth() / 2,
                         comboBox.getLayoutY() + comboBox.getHeight() * (k + 1.2f));
 
-            waitForLatch(selectedLatch, 10, "Failed to select " + i + "th choice.");
+            Util.waitForLatch(selectedLatch, 10, "Failed to select " + i + "th choice.");
         }
         Assert.assertEquals("ComboBox popup list should be displayed " +
             ITEM_COUNT + " times.", ITEM_COUNT, onShownCount);
@@ -204,9 +203,5 @@ public class ComboBoxTest {
             stage.setAlwaysOnTop(true);
             stage.show();
         }
-    }
-
-    public static void waitForLatch(CountDownLatch latch, int seconds, String msg) throws Exception {
-        Assert.assertTrue("Timeout: " + msg, latch.await(seconds, TimeUnit.SECONDS));
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/ComboBoxTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ComboBoxTest.java
@@ -181,7 +181,7 @@ public class ComboBoxTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        Util.launch(startupLatch, 10, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/scene/ComboBoxTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ComboBoxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,20 +24,20 @@
  */
 package test.robot.javafx.scene;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.beans.value.ChangeListener;
+import javafx.scene.Scene;
 import javafx.scene.control.ComboBox;
 import javafx.scene.input.MouseButton;
 import javafx.scene.layout.VBox;
 import javafx.scene.robot.Robot;
-import javafx.scene.Scene;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.WindowEvent;
-
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -45,7 +45,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.fail;
 
 import test.util.Util;
 
@@ -183,16 +182,15 @@ public class ComboBoxTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        waitForLatch(startupLatch, 10, "FX runtime failed to start.");
+        Util.launch(startupLatch, 10, TestApp.class);
     }
 
     @AfterClass
     public static void exit() {
-        Util.runAndWait(() -> {
-            stage.hide();
+        Platform.runLater(() -> {
+            Util.hide(stage);
+            Platform.exit();
         });
-        Platform.exit();
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/DatePickerTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/DatePickerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,10 @@
  */
 package test.robot.javafx.scene;
 
-import com.sun.javafx.PlatformUtil;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -36,17 +39,14 @@ import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.WindowEvent;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+
+import com.sun.javafx.PlatformUtil;
 
 import test.util.Util;
 
@@ -79,7 +79,7 @@ public class DatePickerTest {
         mouseClick(datePicker.getLayoutX() + datePicker.getWidth() - 15,
                     datePicker.getLayoutY() + datePicker.getHeight() / 2);
         Thread.sleep(400); // DatePicker takes some time to display the calendar popup.
-        waitForLatch(onShownLatch, 10, "Failed to show Calendar popup.");
+        Util.waitForLatch(onShownLatch, 10, "Failed to show Calendar popup.");
     }
 
     private void clickDatePickerCalendarPopup(int yFactor) throws Exception {
@@ -87,7 +87,7 @@ public class DatePickerTest {
         mouseClick(datePicker.getLayoutX() + datePicker.getWidth() / 2,
                     datePicker.getLayoutY() + datePicker.getHeight() * yFactor);
         Thread.sleep(400);
-        waitForLatch(onActionLatch, 10, "Failed to receive onAction call.");
+        Util.waitForLatch(onActionLatch, 10, "Failed to receive onAction call.");
     }
 
     // This test is for verifying a specific behavior.
@@ -114,7 +114,7 @@ public class DatePickerTest {
             datePicker.show();
             root.getChildren().add(datePicker);
         });
-        waitForLatch(onShownLatch, 10, "Failed to show calendar popup.");
+        Util.waitForLatch(onShownLatch, 10, "Failed to show calendar popup.");
         Thread.sleep(400); // DatePicker takes some time to display the calendar popup.
         // 2.
         Assert.assertEquals("DatePicker calendar popup should be shown once.", 1, onShownCount);
@@ -175,16 +175,15 @@ public class DatePickerTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        waitForLatch(startupLatch, 10, "FX runtime failed to start.");
+        Util.launch(startupLatch, 10, TestApp.class);
     }
 
     @AfterClass
     public static void exit() {
         Platform.runLater(() -> {
-            stage.hide();
+            Util.hide(stage);
+            Platform.exit();
         });
-        Platform.exit();
     }
 
     public static class TestApp extends Application {
@@ -201,9 +200,5 @@ public class DatePickerTest {
             stage.setAlwaysOnTop(true);
             stage.show();
         }
-    }
-
-    public static void waitForLatch(CountDownLatch latch, int seconds, String msg) throws Exception {
-        Assert.assertTrue("Timeout: " + msg, latch.await(seconds, TimeUnit.SECONDS));
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/DatePickerTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/DatePickerTest.java
@@ -175,7 +175,7 @@ public class DatePickerTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        Util.launch(startupLatch, 10, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/scene/DatePickerTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/DatePickerTest.java
@@ -180,10 +180,7 @@ public class DatePickerTest {
 
     @AfterClass
     public static void exit() {
-        Platform.runLater(() -> {
-            Util.hide(stage);
-            Platform.exit();
-        });
+        Util.shutdown(stage);
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/DoubleShortcutProcessingTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/DoubleShortcutProcessingTest.java
@@ -77,10 +77,7 @@ public class DoubleShortcutProcessingTest {
 
     @AfterAll
     static void exit() {
-        Platform.runLater(() -> {
-            Util.hide(stage);
-            Platform.exit();
-        });
+        Util.shutdown(stage);
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/DoubleShortcutProcessingTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/DoubleShortcutProcessingTest.java
@@ -72,7 +72,7 @@ public class DoubleShortcutProcessingTest {
 
     @BeforeAll
     static void initFX() throws Exception {
-        Util.launch(startupLatch, 10, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterAll

--- a/tests/system/src/test/java/test/robot/javafx/scene/DoubleShortcutProcessingTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/DoubleShortcutProcessingTest.java
@@ -25,10 +25,20 @@
 
 package test.robot.javafx.scene;
 
-import com.sun.javafx.PlatformUtil;
-
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.VBox;
+import javafx.scene.robot.Robot;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -36,18 +46,9 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import javafx.application.Application;
-import javafx.application.Platform;
-import javafx.scene.Parent;
-import javafx.scene.Scene;
-import javafx.scene.control.Label;
-import javafx.scene.input.KeyEvent;
-import javafx.scene.input.KeyCode;
-import javafx.scene.layout.VBox;
-import javafx.scene.robot.Robot;
-import javafx.stage.Modality;
-import javafx.stage.Stage;
-import javafx.stage.StageStyle;
+import com.sun.javafx.PlatformUtil;
+
+import test.util.Util;
 
 // When a key equivalent closes a window it can be passed
 // to the new key window and processed twice.
@@ -63,7 +64,7 @@ public class DoubleShortcutProcessingTest {
     void testDoubleShortcut() {
         Assumptions.assumeTrue(PlatformUtil.isMac());
         testApp.startTest();
-        waitForLatch(dialogLatch, 5, "Dialog never received shortcut");
+        Util.waitForLatch(dialogLatch, 5, "Dialog never received shortcut");
         if (testApp.failed()) {
             Assertions.fail("performKeyEquivalent was handled twice in separate windows");
         }
@@ -71,14 +72,15 @@ public class DoubleShortcutProcessingTest {
 
     @BeforeAll
     static void initFX() throws Exception {
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        waitForLatch(startupLatch, 10, "FX runtime failed to start.");
+        Util.launch(startupLatch, 10, TestApp.class);
     }
 
     @AfterAll
     static void exit() {
-        Platform.runLater(stage::hide);
-        Platform.exit();
+        Platform.runLater(() -> {
+            Util.hide(stage);
+            Platform.exit();
+        });
     }
 
     public static class TestApp extends Application {
@@ -150,16 +152,6 @@ public class DoubleShortcutProcessingTest {
                 this.initOwner(owner);
                 this.setResizable(true);
             }
-        }
-    }
-
-    private static void waitForLatch(CountDownLatch latch, int seconds, String msg) {
-        try {
-            if (!latch.await(seconds, TimeUnit.SECONDS)) {
-                Assertions.fail(msg);
-            }
-        } catch (Exception ex) {
-            Assertions.fail("Unexpected exception: " + ex);
         }
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
@@ -26,22 +26,23 @@
 package test.robot.javafx.scene;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
-import javafx.application.Platform;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.robot.Robot;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
 import test.util.Util;
 
 
 public class MouseLocationOnScreenTest {
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static Robot robot;
     private static int DELAY_TIME = 1;
 
@@ -56,17 +57,12 @@ public class MouseLocationOnScreenTest {
 
     @BeforeClass
     public static void initFX() {
-        startupLatch = new CountDownLatch(1);
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
 
-        new Thread(() -> Application.launch(TestApp.class, (String[]) null))
-                .start();
-        try {
-            if (!startupLatch.await(15, TimeUnit.SECONDS)) {
-                Assert.fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            Assert.fail("Unexpected exception: " + ex);
-        }
+    @AfterClass
+    public static void teardown() {
+        Util.shutdown();
     }
 
     @Test(timeout = 120000)
@@ -116,11 +112,6 @@ public class MouseLocationOnScreenTest {
         Util.runAndWait(() -> {
             cross(robot, x1, y2, x2, y1); // cross left-top
         });
-    }
-
-    @AfterClass
-    public static void teardown() {
-        Platform.exit();
     }
 
     /**

--- a/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/MouseLocationOnScreenTest.java
@@ -57,7 +57,7 @@ public class MouseLocationOnScreenTest {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/scene/PixelBufferDrawTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/PixelBufferDrawTest.java
@@ -287,7 +287,7 @@ public class PixelBufferDrawTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        Util.launch(startupLatch, 10, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/scene/PixelBufferDrawTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/PixelBufferDrawTest.java
@@ -25,21 +25,7 @@
 
 package test.robot.javafx.scene;
 
-import javafx.application.Application;
-import javafx.application.Platform;
-import javafx.geometry.Rectangle2D;
-import javafx.scene.robot.Robot;
-import javafx.scene.Scene;
-import javafx.scene.image.ImageView;
-import javafx.scene.image.PixelBuffer;
-import javafx.scene.image.PixelFormat;
-import javafx.scene.image.WritableImage;
-import javafx.scene.layout.HBox;
-import javafx.scene.paint.Color;
-import javafx.stage.Stage;
-import javafx.stage.StageStyle;
-import javafx.stage.WindowEvent;
-import javafx.util.Callback;
+import static org.junit.Assert.fail;
 
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
@@ -48,13 +34,27 @@ import java.nio.IntBuffer;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.geometry.Rectangle2D;
+import javafx.scene.Scene;
+import javafx.scene.image.ImageView;
+import javafx.scene.image.PixelBuffer;
+import javafx.scene.image.PixelFormat;
+import javafx.scene.image.WritableImage;
+import javafx.scene.layout.HBox;
+import javafx.scene.paint.Color;
+import javafx.scene.robot.Robot;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+import javafx.stage.WindowEvent;
+import javafx.util.Callback;
+
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.After;
 import org.junit.Test;
-
-import static org.junit.Assert.fail;
 
 import test.util.Util;
 
@@ -87,7 +87,7 @@ public class PixelBufferDrawTest {
     private static Stage stage;
     private static Scene scene;
     private static Robot robot;
-    private static CountDownLatch startupLatch;
+    private static CountDownLatch startupLatch = new CountDownLatch(1);
 
     private static final int DELAY = 500;
     private static final int NUM_IMAGES = 4;
@@ -288,9 +288,12 @@ public class PixelBufferDrawTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
-        waitForLatch(startupLatch, 10, "Timeout waiting for FX runtime to start");
+        Util.launch(startupLatch, 10, TestApp.class);
+    }
+
+    @AfterClass
+    public static void exit() {
+        Util.shutdown(stage);
     }
 
     @After
@@ -300,12 +303,6 @@ public class PixelBufferDrawTest {
             scene = new Scene(root, SCENE_WIDTH, SCENE_HEIGHT);
             stage.setScene(scene);
         });
-    }
-
-    @AfterClass
-    public static void exit() {
-        Platform.runLater(() -> stage.hide());
-        Platform.exit();
     }
 
     private static void delay() {

--- a/tests/system/src/test/java/test/robot/javafx/scene/PixelBufferDrawTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/PixelBufferDrawTest.java
@@ -32,7 +32,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.IntBuffer;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -311,9 +310,5 @@ public class PixelBufferDrawTest {
         } catch (Exception ex) {
             fail("Thread was interrupted." + ex);
         }
-    }
-
-    public static void waitForLatch(CountDownLatch latch, int seconds, String msg) throws Exception {
-        Assert.assertTrue(msg, latch.await(seconds, TimeUnit.SECONDS));
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
@@ -182,7 +182,7 @@ public class RobotTest {
             });
             stage.setScene(scene);
         });
-        waitForLatch(setSceneLatch, 5, "Timeout while waiting for scene to be set on stage.");
+        Util.waitForLatch(setSceneLatch, 5, "Timeout while waiting for scene to be set on stage.");
         Util.runAndWait(() -> {
             int mouseX = (int) (scene.getWindow().getX() + scene.getX() +
                     textField.getLayoutX() + textField.getLayoutBounds().getWidth() / 2);
@@ -200,7 +200,7 @@ public class RobotTest {
                     break;
             }
         });
-        waitForLatch(keyActionLatch, 5, "Timeout while waiting for textField.onKey" +
+        Util.waitForLatch(keyActionLatch, 5, "Timeout while waiting for textField.onKey" +
                 capFirst(keyAction.name()) + "().");
         Assert.assertEquals("letter 'a' should be " + keyAction.name().toLowerCase() +
                 " by Robot", "a", textField.getText());
@@ -271,7 +271,7 @@ public class RobotTest {
             });
             stage.setScene(scene);
         });
-        waitForLatch(setSceneLatch, 5, "Timeout while waiting for scene to be set on stage.");
+        Util.waitForLatch(setSceneLatch, 5, "Timeout while waiting for scene to be set on stage.");
         AtomicReference<Point2D> mousePosition = new AtomicReference<>();
         Util.runAndWait(() -> {
             if (primitiveArg) {
@@ -412,7 +412,7 @@ public class RobotTest {
             });
             stage.setScene(scene);
         });
-        waitForLatch(setSceneLatch, 5, "Timeout while waiting for scene to be set on stage.");
+        Util.waitForLatch(setSceneLatch, 5, "Timeout while waiting for scene to be set on stage.");
         int mouseX = (int) (scene.getWindow().getX() + scene.getX() +
                 button.getLayoutX() + button.getLayoutBounds().getWidth() / 2);
         int mouseY = (int) (scene.getWindow().getY() + scene.getY() +
@@ -430,7 +430,7 @@ public class RobotTest {
                     break;
             }
         });
-        waitForLatch(onClickLatch, 5, "Timeout while waiting for button.onMouse" +
+        Util.waitForLatch(onClickLatch, 5, "Timeout while waiting for button.onMouse" +
                 capFirst(mouseAction.name()) + "().");
         Assert.assertEquals(mouseButton + " mouse button should be " + mouseAction.name().toLowerCase() + " by Robot",
                 expectedText, button.getText());
@@ -553,7 +553,7 @@ public class RobotTest {
             });
             stage.setScene(scene);
         });
-        waitForLatch(setSceneLatch, 5, "Timeout while waiting for scene to be set on stage.");
+        Util.waitForLatch(setSceneLatch, 5, "Timeout while waiting for scene to be set on stage.");
         Util.runAndWait(() -> {
             int mouseX = (int) (scene.getWindow().getX() + scene.getX() +
                     label.getLayoutX() + label.getLayoutBounds().getWidth() / 2);
@@ -566,7 +566,7 @@ public class RobotTest {
             }
             robot.mouseRelease(mouseButton);
         });
-        waitForLatch(mouseDragLatch, 5, "Timeout while waiting for button.onMouseDragged().");
+        Util.waitForLatch(mouseDragLatch, 5, "Timeout while waiting for button.onMouseDragged().");
     }
 
     @Test
@@ -614,7 +614,7 @@ public class RobotTest {
             });
             stage.setScene(scene);
         });
-        waitForLatch(setSceneLatch, 5, "Timeout while waiting for scene to be set on stage.");
+        Util.waitForLatch(setSceneLatch, 5, "Timeout while waiting for scene to be set on stage.");
         Util.runAndWait(() -> {
             int mouseX = (int) (scene.getWindow().getX() + scene.getX() +
                     button.getLayoutX() + button.getLayoutBounds().getWidth() / 2);
@@ -623,7 +623,7 @@ public class RobotTest {
             robot.mouseMove(mouseX, mouseY);
             robot.mouseWheel(amount);
         });
-        waitForLatch(onScrollLatch, 5, "Timeout while waiting for button.onScroll().");
+        Util.waitForLatch(onScrollLatch, 5, "Timeout while waiting for button.onScroll().");
         Assert.assertEquals("mouse wheel should be scrolled " + amount + " vertical units by Robot",
                 "Scrolled " + amount, button.getText());
     }
@@ -662,7 +662,7 @@ public class RobotTest {
             });
             stage.setScene(scene);
         });
-        waitForLatch(setSceneLatch, 5, "Timeout while waiting for scene to be set on stage.");
+        Util.waitForLatch(setSceneLatch, 5, "Timeout while waiting for scene to be set on stage.");
         AtomicReference<Color> captureColor = new AtomicReference<>();
         Thread.sleep(1000);
         Util.runAndWait(() -> {
@@ -692,7 +692,7 @@ public class RobotTest {
             });
             stage.setScene(scene);
         });
-        waitForLatch(setSceneLatch, 5, "Timeout while waiting for scene to be set on stage.");
+        Util.waitForLatch(setSceneLatch, 5, "Timeout while waiting for scene to be set on stage.");
         AtomicReference<Color> captureColor = new AtomicReference<>();
         Thread.sleep(1000);
         Util.runAndWait(() -> {
@@ -743,7 +743,7 @@ public class RobotTest {
             });
             stage.setScene(scene);
         });
-        waitForLatch(setSceneLatch, 5, "Timeout while waiting for scene to be set on stage.");
+        Util.waitForLatch(setSceneLatch, 5, "Timeout while waiting for scene to be set on stage.");
         AtomicReference<WritableImage> screenCaptureNotScaledToFit = new AtomicReference<>();
         AtomicReference<WritableImage> screenCaptureScaledToFit = new AtomicReference<>();
         Thread.sleep(1000);
@@ -831,16 +831,6 @@ public class RobotTest {
             }
             robot.keyRelease(KeyCode.A);
         });
-    }
-
-    private static void waitForLatch(CountDownLatch latch, int seconds, String msg) {
-        try {
-            if (!latch.await(seconds, TimeUnit.SECONDS)) {
-                fail(msg);
-            }
-        } catch (Exception ex) {
-            fail("Unexpected exception: " + ex);
-        }
     }
 
     private static void assertColorEquals(Color expected, Color actual, double delta) {

--- a/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
@@ -814,7 +814,7 @@ public class RobotTest {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 10, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
@@ -24,13 +24,15 @@
  */
 package test.robot.javafx.scene;
 
+import static javafx.scene.paint.Color.MAGENTA;
+import static org.junit.Assert.fail;
+
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.sun.javafx.PlatformUtil;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
@@ -65,11 +67,11 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import com.sun.javafx.PlatformUtil;
+
 import junit.framework.AssertionFailedError;
 import test.util.Util;
-
-import static javafx.scene.paint.Color.MAGENTA;
-import static org.junit.Assert.fail;
 
 /**
  * Tests to verify that the native robot implementations all work correctly.
@@ -812,14 +814,12 @@ public class RobotTest {
 
     @BeforeClass
     public static void initFX() {
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        waitForLatch(startupLatch, 10, "Timeout waiting for FX runtime to start");
+        Util.launch(startupLatch, 10, TestApp.class);
     }
 
     @AfterClass
     public static void exit() {
-        Platform.runLater(() -> stage.hide());
-        Platform.exit();
+        Util.shutdown(stage);
     }
 
     @After

--- a/tests/system/src/test/java/test/robot/javafx/scene/SceneChangeEventsTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/SceneChangeEventsTest.java
@@ -89,7 +89,7 @@ public class SceneChangeEventsTest {
         Platform.runLater(() -> {
             stage.setScene(scene);
         });
-        waitForLatch(setSceneLatch, 5, "Timeout while waiting for scene to be set on stage.");
+        Util.waitForLatch(setSceneLatch, 5, "Timeout while waiting for scene to be set on stage.");
 
         scene.setOnMouseExited(event -> {
             mouseExited = true;
@@ -104,7 +104,7 @@ public class SceneChangeEventsTest {
             robot.mousePress(MouseButton.PRIMARY);
             robot.mouseRelease(MouseButton.PRIMARY);
         });
-        waitForLatch(onActionLatch, 5, "Timeout while waiting for button.onAction().");
+        Util.waitForLatch(onActionLatch, 5, "Timeout while waiting for button.onAction().");
 
         Assert.assertTrue("MOUSE_EXITED should be received when scene is " +
             " changed.", mouseExited);
@@ -135,15 +135,5 @@ public class SceneChangeEventsTest {
     @AfterClass
     public static void exit() {
         Util.shutdown(stage);
-    }
-
-    public static void waitForLatch(CountDownLatch latch, int seconds, String msg) {
-        try {
-            if (!latch.await(seconds, TimeUnit.SECONDS)) {
-                fail(msg);
-            }
-        } catch (Exception ex) {
-            fail("Unexpected exception: " + ex);
-        }
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/SceneChangeEventsTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/SceneChangeEventsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,11 @@
 
 package test.robot.javafx.scene;
 
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -36,14 +41,12 @@ import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.WindowEvent;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.fail;
+
+import test.util.Util;
 
 /*
  * Test to verify the events when scene of stage is changed.
@@ -56,7 +59,7 @@ import static org.junit.Assert.fail;
  */
 
 public class SceneChangeEventsTest {
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static Robot robot;
     static volatile Stage stage;
     boolean mouseExited = false;
@@ -126,17 +129,12 @@ public class SceneChangeEventsTest {
 
     @BeforeClass
     public static void initFX() {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        waitForLatch(startupLatch, 10, "Timeout waiting for FX runtime to start");
+        Util.launch(startupLatch, 10, TestApp.class);
     }
 
     @AfterClass
     public static void exit() {
-        Platform.runLater(() -> {
-            stage.hide();
-        });
-        Platform.exit();
+        Util.shutdown(stage);
     }
 
     public static void waitForLatch(CountDownLatch latch, int seconds, String msg) {

--- a/tests/system/src/test/java/test/robot/javafx/scene/SceneChangeEventsTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/SceneChangeEventsTest.java
@@ -129,7 +129,7 @@ public class SceneChangeEventsTest {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 10, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/scene/TabContextMenuCloseButtonTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TabContextMenuCloseButtonTest.java
@@ -24,10 +24,7 @@
  */
 package test.robot.javafx.scene;
 
-import static org.junit.Assert.fail;
-
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -104,7 +101,7 @@ public class TabContextMenuCloseButtonTest {
             robot.mousePress(MouseButton.SECONDARY);
             robot.mouseRelease(MouseButton.SECONDARY);
         });
-        waitForLatch(cmlatch, 5, "Timeout waiting for ContextMenu to be shown.");
+        Util.waitForLatch(cmlatch, 5, "Timeout waiting for ContextMenu to be shown.");
     }
 
     @After
@@ -149,16 +146,6 @@ public class TabContextMenuCloseButtonTest {
                     Platform.runLater(startupLatch::countDown));
             stage.setAlwaysOnTop(true);
             stage.show();
-        }
-    }
-
-    public static void waitForLatch(CountDownLatch latch, int seconds, String msg) {
-        try {
-            if (!latch.await(seconds, TimeUnit.SECONDS)) {
-                fail(msg);
-            }
-        } catch (Exception ex) {
-            fail("Unexpected exception: " + ex);
         }
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/TabContextMenuCloseButtonTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TabContextMenuCloseButtonTest.java
@@ -123,7 +123,7 @@ public class TabContextMenuCloseButtonTest {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 10, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/scene/TabContextMenuCloseButtonTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TabContextMenuCloseButtonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,11 @@
  */
 package test.robot.javafx.scene;
 
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -37,16 +42,12 @@ import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.WindowEvent;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.fail;
 
 import test.util.Util;
 
@@ -125,16 +126,12 @@ public class TabContextMenuCloseButtonTest {
 
     @BeforeClass
     public static void initFX() {
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        waitForLatch(startupLatch, 10, "Timeout waiting for FX runtime to start");
+        Util.launch(startupLatch, 10, TestApp.class);
     }
 
     @AfterClass
     public static void exit() {
-        Platform.runLater(() -> {
-            stage.hide();
-        });
-        Platform.exit();
+        Util.shutdown(stage);
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/TabPaneDragPolicyTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TabPaneDragPolicyTest.java
@@ -348,7 +348,7 @@ public class TabPaneDragPolicyTest {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 10, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/scene/TabPaneDragPolicyTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TabPaneDragPolicyTest.java
@@ -268,14 +268,14 @@ public class TabPaneDragPolicyTest {
             robot.mousePress(MouseButton.PRIMARY);
             robot.mouseRelease(MouseButton.PRIMARY);
         });
-        waitForLatch(latches[0], 5, "Timeout waiting tabs[0] to get selected.");
+        Util.waitForLatch(latches[0], 5, "Timeout waiting tabs[0] to get selected.");
 
         CountDownLatch pressLatch = new CountDownLatch(1);
         Platform.runLater(() -> {
             robot.mousePress(MouseButton.PRIMARY);
             pressLatch.countDown();
         });
-        waitForLatch(pressLatch, 5, "Timeout waiting for robot.mousePress(Robot.MOUSE_LEFT_BTN).");
+        Util.waitForLatch(pressLatch, 5, "Timeout waiting for robot.mousePress(Robot.MOUSE_LEFT_BTN).");
         for (int i = 0; i < DRAG_DISTANCE; i++) {
             final int c = i;
             CountDownLatch moveLatch = new CountDownLatch(1);
@@ -291,7 +291,7 @@ public class TabPaneDragPolicyTest {
                 }
                 moveLatch.countDown();
             });
-            waitForLatch(moveLatch, 5, "Timeout waiting for robot.mouseMove(023).");
+            Util.waitForLatch(moveLatch, 5, "Timeout waiting for robot.mouseMove(023).");
         }
 
         CountDownLatch releaseLatch = new CountDownLatch(1);
@@ -299,11 +299,11 @@ public class TabPaneDragPolicyTest {
             robot.mouseRelease(MouseButton.PRIMARY);
             releaseLatch.countDown();
         });
-        waitForLatch(releaseLatch, 5, "Timeout waiting for robot.mouseRelease(Robot.MOUSE_LEFT_BTN).");
+        Util.waitForLatch(releaseLatch, 5, "Timeout waiting for robot.mouseRelease(Robot.MOUSE_LEFT_BTN).");
 
         if (isFixed) {
             Util.runAndWait(() -> tabPane.getSelectionModel().select(tabs[2]));
-            waitForLatch(latches[2], 5, "Timeout waiting tabs[2] to get selected.");
+            Util.waitForLatch(latches[2], 5, "Timeout waiting tabs[2] to get selected.");
             latches[0] = new CountDownLatch(1);
         }
 
@@ -321,11 +321,11 @@ public class TabPaneDragPolicyTest {
             } catch (Exception ex) {
                 fail("Thread was interrupted." + ex);
             }
-            waitForLatch(latches[0], 5, "Timeout waiting tabs[0] to get selected.");
+            Util.waitForLatch(latches[0], 5, "Timeout waiting tabs[0] to get selected.");
         } else {
             // For REORDER drag policy, tabs[1] should be the first tab.
-            waitForLatch(changeListenerLatch, 5, "Timeout waiting ChangeListener to get called.");
-            waitForLatch(latches[1], 5, "Timeout waiting tabs[1] to get selected.");
+            Util.waitForLatch(changeListenerLatch, 5, "Timeout waiting ChangeListener to get called.");
+            Util.waitForLatch(latches[1], 5, "Timeout waiting tabs[1] to get selected.");
         }
     }
 
@@ -377,7 +377,7 @@ public class TabPaneDragPolicyTest {
             }
             latch.countDown();
         });
-        waitForLatch(latch, 5, "Timeout waiting for setupTest().");
+        Util.waitForLatch(latch, 5, "Timeout waiting for setupTest().");
     }
 
     @After
@@ -394,17 +394,7 @@ public class TabPaneDragPolicyTest {
             tabs = null;
             latch.countDown();
         });
-        waitForLatch(latch, 5, "Timeout waiting for resetTest().");
-    }
-
-    public static void waitForLatch(CountDownLatch latch, int seconds, String msg) {
-        try {
-            if (!latch.await(seconds, TimeUnit.SECONDS)) {
-                fail(msg);
-            }
-        } catch (Exception ex) {
-            fail("Unexpected exception: " + ex);
-        }
+        Util.waitForLatch(latch, 5, "Timeout waiting for resetTest().");
     }
 
     public void setDragPolicyAndSide(TabPane.TabDragPolicy dragPolicy, Side side) {

--- a/tests/system/src/test/java/test/robot/javafx/scene/TabPaneDragPolicyTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TabPaneDragPolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,11 +24,16 @@
  */
 package test.robot.javafx.scene;
 
-import com.sun.javafx.PlatformUtil;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.collections.ListChangeListener;
+import javafx.geometry.Side;
 import javafx.scene.Scene;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
@@ -37,10 +42,6 @@ import javafx.scene.robot.Robot;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.WindowEvent;
-import javafx.geometry.Side;
-
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -48,8 +49,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.fail;
-import static org.junit.Assume.assumeTrue;
+
+import com.sun.javafx.PlatformUtil;
 
 import test.util.Util;
 
@@ -75,7 +76,7 @@ import test.util.Util;
 public class TabPaneDragPolicyTest {
     CountDownLatch[] latches;
     CountDownLatch changeListenerLatch;
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static Robot robot;
     static TabPane tabPane;
     static volatile Stage stage;
@@ -347,17 +348,12 @@ public class TabPaneDragPolicyTest {
 
     @BeforeClass
     public static void initFX() {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        waitForLatch(startupLatch, 10, "Timeout waiting for FX runtime to start");
+        Util.launch(startupLatch, 10, TestApp.class);
     }
 
     @AfterClass
     public static void exit() {
-        Platform.runLater(() -> {
-            stage.hide();
-        });
-        Platform.exit();
+        Util.shutdown(stage);
     }
 
     @Before

--- a/tests/system/src/test/java/test/robot/javafx/scene/TabPaneReorderTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TabPaneReorderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,10 +24,16 @@
  */
 package test.robot.javafx.scene;
 
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.collections.ListChangeListener;
+import javafx.geometry.Side;
 import javafx.scene.Scene;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
@@ -37,11 +43,6 @@ import javafx.scene.layout.HBox;
 import javafx.scene.robot.Robot;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
-import javafx.stage.WindowEvent;
-import javafx.geometry.Side;
-
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -49,8 +50,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertTrue;
 
 import test.util.Util;
 
@@ -68,7 +67,7 @@ import test.util.Util;
  */
 public class TabPaneReorderTest {
     static CountDownLatch selectionLatch;
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static Robot robot;
     static HBox root;
     static volatile Scene scene;
@@ -208,18 +207,12 @@ public class TabPaneReorderTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        assertTrue("Timeout waiting for FX runtime to start",
-                startupLatch.await(15, TimeUnit.SECONDS));
+        Util.launch(startupLatch, 15, TestApp.class);
     }
 
     @AfterClass
     public static void exit() {
-        Platform.runLater(() -> {
-            stage.hide();
-        });
-        Platform.exit();
+        Util.shutdown(stage);
     }
 
     @Before

--- a/tests/system/src/test/java/test/robot/javafx/scene/TabPaneReorderTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TabPaneReorderTest.java
@@ -204,7 +204,7 @@ public class TabPaneReorderTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/scene/TabPaneReorderTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TabPaneReorderTest.java
@@ -24,10 +24,7 @@
  */
 package test.robot.javafx.scene;
 
-import static org.junit.Assert.fail;
-
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -141,7 +138,7 @@ public class TabPaneReorderTest {
                 (int)(scene.getWindow().getY() + scene.getY() + dY));
             robot.mousePress(MouseButton.PRIMARY);
         });
-        waitForLatch(selectionLatch, 5, "Timeout waiting for the tab to get selected.");
+        Util.waitForLatch(selectionLatch, 5, "Timeout waiting for the tab to get selected.");
         tabPane.getSelectionModel().selectedItemProperty().
                 removeListener(selectionChangeListener);
 
@@ -170,7 +167,7 @@ public class TabPaneReorderTest {
                 addListener(selectionChangeListener);
         selectionLatch = new CountDownLatch(1);
         tabPane.getSelectionModel().select(0);
-        waitForLatch(selectionLatch, 5, "Timeout waiting for tab[0] to get selected.");
+        Util.waitForLatch(selectionLatch, 5, "Timeout waiting for tab[0] to get selected.");
 
         for (int i = 1; i < TAB_COUNT; i++) {
             Util.runAndWait(() -> {
@@ -178,7 +175,7 @@ public class TabPaneReorderTest {
                 robot.keyPress(KeyCode.RIGHT);
                 robot.keyRelease(KeyCode.RIGHT);
             });
-            waitForLatch(selectionLatch, 5, "Timeout waiting for tab[" +
+            Util.waitForLatch(selectionLatch, 5, "Timeout waiting for tab[" +
                          i + "] to get selected.");
         }
         tabPane.getSelectionModel().selectedItemProperty().
@@ -238,7 +235,7 @@ public class TabPaneReorderTest {
             tabPane.getTabs().addListener(reorderListener);
             root.getChildren().add(tabPane);
         });
-        waitForLatch(tabPaneLayoutLatch, 5, "Timeout waiting for TabPane layout.");
+        Util.waitForLatch(tabPaneLayoutLatch, 5, "Timeout waiting for TabPane layout.");
     }
 
     @After
@@ -250,16 +247,6 @@ public class TabPaneReorderTest {
             tabPane.getTabs().clear();
             tabPane = null;
         });
-    }
-
-    private static void waitForLatch(CountDownLatch latch, int seconds, String msg) {
-        try {
-            if (!latch.await(seconds, TimeUnit.SECONDS)) {
-                fail(msg);
-            }
-        } catch (Exception ex) {
-            fail("Unexpected exception: " + ex);
-        }
     }
 
     private void setDragPolicyAndSide(TabPane.TabDragPolicy dragPolicy, Side side) {
@@ -283,6 +270,6 @@ public class TabPaneReorderTest {
             }
             moveLatch.countDown();
         });
-        waitForLatch(moveLatch, 5, "Timeout waiting for robot.mouseMove().");
+        Util.waitForLatch(moveLatch, 5, "Timeout waiting for robot.mouseMove().");
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/canvas/ImageSmoothingDrawTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/canvas/ImageSmoothingDrawTest.java
@@ -24,12 +24,9 @@
  */
 package test.robot.javafx.scene.canvas;
 
-import static org.junit.Assert.fail;
-
 import java.io.FileInputStream;
 import java.net.URL;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -139,16 +136,6 @@ public class ImageSmoothingDrawTest {
                     Platform.runLater(startupLatch::countDown));
             stage.setAlwaysOnTop(true);
             stage.show();
-        }
-    }
-
-    public static void waitForLatch(CountDownLatch latch, int seconds, String msg) {
-        try {
-            if (!latch.await(seconds, TimeUnit.SECONDS)) {
-                fail(msg);
-            }
-        } catch (Exception ex) {
-            fail("Unexpected exception: " + ex);
         }
     }
 

--- a/tests/system/src/test/java/test/robot/javafx/scene/canvas/ImageSmoothingDrawTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/canvas/ImageSmoothingDrawTest.java
@@ -104,7 +104,7 @@ public class ImageSmoothingDrawTest {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 10, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/scene/canvas/ImageSmoothingDrawTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/canvas/ImageSmoothingDrawTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,12 @@
  */
 package test.robot.javafx.scene.canvas;
 
+import static org.junit.Assert.fail;
+
 import java.io.FileInputStream;
 import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -40,14 +44,10 @@ import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.WindowEvent;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.fail;
 
 import test.util.Util;
 
@@ -107,16 +107,12 @@ public class ImageSmoothingDrawTest {
 
     @BeforeClass
     public static void initFX() {
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        waitForLatch(startupLatch, 10, "Timeout waiting for FX runtime to start");
+        Util.launch(startupLatch, 10, TestApp.class);
     }
 
     @AfterClass
     public static void exit() {
-        Platform.runLater(() -> {
-            stage.hide();
-        });
-        Platform.exit();
+        Util.shutdown(stage);
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogRepeatedShowHideTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogRepeatedShowHideTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package test.robot.javafx.scene.dialog;
 
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -32,20 +34,18 @@ import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Dialog;
 import javafx.scene.control.Label;
+import javafx.scene.input.MouseButton;
 import javafx.scene.robot.Robot;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.WindowEvent;
-import javafx.scene.input.MouseButton;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import test.util.Util;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import test.util.Util;
 
 //see JDK8193502
 public class DialogRepeatedShowHideTest {
@@ -78,26 +78,27 @@ public class DialogRepeatedShowHideTest {
         mouseClick(button.getLayoutX() + button.getWidth() / 2, button.getLayoutY() + button.getHeight() / 2);
 
         Thread.sleep(400);
-        waitForLatch(dialogShownLatch, 10, "Failed to show Dialog");
+        Util.waitForLatch(dialogShownLatch, 10, "Failed to show Dialog");
     }
 
     private void hide() throws Exception {
         dialogHideLatch = new CountDownLatch(1);
         Platform.runLater(() -> dialog.close());
         Thread.sleep(600);
-        waitForLatch(dialogHideLatch, 10, "Failed to hide Dialog");
+        Util.waitForLatch(dialogHideLatch, 10, "Failed to hide Dialog");
     }
 
     @BeforeClass
     public static void initFX() throws Exception {
-        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
-        waitForLatch(startupLatch, 10, "FX runtime failed to start.");
+        Util.launch(startupLatch, 10, TestApp.class);
     }
 
     @AfterClass
     public static void exit() {
-        Platform.runLater(() -> stage.hide());
-        Platform.exit();
+        Platform.runLater(() -> {
+            Util.hide(stage);
+            Platform.exit();
+       });
     }
 
     private void mouseClick(double x, double y) {
@@ -146,9 +147,5 @@ public class DialogRepeatedShowHideTest {
 
             return testDialog;
         }
-    }
-
-    public static void waitForLatch(CountDownLatch latch, int seconds, String msg) throws Exception {
-        Assert.assertTrue("Timeout: " + msg, latch.await(seconds, TimeUnit.SECONDS));
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogRepeatedShowHideTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogRepeatedShowHideTest.java
@@ -90,7 +90,7 @@ public class DialogRepeatedShowHideTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        Util.launch(startupLatch, 10, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogRepeatedShowHideTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogRepeatedShowHideTest.java
@@ -95,10 +95,7 @@ public class DialogRepeatedShowHideTest {
 
     @AfterClass
     public static void exit() {
-        Platform.runLater(() -> {
-            Util.hide(stage);
-            Platform.exit();
-       });
+        Util.shutdown(stage);
     }
 
     private void mouseClick(double x, double y) {

--- a/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogWithOwnerSizingTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogWithOwnerSizingTest.java
@@ -90,7 +90,7 @@ public class DialogWithOwnerSizingTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        Util.launch(startupLatch, 15, SizingTestApp.class);
+        Util.launch(startupLatch, SizingTestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogWithOwnerSizingTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogWithOwnerSizingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,26 +25,26 @@
 
 package test.robot.javafx.scene.dialog;
 
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Dialog;
+import javafx.scene.input.MouseButton;
 import javafx.scene.robot.Robot;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.WindowEvent;
-import javafx.scene.input.MouseButton;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import test.util.Util;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import test.util.Util;
 
 //see JDK-8193502
 public class DialogWithOwnerSizingTest {
@@ -54,7 +54,7 @@ public class DialogWithOwnerSizingTest {
     static Scene scene;
     static Dialog<ButtonType> dialog;
     static Dialog<ButtonType> dialog2;
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
     static CountDownLatch dialogShownLatch;
     static CountDownLatch dialogHideLatch;
 
@@ -76,7 +76,7 @@ public class DialogWithOwnerSizingTest {
         dialogShownLatch = new CountDownLatch(2);
         mouseClick(button.getLayoutX() + button.getWidth() / 2, button.getLayoutY() + button.getHeight() / 2);
 
-        waitForLatch(dialogShownLatch, 10, "Failed to show Dialog");
+        Util.waitForLatch(dialogShownLatch, 10, "Failed to show Dialog");
     }
 
     private void hide() throws Exception {
@@ -85,20 +85,20 @@ public class DialogWithOwnerSizingTest {
             dialog.close();
             dialog2.close();
         });
-        waitForLatch(dialogHideLatch, 10, "Failed to hide Dialog");
+        Util.waitForLatch(dialogHideLatch, 10, "Failed to hide Dialog");
     }
 
     @BeforeClass
     public static void initFX() throws Exception {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(SizingTestApp.class, (String[]) null)).start();
-        waitForLatch(startupLatch, 15, "FX runtime failed to start.");
+        Util.launch(startupLatch, 15, SizingTestApp.class);
     }
 
     @AfterClass
     public static void exit() {
-        Platform.runLater(() -> stage.hide());
-        Platform.exit();
+        Platform.runLater(() -> {
+            Util.hide(stage);
+            Platform.exit();
+        });
     }
 
     private void mouseClick(double x, double y) {
@@ -154,9 +154,5 @@ public class DialogWithOwnerSizingTest {
 
             return testDialog;
         }
-    }
-
-    public static void waitForLatch(CountDownLatch latch, int seconds, String msg) throws Exception {
-        Assert.assertTrue("Timeout: " + msg, latch.await(seconds, TimeUnit.SECONDS));
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogWithOwnerSizingTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogWithOwnerSizingTest.java
@@ -95,10 +95,7 @@ public class DialogWithOwnerSizingTest {
 
     @AfterClass
     public static void exit() {
-        Platform.runLater(() -> {
-            Util.hide(stage);
-            Platform.exit();
-        });
+        Util.shutdown(stage);
     }
 
     private void mouseClick(double x, double y) {

--- a/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewResizeColumnToFitContentTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewResizeColumnToFitContentTest.java
@@ -106,7 +106,7 @@ public class TableViewResizeColumnToFitContentTest {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 10, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewResizeColumnToFitContentTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewResizeColumnToFitContentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,26 +25,28 @@
 
 package test.robot.javafx.scene.tableview;
 
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.scene.Scene;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
-import javafx.scene.Scene;
 import javafx.scene.input.MouseButton;
 import javafx.scene.robot.Robot;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.WindowEvent;
 
-import javafx.beans.property.SimpleObjectProperty;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.fail;
+
+import test.util.Util;
 
 /*
  * Test to verify TableView resizeColumnToFitContent with
@@ -58,7 +60,7 @@ public class TableViewResizeColumnToFitContentTest {
     static volatile Scene scene;
     static final int SCENE_WIDTH = 450;
     static final int SCENE_HEIGHT = 100;
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
 
     public static void main(String[] args) {
         TableViewResizeColumnToFitContentTest test =
@@ -87,7 +89,7 @@ public class TableViewResizeColumnToFitContentTest {
             robot.mouseRelease(MouseButton.PRIMARY);
             latch.countDown();
         });
-        waitForLatch(latch, 5, "Timeout while waiting for mouse double click");
+        Util.waitForLatch(latch, 5, "Timeout while waiting for mouse double click");
         try {
             Thread.sleep(1000); // Delay for table resizing of table columns.
         } catch (Exception e) {
@@ -104,30 +106,12 @@ public class TableViewResizeColumnToFitContentTest {
 
     @BeforeClass
     public static void initFX() {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(
-                TableViewResizeColumnToFitContentTest.TestApp.class,
-                (String[]) null)).start();
-        waitForLatch(startupLatch, 10, "Timeout waiting for FX runtime to start");
+        Util.launch(startupLatch, 10, TestApp.class);
     }
 
     @AfterClass
     public static void exit() {
-        Platform.runLater(() -> {
-            stage.hide();
-        });
-        Platform.exit();
-    }
-
-    public static void waitForLatch(CountDownLatch latch,
-            int seconds, String msg) {
-        try {
-            if (!latch.await(seconds, TimeUnit.SECONDS)) {
-                fail(msg);
-            }
-        } catch (Exception ex) {
-            fail("Unexpected exception: " + ex);
-        }
+        Util.shutdown(stage);
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/treetableview/TreeTableViewResizeColumnToFitContentTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/treetableview/TreeTableViewResizeColumnToFitContentTest.java
@@ -106,7 +106,7 @@ public class TreeTableViewResizeColumnToFitContentTest {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 10, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/scene/treetableview/TreeTableViewResizeColumnToFitContentTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/treetableview/TreeTableViewResizeColumnToFitContentTest.java
@@ -28,7 +28,6 @@ package test.robot.javafx.scene.treetableview;
 import static org.junit.Assert.fail;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -90,7 +89,7 @@ public class TreeTableViewResizeColumnToFitContentTest {
             robot.mouseRelease(MouseButton.PRIMARY);
             latch.countDown();
         });
-        waitForLatch(latch, 5, "Timeout while waiting for mouse double click");
+        Util.waitForLatch(latch, 5, "Timeout while waiting for mouse double click");
         try {
             Thread.sleep(1000); // Delay for table resizing of table columns.
         } catch (Exception e) {
@@ -113,17 +112,6 @@ public class TreeTableViewResizeColumnToFitContentTest {
     @AfterClass
     public static void exit() {
         Util.shutdown(stage);
-    }
-
-    public static void waitForLatch(CountDownLatch latch,
-                                    int seconds, String msg) {
-        try {
-            if (!latch.await(seconds, TimeUnit.SECONDS)) {
-                fail(msg);
-            }
-        } catch (Exception ex) {
-            fail("Unexpected exception: " + ex);
-        }
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/treetableview/TreeTableViewResizeColumnToFitContentTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/treetableview/TreeTableViewResizeColumnToFitContentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,27 +25,30 @@
 
 package test.robot.javafx.scene.treetableview;
 
+import static org.junit.Assert.fail;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
-import javafx.scene.control.cell.TreeItemPropertyValueFactory;
+import javafx.scene.Scene;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeTableColumn;
 import javafx.scene.control.TreeTableView;
-import javafx.scene.Scene;
+import javafx.scene.control.cell.TreeItemPropertyValueFactory;
 import javafx.scene.input.MouseButton;
 import javafx.scene.robot.Robot;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.WindowEvent;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import static org.junit.Assert.fail;
+
+import test.util.Util;
 
 /*
  * Test to verify treeTableView resizeColumnToFitContent with
@@ -59,7 +62,7 @@ public class TreeTableViewResizeColumnToFitContentTest {
     static volatile Scene scene;
     static final int SCENE_WIDTH = 450;
     static final int SCENE_HEIGHT = 100;
-    static CountDownLatch startupLatch;
+    static CountDownLatch startupLatch = new CountDownLatch(1);
 
     public static void main(String[] args) {
         TreeTableViewResizeColumnToFitContentTest test =
@@ -104,19 +107,12 @@ public class TreeTableViewResizeColumnToFitContentTest {
 
     @BeforeClass
     public static void initFX() {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(
-                TreeTableViewResizeColumnToFitContentTest.TestApp.class,
-                (String[]) null)).start();
-        waitForLatch(startupLatch, 10, "Timeout waiting for FX runtime to start");
+        Util.launch(startupLatch, 10, TestApp.class);
     }
 
     @AfterClass
     public static void exit() {
-        Platform.runLater(() -> {
-            stage.hide();
-        });
-        Platform.exit();
+        Util.shutdown(stage);
     }
 
     public static void waitForLatch(CountDownLatch latch,

--- a/tests/system/src/test/java/test/robot/javafx/stage/CheckWindowOrderTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/CheckWindowOrderTest.java
@@ -26,7 +26,6 @@
 package test.robot.javafx.stage;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -65,13 +64,7 @@ public class CheckWindowOrderTest {
 
     @AfterClass
     public static void exit() {
-        Platform.runLater(() -> {
-            Util.hide(lastWindow);
-            Util.hide(secondWindow);
-            Util.hide(firstWindow);
-            Util.hide(stage);
-            Platform.exit();
-        });
+        Util.shutdown(lastWindow, secondWindow, firstWindow, stage);
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/stage/CheckWindowOrderTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/CheckWindowOrderTest.java
@@ -59,7 +59,7 @@ public class CheckWindowOrderTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        Util.launch(startupLatch, 10, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/stage/CheckWindowOrderTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/CheckWindowOrderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,9 @@
 
 package test.robot.javafx.stage;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -32,13 +35,13 @@ import javafx.scene.control.Label;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.stage.Window;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import test.util.Util;
 
 // See JDK8220272
 public class CheckWindowOrderTest {
@@ -57,19 +60,18 @@ public class CheckWindowOrderTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
-        waitForLatch(startupLatch, 10, "FX runtime failed to start.");
+        Util.launch(startupLatch, 10, TestApp.class);
     }
 
     @AfterClass
     public static void exit() {
         Platform.runLater(() -> {
-            lastWindow.hide();
-            secondWindow.hide();
-            firstWindow.hide();
-            stage.hide();
+            Util.hide(lastWindow);
+            Util.hide(secondWindow);
+            Util.hide(firstWindow);
+            Util.hide(stage);
+            Platform.exit();
         });
-        Platform.exit();
     }
 
     public static class TestApp extends Application {
@@ -98,10 +100,6 @@ public class CheckWindowOrderTest {
 
             return stage;
         }
-    }
-
-    public static void waitForLatch(CountDownLatch latch, int seconds, String msg) throws Exception {
-        Assert.assertTrue("Timeout: " + msg, latch.await(seconds, TimeUnit.SECONDS));
     }
 
     static class TestStage extends Stage {

--- a/tests/system/src/test/java/test/robot/javafx/stage/DualWindowTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/DualWindowTest.java
@@ -119,11 +119,7 @@ public class DualWindowTest {
 
     @AfterClass
     public static void teardown() {
-        Platform.runLater(() -> {
-            Util.hide(stage1);
-            Util.hide(stage2);
-            Platform.exit();
-        });
+        Util.shutdown(stage1, stage2);
     }
 
     @Before
@@ -165,5 +161,4 @@ public class DualWindowTest {
         clickButton(button1);
         clickButton(button2);
     }
-
 }

--- a/tests/system/src/test/java/test/robot/javafx/stage/DualWindowTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/DualWindowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,12 @@
 
 package test.robot.javafx.stage;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -36,13 +40,13 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.robot.Robot;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
+
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import test.util.Util;
 
-import static org.junit.Assert.*;
+import test.util.Util;
 
 public class DualWindowTest {
 
@@ -110,16 +114,14 @@ public class DualWindowTest {
     @BeforeClass
     public static void setupOnce() throws Exception {
         startupLatch = new CountDownLatch(2);
-        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
-        assertTrue("Timeout waiting for FX runtime to start",
-                startupLatch.await(15, TimeUnit.SECONDS));
+        Util.launch(startupLatch, 15, TestApp.class);
     }
 
     @AfterClass
     public static void teardown() {
         Platform.runLater(() -> {
-            if (stage1 != null) stage1.hide();
-            if (stage2 != null) stage2.hide();
+            Util.hide(stage1);
+            Util.hide(stage2);
             Platform.exit();
         });
     }

--- a/tests/system/src/test/java/test/robot/javafx/stage/DualWindowTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/DualWindowTest.java
@@ -114,7 +114,7 @@ public class DualWindowTest {
     @BeforeClass
     public static void setupOnce() throws Exception {
         startupLatch = new CountDownLatch(2);
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/stage/FocusParentWindowOnChildCloseTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/FocusParentWindowOnChildCloseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package test.robot.javafx.stage;
 
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -36,14 +38,13 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.robot.Robot;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import test.util.Util;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import test.util.Util;
 
 // See JDK-8210973
 public class FocusParentWindowOnChildCloseTest {
@@ -70,22 +71,21 @@ public class FocusParentWindowOnChildCloseTest {
         mouseClick(button.getLayoutX() + button.getWidth() / 2, button.getLayoutY() + button.getHeight() / 2);
 
         Thread.sleep(400);
-        waitForLatch(alertShownLatch, 10, "Failed to show Alert");
+        Util.waitForLatch(alertShownLatch, 10, "Failed to show Alert");
     }
 
     @BeforeClass
     public static void initFX() throws Exception {
-        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
-        waitForLatch(startupLatch, 10, "FX runtime failed to start.");
+        Util.launch(startupLatch, 10, TestApp.class);
     }
 
     @AfterClass
     public static void exit() {
         Platform.runLater(() -> {
-            stage.hide();
-            stage2.hide();
+            Util.hide(stage);
+            Util.hide(stage2);
+            Platform.exit();
         });
-        Platform.exit();
     }
 
     private void mouseClick(double x, double y) {
@@ -104,7 +104,7 @@ public class FocusParentWindowOnChildCloseTest {
                     okButton.fire();
                 });
         Thread.sleep(400);
-        waitForLatch(alertCloseLatch, 10, "Failed to close alert.");
+        Util.waitForLatch(alertCloseLatch, 10, "Failed to close alert.");
     }
 
     public static class TestApp extends Application {
@@ -151,9 +151,5 @@ public class FocusParentWindowOnChildCloseTest {
             stage2.addEventHandler(WindowEvent.WINDOW_SHOWN, e -> Platform.runLater(startupLatch::countDown));
             stage2.show();
         }
-    }
-
-    public static void waitForLatch(CountDownLatch latch, int seconds, String msg) throws Exception {
-        Assert.assertTrue("Timeout: " + msg, latch.await(seconds, TimeUnit.SECONDS));
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/stage/FocusParentWindowOnChildCloseTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/FocusParentWindowOnChildCloseTest.java
@@ -81,11 +81,7 @@ public class FocusParentWindowOnChildCloseTest {
 
     @AfterClass
     public static void exit() {
-        Platform.runLater(() -> {
-            Util.hide(stage);
-            Util.hide(stage2);
-            Platform.exit();
-        });
+        Util.shutdown(stage, stage2);
     }
 
     private void mouseClick(double x, double y) {

--- a/tests/system/src/test/java/test/robot/javafx/stage/FocusParentWindowOnChildCloseTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/FocusParentWindowOnChildCloseTest.java
@@ -76,7 +76,7 @@ public class FocusParentWindowOnChildCloseTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        Util.launch(startupLatch, 10, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/stage/WrongStageFocusWithApplicationModalityTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/WrongStageFocusWithApplicationModalityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,8 @@
 
 package test.robot.javafx.stage;
 
+import java.util.concurrent.CountDownLatch;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -34,14 +36,12 @@ import javafx.scene.input.MouseButton;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.robot.Robot;
 import javafx.stage.Stage;
+
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import test.util.Util;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
+import test.util.Util;
 
 public class WrongStageFocusWithApplicationModalityTest {
     private static Robot robot;
@@ -52,8 +52,12 @@ public class WrongStageFocusWithApplicationModalityTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        new Thread(() -> Application.launch(TestApp.class, (String[]) null)).start();
-        waitForLatch(startupLatch, 15, "FX runtime failed to start.");
+        Util.launch(startupLatch, 15, TestApp.class);
+    }
+
+    @AfterClass
+    public static void exit() {
+        Util.shutdown(stage);
     }
 
     @Test(timeout = 25000)
@@ -67,19 +71,7 @@ public class WrongStageFocusWithApplicationModalityTest {
         Thread.sleep(500);
         keyPress(KeyCode.ESCAPE);
         Thread.sleep(500);
-        waitForLatch(alertCloseLatch, 10, "Alerts not closed, wrong focus");
-    }
-
-    @AfterClass
-    public static void exit() {
-        Platform.runLater(() -> {
-            stage.hide();
-        });
-        Platform.exit();
-    }
-
-    private static void waitForLatch(CountDownLatch latch, int seconds, String msg) throws Exception {
-        Assert.assertTrue("Timeout: " + msg, latch.await(seconds, TimeUnit.SECONDS));
+        Util.waitForLatch(alertCloseLatch, 10, "Alerts not closed, wrong focus");
     }
 
     private static void keyPress(KeyCode code) throws Exception {

--- a/tests/system/src/test/java/test/robot/javafx/stage/WrongStageFocusWithApplicationModalityTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/WrongStageFocusWithApplicationModalityTest.java
@@ -52,7 +52,7 @@ public class WrongStageFocusWithApplicationModalityTest {
 
     @BeforeClass
     public static void initFX() throws Exception {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/web/PointerEventTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/web/PointerEventTest.java
@@ -24,40 +24,31 @@
 
 package test.robot.javafx.web;
 
-import com.sun.javafx.PlatformUtil;
-
-import javafx.application.Application;
-import javafx.application.Platform;
-import javafx.beans.value.ObservableValue;
-import javafx.concurrent.Worker.State;
-import javafx.concurrent.Worker;
-import javafx.scene.input.MouseButton;
-import javafx.scene.layout.StackPane;
-import javafx.scene.robot.Robot;
-import javafx.scene.Scene;
-import javafx.scene.web.WebEngine;
-import javafx.scene.web.WebView;
-import javafx.scene.input.KeyCode;
-import javafx.stage.Stage;
-
-import java.lang.Integer;
-import java.lang.Number;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
+import javafx.application.Application;
+import javafx.concurrent.Worker;
+import javafx.scene.Scene;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.MouseButton;
+import javafx.scene.layout.StackPane;
+import javafx.scene.robot.Robot;
+import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
+import javafx.stage.Stage;
 
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
 import test.util.Util;
-
-import static org.junit.Assert.*;
 
 /*
  * Tests for validating the buttons property received in "pointermove" event,
@@ -85,7 +76,7 @@ public class PointerEventTest {
     private final int DX = 125;
     private final int DY = 125;
 
-    private static CountDownLatch startupLatch;
+    private static CountDownLatch startupLatch = new CountDownLatch(2);
 
     static Document document;
     static Element element;
@@ -192,17 +183,12 @@ public class PointerEventTest {
 
     @BeforeClass
     public static void initFX() {
-        startupLatch = new CountDownLatch(2);
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        waitForLatch(startupLatch, 15, "Timeout waiting for FX runtime to start");
+        Util.launch(startupLatch, 15, TestApp.class);
     }
 
     @AfterClass
     public static void exit() {
-        Platform.runLater(() -> {
-            stage.hide();
-        });
-        Platform.exit();
+        Util.shutdown(stage);
     }
 
     @After

--- a/tests/system/src/test/java/test/robot/javafx/web/PointerEventTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/web/PointerEventTest.java
@@ -181,7 +181,7 @@ public class PointerEventTest {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 15, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/javafx/web/PointerEventTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/web/PointerEventTest.java
@@ -25,10 +25,8 @@
 package test.robot.javafx.web;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import javafx.application.Application;
 import javafx.concurrent.Worker;
@@ -197,15 +195,5 @@ public class PointerEventTest {
             robot.mouseRelease(MouseButton.PRIMARY, MouseButton.MIDDLE, MouseButton.SECONDARY);
             robot.keyType(KeyCode.ESCAPE);
         });
-    }
-
-    public static void waitForLatch(CountDownLatch latch, int seconds, String msg) {
-        try {
-            if (!latch.await(seconds, TimeUnit.SECONDS)) {
-                fail(msg);
-            }
-        } catch (Exception ex) {
-            fail("Unexpected exception: " + ex);
-        }
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/web/TooltipFXTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/web/TooltipFXTest.java
@@ -25,28 +25,30 @@
 
 package test.robot.javafx.web;
 
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static test.util.Util.TIMEOUT;
+
 import java.lang.ref.WeakReference;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.concurrent.Worker;
+import javafx.scene.Scene;
 import javafx.scene.input.MouseButton;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.paint.Color;
-import javafx.scene.Scene;
 import javafx.scene.robot.Robot;
 import javafx.scene.web.WebView;
 import javafx.stage.Stage;
-import junit.framework.AssertionFailedError;
-import org.junit.After;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import test.util.Util;
 
-import static org.junit.Assert.*;
-import static test.util.Util.TIMEOUT;
+import test.util.Util;
 
 public class TooltipFXTest {
 
@@ -63,7 +65,7 @@ public class TooltipFXTest {
     // Sleep time to allow tooltip to show in milliseconds
     private static final int TOOLTIP_SLEEP_TIME = 3000;
 
-    private static CountDownLatch startupLatch;
+    private static CountDownLatch startupLatch = new CountDownLatch(1);
 
     private Scene scene;
 
@@ -98,20 +100,12 @@ public class TooltipFXTest {
 
     @BeforeClass
     public static void initFX() {
-        startupLatch = new CountDownLatch(1);
-        new Thread(() -> Application.launch(TestApp.class, (String[])null)).start();
-        try {
-            if (!startupLatch.await(TIMEOUT, TimeUnit.MILLISECONDS)) {
-                fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            fail("Unexpected exception: " + ex);
-        }
+        Util.launch(startupLatch, 10, TestApp.class);
     }
 
     @AfterClass
     public static void teardown() {
-        Platform.exit();
+        Util.shutdown();
     }
 
 // ========================== TEST CASE ==========================

--- a/tests/system/src/test/java/test/robot/javafx/web/TooltipFXTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/web/TooltipFXTest.java
@@ -100,7 +100,7 @@ public class TooltipFXTest {
 
     @BeforeClass
     public static void initFX() {
-        Util.launch(startupLatch, 10, TestApp.class);
+        Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass

--- a/tests/system/src/test/java/test/robot/testharness/VisualTestBase.java
+++ b/tests/system/src/test/java/test/robot/testharness/VisualTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,14 @@
  */
 package test.robot.testharness;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
 import javafx.animation.AnimationTimer;
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -33,20 +41,13 @@ import javafx.scene.robot.Robot;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import junit.framework.AssertionFailedError;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+
+import junit.framework.AssertionFailedError;
 import test.util.Util;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static test.util.Util.TIMEOUT;
 
 /**
  * Common base class for testing snapshot.
@@ -88,25 +89,13 @@ public abstract class VisualTestBase {
 
     @BeforeClass
     public static void doSetupOnce() {
-        // Start the Application
-        new Thread(() -> Application.launch(MyApp.class, (String[]) null)).start();
-
-        try {
-            if (!launchLatch.await(TIMEOUT, TimeUnit.MILLISECONDS)) {
-                throw new AssertionFailedError("Timeout waiting for Application to launch");
-            }
-        } catch (InterruptedException ex) {
-            AssertionFailedError err = new AssertionFailedError("Unexpected exception");
-            err.initCause(ex);
-            throw err;
-        }
-
+        Util.launch(launchLatch, 10, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 
     @AfterClass
     public static void doTeardownOnce() {
-        Platform.exit();
+        Util.shutdown();
     }
 
     @Before

--- a/tests/system/src/test/java/test/robot/testharness/VisualTestBase.java
+++ b/tests/system/src/test/java/test/robot/testharness/VisualTestBase.java
@@ -89,7 +89,7 @@ public abstract class VisualTestBase {
 
     @BeforeClass
     public static void doSetupOnce() {
-        Util.launch(launchLatch, 10, MyApp.class);
+        Util.launch(launchLatch, MyApp.class);
         assertEquals(0, launchLatch.getCount());
     }
 

--- a/tests/system/src/test/java/test/util/Util.java
+++ b/tests/system/src/test/java/test/util/Util.java
@@ -303,6 +303,25 @@ public class Util {
 
     /**
      * Launches an FX application, at the same time ensuring that it has been
+     * actually launched within 15 seconds.
+     * <p>
+     * The application being started must call {@link CountdownLatch#countDown()} once to signal
+     * its successful start (for example, by setting a handler for {@link javafx.stage.WindowEvent.WINDOW_SHOWN} event
+     * on its primary Stage).
+     *
+     * @param startupLatch
+     * @param applicationClass - application to launch
+     * @param args - command line arguments
+     */
+    public static <T extends Application> void launch (
+            CountDownLatch startupLatch,
+            Class<T> applicationClass,
+            String... args) {
+        launch(startupLatch, 15, applicationClass, args);
+    }
+
+    /**
+     * Launches an FX application, at the same time ensuring that it has been
      * actually launched within the specified time.
      * <p>
      * The application being started must call {@link CountdownLatch#countDown()} once to signal

--- a/tests/system/src/test/java/test/util/Util.java
+++ b/tests/system/src/test/java/test/util/Util.java
@@ -83,7 +83,6 @@ public class Util {
         } catch (InterruptedException ex) {}
     }
 
-    // FIX remove
     public static boolean await(final CountDownLatch latch) {
         try {
             return latch.await(TIMEOUT, TimeUnit.MILLISECONDS);
@@ -346,6 +345,10 @@ public class Util {
         });
     }
 
+    /**
+     * Calls CountDownLatch.await() with the specified timeout (in seconds).
+     * Throws an exception if await() returns false or the process gets interrupted.
+     */
     public static void waitForLatch(CountDownLatch latch, int seconds, String msg) {
         try {
             Assert.assertTrue("Timeout: " + msg, latch.await(seconds, TimeUnit.SECONDS));

--- a/tests/system/src/test/java/test/util/Util.java
+++ b/tests/system/src/test/java/test/util/Util.java
@@ -334,4 +334,12 @@ public class Util {
             throw new AssertionError(e);
         }
     }
+
+    public static void waitForLatch(CountDownLatch latch, int seconds, String msg) {
+        try {
+            Assert.assertTrue("Timeout: " + msg, latch.await(seconds, TimeUnit.SECONDS));
+        } catch (InterruptedException e) {
+            throw new AssertionError(e);
+        }
+    }
 }

--- a/tests/system/src/test/java/test/util/Util.java
+++ b/tests/system/src/test/java/test/util/Util.java
@@ -334,8 +334,7 @@ public class Util {
      * in the platform thread, then calls {@link Platform.exit()}.
      */
     public static void shutdown(Stage... stages) {
-        // why isn't runAndWait() exposed as a public API?
-        PlatformImpl.runAndWait(() -> {
+        runAndWait(() -> {
             for (Stage s : stages) {
                 if (s != null) {
                     s.hide();

--- a/tests/system/src/test/java/test/util/Util.java
+++ b/tests/system/src/test/java/test/util/Util.java
@@ -44,6 +44,8 @@ import javafx.stage.Stage;
 
 import org.junit.Assert;
 
+import com.sun.javafx.application.PlatformImpl;
+
 import junit.framework.AssertionFailedError;
 
 /**
@@ -300,13 +302,6 @@ public class Util {
         return cmd;
     }
 
-    /** closes the stage, ignoring a null value */
-    public static void hide(Stage s) {
-        if (s != null) {
-            s.hide();
-        }
-    }
-
     /**
      * Launches an FX application, at the same time ensuring that it has been
      * actually launched within the specified time.
@@ -333,6 +328,22 @@ public class Util {
         } catch (InterruptedException e) {
             throw new AssertionError(e);
         }
+    }
+
+    /**
+     * This synchronous method first hides all the specified stages (ignoring any null Stages)
+     * in the platform thread, then calls {@link Platform.exit()}.
+     */
+    public static void shutdown(Stage... stages) {
+        // why isn't runAndWait() exposed as a public API?
+        PlatformImpl.runAndWait(() -> {
+            for (Stage s : stages) {
+                if (s != null) {
+                    s.hide();
+                }
+            }
+            Platform.exit();
+        });
     }
 
     public static void waitForLatch(CountDownLatch latch, int seconds, String msg) {


### PR DESCRIPTION
1. Introduced the following utility methods:
- Util.launch
- Util.shutdown
- Util.waitForLatch
2. Fixed the out-of order calls to Stage.hide() and Platform.exit() in many tests' shutdowns.
3. Replaced local waitForLatch copies with Util.waitForLatch

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8206430](https://bugs.openjdk.org/browse/JDK-8206430): Use consistent pattern for startup in FX system tests


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/950/head:pull/950` \
`$ git checkout pull/950`

Update a local copy of the PR: \
`$ git checkout pull/950` \
`$ git pull https://git.openjdk.org/jfx pull/950/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 950`

View PR using the GUI difftool: \
`$ git pr show -t 950`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/950.diff">https://git.openjdk.org/jfx/pull/950.diff</a>

</details>
