### PR TITLE
8299423: JavaFX Mac system menubar leaks

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacMenuDelegate.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacMenuDelegate.java
@@ -29,6 +29,7 @@ import com.sun.glass.ui.MenuItem.Callback;
 import com.sun.glass.ui.Pixels;
 import com.sun.glass.ui.delegate.MenuDelegate;
 import com.sun.glass.ui.delegate.MenuItemDelegate;
+import javafx.application.Platform;
 
 class MacMenuDelegate implements MenuDelegate, MenuItemDelegate {
 
@@ -42,6 +43,11 @@ class MacMenuDelegate implements MenuDelegate, MenuItemDelegate {
 
     // GlassMenu <-> Menu
     private Menu menu;
+
+    boolean isInserted = false;
+    Callback callback = null;
+
+    private Callback lastSetCallback = null;
     public MacMenuDelegate(final Menu menu) {
         this.menu = menu;
     }
@@ -63,19 +69,27 @@ class MacMenuDelegate implements MenuDelegate, MenuItemDelegate {
                                             int shortcutKey, int shortcutModifiers, Pixels pixels,
                                             boolean enabled, boolean checked) {
         ptr = _createMenuItem(title, (char)shortcutKey, shortcutModifiers,
-                              pixels, enabled, checked, callback);
+                pixels, enabled, checked, callback);
+        this.callback = callback;
+        isInserted = true;
         return ptr != 0;
     }
 
     private native void _insert(long menuPtr, long submenuPtr, int pos);
     @Override public boolean insert(MenuDelegate menu, int pos) {
         MacMenuDelegate macMenu = (MacMenuDelegate)menu;
+        macMenu.isInserted = true;
+        macMenu.updateCallback();
         _insert(ptr, macMenu.ptr, pos);
         return true;
     }
 
     @Override public boolean insert(MenuItemDelegate item, int pos) {
         MacMenuDelegate macMenu = (MacMenuDelegate)item;
+        if(macMenu != null) {
+            macMenu.isInserted = true;
+            macMenu.updateCallback();
+        }
         _insert(ptr, macMenu != null ? macMenu.ptr : 0, pos);
         return true;
     }
@@ -83,13 +97,29 @@ class MacMenuDelegate implements MenuDelegate, MenuItemDelegate {
     private native void _remove(long menuPtr, long submenuPtr, int pos);
     @Override public boolean remove(MenuDelegate menu, int pos) {
         MacMenuDelegate macMenu = (MacMenuDelegate)menu;
+        macMenu.isInserted = false;
+        macMenu.callback = null;
         _remove(ptr, macMenu.ptr, pos);
+        Platform.runLater(() -> {
+            // runLater seems to be important, because otherwise sometimes the callable isn't called.
+            // This is probably, because the menu is closed before the callback is called.
+            macMenu.updateCallback();
+        });
         return true;
     }
 
     @Override public boolean remove(MenuItemDelegate item, int pos) {
         MacMenuDelegate macMenu = (MacMenuDelegate)item;
         _remove(ptr, macMenu == null ? 0L : macMenu.ptr, pos);
+        if(macMenu != null) {
+            macMenu.isInserted = false;
+            macMenu.callback = null;
+            Platform.runLater(() -> {
+                // runLater seems to be important, because otherwise sometimes the callable isn't called.
+                // This is probably, because the menu is closed before the callback is called.
+                macMenu.updateCallback();
+            });
+        }
         return true;
     }
 
@@ -124,8 +154,22 @@ class MacMenuDelegate implements MenuDelegate, MenuItemDelegate {
     }
 
     private native void _setCallback(long menuPtr, Callback callback);
+    private void updateCallback() {
+        if (isInserted) {
+            if(lastSetCallback != callback) {
+                _setCallback(ptr, callback);
+                lastSetCallback = callback;
+            }
+        } else {
+            if(lastSetCallback != null) {
+                _setCallback(ptr, null);
+                lastSetCallback = null;
+            }
+        }
+    }
     @Override public boolean setCallback(Callback callback) {
-        _setCallback(ptr, callback);
+        this.callback = callback;
+        updateCallback();
         return true;
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacMenuDelegate.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacMenuDelegate.java
@@ -86,7 +86,7 @@ class MacMenuDelegate implements MenuDelegate, MenuItemDelegate {
 
     @Override public boolean insert(MenuItemDelegate item, int pos) {
         MacMenuDelegate macMenu = (MacMenuDelegate)item;
-        if(macMenu != null) {
+        if (macMenu != null) {
             macMenu.isInserted = true;
             macMenu.updateCallback();
         }
@@ -111,7 +111,7 @@ class MacMenuDelegate implements MenuDelegate, MenuItemDelegate {
     @Override public boolean remove(MenuItemDelegate item, int pos) {
         MacMenuDelegate macMenu = (MacMenuDelegate)item;
         _remove(ptr, macMenu == null ? 0L : macMenu.ptr, pos);
-        if(macMenu != null) {
+        if (macMenu != null) {
             macMenu.isInserted = false;
             macMenu.callback = null;
             Platform.runLater(() -> {
@@ -156,12 +156,12 @@ class MacMenuDelegate implements MenuDelegate, MenuItemDelegate {
     private native void _setCallback(long menuPtr, Callback callback);
     private void updateCallback() {
         if (isInserted) {
-            if(lastSetCallback != callback) {
+            if (lastSetCallback != callback) {
                 _setCallback(ptr, callback);
                 lastSetCallback = callback;
             }
         } else {
-            if(lastSetCallback != null) {
+            if (lastSetCallback != null) {
                 _setCallback(ptr, null);
                 lastSetCallback = null;
             }

--- a/tests/system/src/test/java/test/javafx/scene/control/SystemMenuBarTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/SystemMenuBarTest.java
@@ -1,0 +1,86 @@
+package test.javafx.scene.control;
+
+import com.sun.javafx.tk.Toolkit;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.scene.Scene;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuBar;
+import javafx.scene.control.MenuItem;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
+import org.junit.*;
+import test.com.sun.javafx.pgstub.StubToolkit;
+import test.util.Util;
+import test.util.memory.JMemoryBuddy;
+import javafx.application.Platform;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+
+public class SystemMenuBarTest {
+
+    @BeforeClass
+    public static void initFX() throws Exception {
+        CountDownLatch startupLatch = new CountDownLatch(1);
+        Platform.setImplicitExit(false);
+        Util.startup(startupLatch, startupLatch::countDown);
+    }
+
+    @AfterClass
+    public static void teardownOnce() {
+        Util.shutdown();
+    }
+
+    @Test
+    public void test_JDK_8299423() {
+        /**
+         * We want to test, if we add a menu to the system-menu, whether it's callable get's collected after the entry is removed.
+         *
+         */
+        JMemoryBuddy.memoryTest((checker) -> {
+            CountDownLatch latch = new CountDownLatch(1);
+            Platform.runLater(() -> {
+                Stage stage = new Stage();
+                MenuBar menuBar = new MenuBar();
+                VBox root = new VBox(menuBar);
+                stage.setScene(new Scene(root));
+                menuBar.setUseSystemMenuBar(true);
+                Menu menu1 = new Menu("menu-1");
+                var item2 = new MenuItem("remove above");
+                menu1.getItems().add(item2);
+                menuBar.getMenus().add(menu1);
+                EventHandler<ActionEvent> listener = new EventHandler<ActionEvent>() {
+                    @Override
+                    public void handle(ActionEvent event) {
+                        System.out.println("I'm the listener, but no one calls me.");
+                    }
+                };
+                item2.setOnAction(listener);
+                stage.show();
+
+                checker.assertCollectable(listener);
+
+                new Thread(() -> {
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException e) {
+                        e.printStackTrace();
+                    }
+                    Platform.runLater(() -> {
+                        menu1.getItems().clear();
+                        latch.countDown();
+                    });
+                }).start();
+            });
+
+            try {
+                assertTrue("Timeout waiting for setOnShown", latch.await(15, TimeUnit.SECONDS));
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        });
+    }
+
+}


### PR DESCRIPTION
This PR fixes the leak in the mac system menu bar.

Inside the native code, NewGlobalRef is called for the callable.
Which makes it into a "GC-Root" until DeleteGlobalRef is called.

The DeleteGlobalRef is never called for the MenuEntry, if it's removed from the menu without removing it's callable.
This PR adds logic, whether the Menu is inserted. If it's not inserted in a Menu anymore, then DeleteGlobalRef is called, by calling `_setCallback` with the callable "null".

The unit test verifies, that this bug happened without this change, but no longer happens with this change.