### PR TITLE
8252863: Spinner keeps spinning if removed from Scene

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/SpinnerBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/SpinnerBehavior.java
@@ -53,7 +53,8 @@ public class SpinnerBehavior<T> extends BehaviorBase<Spinner<T>> {
 
     private boolean isIncrementing = false;
 
-    private Timeline timeline;
+    /* Package-private for testing purposes */
+    Timeline timeline;
 
     final EventHandler<ActionEvent> spinningKeyFrameEventHandler = event -> {
         final SpinnerValueFactory<T> valueFactory = getNode().getValueFactory();
@@ -122,7 +123,6 @@ public class SpinnerBehavior<T> extends BehaviorBase<Spinner<T>> {
 
     public void startSpinning(boolean increment) {
         isIncrementing = increment;
-
         if (timeline != null) {
             timeline.stop();
         }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/SpinnerBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/SpinnerBehavior.java
@@ -123,6 +123,7 @@ public class SpinnerBehavior<T> extends BehaviorBase<Spinner<T>> {
 
     public void startSpinning(boolean increment) {
         isIncrementing = increment;
+
         if (timeline != null) {
             timeline.stop();
         }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
@@ -81,7 +81,8 @@ public class SpinnerSkin<T> extends SkinBase<Spinner<T>> {
     private static final int SPLIT_ARROWS_HORIZONTAL    = 5;
 
     private int layoutMode = 0;
-    private final SpinnerBehavior behavior;
+    /* Package-private for testing purposes */
+    final SpinnerBehavior behavior;
 
 
     /* *************************************************************************
@@ -249,6 +250,12 @@ public class SpinnerSkin<T> extends SkinBase<Spinner<T>> {
                 return null;
             }
         }));
+
+        getSkinnable().sceneProperty().addListener((observable, oldValue, newValue) -> {
+            // Stop spinning when sceneProperty is modified
+            behavior.stopSpinning();
+        });
+
     }
 
     private boolean isIncDecKeyEvent(KeyEvent ke) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
@@ -255,7 +255,6 @@ public class SpinnerSkin<T> extends SkinBase<Spinner<T>> {
             // Stop spinning when sceneProperty is modified
             behavior.stopSpinning();
         });
-
     }
 
     private boolean isIncDecKeyEvent(KeyEvent ke) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/SpinnerSkin.java
@@ -251,7 +251,7 @@ public class SpinnerSkin<T> extends SkinBase<Spinner<T>> {
             }
         }));
 
-        getSkinnable().sceneProperty().addListener((observable, oldValue, newValue) -> {
+        lh.addChangeListener(control.sceneProperty(), (op) -> {
             // Stop spinning when sceneProperty is modified
             behavior.stopSpinning();
         });

--- a/modules/javafx.controls/src/shims/java/com/sun/javafx/scene/control/behavior/SpinnerBehaviorShim.java
+++ b/modules/javafx.controls/src/shims/java/com/sun/javafx/scene/control/behavior/SpinnerBehaviorShim.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.scene.control.behavior;
+
+import javafx.animation.Timeline;
+
+import com.sun.javafx.scene.control.behavior.SpinnerBehavior;
+
+public class SpinnerBehaviorShim {
+
+    public static Timeline getTimeline(SpinnerBehavior spinnerBehavior) {
+        return spinnerBehavior.timeline;
+    }
+
+}

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/SpinnerSkinShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/SpinnerSkinShim.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package javafx.scene.control.skin;
+
+import javafx.scene.control.skin.SpinnerSkin;
+
+import com.sun.javafx.scene.control.behavior.SpinnerBehavior;
+
+public class SpinnerSkinShim {
+
+    public static SpinnerBehavior getSpinnerBehavior(SpinnerSkin spinnerSkin) {
+        return spinnerSkin.behavior;
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SpinnerSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SpinnerSkinTest.java
@@ -162,7 +162,6 @@ public class SpinnerSkinTest {
     @Test
     public void testSpinnerIncrementOnRemovingFromScene() {
         spinner = new Spinner<>(0, 1000, 0);
-        // spinner.setEditable(true);
         spinner.setSkin(new SpinnerSkin<>(spinner));
 
         HBox root = new HBox(spinner);

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SpinnerSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SpinnerSkinTest.java
@@ -176,5 +176,7 @@ public class SpinnerSkinTest {
         assertEquals(Status.RUNNING, SpinnerBehaviorShim.getTimeline(behavior).getStatus());
         root.getChildren().clear();
         assertEquals(Status.STOPPED, SpinnerBehaviorShim.getTimeline(behavior).getStatus());
+        root.getChildren().setAll(spinner);
+        assertEquals(Status.STOPPED, SpinnerBehaviorShim.getTimeline(behavior).getStatus());
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SpinnerSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SpinnerSkinTest.java
@@ -30,11 +30,20 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 
+import javafx.animation.Animation.Status;
 import javafx.geometry.BoundingBox;
 import javafx.geometry.Insets;
 import javafx.scene.control.Spinner;
+import javafx.scene.control.SpinnerShim;
 import javafx.scene.control.skin.SpinnerSkin;
+import javafx.scene.control.skin.SpinnerSkinShim;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+
+import com.sun.javafx.scene.control.behavior.SpinnerBehavior;
+import com.sun.javafx.scene.control.behavior.SpinnerBehaviorShim;
 
 /**
  * Tests for SpinnerSkin
@@ -148,5 +157,25 @@ public class SpinnerSkinTest {
         Spinner<?> spinner = new Spinner<>();
         spinner.setSkin(new SpinnerSkin<>(spinner));
         spinner.setSkin(new SpinnerSkin<>(spinner));
+    }
+
+    @Test
+    public void testSpinnerIncrementOnRemovingFromScene() {
+        spinner = new Spinner<>(0, 1000, 0);
+        // spinner.setEditable(true);
+        spinner.setSkin(new SpinnerSkin<>(spinner));
+
+        HBox root = new HBox(spinner);
+        Scene scene = new Scene(root);
+        Stage stage = new Stage();
+        stage.setScene(scene);
+        stage.show();
+
+        SpinnerBehavior behavior = SpinnerSkinShim.getSpinnerBehavior((SpinnerSkin)spinner.getSkin());
+        behavior.startSpinning(true);
+
+        assertEquals(Status.RUNNING, SpinnerBehaviorShim.getTimeline(behavior).getStatus());
+        root.getChildren().clear();
+        assertEquals(Status.STOPPED, SpinnerBehaviorShim.getTimeline(behavior).getStatus());
     }
 }


### PR DESCRIPTION
Spinner was not stopping because it was getting removed from scene before the mouse release event handler was getting invoked.

Added listener for `sceneProperty` so that when Spinner is removed from the scene, `stopSpinning` method shall be called.

Added unit test to validate the fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8252863](https://bugs.openjdk.org/browse/JDK-8252863): Spinner keeps spinning if removed from Scene


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Committer)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/976/head:pull/976` \
`$ git checkout pull/976`

Update a local copy of the PR: \
`$ git checkout pull/976` \
`$ git pull https://git.openjdk.org/jfx pull/976/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 976`

View PR using the GUI difftool: \
`$ git pr show -t 976`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/976.diff">https://git.openjdk.org/jfx/pull/976.diff</a>

</details>
