### PR TITLE
8238968: Inconsisent formatting of Rectangle2D toString method

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/geometry/Rectangle2D.java
+++ b/modules/javafx.graphics/src/main/java/javafx/geometry/Rectangle2D.java
@@ -243,7 +243,7 @@ public class Rectangle2D {
      * The returned string might be empty but cannot be {@code null}.
      */
     @Override public String toString() {
-        return "Rectangle2D [minX = " + minX
+        return "Rectangle2D [minX=" + minX
                 + ", minY=" + minY
                 + ", maxX=" + maxX
                 + ", maxY=" + maxY


### PR DESCRIPTION
The string was fixed to match other parameters' formatting.

There was a PR submitted for this change a long time ago, but there were some issue with its previous author. Today I found the issue being assigned to me, so I figured I might as well submit a patch for it as it was a quick & easy fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8238968](https://bugs.openjdk.org/browse/JDK-8238968): Inconsisent formatting of Rectangle2D toString method


### Reviewers
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/967/head:pull/967` \
`$ git checkout pull/967`

Update a local copy of the PR: \
`$ git checkout pull/967` \
`$ git pull https://git.openjdk.org/jfx pull/967/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 967`

View PR using the GUI difftool: \
`$ git pr show -t 967`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/967.diff">https://git.openjdk.org/jfx/pull/967.diff</a>

</details>
