### PR TITLE
8297362: EOS might not be delivered by progressbuffer in some cases

### DIFF
--- a/modules/javafx.media/src/main/native/xcode_project/JFXMedia.xcodeproj/project.pbxproj
+++ b/modules/javafx.media/src/main/native/xcode_project/JFXMedia.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		114ECB8E2928543700BE8CE2 /* plugins */ = {isa = PBXFileReference; lastKnownFileType = folder; name = plugins; path = ../gstreamer/plugins; sourceTree = "<group>"; };
 		652BECE8199BCFD4007217BB /* NullAudioEqualizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NullAudioEqualizer.h; sourceTree = "<group>"; };
 		652BECEB199BD515007217BB /* NullAudioSpectrum.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NullAudioSpectrum.h; sourceTree = "<group>"; };
 		652BECED199BDB28007217BB /* NativeAudioEqualizer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NativeAudioEqualizer.cpp; sourceTree = "<group>"; };
@@ -613,6 +614,7 @@
 		65FF278A1991545E006BF9EE = {
 			isa = PBXGroup;
 			children = (
+				114ECB8E2928543700BE8CE2 /* plugins */,
 				B3BFE7721D7A15FA00E48712 /* glib */,
 				B3BFE7711D7A159A00E48712 /* gstreamer-lite */,
 				65989B121991823700319296 /* build_prereqs.sh */,
@@ -712,6 +714,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 				Base,
 			);
@@ -948,7 +951,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				GLIB_LITE_DIR = "../gstreamer/3rd_party/glib";
+				GLIB_LITE_DIR = ../gstreamer/3rd_party/glib;
 				GSTREAMER_LITE_DIR = "../gstreamer/gstreamer-lite";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1000,7 +1003,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				GLIB_LITE_DIR = "../gstreamer/3rd_party/glib";
+				GLIB_LITE_DIR = ../gstreamer/3rd_party/glib;
 				GSTREAMER_LITE_DIR = "../gstreamer/gstreamer-lite";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
This is regression from [JDK-8043352](https://bugs.openjdk.org/browse/JDK-8043352). [JDK-8043352](https://bugs.openjdk.org/browse/JDK-8043352) moved clearing pending events in progress buffer when upstream sends EOS. We need to do this for any other events except EOS. If we clear pending EOS, then it will not be delivered and we will hang due to downstream waiting for data or EOS. We still need to clear any other events such as new segment and not deliver it once we receive EOS.

Added "plugins" folder to macOS project. For some reason it was missing and debugging plugins with xcode was not possible.

Tested on all platforms with all formats over FILE and HTTP protocol. EOS was delivered correctly in all cases.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8297362](https://bugs.openjdk.org/browse/JDK-8297362): EOS might not be delivered by progressbuffer in some cases


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/961/head:pull/961` \
`$ git checkout pull/961`

Update a local copy of the PR: \
`$ git checkout pull/961` \
`$ git pull https://git.openjdk.org/jfx pull/961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 961`

View PR using the GUI difftool: \
`$ git pr show -t 961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/961.diff">https://git.openjdk.org/jfx/pull/961.diff</a>

</details>
