### PR TITLE
8299348: Size-restricted window can be observed with incorrect dimensions

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -165,29 +165,6 @@ void GlassWindow::setMaxSize(long width, long height)
 {
     m_maxSize.x = width;
     m_maxSize.y = height;
-}
-
-void GlassWindow::updateMinMaxSize(RECT &windowRect)
-{
-    if (m_minSize.x >= 0) {
-        // min size has been set
-        if (windowRect.right - windowRect.left < m_minSize.x) {
-            windowRect.right = windowRect.left + m_minSize.x;
-        }
-        if (windowRect.bottom - windowRect.top < m_minSize.y) {
-            windowRect.bottom = windowRect.top + m_minSize.y;
-        }
-    }
-    if (m_maxSize.x >= 0) {
-        // max size has been set
-        if (windowRect.right - windowRect.left > m_maxSize.x) {
-            windowRect.right = windowRect.left + m_maxSize.x;
-        }
-        if (windowRect.bottom - windowRect.top > m_maxSize.y) {
-            windowRect.bottom = windowRect.top + m_maxSize.y;
-        }
-    }
-
 }
 
 void GlassWindow::SetFocusable(bool isFocusable)
@@ -1538,6 +1515,13 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_win_WinWindow__1setBounds
                        cw > 0 ? cw + is.right + is.left : r.right - r.left;
         int newH = h > 0 ? h :
                        ch > 0 ? ch + is.bottom + is.top : r.bottom - r.top;
+
+        POINT minSize = pWindow->getMinSize();
+        POINT maxSize = pWindow->getMaxSize();
+        if (minSize.x >= 0) newW = max(newW, minSize.x);
+        if (minSize.y >= 0) newH = max(newH, minSize.y);
+        if (maxSize.x >= 0) newW = min(newW, maxSize.x);
+        if (maxSize.y >= 0) newH = min(newH, maxSize.y);
 
         if (xSet || ySet) {
             ::SetWindowPos(hWnd, NULL, newX, newY, newW, newH,

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,9 +44,9 @@ public:
 
     void setMinSize(long width, long height);
     void setMaxSize(long width, long height);
+    POINT getMinSize() { return m_minSize; }
+    POINT getMaxSize() { return m_maxSize; }
 
-    // ensures the rect comply min/max size restrictions (if set)
-    void updateMinMaxSize(RECT &windowRect);
     HMONITOR GetMonitor();
     void SetMonitor(HMONITOR hMonitor);
 

--- a/tests/system/src/test/java/test/com/sun/glass/ui/InitialWindowSizeTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/InitialWindowSizeTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.glass.ui;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import test.util.Util;
+import javafx.application.Application;
+import javafx.geometry.Dimension2D;
+import javafx.scene.Scene;
+import javafx.scene.layout.StackPane;
+import javafx.scene.shape.Rectangle;
+import javafx.stage.Stage;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.*;
+
+public class InitialWindowSizeTest {
+
+    private static final CountDownLatch startupLatch = new CountDownLatch(1);
+    private static volatile Dimension2D showingSize, shownSize;
+
+    public static class TestApp extends Application {
+        @Override
+        public void start(Stage stage) {
+            stage.setMinWidth(300);
+            stage.setMinHeight(200);
+            stage.setScene(new Scene(new StackPane(new Rectangle(20, 20))));
+            stage.setOnShowing(event -> showingSize = new Dimension2D(stage.getWidth(), stage.getHeight()));
+            stage.setOnShown(event -> {
+                shownSize = new Dimension2D(stage.getWidth(), stage.getHeight());
+                startupLatch.countDown();
+            });
+            stage.show();
+        }
+    }
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        Util.launch(startupLatch, TestApp.class);
+    }
+
+    @AfterClass
+    public static void shutdown() {
+        Util.shutdown();
+    }
+
+    @Test
+    public void testInitialWindowSize() {
+        Util.waitForLatch(startupLatch, 10, "startupLatch");
+
+        assertTrue("width = " + showingSize.getWidth() + ", expected = NaN",
+                   Double.isNaN(showingSize.getWidth()));
+        assertTrue("height = " + showingSize.getHeight() + ", expected = NaN",
+                   Double.isNaN(showingSize.getHeight()));
+
+        assertEquals(300.0, shownSize.getWidth(), 0.001);
+        assertEquals(200.0, shownSize.getHeight(), 0.001);
+    }
+}


### PR DESCRIPTION
On Windows, a `Stage` that is restricted by minimum and maximum sizes can briefly be observed to appear with incorrect dimensions when it is first shown. The root cause of this bug is that the native `WinWindow._setBounds` method doesn't respect min/max sizes when calculating the window rect.

Note to reviewers: I've removed the unused `GlassWindow::updateMinMaxSize` method as to not confuse readers where min-max handling actually happens.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8299348](https://bugs.openjdk.org/browse/JDK-8299348): Size-restricted window can be observed with incorrect dimensions


### Reviewers
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/984/head:pull/984` \
`$ git checkout pull/984`

Update a local copy of the PR: \
`$ git checkout pull/984` \
`$ git pull https://git.openjdk.org/jfx.git pull/984/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 984`

View PR using the GUI difftool: \
`$ git pr show -t 984`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/984.diff">https://git.openjdk.org/jfx/pull/984.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/984#issuecomment-1364837225)