### PR TITLE
JDK-8298200 Clean up raw type warnings in javafx.beans.property.* and com.sun.javafx.property.*

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/property/JavaBeanAccessHelper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/property/JavaBeanAccessHelper.java
@@ -58,7 +58,7 @@ public final class JavaBeanAccessHelper {
     private static void init() {
         if (!initialized) {
             try {
-                Class accessor = Class.forName(
+                Class<?> accessor = Class.forName(
                         "com.sun.javafx.property.adapter.JavaBeanQuickAccessor",
                         true, JavaBeanAccessHelper.class.getClassLoader());
                 JAVA_BEAN_QUICK_ACCESSOR_CREATE_RO =

--- a/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/Disposer.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/Disposer.java
@@ -43,8 +43,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * of the associated Runnable object will be called.
  */
 public class Disposer implements Runnable {
-    private static final ReferenceQueue<Object> QUEUE = new ReferenceQueue<>();
-    private static final Map<Reference<?>, Runnable> RECORDS = new ConcurrentHashMap<>();
+    private static final ReferenceQueue<Object> queue = new ReferenceQueue<>();
+    private static final Map<Reference<?>, Runnable> records = new ConcurrentHashMap<>();
     private static Disposer disposerInstance;
 
     static {
@@ -81,17 +81,17 @@ public class Disposer implements Runnable {
      * @param rec the associated Runnable object
      */
     public static void addRecord(Object target, Runnable rec) {
-        PhantomReference<Object> ref = new PhantomReference<>(target, QUEUE);
-        RECORDS.put(ref, rec);
+        PhantomReference<Object> ref = new PhantomReference<>(target, queue);
+        records.put(ref, rec);
     }
 
     @Override
     public void run() {
         while (true) {
             try {
-                Reference<?> reference = QUEUE.remove();
+                Reference<?> reference = queue.remove();
                 reference.clear();
-                Runnable rec = RECORDS.remove(reference);
+                Runnable rec = records.remove(reference);
                 rec.run();
             } catch (Exception e) {
                 System.out.println("Exception while removing reference: " + e);

--- a/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/Disposer.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/Disposer.java
@@ -43,8 +43,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * of the associated Runnable object will be called.
  */
 public class Disposer implements Runnable {
-    private static final ReferenceQueue queue = new ReferenceQueue();
-    private static final Map<Object, Runnable> records = new ConcurrentHashMap<>();
+    private static final ReferenceQueue<Object> QUEUE = new ReferenceQueue<>();
+    private static final Map<Reference<?>, Runnable> RECORDS = new ConcurrentHashMap<>();
     private static Disposer disposerInstance;
 
     static {
@@ -52,7 +52,7 @@ public class Disposer implements Runnable {
 
         @SuppressWarnings("removal")
         var dummy = java.security.AccessController.doPrivileged(
-            new java.security.PrivilegedAction() {
+            new java.security.PrivilegedAction<>() {
                 @Override
                 public Object run() {
                     /* The thread must be a member of a thread group
@@ -81,17 +81,17 @@ public class Disposer implements Runnable {
      * @param rec the associated Runnable object
      */
     public static void addRecord(Object target, Runnable rec) {
-        PhantomReference ref = new PhantomReference<>(target, queue);
-        records.put(ref, rec);
+        PhantomReference<Object> ref = new PhantomReference<>(target, QUEUE);
+        RECORDS.put(ref, rec);
     }
 
     @Override
     public void run() {
         while (true) {
             try {
-                Object obj = queue.remove();
-                ((Reference)obj).clear();
-                Runnable rec = records.remove(obj);
+                Reference<?> reference = QUEUE.remove();
+                reference.clear();
+                Runnable rec = RECORDS.remove(reference);
                 rec.run();
             } catch (Exception e) {
                 System.out.println("Exception while removing reference: " + e);

--- a/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/JavaBeanPropertyBuilderHelper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/JavaBeanPropertyBuilderHelper.java
@@ -30,7 +30,7 @@ import com.sun.javafx.reflect.ReflectUtil;
 
 /**
  */
-public class JavaBeanPropertyBuilderHelper {
+public class JavaBeanPropertyBuilderHelper<T> {
 
     private static final String IS_PREFIX = "is";
     private static final String GET_PREFIX = "get";
@@ -43,7 +43,7 @@ public class JavaBeanPropertyBuilderHelper {
     private String setterName;
     private Method getter;
     private Method setter;
-    private PropertyDescriptor descriptor;
+    private PropertyDescriptor<T> descriptor;
 
     public void name(String propertyName) {
         if ((propertyName == null)? this.propertyName != null : !propertyName.equals(this.propertyName)) {
@@ -104,7 +104,7 @@ public class JavaBeanPropertyBuilderHelper {
         }
     }
 
-    public PropertyDescriptor getDescriptor() throws NoSuchMethodException {
+    public PropertyDescriptor<T> getDescriptor() throws NoSuchMethodException {
         if (descriptor == null) {
             if (propertyName == null) {
                 throw new NullPointerException("Property name has to be specified");
@@ -134,7 +134,7 @@ public class JavaBeanPropertyBuilderHelper {
                     setterMethod = beanClass.getMethod(SET_PREFIX + capitalizedName, type);
                 }
             }
-            descriptor = new PropertyDescriptor(propertyName, beanClass, getterMethod, setterMethod);
+            descriptor = new PropertyDescriptor<>(propertyName, beanClass, getterMethod, setterMethod);
         }
         return descriptor;
     }

--- a/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/PropertyDescriptor.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/PropertyDescriptor.java
@@ -39,7 +39,7 @@ import java.lang.reflect.Method;
 
 /**
  */
-public class PropertyDescriptor extends ReadOnlyPropertyDescriptor {
+public class PropertyDescriptor<T> extends ReadOnlyPropertyDescriptor<T> {
 
     private static final String ADD_VETOABLE_LISTENER_METHOD_NAME = "addVetoableChangeListener";
     private static final String REMOVE_VETOABLE_LISTENER_METHOD_NAME = "removeVetoableChangeListener";
@@ -142,7 +142,7 @@ public class PropertyDescriptor extends ReadOnlyPropertyDescriptor {
         }
     }
 
-    public class Listener<T> extends ReadOnlyListener<T> implements ChangeListener<T>, VetoableChangeListener {
+    public class Listener extends ReadOnlyListener implements ChangeListener<T>, VetoableChangeListener {
 
         private boolean updating;
 
@@ -174,7 +174,7 @@ public class PropertyDescriptor extends ReadOnlyPropertyDescriptor {
         public void vetoableChange(PropertyChangeEvent propertyChangeEvent) throws PropertyVetoException {
             if (bean.equals(propertyChangeEvent.getSource()) && name.equals(propertyChangeEvent.getPropertyName())) {
                 final ReadOnlyJavaBeanProperty<T> property = checkRef();
-                if ((property instanceof Property) && (((Property)property).isBound()) && !updating) {
+                if ((property instanceof Property) && (((Property<?>)property).isBound()) && !updating) {
                     throw new PropertyVetoException("A bound value cannot be set.", propertyChangeEvent);
                 }
             }

--- a/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/PropertyDescriptor.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/PropertyDescriptor.java
@@ -173,8 +173,7 @@ public class PropertyDescriptor<T> extends ReadOnlyPropertyDescriptor<T> {
         @Override
         public void vetoableChange(PropertyChangeEvent propertyChangeEvent) throws PropertyVetoException {
             if (bean.equals(propertyChangeEvent.getSource()) && name.equals(propertyChangeEvent.getPropertyName())) {
-                final ReadOnlyJavaBeanProperty<T> property = checkRef();
-                if ((property instanceof Property) && (((Property<?>)property).isBound()) && !updating) {
+                if ((checkRef() instanceof Property<?> property) && property.isBound() && !updating) {
                     throw new PropertyVetoException("A bound value cannot be set.", propertyChangeEvent);
                 }
             }

--- a/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/ReadOnlyJavaBeanPropertyBuilderHelper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/ReadOnlyJavaBeanPropertyBuilderHelper.java
@@ -30,7 +30,7 @@ import com.sun.javafx.reflect.ReflectUtil;
 
 /**
  */
-public class ReadOnlyJavaBeanPropertyBuilderHelper {
+public class ReadOnlyJavaBeanPropertyBuilderHelper<T> {
 
     private static final String IS_PREFIX = "is";
     private static final String GET_PREFIX = "get";
@@ -40,7 +40,7 @@ public class ReadOnlyJavaBeanPropertyBuilderHelper {
     private Object bean;
     private String getterName;
     private Method getter;
-    private ReadOnlyPropertyDescriptor descriptor;
+    private ReadOnlyPropertyDescriptor<T> descriptor;
 
     public void name(String propertyName) {
         if ((propertyName == null)? this.propertyName != null : !propertyName.equals(this.propertyName)) {
@@ -87,7 +87,7 @@ public class ReadOnlyJavaBeanPropertyBuilderHelper {
         }
     }
 
-    public ReadOnlyPropertyDescriptor getDescriptor() throws NoSuchMethodException {
+    public ReadOnlyPropertyDescriptor<T> getDescriptor() throws NoSuchMethodException {
         if (descriptor == null) {
             if ((propertyName == null) || (bean == null)) {
                 throw new NullPointerException("Bean and property name have to be specified");
@@ -107,7 +107,7 @@ public class ReadOnlyJavaBeanPropertyBuilderHelper {
                     }
                 }
             }
-            descriptor = new ReadOnlyPropertyDescriptor(propertyName, beanClass, getter);
+            descriptor = new ReadOnlyPropertyDescriptor<>(propertyName, beanClass, getter);
         }
         return descriptor;
     }

--- a/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/ReadOnlyPropertyDescriptor.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/property/adapter/ReadOnlyPropertyDescriptor.java
@@ -40,7 +40,7 @@ import static java.util.Locale.ENGLISH;
 
 /**
  */
-public class ReadOnlyPropertyDescriptor {
+public class ReadOnlyPropertyDescriptor<T> {
 
     private static final String ADD_LISTENER_METHOD_NAME = "addPropertyChangeListener";
     private static final String REMOVE_LISTENER_METHOD_NAME = "removePropertyChangeListener";
@@ -149,7 +149,7 @@ public class ReadOnlyPropertyDescriptor {
         }
     }
 
-    public class ReadOnlyListener<T> implements PropertyChangeListener, WeakListener {
+    public class ReadOnlyListener implements PropertyChangeListener, WeakListener {
 
         protected final Object bean;
         private final WeakReference<ReadOnlyJavaBeanProperty<T>> propertyRef;

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyListProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyListProperty.java
@@ -27,6 +27,8 @@ package javafx.beans.property;
 
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Objects;
+
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.ListExpression;
 import javafx.collections.ObservableList;
@@ -111,24 +113,19 @@ public abstract class ReadOnlyListProperty<E> extends ListExpression<E>
         if (this == obj) {
             return true;
         }
-        if (!(obj instanceof List)) {
-            return false;
-        }
-
-        final List<?> list = (List<?>)obj;
-
-        if (size() != list.size()) {
+        if (!(obj instanceof List<?> otherList) || size() != otherList.size()) {
             return false;
         }
 
         ListIterator<E> e1 = listIterator();
-        ListIterator<?> e2 = list.listIterator();
+        ListIterator<?> e2 = otherList.listIterator();
+
         while (e1.hasNext() && e2.hasNext()) {
-            E o1 = e1.next();
-            Object o2 = e2.next();
-            if (!(o1==null ? o2==null : o1.equals(o2)))
+            if (!Objects.equals(e1.next(), e2.next())) {
                 return false;
+            }
         }
+
         return true;
     }
 

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyListProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyListProperty.java
@@ -115,15 +115,14 @@ public abstract class ReadOnlyListProperty<E> extends ListExpression<E>
             return false;
         }
 
-        @SuppressWarnings("unchecked")
-        final List<E> list = (List<E>)obj;  // safe cast as elements are only referenced
+        final List<?> list = (List<?>)obj;
 
         if (size() != list.size()) {
             return false;
         }
 
         ListIterator<E> e1 = listIterator();
-        ListIterator<E> e2 = list.listIterator();
+        ListIterator<?> e2 = list.listIterator();
         while (e1.hasNext() && e2.hasNext()) {
             E o1 = e1.next();
             Object o2 = e2.next();

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyListProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyListProperty.java
@@ -114,14 +114,16 @@ public abstract class ReadOnlyListProperty<E> extends ListExpression<E>
         if (!(obj instanceof List)) {
             return false;
         }
-        final List list = (List)obj;
+
+        @SuppressWarnings("unchecked")
+        final List<E> list = (List<E>)obj;  // safe cast as elements are only referenced
 
         if (size() != list.size()) {
             return false;
         }
 
         ListIterator<E> e1 = listIterator();
-        ListIterator e2 = list.listIterator();
+        ListIterator<E> e2 = list.listIterator();
         while (e1.hasNext() && e2.hasNext()) {
             E o1 = e1.next();
             Object o2 = e2.next();

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyMapProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyMapProperty.java
@@ -107,37 +107,30 @@ public abstract class ReadOnlyMapProperty<K, V> extends MapExpression<K, V> impl
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == this)
+        if (obj == this) {
             return true;
-
-        if (!(obj instanceof Map))
-            return false;
-
-        @SuppressWarnings("unchecked")
-        Map<K,V> m = (Map<K,V>) obj;  // safe cast as elements are only referenced
-
-        if (m.size() != size())
-            return false;
-
-        try {
-            for (Entry<K,V> e : entrySet()) {
-                K key = e.getKey();
-                V value = e.getValue();
-                if (value == null) {
-                    if (!(m.get(key)==null && m.containsKey(key)))
-                        return false;
-                } else {
-                    if (!value.equals(m.get(key)))
-                        return false;
-                }
-            }
-        } catch (ClassCastException unused) {
-            return false;
-        } catch (NullPointerException unused) {
+        }
+        if (!(obj instanceof Map<?, ?> otherMap) || otherMap.size() != size()) {
             return false;
         }
 
-        return true;
+        try {
+            for (Entry<K, V> e : entrySet()) {
+                K key = e.getKey();
+                V value = e.getValue();
+                if (value == null) {
+                    if (otherMap.get(key) != null || !otherMap.containsKey(key)) {
+                        return false;
+                    }
+                } else if (!value.equals(otherMap.get(key))) {
+                    return false;
+                }
+            }
+
+            return true;
+        } catch (ClassCastException | NullPointerException unused) {
+            return false;
+        }
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyMapProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlyMapProperty.java
@@ -112,7 +112,10 @@ public abstract class ReadOnlyMapProperty<K, V> extends MapExpression<K, V> impl
 
         if (!(obj instanceof Map))
             return false;
-        Map<K,V> m = (Map<K,V>) obj;
+
+        @SuppressWarnings("unchecked")
+        Map<K,V> m = (Map<K,V>) obj;  // safe cast as elements are only referenced
+
         if (m.size() != size())
             return false;
 

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlySetProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlySetProperty.java
@@ -106,22 +106,16 @@ public abstract class ReadOnlySetProperty<E> extends SetExpression<E> implements
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == this)
+        if (obj == this) {
             return true;
-
-        if (!(obj instanceof Set))
+        }
+        if (!(obj instanceof Set<?> otherSet) || otherSet.size() != size()) {
             return false;
+        }
 
-        @SuppressWarnings("unchecked")
-        Set<E> c = (Set<E>) obj;  // safe cast as elements are only referenced
-
-        if (c.size() != size())
-            return false;
         try {
-            return containsAll(c);
-        } catch (ClassCastException unused)   {
-            return false;
-        } catch (NullPointerException unused) {
+            return containsAll(otherSet);
+        } catch (ClassCastException | NullPointerException unused)   {
             return false;
         }
     }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlySetProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/ReadOnlySetProperty.java
@@ -111,7 +111,10 @@ public abstract class ReadOnlySetProperty<E> extends SetExpression<E> implements
 
         if (!(obj instanceof Set))
             return false;
-        Set c = (Set) obj;
+
+        @SuppressWarnings("unchecked")
+        Set<E> c = (Set<E>) obj;  // safe cast as elements are only referenced
+
         if (c.size() != size())
             return false;
         try {

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/DescriptorListenerCleaner.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/DescriptorListenerCleaner.java
@@ -28,19 +28,19 @@ import java.lang.ref.WeakReference;
 
 import com.sun.javafx.property.adapter.ReadOnlyPropertyDescriptor;
 
-class DescriptorListenerCleaner implements Runnable{
+class DescriptorListenerCleaner<T> implements Runnable {
 
-    private final ReadOnlyPropertyDescriptor pd;
-    private final WeakReference<ReadOnlyPropertyDescriptor.ReadOnlyListener<?>> lRef;
+    private final ReadOnlyPropertyDescriptor<T> pd;
+    private final WeakReference<ReadOnlyPropertyDescriptor<T>.ReadOnlyListener> lRef;
 
-    DescriptorListenerCleaner(ReadOnlyPropertyDescriptor pd, ReadOnlyPropertyDescriptor.ReadOnlyListener<?> l) {
+    DescriptorListenerCleaner(ReadOnlyPropertyDescriptor<T> pd, ReadOnlyPropertyDescriptor<T>.ReadOnlyListener l) {
         this.pd = pd;
         this.lRef = new WeakReference<>(l);
     }
 
     @Override
     public void run() {
-        ReadOnlyPropertyDescriptor.ReadOnlyListener<?> l = lRef.get();
+        ReadOnlyPropertyDescriptor<T>.ReadOnlyListener l = lRef.get();
         if (l != null) {
             pd.removeListener(l);
         }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanBooleanProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanBooleanProperty.java
@@ -90,8 +90,8 @@ import java.security.PrivilegedAction;
  */
 public final class JavaBeanBooleanProperty extends BooleanProperty implements JavaBeanProperty<Boolean> {
 
-    private final PropertyDescriptor descriptor;
-    private final PropertyDescriptor.Listener<Boolean> listener;
+    private final PropertyDescriptor<Boolean> descriptor;
+    private final PropertyDescriptor<Boolean>.Listener listener;
 
     private ObservableValue<? extends Boolean> observable = null;
     private ExpressionHelper<Boolean> helper = null;
@@ -99,11 +99,11 @@ public final class JavaBeanBooleanProperty extends BooleanProperty implements Ja
     @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
-    JavaBeanBooleanProperty(PropertyDescriptor descriptor, Object bean) {
+    JavaBeanBooleanProperty(PropertyDescriptor<Boolean> descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new Listener<>(bean, this);
+        this.listener = descriptor.new Listener(bean, this);
         descriptor.addListener(listener);
-        Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
+        Disposer.addRecord(this, new DescriptorListenerCleaner<>(descriptor, listener));
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanBooleanPropertyBuilder.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanBooleanPropertyBuilder.java
@@ -59,7 +59,7 @@ import java.lang.reflect.Method;
  */
 public final class JavaBeanBooleanPropertyBuilder {
 
-    private final JavaBeanPropertyBuilderHelper helper = new JavaBeanPropertyBuilderHelper();
+    private final JavaBeanPropertyBuilderHelper<Boolean> helper = new JavaBeanPropertyBuilderHelper<>();
 
     private JavaBeanBooleanPropertyBuilder() {}
 
@@ -82,7 +82,7 @@ public final class JavaBeanBooleanPropertyBuilder {
      * {@code boolean} or {@code Boolean}
      */
     public JavaBeanBooleanProperty build() throws NoSuchMethodException {
-        final PropertyDescriptor descriptor = helper.getDescriptor();
+        final PropertyDescriptor<Boolean> descriptor = helper.getDescriptor();
         if (!boolean.class.equals(descriptor.getType()) && !Boolean.class.equals(descriptor.getType())) {
             throw new IllegalArgumentException("Not a boolean property");
         }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanDoubleProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanDoubleProperty.java
@@ -90,8 +90,8 @@ import java.security.PrivilegedAction;
  */
 public final class JavaBeanDoubleProperty extends DoubleProperty implements JavaBeanProperty<Number> {
 
-    private final PropertyDescriptor descriptor;
-    private final PropertyDescriptor.Listener<Number> listener;
+    private final PropertyDescriptor<Number> descriptor;
+    private final PropertyDescriptor<Number>.Listener listener;
 
     private ObservableValue<? extends Number> observable = null;
     private ExpressionHelper<Number> helper = null;
@@ -99,11 +99,11 @@ public final class JavaBeanDoubleProperty extends DoubleProperty implements Java
     @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
-    JavaBeanDoubleProperty(PropertyDescriptor descriptor, Object bean) {
+    JavaBeanDoubleProperty(PropertyDescriptor<Number> descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new Listener<>(bean, this);
+        this.listener = descriptor.new Listener(bean, this);
         descriptor.addListener(listener);
-        Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
+        Disposer.addRecord(this, new DescriptorListenerCleaner<>(descriptor, listener));
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanDoublePropertyBuilder.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanDoublePropertyBuilder.java
@@ -59,7 +59,7 @@ import java.lang.reflect.Method;
  */
 public final class JavaBeanDoublePropertyBuilder {
 
-    private final JavaBeanPropertyBuilderHelper helper = new JavaBeanPropertyBuilderHelper();
+    private final JavaBeanPropertyBuilderHelper<Number> helper = new JavaBeanPropertyBuilderHelper<>();
 
     private JavaBeanDoublePropertyBuilder() {}
 
@@ -82,7 +82,7 @@ public final class JavaBeanDoublePropertyBuilder {
      * {@code double} or {@code Double}
      */
     public JavaBeanDoubleProperty build() throws NoSuchMethodException {
-        final PropertyDescriptor descriptor = helper.getDescriptor();
+        final PropertyDescriptor<Number> descriptor = helper.getDescriptor();
         if (!double.class.equals(descriptor.getType()) && !Number.class.isAssignableFrom(descriptor.getType())) {
             throw new IllegalArgumentException("Not a double property");
         }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanFloatProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanFloatProperty.java
@@ -90,8 +90,8 @@ import java.security.PrivilegedAction;
  */
 public final class JavaBeanFloatProperty extends FloatProperty implements JavaBeanProperty<Number> {
 
-    private final PropertyDescriptor descriptor;
-    private final PropertyDescriptor.Listener<Number> listener;
+    private final PropertyDescriptor<Number> descriptor;
+    private final PropertyDescriptor<Number>.Listener listener;
 
     private ObservableValue<? extends Number> observable = null;
     private ExpressionHelper<Number> helper = null;
@@ -99,11 +99,11 @@ public final class JavaBeanFloatProperty extends FloatProperty implements JavaBe
     @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
-    JavaBeanFloatProperty(PropertyDescriptor descriptor, Object bean) {
+    JavaBeanFloatProperty(PropertyDescriptor<Number> descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new Listener<>(bean, this);
+        this.listener = descriptor.new Listener(bean, this);
         descriptor.addListener(listener);
-        Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
+        Disposer.addRecord(this, new DescriptorListenerCleaner<>(descriptor, listener));
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanFloatPropertyBuilder.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanFloatPropertyBuilder.java
@@ -59,7 +59,7 @@ import java.lang.reflect.Method;
  */
 public final class JavaBeanFloatPropertyBuilder {
 
-    private JavaBeanPropertyBuilderHelper helper = new JavaBeanPropertyBuilderHelper();
+    private JavaBeanPropertyBuilderHelper<Number> helper = new JavaBeanPropertyBuilderHelper<>();
 
     private JavaBeanFloatPropertyBuilder() {}
 
@@ -82,7 +82,7 @@ public final class JavaBeanFloatPropertyBuilder {
      * {@code float} or {@code Float}
      */
     public JavaBeanFloatProperty build() throws NoSuchMethodException {
-        final PropertyDescriptor descriptor = helper.getDescriptor();
+        final PropertyDescriptor<Number> descriptor = helper.getDescriptor();
         if (!float.class.equals(descriptor.getType()) && !Number.class.isAssignableFrom(descriptor.getType())) {
             throw new IllegalArgumentException("Not a float property");
         }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanIntegerProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanIntegerProperty.java
@@ -90,8 +90,8 @@ import java.security.PrivilegedAction;
  */
 public final class JavaBeanIntegerProperty extends IntegerProperty implements JavaBeanProperty<Number> {
 
-    private final PropertyDescriptor descriptor;
-    private final PropertyDescriptor.Listener<Number> listener;
+    private final PropertyDescriptor<Number> descriptor;
+    private final PropertyDescriptor<Number>.Listener listener;
 
     private ObservableValue<? extends Number> observable = null;
     private ExpressionHelper<Number> helper = null;
@@ -99,11 +99,11 @@ public final class JavaBeanIntegerProperty extends IntegerProperty implements Ja
     @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
-    JavaBeanIntegerProperty(PropertyDescriptor descriptor, Object bean) {
+    JavaBeanIntegerProperty(PropertyDescriptor<Number> descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new Listener<>(bean, this);
+        this.listener = descriptor.new Listener(bean, this);
         descriptor.addListener(listener);
-        Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
+        Disposer.addRecord(this, new DescriptorListenerCleaner<>(descriptor, listener));
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanIntegerPropertyBuilder.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanIntegerPropertyBuilder.java
@@ -59,7 +59,7 @@ import java.lang.reflect.Method;
  */
 public final class JavaBeanIntegerPropertyBuilder {
 
-    private JavaBeanPropertyBuilderHelper helper = new JavaBeanPropertyBuilderHelper();
+    private JavaBeanPropertyBuilderHelper<Number> helper = new JavaBeanPropertyBuilderHelper<>();
 
     private JavaBeanIntegerPropertyBuilder() {}
 
@@ -82,7 +82,7 @@ public final class JavaBeanIntegerPropertyBuilder {
      * {@code int} or {@code Integer}
      */
     public JavaBeanIntegerProperty build() throws NoSuchMethodException {
-        final PropertyDescriptor descriptor = helper.getDescriptor();
+        final PropertyDescriptor<Number> descriptor = helper.getDescriptor();
         if (!int.class.equals(descriptor.getType()) && !Number.class.isAssignableFrom(descriptor.getType())) {
             throw new IllegalArgumentException("Not an int property");
         }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanLongProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanLongProperty.java
@@ -90,8 +90,8 @@ import java.security.PrivilegedAction;
  */
 public final class JavaBeanLongProperty extends LongProperty implements JavaBeanProperty<Number> {
 
-    private final PropertyDescriptor descriptor;
-    private final PropertyDescriptor.Listener<Number> listener;
+    private final PropertyDescriptor<Number> descriptor;
+    private final PropertyDescriptor<Number>.Listener listener;
 
     private ObservableValue<? extends Number> observable = null;
     private ExpressionHelper<Number> helper = null;
@@ -99,11 +99,11 @@ public final class JavaBeanLongProperty extends LongProperty implements JavaBean
     @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
-    JavaBeanLongProperty(PropertyDescriptor descriptor, Object bean) {
+    JavaBeanLongProperty(PropertyDescriptor<Number> descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new Listener<>(bean, this);
+        this.listener = descriptor.new Listener(bean, this);
         descriptor.addListener(listener);
-        Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
+        Disposer.addRecord(this, new DescriptorListenerCleaner<>(descriptor, listener));
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanLongPropertyBuilder.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanLongPropertyBuilder.java
@@ -59,7 +59,7 @@ import java.lang.reflect.Method;
  */
 public final class JavaBeanLongPropertyBuilder {
 
-    private JavaBeanPropertyBuilderHelper helper = new JavaBeanPropertyBuilderHelper();
+    private JavaBeanPropertyBuilderHelper<Number> helper = new JavaBeanPropertyBuilderHelper<>();
 
     private JavaBeanLongPropertyBuilder() {}
 
@@ -82,7 +82,7 @@ public final class JavaBeanLongPropertyBuilder {
      * {@code long} or {@code Long}
      */
     public JavaBeanLongProperty build() throws NoSuchMethodException {
-        final PropertyDescriptor descriptor = helper.getDescriptor();
+        final PropertyDescriptor<Number> descriptor = helper.getDescriptor();
         if (!long.class.equals(descriptor.getType()) && !Number.class.isAssignableFrom(descriptor.getType())) {
             throw new IllegalArgumentException("Not a long property");
         }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanObjectProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanObjectProperty.java
@@ -92,8 +92,8 @@ import java.security.PrivilegedAction;
  */
 public final class JavaBeanObjectProperty<T> extends ObjectProperty<T> implements JavaBeanProperty<T> {
 
-    private final PropertyDescriptor descriptor;
-    private final PropertyDescriptor.Listener<T> listener;
+    private final PropertyDescriptor<T> descriptor;
+    private final PropertyDescriptor<T>.Listener listener;
 
     private ObservableValue<? extends T> observable = null;
     private ExpressionHelper<T> helper = null;
@@ -101,11 +101,11 @@ public final class JavaBeanObjectProperty<T> extends ObjectProperty<T> implement
     @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
-    JavaBeanObjectProperty(PropertyDescriptor descriptor, Object bean) {
+    JavaBeanObjectProperty(PropertyDescriptor<T> descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new Listener<>(bean, this);
+        this.listener = descriptor.new Listener(bean, this);
         descriptor.addListener(listener);
-        Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
+        Disposer.addRecord(this, new DescriptorListenerCleaner<>(descriptor, listener));
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanObjectPropertyBuilder.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanObjectPropertyBuilder.java
@@ -59,9 +59,10 @@ import java.lang.reflect.Method;
  * @param <T> the type of the wrapped {@code Object}
  * @since JavaFX 2.1
  */
+// TODO Update API: all public methods should have type <T> added instead of returning raw types
 public final class JavaBeanObjectPropertyBuilder<T> {
 
-    private JavaBeanPropertyBuilderHelper helper = new JavaBeanPropertyBuilderHelper();
+    private JavaBeanPropertyBuilderHelper<T> helper = new JavaBeanPropertyBuilderHelper<>();
 
     private JavaBeanObjectPropertyBuilder() {}
 
@@ -71,7 +72,7 @@ public final class JavaBeanObjectPropertyBuilder<T> {
      * @return the new {@code JavaBeanObjectPropertyBuilder}
      */
     public static JavaBeanObjectPropertyBuilder create() {
-        return new JavaBeanObjectPropertyBuilder();
+        return new JavaBeanObjectPropertyBuilder<>();
     }
 
     /**
@@ -82,7 +83,7 @@ public final class JavaBeanObjectPropertyBuilder<T> {
      * the getter and the setter of the Java Bean property
      */
     public JavaBeanObjectProperty<T> build() throws NoSuchMethodException {
-        final PropertyDescriptor descriptor = helper.getDescriptor();
+        final PropertyDescriptor<T> descriptor = helper.getDescriptor();
         return new JavaBeanObjectProperty<>(descriptor, helper.getBean());
     }
 

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanStringProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanStringProperty.java
@@ -90,8 +90,8 @@ import java.security.PrivilegedAction;
  */
 public final class JavaBeanStringProperty extends StringProperty implements JavaBeanProperty<String> {
 
-    private final PropertyDescriptor descriptor;
-    private final PropertyDescriptor.Listener<String> listener;
+    private final PropertyDescriptor<String> descriptor;
+    private final PropertyDescriptor<String>.Listener listener;
 
     private ObservableValue<? extends String> observable = null;
     private ExpressionHelper<String> helper = null;
@@ -99,11 +99,11 @@ public final class JavaBeanStringProperty extends StringProperty implements Java
     @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
-    JavaBeanStringProperty(PropertyDescriptor descriptor, Object bean) {
+    JavaBeanStringProperty(PropertyDescriptor<String> descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new Listener<>(bean, this);
+        this.listener = descriptor.new Listener(bean, this);
         descriptor.addListener(listener);
-        Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
+        Disposer.addRecord(this, new DescriptorListenerCleaner<>(descriptor, listener));
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanStringPropertyBuilder.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/JavaBeanStringPropertyBuilder.java
@@ -59,7 +59,7 @@ import java.lang.reflect.Method;
  */
 public final class JavaBeanStringPropertyBuilder {
 
-    private JavaBeanPropertyBuilderHelper helper = new JavaBeanPropertyBuilderHelper();
+    private JavaBeanPropertyBuilderHelper<String> helper = new JavaBeanPropertyBuilderHelper<>();
 
     private JavaBeanStringPropertyBuilder() {}
 
@@ -82,7 +82,7 @@ public final class JavaBeanStringPropertyBuilder {
      * {@code String}
      */
     public JavaBeanStringProperty build() throws NoSuchMethodException {
-        final PropertyDescriptor descriptor = helper.getDescriptor();
+        final PropertyDescriptor<String> descriptor = helper.getDescriptor();
         if (!String.class.equals(descriptor.getType())) {
             throw new IllegalArgumentException("Not a String property");
         }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanBooleanProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanBooleanProperty.java
@@ -82,17 +82,17 @@ import java.security.PrivilegedAction;
  */
 public final class ReadOnlyJavaBeanBooleanProperty extends ReadOnlyBooleanPropertyBase implements ReadOnlyJavaBeanProperty<Boolean> {
 
-    private final ReadOnlyPropertyDescriptor descriptor;
-    private final ReadOnlyPropertyDescriptor.ReadOnlyListener<Boolean> listener;
+    private final ReadOnlyPropertyDescriptor<Boolean> descriptor;
+    private final ReadOnlyPropertyDescriptor<Boolean>.ReadOnlyListener listener;
 
     @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
-    ReadOnlyJavaBeanBooleanProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
+    ReadOnlyJavaBeanBooleanProperty(ReadOnlyPropertyDescriptor<Boolean> descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new ReadOnlyListener<>(bean, this);
+        this.listener = descriptor.new ReadOnlyListener(bean, this);
         descriptor.addListener(listener);
-        Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
+        Disposer.addRecord(this, new DescriptorListenerCleaner<>(descriptor, listener));
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanBooleanPropertyBuilder.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanBooleanPropertyBuilder.java
@@ -58,7 +58,7 @@ import java.lang.reflect.Method;
  */
 public final class ReadOnlyJavaBeanBooleanPropertyBuilder {
 
-    private final ReadOnlyJavaBeanPropertyBuilderHelper helper = new ReadOnlyJavaBeanPropertyBuilderHelper();
+    private final ReadOnlyJavaBeanPropertyBuilderHelper<Boolean> helper = new ReadOnlyJavaBeanPropertyBuilderHelper<>();
 
     private ReadOnlyJavaBeanBooleanPropertyBuilder() {}
 
@@ -81,7 +81,7 @@ public final class ReadOnlyJavaBeanBooleanPropertyBuilder {
      * {@code boolean} or {@code Boolean}
      */
     public ReadOnlyJavaBeanBooleanProperty build() throws NoSuchMethodException {
-        final ReadOnlyPropertyDescriptor descriptor = helper.getDescriptor();
+        final ReadOnlyPropertyDescriptor<Boolean> descriptor = helper.getDescriptor();
         if (!boolean.class.equals(descriptor.getType()) && !Boolean.class.equals(descriptor.getType())) {
             throw new IllegalArgumentException("Not a boolean property");
         }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanDoubleProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanDoubleProperty.java
@@ -82,17 +82,17 @@ import java.security.PrivilegedAction;
  */
 public final class ReadOnlyJavaBeanDoubleProperty extends ReadOnlyDoublePropertyBase implements ReadOnlyJavaBeanProperty<Number> {
 
-    private final ReadOnlyPropertyDescriptor descriptor;
-    private final ReadOnlyPropertyDescriptor.ReadOnlyListener<Number> listener;
+    private final ReadOnlyPropertyDescriptor<Number> descriptor;
+    private final ReadOnlyPropertyDescriptor<Number>.ReadOnlyListener listener;
 
     @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
-    ReadOnlyJavaBeanDoubleProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
+    ReadOnlyJavaBeanDoubleProperty(ReadOnlyPropertyDescriptor<Number> descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new ReadOnlyListener<>(bean, this);
+        this.listener = descriptor.new ReadOnlyListener(bean, this);
         descriptor.addListener(listener);
-        Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
+        Disposer.addRecord(this, new DescriptorListenerCleaner<>(descriptor, listener));
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanDoublePropertyBuilder.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanDoublePropertyBuilder.java
@@ -58,7 +58,7 @@ import java.lang.reflect.Method;
  */
 public final class ReadOnlyJavaBeanDoublePropertyBuilder {
 
-    private final ReadOnlyJavaBeanPropertyBuilderHelper helper = new ReadOnlyJavaBeanPropertyBuilderHelper();
+    private final ReadOnlyJavaBeanPropertyBuilderHelper<Number> helper = new ReadOnlyJavaBeanPropertyBuilderHelper<>();
 
     private ReadOnlyJavaBeanDoublePropertyBuilder() {}
 
@@ -81,7 +81,7 @@ public final class ReadOnlyJavaBeanDoublePropertyBuilder {
      * {@code double} or {@code Double}
      */
     public ReadOnlyJavaBeanDoubleProperty build() throws NoSuchMethodException {
-        final ReadOnlyPropertyDescriptor descriptor = helper.getDescriptor();
+        final ReadOnlyPropertyDescriptor<Number> descriptor = helper.getDescriptor();
         if (!double.class.equals(descriptor.getType()) && !Number.class.isAssignableFrom(descriptor.getType())) {
             throw new IllegalArgumentException("Not a double property");
         }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanFloatProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanFloatProperty.java
@@ -82,17 +82,17 @@ import java.security.PrivilegedAction;
  */
 public final class ReadOnlyJavaBeanFloatProperty extends ReadOnlyFloatPropertyBase implements ReadOnlyJavaBeanProperty<Number> {
 
-    private final ReadOnlyPropertyDescriptor descriptor;
-    private final ReadOnlyPropertyDescriptor.ReadOnlyListener<Number> listener;
+    private final ReadOnlyPropertyDescriptor<Number> descriptor;
+    private final ReadOnlyPropertyDescriptor<Number>.ReadOnlyListener listener;
 
     @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
-    ReadOnlyJavaBeanFloatProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
+    ReadOnlyJavaBeanFloatProperty(ReadOnlyPropertyDescriptor<Number> descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new ReadOnlyListener<>(bean, this);
+        this.listener = descriptor.new ReadOnlyListener(bean, this);
         descriptor.addListener(listener);
-        Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
+        Disposer.addRecord(this, new DescriptorListenerCleaner<>(descriptor, listener));
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanFloatPropertyBuilder.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanFloatPropertyBuilder.java
@@ -58,7 +58,7 @@ import java.lang.reflect.Method;
  */
 public final class ReadOnlyJavaBeanFloatPropertyBuilder {
 
-    private final ReadOnlyJavaBeanPropertyBuilderHelper helper = new ReadOnlyJavaBeanPropertyBuilderHelper();
+    private final ReadOnlyJavaBeanPropertyBuilderHelper<Number> helper = new ReadOnlyJavaBeanPropertyBuilderHelper<>();
 
     private ReadOnlyJavaBeanFloatPropertyBuilder() {}
 
@@ -81,7 +81,7 @@ public final class ReadOnlyJavaBeanFloatPropertyBuilder {
      * {@code float} or {@code Float}
      */
     public ReadOnlyJavaBeanFloatProperty build() throws NoSuchMethodException {
-        final ReadOnlyPropertyDescriptor descriptor = helper.getDescriptor();
+        final ReadOnlyPropertyDescriptor<Number> descriptor = helper.getDescriptor();
         if (!float.class.equals(descriptor.getType()) && !Number.class.isAssignableFrom(descriptor.getType())) {
             throw new IllegalArgumentException("Not a float property");
         }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanIntegerProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanIntegerProperty.java
@@ -82,17 +82,17 @@ import java.security.PrivilegedAction;
  */
 public final class ReadOnlyJavaBeanIntegerProperty extends ReadOnlyIntegerPropertyBase implements ReadOnlyJavaBeanProperty<Number> {
 
-    private final ReadOnlyPropertyDescriptor descriptor;
-    private final ReadOnlyPropertyDescriptor.ReadOnlyListener<Number> listener;
+    private final ReadOnlyPropertyDescriptor<Number> descriptor;
+    private final ReadOnlyPropertyDescriptor<Number>.ReadOnlyListener listener;
 
     @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
-    ReadOnlyJavaBeanIntegerProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
+    ReadOnlyJavaBeanIntegerProperty(ReadOnlyPropertyDescriptor<Number> descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new ReadOnlyListener<>(bean, this);
+        this.listener = descriptor.new ReadOnlyListener(bean, this);
         descriptor.addListener(listener);
-        Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
+        Disposer.addRecord(this, new DescriptorListenerCleaner<>(descriptor, listener));
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanIntegerPropertyBuilder.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanIntegerPropertyBuilder.java
@@ -58,7 +58,7 @@ import java.lang.reflect.Method;
  */
 public final class ReadOnlyJavaBeanIntegerPropertyBuilder {
 
-    private final ReadOnlyJavaBeanPropertyBuilderHelper helper = new ReadOnlyJavaBeanPropertyBuilderHelper();
+    private final ReadOnlyJavaBeanPropertyBuilderHelper<Number> helper = new ReadOnlyJavaBeanPropertyBuilderHelper<>();
 
     private ReadOnlyJavaBeanIntegerPropertyBuilder() {}
 
@@ -81,7 +81,7 @@ public final class ReadOnlyJavaBeanIntegerPropertyBuilder {
      * {@code int} or {@code Integer}
      */
     public ReadOnlyJavaBeanIntegerProperty build() throws NoSuchMethodException {
-        final ReadOnlyPropertyDescriptor descriptor = helper.getDescriptor();
+        final ReadOnlyPropertyDescriptor<Number> descriptor = helper.getDescriptor();
         if (!int.class.equals(descriptor.getType()) && !Number.class.isAssignableFrom(descriptor.getType())) {
             throw new IllegalArgumentException("Not an int property");
         }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanLongProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanLongProperty.java
@@ -82,17 +82,17 @@ import java.security.PrivilegedAction;
  */
 public final class ReadOnlyJavaBeanLongProperty extends ReadOnlyLongPropertyBase implements ReadOnlyJavaBeanProperty<Number> {
 
-    private final ReadOnlyPropertyDescriptor descriptor;
-    private final ReadOnlyPropertyDescriptor.ReadOnlyListener<Number> listener;
+    private final ReadOnlyPropertyDescriptor<Number> descriptor;
+    private final ReadOnlyPropertyDescriptor<Number>.ReadOnlyListener listener;
 
     @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
-    ReadOnlyJavaBeanLongProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
+    ReadOnlyJavaBeanLongProperty(ReadOnlyPropertyDescriptor<Number> descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new ReadOnlyListener<>(bean, this);
+        this.listener = descriptor.new ReadOnlyListener(bean, this);
         descriptor.addListener(listener);
-        Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
+        Disposer.addRecord(this, new DescriptorListenerCleaner<>(descriptor, listener));
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanLongPropertyBuilder.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanLongPropertyBuilder.java
@@ -58,7 +58,7 @@ import java.lang.reflect.Method;
  */
 public final class ReadOnlyJavaBeanLongPropertyBuilder {
 
-    private final ReadOnlyJavaBeanPropertyBuilderHelper helper = new ReadOnlyJavaBeanPropertyBuilderHelper();
+    private final ReadOnlyJavaBeanPropertyBuilderHelper<Number> helper = new ReadOnlyJavaBeanPropertyBuilderHelper<>();
 
     private ReadOnlyJavaBeanLongPropertyBuilder() {}
 
@@ -81,7 +81,7 @@ public final class ReadOnlyJavaBeanLongPropertyBuilder {
      * {@code long} or {@code Long}
      */
     public ReadOnlyJavaBeanLongProperty build() throws NoSuchMethodException {
-        final ReadOnlyPropertyDescriptor descriptor = helper.getDescriptor();
+        final ReadOnlyPropertyDescriptor<Number> descriptor = helper.getDescriptor();
         if (!long.class.equals(descriptor.getType()) && !Number.class.isAssignableFrom(descriptor.getType())) {
             throw new IllegalArgumentException("Not a long property");
         }

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanObjectProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanObjectProperty.java
@@ -84,17 +84,17 @@ import java.security.PrivilegedAction;
  */
 public final class ReadOnlyJavaBeanObjectProperty<T> extends ReadOnlyObjectPropertyBase<T> implements ReadOnlyJavaBeanProperty<T> {
 
-    private final ReadOnlyPropertyDescriptor descriptor;
-    private final ReadOnlyPropertyDescriptor.ReadOnlyListener<T> listener;
+    private final ReadOnlyPropertyDescriptor<T> descriptor;
+    private final ReadOnlyPropertyDescriptor<T>.ReadOnlyListener listener;
 
     @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
-    ReadOnlyJavaBeanObjectProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
+    ReadOnlyJavaBeanObjectProperty(ReadOnlyPropertyDescriptor<T> descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new ReadOnlyListener<>(bean, this);
+        this.listener = descriptor.new ReadOnlyListener(bean, this);
         descriptor.addListener(listener);
-        Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
+        Disposer.addRecord(this, new DescriptorListenerCleaner<>(descriptor, listener));
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanObjectPropertyBuilder.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanObjectPropertyBuilder.java
@@ -60,7 +60,7 @@ import java.lang.reflect.Method;
  */
 public final class ReadOnlyJavaBeanObjectPropertyBuilder<T> {
 
-    private final ReadOnlyJavaBeanPropertyBuilderHelper helper = new ReadOnlyJavaBeanPropertyBuilderHelper();
+    private final ReadOnlyJavaBeanPropertyBuilderHelper<T> helper = new ReadOnlyJavaBeanPropertyBuilderHelper<>();
 
     private ReadOnlyJavaBeanObjectPropertyBuilder() {}
 
@@ -82,7 +82,7 @@ public final class ReadOnlyJavaBeanObjectPropertyBuilder<T> {
      * the getter of the Java Bean property
      */
     public ReadOnlyJavaBeanObjectProperty<T> build() throws NoSuchMethodException {
-        final ReadOnlyPropertyDescriptor descriptor = helper.getDescriptor();
+        final ReadOnlyPropertyDescriptor<T> descriptor = helper.getDescriptor();
         return new ReadOnlyJavaBeanObjectProperty<>(descriptor, helper.getBean());
     }
 

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanStringProperty.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanStringProperty.java
@@ -82,17 +82,17 @@ import java.security.PrivilegedAction;
  */
 public final class ReadOnlyJavaBeanStringProperty extends ReadOnlyStringPropertyBase implements ReadOnlyJavaBeanProperty<String> {
 
-    private final ReadOnlyPropertyDescriptor descriptor;
-    private final ReadOnlyPropertyDescriptor.ReadOnlyListener<String> listener;
+    private final ReadOnlyPropertyDescriptor<String> descriptor;
+    private final ReadOnlyPropertyDescriptor<String>.ReadOnlyListener listener;
 
     @SuppressWarnings("removal")
     private final AccessControlContext acc = AccessController.getContext();
 
-    ReadOnlyJavaBeanStringProperty(ReadOnlyPropertyDescriptor descriptor, Object bean) {
+    ReadOnlyJavaBeanStringProperty(ReadOnlyPropertyDescriptor<String> descriptor, Object bean) {
         this.descriptor = descriptor;
-        this.listener = descriptor.new ReadOnlyListener<>(bean, this);
+        this.listener = descriptor.new ReadOnlyListener(bean, this);
         descriptor.addListener(listener);
-        Disposer.addRecord(this, new DescriptorListenerCleaner(descriptor, listener));
+        Disposer.addRecord(this, new DescriptorListenerCleaner<>(descriptor, listener));
     }
 
     /**

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanStringPropertyBuilder.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/ReadOnlyJavaBeanStringPropertyBuilder.java
@@ -58,7 +58,7 @@ import java.lang.reflect.Method;
  */
 public final class ReadOnlyJavaBeanStringPropertyBuilder {
 
-    private final ReadOnlyJavaBeanPropertyBuilderHelper helper = new ReadOnlyJavaBeanPropertyBuilderHelper();
+    private final ReadOnlyJavaBeanPropertyBuilderHelper<String> helper = new ReadOnlyJavaBeanPropertyBuilderHelper<>();
 
     private ReadOnlyJavaBeanStringPropertyBuilder() {}
 
@@ -81,7 +81,7 @@ public final class ReadOnlyJavaBeanStringPropertyBuilder {
      * {@code String}
      */
     public ReadOnlyJavaBeanStringProperty build() throws NoSuchMethodException {
-        final ReadOnlyPropertyDescriptor descriptor = helper.getDescriptor();
+        final ReadOnlyPropertyDescriptor<String> descriptor = helper.getDescriptor();
         if (!String.class.equals(descriptor.getType())) {
             throw new IllegalArgumentException("Not a String property");
         }


### PR DESCRIPTION
- Added generics (to package private or internal classes only)
- Minor clean-ups of code I touched (naming)
- Fixed incorrect use of generics
- Fixed raw type warnings

Note: some raw types have leaked into public API.  These could be fixed without incompatibilities.  For specifics see `JavaBeanObjectPropertyBuilder`.  The javadoc would have the method signatures change (`<T>` would be appended to the affected methods).  For now I've added a TODO there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298200](https://bugs.openjdk.org/browse/JDK-8298200): Clean up raw type warnings in javafx.beans.property.* and com.sun.javafx.property.*


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/969/head:pull/969` \
`$ git checkout pull/969`

Update a local copy of the PR: \
`$ git checkout pull/969` \
`$ git pull https://git.openjdk.org/jfx pull/969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 969`

View PR using the GUI difftool: \
`$ git pr show -t 969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/969.diff">https://git.openjdk.org/jfx/pull/969.diff</a>

</details>
