### PR TITLE
8137244: Empty Tree/TableView with CONSTRAINED_RESIZE_POLICY is not properly resized

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableSkinUtils.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableSkinUtils.java
@@ -204,4 +204,15 @@ class TableSkinUtils {
     public static boolean isConstrainedResizePolicy(Callback<? extends ResizeFeaturesBase, Boolean> x) {
         return (x instanceof ConstrainedColumnResizeBase);
     }
+
+    /** returns the number of visible rows in Tree/TableView */
+    public static int getItemCount(TableViewSkinBase<?,?,?,?,?> skin) {
+        Object control = skin.getSkinnable();
+        if (control instanceof TableView table) {
+            return table.getItems().size();
+        } else if (control instanceof TreeTableView tree) {
+            return tree.getExpandedItemCount();
+        }
+        return 0;
+    }
 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
@@ -907,15 +907,15 @@ public abstract class TableViewSkinBase<M, S, C extends Control, I extends Index
             contentWidth -= flow.getVbar().getWidth();
         }
 
-        if (contentWidth <= 0) {
-            // Fix for RT-14855 when there is no content in the TableView.
+        if ((contentWidth <= 0) || (TableSkinUtils.getItemCount(this) == 0)) {
+            // when there is no content in the TableView.
             Control c = getSkinnable();
             contentWidth = c.getWidth() - (snappedLeftInset() + snappedRightInset());
         }
 
         contentWidth = Math.max(0.0, contentWidth);
 
-        // FIXME this isn't perfect, but it prevents RT-14885, which results in
+        // this isn't perfect, but it prevents RT-14885/JDK-8089280, which results in
         // undesired horizontal scrollbars when in constrained resize mode
         getSkinnable().getProperties().put("TableView.contentWidth", Math.floor(contentWidth));
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ResizeHelperTestBase.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ResizeHelperTestBase.java
@@ -65,6 +65,14 @@ public abstract class ResizeHelperTestBase {
         }
     }
 
