### PR TITLE
8231864: JavaFX Labels in Tab's VBox is not displayed until it is clicked

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGNode.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGNode.java
@@ -330,12 +330,12 @@ public abstract class NGNode {
         // cache needs to be regenerated. So we will not invalidate it here.
         if (dirtyBounds.isEmpty()) {
             dirtyBounds = dirtyBounds.deriveWithNewBounds(transformedBounds);
-            dirtyBounds = dirtyBounds.deriveWithUnion(bounds);
         } else {
             // TODO I think this is vestigial from Scenario and will never
             // actually occur in real life... (RT-23956)
             dirtyBounds = dirtyBounds.deriveWithUnion(transformedBounds);
         }
+        dirtyBounds = dirtyBounds.deriveWithUnion(bounds);
         transformedBounds = transformedBounds.deriveWithNewBounds(bounds);
         if (hasVisuals() && !byTransformChangeOnly) {
             markDirty();


### PR DESCRIPTION
Creating a not-displayed node and then modifying its contents caused JFX to not consume its old dirty region and thus not update it. When such node was displayed, its old dirty region was used for drawing, which in some cases (ex. new content taking more space - a Label having more text as in bug request) caused it to clip.

Resolved by always unionizing dirty regions with new bounds when calculating Node's transformed bounds.

Change was tested on macOS and Windows 10 and does not affect any tests.