### PR TITLE
8299526: Bindings bindContentBidirectional (all variants) should reject circular and duplicate bindings

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/BidirectionalContentBinding.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/BidirectionalContentBinding.java
@@ -102,7 +102,7 @@ public class BidirectionalContentBinding {
     }
 
     private static class ListContentBinding implements ListChangeListener<Object>, WeakListener {
-        private static final Map<ObservableList<?>, Set<ListContentBinding>> BINDINGS = new WeakHashMap<>();
+        private static final WeakIdentityHashMap<ObservableList<?>, Set<ListContentBinding>> BINDINGS = new WeakIdentityHashMap<>();
 
         private final WeakReference<ObservableList<?>> propertyRef1;
         private final WeakReference<ObservableList<?>> propertyRef2;
@@ -125,7 +125,7 @@ public class BidirectionalContentBinding {
                 .flatMap(Set::stream)
                 .map(binding -> binding.propertyRef2.get())
                 .filter(Objects::nonNull)  // skip if reference is gone
-                .filter(observable -> observable != obj)  // skip if "target" is same same as "source" vertex in a DAG
+                .filter(observable -> observable != obj)  // skip if "target" is same as "source" vertex in a DAG
                 .toList()
             );
 
@@ -159,9 +159,13 @@ public class BidirectionalContentBinding {
             }
         }
 
+        private final int hashCode;
+
         private <E> ListContentBinding(ObservableList<E> list1, ObservableList<E> list2) {
             propertyRef1 = new WeakReference<>(list1);
             propertyRef2 = new WeakReference<>(list2);
+
+            hashCode = System.identityHashCode(list1) ^ System.identityHashCode(list2);
         }
 
         @Override
@@ -211,11 +215,7 @@ public class BidirectionalContentBinding {
 
         @Override
         public int hashCode() {
-            final ObservableList<?> list1 = propertyRef1.get();
-            final ObservableList<?> list2 = propertyRef2.get();
-            final int hc1 = (list1 == null)? 0 : list1.hashCode();
-            final int hc2 = (list2 == null)? 0 : list2.hashCode();
-            return hc1 * hc2;
+            return hashCode;
         }
 
         @Override

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/WeakIdentityHashMap.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/WeakIdentityHashMap.java
@@ -1,0 +1,114 @@
+package com.sun.javafx.binding;
+
+import java.lang.ref.Reference;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+public class WeakIdentityHashMap<K, V> {
+    private final Map<WeakReference<K>, V> map = new HashMap<>();
+    private final ReferenceQueue<K> referenceQueue = new ReferenceQueue<>();
+
+    public V get(Object key) {
+        cleanQueued();
+
+        return map.get(new IdentityWeakReference<>(key));
+    }
+
+    public V put(K key, V value) {
+        cleanQueued();
+
+        return map.put(new IdentityWeakReference<>(key, referenceQueue), value);
+    }
+
+    public V remove(K key) {
+        cleanQueued();
+
+        return map.remove(new IdentityWeakReference<>(key));
+    }
+
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+        Objects.requireNonNull(mappingFunction);
+        V value = get(key);
+
+        if (value != null) {
+            return value;
+        }
+
+        V newValue = mappingFunction.apply(key);
+
+        if (newValue != null) {
+            put(key, newValue);
+        }
+
+        return newValue;
+    }
+
+    public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        Objects.requireNonNull(remappingFunction);
+
+        V oldValue = get(key);
+
+        if (oldValue == null) {
+            return null;
+        }
+
+        V newValue = remappingFunction.apply(key, oldValue);
+
+        if (newValue != null) {
+            put(key, newValue);
+        }
+        else {
+            remove(key);
+        }
+
+        return newValue;
+    }
+
+    private void cleanQueued() {
+        Reference<? extends K> reference;
+
+        while ((reference = referenceQueue.poll()) != null) {
+            map.remove(reference);
+        }
+    }
+
+    private static class IdentityWeakReference<T> extends WeakReference<T> {
+        private final int hashCode;
+
+        IdentityWeakReference(T obj) {
+            this(obj, null);
+        }
+
+        IdentityWeakReference(T obj, ReferenceQueue<T> queue) {
+            super(Objects.requireNonNull(obj, "obj"), queue);
+
+            this.hashCode = System.identityHashCode(obj);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof IdentityWeakReference<?>)) {
+                return false;
+            }
+
+            @SuppressWarnings("unchecked")
+            IdentityWeakReference<T> other = (IdentityWeakReference<T>) obj;
+            T referent = get();
+
+            return referent != null && other.refersTo(referent);
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
+    }
+}


### PR DESCRIPTION
Concept code to reject circular and duplicate content bindings.  Only for lists for now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Too few reviewers with at least role reviewer found (have 0, need at least 1) (failed with the updated jcheck configuration)

### Issue
 * [JDK-8299526](https://bugs.openjdk.org/browse/JDK-8299526): Bindings bindContentBidirectional (all variants) should reject circular and duplicate bindings


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/988/head:pull/988` \
`$ git checkout pull/988`

Update a local copy of the PR: \
`$ git checkout pull/988` \
`$ git pull https://git.openjdk.org/jfx pull/988/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 988`

View PR using the GUI difftool: \
`$ git pr show -t 988`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/988.diff">https://git.openjdk.org/jfx/pull/988.diff</a>

</details>