+    protected static double sumColumnWidths(List<? extends TableColumnBase<?,?>> cols) {
+        double w = 0.0;
+        for (TableColumnBase<?,?> c: cols) {
+            w += c.getWidth();
+        }
+        return w;
+    }
+
     protected static class SpecGen {
         public static final int[] WIDTHS = {
             0, 10, 100, 10_000, 200, 50

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewResizeTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewResizeTest.java
@@ -236,27 +236,29 @@ public class TableViewResizeTest extends ResizeHelperTestBase {
         };
         // allow for borders
         double tolerance = 6.0;
-        TableView<String> table = createTable(spec);
-        stageLoader = new StageLoader(new BorderPane(table));
+
+        TableView<String> t = createTable(spec);
+
+        stageLoader = new StageLoader(new BorderPane(t));
         try {
             for (int ip = 0; ip < POLICIES.length; ip++) {
                 Callback<TableView.ResizeFeatures, Boolean> policy = createPolicy(ip);
-                table.setColumnResizePolicy(policy);
+                t.setColumnResizePolicy(policy);
 
                 // smaller than preferred
-                table.setPrefWidth(300);
+                t.setPrefWidth(300);
                 Toolkit.getToolkit().firePulse();
-                checkInvariants(table);
-                Assert.assertEquals(table.getWidth(), sumColumnWidths(table.getColumns()), tolerance);
+                checkInvariants(t);
+                Assert.assertEquals(t.getWidth(), sumColumnWidths(t.getColumns()), tolerance);
 
                 // clear items
-                table.getItems().clear();
+                t.getItems().clear();
 
                 // make it wider, check if resized correctly
-                table.setPrefWidth(1000);
+                t.setPrefWidth(1000);
                 Toolkit.getToolkit().firePulse();
-                checkInvariants(table);
-                Assert.assertEquals(table.getWidth(), sumColumnWidths(table.getColumns()), tolerance);
+                checkInvariants(t);
+                Assert.assertEquals(t.getWidth(), sumColumnWidths(t.getColumns()), tolerance);
             }
         } finally {
             stageLoader.dispose();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewResizeTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewResizeTest.java
@@ -26,6 +26,9 @@ package test.javafx.scene.control;
 
 import static org.junit.Assert.assertEquals;
 import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+import com.sun.javafx.tk.Toolkit;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.scene.control.ConstrainedColumnResizeBase;
 import javafx.scene.control.SelectionMode;
@@ -35,8 +38,6 @@ import javafx.scene.control.TreeTableColumn;
 import javafx.scene.control.TreeTableView;
 import javafx.scene.layout.BorderPane;
 import javafx.util.Callback;
-import org.junit.Test;
-import com.sun.javafx.tk.Toolkit;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 
 /**
@@ -222,5 +223,44 @@ public class TreeTableViewResizeTest extends ResizeHelperTestBase {
 
     protected static Callback<TreeTableView.ResizeFeatures, Boolean> createPolicy(int ix) {
         return (Callback<TreeTableView.ResizeFeatures, Boolean>)POLICIES[ix];
+    }
+
+    /**
+     * Verifies that the constrained resize policy still works once all the items have been removed JDK-8137244.
+     */
+    @Test
+    public void testConstrainedResizeOfEmptyTable() {
+        Object[] spec = {
+            Cmd.ROWS, 5,
+            Cmd.COL, Cmd.PREF, 200,
+            Cmd.COL, Cmd.PREF, 200,
+        };
+        // allow for borders
+        double tolerance = 6.0;
+        TreeTableView<String> table = createTable(spec);
+        stageLoader = new StageLoader(new BorderPane(table));
+        try {
+            for (int ip = 0; ip < POLICIES.length; ip++) {
+                Callback<TreeTableView.ResizeFeatures, Boolean> policy = createPolicy(ip);
+                table.setColumnResizePolicy(policy);
+
+                // smaller than preferred
+                table.setPrefWidth(300);
+                Toolkit.getToolkit().firePulse();
+                checkInvariants(table);
+                Assert.assertEquals(table.getWidth(), sumColumnWidths(table.getColumns()), tolerance);
+
+                // clear items
+                table.getRoot().getChildren().clear();
+
+                // make it wider, check if resized correctly
+                table.setPrefWidth(1000);
+                Toolkit.getToolkit().firePulse();
+                checkInvariants(table);
+                Assert.assertEquals(table.getWidth(), sumColumnWidths(table.getColumns()), tolerance);
+            }
+        } finally {
+            stageLoader.dispose();
+        }
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewResizeTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewResizeTest.java
@@ -237,27 +237,30 @@ public class TreeTableViewResizeTest extends ResizeHelperTestBase {
         };
         // allow for borders
         double tolerance = 6.0;
-        TreeTableView<String> table = createTable(spec);
-        stageLoader = new StageLoader(new BorderPane(table));
+
+        TreeTableView<String> t = createTable(spec);
+        t.setShowRoot(false);
+
+        stageLoader = new StageLoader(new BorderPane(t));
         try {
             for (int ip = 0; ip < POLICIES.length; ip++) {
                 Callback<TreeTableView.ResizeFeatures, Boolean> policy = createPolicy(ip);
-                table.setColumnResizePolicy(policy);
+                t.setColumnResizePolicy(policy);
 
                 // smaller than preferred
-                table.setPrefWidth(300);
+                t.setPrefWidth(300);
                 Toolkit.getToolkit().firePulse();
-                checkInvariants(table);
-                Assert.assertEquals(table.getWidth(), sumColumnWidths(table.getColumns()), tolerance);
+                checkInvariants(t);
+                Assert.assertEquals(t.getWidth(), sumColumnWidths(t.getColumns()), tolerance);
 
                 // clear items
-                table.getRoot().getChildren().clear();
+                t.getRoot().getChildren().clear();
 
                 // make it wider, check if resized correctly
-                table.setPrefWidth(1000);
+                t.setPrefWidth(1000);
                 Toolkit.getToolkit().firePulse();
-                checkInvariants(table);
-                Assert.assertEquals(table.getWidth(), sumColumnWidths(table.getColumns()), tolerance);
+                checkInvariants(t);
+                Assert.assertEquals(t.getWidth(), sumColumnWidths(t.getColumns()), tolerance);
             }
         } finally {
             stageLoader.dispose();


### PR DESCRIPTION
STEPS TO FOLLOW TO REPRODUCE THE PROBLEM :
1. Add data to the tree/table with a constrained resize policy
2. Clear the table
3. Try to resize the tree/table
Expected:
- the tree/table columns get resized
Observed:
- columns are not resized

Caused by an incomplete fix for RT-14855 / JDK-8113886

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8137244](https://bugs.openjdk.org/browse/JDK-8137244): Empty Tree/TableView with CONSTRAINED_RESIZE_POLICY is not properly resized


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/991/head:pull/991` \
`$ git checkout pull/991`

Update a local copy of the PR: \
`$ git checkout pull/991` \
`$ git pull https://git.openjdk.org/jfx pull/991/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 991`

View PR using the GUI difftool: \
`$ git pr show -t 991`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/991.diff">https://git.openjdk.org/jfx/pull/991.diff</a>

</details>
