### PR TITLE
8300013: Node.focusWithin doesn't account for nested focused nodes

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -8241,7 +8241,7 @@ public abstract class Node implements EventTarget, Styleable {
                 do {
                     node.focusWithin.set(value);
                     node = node.getParent();
-                } while (node != null && !node.focused.get());
+                } while (node != null);
             }
         }
     };
@@ -8296,6 +8296,8 @@ public abstract class Node implements EventTarget, Styleable {
      * @since 19
      */
     private final FocusPropertyBase focusWithin = new FocusPropertyBase() {
+        private int count; // the number of downstream focused nodes
+
         @Override
         protected PseudoClass getPseudoClass() {
             return FOCUS_WITHIN_PSEUDOCLASS_STATE;
@@ -8304,6 +8306,15 @@ public abstract class Node implements EventTarget, Styleable {
         @Override
         public String getName() {
             return "focusWithin";
+        }
+
+        @Override
+        public void set(boolean value) {
+            if (value && ++count == 1) {
+                super.set(true);
+            } else if (!value && --count == 0) {
+                super.set(false);
+            }
         }
     };
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -8189,13 +8189,13 @@ public abstract class Node implements EventTarget, Styleable {
      * If the current node has the focusWithin bit, we also need to clear the focusWithin bits of this
      * node's parents. Note that a scene graph can have more than a single focused node, for example when
      * a PopupWindow is used to present a branch of the scene graph. Since we need to preserve multi-level
-     * focus, we need to stop clearing the focusWithin bits if we encounter a parent node that is focused.
+     * focus, we need to adjust the focus-within count on all parents of the node.
      */
     private void clearParentsFocusWithin(Node oldParent) {
         if (oldParent != null && focusWithin.get()) {
             Node node = oldParent;
-            while (node != null && !node.focused.get()) {
-                node.focusWithin.set(false);
+            while (node != null) {
+                node.focusWithin.adjust(-focusWithin.count);
                 node = node.getParent();
             }
 
@@ -8237,9 +8237,11 @@ public abstract class Node implements EventTarget, Styleable {
             if (get() != value) {
                 super.set(value);
 
+                int change = value ? 1 : -1;
                 Node node = Node.this;
+
                 do {
-                    node.focusWithin.set(value);
+                    node.focusWithin.adjust(change);
                     node = node.getParent();
                 } while (node != null);
             }
@@ -8295,8 +8297,10 @@ public abstract class Node implements EventTarget, Styleable {
      * @defaultValue false
      * @since 19
      */
-    private final FocusPropertyBase focusWithin = new FocusPropertyBase() {
-        private int count; // the number of downstream focused nodes
+    private final FocusWithinProperty focusWithin = new FocusWithinProperty();
+
+    private class FocusWithinProperty extends FocusPropertyBase {
+        int count;
 
         @Override
         protected PseudoClass getPseudoClass() {
@@ -8308,12 +8312,16 @@ public abstract class Node implements EventTarget, Styleable {
             return "focusWithin";
         }
 
-        @Override
-        public void set(boolean value) {
-            if (value && ++count == 1) {
-                super.set(true);
-            } else if (!value && --count == 0) {
-                super.set(false);
+        /**
+         * Adjusts the number of focused nodes within this node.
+         */
+        void adjust(int change) {
+            count += change;
+
+            if (count == 1) {
+                set(true);
+            } else if (count == 0) {
+                set(false);
             }
         }
     };

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/FocusTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/FocusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1011,7 +1011,7 @@ public class FocusTest {
      * cleared when a focused node is removed must only be cleared as long as we don't encounter
      * another focused node up the tree.
      */
-    @Test public void testMultiLevelFocusWithinIsPreserved() {
+    @Test public void testMultiLevelFocusWithinIsPreservedWhenFocusedNodeIsRemoved() {
         class N extends Group {
             N(Node... children) {
                 super(children);
@@ -1049,6 +1049,48 @@ public class FocusTest {
         assertIsFocused(node2);
         assertNotFocused(node3);
         assertIsFocused(node4);
+    }
+
+    /**
+     * When a scene graph contains multiple nested focused nodes, the focusWithin bits that would
+     * be cleared when a focused node is de-focused must not be cleared when we have another
+     * focused downstream node.
+     */
+    @Test public void testMultiLevelFocusWithinIsPreservedWhenIntermediateFocusedNodeIsDefocused() {
+        class N extends Group {
+            N(Node... children) { super(children); }
+            void _setFocused(boolean value) { setFocused(value); }
+        }
+
+        N node1, node2, node3, node4;
+
+        scene.setRoot(
+            node1 = new N(
+                node2 = new N(
+                    node3 = new N(
+                        node4 = new N()
+                    )
+                )
+            ));
+
+        node2._setFocused(true);
+        node4._setFocused(true);
+        assertIsFocusWithin(node1);
+        assertIsFocusWithin(node2);
+        assertIsFocusWithin(node3);
+        assertIsFocusWithin(node4);
+
+        node2._setFocused(false);
+        assertIsFocusWithin(node1);
+        assertIsFocusWithin(node2);
+        assertIsFocusWithin(node3);
+        assertIsFocusWithin(node4);
+
+        node4._setFocused(false);
+        assertNotFocusWithin(node1);
+        assertNotFocusWithin(node2);
+        assertNotFocusWithin(node3);
+        assertNotFocusWithin(node4);
     }
 
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/FocusTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/FocusTest.java
@@ -1023,32 +1023,44 @@ public class FocusTest {
             }
         }
 
-        N node1, node2, node3, node4;
+        N node1, node2, node3, node4, node5;
 
         scene.setRoot(
-            node1 = new N(
-                node2 = new N(
-                    node3 = new N(
-                        node4 = new N()
+            node1 = new N(                  // focusWithin=3
+                node2 = new N(              // focusWithin=3, focused
+                    node3 = new N(          // focusWithin=2
+                        node4 = new N(      // focusWithin=2, focused
+                            node5 = new N() // focusWithin=1, focused
+                        )
                     )
                 )
             ));
 
         node2.setFocused();
         node4.setFocused();
+        node5.setFocused();
 
-        // Remove node4 from the scene graph
+        // Detach node4 from the scene graph:
+        //     node1           focusWithin=1
+        //     |--> node2      focusWithin=1, focused
+        //         |--> node3
+        //
+        //     node4           focusWithin=2, focused
+        //     |--> node5      focusWithin=1, focused
+        //
         node3.getChildren().clear();
 
         assertIsFocusWithin(node1);
         assertIsFocusWithin(node2);
         assertNotFocusWithin(node3);
         assertIsFocusWithin(node4);
+        assertIsFocusWithin(node5);
 
         assertNotFocused(node1);
         assertIsFocused(node2);
         assertNotFocused(node3);
         assertIsFocused(node4);
+        assertIsFocused(node5);
     }
 
     /**


### PR DESCRIPTION
When a scene graph contains multiple nested focused nodes (this can happen with `TableView` and other controls), the `focusWithin` bits that are cleared when a focused node is de-focused must only be cleared when there is no other nested node in the scene graph that would also cause `focusWithin` to be set.

For example, consider a scene graph of nested nodes:
A -> B -> C -> D

When B and D are both focused, the scene graph looks like this:
A(`focusWithin`)
-> B(`focused`, `focusWithin`)
-> C(`focusWithin`)
-> D(`focused`, `focusWithin`)

When B is de-focused, the `focusWithin` flags must still be preserved because D remains focused.

This PR fixes the issue by counting the number of times `focusWithin` has been "set", and only clears it when it has been "un-set" an equal number of times.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8300013](https://bugs.openjdk.org/browse/JDK-8300013): Node.focusWithin doesn't account for nested focused nodes


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/993/head:pull/993` \
`$ git checkout pull/993`

Update a local copy of the PR: \
`$ git checkout pull/993` \
`$ git pull https://git.openjdk.org/jfx pull/993/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 993`

View PR using the GUI difftool: \
`$ git pr show -t 993`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/993.diff">https://git.openjdk.org/jfx/pull/993.diff</a>

</details>
