### PR TITLE
8296556: Mark two RobotTest methods as unstable on HiDPI Windows systems

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
@@ -678,7 +678,7 @@ public class RobotTest {
     @Test
     public void testPixelCaptureAverage() throws Exception {
         if (PlatformUtil.isWindows() && Screen.getPrimary().getOutputScaleX() > 1) {
-            //Mark test as unstable for HiDPI scale greater than 100%
+            // Mark this test as unstable on Windows when HiDPI scale is more than 100%
             Assume.assumeTrue(Boolean.getBoolean("unstable.test")); // JDK-8255079
         }
         CountDownLatch setSceneLatch = new CountDownLatch(1);
@@ -734,7 +734,7 @@ public class RobotTest {
     @Test
     public void testScreenCapture() throws Exception {
         if (PlatformUtil.isWindows() && Screen.getPrimary().getOutputScaleX() > 1) {
-            //Mark test as unstable for HiDPI scale greater than 100%
+            // Mark this test as unstable on Windows when HiDPI scale is more than 100%
             Assume.assumeTrue(Boolean.getBoolean("unstable.test")); // JDK-8207379
         }
         CountDownLatch setSceneLatch = new CountDownLatch(1);

--- a/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
@@ -679,7 +679,7 @@ public class RobotTest {
     public void testPixelCaptureAverage() throws Exception {
         if (PlatformUtil.isWindows() && Screen.getPrimary().getOutputScaleX() > 1) {
             //Mark test as unstable for HiDPI scale greater than 100%
-            Assume.assumeTrue(Boolean.getBoolean("unstable.test"));
+            Assume.assumeTrue(Boolean.getBoolean("unstable.test")); // JDK-8255079
         }
         CountDownLatch setSceneLatch = new CountDownLatch(1);
         Pane pane = new StackPane();
@@ -735,7 +735,7 @@ public class RobotTest {
     public void testScreenCapture() throws Exception {
         if (PlatformUtil.isWindows() && Screen.getPrimary().getOutputScaleX() > 1) {
             //Mark test as unstable for HiDPI scale greater than 100%
-            Assume.assumeTrue(Boolean.getBoolean("unstable.test"));
+            Assume.assumeTrue(Boolean.getBoolean("unstable.test")); // JDK-8207379
         }
         CountDownLatch setSceneLatch = new CountDownLatch(1);
         Pane pane = new StackPane();

--- a/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
@@ -677,6 +677,10 @@ public class RobotTest {
 
     @Test
     public void testPixelCaptureAverage() throws Exception {
+        if (PlatformUtil.isWindows() && Screen.getPrimary().getOutputScaleX() > 1) {
+            //Mark test as unstable for HiDPI scale greater than 100%
+            Assume.assumeTrue(Boolean.getBoolean("unstable.test"));
+        }
         CountDownLatch setSceneLatch = new CountDownLatch(1);
         Pane pane = new StackPane();
         InvalidationListener invalidationListener = observable -> setSceneLatch.countDown();
@@ -729,6 +733,10 @@ public class RobotTest {
 
     @Test
     public void testScreenCapture() throws Exception {
+        if (PlatformUtil.isWindows() && Screen.getPrimary().getOutputScaleX() > 1) {
+            //Mark test as unstable for HiDPI scale greater than 100%
+            Assume.assumeTrue(Boolean.getBoolean("unstable.test"));
+        }
         CountDownLatch setSceneLatch = new CountDownLatch(1);
         Pane pane = new StackPane();
         InvalidationListener invalidationListener = observable -> setSceneLatch.countDown();


### PR DESCRIPTION
Two RobotTest methods are marked as unstable on HiDPI Windows systems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296556](https://bugs.openjdk.org/browse/JDK-8296556): Mark two RobotTest methods as unstable on HiDPI Windows systems


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/951/head:pull/951` \
`$ git checkout pull/951`

Update a local copy of the PR: \
`$ git checkout pull/951` \
`$ git pull https://git.openjdk.org/jfx pull/951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 951`

View PR using the GUI difftool: \
`$ git pr show -t 951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/951.diff">https://git.openjdk.org/jfx/pull/951.diff</a>

</details>
