### PR TITLE
8297130: ComboBox popup doesn't close after selecting value that was added with 'runLater'

### DIFF
--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/FocusTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/FocusTest.java
@@ -117,16 +117,24 @@ public class FocusTest {
         return n(T, T, T);
     }
 
-    private void assertIsFocused(Scene s, Node n) {
-        assertEquals(n, s.getFocusOwner());
+    private void assertIsFocused(Node n) {
         assertTrue(n.isFocused());
         assertTrue(n.getPseudoClassStates().stream().anyMatch(pc -> pc.getPseudoClassName().equals("focused")));
     }
 
-    private void assertNotFocused(Scene s, Node n) {
-        assertTrue(n != s.getFocusOwner());
+    private void assertIsFocused(Scene s, Node n) {
+        assertEquals(n, s.getFocusOwner());
+        assertIsFocused(n);
+    }
+
+    private void assertNotFocused(Node n) {
         assertFalse(n.isFocused());
         assertFalse(n.getPseudoClassStates().stream().anyMatch(pc -> pc.getPseudoClassName().equals("focused")));
+    }
+
+    private void assertNotFocused(Scene s, Node n) {
+        assertTrue(n != s.getFocusOwner());
+        assertNotFocused(n);
     }
 
     private void assertNullFocus(Scene s) {
@@ -996,6 +1004,51 @@ public class FocusTest {
         g2.getChildren().remove(0);
         assertNotFocusWithin(g1);
         assertNotFocusWithin(g2);
+    }
+
+    /**
+     * When a scene graph contains multiple nested focused nodes, the focusWithin bits that are
+     * cleared when a focused node is removed must only be cleared as long as we don't encounter
+     * another focused node up the tree.
+     */
+    @Test public void testMultiLevelFocusWithinIsPreserved() {
+        class N extends Group {
+            N(Node... children) {
+                super(children);
+                setFocusTraversable(true);
+            }
+
+            void setFocused() {
+                setFocused(true);
+            }
+        }
+
+        N node1, node2, node3, node4;
+
+        scene.setRoot(
+            node1 = new N(
+                node2 = new N(
+                    node3 = new N(
+                        node4 = new N()
+                    )
+                )
+            ));
+
+        node2.setFocused();
+        node4.setFocused();
+
+        // Remove node4 from the scene graph
+        node3.getChildren().clear();
+
+        assertIsFocusWithin(node1);
+        assertIsFocusWithin(node2);
+        assertNotFocusWithin(node3);
+        assertIsFocusWithin(node4);
+
+        assertNotFocused(node1);
+        assertIsFocused(node2);
+        assertNotFocused(node3);
+        assertIsFocused(node4);
     }
 
 }


### PR DESCRIPTION
This PR fixes a bug where multi-level focus is not correctly preserved.
The original implementation incorrectly assumed that there can only be a single focused node in the scene graph, which is not the case when a branch of the scene graph is presented by a `PopupWindow`. More specifically, when a focused node was removed from the scene graph, the focus flags of all parents were incorrectly cleared. The correct implementation only clears the `focusWithin` flag of parents (but not `focused` or `focusVisible`), and stops when another focused node is encountered along the way.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8297130](https://bugs.openjdk.org/browse/JDK-8297130): ComboBox popup doesn't close after selecting value that was added with 'runLater'


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Author)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/956/head:pull/956` \
`$ git checkout pull/956`

Update a local copy of the PR: \
`$ git checkout pull/956` \
`$ git pull https://git.openjdk.org/jfx pull/956/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 956`

View PR using the GUI difftool: \
`$ git pr show -t 956`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/956.diff">https://git.openjdk.org/jfx/pull/956.diff</a>

</details>
