### PR TITLE
8298496: IconifyTest fails intermittently on Linux

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/stage/IconifyTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/IconifyTest.java
@@ -57,19 +57,25 @@ public class IconifyTest extends VisualTestBase {
     private Stage topStage;
 
     public void canIconifyStage(StageStyle stageStyle, boolean resizable) throws Exception {
-        final CountDownLatch shownLatch = new CountDownLatch(2);
+        final CountDownLatch bottomShownLatch = new CountDownLatch(1);
+        final CountDownLatch topShownLatch = new CountDownLatch(1);
 
         runAndWait(() -> {
             // Bottom stage, should be visible after top stage is iconified
-            bottomStage = getStage(true);
+            bottomStage = getStage(false);
             Scene bottomScene = new Scene(new Pane(), WIDTH, HEIGHT);
             bottomScene.setFill(BOTTOM_COLOR);
             bottomStage.setScene(bottomScene);
             bottomStage.setX(0);
             bottomStage.setY(0);
-            bottomStage.setOnShown(e -> Platform.runLater(shownLatch::countDown));
+            bottomStage.setOnShown(e -> Platform.runLater(bottomShownLatch::countDown));
             bottomStage.show();
+        });
 
+        assertTrue("Timeout waiting for bottom stage to be shown",
+            bottomShownLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
+
+        runAndWait(() -> {
             // Top stage, will be inconified
             topStage = getStage(true);
             topStage.initStyle(stageStyle);
@@ -79,16 +85,12 @@ public class IconifyTest extends VisualTestBase {
             topStage.setScene(topScene);
             topStage.setX(0);
             topStage.setY(0);
-            topStage.setOnShown(e -> Platform.runLater(shownLatch::countDown));
+            topStage.setOnShown(e -> Platform.runLater(topShownLatch::countDown));
             topStage.show();
         });
 
-        assertTrue("Timeout waiting for stages to be shown",
-            shownLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
-
-        runAndWait(() -> {
-            topStage.toFront();
-        });
+        assertTrue("Timeout waiting for top stage to be shown",
+            topShownLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
 
         sleep(500);
         runAndWait(() -> {

--- a/tests/system/src/test/java/test/robot/javafx/stage/IconifyTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/IconifyTest.java
@@ -92,7 +92,7 @@ public class IconifyTest extends VisualTestBase {
         assertTrue("Timeout waiting for top stage to be shown",
             topShownLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
 
-        sleep(500);
+        sleep(1000);
         runAndWait(() -> {
             assertFalse(topStage.isIconified());
             Color color = getColor(100, 100);
@@ -103,7 +103,7 @@ public class IconifyTest extends VisualTestBase {
             topStage.setIconified(true);
         });
 
-        sleep(500);
+        sleep(1000);
         runAndWait(() -> {
             assertTrue(topStage.isIconified());
             Color color = getColor(100, 100);
@@ -114,7 +114,7 @@ public class IconifyTest extends VisualTestBase {
             topStage.setIconified(false);
         });
 
-        sleep(500);
+        sleep(1000);
         runAndWait(() -> {
             assertFalse(topStage.isIconified());
             Color color = getColor(100, 100);


### PR DESCRIPTION
`IconifyTest` is unstable on Linux, which makes it impossible to rely on it to test the ability to iconify and deiconify a Stage. The reason for the instability is that the stacking order of multiple always-on-top windows on Linux is wrong sometimes. See [JDK-8298499](https://bugs.openjdk.org/browse/JDK-8298499). Using two always-on-top Stages is unnecessary for this test, and the test will be more stable without it. The fix is to create the bottom Stage without setting `alwaysOnTop`, leaving only the top Stage `alwaysOnTop`. Further, the test now waits for the bottom Stage to be shown before creating the top Stage. The call to `topStage.toFront()` is removed as it is unnecessary. It should never have been needed, and its presence suggests that it might have been an attempted workaround for the stacking order problem (now tracked by JDK-8298499 as mentioned previously). Finally, I increased the wait time between operations from 500 msec to 1000 msec, to match what most other similar tests do (this latter helped stability on my old Ubuntu 16.04 system).

With this fix, the test is now stable on Linux (and is still stable on Windows and Mac). It consistently passes on Linux except Ubuntu 22.04, where it now shows a real problem that undecorated/transparent Stages consistently fail to deiconify (the instability of the test was preventing our being able to see that). Given that #915 fixes this newly discovered problem, I won't file a new bug, but rather will add it to that bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298496](https://bugs.openjdk.org/browse/JDK-8298496): IconifyTest fails intermittently on Linux


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/975/head:pull/975` \
`$ git checkout pull/975`

Update a local copy of the PR: \
`$ git checkout pull/975` \
`$ git pull https://git.openjdk.org/jfx pull/975/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 975`

View PR using the GUI difftool: \
`$ git pr show -t 975`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/975.diff">https://git.openjdk.org/jfx/pull/975.diff</a>

</details>
