### PR TITLE
8297213: Robot capture tests should move mouse to corner of screen

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/RT30650GUI.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/RT30650GUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,9 @@ package test.robot.javafx.embed.swing;
 
 import static com.sun.javafx.application.PlatformImpl.runAndWait;
 import com.sun.javafx.tk.TKPulseListener;
+
+import test.util.Util;
+
 import java.awt.Color;
 import javafx.animation.AnimationTimer;
 import javafx.scene.Scene;
@@ -67,6 +70,7 @@ public class RT30650GUI extends Application {
 
     private AnimationTimer animationTimer;
     private TKPulseListener pulseListener;
+    private Robot robot;
 
     @Override
     public void start(final Stage stage) {
@@ -87,6 +91,9 @@ public class RT30650GUI extends Application {
         stage.setScene(scene);
         stage.setTitle("RT-30650");
         stage.show();
+
+        robot = new Robot();
+        Util.parkCursor(robot);
 
         SwingUtilities.invokeLater(() -> {
             JPanel panel = new JPanel();
@@ -113,8 +120,7 @@ public class RT30650GUI extends Application {
 
         final javafx.scene.paint.Color rgb[] = new javafx.scene.paint.Color[1];
         runAndWait(() -> {
-            Robot r = new Robot();
-            rgb[0] = r.getPixelColor(x + SIZE/2, y + SIZE/2);
+            rgb[0] = robot.getPixelColor(x + SIZE/2, y + SIZE/2);
         });
 
         System.out.println("detected color: " + rgb[0].toString());

--- a/tests/system/src/test/java/test/robot/javafx/scene/PixelBufferDrawTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/PixelBufferDrawTest.java
@@ -52,6 +52,7 @@ import javafx.util.Callback;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -295,6 +296,11 @@ public class PixelBufferDrawTest {
         Util.shutdown(stage);
     }
 
+    @Before
+    public void before() {
+        Util.parkCursor(robot);
+    }
+
     @After
     public void cleanupTest() {
         Util.runAndWait(() -> {
@@ -305,10 +311,6 @@ public class PixelBufferDrawTest {
     }
 
     private static void delay() {
-        try {
-            Thread.sleep(DELAY);
-        } catch (Exception ex) {
-            fail("Thread was interrupted." + ex);
-        }
+        Util.sleep(DELAY);
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
@@ -25,12 +25,10 @@
 package test.robot.javafx.scene;
 
 import static javafx.scene.paint.Color.MAGENTA;
-import static org.junit.Assert.fail;
 
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javafx.application.Application;
@@ -144,11 +142,7 @@ public class RobotTest {
 
     @Before
     public void before() {
-        double x = stage.getX() + stage.getWidth();
-        double y = stage.getY() + stage.getHeight();
-        Util.runAndWait(() -> {
-            robot.mouseMove(x,y);
-        });
+        Util.parkCursor(robot);
     }
 
     @Test

--- a/tests/system/src/test/java/test/robot/javafx/scene/canvas/ImageSmoothingDrawTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/canvas/ImageSmoothingDrawTest.java
@@ -43,6 +43,7 @@ import javafx.stage.WindowEvent;
 
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -110,6 +111,11 @@ public class ImageSmoothingDrawTest {
     @AfterClass
     public static void exit() {
         Util.shutdown(stage);
+    }
+
+    @Before
+    public void before() {
+        Util.parkCursor(robot);
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionBackgroundImageUITest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionBackgroundImageUITest.java
@@ -26,14 +26,16 @@ package test.robot.javafx.scene.layout;
 
 import static org.junit.Assume.assumeTrue;
 
+import javafx.geometry.Bounds;
+import javafx.scene.paint.Color;
+
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import com.sun.javafx.PlatformUtil;
 
-import javafx.geometry.Bounds;
-import javafx.scene.paint.Color;
+import test.util.Util;
 
 /**************************************************************************
  *                                                                        *
@@ -45,11 +47,7 @@ public class RegionBackgroundImageUITest extends RegionUITestBase {
 
     @Before
     public void before() {
-        double x = stage.getX() + stage.getWidth();
-        double y = stage.getY() + stage.getHeight();
-        runAndWait(() -> {
-            getRobot().mouseMove(x,y);
-        });
+        Util.parkCursor(getRobot());
     }
 
     @Test(timeout = 20000)

--- a/tests/system/src/test/java/test/robot/testharness/VisualTestBase.java
+++ b/tests/system/src/test/java/test/robot/testharness/VisualTestBase.java
@@ -101,6 +101,7 @@ public abstract class VisualTestBase {
     @Before
     public void doSetup() {
         runAndWait(() -> robot = new Robot());
+        Util.parkCursor(robot);
     }
 
     @After

--- a/tests/system/src/test/java/test/util/Util.java
+++ b/tests/system/src/test/java/test/util/Util.java
@@ -40,6 +40,9 @@ import java.util.concurrent.TimeUnit;
 
 import javafx.application.Application;
 import javafx.application.Platform;
+import javafx.geometry.Rectangle2D;
+import javafx.scene.robot.Robot;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
 
 import org.junit.Assert;
@@ -393,6 +396,29 @@ public class Util {
             Assert.assertTrue("Timeout: " + msg, latch.await(seconds, TimeUnit.SECONDS));
         } catch (InterruptedException e) {
             throw new AssertionError(e);
+        }
+    }
+
+    /**
+     * Moves the cursor outside of the Stage to avoid it interfering with Robot tests.
+     * The cursor is moved to a point close to the lower right corner of the primary screen,
+     * avoiding any areas occupied by dock, tray, or Active Corners.
+     * <p>
+     * This method can be called from any thread.
+     */
+    public static void parkCursor(Robot robot) {
+        Runnable park = () -> {
+            Rectangle2D r = Screen.getPrimary().getVisualBounds();
+            double activeCornersMargin = 5.0;
+            double x = r.getMaxX() - activeCornersMargin;
+            double y = r.getMaxY() - activeCornersMargin;
+            robot.mouseMove(x, y);
+        };
+
+        if (Platform.isFxApplicationThread()) {
+            park.run();
+        } else {
+            runAndWait(park);
         }
     }
 }


### PR DESCRIPTION
Added Util.parkCursor(Robot) method to move the cursor to lower left corner (while avoiding dock, tray, or active corners).