### PR TITLE
JDK-8297332: Remove easy warnings in javafx.base

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/BidirectionalBinding.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/BidirectionalBinding.java
@@ -68,7 +68,7 @@ public abstract class BidirectionalBinding implements InvalidationListener, Weak
                         new BidirectionalLongBinding((LongProperty) property1, (LongProperty) property2)
                 : ((property1 instanceof BooleanProperty) && (property2 instanceof BooleanProperty)) ?
                         new BidirectionalBooleanBinding((BooleanProperty) property1, (BooleanProperty) property2)
-                : new TypedGenericBidirectionalBinding<T>(property1, property2);
+                : new TypedGenericBidirectionalBinding<>(property1, property2);
         property1.setValue(property2.getValue());
         property1.getValue();
         property1.addListener(binding);
@@ -736,7 +736,7 @@ public abstract class BidirectionalBinding implements InvalidationListener, Weak
                     } catch (RuntimeException e) {
                         try {
                             if (property1 == sourceProperty) {
-                                property1.setValue((T)oldValue);
+                                property1.setValue(oldValue);
                                 property1.getValue();
                             } else {
                                 property2.setValue(oldValue);

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/BidirectionalContentBinding.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/BidirectionalContentBinding.java
@@ -47,7 +47,7 @@ public class BidirectionalContentBinding {
 
     public static <E> Object bind(ObservableList<E> list1, ObservableList<E> list2) {
         checkParameters(list1, list2);
-        final ListContentBinding<E> binding = new ListContentBinding<E>(list1, list2);
+        final ListContentBinding<E> binding = new ListContentBinding<>(list1, list2);
         list1.setAll(list2);
         list1.addListener(binding);
         list2.addListener(binding);
@@ -56,7 +56,7 @@ public class BidirectionalContentBinding {
 
     public static <E> Object bind(ObservableSet<E> set1, ObservableSet<E> set2) {
         checkParameters(set1, set2);
-        final SetContentBinding<E> binding = new SetContentBinding<E>(set1, set2);
+        final SetContentBinding<E> binding = new SetContentBinding<>(set1, set2);
         set1.clear();
         set1.addAll(set2);
         set1.addListener(binding);
@@ -66,7 +66,7 @@ public class BidirectionalContentBinding {
 
     public static <K, V> Object bind(ObservableMap<K, V> map1, ObservableMap<K, V> map2) {
         checkParameters(map1, map2);
-        final MapContentBinding<K, V> binding = new MapContentBinding<K, V>(map1, map2);
+        final MapContentBinding<K, V> binding = new MapContentBinding<>(map1, map2);
         map1.clear();
         map1.putAll(map2);
         map1.addListener(binding);
@@ -106,8 +106,8 @@ public class BidirectionalContentBinding {
 
 
         public ListContentBinding(ObservableList<E> list1, ObservableList<E> list2) {
-            propertyRef1 = new WeakReference<ObservableList<E>>(list1);
-            propertyRef2 = new WeakReference<ObservableList<E>>(list2);
+            propertyRef1 = new WeakReference<>(list1);
+            propertyRef2 = new WeakReference<>(list2);
         }
 
         @Override
@@ -200,8 +200,8 @@ public class BidirectionalContentBinding {
 
 
         public SetContentBinding(ObservableSet<E> list1, ObservableSet<E> list2) {
-            propertyRef1 = new WeakReference<ObservableSet<E>>(list1);
-            propertyRef2 = new WeakReference<ObservableSet<E>>(list2);
+            propertyRef1 = new WeakReference<>(list1);
+            propertyRef2 = new WeakReference<>(list2);
         }
 
         @Override
@@ -286,8 +286,8 @@ public class BidirectionalContentBinding {
 
 
         public MapContentBinding(ObservableMap<K, V> list1, ObservableMap<K, V> list2) {
-            propertyRef1 = new WeakReference<ObservableMap<K, V>>(list1);
-            propertyRef2 = new WeakReference<ObservableMap<K, V>>(list2);
+            propertyRef1 = new WeakReference<>(list1);
+            propertyRef2 = new WeakReference<>(list2);
         }
 
         @Override

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/BindingHelperObserver.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/BindingHelperObserver.java
@@ -40,7 +40,7 @@ public class BindingHelperObserver implements InvalidationListener, WeakListener
         if (binding == null) {
             throw new NullPointerException("Binding has to be specified.");
         }
-        ref = new WeakReference<Binding<?>>(binding);
+        ref = new WeakReference<>(binding);
     }
 
     @Override

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/ContentBinding.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/ContentBinding.java
@@ -48,7 +48,7 @@ public class ContentBinding {
 
     public static <E> Object bind(List<E> list1, ObservableList<? extends E> list2) {
         checkParameters(list1, list2);
-        final ListContentBinding<E> contentBinding = new ListContentBinding<E>(list1);
+        final ListContentBinding<E> contentBinding = new ListContentBinding<>(list1);
         if (list1 instanceof ObservableList) {
             ((ObservableList) list1).setAll(list2);
         } else {
@@ -62,7 +62,7 @@ public class ContentBinding {
 
     public static <E> Object bind(Set<E> set1, ObservableSet<? extends E> set2) {
         checkParameters(set1, set2);
-        final SetContentBinding<E> contentBinding = new SetContentBinding<E>(set1);
+        final SetContentBinding<E> contentBinding = new SetContentBinding<>(set1);
         set1.clear();
         set1.addAll(set2);
         set2.removeListener(contentBinding);
@@ -72,7 +72,7 @@ public class ContentBinding {
 
     public static <K, V> Object bind(Map<K, V> map1, ObservableMap<? extends K, ? extends V> map2) {
         checkParameters(map1, map2);
-        final MapContentBinding<K, V> contentBinding = new MapContentBinding<K, V>(map1);
+        final MapContentBinding<K, V> contentBinding = new MapContentBinding<>(map1);
         map1.clear();
         map1.putAll(map2);
         map2.removeListener(contentBinding);
@@ -96,7 +96,7 @@ public class ContentBinding {
         private final WeakReference<List<E>> listRef;
 
         public ListContentBinding(List<E> list) {
-            this.listRef = new WeakReference<List<E>>(list);
+            this.listRef = new WeakReference<>(list);
         }
 
         @Override
@@ -157,7 +157,7 @@ public class ContentBinding {
         private final WeakReference<Set<E>> setRef;
 
         public SetContentBinding(Set<E> set) {
-            this.setRef = new WeakReference<Set<E>>(set);
+            this.setRef = new WeakReference<>(set);
         }
 
         @Override
@@ -210,7 +210,7 @@ public class ContentBinding {
         private final WeakReference<Map<K, V>> mapRef;
 
         public MapContentBinding(Map<K, V> map) {
-            this.mapRef = new WeakReference<Map<K, V>>(map);
+            this.mapRef = new WeakReference<>(map);
         }
 
         @Override

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/ExpressionHelper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/ExpressionHelper.java
@@ -51,7 +51,7 @@ public abstract class ExpressionHelper<T> extends ExpressionHelperBase {
             throw new NullPointerException();
         }
         observable.getValue(); // validate observable
-        return (helper == null)? new SingleInvalidation<T>(observable, listener) : helper.addListener(listener);
+        return (helper == null)? new SingleInvalidation<>(observable, listener) : helper.addListener(listener);
     }
 
     public static <T> ExpressionHelper<T> removeListener(ExpressionHelper<T> helper, InvalidationListener listener) {
@@ -65,7 +65,7 @@ public abstract class ExpressionHelper<T> extends ExpressionHelperBase {
         if ((observable == null) || (listener == null)) {
             throw new NullPointerException();
         }
-        return (helper == null)? new SingleChange<T>(observable, listener) : helper.addListener(listener);
+        return (helper == null)? new SingleChange<>(observable, listener) : helper.addListener(listener);
     }
 
     public static <T> ExpressionHelper<T> removeListener(ExpressionHelper<T> helper, ChangeListener<? super T> listener) {
@@ -112,7 +112,7 @@ public abstract class ExpressionHelper<T> extends ExpressionHelperBase {
 
         @Override
         protected ExpressionHelper<T> addListener(InvalidationListener listener) {
-            return new Generic<T>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -122,7 +122,7 @@ public abstract class ExpressionHelper<T> extends ExpressionHelperBase {
 
         @Override
         protected ExpressionHelper<T> addListener(ChangeListener<? super T> listener) {
-            return new Generic<T>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -153,7 +153,7 @@ public abstract class ExpressionHelper<T> extends ExpressionHelperBase {
 
         @Override
         protected ExpressionHelper<T> addListener(InvalidationListener listener) {
-            return new Generic<T>(observable, listener, this.listener);
+            return new Generic<>(observable, listener, this.listener);
         }
 
         @Override
@@ -163,7 +163,7 @@ public abstract class ExpressionHelper<T> extends ExpressionHelperBase {
 
         @Override
         protected ExpressionHelper<T> addListener(ChangeListener<? super T> listener) {
-            return new Generic<T>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -246,12 +246,12 @@ public abstract class ExpressionHelper<T> extends ExpressionHelperBase {
                     if (listener.equals(invalidationListeners[index])) {
                         if (invalidationSize == 1) {
                             if (changeSize == 1) {
-                                return new SingleChange<T>(observable, changeListeners[0]);
+                                return new SingleChange<>(observable, changeListeners[0]);
                             }
                             invalidationListeners = null;
                             invalidationSize = 0;
                         } else if ((invalidationSize == 2) && (changeSize == 0)) {
-                            return new SingleInvalidation<T>(observable, invalidationListeners[1-index]);
+                            return new SingleInvalidation<>(observable, invalidationListeners[1-index]);
                         } else {
                             final int numMoved = invalidationSize - index - 1;
                             final InvalidationListener[] oldListeners = invalidationListeners;
@@ -306,12 +306,12 @@ public abstract class ExpressionHelper<T> extends ExpressionHelperBase {
                     if (listener.equals(changeListeners[index])) {
                         if (changeSize == 1) {
                             if (invalidationSize == 1) {
-                                return new SingleInvalidation<T>(observable, invalidationListeners[0]);
+                                return new SingleInvalidation<>(observable, invalidationListeners[0]);
                             }
                             changeListeners = null;
                             changeSize = 0;
                         } else if ((changeSize == 2) && (invalidationSize == 0)) {
-                            return new SingleChange<T>(observable, changeListeners[1-index]);
+                            return new SingleChange<>(observable, changeListeners[1-index]);
                         } else {
                             final int numMoved = changeSize - index - 1;
                             final ChangeListener<? super T>[] oldListeners = changeListeners;

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/ListExpressionHelper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/ListExpressionHelper.java
@@ -35,8 +35,6 @@ import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 
 import java.util.Arrays;
-import java.util.List;
-
 import static javafx.collections.ListChangeListener.Change;
 
 /**
@@ -60,7 +58,7 @@ public abstract class ListExpressionHelper<E> extends ExpressionHelperBase {
             throw new NullPointerException();
         }
         observable.getValue(); // validate observable
-        return (helper == null)? new SingleInvalidation<E>(observable, listener) : helper.addListener(listener);
+        return (helper == null)? new SingleInvalidation<>(observable, listener) : helper.addListener(listener);
     }
 
     public static <E> ListExpressionHelper<E> removeListener(ListExpressionHelper<E> helper, InvalidationListener listener) {
@@ -74,7 +72,7 @@ public abstract class ListExpressionHelper<E> extends ExpressionHelperBase {
         if ((observable == null) || (listener == null)) {
             throw new NullPointerException();
         }
-        return (helper == null)? new SingleChange<E>(observable, listener) : helper.addListener(listener);
+        return (helper == null)? new SingleChange<>(observable, listener) : helper.addListener(listener);
     }
 
     public static <E> ListExpressionHelper<E> removeListener(ListExpressionHelper<E> helper, ChangeListener<? super ObservableList<E>> listener) {
@@ -88,7 +86,7 @@ public abstract class ListExpressionHelper<E> extends ExpressionHelperBase {
         if ((observable == null) || (listener == null)) {
             throw new NullPointerException();
         }
-        return (helper == null)? new SingleListChange<E>(observable, listener) : helper.addListener(listener);
+        return (helper == null)? new SingleListChange<>(observable, listener) : helper.addListener(listener);
     }
 
     public static <E> ListExpressionHelper<E> removeListener(ListExpressionHelper<E> helper, ListChangeListener<? super E> listener) {
@@ -145,7 +143,7 @@ public abstract class ListExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected ListExpressionHelper<E> addListener(InvalidationListener listener) {
-            return new Generic<E>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -155,7 +153,7 @@ public abstract class ListExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected ListExpressionHelper<E> addListener(ChangeListener<? super ObservableList<E>> listener) {
-            return new Generic<E>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -165,7 +163,7 @@ public abstract class ListExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected ListExpressionHelper<E> addListener(ListChangeListener<? super E> listener) {
-            return new Generic<E>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -197,7 +195,7 @@ public abstract class ListExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected ListExpressionHelper<E> addListener(InvalidationListener listener) {
-            return new Generic<E>(observable, listener, this.listener);
+            return new Generic<>(observable, listener, this.listener);
         }
 
         @Override
@@ -207,7 +205,7 @@ public abstract class ListExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected ListExpressionHelper<E> addListener(ChangeListener<? super ObservableList<E>> listener) {
-            return new Generic<E>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -217,7 +215,7 @@ public abstract class ListExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected ListExpressionHelper<E> addListener(ListChangeListener<? super E> listener) {
-            return new Generic<E>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -253,7 +251,7 @@ public abstract class ListExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected ListExpressionHelper<E> addListener(InvalidationListener listener) {
-            return new Generic<E>(observable, listener, this.listener);
+            return new Generic<>(observable, listener, this.listener);
         }
 
         @Override
@@ -263,7 +261,7 @@ public abstract class ListExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected ListExpressionHelper<E> addListener(ChangeListener<? super ObservableList<E>> listener) {
-            return new Generic<E>(observable, listener, this.listener);
+            return new Generic<>(observable, listener, this.listener);
         }
 
         @Override
@@ -273,7 +271,7 @@ public abstract class ListExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected ListExpressionHelper<E> addListener(ListChangeListener<? super E> listener) {
-            return new Generic<E>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -290,7 +288,7 @@ public abstract class ListExpressionHelper<E> extends ExpressionHelperBase {
                 final ObservableList<E> safeOldValue = (oldValue == null)?
                         FXCollections.<E>emptyObservableList()
                         : FXCollections.unmodifiableObservableList(oldValue);
-                final Change<E> change = new NonIterableChange.GenericAddRemoveChange<E>(0, safeSize, safeOldValue, observable);
+                final Change<E> change = new NonIterableChange.GenericAddRemoveChange<>(0, safeSize, safeOldValue, observable);
                 listener.onChanged(change);
             }
         }
@@ -388,14 +386,14 @@ public abstract class ListExpressionHelper<E> extends ExpressionHelperBase {
                     if (listener.equals(invalidationListeners[index])) {
                         if (invalidationSize == 1) {
                             if ((changeSize == 1) && (listChangeSize == 0)) {
-                                return new SingleChange<E>(observable, changeListeners[0]);
+                                return new SingleChange<>(observable, changeListeners[0]);
                             } else if ((changeSize == 0) && (listChangeSize == 1)) {
-                                return new SingleListChange<E>(observable, listChangeListeners[0]);
+                                return new SingleListChange<>(observable, listChangeListeners[0]);
                             }
                             invalidationListeners = null;
                             invalidationSize = 0;
                         } else if ((invalidationSize == 2) && (changeSize == 0) && (listChangeSize == 0)) {
-                            return new SingleInvalidation<E>(observable, invalidationListeners[1-index]);
+                            return new SingleInvalidation<>(observable, invalidationListeners[1-index]);
                         } else {
                             final int numMoved = invalidationSize - index - 1;
                             final InvalidationListener[] oldListeners = invalidationListeners;
@@ -450,14 +448,14 @@ public abstract class ListExpressionHelper<E> extends ExpressionHelperBase {
                     if (listener.equals(changeListeners[index])) {
                         if (changeSize == 1) {
                             if ((invalidationSize == 1) && (listChangeSize == 0)) {
-                                return new SingleInvalidation<E>(observable, invalidationListeners[0]);
+                                return new SingleInvalidation<>(observable, invalidationListeners[0]);
                             } else if ((invalidationSize == 0) && (listChangeSize == 1)) {
-                                return new SingleListChange<E>(observable, listChangeListeners[0]);
+                                return new SingleListChange<>(observable, listChangeListeners[0]);
                             }
                             changeListeners = null;
                             changeSize = 0;
                         } else if ((changeSize == 2) && (invalidationSize == 0) && (listChangeSize == 0)) {
-                            return new SingleChange<E>(observable, changeListeners[1-index]);
+                            return new SingleChange<>(observable, changeListeners[1-index]);
                         } else {
                             final int numMoved = changeSize - index - 1;
                             final ChangeListener<? super ObservableList<E>>[] oldListeners = changeListeners;
@@ -512,14 +510,14 @@ public abstract class ListExpressionHelper<E> extends ExpressionHelperBase {
                     if (listener.equals(listChangeListeners[index])) {
                         if (listChangeSize == 1) {
                             if ((invalidationSize == 1) && (changeSize == 0)) {
-                                return new SingleInvalidation<E>(observable, invalidationListeners[0]);
+                                return new SingleInvalidation<>(observable, invalidationListeners[0]);
                             } else if ((invalidationSize == 0) && (changeSize == 1)) {
-                                return new SingleChange<E>(observable, changeListeners[0]);
+                                return new SingleChange<>(observable, changeListeners[0]);
                             }
                             listChangeListeners = null;
                             listChangeSize = 0;
                         } else if ((listChangeSize == 2) && (invalidationSize == 0) && (changeSize == 0)) {
-                            return new SingleListChange<E>(observable, listChangeListeners[1-index]);
+                            return new SingleListChange<>(observable, listChangeListeners[1-index]);
                         } else {
                             final int numMoved = listChangeSize - index - 1;
                             final ListChangeListener<? super E>[] oldListeners = listChangeListeners;

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/MapExpressionHelper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/MapExpressionHelper.java
@@ -46,7 +46,7 @@ public abstract class MapExpressionHelper<K, V> extends ExpressionHelperBase {
             throw new NullPointerException();
         }
         observable.getValue(); // validate observable
-        return (helper == null)? new SingleInvalidation<K, V>(observable, listener) : helper.addListener(listener);
+        return (helper == null)? new SingleInvalidation<>(observable, listener) : helper.addListener(listener);
     }
 
     public static <K, V> MapExpressionHelper<K, V> removeListener(MapExpressionHelper<K, V> helper, InvalidationListener listener) {
@@ -60,7 +60,7 @@ public abstract class MapExpressionHelper<K, V> extends ExpressionHelperBase {
         if ((observable == null) || (listener == null)) {
             throw new NullPointerException();
         }
-        return (helper == null)? new SingleChange<K, V>(observable, listener) : helper.addListener(listener);
+        return (helper == null)? new SingleChange<>(observable, listener) : helper.addListener(listener);
     }
 
     public static <K, V> MapExpressionHelper<K, V> removeListener(MapExpressionHelper<K, V> helper, ChangeListener<? super ObservableMap<K, V>> listener) {
@@ -74,7 +74,7 @@ public abstract class MapExpressionHelper<K, V> extends ExpressionHelperBase {
         if ((observable == null) || (listener == null)) {
             throw new NullPointerException();
         }
-        return (helper == null)? new SingleMapChange<K, V>(observable, listener) : helper.addListener(listener);
+        return (helper == null)? new SingleMapChange<>(observable, listener) : helper.addListener(listener);
     }
 
     public static <K, V> MapExpressionHelper<K, V> removeListener(MapExpressionHelper<K, V> helper, MapChangeListener<? super K, ? super V> listener) {
@@ -131,7 +131,7 @@ public abstract class MapExpressionHelper<K, V> extends ExpressionHelperBase {
 
         @Override
         protected MapExpressionHelper<K, V> addListener(InvalidationListener listener) {
-            return new Generic<K, V>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -141,7 +141,7 @@ public abstract class MapExpressionHelper<K, V> extends ExpressionHelperBase {
 
         @Override
         protected MapExpressionHelper<K, V> addListener(ChangeListener<? super ObservableMap<K, V>> listener) {
-            return new Generic<K, V>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -151,7 +151,7 @@ public abstract class MapExpressionHelper<K, V> extends ExpressionHelperBase {
 
         @Override
         protected MapExpressionHelper<K, V> addListener(MapChangeListener<? super K, ? super V> listener) {
-            return new Generic<K, V>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -183,7 +183,7 @@ public abstract class MapExpressionHelper<K, V> extends ExpressionHelperBase {
 
         @Override
         protected MapExpressionHelper<K, V> addListener(InvalidationListener listener) {
-            return new Generic<K, V>(observable, listener, this.listener);
+            return new Generic<>(observable, listener, this.listener);
         }
 
         @Override
@@ -193,7 +193,7 @@ public abstract class MapExpressionHelper<K, V> extends ExpressionHelperBase {
 
         @Override
         protected MapExpressionHelper<K, V> addListener(ChangeListener<? super ObservableMap<K, V>> listener) {
-            return new Generic<K, V>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -203,7 +203,7 @@ public abstract class MapExpressionHelper<K, V> extends ExpressionHelperBase {
 
         @Override
         protected MapExpressionHelper<K, V> addListener(MapChangeListener<? super K, ? super V> listener) {
-            return new Generic<K, V>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -239,7 +239,7 @@ public abstract class MapExpressionHelper<K, V> extends ExpressionHelperBase {
 
         @Override
         protected MapExpressionHelper<K, V> addListener(InvalidationListener listener) {
-            return new Generic<K, V>(observable, listener, this.listener);
+            return new Generic<>(observable, listener, this.listener);
         }
 
         @Override
@@ -249,7 +249,7 @@ public abstract class MapExpressionHelper<K, V> extends ExpressionHelperBase {
 
         @Override
         protected MapExpressionHelper<K, V> addListener(ChangeListener<? super ObservableMap<K, V>> listener) {
-            return new Generic<K, V>(observable, listener, this.listener);
+            return new Generic<>(observable, listener, this.listener);
         }
 
         @Override
@@ -259,7 +259,7 @@ public abstract class MapExpressionHelper<K, V> extends ExpressionHelperBase {
 
         @Override
         protected MapExpressionHelper<K, V> addListener(MapChangeListener<? super K, ? super V> listener) {
-            return new Generic<K, V>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -272,7 +272,7 @@ public abstract class MapExpressionHelper<K, V> extends ExpressionHelperBase {
             final ObservableMap<K, V> oldValue = currentValue;
             currentValue = observable.getValue();
             if (currentValue != oldValue) {
-                final SimpleChange<K, V> change = new SimpleChange<K, V>(observable);
+                final SimpleChange<K, V> change = new SimpleChange<>(observable);
                 if (currentValue == null) {
                     for (final Map.Entry<K, V> element : oldValue.entrySet()) {
                         listener.onChanged(change.setRemoved(element.getKey(), element.getValue()));
@@ -306,7 +306,7 @@ public abstract class MapExpressionHelper<K, V> extends ExpressionHelperBase {
 
         @Override
         protected void fireValueChangedEvent(final MapChangeListener.Change<? extends K, ? extends V> change) {
-            listener.onChanged(new SimpleChange<K, V>(observable, change));
+            listener.onChanged(new SimpleChange<>(observable, change));
         }
     }
 
@@ -397,9 +397,9 @@ public abstract class MapExpressionHelper<K, V> extends ExpressionHelperBase {
                     if (listener.equals(invalidationListeners[index])) {
                         if (invalidationSize == 1) {
                             if ((changeSize == 1) && (mapChangeSize == 0)) {
-                                return new SingleChange<K, V>(observable, changeListeners[0]);
+                                return new SingleChange<>(observable, changeListeners[0]);
                             } else if ((changeSize == 0) && (mapChangeSize == 1)) {
-                                return new SingleMapChange<K, V>(observable, mapChangeListeners[0]);
+                                return new SingleMapChange<>(observable, mapChangeListeners[0]);
                             }
                             invalidationListeners = null;
                             invalidationSize = 0;
@@ -459,9 +459,9 @@ public abstract class MapExpressionHelper<K, V> extends ExpressionHelperBase {
                     if (listener.equals(changeListeners[index])) {
                         if (changeSize == 1) {
                             if ((invalidationSize == 1) && (mapChangeSize == 0)) {
-                                return new SingleInvalidation<K, V>(observable, invalidationListeners[0]);
+                                return new SingleInvalidation<>(observable, invalidationListeners[0]);
                             } else if ((invalidationSize == 0) && (mapChangeSize == 1)) {
-                                return new SingleMapChange<K, V>(observable, mapChangeListeners[0]);
+                                return new SingleMapChange<>(observable, mapChangeListeners[0]);
                             }
                             changeListeners = null;
                             changeSize = 0;
@@ -521,9 +521,9 @@ public abstract class MapExpressionHelper<K, V> extends ExpressionHelperBase {
                     if (listener.equals(mapChangeListeners[index])) {
                         if (mapChangeSize == 1) {
                             if ((invalidationSize == 1) && (changeSize == 0)) {
-                                return new SingleInvalidation<K, V>(observable, invalidationListeners[0]);
+                                return new SingleInvalidation<>(observable, invalidationListeners[0]);
                             } else if ((invalidationSize == 0) && (changeSize == 1)) {
-                                return new SingleChange<K, V>(observable, changeListeners[0]);
+                                return new SingleChange<>(observable, changeListeners[0]);
                             }
                             mapChangeListeners = null;
                             mapChangeSize = 0;
@@ -564,7 +564,7 @@ public abstract class MapExpressionHelper<K, V> extends ExpressionHelperBase {
 
         @Override
         protected void fireValueChangedEvent(final MapChangeListener.Change<? extends K, ? extends V> change) {
-            final SimpleChange<K, V> mappedChange = (mapChangeSize == 0)? null : new SimpleChange<K, V>(observable, change);
+            final SimpleChange<K, V> mappedChange = (mapChangeSize == 0)? null : new SimpleChange<>(observable, change);
             notifyListeners(currentValue, mappedChange);
         }
 
@@ -590,7 +590,7 @@ public abstract class MapExpressionHelper<K, V> extends ExpressionHelperBase {
                                 curListChangeList[i].onChanged(change);
                             }
                         } else {
-                            change = new SimpleChange<K, V>(observable);
+                            change = new SimpleChange<>(observable);
                             if (currentValue == null) {
                                 for (final Map.Entry<K, V> element : oldValue.entrySet()) {
                                     change.setRemoved(element.getKey(), element.getValue());

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/ObjectConstant.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/ObjectConstant.java
@@ -38,7 +38,7 @@ public class ObjectConstant<T> implements ObservableObjectValue<T> {
     }
 
     public static <T> ObjectConstant<T> valueOf(T value) {
-        return new ObjectConstant<T>(value);
+        return new ObjectConstant<>(value);
     }
 
     @Override

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/SelectBinding.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/SelectBinding.java
@@ -470,7 +470,7 @@ public class SelectBinding {
                     if ((propRefs[i] == null)
                             || (!obj.getClass().equals(
                             propRefs[i].getContainingClass()))) {
-                        propRefs[i] = new PropertyReference<Object>(obj.getClass(),
+                        propRefs[i] = new PropertyReference<>(obj.getClass(),
                                 propertyNames[i]);
                     }
                     if (propRefs[i].hasProperty()) {

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/SetExpressionHelper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/SetExpressionHelper.java
@@ -45,7 +45,7 @@ public abstract class SetExpressionHelper<E> extends ExpressionHelperBase {
             throw new NullPointerException();
         }
         observable.getValue(); // validate observable
-        return (helper == null)? new SingleInvalidation<E>(observable, listener) : helper.addListener(listener);
+        return (helper == null)? new SingleInvalidation<>(observable, listener) : helper.addListener(listener);
     }
 
     public static <E> SetExpressionHelper<E> removeListener(SetExpressionHelper<E> helper, InvalidationListener listener) {
@@ -59,7 +59,7 @@ public abstract class SetExpressionHelper<E> extends ExpressionHelperBase {
         if ((observable == null) || (listener == null)) {
             throw new NullPointerException();
         }
-        return (helper == null)? new SingleChange<E>(observable, listener) : helper.addListener(listener);
+        return (helper == null)? new SingleChange<>(observable, listener) : helper.addListener(listener);
     }
 
     public static <E> SetExpressionHelper<E> removeListener(SetExpressionHelper<E> helper, ChangeListener<? super ObservableSet<E>> listener) {
@@ -73,7 +73,7 @@ public abstract class SetExpressionHelper<E> extends ExpressionHelperBase {
         if ((observable == null) || (listener == null)) {
             throw new NullPointerException();
         }
-        return (helper == null)? new SingleSetChange<E>(observable, listener) : helper.addListener(listener);
+        return (helper == null)? new SingleSetChange<>(observable, listener) : helper.addListener(listener);
     }
 
     public static <E> SetExpressionHelper<E> removeListener(SetExpressionHelper<E> helper, SetChangeListener<? super E> listener) {
@@ -130,7 +130,7 @@ public abstract class SetExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected SetExpressionHelper<E> addListener(InvalidationListener listener) {
-            return new Generic<E>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -140,7 +140,7 @@ public abstract class SetExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected SetExpressionHelper<E> addListener(ChangeListener<? super ObservableSet<E>> listener) {
-            return new Generic<E>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -150,7 +150,7 @@ public abstract class SetExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected SetExpressionHelper<E> addListener(SetChangeListener<? super E> listener) {
-            return new Generic<E>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -182,7 +182,7 @@ public abstract class SetExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected SetExpressionHelper<E> addListener(InvalidationListener listener) {
-            return new Generic<E>(observable, listener, this.listener);
+            return new Generic<>(observable, listener, this.listener);
         }
 
         @Override
@@ -192,7 +192,7 @@ public abstract class SetExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected SetExpressionHelper<E> addListener(ChangeListener<? super ObservableSet<E>> listener) {
-            return new Generic<E>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -202,7 +202,7 @@ public abstract class SetExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected SetExpressionHelper<E> addListener(SetChangeListener<? super E> listener) {
-            return new Generic<E>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -238,7 +238,7 @@ public abstract class SetExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected SetExpressionHelper<E> addListener(InvalidationListener listener) {
-            return new Generic<E>(observable, listener, this.listener);
+            return new Generic<>(observable, listener, this.listener);
         }
 
         @Override
@@ -248,7 +248,7 @@ public abstract class SetExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected SetExpressionHelper<E> addListener(ChangeListener<? super ObservableSet<E>> listener) {
-            return new Generic<E>(observable, listener, this.listener);
+            return new Generic<>(observable, listener, this.listener);
         }
 
         @Override
@@ -258,7 +258,7 @@ public abstract class SetExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected SetExpressionHelper<E> addListener(SetChangeListener<? super E> listener) {
-            return new Generic<E>(observable, this.listener, listener);
+            return new Generic<>(observable, this.listener, listener);
         }
 
         @Override
@@ -271,7 +271,7 @@ public abstract class SetExpressionHelper<E> extends ExpressionHelperBase {
             final ObservableSet<E> oldValue = currentValue;
             currentValue = observable.getValue();
             if (currentValue != oldValue) {
-                final SimpleChange<E> change = new SimpleChange<E>(observable);
+                final SimpleChange<E> change = new SimpleChange<>(observable);
                 if (currentValue == null) {
                     for (final E element : oldValue) {
                         listener.onChanged(change.setRemoved(element));
@@ -297,7 +297,7 @@ public abstract class SetExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected void fireValueChangedEvent(final SetChangeListener.Change<? extends E> change) {
-            listener.onChanged(new SimpleChange<E>(observable, change));
+            listener.onChanged(new SimpleChange<>(observable, change));
         }
     }
 
@@ -388,9 +388,9 @@ public abstract class SetExpressionHelper<E> extends ExpressionHelperBase {
                     if (listener.equals(invalidationListeners[index])) {
                         if (invalidationSize == 1) {
                             if ((changeSize == 1) && (setChangeSize == 0)) {
-                                return new SingleChange<E>(observable, changeListeners[0]);
+                                return new SingleChange<>(observable, changeListeners[0]);
                             } else if ((changeSize == 0) && (setChangeSize == 1)) {
-                                return new SingleSetChange<E>(observable, setChangeListeners[0]);
+                                return new SingleSetChange<>(observable, setChangeListeners[0]);
                             }
                             invalidationListeners = null;
                             invalidationSize = 0;
@@ -450,9 +450,9 @@ public abstract class SetExpressionHelper<E> extends ExpressionHelperBase {
                     if (listener.equals(changeListeners[index])) {
                         if (changeSize == 1) {
                             if ((invalidationSize == 1) && (setChangeSize == 0)) {
-                                return new SingleInvalidation<E>(observable, invalidationListeners[0]);
+                                return new SingleInvalidation<>(observable, invalidationListeners[0]);
                             } else if ((invalidationSize == 0) && (setChangeSize == 1)) {
-                                return new SingleSetChange<E>(observable, setChangeListeners[0]);
+                                return new SingleSetChange<>(observable, setChangeListeners[0]);
                             }
                             changeListeners = null;
                             changeSize = 0;
@@ -512,9 +512,9 @@ public abstract class SetExpressionHelper<E> extends ExpressionHelperBase {
                     if (listener.equals(setChangeListeners[index])) {
                         if (setChangeSize == 1) {
                             if ((invalidationSize == 1) && (changeSize == 0)) {
-                                return new SingleInvalidation<E>(observable, invalidationListeners[0]);
+                                return new SingleInvalidation<>(observable, invalidationListeners[0]);
                             } else if ((invalidationSize == 0) && (changeSize == 1)) {
-                                return new SingleChange<E>(observable, changeListeners[0]);
+                                return new SingleChange<>(observable, changeListeners[0]);
                             }
                             setChangeListeners = null;
                             setChangeSize = 0;
@@ -555,7 +555,7 @@ public abstract class SetExpressionHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected void fireValueChangedEvent(final SetChangeListener.Change<? extends E> change) {
-            final SimpleChange<E> mappedChange = (setChangeSize == 0)? null : new SimpleChange<E>(observable, change);
+            final SimpleChange<E> mappedChange = (setChangeSize == 0)? null : new SimpleChange<>(observable, change);
             notifyListeners(currentValue, mappedChange);
         }
 
@@ -581,7 +581,7 @@ public abstract class SetExpressionHelper<E> extends ExpressionHelperBase {
                                 curListChangeList[i].onChanged(change);
                             }
                         } else {
-                            change = new SimpleChange<E>(observable);
+                            change = new SimpleChange<>(observable);
                             if (currentValue == null) {
                                 for (final E element : oldValue) {
                                     change.setRemoved(element);

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/StringFormatter.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/StringFormatter.java
@@ -52,7 +52,7 @@ public abstract class StringFormatter extends StringBinding {
     }
 
     private static ObservableValue<?>[] extractDependencies(Object... args) {
-        final List<ObservableValue<?>> dependencies = new ArrayList<ObservableValue<?>>();
+        final List<ObservableValue<?>> dependencies = new ArrayList<>();
         for (final Object obj : args) {
             if (obj instanceof ObservableValue) {
                 dependencies.add((ObservableValue<?>) obj);

--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/ArrayListenerHelper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/ArrayListenerHelper.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 import javafx.beans.InvalidationListener;
 import javafx.collections.ArrayChangeListener;
 import javafx.collections.ObservableArray;
-import com.sun.javafx.logging.PlatformLogger;
 
 /**
  */

--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/ElementObservableListDecorator.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/ElementObservableListDecorator.java
@@ -34,12 +34,11 @@ import java.util.RandomAccess;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.collections.ListChangeListener;
-import javafx.collections.ListChangeListener.Change;
 import javafx.collections.ObservableList;
 import javafx.collections.WeakListChangeListener;
 import javafx.util.Callback;
 
-public final class ElementObservableListDecorator<E> extends ObservableListBase<E> implements ObservableList<E> {
+public final class ElementObservableListDecorator<E> extends ObservableListBase<E> {
 
     private final ObservableList<E> decoratedList;
     private final ListChangeListener<E> listener;
@@ -48,7 +47,7 @@ public final class ElementObservableListDecorator<E> extends ObservableListBase<
 
     public ElementObservableListDecorator(ObservableList<E> decorated,
             Callback<E, Observable[]> extractor) {
-        this.observer = new ElementObserver<E>(extractor, new Callback<E, InvalidationListener>() {
+        this.observer = new ElementObserver<>(extractor, new Callback<E, InvalidationListener>() {
 
             @Override
             public InvalidationListener call(final E e) {
@@ -83,7 +82,7 @@ public final class ElementObservableListDecorator<E> extends ObservableListBase<
         for (int i = 0; i < sz; ++i) {
             observer.attachListener(decoratedList.get(i));
         }
-        listener = new ListChangeListener<E>() {
+        listener = new ListChangeListener<>() {
 
             @Override
             public void onChanged(Change<? extends E> c) {
@@ -110,7 +109,7 @@ public final class ElementObservableListDecorator<E> extends ObservableListBase<
                 fireChange(c);
             }
         };
-        this.decoratedList.addListener(new WeakListChangeListener<E> (listener));
+        this.decoratedList.addListener(new WeakListChangeListener<> (listener));
     }
 
     @Override

--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/ElementObserver.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/ElementObserver.java
@@ -27,8 +27,6 @@ package com.sun.javafx.collections;
 
 import javafx.collections.ObservableListBase;
 import java.util.IdentityHashMap;
-import java.util.Iterator;
-import java.util.RandomAccess;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.util.Callback;
@@ -61,7 +59,7 @@ final class ElementObserver<E> {
     private final Callback<E, InvalidationListener> listenerGenerator;
     private final ObservableListBase<E> list;
     private IdentityHashMap<E, ElementObserver.ElementsMapElement> elementsMap =
-            new IdentityHashMap<E, ElementObserver.ElementsMapElement>();
+            new IdentityHashMap<>();
 
     ElementObserver(Callback<E, Observable[]> extractor, Callback<E, InvalidationListener> listenerGenerator, ObservableListBase<E> list) {
         this.extractor = extractor;

--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/ListListenerHelper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/ListListenerHelper.java
@@ -28,8 +28,6 @@ package com.sun.javafx.collections;
 import com.sun.javafx.binding.ExpressionHelperBase;
 import javafx.beans.InvalidationListener;
 import javafx.collections.ListChangeListener;
-import com.sun.javafx.logging.PlatformLogger;
-
 import java.util.Arrays;
 
 /**
@@ -43,7 +41,7 @@ public abstract class ListListenerHelper<E> extends ExpressionHelperBase {
         if (listener == null) {
             throw new NullPointerException();
         }
-        return (helper == null)? new SingleInvalidation<E>(listener) : helper.addListener(listener);
+        return (helper == null)? new SingleInvalidation<>(listener) : helper.addListener(listener);
     }
 
     public static <E> ListListenerHelper<E> removeListener(ListListenerHelper<E> helper, InvalidationListener listener) {
@@ -57,7 +55,7 @@ public abstract class ListListenerHelper<E> extends ExpressionHelperBase {
         if (listener == null) {
             throw new NullPointerException();
         }
-        return (helper == null)? new SingleChange<E>(listener) : helper.addListener(listener);
+        return (helper == null)? new SingleChange<>(listener) : helper.addListener(listener);
     }
 
     public static <E> ListListenerHelper<E> removeListener(ListListenerHelper<E> helper, ListChangeListener<? super E> listener) {
@@ -102,7 +100,7 @@ public abstract class ListListenerHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected ListListenerHelper<E> addListener(InvalidationListener listener) {
-            return new Generic<E>(this.listener, listener);
+            return new Generic<>(this.listener, listener);
         }
 
         @Override
@@ -112,7 +110,7 @@ public abstract class ListListenerHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected ListListenerHelper<E> addListener(ListChangeListener<? super E> listener) {
-            return new Generic<E>(this.listener, listener);
+            return new Generic<>(this.listener, listener);
         }
 
         @Override
@@ -140,7 +138,7 @@ public abstract class ListListenerHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected ListListenerHelper<E> addListener(InvalidationListener listener) {
-            return new Generic<E>(listener, this.listener);
+            return new Generic<>(listener, this.listener);
         }
 
         @Override
@@ -150,7 +148,7 @@ public abstract class ListListenerHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected ListListenerHelper<E> addListener(ListChangeListener<? super E> listener) {
-            return new Generic<E>(this.listener, listener);
+            return new Generic<>(this.listener, listener);
         }
 
         @Override
@@ -222,12 +220,12 @@ public abstract class ListListenerHelper<E> extends ExpressionHelperBase {
                     if (listener.equals(invalidationListeners[index])) {
                         if (invalidationSize == 1) {
                             if (changeSize == 1) {
-                                return new SingleChange<E>(changeListeners[0]);
+                                return new SingleChange<>(changeListeners[0]);
                             }
                             invalidationListeners = null;
                             invalidationSize = 0;
                         } else if ((invalidationSize == 2) && (changeSize == 0)) {
-                            return new SingleInvalidation<E>(invalidationListeners[1-index]);
+                            return new SingleInvalidation<>(invalidationListeners[1-index]);
                         } else {
                             final int numMoved = invalidationSize - index - 1;
                             final InvalidationListener[] oldListeners = invalidationListeners;
@@ -279,12 +277,12 @@ public abstract class ListListenerHelper<E> extends ExpressionHelperBase {
                     if (listener.equals(changeListeners[index])) {
                         if (changeSize == 1) {
                             if (invalidationSize == 1) {
-                                return new SingleInvalidation<E>(invalidationListeners[0]);
+                                return new SingleInvalidation<>(invalidationListeners[0]);
                             }
                             changeListeners = null;
                             changeSize = 0;
                         } else if ((changeSize == 2) && (invalidationSize == 0)) {
-                            return new SingleChange<E>(changeListeners[1-index]);
+                            return new SingleChange<>(changeListeners[1-index]);
                         } else {
                             final int numMoved = changeSize - index - 1;
                             final ListChangeListener<? super E>[] oldListeners = changeListeners;

--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/MapListenerHelper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/MapListenerHelper.java
@@ -28,8 +28,6 @@ package com.sun.javafx.collections;
 import com.sun.javafx.binding.ExpressionHelperBase;
 import javafx.beans.InvalidationListener;
 import javafx.collections.MapChangeListener;
-import com.sun.javafx.logging.PlatformLogger;
-
 import java.util.Arrays;
 
 /**
@@ -43,7 +41,7 @@ public abstract class MapListenerHelper<K, V> extends ExpressionHelperBase {
         if (listener == null) {
             throw new NullPointerException();
         }
-        return (helper == null)? new SingleInvalidation<K, V>(listener) : helper.addListener(listener);
+        return (helper == null)? new SingleInvalidation<>(listener) : helper.addListener(listener);
     }
 
     public static <K, V> MapListenerHelper<K, V> removeListener(MapListenerHelper<K, V> helper, InvalidationListener listener) {
@@ -57,7 +55,7 @@ public abstract class MapListenerHelper<K, V> extends ExpressionHelperBase {
         if (listener == null) {
             throw new NullPointerException();
         }
-        return (helper == null)? new SingleChange<K, V>(listener) : helper.addListener(listener);
+        return (helper == null)? new SingleChange<>(listener) : helper.addListener(listener);
     }
 
     public static <K, V> MapListenerHelper<K, V> removeListener(MapListenerHelper<K, V> helper, MapChangeListener<? super K, ? super V> listener) {
@@ -101,7 +99,7 @@ public abstract class MapListenerHelper<K, V> extends ExpressionHelperBase {
 
         @Override
         protected MapListenerHelper<K, V> addListener(InvalidationListener listener) {
-            return new Generic<K, V>(this.listener, listener);
+            return new Generic<>(this.listener, listener);
         }
 
         @Override
@@ -111,7 +109,7 @@ public abstract class MapListenerHelper<K, V> extends ExpressionHelperBase {
 
         @Override
         protected MapListenerHelper<K, V> addListener(MapChangeListener<? super K, ? super V> listener) {
-            return new Generic<K, V>(this.listener, listener);
+            return new Generic<>(this.listener, listener);
         }
 
         @Override
@@ -139,7 +137,7 @@ public abstract class MapListenerHelper<K, V> extends ExpressionHelperBase {
 
         @Override
         protected MapListenerHelper<K, V> addListener(InvalidationListener listener) {
-            return new Generic<K, V>(listener, this.listener);
+            return new Generic<>(listener, this.listener);
         }
 
         @Override
@@ -149,7 +147,7 @@ public abstract class MapListenerHelper<K, V> extends ExpressionHelperBase {
 
         @Override
         protected MapListenerHelper<K, V> addListener(MapChangeListener<? super K, ? super V> listener) {
-            return new Generic<K, V>(this.listener, listener);
+            return new Generic<>(this.listener, listener);
         }
 
         @Override
@@ -221,12 +219,12 @@ public abstract class MapListenerHelper<K, V> extends ExpressionHelperBase {
                     if (listener.equals(invalidationListeners[index])) {
                         if (invalidationSize == 1) {
                             if (changeSize == 1) {
-                                return new SingleChange<K, V>(changeListeners[0]);
+                                return new SingleChange<>(changeListeners[0]);
                             }
                             invalidationListeners = null;
                             invalidationSize = 0;
                         } else if ((invalidationSize == 2) && (changeSize == 0)) {
-                            return new SingleInvalidation<K, V>(invalidationListeners[1-index]);
+                            return new SingleInvalidation<>(invalidationListeners[1-index]);
                         } else {
                             final int numMoved = invalidationSize - index - 1;
                             final InvalidationListener[] oldListeners = invalidationListeners;
@@ -278,12 +276,12 @@ public abstract class MapListenerHelper<K, V> extends ExpressionHelperBase {
                     if (listener.equals(changeListeners[index])) {
                         if (changeSize == 1) {
                             if (invalidationSize == 1) {
-                                return new SingleInvalidation<K, V>(invalidationListeners[0]);
+                                return new SingleInvalidation<>(invalidationListeners[0]);
                             }
                             changeListeners = null;
                             changeSize = 0;
                         } else if ((changeSize == 2) && (invalidationSize == 0)) {
-                            return new SingleChange<K, V>(changeListeners[1-index]);
+                            return new SingleChange<>(changeListeners[1-index]);
                         } else {
                             final int numMoved = changeSize - index - 1;
                             final MapChangeListener<? super K, ? super V>[] oldListeners = changeListeners;

--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/MappingChange.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/MappingChange.java
@@ -76,7 +76,7 @@ public final class MappingChange<E, F> extends Change<F>{
     @Override
     public List<F> getRemoved() {
         if (removed == null) {
-            removed = new AbstractList<F>() {
+            removed = new AbstractList<>() {
 
                 @Override
                 public F get(int index) {

--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/ObservableListWrapper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/ObservableListWrapper.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.RandomAccess;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
-import javafx.collections.ObservableList;
 import javafx.util.Callback;
 
 /**
@@ -43,7 +42,7 @@ import javafx.util.Callback;
  *
  */
 public class ObservableListWrapper<E> extends ModifiableObservableListBase<E> implements
-        ObservableList<E>, SortableList<E>, RandomAccess {
+        SortableList<E>, RandomAccess {
 
     private final List<E> backingList;
 
@@ -214,7 +213,7 @@ public class ObservableListWrapper<E> extends ModifiableObservableListBase<E> im
             return;
         }
         int[] perm = getSortHelper().sort((List<? extends Comparable>)backingList);
-        fireChange(new SimplePermutationChange<E>(0, size(), perm, this));
+        fireChange(new SimplePermutationChange<>(0, size(), perm, this));
     }
 
     @Override
@@ -223,7 +222,7 @@ public class ObservableListWrapper<E> extends ModifiableObservableListBase<E> im
             return;
         }
         int[] perm = getSortHelper().sort(backingList, comparator);
-        fireChange(new SimplePermutationChange<E>(0, size(), perm, this));
+        fireChange(new SimplePermutationChange<>(0, size(), perm, this));
     }
 
     private SortHelper getSortHelper() {

--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/ObservableMapWrapper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/ObservableMapWrapper.java
@@ -262,7 +262,7 @@ public class ObservableMapWrapper<K, V> implements ObservableMap<K, V>{
 
         @Override
         public Iterator<K> iterator() {
-            return new Iterator<K>() {
+            return new Iterator<>() {
 
                 private Iterator<Entry<K, V>> entryIt = backingMap.entrySet().iterator();
                 private K lastKey;
@@ -385,7 +385,7 @@ public class ObservableMapWrapper<K, V> implements ObservableMap<K, V>{
 
         @Override
         public Iterator<V> iterator() {
-            return new Iterator<V>() {
+            return new Iterator<>() {
 
                 private Iterator<Entry<K, V>> entryIt = backingMap.entrySet().iterator();
                 private K lastKey;
@@ -573,7 +573,7 @@ public class ObservableMapWrapper<K, V> implements ObservableMap<K, V>{
 
         @Override
         public Iterator<Entry<K, V>> iterator() {
-            return new Iterator<Entry<K, V>>() {
+            return new Iterator<>() {
 
                 private Iterator<Entry<K,V>> backingIt = backingMap.entrySet().iterator();
                 private K lastKey;

--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/ObservableSequentialListWrapper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/ObservableSequentialListWrapper.java
@@ -33,10 +33,9 @@ import java.util.NoSuchElementException;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.collections.ModifiableObservableListBase;
-import javafx.collections.ObservableList;
 import javafx.util.Callback;
 
-public final class ObservableSequentialListWrapper<E> extends ModifiableObservableListBase<E> implements ObservableList<E>, SortableList<E>{
+public final class ObservableSequentialListWrapper<E> extends ModifiableObservableListBase<E> implements SortableList<E>{
     private final List<E> backingList;
     private final ElementObserver elementObserver;
     private SortHelper helper;
@@ -96,7 +95,7 @@ public final class ObservableSequentialListWrapper<E> extends ModifiableObservab
 
     @Override
     public ListIterator<E> listIterator(final int index) {
-        return new ListIterator<E>() {
+        return new ListIterator<>() {
 
             private final ListIterator<E> backingIt = backingList.listIterator(index);
             private E lastReturned;
@@ -237,7 +236,7 @@ public final class ObservableSequentialListWrapper<E> extends ModifiableObservab
             return;
         }
         int[] perm = getSortHelper().sort((List<? extends Comparable>)backingList);
-        fireChange(new NonIterableChange.SimplePermutationChange<E>(0, size(), perm, this));
+        fireChange(new NonIterableChange.SimplePermutationChange<>(0, size(), perm, this));
     }
 
     @Override
@@ -246,7 +245,7 @@ public final class ObservableSequentialListWrapper<E> extends ModifiableObservab
             return;
         }
         int[] perm = getSortHelper().sort(backingList, comparator);
-        fireChange(new NonIterableChange.SimplePermutationChange<E>(0, size(), perm, this));
+        fireChange(new NonIterableChange.SimplePermutationChange<>(0, size(), perm, this));
     }
 
     private SortHelper getSortHelper() {

--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/SetListenerHelper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/SetListenerHelper.java
@@ -28,8 +28,6 @@ package com.sun.javafx.collections;
 import com.sun.javafx.binding.ExpressionHelperBase;
 import javafx.beans.InvalidationListener;
 import javafx.collections.SetChangeListener;
-import com.sun.javafx.logging.PlatformLogger;
-
 import java.util.Arrays;
 
 /**
@@ -43,7 +41,7 @@ public abstract class SetListenerHelper<E> extends ExpressionHelperBase {
         if (listener == null) {
             throw new NullPointerException();
         }
-        return (helper == null)? new SingleInvalidation<E>(listener) : helper.addListener(listener);
+        return (helper == null)? new SingleInvalidation<>(listener) : helper.addListener(listener);
     }
 
     public static <E> SetListenerHelper<E> removeListener(SetListenerHelper<E> helper, InvalidationListener listener) {
@@ -57,7 +55,7 @@ public abstract class SetListenerHelper<E> extends ExpressionHelperBase {
         if (listener == null) {
             throw new NullPointerException();
         }
-        return (helper == null)? new SingleChange<E>(listener) : helper.addListener(listener);
+        return (helper == null)? new SingleChange<>(listener) : helper.addListener(listener);
     }
 
     public static <E> SetListenerHelper<E> removeListener(SetListenerHelper<E> helper, SetChangeListener<? super E> listener) {
@@ -101,7 +99,7 @@ public abstract class SetListenerHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected SetListenerHelper<E> addListener(InvalidationListener listener) {
-            return new Generic<E>(this.listener, listener);
+            return new Generic<>(this.listener, listener);
         }
 
         @Override
@@ -111,7 +109,7 @@ public abstract class SetListenerHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected SetListenerHelper<E> addListener(SetChangeListener<? super E> listener) {
-            return new Generic<E>(this.listener, listener);
+            return new Generic<>(this.listener, listener);
         }
 
         @Override
@@ -139,7 +137,7 @@ public abstract class SetListenerHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected SetListenerHelper<E> addListener(InvalidationListener listener) {
-            return new Generic<E>(listener, this.listener);
+            return new Generic<>(listener, this.listener);
         }
 
         @Override
@@ -149,7 +147,7 @@ public abstract class SetListenerHelper<E> extends ExpressionHelperBase {
 
         @Override
         protected SetListenerHelper<E> addListener(SetChangeListener<? super E> listener) {
-            return new Generic<E>(this.listener, listener);
+            return new Generic<>(this.listener, listener);
         }
 
         @Override
@@ -221,12 +219,12 @@ public abstract class SetListenerHelper<E> extends ExpressionHelperBase {
                     if (listener.equals(invalidationListeners[index])) {
                         if (invalidationSize == 1) {
                             if (changeSize == 1) {
-                                return new SingleChange<E>(changeListeners[0]);
+                                return new SingleChange<>(changeListeners[0]);
                             }
                             invalidationListeners = null;
                             invalidationSize = 0;
                         } else if ((invalidationSize == 2) && (changeSize == 0)) {
-                            return new SingleInvalidation<E>(invalidationListeners[1-index]);
+                            return new SingleInvalidation<>(invalidationListeners[1-index]);
                         } else {
                             final int numMoved = invalidationSize - index - 1;
                             final InvalidationListener[] oldListeners = invalidationListeners;
@@ -278,12 +276,12 @@ public abstract class SetListenerHelper<E> extends ExpressionHelperBase {
                     if (listener.equals(changeListeners[index])) {
                         if (changeSize == 1) {
                             if (invalidationSize == 1) {
-                                return new SingleInvalidation<E>(invalidationListeners[0]);
+                                return new SingleInvalidation<>(invalidationListeners[0]);
                             }
                             changeListeners = null;
                             changeSize = 0;
                         } else if ((changeSize == 2) && (invalidationSize == 0)) {
-                            return new SingleChange<E>(changeListeners[1-index]);
+                            return new SingleChange<>(changeListeners[1-index]);
                         } else {
                             final int numMoved = changeSize - index - 1;
                             final SetChangeListener<? super E>[] oldListeners = changeListeners;

--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/SortHelper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/SortHelper.java
@@ -53,7 +53,7 @@ public class SortHelper {
         ListIterator<T> i = list.listIterator();
         for (int j=0; j<a.length; j++) {
             i.next();
-            i.set((T)a[j]);
+            i.set(a[j]);
         }
         return result;
     }
@@ -74,7 +74,7 @@ public class SortHelper {
     }
 
     public <T> int[] sort(T[] a, Comparator<? super T> c) {
-        T[] aux = (T[]) a.clone();
+        T[] aux = a.clone();
         int[] result = initPermutation(a.length);
         if (c==null)
             mergeSort(aux, a, 0, a.length, 0);
@@ -88,7 +88,7 @@ public class SortHelper {
     public <T> int[] sort(T[] a, int fromIndex, int toIndex,
                 Comparator<? super T> c) {
         rangeCheck(a.length, fromIndex, toIndex);
-        T[] aux = (T[])copyOfRange(a, fromIndex, toIndex);
+        T[] aux = copyOfRange(a, fromIndex, toIndex);
         int[] result = initPermutation(a.length);
         if (c==null)
             mergeSort(aux, a, fromIndex, toIndex, -fromIndex);
@@ -101,7 +101,7 @@ public class SortHelper {
 
     public int[] sort(int[] a, int fromIndex, int toIndex) {
         rangeCheck(a.length, fromIndex, toIndex);
-        int[] aux = (int[])copyOfRange(a, fromIndex, toIndex);
+        int[] aux = copyOfRange(a, fromIndex, toIndex);
         int[] result = initPermutation(a.length);
         mergeSort(aux, a, fromIndex, toIndex, -fromIndex);
         reversePermutation = null;

--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/SortableList.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/SortableList.java
@@ -51,6 +51,7 @@ public interface SortableList<E> extends List<E> {
      * @throws UnsupportedOperationException if the specified list's
      *         list-iterator does not support the <tt>set</tt> operation.
      */
+    @Override
     public void sort(Comparator<? super E> comparator);
 
 }

--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/TrackableObservableList.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/TrackableObservableList.java
@@ -27,7 +27,6 @@ package com.sun.javafx.collections;
 
 import java.util.ArrayList;
 import java.util.List;
-import javafx.collections.ListChangeListener;
 import javafx.collections.ListChangeListener.Change;
 
 /**

--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/UnmodifiableListSet.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/UnmodifiableListSet.java
@@ -55,7 +55,7 @@ public final class UnmodifiableListSet<E> extends AbstractSet<E> {
      */
     @Override public Iterator<E> iterator() {
         final Iterator<E> itr = backingList.iterator();
-        return new Iterator<E>() {
+        return new Iterator<>() {
             @Override public boolean hasNext() {
                 return itr.hasNext();
             }

--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/UnmodifiableObservableMap.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/UnmodifiableObservableMap.java
@@ -28,7 +28,6 @@ package com.sun.javafx.collections;
 import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 
 import javafx.beans.InvalidationListener;
@@ -55,9 +54,9 @@ public class UnmodifiableObservableMap<K, V> extends AbstractMap<K, V>
     public UnmodifiableObservableMap(ObservableMap<K, V> map) {
         this.backingMap = map;
         listener = c -> {
-            callObservers(new MapAdapterChange<K, V>(UnmodifiableObservableMap.this, c));
+            callObservers(new MapAdapterChange<>(UnmodifiableObservableMap.this, c));
         };
-        this.backingMap.addListener(new WeakMapChangeListener<K, V>(listener));
+        this.backingMap.addListener(new WeakMapChangeListener<>(listener));
     }
 
     private void callObservers(Change<? extends K,? extends V> c) {
@@ -109,6 +108,7 @@ public class UnmodifiableObservableMap<K, V> extends AbstractMap<K, V>
         return backingMap.get(key);
     }
 
+    @Override
     public Set<K> keySet() {
         if (keyset == null) {
             keyset = Collections.unmodifiableSet(backingMap.keySet());
@@ -116,6 +116,7 @@ public class UnmodifiableObservableMap<K, V> extends AbstractMap<K, V>
         return keyset;
     }
 
+    @Override
     public Collection<V> values() {
         if (values == null) {
             values = Collections.unmodifiableCollection(backingMap.values());
@@ -123,6 +124,7 @@ public class UnmodifiableObservableMap<K, V> extends AbstractMap<K, V>
         return values;
     }
 
+    @Override
     public Set<Entry<K,V>> entrySet() {
         if (entryset == null) {
             entryset = Collections.unmodifiableMap(backingMap).entrySet();

--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/VetoableListDecorator.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/VetoableListDecorator.java
@@ -74,7 +74,7 @@ public abstract class VetoableListDecorator<E> implements ObservableList<E> {
         this.list = decorated;
         this.list.addListener((ListChangeListener.Change<? extends E> c) -> {
             ListListenerHelper.fireValueChangedEvent(helper,
-                    new SourceAdapterChange<E>(VetoableListDecorator.this, c));
+                    new SourceAdapterChange<>(VetoableListDecorator.this, c));
         });
     }
 

--- a/modules/javafx.base/src/main/java/com/sun/javafx/event/CompositeEventTargetImpl.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/event/CompositeEventTargetImpl.java
@@ -37,7 +37,7 @@ public class CompositeEventTargetImpl implements CompositeEventTarget {
 
     public CompositeEventTargetImpl(final EventTarget... eventTargets) {
         final Set<EventTarget> mutableSet =
-                new HashSet<EventTarget>(eventTargets.length);
+                new HashSet<>(eventTargets.length);
         mutableSet.addAll(Arrays.asList(eventTargets));
 
         this.eventTargets = Collections.unmodifiableSet(mutableSet);

--- a/modules/javafx.base/src/main/java/com/sun/javafx/event/DirectEvent.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/event/DirectEvent.java
@@ -38,7 +38,7 @@ public class DirectEvent extends Event {
     private static final long serialVersionUID = 20121107L;
 
     public static final EventType<DirectEvent> DIRECT =
-            new EventType<DirectEvent>(Event.ANY, "DIRECT");
+            new EventType<>(Event.ANY, "DIRECT");
 
     private final Event originalEvent;
 

--- a/modules/javafx.base/src/main/java/com/sun/javafx/event/EventHandlerManager.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/event/EventHandlerManager.java
@@ -46,9 +46,7 @@ public class EventHandlerManager extends BasicEventDispatcher {
     public EventHandlerManager(final Object eventSource) {
         this.eventSource = eventSource;
 
-        eventHandlerMap =
-                new HashMap<EventType<? extends Event>,
-                            CompositeEventHandler<? extends Event>>();
+        eventHandlerMap = new HashMap<>();
     }
 
     /**
@@ -156,7 +154,7 @@ public class EventHandlerManager extends BasicEventDispatcher {
             if (eventHandler == null) {
                 return;
             }
-            compositeEventHandler = new CompositeEventHandler<T>();
+            compositeEventHandler = new CompositeEventHandler<>();
             eventHandlerMap.put(eventType, compositeEventHandler);
         }
 
@@ -200,7 +198,7 @@ public class EventHandlerManager extends BasicEventDispatcher {
         CompositeEventHandler<T> compositeEventHandler =
                 (CompositeEventHandler<T>) eventHandlerMap.get(eventType);
         if (compositeEventHandler == null) {
-            compositeEventHandler = new CompositeEventHandler<T>();
+            compositeEventHandler = new CompositeEventHandler<>();
             eventHandlerMap.put(eventType, compositeEventHandler);
         }
 

--- a/modules/javafx.base/src/main/java/com/sun/javafx/event/EventQueue.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/event/EventQueue.java
@@ -30,7 +30,7 @@ import java.util.Queue;
 import javafx.event.Event;
 
 public final class EventQueue {
-    private Queue<Event> queue = new ArrayDeque<Event>();
+    private Queue<Event> queue = new ArrayDeque<>();
     private boolean inLoop;
 
     public void postEvent(Event event) {

--- a/modules/javafx.base/src/main/java/com/sun/javafx/event/EventRedirector.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/event/EventRedirector.java
@@ -66,7 +66,7 @@ public class EventRedirector extends BasicEventDispatcher {
      *      ({@code RedirectedEvent} event source)
      */
     public EventRedirector(final Object eventSource) {
-        this.eventDispatchers = new CopyOnWriteArrayList<EventDispatcher>();
+        this.eventDispatchers = new CopyOnWriteArrayList<>();
         this.eventDispatchChain = new EventDispatchChainImpl();
         this.eventSource = eventSource;
     }

--- a/modules/javafx.base/src/main/java/com/sun/javafx/event/RedirectedEvent.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/event/RedirectedEvent.java
@@ -38,7 +38,7 @@ public class RedirectedEvent extends Event {
     private static final long serialVersionUID = 20121107L;
 
     public static final EventType<RedirectedEvent> REDIRECTED =
-            new EventType<RedirectedEvent>(Event.ANY, "REDIRECTED");
+            new EventType<>(Event.ANY, "REDIRECTED");
 
     private final Event originalEvent;
 

--- a/modules/javafx.base/src/main/java/com/sun/javafx/logging/PlatformLogger.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/logging/PlatformLogger.java
@@ -271,7 +271,7 @@ public class PlatformLogger implements System.Logger {
     private boolean loggingEnabled = true;
     public void enableLogging() {
         loggingEnabled = true;
-    };
+    }
 
     public void disableLogging() {
         loggingEnabled = false;

--- a/modules/javafx.base/src/main/java/com/sun/javafx/logging/PrintLogger.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/logging/PrintLogger.java
@@ -55,8 +55,7 @@ class PrintLogger extends Logger {
      * only the time of the pulse is logged.
      */
     @SuppressWarnings("removal")
-    private static long THRESHOLD = (long)
-            AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Integer.getInteger("javafx.pulseLogger.threshold", 17));
+    private static long THRESHOLD = AccessController.doPrivileged((PrivilegedAction<Integer>) () -> Integer.getInteger("javafx.pulseLogger.threshold", 17));
 
     /**
      * Optionally exit after a given number of pulses

--- a/modules/javafx.base/src/main/java/com/sun/javafx/logging/jfr/JFRPulseLogger.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/logging/jfr/JFRPulseLogger.java
@@ -48,13 +48,13 @@ public final class JFRPulseLogger extends Logger {
     private JFRPulseLogger() {
         FlightRecorder.register(JFRInputEvent.class);
         FlightRecorder.register(JFRPulsePhaseEvent.class);
-        currentPulsePhaseEvent = new ThreadLocal<JFRPulsePhaseEvent>() {
+        currentPulsePhaseEvent = new ThreadLocal<>() {
             @Override
             public JFRPulsePhaseEvent initialValue() {
                 return new JFRPulsePhaseEvent();
             }
         };
-        currentInputEvent = new ThreadLocal<JFRInputEvent>() {
+        currentInputEvent = new ThreadLocal<>() {
             @Override
             public JFRInputEvent initialValue() {
                 return new JFRInputEvent();

--- a/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/Disposer.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/Disposer.java
@@ -53,6 +53,7 @@ public class Disposer implements Runnable {
         @SuppressWarnings("removal")
         var dummy = java.security.AccessController.doPrivileged(
             new java.security.PrivilegedAction() {
+                @Override
                 public Object run() {
                     /* The thread must be a member of a thread group
                      * which will not get GCed before VM exit.
@@ -84,12 +85,13 @@ public class Disposer implements Runnable {
         records.put(ref, rec);
     }
 
+    @Override
     public void run() {
         while (true) {
             try {
                 Object obj = queue.remove();
                 ((Reference)obj).clear();
-                Runnable rec = (Runnable)records.remove(obj);
+                Runnable rec = records.remove(obj);
                 rec.run();
             } catch (Exception e) {
                 System.out.println("Exception while removing reference: " + e);

--- a/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/ReadOnlyPropertyDescriptor.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/ReadOnlyPropertyDescriptor.java
@@ -158,7 +158,7 @@ public class ReadOnlyPropertyDescriptor {
 
         public ReadOnlyListener(Object bean, ReadOnlyJavaBeanProperty<T> property) {
             this.bean = bean;
-            this.propertyRef = new WeakReference<ReadOnlyJavaBeanProperty<T>>(property);
+            this.propertyRef = new WeakReference<>(property);
         }
 
         protected ReadOnlyJavaBeanProperty<T> checkRef() {

--- a/modules/javafx.base/src/main/java/com/sun/javafx/reflect/MethodUtil.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/reflect/MethodUtil.java
@@ -25,7 +25,6 @@
 
 package com.sun.javafx.reflect;
 
-import java.io.EOFException;
 import java.security.AllPermission;
 import java.security.AccessController;
 import java.security.PermissionCollection;
@@ -33,17 +32,13 @@ import java.security.SecureClassLoader;
 import java.security.PrivilegedExceptionAction;
 import java.security.CodeSource;
 import java.io.InputStream;
-import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.net.URL;
-import java.net.URLConnection;
 import java.lang.reflect.Method;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import com.sun.javafx.reflect.ReflectUtil;
 
 
 class Trampoline {
@@ -114,7 +109,7 @@ public final class MethodUtil extends SecureClassLoader {
         if (System.getSecurityManager() == null) {
             return cls.getMethods();
         }
-        Map<Signature, Method> sigs = new HashMap<Signature, Method>();
+        Map<Signature, Method> sigs = new HashMap<>();
         while (cls != null) {
             boolean done = getInternalPublicMethods(cls, sigs);
             if (done) {
@@ -298,6 +293,7 @@ public final class MethodUtil extends SecureClassLoader {
         try {
             return AccessController.doPrivileged(
                 new PrivilegedExceptionAction<Method>() {
+                    @Override
                     public Method run() throws Exception {
                         Class<?> t = getTrampolineClass();
                         Class<?>[] types = {
@@ -314,6 +310,7 @@ public final class MethodUtil extends SecureClassLoader {
     }
 
 
+    @Override
     protected synchronized Class<?> loadClass(String name, boolean resolve)
         throws ClassNotFoundException
     {
@@ -337,6 +334,7 @@ public final class MethodUtil extends SecureClassLoader {
     }
 
 
+    @Override
     protected Class<?> findClass(final String name)
         throws ClassNotFoundException
     {
@@ -371,6 +369,7 @@ public final class MethodUtil extends SecureClassLoader {
         return defineClass(name, b, 0, b.length, cs);
     }
 
+    @Override
     protected PermissionCollection getPermissions(CodeSource codesource)
     {
         PermissionCollection perms = super.getPermissions(codesource);

--- a/modules/javafx.base/src/main/java/javafx/beans/WeakInvalidationListener.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/WeakInvalidationListener.java
@@ -26,7 +26,6 @@
 package javafx.beans;
 
 import java.lang.ref.WeakReference;
-import javafx.beans.NamedArg;
 
 /**
  * A {@code WeakInvalidationListener} can be used if an {@link Observable}
@@ -62,7 +61,7 @@ public final class WeakInvalidationListener implements InvalidationListener, Wea
         if (listener == null) {
             throw new NullPointerException("Listener must be specified.");
         }
-        this.ref = new WeakReference<InvalidationListener>(listener);
+        this.ref = new WeakReference<>(listener);
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/beans/binding/Bindings.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/binding/Bindings.java
@@ -178,7 +178,7 @@ public final class Bindings {
                             FXCollections.emptyObservableList()
                         : (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                        : new ImmutableObservableList<Observable>(dependencies);
+                        : new ImmutableObservableList<>(dependencies);
             }
         };
     }
@@ -224,7 +224,7 @@ public final class Bindings {
                             FXCollections.emptyObservableList()
                         : (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                        : new ImmutableObservableList<Observable>(dependencies);
+                        : new ImmutableObservableList<>(dependencies);
             }
         };
     }
@@ -270,7 +270,7 @@ public final class Bindings {
                             FXCollections.emptyObservableList()
                         : (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                        : new ImmutableObservableList<Observable>(dependencies);
+                        : new ImmutableObservableList<>(dependencies);
             }
         };
     }
@@ -316,7 +316,7 @@ public final class Bindings {
                             FXCollections.emptyObservableList()
                         : (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                        : new ImmutableObservableList<Observable>(dependencies);
+                        : new ImmutableObservableList<>(dependencies);
             }
         };
     }
@@ -362,7 +362,7 @@ public final class Bindings {
                             FXCollections.emptyObservableList()
                         : (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                        : new ImmutableObservableList<Observable>(dependencies);
+                        : new ImmutableObservableList<>(dependencies);
             }
         };
     }
@@ -377,7 +377,7 @@ public final class Bindings {
      * @since JavaFX 2.1
      */
     public static <T> ObjectBinding<T> createObjectBinding(final Callable<T> func, final Observable... dependencies) {
-        return new ObjectBinding<T>() {
+        return new ObjectBinding<>() {
             {
                 bind(dependencies);
             }
@@ -409,7 +409,7 @@ public final class Bindings {
                             FXCollections.emptyObservableList()
                         : (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                        : new ImmutableObservableList<Observable>(dependencies);
+                        : new ImmutableObservableList<>(dependencies);
             }
         };
     }
@@ -455,7 +455,7 @@ public final class Bindings {
                             FXCollections.emptyObservableList()
                         : (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                        : new ImmutableObservableList<Observable>(dependencies);
+                        : new ImmutableObservableList<>(dependencies);
             }
         };
     }
@@ -493,7 +493,7 @@ public final class Bindings {
      * @see ObservableValue#flatMap(java.util.function.Function)
      */
     public static <T> ObjectBinding<T> select(ObservableValue<?> root, String... steps) {
-        return new SelectBinding.AsObject<T>(root, steps);
+        return new SelectBinding.AsObject<>(root, steps);
     }
 
     /**
@@ -680,7 +680,7 @@ public final class Bindings {
      * @since JavaFX 8.0
      */
     public static <T> ObjectBinding<T> select(Object root, String... steps) {
-        return new SelectBinding.AsObject<T>(root, steps);
+        return new SelectBinding.AsObject<>(root, steps);
     }
 
     /**
@@ -1388,7 +1388,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableFloatValue) || (op2 instanceof ObservableFloatValue)) {
@@ -1411,7 +1411,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableLongValue) || (op2 instanceof ObservableLongValue)) {
@@ -1434,7 +1434,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else {
@@ -1457,7 +1457,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         }
@@ -1645,7 +1645,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableFloatValue) || (op2 instanceof ObservableFloatValue)) {
@@ -1668,7 +1668,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableLongValue) || (op2 instanceof ObservableLongValue)) {
@@ -1691,7 +1691,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else {
@@ -1714,7 +1714,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         }
@@ -1902,7 +1902,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableFloatValue) || (op2 instanceof ObservableFloatValue)) {
@@ -1925,7 +1925,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableLongValue) || (op2 instanceof ObservableLongValue)) {
@@ -1948,7 +1948,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else {
@@ -1971,7 +1971,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         }
@@ -2159,7 +2159,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableFloatValue) || (op2 instanceof ObservableFloatValue)) {
@@ -2182,7 +2182,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableLongValue) || (op2 instanceof ObservableLongValue)) {
@@ -2205,7 +2205,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else {
@@ -2228,7 +2228,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         }
@@ -2416,7 +2416,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableFloatValue) || (op2 instanceof ObservableFloatValue)) {
@@ -2439,7 +2439,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableLongValue) || (op2 instanceof ObservableLongValue)) {
@@ -2462,7 +2462,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else {
@@ -2485,7 +2485,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         }
@@ -2851,7 +2851,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableFloatValue) || (op2 instanceof ObservableFloatValue)) {
@@ -2874,7 +2874,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableLongValue) || (op2 instanceof ObservableLongValue)) {
@@ -2897,7 +2897,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else {
@@ -2920,7 +2920,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         }
@@ -3286,7 +3286,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableFloatValue) || (op2 instanceof ObservableFloatValue)) {
@@ -3309,7 +3309,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableLongValue) || (op2 instanceof ObservableLongValue)) {
@@ -3332,7 +3332,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else {
@@ -3355,7 +3355,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         }
@@ -3705,7 +3705,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableFloatValue) || (op2 instanceof ObservableFloatValue)) {
@@ -3728,7 +3728,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableLongValue) || (op2 instanceof ObservableLongValue)) {
@@ -3751,7 +3751,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else {
@@ -3774,7 +3774,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         }
@@ -4125,7 +4125,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableFloatValue) || (op2 instanceof ObservableFloatValue)) {
@@ -4148,7 +4148,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableLongValue) || (op2 instanceof ObservableLongValue)) {
@@ -4171,7 +4171,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else {
@@ -4194,7 +4194,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         }
@@ -4382,7 +4382,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableFloatValue) || (op2 instanceof ObservableFloatValue)) {
@@ -4405,7 +4405,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else if ((op1 instanceof ObservableLongValue) || (op2 instanceof ObservableLongValue)) {
@@ -4428,7 +4428,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         } else {
@@ -4451,7 +4451,7 @@ public final class Bindings {
                 public ObservableList<?> getDependencies() {
                     return (dependencies.length == 1)?
                             FXCollections.singletonObservableList(dependencies[0])
-                            : new ImmutableObservableList<Observable>(dependencies);
+                            : new ImmutableObservableList<>(dependencies);
                 }
             };
         }
@@ -4845,7 +4845,7 @@ public final class Bindings {
 
             @Override
             public ObservableList<?> getDependencies() {
-                return new ImmutableObservableList<ObservableBooleanValue>(op1, op2);
+                return new ImmutableObservableList<>(op1, op2);
             }
         };
     }
@@ -4885,7 +4885,7 @@ public final class Bindings {
 
             @Override
             public ObservableList<?> getDependencies() {
-                return new ImmutableObservableList<ObservableBooleanValue>(op1, op2);
+                return new ImmutableObservableList<>(op1, op2);
             }
         };
     }
@@ -5014,7 +5014,7 @@ public final class Bindings {
             public ObservableList<?> getDependencies() {
                 return (dependencies.length == 1)?
                         FXCollections.singletonObservableList(dependencies[0])
-                        : new ImmutableObservableList<Observable>(dependencies);
+                        : new ImmutableObservableList<>(dependencies);
             }
         };
     }
@@ -5106,7 +5106,7 @@ public final class Bindings {
             public ObservableList<?> getDependencies() {
                 return (dependencies.length == 1)?
                         FXCollections.singletonObservableList(dependencies[0])
-                        : new ImmutableObservableList<Observable>(dependencies);
+                        : new ImmutableObservableList<>(dependencies);
             }
         };
     }
@@ -5198,7 +5198,7 @@ public final class Bindings {
             public ObservableList<?> getDependencies() {
                 return (dependencies.length == 1)?
                         FXCollections.singletonObservableList(dependencies[0])
-                        : new ImmutableObservableList<Observable>(dependencies);
+                        : new ImmutableObservableList<>(dependencies);
             }
         };
     }
@@ -5290,7 +5290,7 @@ public final class Bindings {
             public ObservableList<?> getDependencies() {
                 return (dependencies.length == 1)?
                         FXCollections.singletonObservableList(dependencies[0])
-                        : new ImmutableObservableList<Observable>(dependencies);
+                        : new ImmutableObservableList<>(dependencies);
             }
         };
     }
@@ -5383,7 +5383,7 @@ public final class Bindings {
             public ObservableList<?> getDependencies() {
                 return (dependencies.length == 1)?
                         FXCollections.singletonObservableList(dependencies[0])
-                        : new ImmutableObservableList<Observable>(dependencies);
+                        : new ImmutableObservableList<>(dependencies);
             }
         };
     }
@@ -5541,7 +5541,7 @@ public final class Bindings {
             public ObservableList<?> getDependencies() {
                 return (dependencies.length == 1)?
                         FXCollections.singletonObservableList(dependencies[0])
-                        : new ImmutableObservableList<Observable>(dependencies);
+                        : new ImmutableObservableList<>(dependencies);
             }
         };
     }
@@ -5825,7 +5825,7 @@ public final class Bindings {
             public ObservableList<?> getDependencies() {
                 return (dependencies.length == 1)?
                         FXCollections.singletonObservableList(dependencies[0])
-                        : new ImmutableObservableList<Observable>(dependencies);
+                        : new ImmutableObservableList<>(dependencies);
             }
         };
     }
@@ -5908,7 +5908,7 @@ public final class Bindings {
             public ObservableList<?> getDependencies() {
                 return (dependencies.length == 1)?
                         FXCollections.singletonObservableList(dependencies[0])
-                        : new ImmutableObservableList<Observable>(dependencies);
+                        : new ImmutableObservableList<>(dependencies);
             }
         };
     }
@@ -6181,7 +6181,7 @@ public final class Bindings {
             throw new IllegalArgumentException("Index cannot be negative");
         }
 
-        return new ObjectBinding<E>() {
+        return new ObjectBinding<>() {
             {
                 super.bind(op);
             }
@@ -6241,7 +6241,7 @@ public final class Bindings {
             throw new NullPointerException("Operands cannot be null.");
         }
 
-        return new ObjectBinding<E>() {
+        return new ObjectBinding<>() {
             {
                 super.bind(op, index);
             }
@@ -6263,7 +6263,7 @@ public final class Bindings {
 
             @Override
             public ObservableList<?> getDependencies() {
-                return new ImmutableObservableList<Observable>(op, index);
+                return new ImmutableObservableList<>(op, index);
             }
         };
     }
@@ -6378,7 +6378,7 @@ public final class Bindings {
 
             @Override
             public ObservableList<?> getDependencies() {
-                return new ImmutableObservableList<Observable>(op, index);
+                return new ImmutableObservableList<>(op, index);
             }
         };
     }
@@ -6493,7 +6493,7 @@ public final class Bindings {
 
             @Override
             public ObservableList<?> getDependencies() {
-                return new ImmutableObservableList<Observable>(op, index);
+                return new ImmutableObservableList<>(op, index);
             }
         };
     }
@@ -6608,7 +6608,7 @@ public final class Bindings {
 
             @Override
             public ObservableList<?> getDependencies() {
-                return new ImmutableObservableList<Observable>(op, index);
+                return new ImmutableObservableList<>(op, index);
             }
         };
     }
@@ -6723,7 +6723,7 @@ public final class Bindings {
 
             @Override
             public ObservableList<?> getDependencies() {
-                return new ImmutableObservableList<Observable>(op, index);
+                return new ImmutableObservableList<>(op, index);
             }
         };
     }
@@ -6838,7 +6838,7 @@ public final class Bindings {
 
             @Override
             public ObservableList<?> getDependencies() {
-                return new ImmutableObservableList<Observable>(op, index);
+                return new ImmutableObservableList<>(op, index);
             }
         };
     }
@@ -6943,7 +6943,7 @@ public final class Bindings {
 
             @Override
             public ObservableList<?> getDependencies() {
-                return new ImmutableObservableList<Observable>(op, index);
+                return new ImmutableObservableList<>(op, index);
             }
         };
     }
@@ -7459,7 +7459,7 @@ public final class Bindings {
             throw new NullPointerException("Map cannot be null.");
         }
 
-        return new ObjectBinding<V>() {
+        return new ObjectBinding<>() {
             {
                 super.bind(op);
             }
@@ -7507,7 +7507,7 @@ public final class Bindings {
             throw new NullPointerException("Operands cannot be null.");
         }
 
-        return new ObjectBinding<V>() {
+        return new ObjectBinding<>() {
             {
                 super.bind(op, key);
             }
@@ -7533,7 +7533,7 @@ public final class Bindings {
 
             @Override
             public ObservableList<?> getDependencies() {
-                return new ImmutableObservableList<Observable>(op, key);
+                return new ImmutableObservableList<>(op, key);
             }
         };
     }
@@ -7639,7 +7639,7 @@ public final class Bindings {
 
             @Override
             public ObservableList<?> getDependencies() {
-                return new ImmutableObservableList<Observable>(op, key);
+                return new ImmutableObservableList<>(op, key);
             }
         };
     }
@@ -7745,7 +7745,7 @@ public final class Bindings {
 
             @Override
             public ObservableList<?> getDependencies() {
-                return new ImmutableObservableList<Observable>(op, key);
+                return new ImmutableObservableList<>(op, key);
             }
         };
     }
@@ -7851,7 +7851,7 @@ public final class Bindings {
 
             @Override
             public ObservableList<?> getDependencies() {
-                return new ImmutableObservableList<Observable>(op, key);
+                return new ImmutableObservableList<>(op, key);
             }
         };
     }
@@ -7957,7 +7957,7 @@ public final class Bindings {
 
             @Override
             public ObservableList<?> getDependencies() {
-                return new ImmutableObservableList<Observable>(op, key);
+                return new ImmutableObservableList<>(op, key);
             }
         };
     }
@@ -8063,7 +8063,7 @@ public final class Bindings {
 
             @Override
             public ObservableList<?> getDependencies() {
-                return new ImmutableObservableList<Observable>(op, key);
+                return new ImmutableObservableList<>(op, key);
             }
         };
     }
@@ -8159,7 +8159,7 @@ public final class Bindings {
 
             @Override
             public ObservableList<?> getDependencies() {
-                return new ImmutableObservableList<Observable>(op, key);
+                return new ImmutableObservableList<>(op, key);
             }
         };
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/binding/BooleanExpression.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/binding/BooleanExpression.java
@@ -234,7 +234,7 @@ public abstract class BooleanExpression implements ObservableBooleanValue {
      * @since JavaFX 8.0
      */
     public ObjectExpression<Boolean> asObject() {
-        return new ObjectBinding<Boolean>() {
+        return new ObjectBinding<>() {
             {
                 bind(BooleanExpression.this);
             }

--- a/modules/javafx.base/src/main/java/javafx/beans/binding/DoubleExpression.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/binding/DoubleExpression.java
@@ -291,7 +291,7 @@ public abstract class DoubleExpression extends NumberExpressionBase implements
      * @since JavaFX 8.0
      */
     public ObjectExpression<Double> asObject() {
-        return new ObjectBinding<Double>() {
+        return new ObjectBinding<>() {
             {
                 bind(DoubleExpression.this);
             }

--- a/modules/javafx.base/src/main/java/javafx/beans/binding/FloatExpression.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/binding/FloatExpression.java
@@ -66,7 +66,7 @@ public abstract class FloatExpression extends NumberExpressionBase implements
 
     @Override
     public double doubleValue() {
-        return (double) get();
+        return get();
     }
 
     @Override
@@ -271,7 +271,7 @@ public abstract class FloatExpression extends NumberExpressionBase implements
      * @since JavaFX 8.0
      */
     public ObjectExpression<Float> asObject() {
-        return new ObjectBinding<Float>() {
+        return new ObjectBinding<>() {
             {
                 bind(FloatExpression.this);
             }

--- a/modules/javafx.base/src/main/java/javafx/beans/binding/IntegerExpression.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/binding/IntegerExpression.java
@@ -56,17 +56,17 @@ public abstract class IntegerExpression extends NumberExpressionBase implements
 
     @Override
     public long longValue() {
-        return (long) get();
+        return get();
     }
 
     @Override
     public float floatValue() {
-        return (float) get();
+        return get();
     }
 
     @Override
     public double doubleValue() {
-        return (double) get();
+        return get();
     }
 
     @Override
@@ -271,7 +271,7 @@ public abstract class IntegerExpression extends NumberExpressionBase implements
      * @since JavaFX 8.0
      */
     public ObjectExpression<Integer> asObject() {
-        return new ObjectBinding<Integer>() {
+        return new ObjectBinding<>() {
             {
                 bind(IntegerExpression.this);
             }

--- a/modules/javafx.base/src/main/java/javafx/beans/binding/ListBinding.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/binding/ListBinding.java
@@ -70,7 +70,7 @@ public abstract class ListBinding<E> extends ListExpression<E> implements Bindin
     public ListBinding() {
     }
 
-    private final ListChangeListener<E> listChangeListener = new ListChangeListener<E>() {
+    private final ListChangeListener<E> listChangeListener = new ListChangeListener<>() {
         @Override
         public void onChanged(Change<? extends E> change) {
             invalidateProperties();
@@ -111,6 +111,7 @@ public abstract class ListBinding<E> extends ListExpression<E> implements Bindin
             return "size";
         }
 
+        @Override
         protected void fireValueChangedEvent() {
             super.fireValueChangedEvent();
         }
@@ -141,6 +142,7 @@ public abstract class ListBinding<E> extends ListExpression<E> implements Bindin
             return "empty";
         }
 
+        @Override
         protected void fireValueChangedEvent() {
             super.fireValueChangedEvent();
         }

--- a/modules/javafx.base/src/main/java/javafx/beans/binding/ListExpression.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/binding/ListExpression.java
@@ -89,7 +89,7 @@ public abstract class ListExpression<E> implements ObservableListValue<E> {
             throw new NullPointerException("List must be specified.");
         }
         return value instanceof ListExpression ? (ListExpression<E>) value
-                : new ListBinding<E>() {
+                : new ListBinding<>() {
             {
                 super.bind(value);
             }

--- a/modules/javafx.base/src/main/java/javafx/beans/binding/LongExpression.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/binding/LongExpression.java
@@ -60,12 +60,12 @@ public abstract class LongExpression extends NumberExpressionBase implements
 
     @Override
     public float floatValue() {
-        return (float) get();
+        return get();
     }
 
     @Override
     public double doubleValue() {
-        return (double) get();
+        return get();
     }
 
     @Override
@@ -268,7 +268,7 @@ public abstract class LongExpression extends NumberExpressionBase implements
      * @since JavaFX 8.0
      */
     public ObjectExpression<Long> asObject() {
-        return new ObjectBinding<Long>() {
+        return new ObjectBinding<>() {
             {
                 bind(LongExpression.this);
             }

--- a/modules/javafx.base/src/main/java/javafx/beans/binding/MapBinding.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/binding/MapBinding.java
@@ -67,7 +67,7 @@ import javafx.collections.ObservableMap;
  */
 public abstract class MapBinding<K, V> extends MapExpression<K, V> implements Binding<ObservableMap<K, V>> {
 
-    private final MapChangeListener<K, V> mapChangeListener = new MapChangeListener<K, V>() {
+    private final MapChangeListener<K, V> mapChangeListener = new MapChangeListener<>() {
         @Override
         public void onChanged(Change<? extends K, ? extends V> change) {
             invalidateProperties();
@@ -114,6 +114,7 @@ public abstract class MapBinding<K, V> extends MapExpression<K, V> implements Bi
             return "size";
         }
 
+        @Override
         protected void fireValueChangedEvent() {
             super.fireValueChangedEvent();
         }
@@ -144,6 +145,7 @@ public abstract class MapBinding<K, V> extends MapExpression<K, V> implements Bi
             return "empty";
         }
 
+        @Override
         protected void fireValueChangedEvent() {
             super.fireValueChangedEvent();
         }

--- a/modules/javafx.base/src/main/java/javafx/beans/binding/MapExpression.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/binding/MapExpression.java
@@ -119,7 +119,7 @@ public abstract class MapExpression<K, V> implements ObservableMapValue<K, V> {
             throw new NullPointerException("Map must be specified.");
         }
         return value instanceof MapExpression ? (MapExpression<K, V>) value
-                : new MapBinding<K, V>() {
+                : new MapBinding<>() {
             {
                 super.bind(value);
             }

--- a/modules/javafx.base/src/main/java/javafx/beans/binding/ObjectExpression.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/binding/ObjectExpression.java
@@ -77,7 +77,7 @@ public abstract class ObjectExpression<T> implements ObservableObjectValue<T> {
             throw new NullPointerException("Value must be specified.");
         }
         return value instanceof ObjectExpression ? (ObjectExpression<T>) value
-                : new ObjectBinding<T>() {
+                : new ObjectBinding<>() {
                     {
                         super.bind(value);
                     }

--- a/modules/javafx.base/src/main/java/javafx/beans/binding/SetBinding.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/binding/SetBinding.java
@@ -71,7 +71,7 @@ public abstract class SetBinding<E> extends SetExpression<E> implements Binding<
     public SetBinding() {
     }
 
-    private final SetChangeListener<E> setChangeListener = new SetChangeListener<E>() {
+    private final SetChangeListener<E> setChangeListener = new SetChangeListener<>() {
         @Override
         public void onChanged(Change<? extends E> change) {
             invalidateProperties();
@@ -112,6 +112,7 @@ public abstract class SetBinding<E> extends SetExpression<E> implements Binding<
             return "size";
         }
 
+        @Override
         protected void fireValueChangedEvent() {
             super.fireValueChangedEvent();
         }
@@ -142,6 +143,7 @@ public abstract class SetBinding<E> extends SetExpression<E> implements Binding<
             return "empty";
         }
 
+        @Override
         protected void fireValueChangedEvent() {
             super.fireValueChangedEvent();
         }

--- a/modules/javafx.base/src/main/java/javafx/beans/binding/SetExpression.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/binding/SetExpression.java
@@ -142,7 +142,7 @@ public abstract class SetExpression<E> implements ObservableSetValue<E> {
             throw new NullPointerException("Set must be specified.");
         }
         return value instanceof SetExpression ? (SetExpression<E>) value
-                : new SetBinding<E>() {
+                : new SetBinding<>() {
             {
                 super.bind(value);
             }

--- a/modules/javafx.base/src/main/java/javafx/beans/binding/When.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/binding/When.java
@@ -84,7 +84,7 @@ public class When {
         private final WeakReference<Binding<?>> ref;
 
         private WhenListener(Binding<?> binding, ObservableBooleanValue condition, ObservableValue<?> thenValue, ObservableValue<?> otherwiseValue) {
-            this.ref = new WeakReference<Binding<?>>(binding);
+            this.ref = new WeakReference<>(binding);
             this.condition = condition;
             this.thenValue = thenValue;
             this.otherwiseValue = otherwiseValue;
@@ -836,9 +836,9 @@ public class When {
                 throw new NullPointerException("Value needs to be specified");
             }
             if (trueResult != null)
-                return new ObjectCondition<T>(trueResult, otherwiseValue);
+                return new ObjectCondition<>(trueResult, otherwiseValue);
             else
-                return new ObjectCondition<T>(trueResultValue, otherwiseValue);
+                return new ObjectCondition<>(trueResultValue, otherwiseValue);
         }
 
         /**
@@ -851,9 +851,9 @@ public class When {
          */
         public ObjectBinding<T> otherwise(final T otherwiseValue) {
             if (trueResult != null)
-                return new ObjectCondition<T>(trueResult, otherwiseValue);
+                return new ObjectCondition<>(trueResult, otherwiseValue);
             else
-                return new ObjectCondition<T>(trueResultValue, otherwiseValue);
+                return new ObjectCondition<>(trueResultValue, otherwiseValue);
         }
     }
 
@@ -870,7 +870,7 @@ public class When {
         if (thenValue == null) {
             throw new NullPointerException("Value needs to be specified");
         }
-        return new ObjectConditionBuilder<T>(thenValue);
+        return new ObjectConditionBuilder<>(thenValue);
     }
 
     /**
@@ -883,7 +883,7 @@ public class When {
      * @return the intermediate result which still requires the otherwise-branch
      */
     public <T> ObjectConditionBuilder<T> then(final T thenValue) {
-        return new ObjectConditionBuilder<T>(thenValue);
+        return new ObjectConditionBuilder<>(thenValue);
     }
 
 }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/FloatPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/FloatPropertyBase.java
@@ -53,7 +53,7 @@ import javafx.beans.value.ObservableNumberValue;
 public abstract class FloatPropertyBase extends FloatProperty {
 
     private float value;
-    private ObservableFloatValue observable = null;;
+    private ObservableFloatValue observable = null;
     private InvalidationListener listener = null;
     private boolean valid = true;
     private ExpressionHelper<Number> helper = null;

--- a/modules/javafx.base/src/main/java/javafx/beans/property/IntegerPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/IntegerPropertyBase.java
@@ -53,7 +53,7 @@ import javafx.beans.value.ObservableNumberValue;
 public abstract class IntegerPropertyBase extends IntegerProperty {
 
     private int value;
-    private ObservableIntegerValue observable = null;;
+    private ObservableIntegerValue observable = null;
     private InvalidationListener listener = null;
     private boolean valid = true;
     private ExpressionHelper<Number> helper = null;

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ListPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ListPropertyBase.java
@@ -108,6 +108,7 @@ public abstract class ListPropertyBase<E> extends ListProperty<E> {
             return "size";
         }
 
+        @Override
         protected void fireValueChangedEvent() {
             super.fireValueChangedEvent();
         }
@@ -138,6 +139,7 @@ public abstract class ListPropertyBase<E> extends ListProperty<E> {
             return "empty";
         }
 
+        @Override
         protected void fireValueChangedEvent() {
             super.fireValueChangedEvent();
         }
@@ -324,7 +326,7 @@ public abstract class ListPropertyBase<E> extends ListProperty<E> {
         private final WeakReference<ListPropertyBase<E>> wref;
 
         public Listener(ListPropertyBase<E> ref) {
-            this.wref = new WeakReference<ListPropertyBase<E>>(ref);
+            this.wref = new WeakReference<>(ref);
         }
 
         @Override

--- a/modules/javafx.base/src/main/java/javafx/beans/property/LongPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/LongPropertyBase.java
@@ -53,7 +53,7 @@ import javafx.beans.value.ObservableNumberValue;
 public abstract class LongPropertyBase extends LongProperty {
 
     private long value;
-    private ObservableLongValue observable = null;;
+    private ObservableLongValue observable = null;
     private InvalidationListener listener = null;
     private boolean valid = true;
     private ExpressionHelper<Number> helper = null;

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ObjectPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ObjectPropertyBase.java
@@ -52,7 +52,7 @@ import javafx.beans.WeakListener;
 public abstract class ObjectPropertyBase<T> extends ObjectProperty<T> {
 
     private T value;
-    private ObservableValue<? extends T> observable = null;;
+    private ObservableValue<? extends T> observable = null;
     private InvalidationListener listener = null;
     private boolean valid = true;
     private ExpressionHelper<T> helper = null;
@@ -222,7 +222,7 @@ public abstract class ObjectPropertyBase<T> extends ObjectProperty<T> {
         private final WeakReference<ObjectPropertyBase<?>> wref;
 
         public Listener(ObjectPropertyBase<?> ref) {
-            this.wref = new WeakReference<ObjectPropertyBase<?>>(ref);
+            this.wref = new WeakReference<>(ref);
         }
 
         @Override

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyBooleanProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyBooleanProperty.java
@@ -26,7 +26,6 @@
 package javafx.beans.property;
 
 import javafx.beans.InvalidationListener;
-import javafx.beans.Observable;
 import javafx.beans.WeakInvalidationListener;
 import javafx.beans.binding.BooleanExpression;
 
@@ -135,7 +134,7 @@ public abstract class ReadOnlyBooleanProperty extends BooleanExpression
      */
     @Override
     public ReadOnlyObjectProperty<Boolean> asObject() {
-        return new ReadOnlyObjectPropertyBase<Boolean>() {
+        return new ReadOnlyObjectPropertyBase<>() {
 
             private boolean valid = true;
             private final InvalidationListener listener = observable -> {
@@ -165,6 +164,6 @@ public abstract class ReadOnlyBooleanProperty extends BooleanExpression
                 return ReadOnlyBooleanProperty.this.getValue();
             }
         };
-    };
+    }
 
 }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyBooleanWrapper.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyBooleanWrapper.java
@@ -120,5 +120,5 @@ public class ReadOnlyBooleanWrapper extends SimpleBooleanProperty {
         public String getName() {
             return ReadOnlyBooleanWrapper.this.getName();
         }
-    };
+    }
 }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyDoubleProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyDoubleProperty.java
@@ -26,7 +26,6 @@
 package javafx.beans.property;
 
 import javafx.beans.InvalidationListener;
-import javafx.beans.Observable;
 import javafx.beans.WeakInvalidationListener;
 import javafx.beans.binding.DoubleExpression;
 
@@ -136,7 +135,7 @@ public abstract class ReadOnlyDoubleProperty extends DoubleExpression implements
      */
     @Override
     public ReadOnlyObjectProperty<Double> asObject() {
-        return new ReadOnlyObjectPropertyBase<Double>() {
+        return new ReadOnlyObjectPropertyBase<>() {
 
             private boolean valid = true;
             private final InvalidationListener listener = observable -> {
@@ -166,7 +165,7 @@ public abstract class ReadOnlyDoubleProperty extends DoubleExpression implements
                 return ReadOnlyDoubleProperty.this.getValue();
             }
         };
-    };
+    }
 
 
 

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyDoubleWrapper.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyDoubleWrapper.java
@@ -120,5 +120,5 @@ public class ReadOnlyDoubleWrapper extends SimpleDoubleProperty {
         public String getName() {
             return ReadOnlyDoubleWrapper.this.getName();
         }
-    };
+    }
 }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyFloatProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyFloatProperty.java
@@ -26,7 +26,6 @@
 package javafx.beans.property;
 
 import javafx.beans.InvalidationListener;
-import javafx.beans.Observable;
 import javafx.beans.WeakInvalidationListener;
 import javafx.beans.binding.FloatExpression;
 
@@ -136,7 +135,7 @@ public abstract class ReadOnlyFloatProperty extends FloatExpression implements
      */
     @Override
     public ReadOnlyObjectProperty<Float> asObject() {
-        return new ReadOnlyObjectPropertyBase<Float>() {
+        return new ReadOnlyObjectPropertyBase<>() {
 
             private boolean valid = true;
             private final InvalidationListener listener = observable -> {
@@ -166,6 +165,6 @@ public abstract class ReadOnlyFloatProperty extends FloatExpression implements
                 return ReadOnlyFloatProperty.this.getValue();
             }
         };
-    };
+    }
 
 }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyFloatWrapper.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyFloatWrapper.java
@@ -119,5 +119,5 @@ public class ReadOnlyFloatWrapper extends SimpleFloatProperty {
         public String getName() {
             return ReadOnlyFloatWrapper.this.getName();
         }
-    };
+    }
 }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyIntegerProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyIntegerProperty.java
@@ -26,7 +26,6 @@
 package javafx.beans.property;
 
 import javafx.beans.InvalidationListener;
-import javafx.beans.Observable;
 import javafx.beans.WeakInvalidationListener;
 import javafx.beans.binding.IntegerExpression;
 
@@ -137,7 +136,7 @@ public abstract class ReadOnlyIntegerProperty extends IntegerExpression
      */
     @Override
     public ReadOnlyObjectProperty<Integer> asObject() {
-        return new ReadOnlyObjectPropertyBase<Integer>() {
+        return new ReadOnlyObjectPropertyBase<>() {
 
             private boolean valid = true;
             private final InvalidationListener listener = observable -> {
@@ -167,6 +166,6 @@ public abstract class ReadOnlyIntegerProperty extends IntegerExpression
                 return ReadOnlyIntegerProperty.this.getValue();
             }
         };
-    };
+    }
 
 }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyIntegerWrapper.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyIntegerWrapper.java
@@ -119,5 +119,5 @@ public class ReadOnlyIntegerWrapper extends SimpleIntegerProperty {
         public String getName() {
             return ReadOnlyIntegerWrapper.this.getName();
         }
-    };
+    }
 }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyLongProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyLongProperty.java
@@ -26,7 +26,6 @@
 package javafx.beans.property;
 
 import javafx.beans.InvalidationListener;
-import javafx.beans.Observable;
 import javafx.beans.WeakInvalidationListener;
 import javafx.beans.binding.LongExpression;
 
@@ -135,7 +134,7 @@ public abstract class ReadOnlyLongProperty extends LongExpression implements
      */
     @Override
     public ReadOnlyObjectProperty<Long> asObject() {
-        return new ReadOnlyObjectPropertyBase<Long>() {
+        return new ReadOnlyObjectPropertyBase<>() {
 
             private boolean valid = true;
             private final InvalidationListener listener = observable -> {
@@ -165,6 +164,6 @@ public abstract class ReadOnlyLongProperty extends LongExpression implements
                 return ReadOnlyLongProperty.this.getValue();
             }
         };
-    };
+    }
 
 }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyLongWrapper.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyLongWrapper.java
@@ -119,5 +119,5 @@ public class ReadOnlyLongWrapper extends SimpleLongProperty {
         public String getName() {
             return ReadOnlyLongWrapper.this.getName();
         }
-    };
+    }
 }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyMapProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyMapProperty.java
@@ -25,9 +25,7 @@
 
 package javafx.beans.property;
 
-import java.util.Iterator;
 import java.util.Map;
-import java.util.Map.Entry;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.MapExpression;
 import javafx.collections.ObservableMap;

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyObjectWrapper.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyObjectWrapper.java
@@ -119,5 +119,5 @@ public class ReadOnlyObjectWrapper<T> extends SimpleObjectProperty<T> {
         public String getName() {
             return ReadOnlyObjectWrapper.this.getName();
         }
-    };
+    }
 }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlySetProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlySetProperty.java
@@ -25,12 +25,9 @@
 
 package javafx.beans.property;
 
-import java.util.Collection;
-import java.util.Iterator;
 import java.util.Set;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.SetExpression;
-import javafx.collections.ObservableList;
 import javafx.collections.ObservableSet;
 
 /**

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyStringWrapper.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyStringWrapper.java
@@ -120,5 +120,5 @@ public class ReadOnlyStringWrapper extends SimpleStringProperty {
         public String getName() {
             return ReadOnlyStringWrapper.this.getName();
         }
-    };
+    }
 }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/SetProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/SetProperty.java
@@ -26,9 +26,7 @@
 package javafx.beans.property;
 
 import javafx.beans.binding.Bindings;
-import javafx.beans.value.WritableListValue;
 import javafx.beans.value.WritableSetValue;
-import javafx.collections.ObservableList;
 import javafx.collections.ObservableSet;
 
 /**

--- a/modules/javafx.base/src/main/java/javafx/beans/property/SetPropertyBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/SetPropertyBase.java
@@ -326,7 +326,7 @@ public abstract class SetPropertyBase<E> extends SetProperty<E> {
         private final WeakReference<SetPropertyBase<E>> wref;
 
         public Listener(SetPropertyBase<E> ref) {
-            this.wref = new WeakReference<SetPropertyBase<E>>(ref);
+            this.wref = new WeakReference<>(ref);
         }
 
         @Override

--- a/modules/javafx.base/src/main/java/javafx/beans/property/SimpleMapProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/SimpleMapProperty.java
@@ -26,7 +26,6 @@
 package javafx.beans.property;
 
 import javafx.collections.ObservableMap;
-import javafx.collections.ObservableSet;
 
 /**
  * This class provides a full implementation of a {@link Property} wrapping an

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/DescriptorListenerCleaner.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/DescriptorListenerCleaner.java
@@ -35,7 +35,7 @@ class DescriptorListenerCleaner implements Runnable{
 
     DescriptorListenerCleaner(ReadOnlyPropertyDescriptor pd, ReadOnlyPropertyDescriptor.ReadOnlyListener<?> l) {
         this.pd = pd;
-        this.lRef = new WeakReference<ReadOnlyPropertyDescriptor.ReadOnlyListener<?>>(l);
+        this.lRef = new WeakReference<>(l);
     }
 
     @Override

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanBooleanProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanBooleanProperty.java
@@ -101,7 +101,7 @@ public final class JavaBeanBooleanProperty extends BooleanProperty implements Ja
 
     JavaBeanBooleanProperty(PropertyDescriptor descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new Listener<Boolean>(bean, this);
+        this.listener = descriptor.new Listener<>(bean, this);
         descriptor.addListener(listener);
         Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanDoubleProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanDoubleProperty.java
@@ -101,7 +101,7 @@ public final class JavaBeanDoubleProperty extends DoubleProperty implements Java
 
     JavaBeanDoubleProperty(PropertyDescriptor descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new Listener<Number>(bean, this);
+        this.listener = descriptor.new Listener<>(bean, this);
         descriptor.addListener(listener);
         Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanFloatProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanFloatProperty.java
@@ -101,7 +101,7 @@ public final class JavaBeanFloatProperty extends FloatProperty implements JavaBe
 
     JavaBeanFloatProperty(PropertyDescriptor descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new Listener<Number>(bean, this);
+        this.listener = descriptor.new Listener<>(bean, this);
         descriptor.addListener(listener);
         Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanIntegerProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanIntegerProperty.java
@@ -101,7 +101,7 @@ public final class JavaBeanIntegerProperty extends IntegerProperty implements Ja
 
     JavaBeanIntegerProperty(PropertyDescriptor descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new Listener<Number>(bean, this);
+        this.listener = descriptor.new Listener<>(bean, this);
         descriptor.addListener(listener);
         Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanLongProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanLongProperty.java
@@ -101,7 +101,7 @@ public final class JavaBeanLongProperty extends LongProperty implements JavaBean
 
     JavaBeanLongProperty(PropertyDescriptor descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new Listener<Number>(bean, this);
+        this.listener = descriptor.new Listener<>(bean, this);
         descriptor.addListener(listener);
         Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanObjectProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanObjectProperty.java
@@ -103,7 +103,7 @@ public final class JavaBeanObjectProperty<T> extends ObjectProperty<T> implement
 
     JavaBeanObjectProperty(PropertyDescriptor descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new Listener<T>(bean, this);
+        this.listener = descriptor.new Listener<>(bean, this);
         descriptor.addListener(listener);
         Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanObjectPropertyBuilder.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanObjectPropertyBuilder.java
@@ -83,7 +83,7 @@ public final class JavaBeanObjectPropertyBuilder<T> {
      */
     public JavaBeanObjectProperty<T> build() throws NoSuchMethodException {
         final PropertyDescriptor descriptor = helper.getDescriptor();
-        return new JavaBeanObjectProperty<T>(descriptor, helper.getBean());
+        return new JavaBeanObjectProperty<>(descriptor, helper.getBean());
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanStringProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanStringProperty.java
@@ -101,7 +101,7 @@ public final class JavaBeanStringProperty extends StringProperty implements Java
 
     JavaBeanStringProperty(PropertyDescriptor descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new Listener<String>(bean, this);
+        this.listener = descriptor.new Listener<>(bean, this);
         descriptor.addListener(listener);
         Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanBooleanProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanBooleanProperty.java
@@ -90,7 +90,7 @@ public final class ReadOnlyJavaBeanBooleanProperty extends ReadOnlyBooleanProper
 
     ReadOnlyJavaBeanBooleanProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new ReadOnlyListener<Boolean>(bean, this);
+        this.listener = descriptor.new ReadOnlyListener<>(bean, this);
         descriptor.addListener(listener);
         Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanDoubleProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanDoubleProperty.java
@@ -90,7 +90,7 @@ public final class ReadOnlyJavaBeanDoubleProperty extends ReadOnlyDoubleProperty
 
     ReadOnlyJavaBeanDoubleProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new ReadOnlyListener<Number>(bean, this);
+        this.listener = descriptor.new ReadOnlyListener<>(bean, this);
         descriptor.addListener(listener);
         Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanFloatProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanFloatProperty.java
@@ -90,7 +90,7 @@ public final class ReadOnlyJavaBeanFloatProperty extends ReadOnlyFloatPropertyBa
 
     ReadOnlyJavaBeanFloatProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new ReadOnlyListener<Number>(bean, this);
+        this.listener = descriptor.new ReadOnlyListener<>(bean, this);
         descriptor.addListener(listener);
         Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanIntegerProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanIntegerProperty.java
@@ -90,7 +90,7 @@ public final class ReadOnlyJavaBeanIntegerProperty extends ReadOnlyIntegerProper
 
     ReadOnlyJavaBeanIntegerProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new ReadOnlyListener<Number>(bean, this);
+        this.listener = descriptor.new ReadOnlyListener<>(bean, this);
         descriptor.addListener(listener);
         Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanLongProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanLongProperty.java
@@ -90,7 +90,7 @@ public final class ReadOnlyJavaBeanLongProperty extends ReadOnlyLongPropertyBase
 
     ReadOnlyJavaBeanLongProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new ReadOnlyListener<Number>(bean, this);
+        this.listener = descriptor.new ReadOnlyListener<>(bean, this);
         descriptor.addListener(listener);
         Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanObjectProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanObjectProperty.java
@@ -92,7 +92,7 @@ public final class ReadOnlyJavaBeanObjectProperty<T> extends ReadOnlyObjectPrope
 
     ReadOnlyJavaBeanObjectProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new ReadOnlyListener<T>(bean, this);
+        this.listener = descriptor.new ReadOnlyListener<>(bean, this);
         descriptor.addListener(listener);
         Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanObjectPropertyBuilder.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanObjectPropertyBuilder.java
@@ -71,7 +71,7 @@ public final class ReadOnlyJavaBeanObjectPropertyBuilder<T> {
      * @return the new {@code ReadOnlyJavaBeanObjectPropertyBuilder}
      */
     public static <T> ReadOnlyJavaBeanObjectPropertyBuilder<T> create() {
-        return new ReadOnlyJavaBeanObjectPropertyBuilder<T>();
+        return new ReadOnlyJavaBeanObjectPropertyBuilder<>();
     }
 
     /**
@@ -83,7 +83,7 @@ public final class ReadOnlyJavaBeanObjectPropertyBuilder<T> {
      */
     public ReadOnlyJavaBeanObjectProperty<T> build() throws NoSuchMethodException {
         final ReadOnlyPropertyDescriptor descriptor = helper.getDescriptor();
-        return new ReadOnlyJavaBeanObjectProperty<T>(descriptor, helper.getBean());
+        return new ReadOnlyJavaBeanObjectProperty<>(descriptor, helper.getBean());
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanStringProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanStringProperty.java
@@ -90,7 +90,7 @@ public final class ReadOnlyJavaBeanStringProperty extends ReadOnlyStringProperty
 
     ReadOnlyJavaBeanStringProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new ReadOnlyListener<String>(bean, this);
+        this.listener = descriptor.new ReadOnlyListener<>(bean, this);
         descriptor.addListener(listener);
         Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/value/ObservableValueBase.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/value/ObservableValueBase.java
@@ -25,12 +25,8 @@
 
 package javafx.beans.value;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import com.sun.javafx.binding.ExpressionHelper;
 import javafx.beans.InvalidationListener;
-import javafx.beans.Observable;
 
 /**
  * A convenience class for creating implementations of {@link ObservableValue}.

--- a/modules/javafx.base/src/main/java/javafx/beans/value/WeakChangeListener.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/value/WeakChangeListener.java
@@ -64,7 +64,7 @@ public final class WeakChangeListener<T> implements ChangeListener<T>, WeakListe
         if (listener == null) {
             throw new NullPointerException("Listener must be specified.");
         }
-        this.ref = new WeakReference<ChangeListener<T>>(listener);
+        this.ref = new WeakReference<>(listener);
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/collections/FXCollections.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/FXCollections.java
@@ -61,7 +61,6 @@ import com.sun.javafx.collections.SortableList;
 import com.sun.javafx.collections.SourceAdapterChange;
 import java.util.RandomAccess;
 import javafx.beans.Observable;
-import javafx.collections.ListChangeListener.Change;
 import javafx.util.Callback;
 
 /**
@@ -97,8 +96,8 @@ public class FXCollections {
         if (list == null) {
             throw new NullPointerException();
         }
-        return list instanceof RandomAccess ? new ObservableListWrapper<E>(list) :
-                new ObservableSequentialListWrapper<E>(list);
+        return list instanceof RandomAccess ? new ObservableListWrapper<>(list) :
+                new ObservableSequentialListWrapper<>(list);
     }
 
     /**
@@ -125,8 +124,8 @@ public class FXCollections {
         if (list == null || extractor == null) {
             throw new NullPointerException();
         }
-        return list instanceof RandomAccess ? new ObservableListWrapper<E>(list, extractor) :
-            new ObservableSequentialListWrapper<E>(list, extractor);
+        return list instanceof RandomAccess ? new ObservableListWrapper<>(list, extractor) :
+            new ObservableSequentialListWrapper<>(list, extractor);
     }
 
     /**
@@ -144,7 +143,7 @@ public class FXCollections {
         if (map == null) {
             throw new NullPointerException();
         }
-        return new ObservableMapWrapper<K, V>(map);
+        return new ObservableMapWrapper<>(map);
     }
 
     /**
@@ -162,7 +161,7 @@ public class FXCollections {
         if (set == null) {
             throw new NullPointerException();
         }
-        return new ObservableSetWrapper<E>(set);
+        return new ObservableSetWrapper<>(set);
     }
 
     /**
@@ -177,9 +176,9 @@ public class FXCollections {
         if (elements == null) {
             throw new NullPointerException();
         }
-        Set<E> set = new HashSet<E>(elements.length);
+        Set<E> set = new HashSet<>(elements.length);
         Collections.addAll(set, elements);
-        return new ObservableSetWrapper<E>(set);
+        return new ObservableSetWrapper<>(set);
     }
 
     /**
@@ -196,7 +195,7 @@ public class FXCollections {
         if (map == null) {
             throw new NullPointerException();
         }
-        return new com.sun.javafx.collections.UnmodifiableObservableMap<K, V>(map);
+        return new com.sun.javafx.collections.UnmodifiableObservableMap<>(map);
     }
 
     /**
@@ -214,7 +213,7 @@ public class FXCollections {
         if (map == null || keyType == null || valueType == null) {
             throw new NullPointerException();
         }
-        return new CheckedObservableMap<K, V>(map, keyType, valueType);
+        return new CheckedObservableMap<>(map, keyType, valueType);
     }
 
     /**
@@ -230,7 +229,7 @@ public class FXCollections {
         if (map == null) {
             throw new NullPointerException();
         }
-        return new SynchronizedObservableMap<K, V>(map);
+        return new SynchronizedObservableMap<>(map);
     }
 
     private static ObservableMap EMPTY_OBSERVABLE_MAP = new EmptyObservableMap();
@@ -385,7 +384,7 @@ public class FXCollections {
         if (lists.length == 1) {
             return observableArrayList(lists[0]);
         }
-        ArrayList<E> backingList = new ArrayList<E>();
+        ArrayList<E> backingList = new ArrayList<>();
         for (ObservableList<E> s : lists) {
             backingList.addAll(s);
         }
@@ -404,7 +403,7 @@ public class FXCollections {
         if (list == null) {
             throw new NullPointerException();
         }
-        return new UnmodifiableObservableListImpl<E>(list);
+        return new UnmodifiableObservableListImpl<>(list);
     }
 
     /**
@@ -419,7 +418,7 @@ public class FXCollections {
         if (list == null) {
             throw new NullPointerException();
         }
-        return new CheckedObservableList<E>(list, type);
+        return new CheckedObservableList<>(list, type);
     }
 
     /**
@@ -433,7 +432,7 @@ public class FXCollections {
         if (list == null) {
             throw new NullPointerException();
         }
-        return new SynchronizedObservableList<E>(list);
+        return new SynchronizedObservableList<>(list);
     }
 
     private static ObservableList EMPTY_OBSERVABLE_LIST = new EmptyObservableList();
@@ -458,7 +457,7 @@ public class FXCollections {
      * @see Collections#singletonList(java.lang.Object)
      */
     public static<E> ObservableList<E> singletonObservableList(E e) {
-        return new SingletonObservableList<E>(e);
+        return new SingletonObservableList<>(e);
     }
 
     /**
@@ -473,7 +472,7 @@ public class FXCollections {
         if (set == null) {
             throw new NullPointerException();
         }
-        return new UnmodifiableObservableSet<E>(set);
+        return new UnmodifiableObservableSet<>(set);
     }
 
     /**
@@ -489,7 +488,7 @@ public class FXCollections {
         if (set == null) {
             throw new NullPointerException();
         }
-        return new CheckedObservableSet<E>(set, type);
+        return new CheckedObservableSet<>(set, type);
     }
 
     /**
@@ -504,7 +503,7 @@ public class FXCollections {
         if (set == null) {
             throw new NullPointerException();
         }
-        return new SynchronizedObservableSet<E>(set);
+        return new SynchronizedObservableSet<>(set);
     }
 
     private static ObservableSet EMPTY_OBSERVABLE_SET = new EmptyObservableSet();
@@ -681,9 +680,9 @@ public class FXCollections {
         if (list instanceof SortableList) {
             ((SortableList<? extends T>)list).sort();
         } else {
-            List<T> newContent = new ArrayList<T>(list);
+            List<T> newContent = new ArrayList<>(list);
             Collections.sort(newContent);
-            list.setAll((Collection<T>)newContent);
+            list.setAll(newContent);
         }
     }
 
@@ -700,9 +699,9 @@ public class FXCollections {
         if (list instanceof SortableList) {
             ((SortableList<? extends T>)list).sort(c);
         } else {
-            List<T> newContent = new ArrayList<T>(list);
+            List<T> newContent = new ArrayList<>(list);
             Collections.sort(newContent, c);
-            list.setAll((Collection<T>)newContent);
+            list.setAll(newContent);
         }
     }
 
@@ -948,7 +947,7 @@ public class FXCollections {
 
     }
 
-    private static class UnmodifiableObservableListImpl<T> extends ObservableListBase<T> implements ObservableList<T> {
+    private static class UnmodifiableObservableListImpl<T> extends ObservableListBase<T> {
 
         private final ObservableList<T> backingList;
         private final ListChangeListener<T> listener;
@@ -956,9 +955,9 @@ public class FXCollections {
         public UnmodifiableObservableListImpl(ObservableList<T> backingList) {
             this.backingList = backingList;
             listener = c -> {
-                fireChange(new SourceAdapterChange<T>(UnmodifiableObservableListImpl.this, c));
+                fireChange(new SourceAdapterChange<>(UnmodifiableObservableListImpl.this, c));
             };
-            this.backingList.addListener(new WeakListChangeListener<T>(listener));
+            this.backingList.addListener(new WeakListChangeListener<>(listener));
         }
 
         @Override
@@ -1171,7 +1170,7 @@ public class FXCollections {
         @Override
         public List<T> subList(int fromIndex, int toIndex) {
             synchronized(mutex) {
-                return new SynchronizedList<T>(backingList.subList(fromIndex, toIndex),
+                return new SynchronizedList<>(backingList.subList(fromIndex, toIndex),
                         mutex);
             }
         }
@@ -1210,9 +1209,9 @@ public class FXCollections {
             super(seq);
             this.backingList = seq;
             listener = c -> {
-                ListListenerHelper.fireValueChangedEvent(helper, new SourceAdapterChange<T>(SynchronizedObservableList.this, c));
+                ListListenerHelper.fireValueChangedEvent(helper, new SourceAdapterChange<>(SynchronizedObservableList.this, c));
             };
-            backingList.addListener(new WeakListChangeListener<T>(listener));
+            backingList.addListener(new WeakListChangeListener<>(listener));
         }
 
         @Override
@@ -1288,7 +1287,7 @@ public class FXCollections {
 
     }
 
-    private static class CheckedObservableList<T> extends ObservableListBase<T> implements ObservableList<T> {
+    private static class CheckedObservableList<T> extends ObservableListBase<T> {
 
         private final ObservableList<T> list;
         private final Class<T> type;
@@ -1301,9 +1300,9 @@ public class FXCollections {
             this.list = list;
             this.type = type;
             listener = c -> {
-                fireChange(new SourceAdapterChange<T>(CheckedObservableList.this, c));
+                fireChange(new SourceAdapterChange<>(CheckedObservableList.this, c));
             };
-            list.addListener(new WeakListChangeListener<T>(listener));
+            list.addListener(new WeakListChangeListener<>(listener));
         }
 
         void typeCheck(Object o) {
@@ -1459,7 +1458,7 @@ public class FXCollections {
 
         @Override
         public ListIterator<T> listIterator(final int index) {
-            return new ListIterator<T>() {
+            return new ListIterator<>() {
 
                 ListIterator<T> i = list.listIterator(index);
 
@@ -1514,7 +1513,7 @@ public class FXCollections {
 
         @Override
         public Iterator<T> iterator() {
-            return new Iterator<T>() {
+            return new Iterator<>() {
 
                 private final Iterator<T> it = list.iterator();
 
@@ -1674,9 +1673,9 @@ public class FXCollections {
         private void initListener() {
             if (listener == null) {
                 listener = c -> {
-                    callObservers(new SetAdapterChange<E>(UnmodifiableObservableSet.this, c));
+                    callObservers(new SetAdapterChange<>(UnmodifiableObservableSet.this, c));
                 };
-                this.backingSet.addListener(new WeakSetChangeListener<E>(listener));
+                this.backingSet.addListener(new WeakSetChangeListener<>(listener));
             }
         }
 
@@ -1686,7 +1685,7 @@ public class FXCollections {
 
         @Override
         public Iterator<E> iterator() {
-            return new Iterator<E>() {
+            return new Iterator<>() {
                 private final Iterator<? extends E> i = backingSet.iterator();
 
                 @Override
@@ -1900,9 +1899,9 @@ public class FXCollections {
             super(set);
             backingSet = set;
             listener = c -> {
-                SetListenerHelper.fireValueChangedEvent(listenerHelper, new SetAdapterChange<E>(SynchronizedObservableSet.this, c));
+                SetListenerHelper.fireValueChangedEvent(listenerHelper, new SetAdapterChange<>(SynchronizedObservableSet.this, c));
             };
-            backingSet.addListener(new WeakSetChangeListener<E>(listener));
+            backingSet.addListener(new WeakSetChangeListener<>(listener));
         }
 
         @Override
@@ -1947,9 +1946,9 @@ public class FXCollections {
             backingSet = set;
             this.type = type;
             listener = c -> {
-                callObservers(new SetAdapterChange<E>(CheckedObservableSet.this, c));
+                callObservers(new SetAdapterChange<>(CheckedObservableSet.this, c));
             };
-            backingSet.addListener(new WeakSetChangeListener<E>(listener));
+            backingSet.addListener(new WeakSetChangeListener<>(listener));
         }
 
         private void callObservers(SetChangeListener.Change<? extends E> c) {
@@ -2067,7 +2066,7 @@ public class FXCollections {
         public Iterator<E> iterator() {
             final Iterator<E> it = backingSet.iterator();
 
-            return new Iterator<E>() {
+            return new Iterator<>() {
                 @Override
                 public boolean hasNext() {
                     return it.hasNext();
@@ -2172,9 +2171,9 @@ public class FXCollections {
             this.keyType = keyType;
             this.valueType = valueType;
             listener = c -> {
-                callObservers(new MapAdapterChange<K, V>(CheckedObservableMap.this, c));
+                callObservers(new MapAdapterChange<>(CheckedObservableMap.this, c));
             };
-            backingMap.addListener(new WeakMapChangeListener<K, V>(listener));
+            backingMap.addListener(new WeakMapChangeListener<>(listener));
         }
 
         private void callObservers(MapChangeListener.Change<? extends K, ? extends V> c) {
@@ -2261,14 +2260,14 @@ public class FXCollections {
             // - correct behavior if t is a concurrent map
             Object[] entries = t.entrySet().toArray();
             List<Map.Entry<K,V>> checked =
-                new ArrayList<Map.Entry<K,V>>(entries.length);
+                new ArrayList<>(entries.length);
             for (Object o : entries) {
                 Map.Entry<?,?> e = (Map.Entry<?,?>) o;
                 Object k = e.getKey();
                 Object v = e.getValue();
                 typeCheck(k, v);
                 checked.add(
-                    new AbstractMap.SimpleImmutableEntry<K,V>((K) k, (V) v));
+                    new AbstractMap.SimpleImmutableEntry<>((K) k, (V) v));
             }
             for (Map.Entry<K,V> e : checked)
                 backingMap.put(e.getKey(), e.getValue());
@@ -2294,7 +2293,7 @@ public class FXCollections {
         @Override
         public Set entrySet() {
             if (entrySet==null)
-                entrySet = new CheckedEntrySet<K,V>(backingMap.entrySet(), valueType);
+                entrySet = new CheckedEntrySet<>(backingMap.entrySet(), valueType);
             return entrySet;
         }
 
@@ -2357,7 +2356,7 @@ public class FXCollections {
                 final Iterator<Map.Entry<K, V>> i = s.iterator();
                 final Class<V> valueType = this.valueType;
 
-                return new Iterator<Map.Entry<K,V>>() {
+                return new Iterator<>() {
                     @Override
                     public boolean hasNext() {
                         return i.hasNext();
@@ -2485,7 +2484,7 @@ public class FXCollections {
 
             static <K,V,T> CheckedEntry<K,V,T> checkedEntry(Map.Entry<K,V> e,
                                                             Class<T> valueType) {
-                return new CheckedEntry<K,V,T>(e, valueType);
+                return new CheckedEntry<>(e, valueType);
             }
 
             /**
@@ -2630,7 +2629,7 @@ public class FXCollections {
         public Set<K> keySet() {
             synchronized(mutex) {
                 if (keySet==null)
-                    keySet = new SynchronizedSet<K>(backingMap.keySet(), mutex);
+                    keySet = new SynchronizedSet<>(backingMap.keySet(), mutex);
                 return keySet;
             }
         }
@@ -2639,7 +2638,7 @@ public class FXCollections {
         public Collection<V> values() {
             synchronized(mutex) {
                 if (values==null)
-                    values = new SynchronizedCollection<V>(backingMap.values(), mutex);
+                    values = new SynchronizedCollection<>(backingMap.values(), mutex);
                 return values;
             }
         }
@@ -2648,7 +2647,7 @@ public class FXCollections {
         public Set<Entry<K, V>> entrySet() {
             synchronized(mutex) {
                 if (entrySet==null)
-                    entrySet = new SynchronizedSet<Map.Entry<K,V>>(backingMap.entrySet(), mutex);
+                    entrySet = new SynchronizedSet<>(backingMap.entrySet(), mutex);
                 return entrySet;
             }
         }
@@ -2786,9 +2785,9 @@ public class FXCollections {
             super(map);
             backingMap = map;
             listener = c -> {
-                MapListenerHelper.fireValueChangedEvent(listenerHelper, new MapAdapterChange<K, V>(SynchronizedObservableMap.this, c));
+                MapListenerHelper.fireValueChangedEvent(listenerHelper, new MapAdapterChange<>(SynchronizedObservableMap.this, c));
             };
-            backingMap.addListener(new WeakMapChangeListener<K, V>(listener));
+            backingMap.addListener(new WeakMapChangeListener<>(listener));
         }
 
         @Override

--- a/modules/javafx.base/src/main/java/javafx/collections/ListChangeBuilder.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/ListChangeBuilder.java
@@ -47,7 +47,7 @@ final class ListChangeBuilder<E> {
 
     private void checkAddRemoveList() {
         if (addRemoveChanges == null) {
-            addRemoveChanges = new ArrayList<SubChange<E>>();
+            addRemoveChanges = new ArrayList<>();
         }
     }
 
@@ -105,9 +105,9 @@ final class ListChangeBuilder<E> {
                 change.to--;
                 change.removed.add(0, removed);
             } else {
-                ArrayList<E> removedList = new ArrayList<E>();
+                ArrayList<E> removedList = new ArrayList<>();
                 removedList.add(removed);
-                addRemoveChanges.add(idx, new SubChange<E>(pos, pos, removedList, EMPTY_PERM, false));
+                addRemoveChanges.add(idx, new SubChange<>(pos, pos, removedList, EMPTY_PERM, false));
             }
         } else {
             SubChange<E> change = addRemoveChanges.get(idx);
@@ -135,7 +135,7 @@ final class ListChangeBuilder<E> {
                 change.to = to;
                 --idx;
             } else {
-                addRemoveChanges.add(idx, new SubChange<E>(from, to, new ArrayList<E>(), EMPTY_PERM, false));
+                addRemoveChanges.add(idx, new SubChange<>(from, to, new ArrayList<E>(), EMPTY_PERM, false));
             }
         } else {
             SubChange<E> change = addRemoveChanges.get(idx);
@@ -159,7 +159,7 @@ final class ListChangeBuilder<E> {
                 prev.to = cur.to;
                 if (prev.removed != null || cur.removed != null) {
                     if (prev.removed == null) {
-                        prev.removed = new ArrayList<E>();
+                        prev.removed = new ArrayList<>();
                     }
                     prev.removed.addAll(cur.removed);
                 }
@@ -293,7 +293,7 @@ final class ListChangeBuilder<E> {
             // items were permutated by our new permutation.
             int[] mapToOriginal = new int[list.size()];
             // Marks the original-list indexes that were removed
-            Set<Integer> removed = new TreeSet<Integer>();
+            Set<Integer> removed = new TreeSet<>();
             int last = 0;
             int offset = 0;
             for (int i = 0, sz = addRemoveChanges.size(); i < sz; ++i) {
@@ -368,12 +368,12 @@ final class ListChangeBuilder<E> {
                 permutationChange.perm = newPerm;
             }
         } else {
-            permutationChange = new SubChange<E>(prePermFrom, prePermTo, null, prePerm, false);
+            permutationChange = new SubChange<>(prePermFrom, prePermTo, null, prePerm, false);
         }
 
         if ((addRemoveChanges != null && !addRemoveChanges.isEmpty())) {
-            Set<Integer> newAdded = new TreeSet<Integer>();
-            Map<Integer, List<E>> newRemoved = new HashMap<Integer, List<E>>();
+            Set<Integer> newAdded = new TreeSet<>();
+            Map<Integer, List<E>> newRemoved = new HashMap<>();
             for (int i = 0, sz = addRemoveChanges.size(); i < sz; ++i) {
                 SubChange<E> change = addRemoveChanges.get(i);
                 for (int cIndex = change.from; cIndex < change.to; ++cIndex) {
@@ -395,7 +395,7 @@ final class ListChangeBuilder<E> {
             SubChange<E> lastChange = null;
             for (Integer i : newAdded) {
                 if (lastChange == null || lastChange.to != i) {
-                    lastChange = new SubChange<E>(i, i + 1, null, EMPTY_PERM, false);
+                    lastChange = new SubChange<>(i, i + 1, null, EMPTY_PERM, false);
                     addRemoveChanges.add(lastChange);
                 } else {
                     lastChange.to = i + 1;
@@ -414,12 +414,12 @@ final class ListChangeBuilder<E> {
                 final Integer at = e.getKey();
                 int idx = findSubChange(at, addRemoveChanges);
                 assert(idx < 0);
-                addRemoveChanges.add(~idx, new SubChange<E>(at, at, e.getValue(), new int[0], false));
+                addRemoveChanges.add(~idx, new SubChange<>(at, at, e.getValue(), new int[0], false));
             }
         }
 
         if (updateChanges != null && !updateChanges.isEmpty()) {
-            Set<Integer> newUpdated = new TreeSet<Integer>();
+            Set<Integer> newUpdated = new TreeSet<>();
             for (int i = 0, sz = updateChanges.size(); i < sz; ++i) {
                 SubChange<E> change = updateChanges.get(i);
                 for (int cIndex = change.from; cIndex < change.to; ++cIndex) {
@@ -434,7 +434,7 @@ final class ListChangeBuilder<E> {
             SubChange<E> lastUpdateChange = null;
             for (Integer i : newUpdated) {
                 if (lastUpdateChange == null || lastUpdateChange.to != i) {
-                    lastUpdateChange = new SubChange<E>(i, i + 1, null, EMPTY_PERM, true);
+                    lastUpdateChange = new SubChange<>(i, i + 1, null, EMPTY_PERM, true);
                     updateChanges.add(lastUpdateChange);
                 } else {
                     lastUpdateChange.to = i + 1;
@@ -458,7 +458,7 @@ final class ListChangeBuilder<E> {
     public void nextUpdate(int idx) {
         checkState();
         if (updateChanges == null) {
-            updateChanges = new ArrayList<SubChange<E>>();
+            updateChanges = new ArrayList<>();
         }
         final SubChange<E> last = updateChanges.isEmpty() ? null : updateChanges.get(updateChanges.size() - 1);
         if (last != null && last.to == idx) {
@@ -479,13 +479,13 @@ final class ListChangeBuilder<E> {
                     (addRemoveChanges != null ? addRemoveChanges.size() : 0) + (permutationChange != null ? 1 : 0);
             if (totalSize == 1) {
                 if (addRemoveNotEmpty) {
-                    list.fireChange(new SingleChange<E>(finalizeSubChange(addRemoveChanges.get(0)), list));
+                    list.fireChange(new SingleChange<>(finalizeSubChange(addRemoveChanges.get(0)), list));
                     addRemoveChanges.clear();
                 } else if (updateNotEmpty) {
-                    list.fireChange(new SingleChange<E>(finalizeSubChange(updateChanges.get(0)), list));
+                    list.fireChange(new SingleChange<>(finalizeSubChange(updateChanges.get(0)), list));
                     updateChanges.clear();
                 } else {
-                    list.fireChange(new SingleChange<E>(finalizeSubChange(permutationChange), list));
+                    list.fireChange(new SingleChange<>(finalizeSubChange(permutationChange), list));
                     permutationChange = null;
                 }
             } else {
@@ -521,7 +521,7 @@ final class ListChangeBuilder<E> {
                         }
                     }
                 }
-                list.fireChange(new IterableChange<E>(finalizeSubChangeArray(array), list));
+                list.fireChange(new IterableChange<>(finalizeSubChangeArray(array), list));
                 if (addRemoveChanges != null) addRemoveChanges.clear();
                 if (updateChanges != null) updateChanges.clear();
                 permutationChange = null;

--- a/modules/javafx.base/src/main/java/javafx/collections/ObservableListBase.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/ObservableListBase.java
@@ -27,7 +27,6 @@ package javafx.collections;
 
 import com.sun.javafx.collections.ListListenerHelper;
 import java.util.AbstractList;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -91,7 +90,7 @@ import javafx.beans.InvalidationListener;
 public abstract class ObservableListBase<E> extends AbstractList<E>  implements ObservableList<E> {
 
     private ListListenerHelper<E> listenerHelper;
-    private final ListChangeBuilder<E> changeBuilder = new ListChangeBuilder<E>(this);
+    private final ListChangeBuilder<E> changeBuilder = new ListChangeBuilder<>(this);
 
     /**
      * Creates a default {@code ObservableListBase}.

--- a/modules/javafx.base/src/main/java/javafx/collections/WeakListChangeListener.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/WeakListChangeListener.java
@@ -67,7 +67,7 @@ public final class WeakListChangeListener<E> implements ListChangeListener<E>, W
         if (listener == null) {
             throw new NullPointerException("Listener must be specified.");
         }
-        this.ref = new WeakReference<ListChangeListener<E>>(listener);
+        this.ref = new WeakReference<>(listener);
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/collections/WeakMapChangeListener.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/WeakMapChangeListener.java
@@ -67,7 +67,7 @@ public final class WeakMapChangeListener<K, V> implements MapChangeListener<K, V
         if (listener == null) {
             throw new NullPointerException("Listener must be specified.");
         }
-        this.ref = new WeakReference<MapChangeListener<K, V>>(listener);
+        this.ref = new WeakReference<>(listener);
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/collections/WeakSetChangeListener.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/WeakSetChangeListener.java
@@ -67,7 +67,7 @@ public final class WeakSetChangeListener<E> implements SetChangeListener<E>, Wea
         if (listener == null) {
             throw new NullPointerException("Listener must be specified.");
         }
-        this.ref = new WeakReference<SetChangeListener<E>>(listener);
+        this.ref = new WeakReference<>(listener);
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/collections/transformation/FilteredList.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/transformation/FilteredList.java
@@ -96,7 +96,7 @@ public final class FilteredList<E> extends TransformationList<E, E>{
 
     public final ObjectProperty<Predicate<? super E>> predicateProperty() {
         if (predicate == null) {
-            predicate = new ObjectPropertyBase<Predicate<? super E>>() {
+            predicate = new ObjectPropertyBase<>() {
                 @Override
                 protected void invalidated() {
                     refilter();
@@ -207,7 +207,6 @@ public final class FilteredList<E> extends TransformationList<E, E>{
     }
 
 
-    @SuppressWarnings("unchecked")
     private void ensureSize(int size) {
         if (filtered.length < size) {
             int[] replacement = new int[size * 3/2 + 1];
@@ -317,7 +316,6 @@ public final class FilteredList<E> extends TransformationList<E, E>{
         }
     }
 
-    @SuppressWarnings("unchecked")
     private void refilter() {
         ensureSize(getSource().size());
         List<E> removed = null;

--- a/modules/javafx.base/src/main/java/javafx/collections/transformation/SortedList.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/transformation/SortedList.java
@@ -73,11 +73,11 @@ public final class SortedList<E> extends TransformationList<E, E>{
     @SuppressWarnings("unchecked")
     public SortedList(@NamedArg("source") ObservableList<? extends E> source, @NamedArg("comparator") Comparator<? super E> comparator) {
         super(source);
-        sorted = (Element<E>[]) new Element[source.size() *3/2 + 1];
+        sorted = new Element[source.size() *3/2 + 1];
         perm = new int[sorted.length];
         size = source.size();
         for (int i = 0; i < size; ++i) {
-            sorted[i] = new Element<E>(source.get(i), i);
+            sorted[i] = new Element<>(source.get(i), i);
             perm[i] = i;
         }
         if (comparator != null) {
@@ -113,7 +113,7 @@ public final class SortedList<E> extends TransformationList<E, E>{
             updateUnsorted(c);
             fireChange(new SourceAdapterChange<>(this, c));
         }
-    };
+    }
 
     /**
      * The comparator that denotes the order of this SortedList.
@@ -123,7 +123,7 @@ public final class SortedList<E> extends TransformationList<E, E>{
 
     public final ObjectProperty<Comparator<? super E>> comparatorProperty() {
         if (comparator == null) {
-            comparator = new ObjectPropertyBase<Comparator<? super E>>() {
+            comparator = new ObjectPropertyBase<>() {
 
                 @Override
                 protected void invalidated() {
@@ -267,7 +267,7 @@ public final class SortedList<E> extends TransformationList<E, E>{
                 System.arraycopy(perm, c.getFrom(), perm, c.getTo(), size - c.getFrom());
                 size += c.getAddedSize();
                 for (int i = c.getFrom(); i < c.getTo(); ++i) {
-                    sorted[i] = new Element<E>(c.getList().get(i), i);
+                    sorted[i] = new Element<>(c.getList().get(i), i);
                     perm[i] = i;
                 }
             }
@@ -294,7 +294,6 @@ public final class SortedList<E> extends TransformationList<E, E>{
         }
 
         @Override
-        @SuppressWarnings("unchecked")
         public int compare(Element<E> o1, Element<E> o2) {
             return comparator.compare(o1.e, o2.e);
         }
@@ -352,7 +351,7 @@ public final class SortedList<E> extends TransformationList<E, E>{
         ensureSize(to);
         size = to;
         for (int i = 0; i < to; ++i) {
-            sorted[i] = new Element<E>(list.get(i), i);
+            sorted[i] = new Element<>(list.get(i), i);
         }
         int[] perm = helper.sort(sorted, 0, size, elementComparator);
         System.arraycopy(perm, 0, this.perm, 0, size);

--- a/modules/javafx.base/src/main/java/javafx/collections/transformation/TransformationList.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/transformation/TransformationList.java
@@ -42,7 +42,7 @@ import javafx.collections.WeakListChangeListener;
  * @param <F> the upper bound of the type of the source list
  * @since JavaFX 8.0
  */
-public abstract class TransformationList<E, F> extends ObservableListBase<E> implements ObservableList<E> {
+public abstract class TransformationList<E, F> extends ObservableListBase<E> {
 
     /**
      * Contains the source list of this transformation list.
@@ -59,7 +59,6 @@ public abstract class TransformationList<E, F> extends ObservableListBase<E> imp
      * Creates a new Transformation list wrapped around the source list.
      * @param source the wrapped list
      */
-    @SuppressWarnings("unchecked")
     protected TransformationList(ObservableList<? extends F> source) {
         if (source == null) {
             throw new NullPointerException();

--- a/modules/javafx.base/src/main/java/javafx/event/ActionEvent.java
+++ b/modules/javafx.base/src/main/java/javafx/event/ActionEvent.java
@@ -39,7 +39,7 @@ public class ActionEvent extends Event {
      * The only valid EventType for the ActionEvent.
      */
     public static final EventType<ActionEvent> ACTION =
-            new EventType<ActionEvent>(Event.ANY, "ACTION");
+            new EventType<>(Event.ANY, "ACTION");
 
     /**
      * Common supertype for all action event types.

--- a/modules/javafx.base/src/main/java/javafx/event/EventType.java
+++ b/modules/javafx.base/src/main/java/javafx/event/EventType.java
@@ -65,7 +65,7 @@ public final class EventType<T extends Event> implements Serializable{
      * has its super event type set to {@code null}.
      */
     public static final EventType<Event> ROOT =
-            new EventType<Event>("EVENT", null);
+            new EventType<>("EVENT", null);
 
     private WeakHashMap<EventType<? extends T>, Void> subTypes;
 
@@ -178,7 +178,7 @@ public final class EventType<T extends Event> implements Serializable{
 
     private void register(javafx.event.EventType<? extends T> subType) {
         if (subTypes == null) {
-            subTypes = new WeakHashMap<EventType<? extends T>, Void>();
+            subTypes = new WeakHashMap<>();
         }
         for (EventType<? extends T> t : subTypes.keySet()) {
             if (((t.name == null && subType.name == null) || (t.name != null && t.name.equals(subType.name)))) {
@@ -189,14 +189,14 @@ public final class EventType<T extends Event> implements Serializable{
         subTypes.put(subType, null);
     }
 
-    private Object writeReplace() throws ObjectStreamException {
-        Deque<String> path = new LinkedList<String>();
+    private Object writeReplace() {
+        Deque<String> path = new LinkedList<>();
         EventType<?> t = this;
         while (t != ROOT) {
             path.addFirst(t.name);
             t = t.superType;
         }
-        return new EventTypeSerialization(new ArrayList<String>(path));
+        return new EventTypeSerialization(new ArrayList<>(path));
     }
 
     static class EventTypeSerialization implements Serializable {

--- a/modules/javafx.base/src/main/java/javafx/event/WeakEventHandler.java
+++ b/modules/javafx.base/src/main/java/javafx/event/WeakEventHandler.java
@@ -52,7 +52,7 @@ public final class WeakEventHandler<T extends Event>
      *      notifications
      */
     public WeakEventHandler(final @NamedArg("eventHandler") EventHandler<T> eventHandler) {
-        weakRef = new WeakReference<EventHandler<T>>(eventHandler);
+        weakRef = new WeakReference<>(eventHandler);
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/util/converter/BigDecimalStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/BigDecimalStringConverter.java
@@ -63,6 +63,6 @@ public class BigDecimalStringConverter extends StringConverter<BigDecimal> {
             return "";
         }
 
-        return ((BigDecimal)value).toString();
+        return value.toString();
     }
 }

--- a/modules/javafx.base/src/main/java/javafx/util/converter/BigIntegerStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/BigIntegerStringConverter.java
@@ -63,6 +63,6 @@ public class BigIntegerStringConverter extends StringConverter<BigInteger> {
             return "";
         }
 
-        return ((BigInteger)value).toString();
+        return value.toString();
     }
 }

--- a/modules/javafx.base/src/main/java/javafx/util/converter/DateStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/DateStringConverter.java
@@ -127,7 +127,6 @@ public class DateStringConverter extends DateTimeStringConverter {
     // --------------------------------------------------------- Private Methods
 
     /** {@inheritDoc} */
-    @SuppressWarnings("removal")
     @Override protected DateFormat getDateFormat() {
         DateFormat df = null;
 

--- a/modules/javafx.base/src/main/java/javafx/util/converter/FloatStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/FloatStringConverter.java
@@ -63,6 +63,6 @@ public class FloatStringConverter extends StringConverter<Float> {
             return "";
         }
 
-        return Float.toString(((Float)value).floatValue());
+        return Float.toString(value.floatValue());
     }
 }

--- a/modules/javafx.base/src/main/java/javafx/util/converter/IntegerStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/IntegerStringConverter.java
@@ -63,6 +63,6 @@ public class IntegerStringConverter extends StringConverter<Integer> {
             return "";
         }
 
-        return (Integer.toString(((Integer)value).intValue()));
+        return (Integer.toString(value.intValue()));
     }
 }

--- a/modules/javafx.base/src/main/java/javafx/util/converter/LocalDateStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/LocalDateStringConverter.java
@@ -63,7 +63,7 @@ public class LocalDateStringConverter extends StringConverter<LocalDate> {
      * parsed leniently as expected in these locales.</p>
      */
     public LocalDateStringConverter() {
-        ldtConverter = new LdtConverter<LocalDate>(LocalDate.class, null, null,
+        ldtConverter = new LdtConverter<>(LocalDate.class, null, null,
                                                   null, null, null, null);
     }
 
@@ -76,7 +76,7 @@ public class LocalDateStringConverter extends StringConverter<LocalDate> {
      * formatter and parser. If null then {@link FormatStyle#SHORT} will be used.
      */
     public LocalDateStringConverter(FormatStyle dateStyle) {
-        ldtConverter = new LdtConverter<LocalDate>(LocalDate.class, null, null,
+        ldtConverter = new LdtConverter<>(LocalDate.class, null, null,
                                                   dateStyle, null, null, null);
     }
 
@@ -104,7 +104,7 @@ public class LocalDateStringConverter extends StringConverter<LocalDate> {
      * then a default parser will be used.
      */
     public LocalDateStringConverter(DateTimeFormatter formatter, DateTimeFormatter parser) {
-        ldtConverter = new LdtConverter<LocalDate>(LocalDate.class, formatter, parser,
+        ldtConverter = new LdtConverter<>(LocalDate.class, formatter, parser,
                                                    null, null, null, null);
     }
 
@@ -123,7 +123,7 @@ public class LocalDateStringConverter extends StringConverter<LocalDate> {
      * formatter and parser. If null then {@link IsoChronology#INSTANCE} will be used.
      */
     public LocalDateStringConverter(FormatStyle dateStyle, Locale locale, Chronology chronology) {
-        ldtConverter = new LdtConverter<LocalDate>(LocalDate.class, null, null,
+        ldtConverter = new LdtConverter<>(LocalDate.class, null, null,
                                                   dateStyle, null, locale, chronology);
     }
 

--- a/modules/javafx.base/src/main/java/javafx/util/converter/LocalDateTimeStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/LocalDateTimeStringConverter.java
@@ -25,13 +25,10 @@
 
 package javafx.util.converter;
 
-import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.LocalDateTime;
 import java.time.chrono.Chronology;
-import java.time.chrono.ChronoLocalDate;
-import java.time.chrono.ChronoLocalDateTime;
 import java.time.chrono.IsoChronology;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
@@ -42,8 +39,6 @@ import java.time.temporal.TemporalAccessor;
 import java.util.Locale;
 
 import javafx.util.StringConverter;
-
-import com.sun.javafx.binding.Logging;
 
 /**
  * <p>{@link StringConverter} implementation for {@link LocalDateTime} values.</p>
@@ -76,7 +71,7 @@ public class LocalDateTimeStringConverter extends StringConverter<LocalDateTime>
      * parsed as expected in these locales.</p>
      */
     public LocalDateTimeStringConverter() {
-        ldtConverter = new LdtConverter<LocalDateTime>(LocalDateTime.class, null, null,
+        ldtConverter = new LdtConverter<>(LocalDateTime.class, null, null,
                                                        null, null, null, null);
     }
 
@@ -94,7 +89,7 @@ public class LocalDateTimeStringConverter extends StringConverter<LocalDateTime>
      * will be used.
      */
     public LocalDateTimeStringConverter(FormatStyle dateStyle, FormatStyle timeStyle) {
-        ldtConverter = new LdtConverter<LocalDateTime>(LocalDateTime.class, null, null,
+        ldtConverter = new LdtConverter<>(LocalDateTime.class, null, null,
                                                        dateStyle, timeStyle, null, null);
     }
 
@@ -122,7 +117,7 @@ public class LocalDateTimeStringConverter extends StringConverter<LocalDateTime>
      * then a default parser will be used.
      */
     public LocalDateTimeStringConverter(DateTimeFormatter formatter, DateTimeFormatter parser) {
-        ldtConverter = new LdtConverter<LocalDateTime>(LocalDateTime.class, formatter, parser,
+        ldtConverter = new LdtConverter<>(LocalDateTime.class, formatter, parser,
                                                        null, null, null, null);
     }
 
@@ -146,7 +141,7 @@ public class LocalDateTimeStringConverter extends StringConverter<LocalDateTime>
      */
     public LocalDateTimeStringConverter(FormatStyle dateStyle, FormatStyle timeStyle,
                                         Locale locale, Chronology chronology) {
-        ldtConverter = new LdtConverter<LocalDateTime>(LocalDateTime.class, null, null,
+        ldtConverter = new LdtConverter<>(LocalDateTime.class, null, null,
                                                        dateStyle, timeStyle, locale, chronology);
     }
 

--- a/modules/javafx.base/src/main/java/javafx/util/converter/LocalTimeStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/LocalTimeStringConverter.java
@@ -52,7 +52,7 @@ public class LocalTimeStringConverter extends StringConverter<LocalTime> {
      * user's {@link Locale}.
      */
     public LocalTimeStringConverter() {
-        ldtConverter = new LdtConverter<LocalTime>(LocalTime.class, null, null,
+        ldtConverter = new LdtConverter<>(LocalTime.class, null, null,
                                                   null, null, null, null);
     }
 
@@ -65,7 +65,7 @@ public class LocalTimeStringConverter extends StringConverter<LocalTime> {
      * formatter and parser. If null then {@link FormatStyle#SHORT} will be used.
      */
     public LocalTimeStringConverter(FormatStyle timeStyle) {
-        ldtConverter = new LdtConverter<LocalTime>(LocalTime.class, null, null,
+        ldtConverter = new LdtConverter<>(LocalTime.class, null, null,
                                                   null, timeStyle, null, null);
     }
 
@@ -81,7 +81,7 @@ public class LocalTimeStringConverter extends StringConverter<LocalTime> {
      * {@code Locale.getDefault(Locale.Category.FORMAT)} will be used.
      */
     public LocalTimeStringConverter(FormatStyle timeStyle, Locale locale) {
-        ldtConverter = new LdtConverter<LocalTime>(LocalTime.class, null, null,
+        ldtConverter = new LdtConverter<>(LocalTime.class, null, null,
                                                   null, timeStyle, locale, null);
     }
 
@@ -108,7 +108,7 @@ public class LocalTimeStringConverter extends StringConverter<LocalTime> {
      * used.
      */
     public LocalTimeStringConverter(DateTimeFormatter formatter, DateTimeFormatter parser) {
-        ldtConverter = new LdtConverter<LocalTime>(LocalTime.class, formatter, parser,
+        ldtConverter = new LdtConverter<>(LocalTime.class, formatter, parser,
                                                    null, null, null, null);
     }
 

--- a/modules/javafx.base/src/main/java/javafx/util/converter/LongStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/LongStringConverter.java
@@ -63,6 +63,6 @@ public class LongStringConverter extends StringConverter<Long> {
             return "";
         }
 
-        return Long.toString(((Long)value).longValue());
+        return Long.toString(value.longValue());
     }
 }

--- a/modules/javafx.base/src/main/java/javafx/util/converter/ShortStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/ShortStringConverter.java
@@ -63,6 +63,6 @@ public class ShortStringConverter extends StringConverter<Short> {
             return "";
         }
 
-        return Short.toString(((Short)value).shortValue());
+        return Short.toString(value.shortValue());
     }
 }

--- a/modules/javafx.base/src/main/java/javafx/util/converter/TimeStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/TimeStringConverter.java
@@ -128,7 +128,6 @@ public class TimeStringConverter extends DateTimeStringConverter {
     // --------------------------------------------------------- Private Methods
 
     /** {@inheritDoc} */
-    @SuppressWarnings("removal")
     @Override protected DateFormat getDateFormat() {
         DateFormat df = null;
 

--- a/modules/javafx.base/src/shims/java/javafx/beans/value/ObservableValueStub.java
+++ b/modules/javafx.base/src/shims/java/javafx/beans/value/ObservableValueStub.java
@@ -26,7 +26,7 @@
 package javafx.beans.value;
 
 
-public class ObservableValueStub<T> extends ObservableValueBase<T> implements ObservableValue<T> {
+public class ObservableValueStub<T> extends ObservableValueBase<T> {
 
     private T value;
 

--- a/modules/javafx.base/src/shims/java/javafx/collections/ListChangeBuilderShim.java
+++ b/modules/javafx.base/src/shims/java/javafx/collections/ListChangeBuilderShim.java
@@ -31,7 +31,7 @@ public class ListChangeBuilderShim<E> {
     private ListChangeBuilder lcb;
 
     public ListChangeBuilderShim(ObservableListBase<E> list) {
-        lcb = new ListChangeBuilder<E>(list);
+        lcb = new ListChangeBuilder<>(list);
     }
 
     public ListChangeBuilder<E> getBuilder() {

--- a/modules/javafx.base/src/shims/java/javafx/collections/ObservableListWrapperShim.java
+++ b/modules/javafx.base/src/shims/java/javafx/collections/ObservableListWrapperShim.java
@@ -24,10 +24,8 @@
  */
 package javafx.collections;
 
-import com.sun.javafx.collections.ListListenerHelper;
 import com.sun.javafx.collections.ObservableListWrapper;
 import java.util.List;
-import javafx.beans.InvalidationListener;
 
 public class ObservableListWrapperShim<E> extends ObservableListWrapper<E> {
 

--- a/modules/javafx.base/src/shims/java/javafx/event/EventTypeShim.java
+++ b/modules/javafx.base/src/shims/java/javafx/event/EventTypeShim.java
@@ -27,7 +27,7 @@ package javafx.event;
 
 import java.util.List;
 
-public class EventTypeShim<T extends Event> {
+public class EventTypeShim {
 
     public static Object getEventTypeSerialization(List<String> path) {
         return new EventType.EventTypeSerialization(path);

--- a/modules/javafx.base/src/shims/java/javafx/util/converter/DateTimeStringConverterShim.java
+++ b/modules/javafx.base/src/shims/java/javafx/util/converter/DateTimeStringConverterShim.java
@@ -30,32 +30,26 @@ import java.util.Locale;
 
 public class DateTimeStringConverterShim {
 
-    @SuppressWarnings("removal")
     public static int getTimeStyle(DateTimeStringConverter tsc) {
         return tsc.timeStyle;
     }
 
-    @SuppressWarnings("removal")
     public static String getPattern(DateTimeStringConverter tsc) {
         return tsc.pattern;
     }
 
-    @SuppressWarnings("removal")
     public static int getDateStyle(DateTimeStringConverter tsc) {
         return tsc.dateStyle;
     }
 
-    @SuppressWarnings("removal")
     public static DateFormat getDateFormat(DateTimeStringConverter tsc) {
         return tsc.getDateFormat();
     }
 
-    @SuppressWarnings("removal")
     public static DateFormat getDateFormatVar(DateTimeStringConverter tsc) {
         return tsc.dateFormat;
     }
 
-    @SuppressWarnings("removal")
     public static Locale getLocale(DateTimeStringConverter tsc) {
         return tsc.locale;
     }

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/BidirectionalBindingWithConversionTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/BidirectionalBindingWithConversionTest.java
@@ -29,7 +29,6 @@ import com.sun.javafx.binding.BidirectionalBinding;
 import javafx.beans.InvalidationListener;
 import javafx.beans.binding.Bindings;
 import javafx.beans.property.*;
-import javafx.beans.value.ChangeListener;
 import javafx.util.StringConverter;
 import org.junit.Before;
 import org.junit.Test;
@@ -173,7 +172,7 @@ public class BidirectionalBindingWithConversionTest<S, T> {
         final Date[] dates = new Date[] {new Date(), new Date(0), new Date(Integer.MAX_VALUE), new Date(Long.MAX_VALUE)};
         final String[] strings = new String[] {format.format(dates[0]), format.format(dates[1]), format.format(dates[2]), format.format(dates[3])};
 
-        final StringConverter<Date> converter = new StringConverter<Date>() {
+        final StringConverter<Date> converter = new StringConverter<>() {
             @Override
             public String toString(Date object) {
                 return format.format(object);
@@ -199,7 +198,7 @@ public class BidirectionalBindingWithConversionTest<S, T> {
                     }
                     @Override
                     public PropertyMock<Date> create1() {
-                        return new ObjectPropertyMock<Date>();
+                        return new ObjectPropertyMock<>();
                     }
                     @Override
                     public void bind(PropertyMock<String> op0, PropertyMock<Date> op1) {
@@ -236,7 +235,7 @@ public class BidirectionalBindingWithConversionTest<S, T> {
                     }
                     @Override
                     public PropertyMock<Date> create1() {
-                        return new ObjectPropertyMock<Date>();
+                        return new ObjectPropertyMock<>();
                     }
                     @Override
                     public void bind(PropertyMock<String> op0, PropertyMock<Date> op1) {

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/BidirectionalContentBindingListTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/BidirectionalContentBindingListTest.java
@@ -49,9 +49,9 @@ public class BidirectionalContentBindingListTest {
 
     @Before
     public void setUp() {
-        list0 = new ArrayList<Integer>();
-        list1 = new ArrayList<Integer>(Arrays.asList(-1));
-        list2 = new ArrayList<Integer>(Arrays.asList(2, 1));
+        list0 = new ArrayList<>();
+        list1 = new ArrayList<>(Arrays.asList(-1));
+        list2 = new ArrayList<>(Arrays.asList(2, 1));
 
         op1 = FXCollections.observableArrayList(list1);
         op2 = FXCollections.observableArrayList(list2);
@@ -60,7 +60,7 @@ public class BidirectionalContentBindingListTest {
 
     @Test
     public void testBind() {
-        final List<Integer> list2_sorted = new ArrayList<Integer>(Arrays.asList(1, 2));
+        final List<Integer> list2_sorted = new ArrayList<>(Arrays.asList(1, 2));
 
         Bindings.bindContentBidirectional(op1, op2);
         System.gc(); // making sure we did not not overdo weak references

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/BidirectionalContentBindingMapTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/BidirectionalContentBindingMapTest.java
@@ -52,10 +52,10 @@ public class BidirectionalContentBindingMapTest {
 
     @Before
     public void setUp() {
-        map0 = new HashMap<String, Integer>();
-        map1 = new HashMap<String, Integer>();
+        map0 = new HashMap<>();
+        map1 = new HashMap<>();
         map1.put(key1, -1);
-        map2 = new HashMap<String, Integer>();
+        map2 = new HashMap<>();
         map2.put(key2_1, 2);
         map2.put(key2_2, 1);
 

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/BidirectionalContentBindingSetTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/BidirectionalContentBindingSetTest.java
@@ -48,10 +48,10 @@ public class BidirectionalContentBindingSetTest {
 
     @Before
     public void setUp() {
-        set0 = new HashSet<Integer>();
-        set1 = new HashSet<Integer>();
+        set0 = new HashSet<>();
+        set1 = new HashSet<>();
         set1.add(-1);
-        set2 = new HashSet<Integer>();
+        set2 = new HashSet<>();
         set2.add(2);
         set2.add(1);
 

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ContentBindingListTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ContentBindingListTest.java
@@ -49,18 +49,18 @@ public class ContentBindingListTest {
 
     @Before
     public void setUp() {
-        list0 = new ArrayList<Integer>();
-        list1 = new ArrayList<Integer>(Arrays.asList(0));
-        list2 = new ArrayList<Integer>(Arrays.asList(2, 1));
+        list0 = new ArrayList<>();
+        list1 = new ArrayList<>(Arrays.asList(0));
+        list2 = new ArrayList<>(Arrays.asList(2, 1));
 
-        op1 = new ArrayList<Integer>(list1);
+        op1 = new ArrayList<>(list1);
         op2 = FXCollections.observableArrayList(list2);
         op3 = FXCollections.observableArrayList(list0);
     }
 
     @Test
     public void testBind() {
-        List<Integer> list2_sorted = new ArrayList<Integer>(Arrays.asList(1, 2));
+        List<Integer> list2_sorted = new ArrayList<>(Arrays.asList(1, 2));
 
         Bindings.bindContent(op1, op2);
         System.gc(); // making sure we did not not overdo weak references

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ContentBindingMapTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ContentBindingMapTest.java
@@ -52,14 +52,14 @@ public class ContentBindingMapTest {
 
     @Before
     public void setUp() {
-        map0 = new HashMap<String, Integer>();
-        map1 = new HashMap<String, Integer>();
+        map0 = new HashMap<>();
+        map1 = new HashMap<>();
         map1.put(key1, -1);
-        map2 = new HashMap<String, Integer>();
+        map2 = new HashMap<>();
         map2.put(key2_1, 2);
         map2.put(key2_2, 1);
 
-        op1 = new HashMap<String, Integer>(map1);
+        op1 = new HashMap<>(map1);
         op2 = FXCollections.observableMap(map2);
         op3 = FXCollections.observableMap(map0);
     }

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ContentBindingSetTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ContentBindingSetTest.java
@@ -48,14 +48,14 @@ public class ContentBindingSetTest {
 
     @Before
     public void setUp() {
-        set0 = new HashSet<Integer>();
-        set1 = new HashSet<Integer>();
+        set0 = new HashSet<>();
+        set1 = new HashSet<>();
         set1.add(-1);
-        set2 = new HashSet<Integer>(2, 1);
+        set2 = new HashSet<>(2, 1);
         set2.add(2);
         set2.add(1);
 
-        op1 = new HashSet<Integer>(set1);
+        op1 = new HashSet<>(set1);
         op2 = FXCollections.observableSet(set2);
         op3 = FXCollections.observableSet(set0);
     }

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ExpressionHelperTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ExpressionHelperTest.java
@@ -65,7 +65,7 @@ public class ExpressionHelperTest {
                 new InvalidationListenerMock(), new InvalidationListenerMock(), new InvalidationListenerMock(), new InvalidationListenerMock()
         };
         changeListener = new ChangeListenerMock[] {
-                new ChangeListenerMock<Object>(UNDEFINED), new ChangeListenerMock<Object>(UNDEFINED), new ChangeListenerMock<Object>(UNDEFINED), new ChangeListenerMock<Object>(UNDEFINED)
+                new ChangeListenerMock<>(UNDEFINED), new ChangeListenerMock<>(UNDEFINED), new ChangeListenerMock<>(UNDEFINED), new ChangeListenerMock<>(UNDEFINED)
         };
     }
 

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ListExpressionHelperTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ListExpressionHelperTest.java
@@ -36,7 +36,6 @@ import javafx.beans.property.SimpleListProperty;
 import javafx.beans.value.ChangeListener;
 import test.javafx.beans.value.ChangeListenerMock;
 import javafx.beans.value.ObservableValue;
-import javafx.beans.value.ObservableValueStub;
 import test.javafx.beans.value.WeakChangeListenerMock;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
@@ -76,7 +75,7 @@ public class ListExpressionHelperTest {
 //        change_1_2 = new NonIterableChange.SimpleAddChange(0, 1, data2);
 //        change_2_1 = new NonIterableChange.SimpleRemovedChange(0, 1, listItem, data1);
         helper = null;
-        observable = new SimpleListProperty<Object>(data1);
+        observable = new SimpleListProperty<>(data1);
 
         invalidationListener = new InvalidationListenerMock[] {
                 new InvalidationListenerMock(), new InvalidationListenerMock(), new InvalidationListenerMock(), new InvalidationListenerMock()
@@ -85,7 +84,7 @@ public class ListExpressionHelperTest {
                 new ChangeListenerMock(UNDEFINED), new ChangeListenerMock(UNDEFINED), new ChangeListenerMock(UNDEFINED), new ChangeListenerMock(UNDEFINED)
         };
         listChangeListener = new MockListObserver[] {
-                new MockListObserver<Object>(), new MockListObserver<Object>(), new MockListObserver<Object>(), new MockListObserver<Object>()
+                new MockListObserver<>(), new MockListObserver<>(), new MockListObserver<>(), new MockListObserver<>()
         };
     }
 

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/SelectBindingTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/SelectBindingTest.java
@@ -539,7 +539,7 @@ public class SelectBindingTest {
     @Test
     public void stressTestRandomOperationsResultInCorrectListenersInstalled() {
 
-        List<String> steps = new ArrayList<String>();
+        List<String> steps = new ArrayList<>();
 
         Random rand = new Random(System.currentTimeMillis());
         for (int i = 0; i < 10000; i++) {

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/StringFormatterTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/StringFormatterTest.java
@@ -53,7 +53,6 @@ import test.javafx.binding.DependencyUtils;
 import org.junit.Before;
 import org.junit.Test;
 
-@SuppressWarnings("WebTest")
 public class StringFormatterTest {
 
     private double double0;
@@ -104,7 +103,7 @@ public class StringFormatterTest {
         intV = new SimpleIntegerProperty(int0);
         booleanV = new SimpleBooleanProperty(boolean0);
         stringV = new SimpleStringProperty(string0);
-        dateV = new SimpleObjectProperty<Date>(date0);
+        dateV = new SimpleObjectProperty<>(date0);
     }
 
     @Test

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/collections/ListListenerHelperTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/collections/ListListenerHelperTest.java
@@ -66,14 +66,14 @@ public class ListListenerHelperTest {
                 new InvalidationListenerMock()
         };
         changeListenerMock = new MockListObserver[] {
-                new MockListObserver<Object>(),
-                new MockListObserver<Object>(),
-                new MockListObserver<Object>(),
-                new MockListObserver<Object>()
+                new MockListObserver<>(),
+                new MockListObserver<>(),
+                new MockListObserver<>(),
+                new MockListObserver<>()
         };
         helper = null;
         list = FXCollections.emptyObservableList();
-        change = new NonIterableChange.SimpleRemovedChange<Object>(0, 1, new Object(), list);
+        change = new NonIterableChange.SimpleRemovedChange<>(0, 1, new Object(), list);
     }
 
     private void resetAllListeners() {
@@ -252,7 +252,7 @@ public class ListListenerHelperTest {
 
     @Test
     public void testGeneric_AddInvalidationInPulse() {
-        final ListChangeListener<Object> addListener = new ListChangeListener<Object>() {
+        final ListChangeListener<Object> addListener = new ListChangeListener<>() {
             int counter;
             @Override
             public void onChanged(Change<? extends Object> c) {
@@ -363,7 +363,7 @@ public class ListListenerHelperTest {
 
     @Test
     public void testGeneric_RemoveInvalidationInPulse() {
-        final ListChangeListener<Object> removeListener = new ListChangeListener<Object>() {
+        final ListChangeListener<Object> removeListener = new ListChangeListener<>() {
             int counter;
             @Override
             public void onChanged(Change<? extends Object> c) {

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/collections/MapListenerHelperTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/collections/MapListenerHelperTest.java
@@ -65,14 +65,14 @@ public class MapListenerHelperTest {
                 new InvalidationListenerMock()
         };
         changeListenerMock = new MockMapObserver[] {
-                new MockMapObserver<Object, Object>(),
-                new MockMapObserver<Object, Object>(),
-                new MockMapObserver<Object, Object>(),
-                new MockMapObserver<Object, Object>()
+                new MockMapObserver<>(),
+                new MockMapObserver<>(),
+                new MockMapObserver<>(),
+                new MockMapObserver<>()
         };
         helper = null;
         map = FXCollections.observableHashMap();
-        change = new MapExpressionHelper.SimpleChange<Object, Object>(map).setRemoved(new Object(), new Object());
+        change = new MapExpressionHelper.SimpleChange<>(map).setRemoved(new Object(), new Object());
     }
 
     private void resetAllListeners() {
@@ -251,7 +251,7 @@ public class MapListenerHelperTest {
 
     @Test
     public void testGeneric_AddInvalidationInPulse() {
-        final MapChangeListener<Object, Object> addListener = new MapChangeListener<Object, Object>() {
+        final MapChangeListener<Object, Object> addListener = new MapChangeListener<>() {
             int counter;
             @Override
             public void onChanged(Change<? extends Object, ? extends Object> change) {
@@ -362,7 +362,7 @@ public class MapListenerHelperTest {
 
     @Test
     public void testGeneric_RemoveInvalidationInPulse() {
-        final MapChangeListener<Object, Object> removeListener = new MapChangeListener<Object, Object>() {
+        final MapChangeListener<Object, Object> removeListener = new MapChangeListener<>() {
             int counter;
             @Override
             public void onChanged(Change<? extends Object, ? extends Object> change) {

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/collections/MappingChangeTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/collections/MappingChangeTest.java
@@ -49,8 +49,8 @@ public class MappingChangeTest {
 
     @Test
     public void testAddRemove() {
-        Change<Integer> change = new NonIterableChange.SimpleRemovedChange<Integer>(0, 1, Integer.valueOf(5), originalList);
-        MappingChange<Integer, String> mapChange = new MappingChange<Integer, String>(change,
+        Change<Integer> change = new NonIterableChange.SimpleRemovedChange<>(0, 1, Integer.valueOf(5), originalList);
+        MappingChange<Integer, String> mapChange = new MappingChange<>(change,
                 e -> e.toString(), list);
 
         assertTrue(mapChange.next());
@@ -64,8 +64,8 @@ public class MappingChangeTest {
 
     @Test
     public void testUpdate() {
-        Change<Integer> change = new NonIterableChange.SimpleUpdateChange<Integer>(0, 1, originalList);
-        MappingChange<Integer, String> mapChange = new MappingChange<Integer, String>(change,
+        Change<Integer> change = new NonIterableChange.SimpleUpdateChange<>(0, 1, originalList);
+        MappingChange<Integer, String> mapChange = new MappingChange<>(change,
                 e -> e.toString(), list);
 
         assertTrue(mapChange.next());
@@ -79,8 +79,8 @@ public class MappingChangeTest {
 
     @Test
     public void testPermutation() {
-        Change<Integer> change = new NonIterableChange.SimplePermutationChange<Integer>(0, 2, new int[] {1, 0}, originalList);
-        MappingChange<Integer, String> mapChange = new MappingChange<Integer, String>(change,
+        Change<Integer> change = new NonIterableChange.SimplePermutationChange<>(0, 2, new int[] {1, 0}, originalList);
+        MappingChange<Integer, String> mapChange = new MappingChange<>(change,
                 e -> e.toString(), list);
 
         assertTrue(mapChange.next());
@@ -133,7 +133,7 @@ public class MappingChangeTest {
                 return new int[0];
             }
         };
-        MappingChange<Integer, String> mapChange = new MappingChange<Integer, String>(change,
+        MappingChange<Integer, String> mapChange = new MappingChange<>(change,
                 e -> e.toString(), list);
 
         assertTrue(mapChange.next());

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/collections/NonIterableChangeTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/collections/NonIterableChangeTest.java
@@ -44,7 +44,7 @@ public class NonIterableChangeTest {
 
     @Test
     public void testSimpleAdd() {
-        Change<String> change = new NonIterableChange.SimpleAddChange<String>(0, 1, list);
+        Change<String> change = new NonIterableChange.SimpleAddChange<>(0, 1, list);
 
         assertTrue(change.next());
 
@@ -66,7 +66,7 @@ public class NonIterableChangeTest {
 
     @Test
     public void testSimpleRemove() {
-        Change<String> change = new NonIterableChange.SimpleRemovedChange<String>(0, 0, "a0", list);
+        Change<String> change = new NonIterableChange.SimpleRemovedChange<>(0, 0, "a0", list);
 
         assertTrue(change.next());
 
@@ -88,7 +88,7 @@ public class NonIterableChangeTest {
 
     @Test
     public void testSimpleUpdate() {
-        Change<String> change = new NonIterableChange.SimpleUpdateChange<String>(0, 1, list);
+        Change<String> change = new NonIterableChange.SimpleUpdateChange<>(0, 1, list);
 
         assertTrue(change.next());
 
@@ -110,7 +110,7 @@ public class NonIterableChangeTest {
 
     @Test
     public void testSimplePermutation() {
-        Change<String> change = new NonIterableChange.SimplePermutationChange<String>(0, 2, new int[] {1, 0}, list);
+        Change<String> change = new NonIterableChange.SimplePermutationChange<>(0, 2, new int[] {1, 0}, list);
 
         assertTrue(change.next());
 

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/collections/SetListenerHelperTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/collections/SetListenerHelperTest.java
@@ -65,14 +65,14 @@ public class SetListenerHelperTest {
                 new InvalidationListenerMock()
         };
         changeListenerMock = new MockSetObserver[] {
-                new MockSetObserver<Object>(),
-                new MockSetObserver<Object>(),
-                new MockSetObserver<Object>(),
-                new MockSetObserver<Object>()
+                new MockSetObserver<>(),
+                new MockSetObserver<>(),
+                new MockSetObserver<>(),
+                new MockSetObserver<>()
         };
         helper = null;
         set = FXCollections.observableSet();
-        change = new SetExpressionHelper.SimpleChange<Object>(set).setRemoved(new Object());
+        change = new SetExpressionHelper.SimpleChange<>(set).setRemoved(new Object());
     }
 
     private void resetAllListeners() {
@@ -251,7 +251,7 @@ public class SetListenerHelperTest {
 
     @Test
     public void testGeneric_AddInvalidationInPulse() {
-        final SetChangeListener<Object> addListener = new SetChangeListener<Object>() {
+        final SetChangeListener<Object> addListener = new SetChangeListener<>() {
             int counter;
             @Override
             public void onChanged(Change<? extends Object> change) {
@@ -362,7 +362,7 @@ public class SetListenerHelperTest {
 
     @Test
     public void testGeneric_RemoveInvalidationInPulse() {
-        final SetChangeListener<Object> removeListener = new SetChangeListener<Object>() {
+        final SetChangeListener<Object> removeListener = new SetChangeListener<>() {
             int counter;
             @Override
             public void onChanged(Change<? extends Object> change) {

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/event/CompositeEventHandlerTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/event/CompositeEventHandlerTest.java
@@ -30,8 +30,6 @@ import com.sun.javafx.event.CompositeEventHandlerShim;
 
 import static org.junit.Assert.*;
 
-import test.com.sun.javafx.event.EventCountingHandler;
-import test.com.sun.javafx.event.EmptyEvent;
 import javafx.event.Event;
 import javafx.event.WeakEventHandler;
 import javafx.event.WeakEventHandlerUtil;
@@ -45,7 +43,7 @@ public class CompositeEventHandlerTest {
 
     @Before
     public void setUp() {
-        compositeEventHandler = new CompositeEventHandler<Event>();
+        compositeEventHandler = new CompositeEventHandler<>();
     }
 
     /**
@@ -56,9 +54,9 @@ public class CompositeEventHandlerTest {
     @Test
     public void testHasFilterWeakCleared() {
         final EventCountingHandler<Event> eventCountingHandler =
-                new EventCountingHandler<Event>();
+                new EventCountingHandler<>();
         final WeakEventHandler<Event> weakEventHandler =
-                new WeakEventHandler<Event>(eventCountingHandler);
+                new WeakEventHandler<>(eventCountingHandler);
 
         compositeEventHandler.addEventFilter(weakEventHandler);
         assertFalse("must not have handler after adding filter", compositeEventHandler.hasHandler());
@@ -74,9 +72,9 @@ public class CompositeEventHandlerTest {
     @Test
     public void testHasHandlerAddWeakClear() {
         final EventCountingHandler<Event> eventCountingHandler =
-                new EventCountingHandler<Event>();
+                new EventCountingHandler<>();
         final WeakEventHandler<Event> weakEventHandler =
-                new WeakEventHandler<Event>(eventCountingHandler);
+                new WeakEventHandler<>(eventCountingHandler);
         compositeEventHandler.addEventHandler(weakEventHandler);
         assertTrue("sanity: really added?", CompositeEventHandlerShim.containsHandler(
                 compositeEventHandler, weakEventHandler));
@@ -95,9 +93,9 @@ public class CompositeEventHandlerTest {
     @Test
     public void testHasFilterWeak() {
         final EventCountingHandler<Event> eventCountingHandler =
-                new EventCountingHandler<Event>();
+                new EventCountingHandler<>();
         final WeakEventHandler<Event> weakEventHandler =
-                new WeakEventHandler<Event>(eventCountingHandler);
+                new WeakEventHandler<>(eventCountingHandler);
 
         compositeEventHandler.addEventFilter(weakEventHandler);
         assertFalse("must not have handler after adding filter", compositeEventHandler.hasHandler());
@@ -113,9 +111,9 @@ public class CompositeEventHandlerTest {
     @Test
     public void testHasHandlerAddWeak() {
         final EventCountingHandler<Event> eventCountingHandler =
-                new EventCountingHandler<Event>();
+                new EventCountingHandler<>();
         final WeakEventHandler<Event> weakEventHandler =
-                new WeakEventHandler<Event>(eventCountingHandler);
+                new WeakEventHandler<>(eventCountingHandler);
         compositeEventHandler.addEventHandler(weakEventHandler);
         assertTrue("sanity: really added?", CompositeEventHandlerShim.containsHandler(
                 compositeEventHandler, weakEventHandler));
@@ -132,7 +130,7 @@ public class CompositeEventHandlerTest {
     @Test
     public void testHasFilter() {
         final EventCountingHandler<Event> eventCountingHandler =
-                new EventCountingHandler<Event>();
+                new EventCountingHandler<>();
         compositeEventHandler.addEventFilter(eventCountingHandler);
         assertFalse("must not have handler after adding filter", compositeEventHandler.hasHandler());
         assertTrue("must have filter", compositeEventHandler.hasFilter());
@@ -147,7 +145,7 @@ public class CompositeEventHandlerTest {
     @Test
     public void testHasHandlerAdd() {
         final EventCountingHandler<Event> eventCountingHandler =
-                new EventCountingHandler<Event>();
+                new EventCountingHandler<>();
         compositeEventHandler.addEventHandler(eventCountingHandler);
         assertTrue("sanity: really added?", CompositeEventHandlerShim.containsHandler(
                 compositeEventHandler, eventCountingHandler));
@@ -165,7 +163,7 @@ public class CompositeEventHandlerTest {
     @Test
     public void testHasHandlerSingleton() {
         final EventCountingHandler<Event> eventCountingHandler =
-                new EventCountingHandler<Event>();
+                new EventCountingHandler<>();
         compositeEventHandler.setEventHandler(eventCountingHandler);
         assertFalse("must not have filter after set handler", compositeEventHandler.hasFilter());
         assertTrue("must have handler", compositeEventHandler.hasHandler());
@@ -177,9 +175,9 @@ public class CompositeEventHandlerTest {
     @Test
     public void weakEventHandlerTest() {
         final EventCountingHandler<Event> eventCountingHandler =
-                new EventCountingHandler<Event>();
+                new EventCountingHandler<>();
         final WeakEventHandler<Event> weakEventHandler =
-                new WeakEventHandler<Event>(eventCountingHandler);
+                new WeakEventHandler<>(eventCountingHandler);
 
         compositeEventHandler.addEventHandler(weakEventHandler);
 
@@ -203,9 +201,9 @@ public class CompositeEventHandlerTest {
     @Test
     public void weakEventFilterTest() {
         final EventCountingHandler<Event> eventCountingFilter =
-                new EventCountingHandler<Event>();
+                new EventCountingHandler<>();
         final WeakEventHandler<Event> weakEventFilter =
-                new WeakEventHandler<Event>(eventCountingFilter);
+                new WeakEventHandler<>(eventCountingFilter);
 
         compositeEventHandler.addEventFilter(weakEventFilter);
 

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/event/EmptyEvent.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/event/EmptyEvent.java
@@ -30,7 +30,7 @@ import javafx.event.EventType;
 
 public final class EmptyEvent extends Event {
     public static final EventType<EmptyEvent> EMPTY =
-            new EventType<EmptyEvent>(Event.ANY, "EMPTY");
+            new EventType<>(Event.ANY, "EMPTY");
 
     public EmptyEvent() {
         super(EMPTY);

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/event/EventHandlerManagerTest.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/event/EventHandlerManagerTest.java
@@ -204,7 +204,7 @@ public final class EventHandlerManagerTest {
                 new EventChangingHandler(Operation.mul(7)));
 
         final EventCountingHandler<EmptyEvent> emptyEventCountingHandler =
-                new EventCountingHandler<EmptyEvent>();
+                new EventCountingHandler<>();
         eventHandlerManager.setEventHandler(
                 EmptyEvent.EMPTY,
                 emptyEventCountingHandler);
@@ -268,7 +268,7 @@ public final class EventHandlerManagerTest {
                 new EventChangingHandler(Operation.mul(6)));
 
         final EventCountingHandler<EmptyEvent> emptyEventCountingHandler =
-                new EventCountingHandler<EmptyEvent>();
+                new EventCountingHandler<>();
         eventHandlerManager.addEventHandler(
                 EmptyEvent.EMPTY,
                 emptyEventCountingHandler);
@@ -311,7 +311,7 @@ public final class EventHandlerManagerTest {
                 new EventChangingHandler(Operation.mul(6)));
 
         final EventCountingHandler<EmptyEvent> emptyEventCountingHandler =
-                new EventCountingHandler<EmptyEvent>();
+                new EventCountingHandler<>();
         eventHandlerManager.addEventFilter(
                 EmptyEvent.EMPTY,
                 emptyEventCountingHandler);
@@ -448,15 +448,15 @@ public final class EventHandlerManagerTest {
     @Test
     public void shouldCallHandlersForSuperTypes() {
         final EventCountingHandler<Event> rootEventCounter =
-                new EventCountingHandler<Event>();
+                new EventCountingHandler<>();
         final EventCountingHandler<ValueEvent> valueEventCounter =
-                new EventCountingHandler<ValueEvent>();
+                new EventCountingHandler<>();
         final EventCountingHandler<ValueEvent> valueAEventCounter =
-                new EventCountingHandler<ValueEvent>();
+                new EventCountingHandler<>();
         final EventCountingHandler<Event> valueBEventCounter =
-                new EventCountingHandler<Event>();
+                new EventCountingHandler<>();
         final EventCountingHandler<Event> emptyEventCounter =
-                new EventCountingHandler<Event>();
+                new EventCountingHandler<>();
 
         eventHandlerManager.addEventHandler(
                 EventType.ROOT, rootEventCounter);
@@ -485,15 +485,15 @@ public final class EventHandlerManagerTest {
     @Test
     public void shouldCallFiltersForSuperTypes() {
         final EventCountingHandler<Event> rootEventCounter =
-                new EventCountingHandler<Event>();
+                new EventCountingHandler<>();
         final EventCountingHandler<ValueEvent> valueEventCounter =
-                new EventCountingHandler<ValueEvent>();
+                new EventCountingHandler<>();
         final EventCountingHandler<ValueEvent> valueAEventCounter =
-                new EventCountingHandler<ValueEvent>();
+                new EventCountingHandler<>();
         final EventCountingHandler<Event> valueBEventCounter =
-                new EventCountingHandler<Event>();
+                new EventCountingHandler<>();
         final EventCountingHandler<Event> emptyEventCounter =
-                new EventCountingHandler<Event>();
+                new EventCountingHandler<>();
 
         eventHandlerManager.addEventFilter(
                 EventType.ROOT, rootEventCounter);
@@ -529,9 +529,9 @@ public final class EventHandlerManagerTest {
                                       .append(eventCountingDispatcher);
 
         final EventCountingHandler<Event> eventCountingFilter =
-                new EventCountingHandler<Event>();
+                new EventCountingHandler<>();
         final EventCountingHandler<Event> eventCountingHandler =
-                new EventCountingHandler<Event>();
+                new EventCountingHandler<>();
         final EventConsumingHandler eventConsumingHandler =
                 new EventConsumingHandler();
 
@@ -573,11 +573,11 @@ public final class EventHandlerManagerTest {
                                       .append(eventCountingDispatcher);
 
         final EventCountingHandler<Event> eventCountingFilter =
-                new EventCountingHandler<Event>();
+                new EventCountingHandler<>();
         final EventConsumingHandler eventConsumingFilter =
                 new EventConsumingHandler();
         final EventCountingHandler<Event> eventCountingHandler =
-                new EventCountingHandler<Event>();
+                new EventCountingHandler<>();
 
         eventHandlerManager.addEventHandler(Event.ANY, eventCountingHandler);
 

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/event/StubEventDispatchChain.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/event/StubEventDispatchChain.java
@@ -78,6 +78,6 @@ public final class StubEventDispatchChain implements EventDispatchChain {
 
     private static LinkedList<EventDispatcher> copyDispatchers(
             final List<EventDispatcher> dispatchers) {
-        return new LinkedList<EventDispatcher>(dispatchers);
+        return new LinkedList<>(dispatchers);
     }
 }

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/event/ValueEvent.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/event/ValueEvent.java
@@ -30,14 +30,14 @@ import javafx.event.EventType;
 
 public final class ValueEvent extends Event {
     public static final EventType<ValueEvent> ANY =
-            new EventType<ValueEvent>(Event.ANY, "VALUE");
+            new EventType<>(Event.ANY, "VALUE");
 
     public static final EventType<ValueEvent> VALUE_A =
-            new EventType<ValueEvent>(ValueEvent.ANY, "VALUE_A");
+            new EventType<>(ValueEvent.ANY, "VALUE_A");
     public static final EventType<ValueEvent> VALUE_B =
-            new EventType<ValueEvent>(ValueEvent.ANY, "VALUE_B");
+            new EventType<>(ValueEvent.ANY, "VALUE_B");
     public static final EventType<ValueEvent> VALUE_C =
-            new EventType<ValueEvent>(ValueEvent.ANY, "VALUE_C");
+            new EventType<>(ValueEvent.ANY, "VALUE_C");
 
     private int value;
 

--- a/modules/javafx.base/src/test/java/test/javafx/beans/Foo.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/Foo.java
@@ -30,7 +30,7 @@ import com.sun.javafx.property.PropertyReference;
 // NOTE: Foo must be a public interface, otherwise the test in PropertySupportTest
 // that uses Foo will fail.
 public interface Foo  {
-    public static final PropertyReference<String> NAME = new PropertyReference<String>(Foo.class, "name");
+    public static final PropertyReference<String> NAME = new PropertyReference<>(Foo.class, "name");
     public void setName(String name);
     public String getName();
 }

--- a/modules/javafx.base/src/test/java/test/javafx/beans/InvalidationListenerMock.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/InvalidationListenerMock.java
@@ -26,10 +26,7 @@
 package test.javafx.beans;
 
 import javafx.beans.InvalidationListener;
-import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
-import javafx.beans.Observable;
-
 import static org.junit.Assert.assertEquals;
 
 public class InvalidationListenerMock implements InvalidationListener {

--- a/modules/javafx.base/src/test/java/test/javafx/beans/Person.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/Person.java
@@ -83,21 +83,21 @@ public class Person {
     public void setSomething(double value) {something.set(value);}
     public DoubleProperty somethingProperty() {return something;}
 
-    private final ObjectProperty<Object> data = new SimpleObjectProperty<Object>();
+    private final ObjectProperty<Object> data = new SimpleObjectProperty<>();
     public final Object getData() {return data.get();}
     public void setData(Object value) {data.set(value);}
     public ObjectProperty<Object> dataProperty() {return data;}
 
     public final ReadOnlyIntegerWrapper noWrite = new ReadOnlyIntegerWrapper();
-    public static final PropertyReference<Integer> NO_WRITE = new PropertyReference<Integer>(Person.class, "noWrite");
+    public static final PropertyReference<Integer> NO_WRITE = new PropertyReference<>(Person.class, "noWrite");
     public final int getNoWrite() { return noWrite.get(); }
     public ReadOnlyIntegerProperty noWriteProperty() {return noWrite.getReadOnlyProperty();}
 
     public final IntegerProperty noRead = new SimpleIntegerProperty(); // do not expect it back
-    public static final PropertyReference<Integer> NO_READ = new PropertyReference<Integer>(Person.class, "noRead");
+    public static final PropertyReference<Integer> NO_READ = new PropertyReference<>(Person.class, "noRead");
     public void setNoRead(int value) {noRead.set(value);}
 
     int noReadWrite;
-    public static final PropertyReference<Integer> NO_READ_WRITE = new PropertyReference<Integer>(Person.class, "noReadWrite");
+    public static final PropertyReference<Integer> NO_READ_WRITE = new PropertyReference<>(Person.class, "noReadWrite");
 
 }

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/BooleanPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/BooleanPropertyBaseTest.java
@@ -55,7 +55,7 @@ public class BooleanPropertyBaseTest {
     public void setUp() throws Exception {
         property = new BooleanPropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<Boolean>(UNDEFINED);
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     private void attachInvalidationListener() {
@@ -275,7 +275,7 @@ public class BooleanPropertyBaseTest {
     @Test
     public void testLazyBind_generic() {
         attachInvalidationListener();
-        final ObservableObjectValueStub<Boolean> v = new ObservableObjectValueStub<Boolean>(true);
+        final ObservableObjectValueStub<Boolean> v = new ObservableObjectValueStub<>(true);
 
         property.bind(v);
         assertEquals(true, property.get());
@@ -313,7 +313,7 @@ public class BooleanPropertyBaseTest {
     @Test
     public void testEagerBind_generic() {
         attachChangeListener();
-        final ObservableObjectValueStub<Boolean> v = new ObservableObjectValueStub<Boolean>(true);
+        final ObservableObjectValueStub<Boolean> v = new ObservableObjectValueStub<>(true);
 
         property.bind(v);
         assertEquals(true, property.get());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/BooleanPropertyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/BooleanPropertyTest.java
@@ -136,7 +136,7 @@ public class BooleanPropertyTest {
 
     @Test
     public void testObjectToBoolean() {
-        final ObjectProperty<Boolean> valueModel = new SimpleObjectProperty<Boolean>(true);
+        final ObjectProperty<Boolean> valueModel = new SimpleObjectProperty<>(true);
         final BooleanProperty exp = BooleanProperty.booleanProperty(valueModel);
 
         assertEquals(true, exp.get());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/DoublePropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/DoublePropertyBaseTest.java
@@ -56,7 +56,7 @@ public class DoublePropertyBaseTest {
     public void setUp() throws Exception {
         property = new DoublePropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<Number>(UNDEFINED);
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     private void attachInvalidationListener() {
@@ -278,7 +278,7 @@ public class DoublePropertyBaseTest {
         final double value1 = Math.PI;
         final double value2 = Math.E;
         attachInvalidationListener();
-        final ObservableValueStub<Number> v = new ObservableValueStub<Number>(value1);
+        final ObservableValueStub<Number> v = new ObservableValueStub<>(value1);
 
         property.bind(v);
         assertEquals(value1, property.get(), EPSILON);
@@ -318,7 +318,7 @@ public class DoublePropertyBaseTest {
         final double value1 = Math.PI;
         final double value2 = Math.E;
         attachChangeListener();
-        final ObservableValueStub<Number> v = new ObservableValueStub<Number>(value1);
+        final ObservableValueStub<Number> v = new ObservableValueStub<>(value1);
 
         property.bind(v);
         assertEquals(value1, property.get(), EPSILON);
@@ -429,7 +429,7 @@ public class DoublePropertyBaseTest {
         final double value2 = Math.E;
 
         attachInvalidationListener();
-        final ObservableValueStub<Number> v = new ObservableValueStub<Number>(value1);
+        final ObservableValueStub<Number> v = new ObservableValueStub<>(value1);
         property.bind(v);
         property.unbind();
         assertEquals(value1, property.get(), EPSILON);

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/DoublePropertyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/DoublePropertyTest.java
@@ -138,7 +138,7 @@ public class DoublePropertyTest {
 
     @Test
     public void testObjectToDouble() {
-        final ObjectProperty<Double> valueModel = new SimpleObjectProperty<Double>();
+        final ObjectProperty<Double> valueModel = new SimpleObjectProperty<>();
         final DoubleProperty exp = DoubleProperty.doubleProperty(valueModel);
 
         assertEquals(0.0, exp.doubleValue(), EPSILON);

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/FloatPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/FloatPropertyBaseTest.java
@@ -58,7 +58,7 @@ public class FloatPropertyBaseTest {
     public void setUp() throws Exception {
         property = new FloatPropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<Number>(UNDEFINED);
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     private void attachInvalidationListener() {
@@ -282,7 +282,7 @@ public class FloatPropertyBaseTest {
         final float value1 = (float)Math.PI;
         final float value2 = (float)Math.E;
         attachInvalidationListener();
-        final ObservableValueStub<Number> v = new ObservableValueStub<Number>(value1);
+        final ObservableValueStub<Number> v = new ObservableValueStub<>(value1);
 
         property.bind(v);
         assertEquals(value1, property.get(), EPSILON);
@@ -322,7 +322,7 @@ public class FloatPropertyBaseTest {
         final float value1 = (float)Math.PI;
         final float value2 = (float)Math.E;
         attachChangeListener();
-        final ObservableValueStub<Number> v = new ObservableValueStub<Number>(value1);
+        final ObservableValueStub<Number> v = new ObservableValueStub<>(value1);
 
         property.bind(v);
         assertEquals(value1, property.get(), EPSILON);
@@ -433,7 +433,7 @@ public class FloatPropertyBaseTest {
         final float value2 = (float)Math.E;
 
         attachInvalidationListener();
-        final ObservableValueStub<Number> v = new ObservableValueStub<Number>(value1);
+        final ObservableValueStub<Number> v = new ObservableValueStub<>(value1);
         property.bind(v);
         property.unbind();
         assertEquals(value1, property.get(), EPSILON);

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/FloatPropertyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/FloatPropertyTest.java
@@ -138,7 +138,7 @@ public class FloatPropertyTest {
 
     @Test
     public void testObjectToFloat() {
-        final ObjectProperty<Float> valueModel = new SimpleObjectProperty<Float>(2f);
+        final ObjectProperty<Float> valueModel = new SimpleObjectProperty<>(2f);
         final FloatProperty exp = FloatProperty.floatProperty(valueModel);
 
         assertEquals(2f, exp.floatValue(), EPSILON);

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/IntegerPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/IntegerPropertyBaseTest.java
@@ -57,7 +57,7 @@ public class IntegerPropertyBaseTest {
     public void setUp() throws Exception {
         property = new IntegerPropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<Number>(UNDEFINED);
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     private void attachInvalidationListener() {
@@ -279,7 +279,7 @@ public class IntegerPropertyBaseTest {
         final int value1 = 42;
         final int value2 = -7;
         attachInvalidationListener();
-        final ObservableValueStub<Number> v = new ObservableValueStub<Number>(value1);
+        final ObservableValueStub<Number> v = new ObservableValueStub<>(value1);
 
         property.bind(v);
         assertEquals(value1, property.get());
@@ -319,7 +319,7 @@ public class IntegerPropertyBaseTest {
         final int value1 = 42;
         final int value2 = -7;
         attachChangeListener();
-        final ObservableValueStub<Number> v = new ObservableValueStub<Number>(value1);
+        final ObservableValueStub<Number> v = new ObservableValueStub<>(value1);
 
         property.bind(v);
         assertEquals(value1, property.get());
@@ -424,7 +424,7 @@ public class IntegerPropertyBaseTest {
         final int value2 = -42;
 
         attachInvalidationListener();
-        final ObservableValueStub<Number> v = new ObservableValueStub<Number>(value1);
+        final ObservableValueStub<Number> v = new ObservableValueStub<>(value1);
         property.bind(v);
         property.unbind();
         assertEquals(value1, property.get());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/IntegerPropertyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/IntegerPropertyTest.java
@@ -137,7 +137,7 @@ public class IntegerPropertyTest {
 
     @Test
     public void testObjectToInteger() {
-        final ObjectProperty<Integer> valueModel = new SimpleObjectProperty<Integer>(2);
+        final ObjectProperty<Integer> valueModel = new SimpleObjectProperty<>(2);
         final IntegerProperty exp = IntegerProperty.integerProperty(valueModel);
 
         assertEquals(2, exp.intValue());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ListPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ListPropertyBaseTest.java
@@ -65,8 +65,8 @@ public class ListPropertyBaseTest {
     public void setUp() throws Exception {
         property = new ListPropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<ObservableList<Object>>(UNDEFINED);
-        listChangeListener = new MockListObserver<Object>();
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
+        listChangeListener = new MockListObserver<>();
     }
 
     private void attachInvalidationListener() {
@@ -89,12 +89,12 @@ public class ListPropertyBaseTest {
 
     @Test
     public void testConstructor() {
-        final ListProperty<Object> p1 = new SimpleListProperty<Object>();
+        final ListProperty<Object> p1 = new SimpleListProperty<>();
         assertEquals(null, p1.get());
         assertEquals(null, p1.getValue());
         assertFalse(property.isBound());
 
-        final ListProperty<Object> p2 = new SimpleListProperty<Object>(VALUE_1b);
+        final ListProperty<Object> p2 = new SimpleListProperty<>(VALUE_1b);
         assertEquals(VALUE_1b, p2.get());
         assertEquals(VALUE_1b, p2.getValue());
         assertFalse(property.isBound());
@@ -478,7 +478,7 @@ public class ListPropertyBaseTest {
 
     @Test(expected = RuntimeException.class)
     public void testSetBoundValue() {
-        final ListProperty<Object> v = new SimpleListProperty<Object>(VALUE_1a);
+        final ListProperty<Object> v = new SimpleListProperty<>(VALUE_1a);
         property.bind(v);
         property.set(VALUE_1a);
     }
@@ -486,7 +486,7 @@ public class ListPropertyBaseTest {
     @Test
     public void testBind_Invalidation() {
         attachInvalidationListener();
-        final ObservableObjectValueStub<ObservableList<Object>> v = new ObservableObjectValueStub<ObservableList<Object>>(FXCollections.observableArrayList(VALUE_1a));
+        final ObservableObjectValueStub<ObservableList<Object>> v = new ObservableObjectValueStub<>(FXCollections.observableArrayList(VALUE_1a));
 
         property.bind(v);
         assertEquals(VALUE_1a, property.get());
@@ -518,7 +518,7 @@ public class ListPropertyBaseTest {
     @Test
     public void testBind_Change() {
         attachChangeListener();
-        final ObservableObjectValueStub<ObservableList<Object>> v = new ObservableObjectValueStub<ObservableList<Object>>(FXCollections.observableArrayList(VALUE_1a));
+        final ObservableObjectValueStub<ObservableList<Object>> v = new ObservableObjectValueStub<>(FXCollections.observableArrayList(VALUE_1a));
 
         property.bind(v);
         assertEquals(VALUE_1a, property.get());
@@ -550,7 +550,7 @@ public class ListPropertyBaseTest {
     @Test
     public void testBind_ListChange() {
         attachListChangeListener();
-        final ObservableObjectValueStub<ObservableList<Object>> v = new ObservableObjectValueStub<ObservableList<Object>>(FXCollections.observableArrayList(VALUE_1a));
+        final ObservableObjectValueStub<ObservableList<Object>> v = new ObservableObjectValueStub<>(FXCollections.observableArrayList(VALUE_1a));
 
         property.bind(v);
         assertEquals(VALUE_1a, property.get());
@@ -590,8 +590,8 @@ public class ListPropertyBaseTest {
     @Test
     public void testRebind() {
         attachInvalidationListener();
-        final ListProperty<Object> v1 = new SimpleListProperty<Object>(VALUE_1a);
-        final ListProperty<Object> v2 = new SimpleListProperty<Object>(VALUE_2a);
+        final ListProperty<Object> v1 = new SimpleListProperty<>(VALUE_1a);
+        final ListProperty<Object> v2 = new SimpleListProperty<>(VALUE_2a);
         property.bind(v1);
         property.get();
         property.reset();
@@ -667,7 +667,7 @@ public class ListPropertyBaseTest {
     @Test
     public void testUnbind() {
         attachInvalidationListener();
-        final ListProperty<Object> v = new SimpleListProperty<Object>(VALUE_1a);
+        final ListProperty<Object> v = new SimpleListProperty<>(VALUE_1a);
         property.bind(v);
         property.unbind();
         assertEquals(VALUE_1a, property.get());
@@ -691,7 +691,7 @@ public class ListPropertyBaseTest {
 
     @Test
     public void testAddingListenerWillAlwaysReceiveInvalidationEvent() {
-        final ListProperty<Object> v = new SimpleListProperty<Object>(VALUE_1a);
+        final ListProperty<Object> v = new SimpleListProperty<>(VALUE_1a);
         final InvalidationListenerMock listener2 = new InvalidationListenerMock();
         final InvalidationListenerMock listener3 = new InvalidationListenerMock();
 
@@ -769,7 +769,7 @@ public class ListPropertyBaseTest {
         final ObservableList<Object> value0 = null;
         final ObservableList<Object> value1 = FXCollections.observableArrayList(new Object(), new Object());
         final ObservableList<Object> value2 = FXCollections.observableArrayList();
-        final ListProperty<Object> v = new SimpleListProperty<Object>(value2);
+        final ListProperty<Object> v = new SimpleListProperty<>(value2);
 
         property.set(value1);
         assertEquals("ListProperty [value: " + value1 + "]", property.toString());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ListPropertyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ListPropertyTest.java
@@ -52,8 +52,8 @@ public class ListPropertyTest {
 
     @Test
     public void testBindBidirectional() {
-        final ListProperty<Object> p1 = new SimpleListProperty<Object>(VALUE_2);
-        final ListProperty<Object> p2 = new SimpleListProperty<Object>(VALUE_1);
+        final ListProperty<Object> p1 = new SimpleListProperty<>(VALUE_2);
+        final ListProperty<Object> p2 = new SimpleListProperty<>(VALUE_1);
 
         p1.bindBidirectional(p2);
         assertEquals(VALUE_1, p1.get());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/LongPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/LongPropertyBaseTest.java
@@ -57,7 +57,7 @@ public class LongPropertyBaseTest {
     public void setUp() throws Exception {
         property = new LongPropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<Number>(UNDEFINED);
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     private void attachInvalidationListener() {
@@ -279,7 +279,7 @@ public class LongPropertyBaseTest {
         final long value1 = 9876543212345L;
         final long value2 = -123456789098765L;
         attachInvalidationListener();
-        final ObservableValueStub<Number> v = new ObservableValueStub<Number>(value1);
+        final ObservableValueStub<Number> v = new ObservableValueStub<>(value1);
 
         property.bind(v);
         assertEquals(value1, property.get());
@@ -319,7 +319,7 @@ public class LongPropertyBaseTest {
         final long value1 = 9876543212345L;
         final long value2 = -123456789098765L;
         attachChangeListener();
-        final ObservableValueStub<Number> v = new ObservableValueStub<Number>(value1);
+        final ObservableValueStub<Number> v = new ObservableValueStub<>(value1);
 
         property.bind(v);
         assertEquals(value1, property.get());
@@ -424,7 +424,7 @@ public class LongPropertyBaseTest {
         final long value2 = -123456789098765L;
 
         attachInvalidationListener();
-        final ObservableValueStub<Number> v = new ObservableValueStub<Number>(value1);
+        final ObservableValueStub<Number> v = new ObservableValueStub<>(value1);
         property.bind(v);
         property.unbind();
         assertEquals(value1, property.get());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/LongPropertyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/LongPropertyTest.java
@@ -136,7 +136,7 @@ public class LongPropertyTest {
 
     @Test
     public void testObjectToLong() {
-        final ObjectProperty<Long> valueModel = new SimpleObjectProperty<Long>(2L);
+        final ObjectProperty<Long> valueModel = new SimpleObjectProperty<>(2L);
         final LongProperty exp = LongProperty.longProperty(valueModel);
 
         assertEquals(2L, exp.longValue());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/MapPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/MapPropertyBaseTest.java
@@ -63,13 +63,13 @@ public class MapPropertyBaseTest {
     private static final ObservableMap<Object, Object> UNDEFINED = FXCollections.observableMap(Collections.emptyMap());
     private static final ObservableMap<Object, Object> VALUE_1a = FXCollections.observableMap(Collections.emptyMap());
     private static final ObservableMap<Object, Object> VALUE_1b = FXCollections.observableMap(Collections.singletonMap(KEY_1b, DATA_1b));
-    private static final ObservableMap<Object, Object> VALUE_2a = FXCollections.observableMap(new HashMap<Object, Object>());
+    private static final ObservableMap<Object, Object> VALUE_2a = FXCollections.observableMap(new HashMap<>());
 
     static {
         VALUE_2a.put(KEY_2a_0, DATA_2a_0);
         VALUE_2a.put(KEY_2a_1, DATA_2a_1);
     }
-    private static final ObservableMap<Object, Object> VALUE_2b = FXCollections.observableMap(new HashMap<Object, Object>());
+    private static final ObservableMap<Object, Object> VALUE_2b = FXCollections.observableMap(new HashMap<>());
 
     static {
         VALUE_2b.put(KEY_2b_0, DATA_2b_0);
@@ -85,8 +85,8 @@ public class MapPropertyBaseTest {
     public void setUp() throws Exception {
         property = new MapPropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<ObservableMap<Object, Object>>(UNDEFINED);
-        mapChangeListener = new MockMapObserver<Object, Object>();
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
+        mapChangeListener = new MockMapObserver<>();
     }
 
     private void attachInvalidationListener() {
@@ -109,12 +109,12 @@ public class MapPropertyBaseTest {
 
     @Test
     public void testConstructor() {
-        final MapProperty<Object, Object> p1 = new SimpleMapProperty<Object, Object>();
+        final MapProperty<Object, Object> p1 = new SimpleMapProperty<>();
         assertEquals(null, p1.get());
         assertEquals(null, p1.getValue());
         assertFalse(property.isBound());
 
-        final MapProperty<Object, Object> p2 = new SimpleMapProperty<Object, Object>(VALUE_1b);
+        final MapProperty<Object, Object> p2 = new SimpleMapProperty<>(VALUE_1b);
         assertEquals(VALUE_1b, p2.get());
         assertEquals(VALUE_1b, p2.getValue());
         assertFalse(property.isBound());
@@ -179,8 +179,8 @@ public class MapPropertyBaseTest {
 
     @Test
     public void testSourceMap_Invalidation() {
-        final ObservableMap<Object, Object> source1 = FXCollections.observableMap(new HashMap<Object, Object>());
-        final ObservableMap<Object, Object> source2 = FXCollections.observableMap(new HashMap<Object, Object>());
+        final ObservableMap<Object, Object> source1 = FXCollections.observableMap(new HashMap<>());
+        final ObservableMap<Object, Object> source2 = FXCollections.observableMap(new HashMap<>());
         final Object key = new Object();
         final Object value1 = new Object();
         final Object value2 = new Object();
@@ -235,8 +235,8 @@ public class MapPropertyBaseTest {
 
     @Test
     public void testSourceMap_Change() {
-        final ObservableMap<Object, Object> source1 = FXCollections.observableMap(new HashMap<Object, Object>());
-        final ObservableMap<Object, Object> source2 = FXCollections.observableMap(new HashMap<Object, Object>());
+        final ObservableMap<Object, Object> source1 = FXCollections.observableMap(new HashMap<>());
+        final ObservableMap<Object, Object> source2 = FXCollections.observableMap(new HashMap<>());
         final Object key = new Object();
         final Object value1 = new Object();
         final Object value2 = new Object();
@@ -291,8 +291,8 @@ public class MapPropertyBaseTest {
 
     @Test
     public void testSourceMap_MapChange() {
-        final ObservableMap<Object, Object> source1 = FXCollections.observableMap(new HashMap<Object, Object>());
-        final ObservableMap<Object, Object> source2 = FXCollections.observableMap(new HashMap<Object, Object>());
+        final ObservableMap<Object, Object> source1 = FXCollections.observableMap(new HashMap<>());
+        final ObservableMap<Object, Object> source2 = FXCollections.observableMap(new HashMap<>());
         final Object key = new Object();
         final Object value1 = new Object();
         final Object value2 = new Object();
@@ -313,7 +313,7 @@ public class MapPropertyBaseTest {
         source1.put(key, value2);
         assertEquals(value2, property.get(key));
         property.check(1);
-        mapChangeListener.assertMultipleCalls(new Call<Object, Object>(key, value1, value2));
+        mapChangeListener.assertMultipleCalls(new Call<>(key, value1, value2));
         mapChangeListener.clear();
 
         // remove element
@@ -340,7 +340,7 @@ public class MapPropertyBaseTest {
         source2.put(key, value2);
         assertEquals(value2, property.get(key));
         property.check(1);
-        mapChangeListener.assertMultipleCalls(new Call<Object, Object>(key, value1, value2));
+        mapChangeListener.assertMultipleCalls(new Call<>(key, value1, value2));
         mapChangeListener.clear();
 
         // remove element
@@ -501,7 +501,7 @@ public class MapPropertyBaseTest {
 
     @Test(expected = RuntimeException.class)
     public void testMapBoundValue() {
-        final MapProperty<Object, Object> v = new SimpleMapProperty<Object, Object>(VALUE_1a);
+        final MapProperty<Object, Object> v = new SimpleMapProperty<>(VALUE_1a);
         property.bind(v);
         property.set(VALUE_1a);
     }
@@ -509,7 +509,7 @@ public class MapPropertyBaseTest {
     @Test
     public void testBind_Invalidation() {
         attachInvalidationListener();
-        final ObservableObjectValueStub<ObservableMap<Object, Object>> v = new ObservableObjectValueStub<ObservableMap<Object, Object>>(FXCollections.observableMap(VALUE_1a));
+        final ObservableObjectValueStub<ObservableMap<Object, Object>> v = new ObservableObjectValueStub<>(FXCollections.observableMap(VALUE_1a));
 
         property.bind(v);
         assertEquals(VALUE_1a, property.get());
@@ -541,7 +541,7 @@ public class MapPropertyBaseTest {
     @Test
     public void testBind_Change() {
         attachChangeListener();
-        final ObservableObjectValueStub<ObservableMap<Object, Object>> v = new ObservableObjectValueStub<ObservableMap<Object, Object>>(FXCollections.observableMap(VALUE_1a));
+        final ObservableObjectValueStub<ObservableMap<Object, Object>> v = new ObservableObjectValueStub<>(FXCollections.observableMap(VALUE_1a));
 
         property.bind(v);
         assertEquals(VALUE_1a, property.get());
@@ -573,7 +573,7 @@ public class MapPropertyBaseTest {
     @Test
     public void testBind_MapChange() {
         attachMapChangeListener();
-        final ObservableObjectValueStub<ObservableMap<Object, Object>> v = new ObservableObjectValueStub<ObservableMap<Object, Object>>(FXCollections.observableMap(VALUE_1a));
+        final ObservableObjectValueStub<ObservableMap<Object, Object>> v = new ObservableObjectValueStub<>(FXCollections.observableMap(VALUE_1a));
 
         property.bind(v);
         assertEquals(VALUE_1a, property.get());
@@ -613,8 +613,8 @@ public class MapPropertyBaseTest {
     @Test
     public void testRebind() {
         attachInvalidationListener();
-        final MapProperty<Object, Object> v1 = new SimpleMapProperty<Object, Object>(VALUE_1a);
-        final MapProperty<Object, Object> v2 = new SimpleMapProperty<Object, Object>(VALUE_2a);
+        final MapProperty<Object, Object> v1 = new SimpleMapProperty<>(VALUE_1a);
+        final MapProperty<Object, Object> v2 = new SimpleMapProperty<>(VALUE_2a);
         property.bind(v1);
         property.get();
         property.reset();
@@ -688,7 +688,7 @@ public class MapPropertyBaseTest {
     @Test
     public void testUnbind() {
         attachInvalidationListener();
-        final MapProperty<Object, Object> v = new SimpleMapProperty<Object, Object>(VALUE_1a);
+        final MapProperty<Object, Object> v = new SimpleMapProperty<>(VALUE_1a);
         property.bind(v);
         property.unbind();
         assertEquals(VALUE_1a, property.get());
@@ -712,7 +712,7 @@ public class MapPropertyBaseTest {
 
     @Test
     public void testAddingListenerWillAlwaysReceiveInvalidationEvent() {
-        final MapProperty<Object, Object> v = new SimpleMapProperty<Object, Object>(VALUE_1a);
+        final MapProperty<Object, Object> v = new SimpleMapProperty<>(VALUE_1a);
         final InvalidationListenerMock listener2 = new InvalidationListenerMock();
         final InvalidationListenerMock listener3 = new InvalidationListenerMock();
 
@@ -736,11 +736,11 @@ public class MapPropertyBaseTest {
     @Test
     public void testToString() {
         final ObservableMap<Object, Object> value0 = null;
-        final ObservableMap<Object, Object> value1 = FXCollections.observableMap(new HashMap<Object, Object>());
+        final ObservableMap<Object, Object> value1 = FXCollections.observableMap(new HashMap<>());
         value1.put(new Object(), new Object());
         value1.put(new Object(), new Object());
-        final ObservableMap<Object, Object> value2 = FXCollections.observableMap(new HashMap<Object, Object>());
-        final MapProperty<Object, Object> v = new SimpleMapProperty<Object, Object>(value2);
+        final ObservableMap<Object, Object> value2 = FXCollections.observableMap(new HashMap<>());
+        final MapProperty<Object, Object> v = new SimpleMapProperty<>(value2);
 
         property.set(value1);
         assertEquals("MapProperty [value: " + value1 + "]", property.toString());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/MapPropertyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/MapPropertyTest.java
@@ -35,7 +35,6 @@ import javafx.collections.MapChangeListener;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.HashMap;
 import javafx.beans.property.MapProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyIntegerProperty;
@@ -55,8 +54,8 @@ public class MapPropertyTest {
 
     @Test
     public void testBindBidirectional() {
-        final MapProperty<Object, Object> p1 = new SimpleMapProperty<Object, Object>(VALUE_2);
-        final MapProperty<Object, Object> p2 = new SimpleMapProperty<Object, Object>(VALUE_1);
+        final MapProperty<Object, Object> p1 = new SimpleMapProperty<>(VALUE_2);
+        final MapProperty<Object, Object> p2 = new SimpleMapProperty<>(VALUE_1);
 
         p1.bindBidirectional(p2);
         assertEquals(VALUE_1, p1.get());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ObjectPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ObjectPropertyBaseTest.java
@@ -58,7 +58,7 @@ public class ObjectPropertyBaseTest {
     public void setUp() throws Exception {
         property = new ObjectPropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<Object>(UNDEFINED);
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     private void attachInvalidationListener() {
@@ -75,12 +75,12 @@ public class ObjectPropertyBaseTest {
 
     @Test
     public void testConstructor() {
-        final ObjectProperty<Object> p1 = new SimpleObjectProperty<Object>();
+        final ObjectProperty<Object> p1 = new SimpleObjectProperty<>();
         assertEquals(null, p1.get());
         assertEquals(null, p1.getValue());
         assertFalse(property.isBound());
 
-        final ObjectProperty<Object> p2 = new SimpleObjectProperty<Object>(VALUE_1b);
+        final ObjectProperty<Object> p2 = new SimpleObjectProperty<>(VALUE_1b);
         assertEquals(VALUE_1b, p2.get());
         assertEquals(VALUE_1b, p2.getValue());
         assertFalse(property.isBound());
@@ -206,7 +206,7 @@ public class ObjectPropertyBaseTest {
 
     @Test(expected=RuntimeException.class)
     public void testSetBoundValue() {
-        final ObjectProperty<Object> v = new SimpleObjectProperty<Object>(VALUE_1a);
+        final ObjectProperty<Object> v = new SimpleObjectProperty<>(VALUE_1a);
         property.bind(v);
         property.set(VALUE_1a);
     }
@@ -214,7 +214,7 @@ public class ObjectPropertyBaseTest {
     @Test
     public void testLazyBind() {
         attachInvalidationListener();
-        final ObservableObjectValueStub<Object> v = new ObservableObjectValueStub<Object>(VALUE_1a);
+        final ObservableObjectValueStub<Object> v = new ObservableObjectValueStub<>(VALUE_1a);
 
         property.bind(v);
         assertEquals(VALUE_1a, property.get());
@@ -246,7 +246,7 @@ public class ObjectPropertyBaseTest {
     @Test
     public void testEagerBind() {
         attachChangeListener();
-        final ObservableObjectValueStub<Object> v = new ObservableObjectValueStub<Object>(VALUE_1a);
+        final ObservableObjectValueStub<Object> v = new ObservableObjectValueStub<>(VALUE_1a);
 
         property.bind(v);
         assertEquals(VALUE_1a, property.get());
@@ -283,8 +283,8 @@ public class ObjectPropertyBaseTest {
     @Test
     public void testRebind() {
         attachInvalidationListener();
-        final ObjectProperty<Object> v1 = new SimpleObjectProperty<Object>(VALUE_1a);
-        final ObjectProperty<Object> v2 = new SimpleObjectProperty<Object>(VALUE_2a);
+        final ObjectProperty<Object> v1 = new SimpleObjectProperty<>(VALUE_1a);
+        final ObjectProperty<Object> v2 = new SimpleObjectProperty<>(VALUE_2a);
         property.bind(v1);
         property.get();
         property.reset();
@@ -323,7 +323,7 @@ public class ObjectPropertyBaseTest {
     @Test
     public void testUnbind() {
         attachInvalidationListener();
-        final ObjectProperty<Object> v = new SimpleObjectProperty<Object>(VALUE_1a);
+        final ObjectProperty<Object> v = new SimpleObjectProperty<>(VALUE_1a);
         property.bind(v);
         property.unbind();
         assertEquals(VALUE_1a, property.get());
@@ -347,7 +347,7 @@ public class ObjectPropertyBaseTest {
 
     @Test
     public void testAddingListenerWillAlwaysReceiveInvalidationEvent() {
-        final ObjectProperty<Object> v = new SimpleObjectProperty<Object>(VALUE_1a);
+        final ObjectProperty<Object> v = new SimpleObjectProperty<>(VALUE_1a);
         final InvalidationListenerMock listener2 = new InvalidationListenerMock();
         final InvalidationListenerMock listener3 = new InvalidationListenerMock();
 
@@ -372,7 +372,7 @@ public class ObjectPropertyBaseTest {
     public void testToString() {
         final Object value1 = new Object();
         final Object value2 = new Object();
-        final ObjectProperty<Object> v = new SimpleObjectProperty<Object>(value2);
+        final ObjectProperty<Object> v = new SimpleObjectProperty<>(value2);
 
         property.set(value1);
         assertEquals("ObjectProperty [value: " + value1 + "]", property.toString());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ObjectPropertyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ObjectPropertyTest.java
@@ -47,8 +47,8 @@ public class ObjectPropertyTest {
 
     @Test
     public void testBindBidirectional() {
-        final ObjectProperty<Object> p1 = new SimpleObjectProperty<Object>(VALUE_2);
-        final ObjectProperty<Object> p2 = new SimpleObjectProperty<Object>(VALUE_1);
+        final ObjectProperty<Object> p1 = new SimpleObjectProperty<>(VALUE_2);
+        final ObjectProperty<Object> p2 = new SimpleObjectProperty<>(VALUE_1);
 
         p1.bindBidirectional(p2);
         assertEquals(VALUE_1, p1.get());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/PropertyReferenceTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/PropertyReferenceTest.java
@@ -44,7 +44,7 @@ public class PropertyReferenceTest {
 
     @Test
     public void testInteger() {
-        final PropertyReference<Integer> property = new PropertyReference<Integer>(Person.class, "age");
+        final PropertyReference<Integer> property = new PropertyReference<>(Person.class, "age");
         assertTrue(property.isReadable());
         assertTrue(property.isWritable());
         assertTrue((int.class.equals(property.getType())) || (Integer.class.equals(property.getType())));
@@ -60,7 +60,7 @@ public class PropertyReferenceTest {
 
     @Test
     public void testNoRead() {
-        final PropertyReference<Integer> property = new PropertyReference<Integer>(Person.class, "noRead");
+        final PropertyReference<Integer> property = new PropertyReference<>(Person.class, "noRead");
         assertFalse(property.isReadable());
         assertTrue(property.isWritable());
         assertTrue((int.class.equals(property.getType())) || (Integer.class.equals(property.getType())));
@@ -82,7 +82,7 @@ public class PropertyReferenceTest {
 
     @Test
     public void testNoWrite() {
-        final PropertyReference<Integer> property = new PropertyReference<Integer>(Person.class, "noWrite");
+        final PropertyReference<Integer> property = new PropertyReference<>(Person.class, "noWrite");
         assertTrue(property.isReadable());
         assertFalse(property.isWritable());
         assertTrue((int.class.equals(property.getType())) || (Integer.class.equals(property.getType())));
@@ -103,7 +103,7 @@ public class PropertyReferenceTest {
 
     @Test
     public void testNoReadWrite() {
-        final PropertyReference<Integer> property = new PropertyReference<Integer>(Person.class, "noReadWrite");
+        final PropertyReference<Integer> property = new PropertyReference<>(Person.class, "noReadWrite");
         assertFalse(property.isReadable());
         assertFalse(property.isWritable());
     }

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/PropertyReferenceWithInterfacesTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/PropertyReferenceWithInterfacesTest.java
@@ -32,8 +32,6 @@ import org.junit.Test;
 
 import com.sun.javafx.property.PropertyReference;
 import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
-
 import static org.junit.Assert.*;
 
 /**
@@ -53,7 +51,7 @@ public class PropertyReferenceWithInterfacesTest {
     }
 
     public interface Named {
-        public static final PropertyReference<String> NAME = new PropertyReference<String>(Named.class, "name");
+        public static final PropertyReference<String> NAME = new PropertyReference<>(Named.class, "name");
         public String getName();
     }
 

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyBooleanPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyBooleanPropertyBaseTest.java
@@ -47,7 +47,7 @@ public class ReadOnlyBooleanPropertyBaseTest {
     public void setUp() throws Exception {
         property = new ReadOnlyPropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<Boolean>(UNDEFINED);
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     @Test

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyBooleanPropertyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyBooleanPropertyTest.java
@@ -26,21 +26,12 @@
 package test.javafx.beans.property;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import javafx.beans.InvalidationListener;
-import javafx.beans.binding.BooleanBinding;
-import javafx.beans.binding.BooleanExpression;
-import javafx.beans.binding.ObjectExpression;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyBooleanWrapper;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
-import javafx.beans.value.ObservableValueStub;
-import javafx.collections.FXCollections;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -90,7 +81,7 @@ public class ReadOnlyBooleanPropertyTest {
 
     @Test
     public void testObjectToBoolean() {
-        final ReadOnlyObjectWrapper<Boolean> valueModel = new ReadOnlyObjectWrapper<Boolean>();
+        final ReadOnlyObjectWrapper<Boolean> valueModel = new ReadOnlyObjectWrapper<>();
         final ReadOnlyBooleanProperty exp = ReadOnlyBooleanProperty.readOnlyBooleanProperty(valueModel.getReadOnlyProperty());
 
 

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyBooleanWrapperTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyBooleanWrapperTest.java
@@ -62,8 +62,8 @@ public class ReadOnlyBooleanWrapperTest {
         readOnlyProperty = property.getReadOnlyProperty();
         internalInvalidationListener = new InvalidationListenerMock();
         publicInvalidationListener = new InvalidationListenerMock();
-        internalChangeListener = new ChangeListenerMock<Boolean>(UNDEFINED);
-        publicChangeListener = new ChangeListenerMock<Boolean>(UNDEFINED);
+        internalChangeListener = new ChangeListenerMock<>(UNDEFINED);
+        publicChangeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     private void attachInvalidationListeners() {
@@ -91,13 +91,13 @@ public class ReadOnlyBooleanWrapperTest {
     public void testConstructor_NoArguments() {
         final ReadOnlyBooleanWrapper p1 = new ReadOnlyBooleanWrapper();
         assertEquals(DEFAULT, p1.get());
-        assertEquals((Boolean)DEFAULT, p1.getValue());
+        assertEquals(DEFAULT, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(null, p1.getBean());
         assertEquals("", p1.getName());
         final ReadOnlyBooleanProperty r1 = p1.getReadOnlyProperty();
         assertEquals(DEFAULT, r1.get());
-        assertEquals((Boolean)DEFAULT, r1.getValue());
+        assertEquals(DEFAULT, r1.getValue());
         assertEquals(null, r1.getBean());
         assertEquals("", r1.getName());
     }
@@ -106,13 +106,13 @@ public class ReadOnlyBooleanWrapperTest {
     public void testConstructor_InitialValue() {
         final ReadOnlyBooleanWrapper p1 = new ReadOnlyBooleanWrapper(VALUE_1);
         assertEquals(VALUE_1, p1.get());
-        assertEquals((Boolean)VALUE_1, p1.getValue());
+        assertEquals(VALUE_1, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(null, p1.getBean());
         assertEquals("", p1.getName());
         final ReadOnlyBooleanProperty r1 = p1.getReadOnlyProperty();
         assertEquals(VALUE_1, r1.get());
-        assertEquals((Boolean)VALUE_1, r1.getValue());
+        assertEquals(VALUE_1, r1.getValue());
         assertEquals(null, r1.getBean());
         assertEquals("", r1.getName());
     }
@@ -123,13 +123,13 @@ public class ReadOnlyBooleanWrapperTest {
         final String name = "My name";
         final ReadOnlyBooleanWrapper p1 = new ReadOnlyBooleanWrapper(bean, name);
         assertEquals(DEFAULT, p1.get());
-        assertEquals((Boolean)DEFAULT, p1.getValue());
+        assertEquals(DEFAULT, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(bean, p1.getBean());
         assertEquals(name, p1.getName());
         final ReadOnlyBooleanProperty r1 = p1.getReadOnlyProperty();
         assertEquals(DEFAULT, r1.get());
-        assertEquals((Boolean)DEFAULT, r1.getValue());
+        assertEquals(DEFAULT, r1.getValue());
         assertEquals(bean, r1.getBean());
         assertEquals(name, r1.getName());
     }
@@ -140,13 +140,13 @@ public class ReadOnlyBooleanWrapperTest {
         final String name = "My name";
         final ReadOnlyBooleanWrapper p1 = new ReadOnlyBooleanWrapper(bean, name, VALUE_1);
         assertEquals(VALUE_1, p1.get());
-        assertEquals((Boolean)VALUE_1, p1.getValue());
+        assertEquals(VALUE_1, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(bean, p1.getBean());
         assertEquals(name, p1.getName());
         final ReadOnlyBooleanProperty r1 = p1.getReadOnlyProperty();
         assertEquals(VALUE_1, r1.get());
-        assertEquals((Boolean)VALUE_1, r1.getValue());
+        assertEquals(VALUE_1, r1.getValue());
         assertEquals(bean, r1.getBean());
         assertEquals(name, r1.getName());
     }
@@ -441,7 +441,7 @@ public class ReadOnlyBooleanWrapperTest {
     @Test
     public void testLazyBind_generic() {
         attachInvalidationListeners();
-        final ObservableObjectValueStub<Boolean> v = new ObservableObjectValueStub<Boolean>(VALUE_1);
+        final ObservableObjectValueStub<Boolean> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -481,7 +481,7 @@ public class ReadOnlyBooleanWrapperTest {
     @Test
     public void testInternalEagerBind_generic() {
         attachInternalChangeListener();
-        final ObservableObjectValueStub<Boolean> v = new ObservableObjectValueStub<Boolean>(VALUE_1);
+        final ObservableObjectValueStub<Boolean> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -517,7 +517,7 @@ public class ReadOnlyBooleanWrapperTest {
     @Test
     public void testPublicEagerBind_generic() {
         attachPublicChangeListener();
-        final ObservableObjectValueStub<Boolean> v = new ObservableObjectValueStub<Boolean>(VALUE_1);
+        final ObservableObjectValueStub<Boolean> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyDoublePropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyDoublePropertyBaseTest.java
@@ -47,7 +47,7 @@ public class ReadOnlyDoublePropertyBaseTest {
     public void setUp() throws Exception {
         property = new ReadOnlyPropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<Number>(UNDEFINED);
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     @Test

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyDoublePropertyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyDoublePropertyTest.java
@@ -26,17 +26,12 @@
 package test.javafx.beans.property;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import javafx.beans.InvalidationListener;
-import javafx.beans.binding.ObjectExpression;
 import javafx.beans.property.ReadOnlyDoubleProperty;
 import javafx.beans.property.ReadOnlyDoubleWrapper;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.value.ChangeListener;
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -87,7 +82,7 @@ public class ReadOnlyDoublePropertyTest {
 
     @Test
     public void testObjectToDouble() {
-        final ReadOnlyObjectWrapper<Double> valueModel = new ReadOnlyObjectWrapper<Double>();
+        final ReadOnlyObjectWrapper<Double> valueModel = new ReadOnlyObjectWrapper<>();
         final ReadOnlyDoubleProperty exp = ReadOnlyDoubleProperty.readOnlyDoubleProperty(valueModel.getReadOnlyProperty());
 
 

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyDoubleWrapperTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyDoubleWrapperTest.java
@@ -63,8 +63,8 @@ public class ReadOnlyDoubleWrapperTest {
         readOnlyProperty = property.getReadOnlyProperty();
         internalInvalidationListener = new InvalidationListenerMock();
         publicInvalidationListener = new InvalidationListenerMock();
-        internalChangeListener = new ChangeListenerMock<Number>(UNDEFINED);
-        publicChangeListener = new ChangeListenerMock<Number>(UNDEFINED);
+        internalChangeListener = new ChangeListenerMock<>(UNDEFINED);
+        publicChangeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     private void attachInvalidationListeners() {
@@ -92,13 +92,13 @@ public class ReadOnlyDoubleWrapperTest {
     public void testConstructor_NoArguments() {
         final ReadOnlyDoubleWrapper p1 = new ReadOnlyDoubleWrapper();
         assertEquals(DEFAULT, p1.get(), EPSILON);
-        assertEquals((Double)DEFAULT, p1.getValue(), EPSILON);
+        assertEquals(DEFAULT, p1.getValue(), EPSILON);
         assertFalse(property.isBound());
         assertEquals(null, p1.getBean());
         assertEquals("", p1.getName());
         final ReadOnlyDoubleProperty r1 = p1.getReadOnlyProperty();
         assertEquals(DEFAULT, r1.get(), EPSILON);
-        assertEquals((Double)DEFAULT, r1.getValue(), EPSILON);
+        assertEquals(DEFAULT, r1.getValue(), EPSILON);
         assertEquals(null, r1.getBean());
         assertEquals("", r1.getName());
     }
@@ -107,13 +107,13 @@ public class ReadOnlyDoubleWrapperTest {
     public void testConstructor_InitialValue() {
         final ReadOnlyDoubleWrapper p1 = new ReadOnlyDoubleWrapper(VALUE_1);
         assertEquals(VALUE_1, p1.get(), EPSILON);
-        assertEquals((Double)VALUE_1, p1.getValue(), EPSILON);
+        assertEquals(VALUE_1, p1.getValue(), EPSILON);
         assertFalse(property.isBound());
         assertEquals(null, p1.getBean());
         assertEquals("", p1.getName());
         final ReadOnlyDoubleProperty r1 = p1.getReadOnlyProperty();
         assertEquals(VALUE_1, r1.get(), EPSILON);
-        assertEquals((Double)VALUE_1, r1.getValue(), EPSILON);
+        assertEquals(VALUE_1, r1.getValue(), EPSILON);
         assertEquals(null, r1.getBean());
         assertEquals("", r1.getName());
     }
@@ -124,13 +124,13 @@ public class ReadOnlyDoubleWrapperTest {
         final String name = "My name";
         final ReadOnlyDoubleWrapper p1 = new ReadOnlyDoubleWrapper(bean, name);
         assertEquals(DEFAULT, p1.get(), EPSILON);
-        assertEquals((Double)DEFAULT, p1.getValue(), EPSILON);
+        assertEquals(DEFAULT, p1.getValue(), EPSILON);
         assertFalse(property.isBound());
         assertEquals(bean, p1.getBean());
         assertEquals(name, p1.getName());
         final ReadOnlyDoubleProperty r1 = p1.getReadOnlyProperty();
         assertEquals(DEFAULT, r1.get(), EPSILON);
-        assertEquals((Double)DEFAULT, r1.getValue(), EPSILON);
+        assertEquals(DEFAULT, r1.getValue(), EPSILON);
         assertEquals(bean, r1.getBean());
         assertEquals(name, r1.getName());
     }
@@ -141,13 +141,13 @@ public class ReadOnlyDoubleWrapperTest {
         final String name = "My name";
         final ReadOnlyDoubleWrapper p1 = new ReadOnlyDoubleWrapper(bean, name, VALUE_1);
         assertEquals(VALUE_1, p1.get(), EPSILON);
-        assertEquals((Double)VALUE_1, p1.getValue(), EPSILON);
+        assertEquals(VALUE_1, p1.getValue(), EPSILON);
         assertFalse(property.isBound());
         assertEquals(bean, p1.getBean());
         assertEquals(name, p1.getName());
         final ReadOnlyDoubleProperty r1 = p1.getReadOnlyProperty();
         assertEquals(VALUE_1, r1.get(), EPSILON);
-        assertEquals((Double)VALUE_1, r1.getValue(), EPSILON);
+        assertEquals(VALUE_1, r1.getValue(), EPSILON);
         assertEquals(bean, r1.getBean());
         assertEquals(name, r1.getName());
     }
@@ -442,7 +442,7 @@ public class ReadOnlyDoubleWrapperTest {
     @Test
     public void testLazyBind_generic() {
         attachInvalidationListeners();
-        final ObservableObjectValueStub<Double> v = new ObservableObjectValueStub<Double>(VALUE_1);
+        final ObservableObjectValueStub<Double> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get(), EPSILON);
@@ -482,7 +482,7 @@ public class ReadOnlyDoubleWrapperTest {
     @Test
     public void testInternalEagerBind_generic() {
         attachInternalChangeListener();
-        final ObservableObjectValueStub<Double> v = new ObservableObjectValueStub<Double>(VALUE_1);
+        final ObservableObjectValueStub<Double> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get(), EPSILON);
@@ -518,7 +518,7 @@ public class ReadOnlyDoubleWrapperTest {
     @Test
     public void testPublicEagerBind_generic() {
         attachPublicChangeListener();
-        final ObservableObjectValueStub<Double> v = new ObservableObjectValueStub<Double>(VALUE_1);
+        final ObservableObjectValueStub<Double> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get(), EPSILON);

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyFloatPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyFloatPropertyBaseTest.java
@@ -47,7 +47,7 @@ public class ReadOnlyFloatPropertyBaseTest {
     public void setUp() throws Exception {
         property = new ReadOnlyPropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<Number>(UNDEFINED);
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     @Test

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyFloatPropertyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyFloatPropertyTest.java
@@ -26,17 +26,12 @@
 package test.javafx.beans.property;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import javafx.beans.InvalidationListener;
-import javafx.beans.binding.ObjectExpression;
 import javafx.beans.property.ReadOnlyFloatProperty;
 import javafx.beans.property.ReadOnlyFloatWrapper;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.value.ChangeListener;
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -87,7 +82,7 @@ public class ReadOnlyFloatPropertyTest {
 
     @Test
     public void testObjectToFloat() {
-        final ReadOnlyObjectWrapper<Float> valueModel = new ReadOnlyObjectWrapper<Float>();
+        final ReadOnlyObjectWrapper<Float> valueModel = new ReadOnlyObjectWrapper<>();
         final ReadOnlyFloatProperty exp = ReadOnlyFloatProperty.readOnlyFloatProperty(valueModel.getReadOnlyProperty());
 
 

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyFloatWrapperTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyFloatWrapperTest.java
@@ -63,8 +63,8 @@ public class ReadOnlyFloatWrapperTest {
         readOnlyProperty = property.getReadOnlyProperty();
         internalInvalidationListener = new InvalidationListenerMock();
         publicInvalidationListener = new InvalidationListenerMock();
-        internalChangeListener = new ChangeListenerMock<Number>(UNDEFINED);
-        publicChangeListener = new ChangeListenerMock<Number>(UNDEFINED);
+        internalChangeListener = new ChangeListenerMock<>(UNDEFINED);
+        publicChangeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     private void attachInvalidationListeners() {
@@ -92,13 +92,13 @@ public class ReadOnlyFloatWrapperTest {
     public void testConstructor_NoArguments() {
         final ReadOnlyFloatWrapper p1 = new ReadOnlyFloatWrapper();
         assertEquals(DEFAULT, p1.get(), EPSILON);
-        assertEquals((Float)DEFAULT, p1.getValue(), EPSILON);
+        assertEquals(DEFAULT, p1.getValue(), EPSILON);
         assertFalse(property.isBound());
         assertEquals(null, p1.getBean());
         assertEquals("", p1.getName());
         final ReadOnlyFloatProperty r1 = p1.getReadOnlyProperty();
         assertEquals(DEFAULT, r1.get(), EPSILON);
-        assertEquals((Float)DEFAULT, r1.getValue(), EPSILON);
+        assertEquals(DEFAULT, r1.getValue(), EPSILON);
         assertEquals(null, r1.getBean());
         assertEquals("", r1.getName());
     }
@@ -107,13 +107,13 @@ public class ReadOnlyFloatWrapperTest {
     public void testConstructor_InitialValue() {
         final ReadOnlyFloatWrapper p1 = new ReadOnlyFloatWrapper(VALUE_1);
         assertEquals(VALUE_1, p1.get(), EPSILON);
-        assertEquals((Float)VALUE_1, p1.getValue(), EPSILON);
+        assertEquals(VALUE_1, p1.getValue(), EPSILON);
         assertFalse(property.isBound());
         assertEquals(null, p1.getBean());
         assertEquals("", p1.getName());
         final ReadOnlyFloatProperty r1 = p1.getReadOnlyProperty();
         assertEquals(VALUE_1, r1.get(), EPSILON);
-        assertEquals((Float)VALUE_1, r1.getValue(), EPSILON);
+        assertEquals(VALUE_1, r1.getValue(), EPSILON);
         assertEquals(null, r1.getBean());
         assertEquals("", r1.getName());
     }
@@ -124,13 +124,13 @@ public class ReadOnlyFloatWrapperTest {
         final String name = "My name";
         final ReadOnlyFloatWrapper p1 = new ReadOnlyFloatWrapper(bean, name);
         assertEquals(DEFAULT, p1.get(), EPSILON);
-        assertEquals((Float)DEFAULT, p1.getValue(), EPSILON);
+        assertEquals(DEFAULT, p1.getValue(), EPSILON);
         assertFalse(property.isBound());
         assertEquals(bean, p1.getBean());
         assertEquals(name, p1.getName());
         final ReadOnlyFloatProperty r1 = p1.getReadOnlyProperty();
         assertEquals(DEFAULT, r1.get(), EPSILON);
-        assertEquals((Float)DEFAULT, r1.getValue(), EPSILON);
+        assertEquals(DEFAULT, r1.getValue(), EPSILON);
         assertEquals(bean, r1.getBean());
         assertEquals(name, r1.getName());
     }
@@ -141,13 +141,13 @@ public class ReadOnlyFloatWrapperTest {
         final String name = "My name";
         final ReadOnlyFloatWrapper p1 = new ReadOnlyFloatWrapper(bean, name, VALUE_1);
         assertEquals(VALUE_1, p1.get(), EPSILON);
-        assertEquals((Float)VALUE_1, p1.getValue(), EPSILON);
+        assertEquals(VALUE_1, p1.getValue(), EPSILON);
         assertFalse(property.isBound());
         assertEquals(bean, p1.getBean());
         assertEquals(name, p1.getName());
         final ReadOnlyFloatProperty r1 = p1.getReadOnlyProperty();
         assertEquals(VALUE_1, r1.get(), EPSILON);
-        assertEquals((Float)VALUE_1, r1.getValue(), EPSILON);
+        assertEquals(VALUE_1, r1.getValue(), EPSILON);
         assertEquals(bean, r1.getBean());
         assertEquals(name, r1.getName());
     }
@@ -442,7 +442,7 @@ public class ReadOnlyFloatWrapperTest {
     @Test
     public void testLazyBind_generic() {
         attachInvalidationListeners();
-        final ObservableObjectValueStub<Float> v = new ObservableObjectValueStub<Float>(VALUE_1);
+        final ObservableObjectValueStub<Float> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get(), EPSILON);
@@ -482,7 +482,7 @@ public class ReadOnlyFloatWrapperTest {
     @Test
     public void testInternalEagerBind_generic() {
         attachInternalChangeListener();
-        final ObservableObjectValueStub<Float> v = new ObservableObjectValueStub<Float>(VALUE_1);
+        final ObservableObjectValueStub<Float> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get(), EPSILON);
@@ -518,7 +518,7 @@ public class ReadOnlyFloatWrapperTest {
     @Test
     public void testPublicEagerBind_generic() {
         attachPublicChangeListener();
-        final ObservableObjectValueStub<Float> v = new ObservableObjectValueStub<Float>(VALUE_1);
+        final ObservableObjectValueStub<Float> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get(), EPSILON);

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyIntegerPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyIntegerPropertyBaseTest.java
@@ -47,7 +47,7 @@ public class ReadOnlyIntegerPropertyBaseTest {
     public void setUp() throws Exception {
         property = new ReadOnlyPropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<Number>(UNDEFINED);
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     @Test

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyIntegerPropertyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyIntegerPropertyTest.java
@@ -26,17 +26,12 @@
 package test.javafx.beans.property;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import javafx.beans.InvalidationListener;
-import javafx.beans.binding.ObjectExpression;
 import javafx.beans.property.ReadOnlyIntegerProperty;
 import javafx.beans.property.ReadOnlyIntegerWrapper;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.value.ChangeListener;
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -86,7 +81,7 @@ public class ReadOnlyIntegerPropertyTest {
 
     @Test
     public void testObjectToInteger() {
-        final ReadOnlyObjectWrapper<Integer> valueModel = new ReadOnlyObjectWrapper<Integer>();
+        final ReadOnlyObjectWrapper<Integer> valueModel = new ReadOnlyObjectWrapper<>();
         final ReadOnlyIntegerProperty exp = ReadOnlyIntegerProperty.readOnlyIntegerProperty(valueModel.getReadOnlyProperty());
 
         assertEquals(0, exp.intValue());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyIntegerWrapperTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyIntegerWrapperTest.java
@@ -62,8 +62,8 @@ public class ReadOnlyIntegerWrapperTest {
         readOnlyProperty = property.getReadOnlyProperty();
         internalInvalidationListener = new InvalidationListenerMock();
         publicInvalidationListener = new InvalidationListenerMock();
-        internalChangeListener = new ChangeListenerMock<Number>(UNDEFINED);
-        publicChangeListener = new ChangeListenerMock<Number>(UNDEFINED);
+        internalChangeListener = new ChangeListenerMock<>(UNDEFINED);
+        publicChangeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     private void attachInvalidationListeners() {
@@ -441,7 +441,7 @@ public class ReadOnlyIntegerWrapperTest {
     @Test
     public void testLazyBind_generic() {
         attachInvalidationListeners();
-        final ObservableObjectValueStub<Integer> v = new ObservableObjectValueStub<Integer>(VALUE_1);
+        final ObservableObjectValueStub<Integer> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -481,7 +481,7 @@ public class ReadOnlyIntegerWrapperTest {
     @Test
     public void testInternalEagerBind_generic() {
         attachInternalChangeListener();
-        final ObservableObjectValueStub<Integer> v = new ObservableObjectValueStub<Integer>(VALUE_1);
+        final ObservableObjectValueStub<Integer> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -517,7 +517,7 @@ public class ReadOnlyIntegerWrapperTest {
     @Test
     public void testPublicEagerBind_generic() {
         attachPublicChangeListener();
-        final ObservableObjectValueStub<Integer> v = new ObservableObjectValueStub<Integer>(VALUE_1);
+        final ObservableObjectValueStub<Integer> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyListPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyListPropertyBaseTest.java
@@ -53,7 +53,7 @@ public class ReadOnlyListPropertyBaseTest {
     public void setUp() throws Exception {
         property = new ReadOnlyPropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<Object>(UNDEFINED);
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     @Test

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyListWrapperTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyListWrapperTest.java
@@ -62,8 +62,8 @@ public class ReadOnlyListWrapperTest {
         readOnlyProperty = property.getReadOnlyProperty();
         internalInvalidationListener = new InvalidationListenerMock();
         publicInvalidationListener = new InvalidationListenerMock();
-        internalChangeListener = new ChangeListenerMock<Object>(UNDEFINED);
-        publicChangeListener = new ChangeListenerMock<Object>(UNDEFINED);
+        internalChangeListener = new ChangeListenerMock<>(UNDEFINED);
+        publicChangeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     private void attachInvalidationListeners() {
@@ -89,30 +89,30 @@ public class ReadOnlyListWrapperTest {
 
     @Test
     public void testConstructor_NoArguments() {
-        final ReadOnlyListWrapper<Object> p1 = new ReadOnlyListWrapper<Object>();
+        final ReadOnlyListWrapper<Object> p1 = new ReadOnlyListWrapper<>();
         assertEquals(DEFAULT, p1.get());
-        assertEquals((Object)DEFAULT, p1.getValue());
+        assertEquals(DEFAULT, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(null, p1.getBean());
         assertEquals("", p1.getName());
         final ReadOnlyListProperty<Object> r1 = p1.getReadOnlyProperty();
         assertEquals(DEFAULT, r1.get());
-        assertEquals((Object)DEFAULT, r1.getValue());
+        assertEquals(DEFAULT, r1.getValue());
         assertEquals(null, r1.getBean());
         assertEquals("", r1.getName());
     }
 
     @Test
     public void testConstructor_InitialValue() {
-        final ReadOnlyListWrapper<Object> p1 = new ReadOnlyListWrapper<Object>(VALUE_1);
+        final ReadOnlyListWrapper<Object> p1 = new ReadOnlyListWrapper<>(VALUE_1);
         assertEquals(VALUE_1, p1.get());
-        assertEquals((Object)VALUE_1, p1.getValue());
+        assertEquals(VALUE_1, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(null, p1.getBean());
         assertEquals("", p1.getName());
         final ReadOnlyListProperty<Object> r1 = p1.getReadOnlyProperty();
         assertEquals(VALUE_1, r1.get());
-        assertEquals((Object)VALUE_1, r1.getValue());
+        assertEquals(VALUE_1, r1.getValue());
         assertEquals(null, r1.getBean());
         assertEquals("", r1.getName());
     }
@@ -121,15 +121,15 @@ public class ReadOnlyListWrapperTest {
     public void testConstructor_Bean_Name() {
         final Object bean = new Object();
         final String name = "My name";
-        final ReadOnlyListWrapper<Object> p1 = new ReadOnlyListWrapper<Object>(bean, name);
+        final ReadOnlyListWrapper<Object> p1 = new ReadOnlyListWrapper<>(bean, name);
         assertEquals(DEFAULT, p1.get());
-        assertEquals((Object)DEFAULT, p1.getValue());
+        assertEquals(DEFAULT, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(bean, p1.getBean());
         assertEquals(name, p1.getName());
         final ReadOnlyListProperty<Object> r1 = p1.getReadOnlyProperty();
         assertEquals(DEFAULT, r1.get());
-        assertEquals((Object)DEFAULT, r1.getValue());
+        assertEquals(DEFAULT, r1.getValue());
         assertEquals(bean, r1.getBean());
         assertEquals(name, r1.getName());
     }
@@ -138,15 +138,15 @@ public class ReadOnlyListWrapperTest {
     public void testConstructor_Bean_Name_InitialValue() {
         final Object bean = new Object();
         final String name = "My name";
-        final ReadOnlyListWrapper<Object> p1 = new ReadOnlyListWrapper<Object>(bean, name, VALUE_1);
+        final ReadOnlyListWrapper<Object> p1 = new ReadOnlyListWrapper<>(bean, name, VALUE_1);
         assertEquals(VALUE_1, p1.get());
-        assertEquals((Object)VALUE_1, p1.getValue());
+        assertEquals(VALUE_1, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(bean, p1.getBean());
         assertEquals(name, p1.getName());
         final ReadOnlyListProperty<Object> r1 = p1.getReadOnlyProperty();
         assertEquals(VALUE_1, r1.get());
-        assertEquals((Object)VALUE_1, r1.getValue());
+        assertEquals(VALUE_1, r1.getValue());
         assertEquals(bean, r1.getBean());
         assertEquals(name, r1.getName());
     }
@@ -321,7 +321,7 @@ public class ReadOnlyListWrapperTest {
 
     @Test(expected=RuntimeException.class)
     public void testSetBoundValue() {
-        final ListProperty<Object> v = new SimpleListProperty<Object>(VALUE_1);
+        final ListProperty<Object> v = new SimpleListProperty<>(VALUE_1);
         property.bind(v);
         property.set(VALUE_1);
     }
@@ -329,7 +329,7 @@ public class ReadOnlyListWrapperTest {
     @Test
     public void testLazyBind_primitive() {
         attachInvalidationListeners();
-        final ObservableObjectValueStub<ObservableList<Object>> v = new ObservableObjectValueStub<ObservableList<Object>>(VALUE_1);
+        final ObservableObjectValueStub<ObservableList<Object>> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -369,7 +369,7 @@ public class ReadOnlyListWrapperTest {
     @Test
     public void testInternalEagerBind_primitive() {
         attachInternalChangeListener();
-        final ObservableObjectValueStub<ObservableList<Object>> v = new ObservableObjectValueStub<ObservableList<Object>>(VALUE_1);
+        final ObservableObjectValueStub<ObservableList<Object>> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -405,7 +405,7 @@ public class ReadOnlyListWrapperTest {
     @Test
     public void testPublicEagerBind_primitive() {
         attachPublicChangeListener();
-        final ObservableObjectValueStub<ObservableList<Object>> v = new ObservableObjectValueStub<ObservableList<Object>>(VALUE_1);
+        final ObservableObjectValueStub<ObservableList<Object>> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -441,7 +441,7 @@ public class ReadOnlyListWrapperTest {
     @Test
     public void testLazyBind_generic() {
         attachInvalidationListeners();
-        final ObservableObjectValueStub<ObservableList<Object>> v = new ObservableObjectValueStub<ObservableList<Object>>(VALUE_1);
+        final ObservableObjectValueStub<ObservableList<Object>> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -481,7 +481,7 @@ public class ReadOnlyListWrapperTest {
     @Test
     public void testInternalEagerBind_generic() {
         attachInternalChangeListener();
-        final ObservableObjectValueStub<ObservableList<Object>> v = new ObservableObjectValueStub<ObservableList<Object>>(VALUE_1);
+        final ObservableObjectValueStub<ObservableList<Object>> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -517,7 +517,7 @@ public class ReadOnlyListWrapperTest {
     @Test
     public void testPublicEagerBind_generic() {
         attachPublicChangeListener();
-        final ObservableObjectValueStub<ObservableList<Object>> v = new ObservableObjectValueStub<ObservableList<Object>>(VALUE_1);
+        final ObservableObjectValueStub<ObservableList<Object>> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -558,8 +558,8 @@ public class ReadOnlyListWrapperTest {
     @Test
     public void testRebind() {
         attachInvalidationListeners();
-        final ListProperty<Object> v1 = new SimpleListProperty<Object>(VALUE_1);
-        final ListProperty<Object> v2 = new SimpleListProperty<Object>(VALUE_2);
+        final ListProperty<Object> v1 = new SimpleListProperty<>(VALUE_1);
+        final ListProperty<Object> v2 = new SimpleListProperty<>(VALUE_2);
         property.bind(v1);
         property.get();
         readOnlyProperty.get();
@@ -605,7 +605,7 @@ public class ReadOnlyListWrapperTest {
     @Test
     public void testUnbind() {
         attachInvalidationListeners();
-        final ListProperty<Object> v = new SimpleListProperty<Object>(VALUE_1);
+        final ListProperty<Object> v = new SimpleListProperty<>(VALUE_1);
         property.bind(v);
         property.unbind();
         assertEquals(VALUE_1, property.get());
@@ -634,7 +634,7 @@ public class ReadOnlyListWrapperTest {
 
     @Test
     public void testAddingListenerWillAlwaysReceiveInvalidationEvent() {
-        final ListProperty<Object> v = new SimpleListProperty<Object>(VALUE_1);
+        final ListProperty<Object> v = new SimpleListProperty<>(VALUE_1);
         final InvalidationListenerMock internalListener2 = new InvalidationListenerMock();
         final InvalidationListenerMock internalListener3 = new InvalidationListenerMock();
         final InvalidationListenerMock publicListener2 = new InvalidationListenerMock();
@@ -688,15 +688,15 @@ public class ReadOnlyListWrapperTest {
         internalChangeListener.check(null, UNDEFINED, UNDEFINED, 0);
 
         // no read only property created => no-op
-        final ReadOnlyListWrapper<Object> v1 = new ReadOnlyListWrapper<Object>();
+        final ReadOnlyListWrapper<Object> v1 = new ReadOnlyListWrapper<>();
         v1.removeListener(internalInvalidationListener);
         v1.removeListener(internalChangeListener);
     }
 
     @Test
     public void testNoReadOnlyPropertyCreated() {
-        final ListProperty<Object> v1 = new SimpleListProperty<Object>(VALUE_1);
-        final ReadOnlyListWrapper<Object> p1 = new ReadOnlyListWrapper<Object>();
+        final ListProperty<Object> v1 = new SimpleListProperty<>(VALUE_1);
+        final ReadOnlyListWrapper<Object> p1 = new ReadOnlyListWrapper<>();
 
         p1.set(VALUE_1);
         p1.bind(v1);
@@ -707,7 +707,7 @@ public class ReadOnlyListWrapperTest {
 
     @Test
     public void testToString() {
-        final ListProperty<Object> v1 = new SimpleListProperty<Object>(VALUE_1);
+        final ListProperty<Object> v1 = new SimpleListProperty<>(VALUE_1);
 
         property.set(VALUE_1);
         assertEquals("ListProperty [value: " + VALUE_1 + "]", property.toString());
@@ -728,15 +728,15 @@ public class ReadOnlyListWrapperTest {
 
         final Object bean = new Object();
         final String name = "My name";
-        final ReadOnlyListWrapper<Object> v2 = new ReadOnlyListWrapper<Object>(bean, name);
+        final ReadOnlyListWrapper<Object> v2 = new ReadOnlyListWrapper<>(bean, name);
         assertEquals("ListProperty [bean: " + bean.toString() + ", name: My name, value: " + DEFAULT + "]", v2.toString());
         assertEquals("ReadOnlyListProperty [bean: " + bean.toString() + ", name: My name, value: " + DEFAULT + "]", v2.getReadOnlyProperty().toString());
 
-        final ReadOnlyListWrapper<Object> v3 = new ReadOnlyListWrapper<Object>(bean, "");
+        final ReadOnlyListWrapper<Object> v3 = new ReadOnlyListWrapper<>(bean, "");
         assertEquals("ListProperty [bean: " + bean.toString() + ", value: " + DEFAULT + "]", v3.toString());
         assertEquals("ReadOnlyListProperty [bean: " + bean.toString() + ", value: " + DEFAULT + "]", v3.getReadOnlyProperty().toString());
 
-        final ReadOnlyListWrapper<Object> v4 = new ReadOnlyListWrapper<Object>(null, name);
+        final ReadOnlyListWrapper<Object> v4 = new ReadOnlyListWrapper<>(null, name);
         assertEquals("ListProperty [name: My name, value: " + DEFAULT + "]", v4.toString());
         assertEquals("ReadOnlyListProperty [name: My name, value: " + DEFAULT + "]", v4.getReadOnlyProperty().toString());
     }

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyLongPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyLongPropertyBaseTest.java
@@ -47,7 +47,7 @@ public class ReadOnlyLongPropertyBaseTest {
     public void setUp() throws Exception {
         property = new ReadOnlyPropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<Number>(UNDEFINED);
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     @Test

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyLongPropertyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyLongPropertyTest.java
@@ -26,10 +26,7 @@
 package test.javafx.beans.property;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import javafx.beans.InvalidationListener;
-import javafx.beans.binding.ObjectExpression;
 import javafx.beans.property.ReadOnlyLongProperty;
 import javafx.beans.property.ReadOnlyLongWrapper;
 import javafx.beans.property.ReadOnlyObjectProperty;
@@ -86,7 +83,7 @@ public class ReadOnlyLongPropertyTest {
 
     @Test
     public void testObjectToLong() {
-        final ReadOnlyObjectWrapper<Long> valueModel = new ReadOnlyObjectWrapper<Long>();
+        final ReadOnlyObjectWrapper<Long> valueModel = new ReadOnlyObjectWrapper<>();
         final ReadOnlyLongProperty exp = ReadOnlyLongProperty.readOnlyLongProperty(valueModel.getReadOnlyProperty());
 
         assertEquals(0L, exp.longValue());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyLongWrapperTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyLongWrapperTest.java
@@ -62,8 +62,8 @@ public class ReadOnlyLongWrapperTest {
         readOnlyProperty = property.getReadOnlyProperty();
         internalInvalidationListener = new InvalidationListenerMock();
         publicInvalidationListener = new InvalidationListenerMock();
-        internalChangeListener = new ChangeListenerMock<Number>(UNDEFINED);
-        publicChangeListener = new ChangeListenerMock<Number>(UNDEFINED);
+        internalChangeListener = new ChangeListenerMock<>(UNDEFINED);
+        publicChangeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     private void attachInvalidationListeners() {
@@ -441,7 +441,7 @@ public class ReadOnlyLongWrapperTest {
     @Test
     public void testLazyBind_generic() {
         attachInvalidationListeners();
-        final ObservableObjectValueStub<Long> v = new ObservableObjectValueStub<Long>(VALUE_1);
+        final ObservableObjectValueStub<Long> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -481,7 +481,7 @@ public class ReadOnlyLongWrapperTest {
     @Test
     public void testInternalEagerBind_generic() {
         attachInternalChangeListener();
-        final ObservableObjectValueStub<Long> v = new ObservableObjectValueStub<Long>(VALUE_1);
+        final ObservableObjectValueStub<Long> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -517,7 +517,7 @@ public class ReadOnlyLongWrapperTest {
     @Test
     public void testPublicEagerBind_generic() {
         attachPublicChangeListener();
-        final ObservableObjectValueStub<Long> v = new ObservableObjectValueStub<Long>(VALUE_1);
+        final ObservableObjectValueStub<Long> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyMapPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyMapPropertyBaseTest.java
@@ -33,7 +33,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.HashMap;
 import javafx.beans.property.ReadOnlyBooleanProperty;
 import javafx.beans.property.ReadOnlyIntegerProperty;
 import javafx.beans.property.ReadOnlyMapPropertyBase;
@@ -56,7 +55,7 @@ public class ReadOnlyMapPropertyBaseTest {
     public void setUp() throws Exception {
         property = new ReadOnlyPropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<Object>(UNDEFINED);
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     @Test

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyMapWrapperTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyMapWrapperTest.java
@@ -62,8 +62,8 @@ public class ReadOnlyMapWrapperTest {
         readOnlyProperty = property.getReadOnlyProperty();
         internalInvalidationListener = new InvalidationListenerMock();
         publicInvalidationListener = new InvalidationListenerMock();
-        internalChangeListener = new ChangeListenerMock<Object>(UNDEFINED);
-        publicChangeListener = new ChangeListenerMock<Object>(UNDEFINED);
+        internalChangeListener = new ChangeListenerMock<>(UNDEFINED);
+        publicChangeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     private void attachInvalidationListeners() {
@@ -89,30 +89,30 @@ public class ReadOnlyMapWrapperTest {
 
     @Test
     public void testConstructor_NoArguments() {
-        final ReadOnlyMapWrapper<Object, Object> p1 = new ReadOnlyMapWrapper<Object, Object>();
+        final ReadOnlyMapWrapper<Object, Object> p1 = new ReadOnlyMapWrapper<>();
         assertEquals(DEFAULT, p1.get());
-        assertEquals((Object)DEFAULT, p1.getValue());
+        assertEquals(DEFAULT, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(null, p1.getBean());
         assertEquals("", p1.getName());
         final ReadOnlyMapProperty<Object, Object> r1 = p1.getReadOnlyProperty();
         assertEquals(DEFAULT, r1.get());
-        assertEquals((Object)DEFAULT, r1.getValue());
+        assertEquals(DEFAULT, r1.getValue());
         assertEquals(null, r1.getBean());
         assertEquals("", r1.getName());
     }
 
     @Test
     public void testConstructor_InitialValue() {
-        final ReadOnlyMapWrapper<Object, Object> p1 = new ReadOnlyMapWrapper<Object, Object>(VALUE_1);
+        final ReadOnlyMapWrapper<Object, Object> p1 = new ReadOnlyMapWrapper<>(VALUE_1);
         assertEquals(VALUE_1, p1.get());
-        assertEquals((Object)VALUE_1, p1.getValue());
+        assertEquals(VALUE_1, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(null, p1.getBean());
         assertEquals("", p1.getName());
         final ReadOnlyMapProperty<Object, Object> r1 = p1.getReadOnlyProperty();
         assertEquals(VALUE_1, r1.get());
-        assertEquals((Object)VALUE_1, r1.getValue());
+        assertEquals(VALUE_1, r1.getValue());
         assertEquals(null, r1.getBean());
         assertEquals("", r1.getName());
     }
@@ -121,15 +121,15 @@ public class ReadOnlyMapWrapperTest {
     public void testConstructor_Bean_Name() {
         final Object bean = new Object();
         final String name = "My name";
-        final ReadOnlyMapWrapper<Object, Object> p1 = new ReadOnlyMapWrapper<Object, Object>(bean, name);
+        final ReadOnlyMapWrapper<Object, Object> p1 = new ReadOnlyMapWrapper<>(bean, name);
         assertEquals(DEFAULT, p1.get());
-        assertEquals((Object)DEFAULT, p1.getValue());
+        assertEquals(DEFAULT, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(bean, p1.getBean());
         assertEquals(name, p1.getName());
         final ReadOnlyMapProperty<Object, Object> r1 = p1.getReadOnlyProperty();
         assertEquals(DEFAULT, r1.get());
-        assertEquals((Object)DEFAULT, r1.getValue());
+        assertEquals(DEFAULT, r1.getValue());
         assertEquals(bean, r1.getBean());
         assertEquals(name, r1.getName());
     }
@@ -138,15 +138,15 @@ public class ReadOnlyMapWrapperTest {
     public void testConstructor_Bean_Name_InitialValue() {
         final Object bean = new Object();
         final String name = "My name";
-        final ReadOnlyMapWrapper<Object, Object> p1 = new ReadOnlyMapWrapper<Object, Object>(bean, name, VALUE_1);
+        final ReadOnlyMapWrapper<Object, Object> p1 = new ReadOnlyMapWrapper<>(bean, name, VALUE_1);
         assertEquals(VALUE_1, p1.get());
-        assertEquals((Object)VALUE_1, p1.getValue());
+        assertEquals(VALUE_1, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(bean, p1.getBean());
         assertEquals(name, p1.getName());
         final ReadOnlyMapProperty<Object, Object> r1 = p1.getReadOnlyProperty();
         assertEquals(VALUE_1, r1.get());
-        assertEquals((Object)VALUE_1, r1.getValue());
+        assertEquals(VALUE_1, r1.getValue());
         assertEquals(bean, r1.getBean());
         assertEquals(name, r1.getName());
     }
@@ -321,7 +321,7 @@ public class ReadOnlyMapWrapperTest {
 
     @Test(expected=RuntimeException.class)
     public void testMapBoundValue() {
-        final MapProperty<Object, Object> v = new SimpleMapProperty<Object, Object>(VALUE_1);
+        final MapProperty<Object, Object> v = new SimpleMapProperty<>(VALUE_1);
         property.bind(v);
         property.set(VALUE_1);
     }
@@ -329,7 +329,7 @@ public class ReadOnlyMapWrapperTest {
     @Test
     public void testLazyBind_primitive() {
         attachInvalidationListeners();
-        final ObservableObjectValueStub<ObservableMap<Object, Object>> v = new ObservableObjectValueStub<ObservableMap<Object, Object>>(VALUE_1);
+        final ObservableObjectValueStub<ObservableMap<Object, Object>> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -369,7 +369,7 @@ public class ReadOnlyMapWrapperTest {
     @Test
     public void testInternalEagerBind_primitive() {
         attachInternalChangeListener();
-        final ObservableObjectValueStub<ObservableMap<Object, Object>> v = new ObservableObjectValueStub<ObservableMap<Object, Object>>(VALUE_1);
+        final ObservableObjectValueStub<ObservableMap<Object, Object>> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -405,7 +405,7 @@ public class ReadOnlyMapWrapperTest {
     @Test
     public void testPublicEagerBind_primitive() {
         attachPublicChangeListener();
-        final ObservableObjectValueStub<ObservableMap<Object, Object>> v = new ObservableObjectValueStub<ObservableMap<Object, Object>>(VALUE_1);
+        final ObservableObjectValueStub<ObservableMap<Object, Object>> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -441,7 +441,7 @@ public class ReadOnlyMapWrapperTest {
     @Test
     public void testLazyBind_generic() {
         attachInvalidationListeners();
-        final ObservableObjectValueStub<ObservableMap<Object, Object>> v = new ObservableObjectValueStub<ObservableMap<Object, Object>>(VALUE_1);
+        final ObservableObjectValueStub<ObservableMap<Object, Object>> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -481,7 +481,7 @@ public class ReadOnlyMapWrapperTest {
     @Test
     public void testInternalEagerBind_generic() {
         attachInternalChangeListener();
-        final ObservableObjectValueStub<ObservableMap<Object, Object>> v = new ObservableObjectValueStub<ObservableMap<Object, Object>>(VALUE_1);
+        final ObservableObjectValueStub<ObservableMap<Object, Object>> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -517,7 +517,7 @@ public class ReadOnlyMapWrapperTest {
     @Test
     public void testPublicEagerBind_generic() {
         attachPublicChangeListener();
-        final ObservableObjectValueStub<ObservableMap<Object, Object>> v = new ObservableObjectValueStub<ObservableMap<Object, Object>>(VALUE_1);
+        final ObservableObjectValueStub<ObservableMap<Object, Object>> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -558,8 +558,8 @@ public class ReadOnlyMapWrapperTest {
     @Test
     public void testRebind() {
         attachInvalidationListeners();
-        final MapProperty<Object, Object> v1 = new SimpleMapProperty<Object, Object>(VALUE_1);
-        final MapProperty<Object, Object> v2 = new SimpleMapProperty<Object, Object>(VALUE_2);
+        final MapProperty<Object, Object> v1 = new SimpleMapProperty<>(VALUE_1);
+        final MapProperty<Object, Object> v2 = new SimpleMapProperty<>(VALUE_2);
         property.bind(v1);
         property.get();
         readOnlyProperty.get();
@@ -605,7 +605,7 @@ public class ReadOnlyMapWrapperTest {
     @Test
     public void testUnbind() {
         attachInvalidationListeners();
-        final MapProperty<Object, Object> v = new SimpleMapProperty<Object, Object>(VALUE_1);
+        final MapProperty<Object, Object> v = new SimpleMapProperty<>(VALUE_1);
         property.bind(v);
         property.unbind();
         assertEquals(VALUE_1, property.get());
@@ -634,7 +634,7 @@ public class ReadOnlyMapWrapperTest {
 
     @Test
     public void testAddingListenerWillAlwaysReceiveInvalidationEvent() {
-        final MapProperty<Object, Object> v = new SimpleMapProperty<Object, Object>(VALUE_1);
+        final MapProperty<Object, Object> v = new SimpleMapProperty<>(VALUE_1);
         final InvalidationListenerMock internalListener2 = new InvalidationListenerMock();
         final InvalidationListenerMock internalListener3 = new InvalidationListenerMock();
         final InvalidationListenerMock publicListener2 = new InvalidationListenerMock();
@@ -688,15 +688,15 @@ public class ReadOnlyMapWrapperTest {
         internalChangeListener.check(null, UNDEFINED, UNDEFINED, 0);
 
         // no read only property created => no-op
-        final ReadOnlyMapWrapper<Object, Object> v1 = new ReadOnlyMapWrapper<Object, Object>();
+        final ReadOnlyMapWrapper<Object, Object> v1 = new ReadOnlyMapWrapper<>();
         v1.removeListener(internalInvalidationListener);
         v1.removeListener(internalChangeListener);
     }
 
     @Test
     public void testNoReadOnlyPropertyCreated() {
-        final MapProperty<Object, Object> v1 = new SimpleMapProperty<Object, Object>(VALUE_1);
-        final ReadOnlyMapWrapper<Object, Object> p1 = new ReadOnlyMapWrapper<Object, Object>();
+        final MapProperty<Object, Object> v1 = new SimpleMapProperty<>(VALUE_1);
+        final ReadOnlyMapWrapper<Object, Object> p1 = new ReadOnlyMapWrapper<>();
 
         p1.set(VALUE_1);
         p1.bind(v1);
@@ -707,7 +707,7 @@ public class ReadOnlyMapWrapperTest {
 
     @Test
     public void testToString() {
-        final MapProperty<Object, Object> v1 = new SimpleMapProperty<Object, Object>(VALUE_1);
+        final MapProperty<Object, Object> v1 = new SimpleMapProperty<>(VALUE_1);
 
         property.set(VALUE_1);
         assertEquals("MapProperty [value: " + VALUE_1 + "]", property.toString());
@@ -728,15 +728,15 @@ public class ReadOnlyMapWrapperTest {
 
         final Object bean = new Object();
         final String name = "My name";
-        final ReadOnlyMapWrapper<Object, Object> v2 = new ReadOnlyMapWrapper<Object, Object>(bean, name);
+        final ReadOnlyMapWrapper<Object, Object> v2 = new ReadOnlyMapWrapper<>(bean, name);
         assertEquals("MapProperty [bean: " + bean.toString() + ", name: My name, value: " + DEFAULT + "]", v2.toString());
         assertEquals("ReadOnlyMapProperty [bean: " + bean.toString() + ", name: My name, value: " + DEFAULT + "]", v2.getReadOnlyProperty().toString());
 
-        final ReadOnlyMapWrapper<Object, Object> v3 = new ReadOnlyMapWrapper<Object, Object>(bean, "");
+        final ReadOnlyMapWrapper<Object, Object> v3 = new ReadOnlyMapWrapper<>(bean, "");
         assertEquals("MapProperty [bean: " + bean.toString() + ", value: " + DEFAULT + "]", v3.toString());
         assertEquals("ReadOnlyMapProperty [bean: " + bean.toString() + ", value: " + DEFAULT + "]", v3.getReadOnlyProperty().toString());
 
-        final ReadOnlyMapWrapper<Object, Object> v4 = new ReadOnlyMapWrapper<Object, Object>(null, name);
+        final ReadOnlyMapWrapper<Object, Object> v4 = new ReadOnlyMapWrapper<>(null, name);
         assertEquals("MapProperty [name: My name, value: " + DEFAULT + "]", v4.toString());
         assertEquals("ReadOnlyMapProperty [name: My name, value: " + DEFAULT + "]", v4.getReadOnlyProperty().toString());
     }

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyObjectPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyObjectPropertyBaseTest.java
@@ -48,7 +48,7 @@ public class ReadOnlyObjectPropertyBaseTest {
     public void setUp() throws Exception {
         property = new ReadOnlyPropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<Object>(UNDEFINED);
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     @Test

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyObjectPropertyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyObjectPropertyTest.java
@@ -26,8 +26,6 @@
 package test.javafx.beans.property;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import javafx.beans.InvalidationListener;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.value.ChangeListener;

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyObjectWrapperTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyObjectWrapperTest.java
@@ -61,8 +61,8 @@ public class ReadOnlyObjectWrapperTest {
         readOnlyProperty = property.getReadOnlyProperty();
         internalInvalidationListener = new InvalidationListenerMock();
         publicInvalidationListener = new InvalidationListenerMock();
-        internalChangeListener = new ChangeListenerMock<Object>(UNDEFINED);
-        publicChangeListener = new ChangeListenerMock<Object>(UNDEFINED);
+        internalChangeListener = new ChangeListenerMock<>(UNDEFINED);
+        publicChangeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     private void attachInvalidationListeners() {
@@ -88,30 +88,30 @@ public class ReadOnlyObjectWrapperTest {
 
     @Test
     public void testConstructor_NoArguments() {
-        final ReadOnlyObjectWrapper<Object> p1 = new ReadOnlyObjectWrapper<Object>();
+        final ReadOnlyObjectWrapper<Object> p1 = new ReadOnlyObjectWrapper<>();
         assertEquals(DEFAULT, p1.get());
-        assertEquals((Object)DEFAULT, p1.getValue());
+        assertEquals(DEFAULT, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(null, p1.getBean());
         assertEquals("", p1.getName());
         final ReadOnlyObjectProperty<Object> r1 = p1.getReadOnlyProperty();
         assertEquals(DEFAULT, r1.get());
-        assertEquals((Object)DEFAULT, r1.getValue());
+        assertEquals(DEFAULT, r1.getValue());
         assertEquals(null, r1.getBean());
         assertEquals("", r1.getName());
     }
 
     @Test
     public void testConstructor_InitialValue() {
-        final ReadOnlyObjectWrapper<Object> p1 = new ReadOnlyObjectWrapper<Object>(VALUE_1);
+        final ReadOnlyObjectWrapper<Object> p1 = new ReadOnlyObjectWrapper<>(VALUE_1);
         assertEquals(VALUE_1, p1.get());
-        assertEquals((Object)VALUE_1, p1.getValue());
+        assertEquals(VALUE_1, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(null, p1.getBean());
         assertEquals("", p1.getName());
         final ReadOnlyObjectProperty<Object> r1 = p1.getReadOnlyProperty();
         assertEquals(VALUE_1, r1.get());
-        assertEquals((Object)VALUE_1, r1.getValue());
+        assertEquals(VALUE_1, r1.getValue());
         assertEquals(null, r1.getBean());
         assertEquals("", r1.getName());
     }
@@ -120,15 +120,15 @@ public class ReadOnlyObjectWrapperTest {
     public void testConstructor_Bean_Name() {
         final Object bean = new Object();
         final String name = "My name";
-        final ReadOnlyObjectWrapper<Object> p1 = new ReadOnlyObjectWrapper<Object>(bean, name);
+        final ReadOnlyObjectWrapper<Object> p1 = new ReadOnlyObjectWrapper<>(bean, name);
         assertEquals(DEFAULT, p1.get());
-        assertEquals((Object)DEFAULT, p1.getValue());
+        assertEquals(DEFAULT, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(bean, p1.getBean());
         assertEquals(name, p1.getName());
         final ReadOnlyObjectProperty<Object> r1 = p1.getReadOnlyProperty();
         assertEquals(DEFAULT, r1.get());
-        assertEquals((Object)DEFAULT, r1.getValue());
+        assertEquals(DEFAULT, r1.getValue());
         assertEquals(bean, r1.getBean());
         assertEquals(name, r1.getName());
     }
@@ -137,15 +137,15 @@ public class ReadOnlyObjectWrapperTest {
     public void testConstructor_Bean_Name_InitialValue() {
         final Object bean = new Object();
         final String name = "My name";
-        final ReadOnlyObjectWrapper<Object> p1 = new ReadOnlyObjectWrapper<Object>(bean, name, VALUE_1);
+        final ReadOnlyObjectWrapper<Object> p1 = new ReadOnlyObjectWrapper<>(bean, name, VALUE_1);
         assertEquals(VALUE_1, p1.get());
-        assertEquals((Object)VALUE_1, p1.getValue());
+        assertEquals(VALUE_1, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(bean, p1.getBean());
         assertEquals(name, p1.getName());
         final ReadOnlyObjectProperty<Object> r1 = p1.getReadOnlyProperty();
         assertEquals(VALUE_1, r1.get());
-        assertEquals((Object)VALUE_1, r1.getValue());
+        assertEquals(VALUE_1, r1.getValue());
         assertEquals(bean, r1.getBean());
         assertEquals(name, r1.getName());
     }
@@ -320,7 +320,7 @@ public class ReadOnlyObjectWrapperTest {
 
     @Test(expected=RuntimeException.class)
     public void testSetBoundValue() {
-        final ObjectProperty<Object> v = new SimpleObjectProperty<Object>(VALUE_1);
+        final ObjectProperty<Object> v = new SimpleObjectProperty<>(VALUE_1);
         property.bind(v);
         property.set(VALUE_1);
     }
@@ -328,7 +328,7 @@ public class ReadOnlyObjectWrapperTest {
     @Test
     public void testLazyBind_primitive() {
         attachInvalidationListeners();
-        final ObservableObjectValueStub<Object> v = new ObservableObjectValueStub<Object>(VALUE_1);
+        final ObservableObjectValueStub<Object> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -368,7 +368,7 @@ public class ReadOnlyObjectWrapperTest {
     @Test
     public void testInternalEagerBind_primitive() {
         attachInternalChangeListener();
-        final ObservableObjectValueStub<Object> v = new ObservableObjectValueStub<Object>(VALUE_1);
+        final ObservableObjectValueStub<Object> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -404,7 +404,7 @@ public class ReadOnlyObjectWrapperTest {
     @Test
     public void testPublicEagerBind_primitive() {
         attachPublicChangeListener();
-        final ObservableObjectValueStub<Object> v = new ObservableObjectValueStub<Object>(VALUE_1);
+        final ObservableObjectValueStub<Object> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -440,7 +440,7 @@ public class ReadOnlyObjectWrapperTest {
     @Test
     public void testLazyBind_generic() {
         attachInvalidationListeners();
-        final ObservableObjectValueStub<Object> v = new ObservableObjectValueStub<Object>(VALUE_1);
+        final ObservableObjectValueStub<Object> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -480,7 +480,7 @@ public class ReadOnlyObjectWrapperTest {
     @Test
     public void testInternalEagerBind_generic() {
         attachInternalChangeListener();
-        final ObservableObjectValueStub<Object> v = new ObservableObjectValueStub<Object>(VALUE_1);
+        final ObservableObjectValueStub<Object> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -516,7 +516,7 @@ public class ReadOnlyObjectWrapperTest {
     @Test
     public void testPublicEagerBind_generic() {
         attachPublicChangeListener();
-        final ObservableObjectValueStub<Object> v = new ObservableObjectValueStub<Object>(VALUE_1);
+        final ObservableObjectValueStub<Object> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -557,8 +557,8 @@ public class ReadOnlyObjectWrapperTest {
     @Test
     public void testRebind() {
         attachInvalidationListeners();
-        final ObjectProperty<Object> v1 = new SimpleObjectProperty<Object>(VALUE_1);
-        final ObjectProperty<Object> v2 = new SimpleObjectProperty<Object>(VALUE_2);
+        final ObjectProperty<Object> v1 = new SimpleObjectProperty<>(VALUE_1);
+        final ObjectProperty<Object> v2 = new SimpleObjectProperty<>(VALUE_2);
         property.bind(v1);
         property.get();
         readOnlyProperty.get();
@@ -604,7 +604,7 @@ public class ReadOnlyObjectWrapperTest {
     @Test
     public void testUnbind() {
         attachInvalidationListeners();
-        final ObjectProperty<Object> v = new SimpleObjectProperty<Object>(VALUE_1);
+        final ObjectProperty<Object> v = new SimpleObjectProperty<>(VALUE_1);
         property.bind(v);
         property.unbind();
         assertEquals(VALUE_1, property.get());
@@ -633,7 +633,7 @@ public class ReadOnlyObjectWrapperTest {
 
     @Test
     public void testAddingListenerWillAlwaysReceiveInvalidationEvent() {
-        final ObjectProperty<Object> v = new SimpleObjectProperty<Object>(VALUE_1);
+        final ObjectProperty<Object> v = new SimpleObjectProperty<>(VALUE_1);
         final InvalidationListenerMock internalListener2 = new InvalidationListenerMock();
         final InvalidationListenerMock internalListener3 = new InvalidationListenerMock();
         final InvalidationListenerMock publicListener2 = new InvalidationListenerMock();
@@ -687,15 +687,15 @@ public class ReadOnlyObjectWrapperTest {
         internalChangeListener.check(null, UNDEFINED, UNDEFINED, 0);
 
         // no read only property created => no-op
-        final ReadOnlyObjectWrapper<Object> v1 = new ReadOnlyObjectWrapper<Object>();
+        final ReadOnlyObjectWrapper<Object> v1 = new ReadOnlyObjectWrapper<>();
         v1.removeListener(internalInvalidationListener);
         v1.removeListener(internalChangeListener);
     }
 
     @Test
     public void testNoReadOnlyPropertyCreated() {
-        final ObjectProperty<Object> v1 = new SimpleObjectProperty<Object>(VALUE_1);
-        final ReadOnlyObjectWrapper<Object> p1 = new ReadOnlyObjectWrapper<Object>();
+        final ObjectProperty<Object> v1 = new SimpleObjectProperty<>(VALUE_1);
+        final ReadOnlyObjectWrapper<Object> p1 = new ReadOnlyObjectWrapper<>();
 
         p1.set(VALUE_1);
         p1.bind(v1);
@@ -706,7 +706,7 @@ public class ReadOnlyObjectWrapperTest {
 
     @Test
     public void testToString() {
-        final ObjectProperty<Object> v1 = new SimpleObjectProperty<Object>(VALUE_1);
+        final ObjectProperty<Object> v1 = new SimpleObjectProperty<>(VALUE_1);
 
         property.set(VALUE_1);
         assertEquals("ObjectProperty [value: " + VALUE_1 + "]", property.toString());
@@ -727,15 +727,15 @@ public class ReadOnlyObjectWrapperTest {
 
         final Object bean = new Object();
         final String name = "My name";
-        final ReadOnlyObjectWrapper<Object> v2 = new ReadOnlyObjectWrapper<Object>(bean, name);
+        final ReadOnlyObjectWrapper<Object> v2 = new ReadOnlyObjectWrapper<>(bean, name);
         assertEquals("ObjectProperty [bean: " + bean.toString() + ", name: My name, value: " + DEFAULT + "]", v2.toString());
         assertEquals("ReadOnlyObjectProperty [bean: " + bean.toString() + ", name: My name, value: " + DEFAULT + "]", v2.getReadOnlyProperty().toString());
 
-        final ReadOnlyObjectWrapper<Object> v3 = new ReadOnlyObjectWrapper<Object>(bean, "");
+        final ReadOnlyObjectWrapper<Object> v3 = new ReadOnlyObjectWrapper<>(bean, "");
         assertEquals("ObjectProperty [bean: " + bean.toString() + ", value: " + DEFAULT + "]", v3.toString());
         assertEquals("ReadOnlyObjectProperty [bean: " + bean.toString() + ", value: " + DEFAULT + "]", v3.getReadOnlyProperty().toString());
 
-        final ReadOnlyObjectWrapper<Object> v4 = new ReadOnlyObjectWrapper<Object>(null, name);
+        final ReadOnlyObjectWrapper<Object> v4 = new ReadOnlyObjectWrapper<>(null, name);
         assertEquals("ObjectProperty [name: My name, value: " + DEFAULT + "]", v4.toString());
         assertEquals("ReadOnlyObjectProperty [name: My name, value: " + DEFAULT + "]", v4.getReadOnlyProperty().toString());
     }

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlySetPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlySetPropertyBaseTest.java
@@ -53,7 +53,7 @@ public class ReadOnlySetPropertyBaseTest {
     public void setUp() throws Exception {
         property = new ReadOnlyPropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<Object>(UNDEFINED);
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     @Test

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlySetWrapperTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlySetWrapperTest.java
@@ -60,8 +60,8 @@ public class ReadOnlySetWrapperTest {
         readOnlyProperty = property.getReadOnlyProperty();
         internalInvalidationListener = new InvalidationListenerMock();
         publicInvalidationListener = new InvalidationListenerMock();
-        internalChangeListener = new ChangeListenerMock<Object>(UNDEFINED);
-        publicChangeListener = new ChangeListenerMock<Object>(UNDEFINED);
+        internalChangeListener = new ChangeListenerMock<>(UNDEFINED);
+        publicChangeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     private void attachInvalidationListeners() {
@@ -87,30 +87,30 @@ public class ReadOnlySetWrapperTest {
 
     @Test
     public void testConstructor_NoArguments() {
-        final ReadOnlySetWrapper<Object> p1 = new ReadOnlySetWrapper<Object>();
+        final ReadOnlySetWrapper<Object> p1 = new ReadOnlySetWrapper<>();
         assertEquals(DEFAULT, p1.get());
-        assertEquals((Object)DEFAULT, p1.getValue());
+        assertEquals(DEFAULT, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(null, p1.getBean());
         assertEquals("", p1.getName());
         final ReadOnlySetProperty<Object> r1 = p1.getReadOnlyProperty();
         assertEquals(DEFAULT, r1.get());
-        assertEquals((Object)DEFAULT, r1.getValue());
+        assertEquals(DEFAULT, r1.getValue());
         assertEquals(null, r1.getBean());
         assertEquals("", r1.getName());
     }
 
     @Test
     public void testConstructor_InitialValue() {
-        final ReadOnlySetWrapper<Object> p1 = new ReadOnlySetWrapper<Object>(VALUE_1);
+        final ReadOnlySetWrapper<Object> p1 = new ReadOnlySetWrapper<>(VALUE_1);
         assertEquals(VALUE_1, p1.get());
-        assertEquals((Object)VALUE_1, p1.getValue());
+        assertEquals(VALUE_1, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(null, p1.getBean());
         assertEquals("", p1.getName());
         final ReadOnlySetProperty<Object> r1 = p1.getReadOnlyProperty();
         assertEquals(VALUE_1, r1.get());
-        assertEquals((Object)VALUE_1, r1.getValue());
+        assertEquals(VALUE_1, r1.getValue());
         assertEquals(null, r1.getBean());
         assertEquals("", r1.getName());
     }
@@ -119,15 +119,15 @@ public class ReadOnlySetWrapperTest {
     public void testConstructor_Bean_Name() {
         final Object bean = new Object();
         final String name = "My name";
-        final ReadOnlySetWrapper<Object> p1 = new ReadOnlySetWrapper<Object>(bean, name);
+        final ReadOnlySetWrapper<Object> p1 = new ReadOnlySetWrapper<>(bean, name);
         assertEquals(DEFAULT, p1.get());
-        assertEquals((Object)DEFAULT, p1.getValue());
+        assertEquals(DEFAULT, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(bean, p1.getBean());
         assertEquals(name, p1.getName());
         final ReadOnlySetProperty<Object> r1 = p1.getReadOnlyProperty();
         assertEquals(DEFAULT, r1.get());
-        assertEquals((Object)DEFAULT, r1.getValue());
+        assertEquals(DEFAULT, r1.getValue());
         assertEquals(bean, r1.getBean());
         assertEquals(name, r1.getName());
     }
@@ -136,15 +136,15 @@ public class ReadOnlySetWrapperTest {
     public void testConstructor_Bean_Name_InitialValue() {
         final Object bean = new Object();
         final String name = "My name";
-        final ReadOnlySetWrapper<Object> p1 = new ReadOnlySetWrapper<Object>(bean, name, VALUE_1);
+        final ReadOnlySetWrapper<Object> p1 = new ReadOnlySetWrapper<>(bean, name, VALUE_1);
         assertEquals(VALUE_1, p1.get());
-        assertEquals((Object)VALUE_1, p1.getValue());
+        assertEquals(VALUE_1, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(bean, p1.getBean());
         assertEquals(name, p1.getName());
         final ReadOnlySetProperty<Object> r1 = p1.getReadOnlyProperty();
         assertEquals(VALUE_1, r1.get());
-        assertEquals((Object)VALUE_1, r1.getValue());
+        assertEquals(VALUE_1, r1.getValue());
         assertEquals(bean, r1.getBean());
         assertEquals(name, r1.getName());
     }
@@ -319,7 +319,7 @@ public class ReadOnlySetWrapperTest {
 
     @Test(expected=RuntimeException.class)
     public void testSetBoundValue() {
-        final SetProperty<Object> v = new SimpleSetProperty<Object>(VALUE_1);
+        final SetProperty<Object> v = new SimpleSetProperty<>(VALUE_1);
         property.bind(v);
         property.set(VALUE_1);
     }
@@ -327,7 +327,7 @@ public class ReadOnlySetWrapperTest {
     @Test
     public void testLazyBind_primitive() {
         attachInvalidationListeners();
-        final ObservableObjectValueStub<ObservableSet<Object>> v = new ObservableObjectValueStub<ObservableSet<Object>>(VALUE_1);
+        final ObservableObjectValueStub<ObservableSet<Object>> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -367,7 +367,7 @@ public class ReadOnlySetWrapperTest {
     @Test
     public void testInternalEagerBind_primitive() {
         attachInternalChangeListener();
-        final ObservableObjectValueStub<ObservableSet<Object>> v = new ObservableObjectValueStub<ObservableSet<Object>>(VALUE_1);
+        final ObservableObjectValueStub<ObservableSet<Object>> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -403,7 +403,7 @@ public class ReadOnlySetWrapperTest {
     @Test
     public void testPublicEagerBind_primitive() {
         attachPublicChangeListener();
-        final ObservableObjectValueStub<ObservableSet<Object>> v = new ObservableObjectValueStub<ObservableSet<Object>>(VALUE_1);
+        final ObservableObjectValueStub<ObservableSet<Object>> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -439,7 +439,7 @@ public class ReadOnlySetWrapperTest {
     @Test
     public void testLazyBind_generic() {
         attachInvalidationListeners();
-        final ObservableObjectValueStub<ObservableSet<Object>> v = new ObservableObjectValueStub<ObservableSet<Object>>(VALUE_1);
+        final ObservableObjectValueStub<ObservableSet<Object>> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -479,7 +479,7 @@ public class ReadOnlySetWrapperTest {
     @Test
     public void testInternalEagerBind_generic() {
         attachInternalChangeListener();
-        final ObservableObjectValueStub<ObservableSet<Object>> v = new ObservableObjectValueStub<ObservableSet<Object>>(VALUE_1);
+        final ObservableObjectValueStub<ObservableSet<Object>> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -515,7 +515,7 @@ public class ReadOnlySetWrapperTest {
     @Test
     public void testPublicEagerBind_generic() {
         attachPublicChangeListener();
-        final ObservableObjectValueStub<ObservableSet<Object>> v = new ObservableObjectValueStub<ObservableSet<Object>>(VALUE_1);
+        final ObservableObjectValueStub<ObservableSet<Object>> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -556,8 +556,8 @@ public class ReadOnlySetWrapperTest {
     @Test
     public void testRebind() {
         attachInvalidationListeners();
-        final SetProperty<Object> v1 = new SimpleSetProperty<Object>(VALUE_1);
-        final SetProperty<Object> v2 = new SimpleSetProperty<Object>(VALUE_2);
+        final SetProperty<Object> v1 = new SimpleSetProperty<>(VALUE_1);
+        final SetProperty<Object> v2 = new SimpleSetProperty<>(VALUE_2);
         property.bind(v1);
         property.get();
         readOnlyProperty.get();
@@ -603,7 +603,7 @@ public class ReadOnlySetWrapperTest {
     @Test
     public void testUnbind() {
         attachInvalidationListeners();
-        final SetProperty<Object> v = new SimpleSetProperty<Object>(VALUE_1);
+        final SetProperty<Object> v = new SimpleSetProperty<>(VALUE_1);
         property.bind(v);
         property.unbind();
         assertEquals(VALUE_1, property.get());
@@ -632,7 +632,7 @@ public class ReadOnlySetWrapperTest {
 
     @Test
     public void testAddingListenerWillAlwaysReceiveInvalidationEvent() {
-        final SetProperty<Object> v = new SimpleSetProperty<Object>(VALUE_1);
+        final SetProperty<Object> v = new SimpleSetProperty<>(VALUE_1);
         final InvalidationListenerMock internalListener2 = new InvalidationListenerMock();
         final InvalidationListenerMock internalListener3 = new InvalidationListenerMock();
         final InvalidationListenerMock publicListener2 = new InvalidationListenerMock();
@@ -686,15 +686,15 @@ public class ReadOnlySetWrapperTest {
         internalChangeListener.check(null, UNDEFINED, UNDEFINED, 0);
 
         // no read only property created => no-op
-        final ReadOnlySetWrapper<Object> v1 = new ReadOnlySetWrapper<Object>();
+        final ReadOnlySetWrapper<Object> v1 = new ReadOnlySetWrapper<>();
         v1.removeListener(internalInvalidationListener);
         v1.removeListener(internalChangeListener);
     }
 
     @Test
     public void testNoReadOnlyPropertyCreated() {
-        final SetProperty<Object> v1 = new SimpleSetProperty<Object>(VALUE_1);
-        final ReadOnlySetWrapper<Object> p1 = new ReadOnlySetWrapper<Object>();
+        final SetProperty<Object> v1 = new SimpleSetProperty<>(VALUE_1);
+        final ReadOnlySetWrapper<Object> p1 = new ReadOnlySetWrapper<>();
 
         p1.set(VALUE_1);
         p1.bind(v1);
@@ -705,7 +705,7 @@ public class ReadOnlySetWrapperTest {
 
     @Test
     public void testToString() {
-        final SetProperty<Object> v1 = new SimpleSetProperty<Object>(VALUE_1);
+        final SetProperty<Object> v1 = new SimpleSetProperty<>(VALUE_1);
 
         property.set(VALUE_1);
         assertEquals("SetProperty [value: " + VALUE_1 + "]", property.toString());
@@ -726,15 +726,15 @@ public class ReadOnlySetWrapperTest {
 
         final Object bean = new Object();
         final String name = "My name";
-        final ReadOnlySetWrapper<Object> v2 = new ReadOnlySetWrapper<Object>(bean, name);
+        final ReadOnlySetWrapper<Object> v2 = new ReadOnlySetWrapper<>(bean, name);
         assertEquals("SetProperty [bean: " + bean.toString() + ", name: My name, value: " + DEFAULT + "]", v2.toString());
         assertEquals("ReadOnlySetProperty [bean: " + bean.toString() + ", name: My name, value: " + DEFAULT + "]", v2.getReadOnlyProperty().toString());
 
-        final ReadOnlySetWrapper<Object> v3 = new ReadOnlySetWrapper<Object>(bean, "");
+        final ReadOnlySetWrapper<Object> v3 = new ReadOnlySetWrapper<>(bean, "");
         assertEquals("SetProperty [bean: " + bean.toString() + ", value: " + DEFAULT + "]", v3.toString());
         assertEquals("ReadOnlySetProperty [bean: " + bean.toString() + ", value: " + DEFAULT + "]", v3.getReadOnlyProperty().toString());
 
-        final ReadOnlySetWrapper<Object> v4 = new ReadOnlySetWrapper<Object>(null, name);
+        final ReadOnlySetWrapper<Object> v4 = new ReadOnlySetWrapper<>(null, name);
         assertEquals("SetProperty [name: My name, value: " + DEFAULT + "]", v4.toString());
         assertEquals("ReadOnlySetProperty [name: My name, value: " + DEFAULT + "]", v4.getReadOnlyProperty().toString());
     }

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyStringPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyStringPropertyBaseTest.java
@@ -47,7 +47,7 @@ public class ReadOnlyStringPropertyBaseTest {
     public void setUp() throws Exception {
         property = new ReadOnlyPropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<String>(UNDEFINED);
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     @Test

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyStringPropertyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyStringPropertyTest.java
@@ -26,8 +26,6 @@
 package test.javafx.beans.property;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 import javafx.beans.InvalidationListener;
 import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.value.ChangeListener;

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyStringWrapperTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/ReadOnlyStringWrapperTest.java
@@ -62,8 +62,8 @@ public class ReadOnlyStringWrapperTest {
         readOnlyProperty = property.getReadOnlyProperty();
         internalInvalidationListener = new InvalidationListenerMock();
         publicInvalidationListener = new InvalidationListenerMock();
-        internalChangeListener = new ChangeListenerMock<String>(UNDEFINED);
-        publicChangeListener = new ChangeListenerMock<String>(UNDEFINED);
+        internalChangeListener = new ChangeListenerMock<>(UNDEFINED);
+        publicChangeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     private void attachInvalidationListeners() {
@@ -91,13 +91,13 @@ public class ReadOnlyStringWrapperTest {
     public void testConstructor_NoArguments() {
         final ReadOnlyStringWrapper p1 = new ReadOnlyStringWrapper();
         assertEquals(DEFAULT, p1.get());
-        assertEquals((String)DEFAULT, p1.getValue());
+        assertEquals(DEFAULT, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(null, p1.getBean());
         assertEquals("", p1.getName());
         final ReadOnlyStringProperty r1 = p1.getReadOnlyProperty();
         assertEquals(DEFAULT, r1.get());
-        assertEquals((String)DEFAULT, r1.getValue());
+        assertEquals(DEFAULT, r1.getValue());
         assertEquals(null, r1.getBean());
         assertEquals("", r1.getName());
     }
@@ -106,13 +106,13 @@ public class ReadOnlyStringWrapperTest {
     public void testConstructor_InitialValue() {
         final ReadOnlyStringWrapper p1 = new ReadOnlyStringWrapper(VALUE_1);
         assertEquals(VALUE_1, p1.get());
-        assertEquals((String)VALUE_1, p1.getValue());
+        assertEquals(VALUE_1, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(null, p1.getBean());
         assertEquals("", p1.getName());
         final ReadOnlyStringProperty r1 = p1.getReadOnlyProperty();
         assertEquals(VALUE_1, r1.get());
-        assertEquals((String)VALUE_1, r1.getValue());
+        assertEquals(VALUE_1, r1.getValue());
         assertEquals(null, r1.getBean());
         assertEquals("", r1.getName());
     }
@@ -123,13 +123,13 @@ public class ReadOnlyStringWrapperTest {
         final String name = "My name";
         final ReadOnlyStringWrapper p1 = new ReadOnlyStringWrapper(bean, name);
         assertEquals(DEFAULT, p1.get());
-        assertEquals((String)DEFAULT, p1.getValue());
+        assertEquals(DEFAULT, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(bean, p1.getBean());
         assertEquals(name, p1.getName());
         final ReadOnlyStringProperty r1 = p1.getReadOnlyProperty();
         assertEquals(DEFAULT, r1.get());
-        assertEquals((String)DEFAULT, r1.getValue());
+        assertEquals(DEFAULT, r1.getValue());
         assertEquals(bean, r1.getBean());
         assertEquals(name, r1.getName());
     }
@@ -140,13 +140,13 @@ public class ReadOnlyStringWrapperTest {
         final String name = "My name";
         final ReadOnlyStringWrapper p1 = new ReadOnlyStringWrapper(bean, name, VALUE_1);
         assertEquals(VALUE_1, p1.get());
-        assertEquals((String)VALUE_1, p1.getValue());
+        assertEquals(VALUE_1, p1.getValue());
         assertFalse(property.isBound());
         assertEquals(bean, p1.getBean());
         assertEquals(name, p1.getName());
         final ReadOnlyStringProperty r1 = p1.getReadOnlyProperty();
         assertEquals(VALUE_1, r1.get());
-        assertEquals((String)VALUE_1, r1.getValue());
+        assertEquals(VALUE_1, r1.getValue());
         assertEquals(bean, r1.getBean());
         assertEquals(name, r1.getName());
     }
@@ -441,7 +441,7 @@ public class ReadOnlyStringWrapperTest {
     @Test
     public void testLazyBind_generic() {
         attachInvalidationListeners();
-        final ObservableObjectValueStub<String> v = new ObservableObjectValueStub<String>(VALUE_1);
+        final ObservableObjectValueStub<String> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -481,7 +481,7 @@ public class ReadOnlyStringWrapperTest {
     @Test
     public void testInternalEagerBind_generic() {
         attachInternalChangeListener();
-        final ObservableObjectValueStub<String> v = new ObservableObjectValueStub<String>(VALUE_1);
+        final ObservableObjectValueStub<String> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());
@@ -517,7 +517,7 @@ public class ReadOnlyStringWrapperTest {
     @Test
     public void testPublicEagerBind_generic() {
         attachPublicChangeListener();
-        final ObservableObjectValueStub<String> v = new ObservableObjectValueStub<String>(VALUE_1);
+        final ObservableObjectValueStub<String> v = new ObservableObjectValueStub<>(VALUE_1);
 
         property.bind(v);
         assertEquals(VALUE_1, property.get());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/SetPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/SetPropertyBaseTest.java
@@ -26,7 +26,6 @@
 package test.javafx.beans.property;
 
 import test.javafx.collections.MockSetObserver;
-import java.util.HashSet;
 import javafx.beans.property.SetProperty;
 import javafx.beans.property.SetPropertyBase;
 import javafx.beans.property.SimpleSetProperty;
@@ -66,8 +65,8 @@ public class SetPropertyBaseTest {
     public void setUp() throws Exception {
         property = new SetPropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<ObservableSet<Object>>(UNDEFINED);
-        setChangeListener = new MockSetObserver<Object>();
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
+        setChangeListener = new MockSetObserver<>();
     }
 
     private void attachInvalidationListener() {
@@ -90,12 +89,12 @@ public class SetPropertyBaseTest {
 
     @Test
     public void testConstructor() {
-        final SetProperty<Object> p1 = new SimpleSetProperty<Object>();
+        final SetProperty<Object> p1 = new SimpleSetProperty<>();
         assertEquals(null, p1.get());
         assertEquals(null, p1.getValue());
         assertFalse(property.isBound());
 
-        final SetProperty<Object> p2 = new SimpleSetProperty<Object>(VALUE_1b);
+        final SetProperty<Object> p2 = new SimpleSetProperty<>(VALUE_1b);
         assertEquals(VALUE_1b, p2.get());
         assertEquals(VALUE_1b, p2.getValue());
         assertFalse(property.isBound());
@@ -438,7 +437,7 @@ public class SetPropertyBaseTest {
 
     @Test(expected = RuntimeException.class)
     public void testSetBoundValue() {
-        final SetProperty<Object> v = new SimpleSetProperty<Object>(VALUE_1a);
+        final SetProperty<Object> v = new SimpleSetProperty<>(VALUE_1a);
         property.bind(v);
         property.set(VALUE_1a);
     }
@@ -446,7 +445,7 @@ public class SetPropertyBaseTest {
     @Test
     public void testBind_Invalidation() {
         attachInvalidationListener();
-        final ObservableObjectValueStub<ObservableSet<Object>> v = new ObservableObjectValueStub<ObservableSet<Object>>(FXCollections.observableSet(VALUE_1a));
+        final ObservableObjectValueStub<ObservableSet<Object>> v = new ObservableObjectValueStub<>(FXCollections.observableSet(VALUE_1a));
 
         property.bind(v);
         assertEquals(VALUE_1a, property.get());
@@ -478,7 +477,7 @@ public class SetPropertyBaseTest {
     @Test
     public void testBind_Change() {
         attachChangeListener();
-        final ObservableObjectValueStub<ObservableSet<Object>> v = new ObservableObjectValueStub<ObservableSet<Object>>(FXCollections.observableSet(VALUE_1a));
+        final ObservableObjectValueStub<ObservableSet<Object>> v = new ObservableObjectValueStub<>(FXCollections.observableSet(VALUE_1a));
 
         property.bind(v);
         assertEquals(VALUE_1a, property.get());
@@ -510,7 +509,7 @@ public class SetPropertyBaseTest {
     @Test
     public void testBind_SetChange() {
         attachSetChangeListener();
-        final ObservableObjectValueStub<ObservableSet<Object>> v = new ObservableObjectValueStub<ObservableSet<Object>>(FXCollections.observableSet(VALUE_1a));
+        final ObservableObjectValueStub<ObservableSet<Object>> v = new ObservableObjectValueStub<>(FXCollections.observableSet(VALUE_1a));
 
         property.bind(v);
         assertEquals(VALUE_1a, property.get());
@@ -550,8 +549,8 @@ public class SetPropertyBaseTest {
     @Test
     public void testRebind() {
         attachInvalidationListener();
-        final SetProperty<Object> v1 = new SimpleSetProperty<Object>(VALUE_1a);
-        final SetProperty<Object> v2 = new SimpleSetProperty<Object>(VALUE_2a);
+        final SetProperty<Object> v1 = new SimpleSetProperty<>(VALUE_1a);
+        final SetProperty<Object> v2 = new SimpleSetProperty<>(VALUE_2a);
         property.bind(v1);
         property.get();
         property.reset();
@@ -625,7 +624,7 @@ public class SetPropertyBaseTest {
     @Test
     public void testUnbind() {
         attachInvalidationListener();
-        final SetProperty<Object> v = new SimpleSetProperty<Object>(VALUE_1a);
+        final SetProperty<Object> v = new SimpleSetProperty<>(VALUE_1a);
         property.bind(v);
         property.unbind();
         assertEquals(VALUE_1a, property.get());
@@ -649,7 +648,7 @@ public class SetPropertyBaseTest {
 
     @Test
     public void testAddingListenerWillAlwaysReceiveInvalidationEvent() {
-        final SetProperty<Object> v = new SimpleSetProperty<Object>(VALUE_1a);
+        final SetProperty<Object> v = new SimpleSetProperty<>(VALUE_1a);
         final InvalidationListenerMock listener2 = new InvalidationListenerMock();
         final InvalidationListenerMock listener3 = new InvalidationListenerMock();
 
@@ -675,7 +674,7 @@ public class SetPropertyBaseTest {
         final ObservableSet<Object> value0 = null;
         final ObservableSet<Object> value1 = FXCollections.observableSet(new Object(), new Object());
         final ObservableSet<Object> value2 = FXCollections.observableSet();
-        final SetProperty<Object> v = new SimpleSetProperty<Object>(value2);
+        final SetProperty<Object> v = new SimpleSetProperty<>(value2);
 
         property.set(value1);
         assertEquals("SetProperty [value: " + value1 + "]", property.toString());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/SetPropertyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/SetPropertyTest.java
@@ -52,8 +52,8 @@ public class SetPropertyTest {
 
     @Test
     public void testBindBidirectional() {
-        final SetProperty<Object> p1 = new SimpleSetProperty<Object>(VALUE_2);
-        final SetProperty<Object> p2 = new SimpleSetProperty<Object>(VALUE_1);
+        final SetProperty<Object> p1 = new SimpleSetProperty<>(VALUE_2);
+        final SetProperty<Object> p2 = new SimpleSetProperty<>(VALUE_1);
 
         p1.bindBidirectional(p2);
         assertEquals(VALUE_1, p1.get());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/SimpleListPropertyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/SimpleListPropertyTest.java
@@ -43,7 +43,7 @@ public class SimpleListPropertyTest {
 
     @Test
     public void testConstructor_NoArguments() {
-        final ListProperty<Object> v = new SimpleListProperty<Object>();
+        final ListProperty<Object> v = new SimpleListProperty<>();
         assertEquals(DEFAULT_BEAN, v.getBean());
         assertEquals(DEFAULT_NAME, v.getName());
         assertEquals(DEFAULT_VALUE, v.get());
@@ -51,12 +51,12 @@ public class SimpleListPropertyTest {
 
     @Test
     public void testConstructor_InitialValue() {
-        final ListProperty<Object> v1 = new SimpleListProperty<Object>(VALUE_1);
+        final ListProperty<Object> v1 = new SimpleListProperty<>(VALUE_1);
         assertEquals(DEFAULT_BEAN, v1.getBean());
         assertEquals(DEFAULT_NAME, v1.getName());
         assertEquals(VALUE_1, v1.get());
 
-        final ListProperty<Object> v2 = new SimpleListProperty<Object>(DEFAULT_VALUE);
+        final ListProperty<Object> v2 = new SimpleListProperty<>(DEFAULT_VALUE);
         assertEquals(DEFAULT_BEAN, v2.getBean());
         assertEquals(DEFAULT_NAME, v2.getName());
         assertEquals(DEFAULT_VALUE, v2.get());
@@ -66,12 +66,12 @@ public class SimpleListPropertyTest {
     public void testConstructor_Bean_Name() {
         final Object bean = new Object();
         final String name = "My name";
-        final ListProperty<Object> v = new SimpleListProperty<Object>(bean, name);
+        final ListProperty<Object> v = new SimpleListProperty<>(bean, name);
         assertEquals(bean, v.getBean());
         assertEquals(name, v.getName());
         assertEquals(DEFAULT_VALUE, v.get());
 
-        final ListProperty<Object> v2 = new SimpleListProperty<Object>(bean, null);
+        final ListProperty<Object> v2 = new SimpleListProperty<>(bean, null);
         assertEquals(bean, v2.getBean());
         assertEquals(DEFAULT_NAME, v2.getName());
         assertEquals(DEFAULT_VALUE, v2.get());
@@ -81,22 +81,22 @@ public class SimpleListPropertyTest {
     public void testConstructor_Bean_Name_InitialValue() {
         final Object bean = new Object();
         final String name = "My name";
-        final ListProperty<Object> v1 = new SimpleListProperty<Object>(bean, name, VALUE_1);
+        final ListProperty<Object> v1 = new SimpleListProperty<>(bean, name, VALUE_1);
         assertEquals(bean, v1.getBean());
         assertEquals(name, v1.getName());
         assertEquals(VALUE_1, v1.get());
 
-        final ListProperty<Object> v2 = new SimpleListProperty<Object>(bean, name, DEFAULT_VALUE);
+        final ListProperty<Object> v2 = new SimpleListProperty<>(bean, name, DEFAULT_VALUE);
         assertEquals(bean, v2.getBean());
         assertEquals(name, v2.getName());
         assertEquals(DEFAULT_VALUE, v2.get());
 
-        final ListProperty<Object> v3 = new SimpleListProperty<Object>(bean, null, VALUE_1);
+        final ListProperty<Object> v3 = new SimpleListProperty<>(bean, null, VALUE_1);
         assertEquals(bean, v3.getBean());
         assertEquals(DEFAULT_NAME, v3.getName());
         assertEquals(VALUE_1, v3.get());
 
-        final ListProperty<Object> v4 = new SimpleListProperty<Object>(bean, null, DEFAULT_VALUE);
+        final ListProperty<Object> v4 = new SimpleListProperty<>(bean, null, DEFAULT_VALUE);
         assertEquals(bean, v4.getBean());
         assertEquals(DEFAULT_NAME, v4.getName());
         assertEquals(DEFAULT_VALUE, v4.get());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/SimpleObjectPropertyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/SimpleObjectPropertyTest.java
@@ -41,7 +41,7 @@ public class SimpleObjectPropertyTest {
 
     @Test
     public void testConstructor_NoArguments() {
-        final ObjectProperty<Object> v = new SimpleObjectProperty<Object>();
+        final ObjectProperty<Object> v = new SimpleObjectProperty<>();
         assertEquals(DEFAULT_BEAN, v.getBean());
         assertEquals(DEFAULT_NAME, v.getName());
         assertEquals(DEFAULT_VALUE, v.get());
@@ -49,12 +49,12 @@ public class SimpleObjectPropertyTest {
 
     @Test
     public void testConstructor_InitialValue() {
-        final ObjectProperty<Object> v1 = new SimpleObjectProperty<Object>(VALUE_1);
+        final ObjectProperty<Object> v1 = new SimpleObjectProperty<>(VALUE_1);
         assertEquals(DEFAULT_BEAN, v1.getBean());
         assertEquals(DEFAULT_NAME, v1.getName());
         assertEquals(VALUE_1, v1.get());
 
-        final ObjectProperty<Object> v2 = new SimpleObjectProperty<Object>(DEFAULT_VALUE);
+        final ObjectProperty<Object> v2 = new SimpleObjectProperty<>(DEFAULT_VALUE);
         assertEquals(DEFAULT_BEAN, v2.getBean());
         assertEquals(DEFAULT_NAME, v2.getName());
         assertEquals(DEFAULT_VALUE, v2.get());
@@ -64,12 +64,12 @@ public class SimpleObjectPropertyTest {
     public void testConstructor_Bean_Name() {
         final Object bean = new Object();
         final String name = "My name";
-        final ObjectProperty<Object> v = new SimpleObjectProperty<Object>(bean, name);
+        final ObjectProperty<Object> v = new SimpleObjectProperty<>(bean, name);
         assertEquals(bean, v.getBean());
         assertEquals(name, v.getName());
         assertEquals(DEFAULT_VALUE, v.get());
 
-        final ObjectProperty<Object> v2 = new SimpleObjectProperty<Object>(bean, null);
+        final ObjectProperty<Object> v2 = new SimpleObjectProperty<>(bean, null);
         assertEquals(bean, v2.getBean());
         assertEquals(DEFAULT_NAME, v2.getName());
         assertEquals(DEFAULT_VALUE, v2.get());
@@ -79,22 +79,22 @@ public class SimpleObjectPropertyTest {
     public void testConstructor_Bean_Name_InitialValue() {
         final Object bean = new Object();
         final String name = "My name";
-        final ObjectProperty<Object> v1 = new SimpleObjectProperty<Object>(bean, name, VALUE_1);
+        final ObjectProperty<Object> v1 = new SimpleObjectProperty<>(bean, name, VALUE_1);
         assertEquals(bean, v1.getBean());
         assertEquals(name, v1.getName());
         assertEquals(VALUE_1, v1.get());
 
-        final ObjectProperty<Object> v2 = new SimpleObjectProperty<Object>(bean, name, DEFAULT_VALUE);
+        final ObjectProperty<Object> v2 = new SimpleObjectProperty<>(bean, name, DEFAULT_VALUE);
         assertEquals(bean, v2.getBean());
         assertEquals(name, v2.getName());
         assertEquals(DEFAULT_VALUE, v2.get());
 
-        final ObjectProperty<Object> v3 = new SimpleObjectProperty<Object>(bean, null, VALUE_1);
+        final ObjectProperty<Object> v3 = new SimpleObjectProperty<>(bean, null, VALUE_1);
         assertEquals(bean, v3.getBean());
         assertEquals(DEFAULT_NAME, v3.getName());
         assertEquals(VALUE_1, v3.get());
 
-        final ObjectProperty<Object> v4 = new SimpleObjectProperty<Object>(bean, null, DEFAULT_VALUE);
+        final ObjectProperty<Object> v4 = new SimpleObjectProperty<>(bean, null, DEFAULT_VALUE);
         assertEquals(bean, v4.getBean());
         assertEquals(DEFAULT_NAME, v4.getName());
         assertEquals(DEFAULT_VALUE, v4.get());

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/StringPropertyBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/StringPropertyBaseTest.java
@@ -58,7 +58,7 @@ public class StringPropertyBaseTest {
     public void setUp() throws Exception {
         property = new StringPropertyMock();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<String>(UNDEFINED);
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
     }
 
     private void attachInvalidationListener() {

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/adapter/JavaBeanObjectPropertyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/adapter/JavaBeanObjectPropertyTest.java
@@ -57,7 +57,7 @@ public class JavaBeanObjectPropertyTest extends JavaBeanPropertyTestBase<Object>
 
     @Override
     protected Property<Object> createObservable(Object value) {
-        return new SimpleObjectProperty<Object>(value);
+        return new SimpleObjectProperty<>(value);
     }
 
     @Override

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/adapter/JavaBeanPropertyTestBase.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/adapter/JavaBeanPropertyTestBase.java
@@ -26,12 +26,10 @@
 package test.javafx.beans.property.adapter;
 
 import javafx.beans.InvalidationListener;
-import javafx.beans.Observable;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/modules/javafx.base/src/test/java/test/javafx/beans/property/adapter/ReadOnlyJavaBeanPropertyTestBase.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/property/adapter/ReadOnlyJavaBeanPropertyTestBase.java
@@ -26,11 +26,9 @@
 package test.javafx.beans.property.adapter;
 
 import javafx.beans.InvalidationListener;
-import javafx.beans.Observable;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/modules/javafx.base/src/test/java/test/javafx/beans/value/ObservableValueBaseTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/value/ObservableValueBaseTest.java
@@ -25,7 +25,6 @@
 
 package test.javafx.beans.value;
 
-import test.javafx.beans.value.ChangeListenerMock;
 import javafx.beans.InvalidationListener;
 import test.javafx.beans.InvalidationListenerMock;
 import javafx.beans.Observable;
@@ -47,9 +46,9 @@ public class ObservableValueBaseTest {
 
     @Before
     public void setUp() {
-        valueModel = new ObservableObjectValueStub<Object>();
+        valueModel = new ObservableObjectValueStub<>();
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<Object>(UNDEFINED_VALUE);
+        changeListener = new ChangeListenerMock<>(UNDEFINED_VALUE);
     }
 
     @Test

--- a/modules/javafx.base/src/test/java/test/javafx/beans/value/ObservableValueFluentBindingsTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/value/ObservableValueFluentBindingsTest.java
@@ -468,14 +468,14 @@ public class ObservableValueFluentBindingsTest {
                     super.addListener(listener);
 
                     subscribeCount++;
-                };
+                }
 
                 @Override
                 public void removeListener(InvalidationListener listener) {
                     super.removeListener(listener);
 
                     unsubscribeCount++;
-                };
+                }
             };
 
             private ObservableValue<String> observableValue =

--- a/modules/javafx.base/src/test/java/test/javafx/beans/value/WeakChangeListenerTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/value/WeakChangeListenerTest.java
@@ -37,13 +37,13 @@ public class WeakChangeListenerTest {
 
     @Test(expected=NullPointerException.class)
     public void testConstructWithNull() {
-        new WeakChangeListener<Object>(null);
+        new WeakChangeListener<>(null);
     }
 
     @Test
     public void testHandle() {
-        ChangeListenerMock<Object> listener = new ChangeListenerMock<Object>(new Object());
-        final WeakChangeListener<Object> weakListener = new WeakChangeListener<Object>(listener);
+        ChangeListenerMock<Object> listener = new ChangeListenerMock<>(new Object());
+        final WeakChangeListener<Object> weakListener = new WeakChangeListener<>(listener);
         final ObservableMock o = new ObservableMock();
         final Object obj1 = new Object();
         final Object obj2 = new Object();

--- a/modules/javafx.base/src/test/java/test/javafx/binding/BindingToStringTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/BindingToStringTest.java
@@ -155,8 +155,8 @@ public class BindingToStringTest {
     public void testObjectToString() {
         final Object value1 = new Object();
         final Object value2 = new Object();
-        final ObjectProperty<Object> v = new SimpleObjectProperty<Object>(value1);
-        final ObjectBinding<Object> binding = new ObjectBinding<Object>() {
+        final ObjectProperty<Object> v = new SimpleObjectProperty<>(value1);
+        final ObjectBinding<Object> binding = new ObjectBinding<>() {
             {bind(v);}
             @Override
             protected Object computeValue() {
@@ -199,8 +199,8 @@ public class BindingToStringTest {
     public void testListToString() {
         final ObservableList<Object> value1 = FXCollections.observableArrayList(new Object());
         final ObservableList<Object> value2 = FXCollections.observableArrayList(new Object(), new Object());
-        final ListProperty<Object> v = new SimpleListProperty<Object>(value1);
-        final ListBinding<Object> binding = new ListBinding<Object>() {
+        final ListProperty<Object> v = new SimpleListProperty<>(value1);
+        final ListBinding<Object> binding = new ListBinding<>() {
             {bind(v);}
             @Override
             protected ObservableList<Object> computeValue() {

--- a/modules/javafx.base/src/test/java/test/javafx/binding/BindingsArrayTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/BindingsArrayTest.java
@@ -63,7 +63,7 @@ public class BindingsArrayTest {
 
     @Before
     public void setUp() {
-        property = new SimpleListProperty<Object>();
+        property = new SimpleListProperty<>();
         list1 = FXCollections.<Object>observableArrayList(data1, data2);
         list2 = FXCollections.<Object>observableArrayList();
         index = new SimpleIntegerProperty();
@@ -277,7 +277,7 @@ public class BindingsArrayTest {
         final boolean defaultData = false;
         final boolean localData1 = false;
         final boolean localData2 = true;
-        final ListProperty<Boolean> localProperty = new SimpleListProperty<Boolean>();
+        final ListProperty<Boolean> localProperty = new SimpleListProperty<>();
         final ObservableList<Boolean> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Boolean> localList2 = FXCollections.observableArrayList();
 
@@ -337,7 +337,7 @@ public class BindingsArrayTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testBooleanValueAt_Constant_NegativeIndex() {
-        final ListProperty<Boolean> localProperty = new SimpleListProperty<Boolean>();
+        final ListProperty<Boolean> localProperty = new SimpleListProperty<>();
         Bindings.booleanValueAt(localProperty, -1);
     }
 
@@ -346,7 +346,7 @@ public class BindingsArrayTest {
         final boolean defaultData = false;
         final boolean localData1 = false;
         final boolean localData2 = true;
-        final ListProperty<Boolean> localProperty = new SimpleListProperty<Boolean>();
+        final ListProperty<Boolean> localProperty = new SimpleListProperty<>();
         final ObservableList<Boolean> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Boolean> localList2 = FXCollections.observableArrayList();
 
@@ -429,7 +429,7 @@ public class BindingsArrayTest {
 
     @Test(expected = NullPointerException.class)
     public void testBooleanValueAt_Variable_NullIndex() {
-        final ListProperty<Boolean> localProperty = new SimpleListProperty<Boolean>();
+        final ListProperty<Boolean> localProperty = new SimpleListProperty<>();
         Bindings.booleanValueAt(localProperty, null);
     }
 
@@ -438,7 +438,7 @@ public class BindingsArrayTest {
         final double defaultData = 0.0;
         final double localData1 = Math.PI;
         final double localData2 = -Math.E;
-        final ListProperty<Double> localProperty = new SimpleListProperty<Double>();
+        final ListProperty<Double> localProperty = new SimpleListProperty<>();
         final ObservableList<Double> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Double> localList2 = FXCollections.observableArrayList();
 
@@ -498,7 +498,7 @@ public class BindingsArrayTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testDoubleValueAt_Constant_NegativeIndex() {
-        final ListProperty<Double> localProperty = new SimpleListProperty<Double>();
+        final ListProperty<Double> localProperty = new SimpleListProperty<>();
         Bindings.doubleValueAt(localProperty, -1);
     }
 
@@ -507,7 +507,7 @@ public class BindingsArrayTest {
         final double defaultData = 0.0;
         final double localData1 = -Math.PI;
         final double localData2 = Math.E;
-        final ListProperty<Double> localProperty = new SimpleListProperty<Double>();
+        final ListProperty<Double> localProperty = new SimpleListProperty<>();
         final ObservableList<Double> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Double> localList2 = FXCollections.observableArrayList();
 
@@ -590,7 +590,7 @@ public class BindingsArrayTest {
 
     @Test(expected = NullPointerException.class)
     public void testDoubleValueAt_Variable_NullIndex() {
-        final ListProperty<Double> localProperty = new SimpleListProperty<Double>();
+        final ListProperty<Double> localProperty = new SimpleListProperty<>();
         Bindings.doubleValueAt(localProperty, null);
     }
 
@@ -599,7 +599,7 @@ public class BindingsArrayTest {
         final float defaultData = 0.0f;
         final float localData1 = (float)Math.PI;
         final float localData2 = (float)-Math.E;
-        final ListProperty<Float> localProperty = new SimpleListProperty<Float>();
+        final ListProperty<Float> localProperty = new SimpleListProperty<>();
         final ObservableList<Float> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Float> localList2 = FXCollections.observableArrayList();
 
@@ -659,7 +659,7 @@ public class BindingsArrayTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testFloatValueAt_Constant_NegativeIndex() {
-        final ListProperty<Float> localProperty = new SimpleListProperty<Float>();
+        final ListProperty<Float> localProperty = new SimpleListProperty<>();
         Bindings.floatValueAt(localProperty, -1);
     }
 
@@ -668,7 +668,7 @@ public class BindingsArrayTest {
         final float defaultData = 0.0f;
         final float localData1 = (float)-Math.PI;
         final float localData2 = (float)Math.E;
-        final ListProperty<Float> localProperty = new SimpleListProperty<Float>();
+        final ListProperty<Float> localProperty = new SimpleListProperty<>();
         final ObservableList<Float> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Float> localList2 = FXCollections.observableArrayList();
 
@@ -751,7 +751,7 @@ public class BindingsArrayTest {
 
     @Test(expected = NullPointerException.class)
     public void testFloatValueAt_Variable_NullIndex() {
-        final ListProperty<Float> localProperty = new SimpleListProperty<Float>();
+        final ListProperty<Float> localProperty = new SimpleListProperty<>();
         Bindings.floatValueAt(localProperty, null);
     }
 
@@ -760,7 +760,7 @@ public class BindingsArrayTest {
         final int defaultData = 0;
         final int localData1 = 42;
         final int localData2 = -7;
-        final ListProperty<Integer> localProperty = new SimpleListProperty<Integer>();
+        final ListProperty<Integer> localProperty = new SimpleListProperty<>();
         final ObservableList<Integer> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Integer> localList2 = FXCollections.observableArrayList();
 
@@ -820,7 +820,7 @@ public class BindingsArrayTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testIntegerValueAt_Constant_NegativeIndex() {
-        final ListProperty<Integer> localProperty = new SimpleListProperty<Integer>();
+        final ListProperty<Integer> localProperty = new SimpleListProperty<>();
         Bindings.integerValueAt(localProperty, -1);
     }
 
@@ -829,7 +829,7 @@ public class BindingsArrayTest {
         final int defaultData = 0;
         final int localData1 = 42;
         final int localData2 = -7;
-        final ListProperty<Integer> localProperty = new SimpleListProperty<Integer>();
+        final ListProperty<Integer> localProperty = new SimpleListProperty<>();
         final ObservableList<Integer> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Integer> localList2 = FXCollections.observableArrayList();
 
@@ -912,7 +912,7 @@ public class BindingsArrayTest {
 
     @Test(expected = NullPointerException.class)
     public void testIntegerValueAt_Variable_NullIndex() {
-        final ListProperty<Integer> localProperty = new SimpleListProperty<Integer>();
+        final ListProperty<Integer> localProperty = new SimpleListProperty<>();
         Bindings.integerValueAt(localProperty, null);
     }
 
@@ -921,7 +921,7 @@ public class BindingsArrayTest {
         final long defaultData = 0L;
         final long localData1 = 1234567890987654321L;
         final long localData2 = -987654321987654321L;
-        final ListProperty<Long> localProperty = new SimpleListProperty<Long>();
+        final ListProperty<Long> localProperty = new SimpleListProperty<>();
         final ObservableList<Long> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Long> localList2 = FXCollections.observableArrayList();
 
@@ -981,7 +981,7 @@ public class BindingsArrayTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testLongValueAt_Constant_NegativeIndex() {
-        final ListProperty<Long> localProperty = new SimpleListProperty<Long>();
+        final ListProperty<Long> localProperty = new SimpleListProperty<>();
         Bindings.longValueAt(localProperty, -1);
     }
 
@@ -990,7 +990,7 @@ public class BindingsArrayTest {
         final long defaultData = 0;
         final long localData1 = 98765432123456789L;
         final long localData2 = -1234567890123456789L;
-        final ListProperty<Long> localProperty = new SimpleListProperty<Long>();
+        final ListProperty<Long> localProperty = new SimpleListProperty<>();
         final ObservableList<Long> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Long> localList2 = FXCollections.observableArrayList();
 
@@ -1073,7 +1073,7 @@ public class BindingsArrayTest {
 
     @Test(expected = NullPointerException.class)
     public void testLongValueAt_Variable_NullIndex() {
-        final ListProperty<Long> localProperty = new SimpleListProperty<Long>();
+        final ListProperty<Long> localProperty = new SimpleListProperty<>();
         Bindings.longValueAt(localProperty, null);
     }
 
@@ -1082,7 +1082,7 @@ public class BindingsArrayTest {
         final String defaultData = null;
         final String localData1 = "Hello World";
         final String localData2 = "Goodbye World";
-        final ListProperty<String> localProperty = new SimpleListProperty<String>();
+        final ListProperty<String> localProperty = new SimpleListProperty<>();
         final ObservableList<String> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<String> localList2 = FXCollections.observableArrayList();
 
@@ -1142,7 +1142,7 @@ public class BindingsArrayTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testStringValueAt_Constant_NegativeIndex() {
-        final ListProperty<String> localProperty = new SimpleListProperty<String>();
+        final ListProperty<String> localProperty = new SimpleListProperty<>();
         Bindings.stringValueAt(localProperty, -1);
     }
 
@@ -1151,7 +1151,7 @@ public class BindingsArrayTest {
         final String defaultData = null;
         final String localData1 = "Goodbye";
         final String localData2 = "Hello";
-        final ListProperty<String> localProperty = new SimpleListProperty<String>();
+        final ListProperty<String> localProperty = new SimpleListProperty<>();
         final ObservableList<String> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<String> localList2 = FXCollections.observableArrayList();
 
@@ -1223,7 +1223,7 @@ public class BindingsArrayTest {
 
     @Test(expected = NullPointerException.class)
     public void testStringValueAt_Variable_NullIndex() {
-        final ListProperty<String> localProperty = new SimpleListProperty<String>();
+        final ListProperty<String> localProperty = new SimpleListProperty<>();
         Bindings.stringValueAt(localProperty, null);
     }
 

--- a/modules/javafx.base/src/test/java/test/javafx/binding/BindingsEqualsTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/BindingsEqualsTest.java
@@ -218,8 +218,8 @@ public class BindingsEqualsTest<T> {
         final String[] stringData = new String[] {null, "Hello", "Hello World"};
         final String[] ciStringData = new String[] {null, "hello", "HELLO"};
 
-        final ObjectProperty<Object> object1 = new SimpleObjectProperty<Object>();
-        final ObjectProperty<Object> object2 = new SimpleObjectProperty<Object>();
+        final ObjectProperty<Object> object1 = new SimpleObjectProperty<>();
+        final ObjectProperty<Object> object2 = new SimpleObjectProperty<>();
         final Object[] objectData = new Object[] {new Object(), new Object(), new Object()};
 
         return Arrays.asList(new Object[][] {
@@ -1342,6 +1342,6 @@ public class BindingsEqualsTest<T> {
                 objectData
             },
         });
-    };
+    }
 
 }

--- a/modules/javafx.base/src/test/java/test/javafx/binding/BindingsIsNullTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/BindingsIsNullTest.java
@@ -47,7 +47,7 @@ public class BindingsIsNullTest {
 
     @Before
     public void setUp() {
-        oo = new SimpleObjectProperty<Object>();
+        oo = new SimpleObjectProperty<>();
         os = new SimpleStringProperty();
         observer = new InvalidationListenerMock();
     }

--- a/modules/javafx.base/src/test/java/test/javafx/binding/BindingsListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/BindingsListTest.java
@@ -61,7 +61,7 @@ public class BindingsListTest {
 
     @Before
     public void setUp() {
-        property = new SimpleListProperty<Object>();
+        property = new SimpleListProperty<>();
         list1 = FXCollections.<Object>observableArrayList(data1, data2);
         list2 = FXCollections.<Object>observableArrayList();
         index = new SimpleIntegerProperty();
@@ -275,7 +275,7 @@ public class BindingsListTest {
         final boolean defaultData = false;
         final boolean localData1 = false;
         final boolean localData2 = true;
-        final ListProperty<Boolean> localProperty = new SimpleListProperty<Boolean>();
+        final ListProperty<Boolean> localProperty = new SimpleListProperty<>();
         final ObservableList<Boolean> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Boolean> localList2 = FXCollections.observableArrayList();
 
@@ -335,7 +335,7 @@ public class BindingsListTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testBooleanValueAt_Constant_NegativeIndex() {
-        final ListProperty<Boolean> localProperty = new SimpleListProperty<Boolean>();
+        final ListProperty<Boolean> localProperty = new SimpleListProperty<>();
         Bindings.booleanValueAt(localProperty, -1);
     }
 
@@ -344,7 +344,7 @@ public class BindingsListTest {
         final boolean defaultData = false;
         final boolean localData1 = false;
         final boolean localData2 = true;
-        final ListProperty<Boolean> localProperty = new SimpleListProperty<Boolean>();
+        final ListProperty<Boolean> localProperty = new SimpleListProperty<>();
         final ObservableList<Boolean> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Boolean> localList2 = FXCollections.observableArrayList();
 
@@ -427,7 +427,7 @@ public class BindingsListTest {
 
     @Test(expected = NullPointerException.class)
     public void testBooleanValueAt_Variable_NullIndex() {
-        final ListProperty<Boolean> localProperty = new SimpleListProperty<Boolean>();
+        final ListProperty<Boolean> localProperty = new SimpleListProperty<>();
         Bindings.booleanValueAt(localProperty, null);
     }
 
@@ -436,7 +436,7 @@ public class BindingsListTest {
         final double defaultData = 0.0;
         final double localData1 = Math.PI;
         final double localData2 = -Math.E;
-        final ListProperty<Double> localProperty = new SimpleListProperty<Double>();
+        final ListProperty<Double> localProperty = new SimpleListProperty<>();
         final ObservableList<Double> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Double> localList2 = FXCollections.observableArrayList();
 
@@ -496,7 +496,7 @@ public class BindingsListTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testDoubleValueAt_Constant_NegativeIndex() {
-        final ListProperty<Double> localProperty = new SimpleListProperty<Double>();
+        final ListProperty<Double> localProperty = new SimpleListProperty<>();
         Bindings.doubleValueAt(localProperty, -1);
     }
 
@@ -505,7 +505,7 @@ public class BindingsListTest {
         final double defaultData = 0.0;
         final double localData1 = -Math.PI;
         final double localData2 = Math.E;
-        final ListProperty<Double> localProperty = new SimpleListProperty<Double>();
+        final ListProperty<Double> localProperty = new SimpleListProperty<>();
         final ObservableList<Double> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Double> localList2 = FXCollections.observableArrayList();
 
@@ -588,7 +588,7 @@ public class BindingsListTest {
 
     @Test(expected = NullPointerException.class)
     public void testDoubleValueAt_Variable_NullIndex() {
-        final ListProperty<Double> localProperty = new SimpleListProperty<Double>();
+        final ListProperty<Double> localProperty = new SimpleListProperty<>();
         Bindings.doubleValueAt(localProperty, null);
     }
 
@@ -597,7 +597,7 @@ public class BindingsListTest {
         final float defaultData = 0.0f;
         final float localData1 = (float)Math.PI;
         final float localData2 = (float)-Math.E;
-        final ListProperty<Float> localProperty = new SimpleListProperty<Float>();
+        final ListProperty<Float> localProperty = new SimpleListProperty<>();
         final ObservableList<Float> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Float> localList2 = FXCollections.observableArrayList();
 
@@ -657,7 +657,7 @@ public class BindingsListTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testFloatValueAt_Constant_NegativeIndex() {
-        final ListProperty<Float> localProperty = new SimpleListProperty<Float>();
+        final ListProperty<Float> localProperty = new SimpleListProperty<>();
         Bindings.floatValueAt(localProperty, -1);
     }
 
@@ -666,7 +666,7 @@ public class BindingsListTest {
         final float defaultData = 0.0f;
         final float localData1 = (float)-Math.PI;
         final float localData2 = (float)Math.E;
-        final ListProperty<Float> localProperty = new SimpleListProperty<Float>();
+        final ListProperty<Float> localProperty = new SimpleListProperty<>();
         final ObservableList<Float> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Float> localList2 = FXCollections.observableArrayList();
 
@@ -749,7 +749,7 @@ public class BindingsListTest {
 
     @Test(expected = NullPointerException.class)
     public void testFloatValueAt_Variable_NullIndex() {
-        final ListProperty<Float> localProperty = new SimpleListProperty<Float>();
+        final ListProperty<Float> localProperty = new SimpleListProperty<>();
         Bindings.floatValueAt(localProperty, null);
     }
 
@@ -758,7 +758,7 @@ public class BindingsListTest {
         final int defaultData = 0;
         final int localData1 = 42;
         final int localData2 = -7;
-        final ListProperty<Integer> localProperty = new SimpleListProperty<Integer>();
+        final ListProperty<Integer> localProperty = new SimpleListProperty<>();
         final ObservableList<Integer> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Integer> localList2 = FXCollections.observableArrayList();
 
@@ -818,7 +818,7 @@ public class BindingsListTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testIntegerValueAt_Constant_NegativeIndex() {
-        final ListProperty<Integer> localProperty = new SimpleListProperty<Integer>();
+        final ListProperty<Integer> localProperty = new SimpleListProperty<>();
         Bindings.integerValueAt(localProperty, -1);
     }
 
@@ -827,7 +827,7 @@ public class BindingsListTest {
         final int defaultData = 0;
         final int localData1 = 42;
         final int localData2 = -7;
-        final ListProperty<Integer> localProperty = new SimpleListProperty<Integer>();
+        final ListProperty<Integer> localProperty = new SimpleListProperty<>();
         final ObservableList<Integer> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Integer> localList2 = FXCollections.observableArrayList();
 
@@ -910,7 +910,7 @@ public class BindingsListTest {
 
     @Test(expected = NullPointerException.class)
     public void testIntegerValueAt_Variable_NullIndex() {
-        final ListProperty<Integer> localProperty = new SimpleListProperty<Integer>();
+        final ListProperty<Integer> localProperty = new SimpleListProperty<>();
         Bindings.integerValueAt(localProperty, null);
     }
 
@@ -919,7 +919,7 @@ public class BindingsListTest {
         final long defaultData = 0L;
         final long localData1 = 1234567890987654321L;
         final long localData2 = -987654321987654321L;
-        final ListProperty<Long> localProperty = new SimpleListProperty<Long>();
+        final ListProperty<Long> localProperty = new SimpleListProperty<>();
         final ObservableList<Long> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Long> localList2 = FXCollections.observableArrayList();
 
@@ -979,7 +979,7 @@ public class BindingsListTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testLongValueAt_Constant_NegativeIndex() {
-        final ListProperty<Long> localProperty = new SimpleListProperty<Long>();
+        final ListProperty<Long> localProperty = new SimpleListProperty<>();
         Bindings.longValueAt(localProperty, -1);
     }
 
@@ -988,7 +988,7 @@ public class BindingsListTest {
         final long defaultData = 0;
         final long localData1 = 98765432123456789L;
         final long localData2 = -1234567890123456789L;
-        final ListProperty<Long> localProperty = new SimpleListProperty<Long>();
+        final ListProperty<Long> localProperty = new SimpleListProperty<>();
         final ObservableList<Long> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<Long> localList2 = FXCollections.observableArrayList();
 
@@ -1071,7 +1071,7 @@ public class BindingsListTest {
 
     @Test(expected = NullPointerException.class)
     public void testLongValueAt_Variable_NullIndex() {
-        final ListProperty<Long> localProperty = new SimpleListProperty<Long>();
+        final ListProperty<Long> localProperty = new SimpleListProperty<>();
         Bindings.longValueAt(localProperty, null);
     }
 
@@ -1080,7 +1080,7 @@ public class BindingsListTest {
         final String defaultData = null;
         final String localData1 = "Hello World";
         final String localData2 = "Goodbye World";
-        final ListProperty<String> localProperty = new SimpleListProperty<String>();
+        final ListProperty<String> localProperty = new SimpleListProperty<>();
         final ObservableList<String> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<String> localList2 = FXCollections.observableArrayList();
 
@@ -1140,7 +1140,7 @@ public class BindingsListTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testStringValueAt_Constant_NegativeIndex() {
-        final ListProperty<String> localProperty = new SimpleListProperty<String>();
+        final ListProperty<String> localProperty = new SimpleListProperty<>();
         Bindings.stringValueAt(localProperty, -1);
     }
 
@@ -1149,7 +1149,7 @@ public class BindingsListTest {
         final String defaultData = null;
         final String localData1 = "Goodbye";
         final String localData2 = "Hello";
-        final ListProperty<String> localProperty = new SimpleListProperty<String>();
+        final ListProperty<String> localProperty = new SimpleListProperty<>();
         final ObservableList<String> localList1 = FXCollections.observableArrayList(localData1, localData2);
         final ObservableList<String> localList2 = FXCollections.observableArrayList();
 
@@ -1221,7 +1221,7 @@ public class BindingsListTest {
 
     @Test(expected = NullPointerException.class)
     public void testStringValueAt_Variable_NullIndex() {
-        final ListProperty<String> localProperty = new SimpleListProperty<String>();
+        final ListProperty<String> localProperty = new SimpleListProperty<>();
         Bindings.stringValueAt(localProperty, null);
     }
 

--- a/modules/javafx.base/src/test/java/test/javafx/binding/BindingsMapTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/BindingsMapTest.java
@@ -63,7 +63,7 @@ public class BindingsMapTest {
 
     @Before
     public void setUp() {
-        property = new SimpleMapProperty<String, Object>();
+        property = new SimpleMapProperty<>();
         map1 = FXCollections.observableHashMap();
         map1.put(key1, data1);
         map1.put(key2, data2);
@@ -254,7 +254,7 @@ public class BindingsMapTest {
         final boolean defaultData = false;
         final boolean localData1 = false;
         final boolean localData2 = true;
-        final MapProperty<String, Boolean> localProperty = new SimpleMapProperty<String, Boolean>();
+        final MapProperty<String, Boolean> localProperty = new SimpleMapProperty<>();
         final ObservableMap<String, Boolean> localMap1 = FXCollections.observableHashMap();
         localMap1.put(key1, localData1);
         localMap1.put(key2, localData2);
@@ -320,7 +320,7 @@ public class BindingsMapTest {
         final boolean defaultData = false;
         final boolean localData1 = false;
         final boolean localData2 = true;
-        final MapProperty<String, Boolean> localProperty = new SimpleMapProperty<String, Boolean>();
+        final MapProperty<String, Boolean> localProperty = new SimpleMapProperty<>();
         final ObservableMap<String, Boolean> localMap1 = FXCollections.observableHashMap();
         localMap1.put(key1, localData1);
         localMap1.put(key2, localData2);
@@ -395,7 +395,7 @@ public class BindingsMapTest {
 
     @Test(expected = NullPointerException.class)
     public void testBooleanValueAt_Variable_Null_2() {
-        final MapProperty<String, Boolean> localProperty = new SimpleMapProperty<String, Boolean>();
+        final MapProperty<String, Boolean> localProperty = new SimpleMapProperty<>();
         Bindings.booleanValueAt(localProperty, (ObservableValue<String>)null);
     }
 
@@ -404,7 +404,7 @@ public class BindingsMapTest {
         final double defaultData = 0.0;
         final double localData1 = Math.PI;
         final double localData2 = -Math.E;
-        final MapProperty<String, Double> localProperty = new SimpleMapProperty<String, Double>();
+        final MapProperty<String, Double> localProperty = new SimpleMapProperty<>();
         final ObservableMap<String, Double> localMap1 = FXCollections.observableHashMap();
         localMap1.put(key1, localData1);
         localMap1.put(key2, localData2);
@@ -470,7 +470,7 @@ public class BindingsMapTest {
         final double defaultData = 0.0;
         final double localData1 = -Math.PI;
         final double localData2 = Math.E;
-        final MapProperty<String, Double> localProperty = new SimpleMapProperty<String, Double>();
+        final MapProperty<String, Double> localProperty = new SimpleMapProperty<>();
         final ObservableMap<String, Double> localMap1 = FXCollections.observableHashMap();
         localMap1.put(key1, localData1);
         localMap1.put(key2, localData2);
@@ -545,7 +545,7 @@ public class BindingsMapTest {
 
     @Test(expected = NullPointerException.class)
     public void testDoubleValueAt_Variable_Null_2() {
-        final MapProperty<String, Double> localProperty = new SimpleMapProperty<String, Double>();
+        final MapProperty<String, Double> localProperty = new SimpleMapProperty<>();
         Bindings.doubleValueAt(localProperty, (ObservableValue<String>)null);
     }
 
@@ -554,7 +554,7 @@ public class BindingsMapTest {
         final float defaultData = 0.0f;
         final float localData1 = (float)Math.PI;
         final float localData2 = (float)-Math.E;
-        final MapProperty<String, Float> localProperty = new SimpleMapProperty<String, Float>();
+        final MapProperty<String, Float> localProperty = new SimpleMapProperty<>();
         final ObservableMap<String, Float> localMap1 = FXCollections.observableHashMap();
         localMap1.put(key1, localData1);
         localMap1.put(key2, localData2);
@@ -620,7 +620,7 @@ public class BindingsMapTest {
         final float defaultData = 0.0f;
         final float localData1 = (float)-Math.PI;
         final float localData2 = (float)Math.E;
-        final MapProperty<String, Float> localProperty = new SimpleMapProperty<String, Float>();
+        final MapProperty<String, Float> localProperty = new SimpleMapProperty<>();
         final ObservableMap<String, Float> localMap1 = FXCollections.observableHashMap();
         localMap1.put(key1, localData1);
         localMap1.put(key2, localData2);
@@ -695,7 +695,7 @@ public class BindingsMapTest {
 
     @Test(expected = NullPointerException.class)
     public void testFloatValueAt_Variable_Null_2() {
-        final MapProperty<String, Float> localProperty = new SimpleMapProperty<String, Float>();
+        final MapProperty<String, Float> localProperty = new SimpleMapProperty<>();
         Bindings.floatValueAt(localProperty, (ObservableValue<String>)null);
     }
 
@@ -704,7 +704,7 @@ public class BindingsMapTest {
         final int defaultData = 0;
         final int localData1 = 42;
         final int localData2 = -7;
-        final MapProperty<String, Integer> localProperty = new SimpleMapProperty<String, Integer>();
+        final MapProperty<String, Integer> localProperty = new SimpleMapProperty<>();
         final ObservableMap<String, Integer> localMap1 = FXCollections.observableHashMap();
         localMap1.put(key1, localData1);
         localMap1.put(key2, localData2);
@@ -770,7 +770,7 @@ public class BindingsMapTest {
         final int defaultData = 0;
         final int localData1 = 42;
         final int localData2 = -7;
-        final MapProperty<String, Integer> localProperty = new SimpleMapProperty<String, Integer>();
+        final MapProperty<String, Integer> localProperty = new SimpleMapProperty<>();
         final ObservableMap<String, Integer> localMap1 = FXCollections.observableHashMap();
         localMap1.put(key1, localData1);
         localMap1.put(key2, localData2);
@@ -845,7 +845,7 @@ public class BindingsMapTest {
 
     @Test(expected = NullPointerException.class)
     public void testIntegerValueAt_Variable_Null_2() {
-        final MapProperty<String, Integer> localProperty = new SimpleMapProperty<String, Integer>();
+        final MapProperty<String, Integer> localProperty = new SimpleMapProperty<>();
         Bindings.integerValueAt(localProperty, (ObservableValue<String>)null);
     }
 
@@ -854,7 +854,7 @@ public class BindingsMapTest {
         final long defaultData = 0L;
         final long localData1 = 1234567890987654321L;
         final long localData2 = -987654321987654321L;
-        final MapProperty<String, Long> localProperty = new SimpleMapProperty<String, Long>();
+        final MapProperty<String, Long> localProperty = new SimpleMapProperty<>();
         final ObservableMap<String, Long> localMap1 = FXCollections.observableHashMap();
         localMap1.put(key1, localData1);
         localMap1.put(key2, localData2);
@@ -920,7 +920,7 @@ public class BindingsMapTest {
         final long defaultData = 0;
         final long localData1 = 98765432123456789L;
         final long localData2 = -1234567890123456789L;
-        final MapProperty<String, Long> localProperty = new SimpleMapProperty<String, Long>();
+        final MapProperty<String, Long> localProperty = new SimpleMapProperty<>();
         final ObservableMap<String, Long> localMap1 = FXCollections.observableHashMap();
         localMap1.put(key1, localData1);
         localMap1.put(key2, localData2);
@@ -995,7 +995,7 @@ public class BindingsMapTest {
 
     @Test(expected = NullPointerException.class)
     public void testLongValueAt_Variable_Null_2() {
-        final MapProperty<String, Long> localProperty = new SimpleMapProperty<String, Long>();
+        final MapProperty<String, Long> localProperty = new SimpleMapProperty<>();
         Bindings.longValueAt(localProperty, (ObservableValue<String>)null);
     }
 
@@ -1004,7 +1004,7 @@ public class BindingsMapTest {
         final String defaultData = null;
         final String localData1 = "Hello World";
         final String localData2 = "Goodbye World";
-        final MapProperty<String, String> localProperty = new SimpleMapProperty<String, String>();
+        final MapProperty<String, String> localProperty = new SimpleMapProperty<>();
         final ObservableMap<String, String> localMap1 = FXCollections.observableHashMap();
         localMap1.put(key1, localData1);
         localMap1.put(key2, localData2);
@@ -1057,7 +1057,7 @@ public class BindingsMapTest {
         final String defaultData = null;
         final String localData1 = "Goodbye";
         final String localData2 = "Hello";
-        final MapProperty<String, String> localProperty = new SimpleMapProperty<String, String>();
+        final MapProperty<String, String> localProperty = new SimpleMapProperty<>();
         final ObservableMap<String, String> localMap1 = FXCollections.observableHashMap();
         localMap1.put(key1, localData1);
         localMap1.put(key2, localData2);
@@ -1120,7 +1120,7 @@ public class BindingsMapTest {
 
     @Test(expected = NullPointerException.class)
     public void testStringValueAt_Variable_Null_2() {
-        final MapProperty<String, String> localProperty = new SimpleMapProperty<String, String>();
+        final MapProperty<String, String> localProperty = new SimpleMapProperty<>();
         Bindings.stringValueAt(localProperty, (ObservableValue<String>)null);
     }
 

--- a/modules/javafx.base/src/test/java/test/javafx/binding/BindingsSetTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/BindingsSetTest.java
@@ -46,7 +46,7 @@ public class BindingsSetTest {
 
     @Before
     public void setUp() {
-        property = new SimpleSetProperty<Object>();
+        property = new SimpleSetProperty<>();
         set1 = FXCollections.observableSet(data1, data2);
         set2 = FXCollections.observableSet();
     }

--- a/modules/javafx.base/src/test/java/test/javafx/binding/GenericBindingTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/GenericBindingTest.java
@@ -76,7 +76,7 @@ public class GenericBindingTest<T> {
     @Before
     public void setUp() {
         invalidationListener = new InvalidationListenerMock();
-        changeListener = new ChangeListenerMock<Object>(UNDEFINED);
+        changeListener = new ChangeListenerMock<>(UNDEFINED);
         binding0.setValue(value2);
         binding1.setValue(value2);
         binding2.setValue(value2);
@@ -397,6 +397,7 @@ public class GenericBindingTest<T> {
             return value;
         }
 
+        @Override
         public ObservableList<?> getDependencies() {
             fail("Should not reach here");
             return null;
@@ -429,6 +430,7 @@ public class GenericBindingTest<T> {
             return value;
         }
 
+        @Override
         public ObservableList<?> getDependencies() {
             fail("Should not reach here");
             return null;
@@ -461,6 +463,7 @@ public class GenericBindingTest<T> {
             return value;
         }
 
+        @Override
         public ObservableList<?> getDependencies() {
             fail("Should not reach here");
             return null;
@@ -493,6 +496,7 @@ public class GenericBindingTest<T> {
             return value;
         }
 
+        @Override
         public ObservableList<?> getDependencies() {
             fail("Should not reach here");
             return null;
@@ -525,6 +529,7 @@ public class GenericBindingTest<T> {
             return value;
         }
 
+        @Override
         public ObservableList<?> getDependencies() {
             fail("Should not reach here");
             return null;
@@ -557,6 +562,7 @@ public class GenericBindingTest<T> {
             return value;
         }
 
+        @Override
         public ObservableList<?> getDependencies() {
             fail("Should not reach here");
             return null;
@@ -589,6 +595,7 @@ public class GenericBindingTest<T> {
             return value;
         }
 
+        @Override
         public ObservableList<?> getDependencies() {
             fail("Should not reach here");
             return null;
@@ -621,6 +628,7 @@ public class GenericBindingTest<T> {
             return value;
         }
 
+        @Override
         public ObservableList<?> getDependencies() {
             fail("Should not reach here");
             return null;

--- a/modules/javafx.base/src/test/java/test/javafx/binding/ListBindingTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/ListBindingTest.java
@@ -279,6 +279,7 @@ public class ListBindingTest {
             return value;
         }
 
+        @Override
         public ObservableList<?> getDependencies() {
             fail("Should not reach here");
             return null;

--- a/modules/javafx.base/src/test/java/test/javafx/binding/MapBindingTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/MapBindingTest.java
@@ -79,11 +79,11 @@ public class MapBindingTest {
         binding2 = new MapBindingImpl(dependency1, dependency2);
         emptyMap = FXCollections.observableMap(Collections.emptyMap());
         set1 = FXCollections.observableMap(Collections.singletonMap(KEY_1, DATA_1));
-        final Map<Object, Object> map = new HashMap<Object, Object>();
+        final Map<Object, Object> map = new HashMap<>();
         map.put(KEY_2_0, DATA_2_0);
         map.put(KEY_2_1, DATA_2_1);
         set2 = FXCollections.observableMap(map);
-        listener = new MockMapObserver<Object, Object>();
+        listener = new MockMapObserver<>();
         binding0.setValue(set2);
         binding1.setValue(set2);
         binding2.setValue(set2);
@@ -159,7 +159,7 @@ public class MapBindingTest {
         binding1.setValue(set1);
         dependency1.fireValueChangedEvent();
         assertEquals(1, binding1.getComputeValueCounter());
-        listener.assertMultipleCalls(new Call[]{new Call<Object, Object>(KEY_2_0, DATA_2_0, null), new Call<Object, Object>(KEY_2_1, DATA_2_1, null), new Call<Object, Object>(KEY_1, null, DATA_1)});
+        listener.assertMultipleCalls(new Call[]{new Call<>(KEY_2_0, DATA_2_0, null), new Call<>(KEY_2_1, DATA_2_1, null), new Call<>(KEY_1, null, DATA_1)});
         assertEquals(true, binding1.isValid());
         listener.clear();
 
@@ -190,7 +190,7 @@ public class MapBindingTest {
         binding1.setValue(set1);
         dependency1.fireValueChangedEvent();
         assertEquals(2, binding1.getComputeValueCounter());
-        listener.assertMultipleCalls(new Call[]{new Call<Object, Object>(KEY_2_0, DATA_2_0, null), new Call<Object, Object>(KEY_2_1, DATA_2_1, null), new Call<Object, Object>(KEY_1, null, DATA_1)});
+        listener.assertMultipleCalls(new Call[]{new Call<>(KEY_2_0, DATA_2_0, null), new Call<>(KEY_2_1, DATA_2_1, null), new Call<>(KEY_1, null, DATA_1)});
         assertEquals(true, binding1.isValid());
         listener.clear();
 
@@ -206,7 +206,7 @@ public class MapBindingTest {
         binding1.setValue(set2);
         dependency1.fireValueChangedEvent();
         assertEquals(2, binding1.getComputeValueCounter());
-        listener.assertMultipleCalls(new Call[] {new Call<Object, Object>(KEY_1, DATA_1, null), new Call<Object, Object>(KEY_2_0, null, DATA_2_0), new Call<Object, Object>(KEY_2_1, null, DATA_2_1)});
+        listener.assertMultipleCalls(new Call[] {new Call<>(KEY_1, DATA_1, null), new Call<>(KEY_2_0, null, DATA_2_0), new Call<>(KEY_2_1, null, DATA_2_1)});
         assertEquals(true, binding1.isValid());
         listener.clear();
 
@@ -300,6 +300,7 @@ public class MapBindingTest {
             return value;
         }
 
+        @Override
         public ObservableList<?> getDependencies() {
             fail("Should not reach here");
             return null;

--- a/modules/javafx.base/src/test/java/test/javafx/binding/SetBindingTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/SetBindingTest.java
@@ -73,7 +73,7 @@ public class SetBindingTest {
         emptySet = FXCollections.observableSet();
         set1 = FXCollections.observableSet(DATA_1);
         set2 = FXCollections.observableSet(DATA_2_0, DATA_2_1);
-        listener = new MockSetObserver<Object>();
+        listener = new MockSetObserver<>();
         binding0.setValue(set2);
         binding1.setValue(set2);
         binding2.setValue(set2);
@@ -149,7 +149,7 @@ public class SetBindingTest {
         binding1.setValue(set1);
         dependency1.fireValueChangedEvent();
         assertEquals(1, binding1.getComputeValueCounter());
-        listener.assertMultipleCalls(new Call[]{new Call<Object>(DATA_2_0, null), new Call<Object>(DATA_2_1, null), new Call<Object>(null, DATA_1)});
+        listener.assertMultipleCalls(new Call[]{new Call<>(DATA_2_0, null), new Call<>(DATA_2_1, null), new Call<>(null, DATA_1)});
         assertEquals(true, binding1.isValid());
         listener.clear();
 
@@ -180,7 +180,7 @@ public class SetBindingTest {
         binding1.setValue(set1);
         dependency1.fireValueChangedEvent();
         assertEquals(2, binding1.getComputeValueCounter());
-        listener.assertMultipleCalls(new Call[]{new Call<Object>(DATA_2_0, null), new Call<Object>(DATA_2_1, null), new Call<Object>(null, DATA_1)});
+        listener.assertMultipleCalls(new Call[]{new Call<>(DATA_2_0, null), new Call<>(DATA_2_1, null), new Call<>(null, DATA_1)});
         assertEquals(true, binding1.isValid());
         listener.clear();
 
@@ -196,7 +196,7 @@ public class SetBindingTest {
         binding1.setValue(set2);
         dependency1.fireValueChangedEvent();
         assertEquals(2, binding1.getComputeValueCounter());
-        listener.assertMultipleCalls(new Call[] {new Call<Object>(DATA_1, null), new Call<Object>(null, DATA_2_0), new Call<Object>(null, DATA_2_1)});
+        listener.assertMultipleCalls(new Call[] {new Call<>(DATA_1, null), new Call<>(null, DATA_2_0), new Call<>(null, DATA_2_1)});
         assertEquals(true, binding1.isValid());
         listener.clear();
 
@@ -290,6 +290,7 @@ public class SetBindingTest {
             return value;
         }
 
+        @Override
         public ObservableList<?> getDependencies() {
             fail("Should not reach here");
             return null;

--- a/modules/javafx.base/src/test/java/test/javafx/binding/Variable.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/Variable.java
@@ -39,7 +39,7 @@ public class Variable {
         this.name.set(name);
     }
 
-    private final ObjectProperty<Object> next = new SimpleObjectProperty<Object>() {
+    private final ObjectProperty<Object> next = new SimpleObjectProperty<>() {
         @Override
         public void addListener(InvalidationListener listener) {
             super.addListener(listener);

--- a/modules/javafx.base/src/test/java/test/javafx/binding/When_Object_Test.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/When_Object_Test.java
@@ -35,7 +35,7 @@ public class When_Object_Test extends WhenTestBase<Object, ObjectProperty<Object
     public When_Object_Test() {
         super(
             new Object(), new Object(), new Object(), new Object(),
-            new SimpleObjectProperty<Object>(), new SimpleObjectProperty<Object>()
+            new SimpleObjectProperty<>(), new SimpleObjectProperty<>()
         );
     }
 

--- a/modules/javafx.base/src/test/java/test/javafx/binding/expression/AbstractNumberExpressionTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/expression/AbstractNumberExpressionTest.java
@@ -56,7 +56,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-@SuppressWarnings("WebTest")
 public class AbstractNumberExpressionTest {
 
     private static final float EPSILON = 1e-6f;

--- a/modules/javafx.base/src/test/java/test/javafx/binding/expression/BooleanExpressionTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/expression/BooleanExpressionTest.java
@@ -179,7 +179,7 @@ public class BooleanExpressionTest {
 
     @Test
     public void testObjectToBoolean() {
-        final ObservableValueStub<Boolean> valueModel = new ObservableValueStub<Boolean>();
+        final ObservableValueStub<Boolean> valueModel = new ObservableValueStub<>();
         final BooleanExpression exp = BooleanExpression.booleanExpression(valueModel);
 
         assertTrue(exp instanceof BooleanBinding);

--- a/modules/javafx.base/src/test/java/test/javafx/binding/expression/DoubleExpressionTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/expression/DoubleExpressionTest.java
@@ -67,7 +67,7 @@ public class DoubleExpressionTest {
 
     @Test
     public void testGetters() {
-        assertEquals((double)data, op1.doubleValue(), EPSILON);
+        assertEquals(data, op1.doubleValue(), EPSILON);
         assertEquals((float)data, op1.floatValue(), EPSILON);
         assertEquals((long)data, op1.longValue());
         assertEquals((int)data, op1.intValue());
@@ -195,7 +195,7 @@ public class DoubleExpressionTest {
 
     @Test
     public void testObjectToDouble() {
-        final ObservableValueStub<Double> valueModel = new ObservableValueStub<Double>();
+        final ObservableValueStub<Double> valueModel = new ObservableValueStub<>();
         final DoubleExpression exp = DoubleExpression.doubleExpression(valueModel);
 
         assertTrue(exp instanceof DoubleBinding);

--- a/modules/javafx.base/src/test/java/test/javafx/binding/expression/FloatExpressionTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/expression/FloatExpressionTest.java
@@ -68,8 +68,8 @@ public class FloatExpressionTest {
 
     @Test
     public void testGetters() {
-        assertEquals((double)data, op1.doubleValue(), EPSILON);
-        assertEquals((float)data, op1.floatValue(), EPSILON);
+        assertEquals(data, op1.doubleValue(), EPSILON);
+        assertEquals(data, op1.floatValue(), EPSILON);
         assertEquals((long)data, op1.longValue());
         assertEquals((int)data, op1.intValue());
     }
@@ -197,7 +197,7 @@ public class FloatExpressionTest {
 
     @Test
     public void testObjectToFloat() {
-        final ObservableValueStub<Float> valueModel = new ObservableValueStub<Float>();
+        final ObservableValueStub<Float> valueModel = new ObservableValueStub<>();
         final FloatExpression exp = FloatExpression.floatExpression(valueModel);
 
         assertTrue(exp instanceof FloatBinding);

--- a/modules/javafx.base/src/test/java/test/javafx/binding/expression/IntegerExpressionTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/expression/IntegerExpressionTest.java
@@ -70,10 +70,10 @@ public class IntegerExpressionTest {
 
     @Test
     public void testGetters() {
-        assertEquals((double)data, op1.doubleValue(), EPSILON);
-        assertEquals((float)data, op1.floatValue(), EPSILON);
-        assertEquals((long)data, op1.longValue());
-        assertEquals((int)data, op1.intValue());
+        assertEquals(data, op1.doubleValue(), EPSILON);
+        assertEquals(data, op1.floatValue(), EPSILON);
+        assertEquals(data, op1.longValue());
+        assertEquals(data, op1.intValue());
     }
 
     @Test
@@ -198,7 +198,7 @@ public class IntegerExpressionTest {
 
     @Test
     public void testObjectToInteger() {
-        final ObservableValueStub<Integer> valueModel = new ObservableValueStub<Integer>();
+        final ObservableValueStub<Integer> valueModel = new ObservableValueStub<>();
         final IntegerExpression exp = IntegerExpression.integerExpression(valueModel);
 
         assertTrue(exp instanceof IntegerBinding);

--- a/modules/javafx.base/src/test/java/test/javafx/binding/expression/ListExpressionTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/expression/ListExpressionTest.java
@@ -56,10 +56,10 @@ public class ListExpressionTest {
 
     @Before
     public void setUp() {
-        opNull = new SimpleListProperty<Integer>();
-        opEmpty = new SimpleListProperty<Integer>(FXCollections.<Integer>observableArrayList());
-        op1 = new SimpleListProperty<Integer>(FXCollections.observableArrayList(data1_0));
-        op2 = new SimpleListProperty<Integer>(FXCollections.observableArrayList(data2_0, data2_1));
+        opNull = new SimpleListProperty<>();
+        opEmpty = new SimpleListProperty<>(FXCollections.<Integer>observableArrayList());
+        op1 = new SimpleListProperty<>(FXCollections.observableArrayList(data1_0));
+        op2 = new SimpleListProperty<>(FXCollections.observableArrayList(data2_0, data2_1));
     }
 
     @BeforeClass

--- a/modules/javafx.base/src/test/java/test/javafx/binding/expression/LongExpressionTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/expression/LongExpressionTest.java
@@ -69,9 +69,9 @@ public class LongExpressionTest {
 
     @Test
     public void testGetters() {
-        assertEquals((double)data, op1.doubleValue(), EPSILON);
-        assertEquals((float)data, op1.floatValue(), EPSILON);
-        assertEquals((long)data, op1.longValue());
+        assertEquals(data, op1.doubleValue(), EPSILON);
+        assertEquals(data, op1.floatValue(), EPSILON);
+        assertEquals(data, op1.longValue());
         assertEquals((int)data, op1.intValue());
     }
 
@@ -197,7 +197,7 @@ public class LongExpressionTest {
 
     @Test
     public void testObjectToLong() {
-        final ObservableValueStub<Long> valueModel = new ObservableValueStub<Long>();
+        final ObservableValueStub<Long> valueModel = new ObservableValueStub<>();
         final LongExpression exp = LongExpression.longExpression(valueModel);
 
         assertTrue(exp instanceof LongBinding);

--- a/modules/javafx.base/src/test/java/test/javafx/binding/expression/MapExpressionTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/expression/MapExpressionTest.java
@@ -59,13 +59,13 @@ public class MapExpressionTest {
 
     @Before
     public void setUp() {
-        opNull = new SimpleMapProperty<Number, Integer>();
-        opEmpty = new SimpleMapProperty<Number, Integer>(FXCollections.observableMap(Collections.<Number, Integer>emptyMap()));
-        op1 = new SimpleMapProperty<Number, Integer>(FXCollections.observableMap(Collections.singletonMap(key1_0, data1_0)));
-        final Map<Number, Integer> map = new HashMap<Number, Integer>();
+        opNull = new SimpleMapProperty<>();
+        opEmpty = new SimpleMapProperty<>(FXCollections.observableMap(Collections.<Number, Integer>emptyMap()));
+        op1 = new SimpleMapProperty<>(FXCollections.observableMap(Collections.singletonMap(key1_0, data1_0)));
+        final Map<Number, Integer> map = new HashMap<>();
         map.put(key2_0, data2_0);
         map.put(key2_1, data2_1);
-        op2 = new SimpleMapProperty<Number, Integer>(FXCollections.observableMap(map));
+        op2 = new SimpleMapProperty<>(FXCollections.observableMap(map));
     }
 
     @Test
@@ -116,7 +116,7 @@ public class MapExpressionTest {
     public void testIsEqualTo() {
         final ObservableMap<Number, Integer> emptyMap = FXCollections.observableMap(Collections.<Number, Integer>emptyMap());
         final ObservableMap<Number, Integer> map1 = FXCollections.observableMap(Collections.singletonMap(key1_0, data1_0));
-        final Map<Number, Integer> map = new HashMap<Number, Integer>();
+        final Map<Number, Integer> map = new HashMap<>();
         map.put(key2_0, data2_0);
         map.put(key2_1, data2_1);
         final ObservableMap<Number, Integer> map2= FXCollections.observableMap(map);
@@ -155,7 +155,7 @@ public class MapExpressionTest {
     public void testIsNotEqualTo() {
         final ObservableMap<Number, Integer> emptyMap = FXCollections.observableMap(Collections.<Number, Integer>emptyMap());
         final ObservableMap<Number, Integer> list1 = FXCollections.observableMap(Collections.singletonMap(key1_0, data1_0));
-        final Map<Number, Integer> map = new HashMap<Number, Integer>();
+        final Map<Number, Integer> map = new HashMap<>();
         map.put(key2_0, data2_0);
         map.put(key2_1, data2_1);
         final ObservableMap<Number, Integer> list2 = FXCollections.observableMap(map);

--- a/modules/javafx.base/src/test/java/test/javafx/binding/expression/ObjectExpressionTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/expression/ObjectExpressionTest.java
@@ -25,24 +25,17 @@
 
 package test.javafx.binding.expression;
 
-import java.util.Locale;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.binding.ObjectBinding;
 import javafx.beans.binding.ObjectExpression;
 import javafx.beans.binding.StringBinding;
-import javafx.beans.property.DoubleProperty;
-import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.SimpleDoubleProperty;
-import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ObservableObjectValueStub;
 import test.javafx.binding.DependencyUtils;
 import javafx.collections.FXCollections;
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Before;
 import org.junit.Test;
 
@@ -57,8 +50,8 @@ public class ObjectExpressionTest {
     public void setUp() {
         data1 = new Object();
         data2 = new Object();
-        op1 = new SimpleObjectProperty<Object>(data1);
-        op2 = new SimpleObjectProperty<Object>(data2);
+        op1 = new SimpleObjectProperty<>(data1);
+        op2 = new SimpleObjectProperty<>(data2);
     }
 
     @Test
@@ -96,7 +89,7 @@ public class ObjectExpressionTest {
         BooleanBinding binding = op1.isNull();
         assertEquals(false, binding.get());
 
-        ObjectProperty<Object> op3 = new SimpleObjectProperty<Object>(null);
+        ObjectProperty<Object> op3 = new SimpleObjectProperty<>(null);
         binding = op3.isNull();
         assertEquals(true, binding.get());
     }
@@ -106,14 +99,14 @@ public class ObjectExpressionTest {
         BooleanBinding binding = op1.isNotNull();
         assertEquals(true, binding.get());
 
-        ObjectProperty<Object> op3 = new SimpleObjectProperty<Object>(null);
+        ObjectProperty<Object> op3 = new SimpleObjectProperty<>(null);
         binding = op3.isNotNull();
         assertEquals(false, binding.get());
     }
 
     @Test
     public void testFactory() {
-        final ObservableObjectValueStub<Object> valueModel = new ObservableObjectValueStub<Object>();
+        final ObservableObjectValueStub<Object> valueModel = new ObservableObjectValueStub<>();
         final ObjectExpression<Object> exp = ObjectExpression.objectExpression(valueModel);
 
         assertTrue(exp instanceof ObjectBinding);

--- a/modules/javafx.base/src/test/java/test/javafx/binding/expression/SetExpressionTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/expression/SetExpressionTest.java
@@ -52,10 +52,10 @@ public class SetExpressionTest {
 
     @Before
     public void setUp() {
-        opNull = new SimpleSetProperty<Integer>();
-        opEmpty = new SimpleSetProperty<Integer>(FXCollections.<Integer>observableSet());
-        op1 = new SimpleSetProperty<Integer>(FXCollections.observableSet(data1_0));
-        op2 = new SimpleSetProperty<Integer>(FXCollections.observableSet(data2_0, data2_1));
+        opNull = new SimpleSetProperty<>();
+        opEmpty = new SimpleSetProperty<>(FXCollections.<Integer>observableSet());
+        op1 = new SimpleSetProperty<>(FXCollections.observableSet(data1_0));
+        op2 = new SimpleSetProperty<>(FXCollections.observableSet(data2_0, data2_1));
     }
 
     @Test

--- a/modules/javafx.base/src/test/java/test/javafx/collections/FXCollectionsTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/FXCollectionsTest.java
@@ -113,7 +113,7 @@ public class FXCollectionsTest {
     public void copyTest() {
         ObservableList<String> dest = FXCollections.observableArrayList("a", "b", "c", "d");
         ObservableList<String> src = FXCollections.observableArrayList("foo", "bar");
-        final MockListObserver<String> observer = new MockListObserver<String>();
+        final MockListObserver<String> observer = new MockListObserver<>();
 
         dest.addListener(observer);
 
@@ -126,7 +126,7 @@ public class FXCollectionsTest {
     @Test
     public void fillTest() {
         ObservableList<String> seq = FXCollections.observableArrayList("foo", "bar");
-        final MockListObserver<String> observer = new MockListObserver<String>();
+        final MockListObserver<String> observer = new MockListObserver<>();
 
         seq.addListener(observer);
         FXCollections.fill(seq, "ham");
@@ -137,7 +137,7 @@ public class FXCollectionsTest {
     @Test
     public void replaceAllTest() {
         ObservableList<String> seq = FXCollections.observableArrayList("eggs", "ham", "spam", "spam", "eggs", "spam");
-        final MockListObserver<String> observer = new MockListObserver<String>();
+        final MockListObserver<String> observer = new MockListObserver<>();
 
         seq.addListener(observer);
         FXCollections.replaceAll(seq, "spam", "viking");
@@ -149,11 +149,11 @@ public class FXCollectionsTest {
     public void reverseTest() {
 
         ObservableList<String> seq1 = FXCollections.observableArrayList("one", "two", "three", "four");
-        final MockListObserver<String> observer1 = new MockListObserver<String>();
+        final MockListObserver<String> observer1 = new MockListObserver<>();
         seq1.addListener(observer1);
 
         ObservableList<String> seq2 = FXCollections.observableArrayList("one", "two", "three", "four", "five");
-        final MockListObserver<String> observer2 = new MockListObserver<String>();
+        final MockListObserver<String> observer2 = new MockListObserver<>();
         seq2.addListener(observer2);
 
         FXCollections.reverse(seq1);
@@ -169,7 +169,7 @@ public class FXCollectionsTest {
     @Test
     public void rotateTest() {
         ObservableList<String> seq = FXCollections.observableArrayList("one", "two", "three", "four", "five");
-        final MockListObserver<String> observer = new MockListObserver<String>();
+        final MockListObserver<String> observer = new MockListObserver<>();
         seq.addListener(observer);
 
         FXCollections.rotate(seq, 2);
@@ -209,7 +209,7 @@ public class FXCollectionsTest {
     //test sort on bigger elements, so that it is sorted with mergesort and not insert sort
         String[] content = new String[] { "q", "w", "e", "r", "t", "y", "u", "i", "o", "p" };
         ObservableList<String> seq = FXCollections.observableArrayList(content);
-        final MockListObserver<String> observer = new MockListObserver<String>();
+        final MockListObserver<String> observer = new MockListObserver<>();
         seq.addListener(observer);
         FXCollections.sort(seq);
         observer.check1Permutation(seq, new int[] {4, 8, 0, 5, 6, 9, 7, 1, 2, 3});
@@ -222,14 +222,14 @@ public class FXCollectionsTest {
     @Test
     public void sortTest_empty() {
         ObservableList<String> seq = FXCollections.observableArrayList();
-        final MockListObserver<String> observer = new MockListObserver<String>();
+        final MockListObserver<String> observer = new MockListObserver<>();
         seq.addListener(observer);
         FXCollections.sort(seq);
         observer.check0();
     }
 
     private void doSort(ObservableList<String> seq, boolean permutation) {
-        final MockListObserver<String> observer = new MockListObserver<String>();
+        final MockListObserver<String> observer = new MockListObserver<>();
         seq.addListener(observer);
         FXCollections.sort(seq);
         assertArrayEquals(new String[]{"five", "four", "one", "three", "two"}, seq.toArray(new String[0]));
@@ -377,7 +377,7 @@ public class FXCollectionsTest {
     @Test
     public void checkedListenerObservableSetTest() {
         ObservableSet<String> set = FXCollections.checkedObservableSet(FXCollections.observableSet("foo", "foo2"), String.class);
-        final MockSetObserver<String> observer = new MockSetObserver<String>();
+        final MockSetObserver<String> observer = new MockSetObserver<>();
         set.addListener(observer);
         try {
             set.add("foo3");
@@ -417,7 +417,7 @@ public class FXCollectionsTest {
         } catch (UnsupportedOperationException e) {
         }
         try {
-            Map<String, String> putMap = new HashMap<String, String>();
+            Map<String, String> putMap = new HashMap<>();
             putMap.put("bar", "bar");
             map.putAll(putMap);
             fail("Expected UnsupportedOperationException");

--- a/modules/javafx.base/src/test/java/test/javafx/collections/FilteredListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/FilteredListTest.java
@@ -51,7 +51,7 @@ public class FilteredListTest {
         list = FXCollections.observableArrayList();
         list.addAll("a", "c", "d", "c");
         Predicate<String> predicate = (String e) -> !e.equals("c");
-        mlo = new MockListObserver<String>();
+        mlo = new MockListObserver<>();
         filteredList = new FilteredList<>(list, predicate);
         filteredList.addListener(mlo);
     }

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ListChangeBuilderTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ListChangeBuilderTest.java
@@ -25,8 +25,6 @@
 
 package test.javafx.collections;
 
-import test.javafx.collections.MockListObserver;
-import com.sun.javafx.collections.ObservableListWrapper;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -47,11 +45,11 @@ public class ListChangeBuilderTest {
 
     @Before
     public void setUp() {
-        observer = new MockListObserver<String>();
-        list = new ArrayList<String>(Arrays.asList("a", "b", "c", "d"));
-        observableList = new ObservableListWrapperShim<String>(list);
+        observer = new MockListObserver<>();
+        list = new ArrayList<>(Arrays.asList("a", "b", "c", "d"));
+        observableList = new ObservableListWrapperShim<>(list);
         observableList.addListener(observer);
-        builder = new ListChangeBuilderShim<String>(observableList);
+        builder = new ListChangeBuilderShim<>(observableList);
     }
 
     @Test

--- a/modules/javafx.base/src/test/java/test/javafx/collections/MockListObserver.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/MockListObserver.java
@@ -57,13 +57,13 @@ public class MockListObserver<E> implements ListChangeListener<E> {
         }
     }
 
-    List<Call<E>> calls = new LinkedList<Call<E>>();
+    List<Call<E>> calls = new LinkedList<>();
 
     @Override
     public void onChanged(Change<? extends E> change) {
         if (calls.isEmpty()) {
             while (change.next()) {
-                Call<E> call = new Call<E>();
+                Call<E> call = new Call<>();
                 call.list = change.getList();
                 call.removed = change.getRemoved();
                 call.from = change.getFrom();

--- a/modules/javafx.base/src/test/java/test/javafx/collections/MockMapObserver.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/MockMapObserver.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.*;
 
 public class MockMapObserver<K, V> implements MapChangeListener<K, V> {
 
-    private List<Call> calls = new ArrayList<Call>();
+    private List<Call> calls = new ArrayList<>();
 
     @Override
     public void onChanged(Change<? extends K,? extends V> c) {
@@ -72,7 +72,7 @@ public class MockMapObserver<K, V> implements MapChangeListener<K, V> {
     public void assertMultipleRemove(Tuple<K, V>... tuples) {
         assertEquals(this.calls.size(), tuples.length);
         for (Tuple<K,V> t : tuples) {
-            assertTrue(calls + " doesn't contain "  + t, this.calls.contains(new Call<K,V>(t.key, t.val, null)));
+            assertTrue(calls + " doesn't contain "  + t, this.calls.contains(new Call<>(t.key, t.val, null)));
         }
     }
 
@@ -112,7 +112,7 @@ public class MockMapObserver<K, V> implements MapChangeListener<K, V> {
         }
 
         public static<K, V> Call<K, V> call(K k, V o, V n) {
-            return new Call<K, V>(k, o, n);
+            return new Call<>(k, o, n);
         }
 
         @Override
@@ -163,7 +163,7 @@ public class MockMapObserver<K, V> implements MapChangeListener<K, V> {
         }
 
         public static<K, V> Tuple<K, V> tup(K k, V v) {
-            return new Tuple<K, V>(k, v);
+            return new Tuple<>(k, v);
         }
     }
 

--- a/modules/javafx.base/src/test/java/test/javafx/collections/MockSetObserver.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/MockSetObserver.java
@@ -36,11 +36,11 @@ import static org.junit.Assert.assertTrue;
 
 public class MockSetObserver<E> implements SetChangeListener<E> {
 
-    private List<Call> calls = new ArrayList<Call>();
+    private List<Call> calls = new ArrayList<>();
 
     @Override
     public void onChanged(Change<? extends E> c) {
-        calls.add(new Call<E>(c.getElementRemoved(), c.getElementAdded()));
+        calls.add(new Call<>(c.getElementRemoved(), c.getElementAdded()));
     }
 
     public int getCallsNumber() {
@@ -74,7 +74,7 @@ public class MockSetObserver<E> implements SetChangeListener<E> {
     public void assertMultipleRemove(Tuple<E>... tuples) {
         assertEquals(this.calls.size(), tuples.length);
         for (Tuple<E> t : tuples) {
-            assertTrue(calls + " doesn't contain "  + t, this.calls.contains(new Call<E>(t.val, null)));
+            assertTrue(calls + " doesn't contain "  + t, this.calls.contains(new Call<>(t.val, null)));
         }
     }
 
@@ -110,7 +110,7 @@ public class MockSetObserver<E> implements SetChangeListener<E> {
         }
 
         public static<E> Call<E> call(E o, E n) {
-            return new Call<E>(o, n);
+            return new Call<>(o, n);
         }
 
         @Override
@@ -155,7 +155,7 @@ public class MockSetObserver<E> implements SetChangeListener<E> {
         }
 
         public static<E> Tuple<E> tup(E v) {
-            return new Tuple<E>(v);
+            return new Tuple<>(v);
         }
     }
 

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListEmptyTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListEmptyTest.java
@@ -68,7 +68,7 @@ public class ObservableListEmptyTest {
     @Before
     public void setUp() throws Exception {
         list = listFactory.call();
-        mlo = new MockListObserver<String>();
+        mlo = new MockListObserver<>();
         list.addListener(mlo);
     }
 

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListIteratorTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListIteratorTest.java
@@ -73,7 +73,7 @@ public class ObservableListIteratorTest {
     // ========== Utility Functions ==========
 
     List<String> copyOut(Iterator<String> itr) {
-        List<String> out = new ArrayList<String>();
+        List<String> out = new ArrayList<>();
         while (itr.hasNext()) {
             out.add(itr.next());
         }
@@ -159,7 +159,7 @@ public class ObservableListIteratorTest {
 
     @Test
     public void testForEachLoop() {
-        List<String> output = new ArrayList<String>();
+        List<String> output = new ArrayList<>();
         for (String s : list) {
             output.add(s);
         }

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListTest.java
@@ -74,7 +74,7 @@ public class ObservableListTest  {
     @Before
     public void setUp() throws Exception {
         list = listFactory.call();
-        mlo = new MockListObserver<String>();
+        mlo = new MockListObserver<>();
         list.addListener(mlo);
 
         useListData("one", "two", "three");
@@ -97,7 +97,7 @@ public class ObservableListTest  {
 
     @Test
     public void testObserverAddRemove() {
-        MockListObserver<String> mlo2 = new MockListObserver<String>();
+        MockListObserver<String> mlo2 = new MockListObserver<>();
         list.addListener(mlo2);
         list.removeListener(mlo);
         list.add("xyzzy");

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListWithExtractor.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableListWithExtractor.java
@@ -80,7 +80,7 @@ public class ObservableListWithExtractor {
             observedList = modifiedList = FXCollections.observableArrayList(callback);
         } else {
             modifiedList = FXCollections.observableArrayList();
-            observedList = new ElementObservableListDecorator<Person>(modifiedList, callback);
+            observedList = new ElementObservableListDecorator<>(modifiedList, callback);
         }
 
         modifiedList.add(p0);
@@ -334,7 +334,7 @@ public class ObservableListWithExtractor {
 
     @Test
     public void testPreFilledList() {
-        ArrayList<Person> arrayList = new ArrayList<Person>();
+        ArrayList<Person> arrayList = new ArrayList<>();
         arrayList.add(p0);
         obs = new MockListObserver();
         Callback<Person, Observable[]> callback = param -> new Observable[]{param.name};
@@ -342,7 +342,7 @@ public class ObservableListWithExtractor {
             observedList = modifiedList = FXCollections.observableList(arrayList, callback);
         } else {
             modifiedList = FXCollections.observableArrayList(arrayList);
-            observedList = new ElementObservableListDecorator<Person>(modifiedList, callback);
+            observedList = new ElementObservableListDecorator<>(modifiedList, callback);
         }
 
         observedList.addListener(obs);

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableMapTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableMapTest.java
@@ -73,7 +73,7 @@ public class ObservableMapTest {
     @Before
     public void setUp() throws Exception {
         observableMap = mapFactory.call();
-        observer = new MockMapObserver<String, String>();
+        observer = new MockMapObserver<>();
         observableMap.addListener(observer);
 
         useMapData();
@@ -172,7 +172,7 @@ public class ObservableMapTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testPutAll() {
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put("oFoo", "OFoo");
         map.put("pFoo", "PFoo");
         map.put("foo", "foofoo");
@@ -351,7 +351,6 @@ public class ObservableMapTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testEntrySet_RetainAll() {
         observableMap.entrySet().retainAll(Arrays.asList(entry("one","1"), entry("two","2"), entry("three","3")));
 
@@ -383,7 +382,6 @@ public class ObservableMapTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testEntrySet_Other() {
         assertEquals(3, observableMap.entrySet().size());
         assertTrue(observableMap.entrySet().contains(entry("foo", "bar")));
@@ -436,7 +434,7 @@ public class ObservableMapTest {
     }
 
     private<K, V> Map.Entry<K, V> entry(final K key, final V value) {
-        return new Map.Entry<K, V>() {
+        return new Map.Entry<>() {
 
             @Override
             public K getKey() {

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableSetTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableSetTest.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 import javafx.collections.ObservableSet;
 import javafx.collections.SetChangeListener;
@@ -71,7 +70,7 @@ public class ObservableSetTest {
     @Before
     public void setUp() throws Exception {
         observableSet = setFactory.call();
-        observer = new MockSetObserver<String>();
+        observer = new MockSetObserver<>();
         observableSet.addListener(observer);
 
         useSetData("one", "two", "foo");
@@ -113,7 +112,7 @@ public class ObservableSetTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testAddAll() {
-        Set<String> set = new HashSet<String>();
+        Set<String> set = new HashSet<>();
         set.add("oFoo");
         set.add("pFoo");
         set.add("foo");

--- a/modules/javafx.base/src/test/java/test/javafx/collections/ObservableSubListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/ObservableSubListTest.java
@@ -66,7 +66,7 @@ public class ObservableSubListTest {
     @Before
     public void setup() throws Exception {
         list = listFactory.call();
-        mlo = new MockListObserver<String>();
+        mlo = new MockListObserver<>();
         list.addListener(mlo);
         useListData("a", "b", "c", "d", "e", "f");
         sublist = list.subList(1, 5);

--- a/modules/javafx.base/src/test/java/test/javafx/collections/SortedListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/SortedListTest.java
@@ -59,7 +59,7 @@ public class SortedListTest {
         list = FXCollections.observableArrayList();
         list.addAll("a", "c", "d", "c");
         sortedList = list.sorted();
-        mockListObserver = new MockListObserver<String>();
+        mockListObserver = new MockListObserver<>();
         sortedList.addListener(mockListObserver);
     }
 
@@ -393,12 +393,12 @@ public class SortedListTest {
      */
     @Test
     public void testPermutate() {
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
         for (int i = 0; i < 3; i++) {
             list.add(i);
         }
-        Permutator<Integer> permutator = new Permutator<Integer>(list);
-        SortedList<Integer> sorted = new SortedList<Integer>(permutator);
+        Permutator<Integer> permutator = new Permutator<>(list);
+        SortedList<Integer> sorted = new SortedList<>(permutator);
         permutator.swap();
 
         compareIndices(sorted);
@@ -473,7 +473,7 @@ public class SortedListTest {
     @Test
     public void test_rt36353_sortedList() {
         ObservableList<String> data = FXCollections.observableArrayList("2", "1", "3");
-        SortedList<String> sortedList = new SortedList<String>(data);
+        SortedList<String> sortedList = new SortedList<>(data);
 
         HashMap<Integer, Integer> pMap = new HashMap<>();
         sortedList.addListener((ListChangeListener<String>) c -> {

--- a/modules/javafx.base/src/test/java/test/javafx/collections/TestedObservableLists.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/TestedObservableLists.java
@@ -40,7 +40,7 @@ public interface TestedObservableLists {
 
     Callable<ObservableList<String>> LINKED_LIST = () -> FXCollections.observableList(new LinkedList<String>());
 
-    Callable<ObservableList<String>> VETOABLE_LIST = () -> new VetoableListDecorator<String>(FXCollections.<String>observableArrayList()) {
+    Callable<ObservableList<String>> VETOABLE_LIST = () -> new VetoableListDecorator<>(FXCollections.<String>observableArrayList()) {
 
         @Override
         protected void onProposedChange(List list, int... idx) { }

--- a/modules/javafx.base/src/test/java/test/javafx/collections/TransformationListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/TransformationListTest.java
@@ -25,9 +25,7 @@
 
 package test.javafx.collections;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener.Change;
 import javafx.collections.ObservableList;

--- a/modules/javafx.base/src/test/java/test/javafx/collections/UnmodifiableObservableMapTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/UnmodifiableObservableMapTest.java
@@ -68,11 +68,10 @@ public class UnmodifiableObservableMapTest {
     }
 
     @Before
-    @SuppressWarnings("unchecked")
     public void setUp() throws Exception {
         observableMap = mapFactory.call();
         unmodifiableMap = FXCollections.unmodifiableObservableMap(observableMap);
-        observer = new MockMapObserver<String, String>();
+        observer = new MockMapObserver<>();
         unmodifiableMap.addListener(observer);
 
         useMapData();
@@ -120,7 +119,7 @@ public class UnmodifiableObservableMapTest {
 
     @Test
     public void testPutAll() {
-        Map<String, String> map = new HashMap<String, String>();
+        Map<String, String> map = new HashMap<>();
         map.put("oFoo", "OFoo");
         map.put("pFoo", "PFoo");
         map.put("foo", "foofoo");
@@ -201,7 +200,6 @@ public class UnmodifiableObservableMapTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
     public void testEntrySet() {
         try {
             unmodifiableMap.entrySet().remove(entry("one","1"));
@@ -232,7 +230,7 @@ public class UnmodifiableObservableMapTest {
     }
 
     private<K, V> Map.Entry<K, V> entry(final K key, final V value) {
-        return new Map.Entry<K, V>() {
+        return new Map.Entry<>() {
 
             @Override
             public K getKey() {

--- a/modules/javafx.base/src/test/java/test/javafx/collections/VetoableObservableListTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/VetoableObservableListTest.java
@@ -76,8 +76,8 @@ public class VetoableObservableListTest {
 
     @Before
     public void setUp() {
-        calls = new ArrayList<Call>();
-        list = new VetoableListDecorator<String>(FXCollections.<String>observableArrayList()) {
+        calls = new ArrayList<>();
+        list = new VetoableListDecorator<>(FXCollections.<String>observableArrayList()) {
 
             @Override
             protected void onProposedChange(List<String> added, int... removed) {

--- a/modules/javafx.base/src/test/java/test/javafx/collections/WeakListChangeListenerTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/WeakListChangeListenerTest.java
@@ -40,16 +40,16 @@ public class WeakListChangeListenerTest {
 
     @Test(expected=NullPointerException.class)
     public void testConstructWithNull() {
-        new WeakListChangeListener<Object>(null);
+        new WeakListChangeListener<>(null);
     }
 
     @Test
     public void testHandle() {
-        MockListObserver<Object> listener = new MockListObserver<Object>();
-        final WeakListChangeListener<Object> weakListener = new WeakListChangeListener<Object>(listener);
-        final ObservableListWrapper<Object> list = new ObservableListWrapper<Object>(new ArrayList<Object>());
+        MockListObserver<Object> listener = new MockListObserver<>();
+        final WeakListChangeListener<Object> weakListener = new WeakListChangeListener<>(listener);
+        final ObservableListWrapper<Object> list = new ObservableListWrapper<>(new ArrayList<>());
         final Object removedElement = new Object();
-        final ListChangeListener.Change<Object> change = new NonIterableChange.SimpleRemovedChange<Object>(0, 1, removedElement, list);
+        final ListChangeListener.Change<Object> change = new NonIterableChange.SimpleRemovedChange<>(0, 1, removedElement, list);
 
         // regular call
         weakListener.onChanged(change);

--- a/modules/javafx.base/src/test/java/test/javafx/collections/WeakMapChangeListenerTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/WeakMapChangeListenerTest.java
@@ -39,17 +39,17 @@ public class WeakMapChangeListenerTest {
 
     @Test(expected=NullPointerException.class)
     public void testConstructWithNull() {
-        new WeakMapChangeListener<Object, Object>(null);
+        new WeakMapChangeListener<>(null);
     }
 
     @Test
     public void testHandle() {
-        MockMapObserver<Object, Object> listener = new MockMapObserver<Object, Object>();
-        final WeakMapChangeListener<Object, Object> weakListener = new WeakMapChangeListener<Object, Object>(listener);
+        MockMapObserver<Object, Object> listener = new MockMapObserver<>();
+        final WeakMapChangeListener<Object, Object> weakListener = new WeakMapChangeListener<>(listener);
         final ObservableMapMock map = new ObservableMapMock();
         final Object key = new Object();
         final Object value = new Object();
-        final MapChangeListener.Change<Object, Object> change = new MapExpressionHelper.SimpleChange<Object, Object>(map).setRemoved(key, value);
+        final MapChangeListener.Change<Object, Object> change = new MapExpressionHelper.SimpleChange<>(map).setRemoved(key, value);
 
         // regular call
         weakListener.onChanged(change);
@@ -69,7 +69,7 @@ public class WeakMapChangeListenerTest {
         private int removeCounter;
 
         public ObservableMapMock() {
-            super(new HashMap<Object, Object>());
+            super(new HashMap<>());
         }
 
         private void reset() {

--- a/modules/javafx.base/src/test/java/test/javafx/collections/WeakSetChangeListenerTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/collections/WeakSetChangeListenerTest.java
@@ -39,16 +39,16 @@ public class WeakSetChangeListenerTest {
 
     @Test(expected=NullPointerException.class)
     public void testConstructWithNull() {
-        new WeakSetChangeListener<Object>(null);
+        new WeakSetChangeListener<>(null);
     }
 
     @Test
     public void testHandle() {
-        MockSetObserver<Object> listener = new MockSetObserver<Object>();
-        final WeakSetChangeListener<Object> weakListener = new WeakSetChangeListener<Object>(listener);
+        MockSetObserver<Object> listener = new MockSetObserver<>();
+        final WeakSetChangeListener<Object> weakListener = new WeakSetChangeListener<>(listener);
         final ObservableSetMock set = new ObservableSetMock();
         final Object removedElement = new Object();
-        final SetChangeListener.Change<Object> change = new SetExpressionHelper.SimpleChange<Object>(set).setRemoved(removedElement);
+        final SetChangeListener.Change<Object> change = new SetExpressionHelper.SimpleChange<>(set).setRemoved(removedElement);
 
         // regular call
         weakListener.onChanged(change);
@@ -68,7 +68,7 @@ public class WeakSetChangeListenerTest {
         private int removeCounter;
 
         public ObservableSetMock() {
-            super(new HashSet<Object>());
+            super(new HashSet<>());
         }
 
         private void reset() {

--- a/modules/javafx.base/src/test/java/test/javafx/event/EventSerializationEventExists.java
+++ b/modules/javafx.base/src/test/java/test/javafx/event/EventSerializationEventExists.java
@@ -66,7 +66,7 @@ public class EventSerializationEventExists {
             fail("Test error: Event type already registered before the test");
         }
 
-        List<String> l = new ArrayList<String>();
+        List<String> l = new ArrayList<>();
         l.add("ACTION");
         EventTypeShim.EventTypeSerializationShim e = new EventTypeShim.EventTypeSerializationShim(l);
 

--- a/modules/javafx.base/src/test/java/test/javafx/event/EventSerializationTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/event/EventSerializationTest.java
@@ -37,7 +37,6 @@ import javafx.event.ActionEvent;
 import javafx.event.Event;
 import javafx.event.EventType;
 import javafx.event.EventTypeShim;
-import javafx.event.EventTypeShim.EventTypeSerializationShim;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -77,7 +76,7 @@ public class EventSerializationTest {
 
     @Test
     public void testNewEventTypeSerialization() throws IOException, ClassNotFoundException {
-        EventType<Event> eventType = new EventType<Event>(Event.ANY, "MY_TYPE");
+        EventType<Event> eventType = new EventType<>(Event.ANY, "MY_TYPE");
         Event e = new Event(eventType);
 
         objectOutputStream.writeObject(e);
@@ -92,7 +91,7 @@ public class EventSerializationTest {
 
     @Test(expected=InvalidObjectException.class)
     public void testUnknownEventTypeSerialization() throws IOException, ClassNotFoundException {
-        List<String> l = new ArrayList<String>();
+        List<String> l = new ArrayList<>();
         l.add("UNKNOWN");
         Object e = EventTypeShim.getEventTypeSerialization(l);
 

--- a/modules/javafx.base/src/test/java/test/javafx/util/DurationValueOfTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/DurationValueOfTest.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import javafx.util.Duration;
 
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/BigDecimalStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/BigDecimalStringConverterTest.java
@@ -27,22 +27,11 @@ package test.javafx.util.converter;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Arrays;
-import java.util.Collection;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-
-import javafx.util.StringConverter;
 import javafx.util.converter.BigDecimalStringConverter;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 /**
  */

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/BooleanStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/BooleanStringConverterTest.java
@@ -25,7 +25,6 @@
 
 package test.javafx.util.converter;
 
-import java.math.BigInteger;
 import javafx.util.converter.BooleanStringConverter;
 import static org.junit.Assert.assertEquals;
 

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/CharacterStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/CharacterStringConverterTest.java
@@ -52,11 +52,11 @@ public class CharacterStringConverterTest {
     }
 
     @Test public void fromString_testValidStringInput_differentCase_one() {
-        assertNotSame((Object)char_C, converter.fromString("c"));
+        assertNotSame(char_C, converter.fromString("c"));
     }
 
     @Test public void fromString_testValidStringInput_differentCase_two() {
-        assertNotSame((Object)char_c, converter.fromString("C"));
+        assertNotSame(char_c, converter.fromString("C"));
     }
 
     @Test public void fromString_testValidStringInputWithWhiteSpace_lowercase() {

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/CurrencyStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/CurrencyStringConverterTest.java
@@ -27,9 +27,7 @@ package test.javafx.util.converter;
 
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
-import java.util.Currency;
 import java.util.Locale;
-import javafx.util.converter.LocalTimeStringConverterShim;
 import javafx.util.converter.CurrencyStringConverter;
 import javafx.util.converter.NumberStringConverterShim;
 import static org.junit.Assert.*;

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/DateStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/DateStringConverterTest.java
@@ -33,14 +33,12 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
-import javafx.util.converter.LocalTimeStringConverterShim;
 import javafx.util.converter.DateStringConverter;
 import javafx.util.converter.DateTimeStringConverterShim;
 import static org.junit.Assert.*;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/DateTimeStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/DateTimeStringConverterTest.java
@@ -33,14 +33,12 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
-import javafx.util.converter.LocalTimeStringConverterShim;
 import javafx.util.converter.DateTimeStringConverter;
 import javafx.util.converter.DateTimeStringConverterShim;
 import static org.junit.Assert.*;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/DefaultStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/DefaultStringConverterTest.java
@@ -25,8 +25,6 @@
 
 package test.javafx.util.converter;
 
-import java.util.Arrays;
-import java.util.Collection;
 import javafx.util.converter.DefaultStringConverter;
 import static org.junit.Assert.assertEquals;
 

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateStringConverterTest.java
@@ -27,22 +27,18 @@ package test.javafx.util.converter;
 
 import java.util.Arrays;
 import java.time.LocalDate;
-import java.time.chrono.Chronology;
 import java.time.chrono.IsoChronology;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.Collection;
 import java.util.Locale;
 
-import javafx.util.StringConverter;
-import javafx.util.converter.LocalTimeStringConverterShim;
 import javafx.util.converter.LocalDateStringConverter;
 import javafx.util.converter.LocalDateStringConverterShim;
 
 import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
@@ -40,7 +40,6 @@ import javafx.util.StringConverter;
 import javafx.util.converter.LocalDateTimeStringConverter;
 import javafx.util.converter.LocalDateTimeStringConverterShim;
 
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalTimeStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalTimeStringConverterTest.java
@@ -26,15 +26,12 @@
 package test.javafx.util.converter;
 
 import java.time.LocalTime;
-import java.time.chrono.Chronology;
-import java.time.chrono.IsoChronology;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Locale;
 
-import javafx.util.StringConverter;
 import javafx.util.converter.LocalTimeStringConverterShim;
 import javafx.util.converter.LocalTimeStringConverter;
 

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/NumberStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/NumberStringConverterTest.java
@@ -28,7 +28,6 @@ package test.javafx.util.converter;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Locale;
-import javafx.util.converter.LocalTimeStringConverterShim;
 import javafx.util.converter.NumberStringConverter;
 import javafx.util.converter.NumberStringConverterShim;
 import static org.junit.Assert.*;

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/ParameterizedConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/ParameterizedConverterTest.java
@@ -28,11 +28,7 @@ package test.javafx.util.converter;
 import java.util.Arrays;
 import java.util.Collection;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-
 import javafx.util.StringConverter;
 import javafx.util.converter.BigDecimalStringConverter;
 import javafx.util.converter.BigIntegerStringConverter;
@@ -54,7 +50,6 @@ import javafx.util.converter.TimeStringConverter;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/PercentageStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/PercentageStringConverterTest.java
@@ -25,10 +25,8 @@
 
 package test.javafx.util.converter;
 
-import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Locale;
-import javafx.util.converter.LocalTimeStringConverterShim;
 import javafx.util.converter.NumberStringConverterShim;
 import javafx.util.converter.PercentageStringConverter;
 import static org.junit.Assert.*;

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/TimeStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/TimeStringConverterTest.java
@@ -33,7 +33,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
-import javafx.util.converter.LocalTimeStringConverterShim;
 import javafx.util.converter.DateTimeStringConverterShim;
 import javafx.util.converter.TimeStringConverter;
 import static org.junit.Assert.*;

--- a/modules/javafx.base/src/test/java/test/util/memory/JMemoryBuddy.java
+++ b/modules/javafx.base/src/test/java/test/util/memory/JMemoryBuddy.java
@@ -36,7 +36,6 @@ import java.util.Date;
 import java.util.LinkedList;
 import java.util.Objects;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 
 /**
@@ -121,7 +120,7 @@ public class JMemoryBuddy {
         }
 
         if (weakReference.get() == null && counter < steps / 3) {
-            int percentageUsed = (int) ((steps - counter) / steps * 100);
+            int percentageUsed = (steps - counter) / steps * 100;
             System.out.println("Warning test seems to be unstable. time used: " + percentageUsed + "%");
         }
 
@@ -157,19 +156,22 @@ public class JMemoryBuddy {
      * @param f A function which get's executed with the API to define the required memory semantic.
      */
     public static void memoryTest(Consumer<MemoryTestAPI> f) {
-        LinkedList<WeakReference> toBeCollected = new LinkedList<WeakReference>();
-        LinkedList<AssertNotCollectable> toBeNotCollected = new LinkedList<AssertNotCollectable>();
-        LinkedList<SetAsReferenced> toBeReferenced = new LinkedList<SetAsReferenced>();
+        LinkedList<WeakReference> toBeCollected = new LinkedList<>();
+        LinkedList<AssertNotCollectable> toBeNotCollected = new LinkedList<>();
+        LinkedList<SetAsReferenced> toBeReferenced = new LinkedList<>();
 
         f.accept(new MemoryTestAPI() {
+            @Override
             public void assertCollectable(Object ref) {
                 Objects.requireNonNull(ref);
-                toBeCollected.add(new WeakReference<Object>(ref));
+                toBeCollected.add(new WeakReference<>(ref));
             }
+            @Override
             public void assertNotCollectable(Object ref) {
                 Objects.requireNonNull(ref);
                 toBeNotCollected.add(new AssertNotCollectable(ref));
             }
+            @Override
             public void setAsReferenced(Object ref) {
                 Objects.requireNonNull(ref);
                 toBeReferenced.add(new SetAsReferenced(ref));
@@ -188,12 +190,12 @@ public class JMemoryBuddy {
         for (AssertNotCollectable wRef: toBeNotCollected) {
             if (!checkNotCollectable(wRef.getWeakReference())) {
                 failed = true;
-            };
+            }
         }
 
         if (failed) {
-            LinkedList<AssertCollectable> toBeCollectedMarked = new LinkedList<AssertCollectable>();
-            LinkedList<AssertNotCollectable> toBeNotCollectedMarked = new LinkedList<AssertNotCollectable>();
+            LinkedList<AssertCollectable> toBeCollectedMarked = new LinkedList<>();
+            LinkedList<AssertNotCollectable> toBeNotCollectedMarked = new LinkedList<>();
 
             for (WeakReference wRef: toBeCollected) {
                 if (wRef.get() != null) {


### PR DESCRIPTION
- Remove unsupported/unnecessary SuppressWarning annotations
- Remove reduntant type specifications (use diamond operator)
- Remove unused or duplicate imports
- Remove unnecessary casts (type is already correct type or can be autoboxed)
- Remove unnecessary semi-colons (at end of class definitions, or just repeated ones)
- Remove redundant super interfaces (interface that is already inherited)
- Remove unused type parameters
- Remove declared checked exceptions that are never thrown
- Add missing `@Override` annotations

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8297332](https://bugs.openjdk.org/browse/JDK-8297332): Remove easy warnings in javafx.base


### Reviewers
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/957/head:pull/957` \
`$ git checkout pull/957`

Update a local copy of the PR: \
`$ git checkout pull/957` \
`$ git pull https://git.openjdk.org/jfx pull/957/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 957`

View PR using the GUI difftool: \
`$ git pr show -t 957`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/957.diff">https://git.openjdk.org/jfx/pull/957.diff</a>

</details>
