### PR TITLE
8296854: NULL check of CTFontCopyAvailableTables return value is required

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/DFontDecoder.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/DFontDecoder.java
@@ -64,6 +64,9 @@ class DFontDecoder extends FontFileWriter {
                 throw new IOException("Unsupported Dfont");
             }
             int[] tags = DFontDecoder.getCTFontTags(fontRef);
+            if (tags == null) {
+                throw new IOException("Could not get tables for Dfont");
+            }
             short numTables = (short)tags.length;
             int size = TTCHEADERSIZE + (DIRECTORYENTRYSIZE * numTables);
             byte[][] tableData = new byte[numTables][];

--- a/modules/javafx.graphics/src/main/native-font/dfontdecoder.c
+++ b/modules/javafx.graphics/src/main/native-font/dfontdecoder.c
@@ -117,6 +117,9 @@ JNIEXPORT jintArray JNICALL Java_com_sun_javafx_font_DFontDecoder_getCTFontTags
     CTFontRef fontRef = (CTFontRef)fontPtr;
     CTFontTableOptions  options = kCTFontTableOptionNoOptions;
     CFArrayRef tags = CTFontCopyAvailableTables(fontRef, options);
+    if (tags == NULL) {
+        return NULL;
+    }
     CFIndex count = CFArrayGetCount(tags);
     jintArray intArrObj = (*env)->NewIntArray(env, count);
     if (intArrObj == NULL) {


### PR DESCRIPTION
Guard against de-referencing null, although it is currently theoretical as far as I can see (more info in the bug eval)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296854](https://bugs.openjdk.org/browse/JDK-8296854): NULL check of CTFontCopyAvailableTables return value is required


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/968/head:pull/968` \
`$ git checkout pull/968`

Update a local copy of the PR: \
`$ git checkout pull/968` \
`$ git pull https://git.openjdk.org/jfx pull/968/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 968`

View PR using the GUI difftool: \
`$ git pr show -t 968`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/968.diff">https://git.openjdk.org/jfx/pull/968.diff</a>

</details>
