### PR TITLE
8297680: JavaDoc example for PseudoClass has minor typo

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/css/PseudoClass.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/PseudoClass.java
@@ -55,7 +55,7 @@ import com.sun.javafx.css.PseudoClassState;
  *       new BooleanPropertyBase(false) {
  *
  *       {@literal @}Override protected void invalidated() {
- *           pseudoClassStateChanged(MAGIC_PSEUDO_CLASS. get());
+ *           pseudoClassStateChanged(MAGIC_PSEUDO_CLASS, get());
  *       }
  *
  *       {@literal @}Override public Object getBean() {


### PR DESCRIPTION
Fixed the typo in JavaDoc example code for PseudoClass

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297680](https://bugs.openjdk.org/browse/JDK-8297680): JavaDoc example for PseudoClass has minor typo


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/964/head:pull/964` \
`$ git checkout pull/964`

Update a local copy of the PR: \
`$ git checkout pull/964` \
`$ git pull https://git.openjdk.org/jfx pull/964/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 964`

View PR using the GUI difftool: \
`$ git pr show -t 964`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/964.diff">https://git.openjdk.org/jfx/pull/964.diff</a>

</details>
