### PR TITLE
8216507: StyleablePropertyFactory: example in class javadoc does not compile

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/css/StyleablePropertyFactory.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/StyleablePropertyFactory.java
@@ -121,7 +121,7 @@ import java.util.function.Function;
  * <pre><code>
  public final class MyButton extends Button {
 
-     private static CssMetaData<JavadocFixStylableProperty, Boolean> SELECTED;
+     private static {@literal CssMetaData<MyButton, Boolean>} SELECTED;
 
      private static final {@literal StyleablePropertyFactory<MyButton>} FACTORY =
          new {@literal StyleablePropertyFactory<>}(Button.getClassCssMetaData()) {

--- a/modules/javafx.graphics/src/main/java/javafx/css/StyleablePropertyFactory.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/StyleablePropertyFactory.java
@@ -121,12 +121,14 @@ import java.util.function.Function;
  * <pre><code>
  public final class MyButton extends Button {
 
+     private static CssMetaData<JavadocFixStylableProperty, Boolean> SELECTED;
+
      private static final {@literal StyleablePropertyFactory<MyButton>} FACTORY =
          new {@literal StyleablePropertyFactory<>}(Button.getClassCssMetaData()) {
          {
-             createBooleanCssMetaData("-my-selected", s {@literal ->} s.selected, false, false);
+             SELECTED = createBooleanCssMetaData("-my-selected", s {@literal ->} s.selected, false, false);
          }
-     }
+     };
 
 
      MyButton(String labelText) {
@@ -141,7 +143,7 @@ import java.util.function.Function;
 
      // StyleableProperty implementation reduced to one line
      private final {@literal StyleableProperty<Boolean>} selected =
-         new SimpleStyleableBooleanProperty(this, "selected", "my-selected");
+         new SimpleStyleableBooleanProperty(SELECTED, "selected", "my-selected");
 
      public static {@literal List<CssMetaData<? extends Styleable, ?>>} getClassCssMetaData() {
          return FACTORY.getCssMetaData();

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/StyleablePropertyFactoryTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/StyleablePropertyFactoryTest.java
@@ -57,6 +57,7 @@ import javafx.css.CssMetaData;
 import javafx.css.Styleable;
 import javafx.css.StyleableProperty;
 import javafx.css.StyleablePropertyFactory;
+import javafx.css.SimpleStyleableBooleanProperty;
 
 import static org.junit.Assert.*;
 
@@ -125,7 +126,8 @@ public class StyleablePropertyFactoryTest {
                 },
                 {new Data("myNumber", "-my-number: 2em;", Font.getDefault().getSize()*2)},
                 {new Data("myString", "-my-string: \"yaba daba do\";", "yaba daba do")},
-                {new Data("myUrl", "-my-url: url('http://www.oracle.com');", "http://www.oracle.com")}
+                {new Data("myUrl", "-my-url: url('http://www.oracle.com');", "http://www.oracle.com")},
+                {new Data("mySelected", "-my-selected: false;", Boolean.FALSE)}
         });
 
     }
@@ -203,6 +205,17 @@ public class StyleablePropertyFactoryTest {
         public String getMyUrl() { return myUrl.getValue(); }
         public void setMyUrl(String value) { myUrl.setValue(value); }
         private final StyleableProperty<String> myUrl = fac.createStyleableUrlProperty(this, "myUrl", "-my-url", s -> ((MyStyleable) s).myUrl);
+
+        private static CssMetaData<MyStyleable, Boolean> SELECTED;
+        private static final StyleablePropertyFactory<MyStyleable> FACTORY = new StyleablePropertyFactory<>(null){
+            {
+                SELECTED = createBooleanCssMetaData("-my-selected", s -> ((MyStyleable) s).mySelected, false, false);
+            }
+        };
+        public ObservableValue<Boolean> mySelectedProperty() { return (ObservableValue<Boolean>)mySelected; }
+        public final boolean getMySelected() { return mySelected.getValue(); }
+        public final void setMySelected(boolean isSelected) { mySelected.setValue(isSelected); }
+        private final StyleableProperty<Boolean> mySelected = new SimpleStyleableBooleanProperty(SELECTED, "mySelected", "my-selected");
 
         @Override
         public String getTypeSelector() {


### PR DESCRIPTION
In the javadoc example of `StyleablePropertyFactory` class, wrong parameter was used while initializing `StyleableProperty`. 

Assigned the `CssMetadData` object to `SELECTED` variable returned by `createBooleanCssMetaData` method called in anonymous inner-class class, which is then used while initializing `StyleableProperty`.

Added missing semicolon in the same example.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8216507](https://bugs.openjdk.org/browse/JDK-8216507): StyleablePropertyFactory: example in class javadoc does not compile


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Committer)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/983/head:pull/983` \
`$ git checkout pull/983`

Update a local copy of the PR: \
`$ git checkout pull/983` \
`$ git pull https://git.openjdk.org/jfx pull/983/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 983`

View PR using the GUI difftool: \
`$ git pr show -t 983`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/983.diff">https://git.openjdk.org/jfx/pull/983.diff</a>

</details>
