### PR TITLE
8290092: Temporary files are kept when call Clipboard.getSystemClipboard().getImage()

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/GlassClipboard.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassClipboard.cpp
@@ -435,10 +435,13 @@ HRESULT PopImage(
     IStoragePtr spStorage;
     OLE_HRT( ::StgCreateDocfile(
         NULL,
-        STGM_READWRITE | STGM_SHARE_EXCLUSIVE | STGM_DIRECT | STGM_CREATE,
+        STGM_READWRITE | STGM_SHARE_EXCLUSIVE | STGM_DIRECT | STGM_CREATE | STGM_DELETEONRELEASE,
         NULL,
         &spStorage))
 
+    STATSTG stgStats;
+    spStorage->Stat(&stgStats, STATFLAG_DEFAULT);
+    STRACE(stgStats.pwcsName);
     IViewObject2Ptr view;
     OLE_HRT(::OleCreateStaticFromData(
         p,
@@ -506,6 +509,7 @@ HRESULT PopImage(
                     SelectBitmap(hMemoryDC, hOldBM);
                 }
             }
+            
             ::DeleteDC(hMemoryDC);
         }
         STRACE(_T("IViewObject size: %08x %08x"), size.cx, size.cy);


### PR DESCRIPTION
Windows implementation of GlassClipboard.cpp uses IStorage interface in `PopImage()` to allocate a temporary file, which is then used to capture Image data from system clipboard and move it to JVM side. In order for temporary file to be removed automatically on `IStorage::Release()`, `StgCreateDocfile` API requires passing STGM_DELETEONRELEASE flag - otherwise the file will be left behind when IStorage is released. Contents of temporary file are immediately copied to a JNI Byte Array after acquiring them from clibpoard, so it is safe to provide this flag and remove the file after `PopImage()` is done.

Creating a unit test for this case would a bit difficult, as IStorage and its file are created with random temporary name each time, which we cannot easily access. On the other hand, just scouting the temp directory for any leftover .TMP files might prove false results, as other apps or even JFX itself might use IStorage temporary files for some other purposes than managing clipboard images. As such, because this is a simple API change, I did not make a test for this.

Tested this change on Windows 10 and it doesn't break any existing tests. Calling `Clipboard.getSystemClipboard().getImage()` with an image stored inside the system clipboard now leaves no leftover files.