### PR TITLE
8296654: [macos] Crash when launching JavaFX app with JDK that targets SDK 13

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
@@ -263,7 +263,9 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
     (*env)->CallVoidMethod(env, self->jView, jViewNotifyResize, (int)newSize.width, (int)newSize.height);
     GLASS_CHECK_EXCEPTION(env);
 
-    [self->nsView removeTrackingRect:self->trackingRect];
+    if (self->trackingRect) {
+        [self->nsView removeTrackingRect:self->trackingRect];
+    }
     self->trackingRect = [self->nsView addTrackingRect:[self->nsView bounds] owner:self->nsView userData:nil assumeInside:NO];
 }
 
@@ -277,13 +279,17 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
     (*env)->CallVoidMethod(env, self->jView, jViewNotifyResize, (int)frameRect.size.width, (int)frameRect.size.height);
     GLASS_CHECK_EXCEPTION(env);
 
-    [self->nsView removeTrackingRect:self->trackingRect];
+    if (self->trackingRect) {
+        [self->nsView removeTrackingRect:self->trackingRect];
+    }
     self->trackingRect = [self->nsView addTrackingRect:[self->nsView bounds] owner:self->nsView userData:nil assumeInside:NO];
 }
 
 - (void)updateTrackingAreas
 {
-    [self->nsView removeTrackingRect:self->trackingRect];
+    if (self->trackingRect) {
+        [self->nsView removeTrackingRect:self->trackingRect];
+    }
     self->trackingRect = [self->nsView addTrackingRect:[self->nsView bounds] owner:self->nsView userData:nil assumeInside:NO];
 }
 


### PR DESCRIPTION
Apple has changed the behavior for applications that are built using the macOS SDK 13 (which is what XCode 14 uses), such that passing in a null tracking rect to `NSView::removeTrackingRect` will cause now cause a crash. This has exposed a latent bug in the JavaFX macOS glass code that removes the previous tracking rect even if it is null in `setFrame`, `setFrameSize`,  and `updateTrackingAreas`.

The fix is to check that the current tracking rect is non null before calling `removeTrackingRect` as suggested in both this bug report and duplicate bug [JDK-8297131](https://bugs.openjdk.org/browse/JDK-8297131). The latter bug report describes an easy way to reproduce this without building your own JDK, by making a copy of the JDK and modifying the meta-data that indicates the target version of the macOS SDK. I did that, and can reproduce this crash with any JavaFX program without this fix, and verified that it works correctly with this fix.

NOTE: it is the version of the SDK (Xcode) that the JDK is targeted to that matters. It is irrelevant what version of the SDK (i.e., what Xcode) is used to build JavaFX. This make this a more serious bug than it otherwise would be.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296654](https://bugs.openjdk.org/browse/JDK-8296654): [macos] Crash when launching JavaFX app with JDK that targets SDK 13


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/981/head:pull/981` \
`$ git checkout pull/981`

Update a local copy of the PR: \
`$ git checkout pull/981` \
`$ git pull https://git.openjdk.org/jfx pull/981/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 981`

View PR using the GUI difftool: \
`$ git pr show -t 981`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/981.diff">https://git.openjdk.org/jfx/pull/981.diff</a>

</details>
