### PR TITLE
8230833: LabeledSkinBase computes wrong height with ContentDisplay.GRAPHIC_ONLY

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
@@ -328,7 +328,7 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
         double textWidth = emptyText ? 0.0 : Utils.computeTextWidth(font, cleanText, 0);
 
         double width;
-        if(isIgnoreGraphic()) {
+        if (isIgnoreGraphic()) {
             width = textWidth;
         } else {
             // Fix for RT-39889
@@ -390,7 +390,7 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
             // Add the graphic, gap, and padding as appropriate
             if (isIgnoreText()) {
                 height = graphicHeight;
-            } else if (contentDisplay == TOP || contentDisplay == BOTTOM){
+            } else if (contentDisplay == TOP || contentDisplay == BOTTOM) {
                 height = graphicHeight + gap + textHeight;
             } else {
                 height = Math.max(textHeight, graphicHeight);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
@@ -377,14 +377,20 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
                 labeled.getLineSpacing(), text.getBoundsType());
 
         // Now we want to add on the graphic if necessary!
-        double h = textHeight;
-        if (!isIgnoreGraphic()) {
-            final Node graphic = labeled.getGraphic();
-            if (contentDisplay == TOP || contentDisplay == BOTTOM) {
-                h = graphic.prefHeight(width) + gap + textHeight;
-            } else {
-                h = Math.max(textHeight, graphic.prefHeight(width));
-            }
+        double graphicHeight = graphic == null ? 0.0 :
+                Utils.boundedSize(graphic.prefHeight(-1), graphic.minHeight(-1), graphic.maxHeight(-1));
+
+        // Now add on the graphic, gap, and padding as appropriate
+        final Node graphic = labeled.getGraphic();
+        double height;
+        if (isIgnoreGraphic()) {
+            height = textHeight;
+        } else if (isIgnoreText()) {
+            height = graphicHeight;
+        } else if (contentDisplay == TOP || contentDisplay == BOTTOM){
+            height = graphic.prefHeight(-1) + gap + textHeight;
+        } else {
+            height = Math.max(textHeight, graphic.prefHeight(-1));
         }
 
         double padding = topInset + bottomInset;
@@ -393,7 +399,7 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
             padding += topLabelPadding() + bottomLabelPadding();
         }
 
-        return  h + padding;
+        return  height + padding;
     }
 
     /** {@inheritDoc} */

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
@@ -319,9 +319,10 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
         final ContentDisplay contentDisplay = labeled.getContentDisplay();
         String cleanText = getCleanText();
         boolean emptyText = cleanText == null || cleanText.isEmpty();
+        boolean isIgnoreText = isIgnoreText();
         double widthPadding = leftInset + rightInset;
 
-        if (!isIgnoreText()) {
+        if (!isIgnoreText) {
             widthPadding += leftLabelPadding() + rightLabelPadding();
         }
 
@@ -335,7 +336,7 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
             double graphicWidth = graphic == null ? 0.0 :
                     Utils.boundedSize(graphic.prefWidth(-1), graphic.minWidth(-1), graphic.maxWidth(-1));
 
-            if (isIgnoreText()) {
+            if (isIgnoreText) {
                 width = graphicWidth;
             } else if (contentDisplay == ContentDisplay.LEFT
                     || contentDisplay == ContentDisplay.RIGHT) {
@@ -354,10 +355,12 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
         final Font font = text.getFont();
         final ContentDisplay contentDisplay = labeled.getContentDisplay();
         final double gap = labeled.getGraphicTextGap();
+        boolean isIgnoreText = isIgnoreText();
+        boolean isIgnoreGraphic = isIgnoreGraphic();
 
         width -= leftInset + rightInset;
         double padding = topInset + bottomInset;
-        if (!isIgnoreText()) {
+        if (!isIgnoreText) {
             width -= leftLabelPadding() + rightLabelPadding();
             padding += topLabelPadding() + bottomLabelPadding();
         }
@@ -369,7 +372,7 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
         }
 
         double textWidth = width;
-        if (!isIgnoreGraphic() &&
+        if (!isIgnoreGraphic &&
                 (contentDisplay == LEFT || contentDisplay == RIGHT)) {
             textWidth -= (graphic.prefWidth(-1) + gap);
         }
@@ -380,7 +383,7 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
                 labeled.getLineSpacing(), text.getBoundsType());
 
         double height;
-        if (isIgnoreGraphic()) {
+        if (isIgnoreGraphic) {
             height = textHeight;
         } else {
             // Calculate the graphic height and use based on contentDisplay value
@@ -388,7 +391,7 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
                 Utils.boundedSize(graphic.prefHeight(width), graphic.minHeight(width), graphic.maxHeight(width));
 
             // Add the graphic, gap, and padding as appropriate
-            if (isIgnoreText()) {
+            if (isIgnoreText) {
                 height = graphicHeight;
             } else if (contentDisplay == TOP || contentDisplay == BOTTOM) {
                 height = graphicHeight + gap + textHeight;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
@@ -376,9 +376,9 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
                 labeled.isWrapText() ? textWidth : 0,
                 labeled.getLineSpacing(), text.getBoundsType());
 
-        // Now we want to add on the graphic if necessary!
+        // Calculate the graphic height and use based on contentDisplay value
         double graphicHeight = graphic == null ? 0.0 :
-                Utils.boundedSize(graphic.prefHeight(-1), graphic.minHeight(-1), graphic.maxHeight(-1));
+                Utils.boundedSize(graphic.prefHeight(width), graphic.minHeight(width), graphic.maxHeight(width));
 
         // Now add on the graphic, gap, and padding as appropriate
         final Node graphic = labeled.getGraphic();
@@ -388,9 +388,9 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
         } else if (isIgnoreText()) {
             height = graphicHeight;
         } else if (contentDisplay == TOP || contentDisplay == BOTTOM){
-            height = graphic.prefHeight(-1) + gap + textHeight;
+            height = graphicHeight + gap + textHeight;
         } else {
-            height = Math.max(textHeight, graphic.prefHeight(-1));
+            height = Math.max(textHeight, graphicHeight);
         }
 
         double padding = topInset + bottomInset;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
@@ -1249,8 +1249,7 @@ public class LabelSkinTest {
         label.setGraphicTextGap(2);
         label.setGraphic(r);
         label.setContentDisplay(ContentDisplay.TOP);
-        final double lineHeight = Utils.computeTextHeight(label.getFont(), " ", 0, text.getBoundsType());
-        assertEquals(14 + 23 + lineHeight + 2, label.prefHeight(-1), 0);
+        assertEquals(14 + 23, label.prefHeight(-1), 0);
     }
 
     @Test public void whenTextIsEmptyAndGraphicIsSetWithTOPContentDisplay_computePrefHeight_ReturnsRightAnswer() {
@@ -1260,8 +1259,7 @@ public class LabelSkinTest {
         label.setGraphicTextGap(2);
         label.setGraphic(r);
         label.setContentDisplay(ContentDisplay.TOP);
-        final double lineHeight = Utils.computeTextHeight(label.getFont(), " ", 0, text.getBoundsType());
-        assertEquals(14 + 23 + lineHeight + 2, label.prefHeight(-1), 0);
+        assertEquals(14 + 23, label.prefHeight(-1), 0);
     }
 
     @Test public void whenTextIsSetAndGraphicIsSetWithTOPContentDisplay_computePrefHeight_ReturnsRightAnswer() {
@@ -1312,8 +1310,7 @@ public class LabelSkinTest {
         label.setGraphicTextGap(2);
         label.setGraphic(r);
         label.setContentDisplay(ContentDisplay.BOTTOM);
-        final double lineHeight = Utils.computeTextHeight(label.getFont(), " ", 0, text.getBoundsType());
-        assertEquals(14 + 23 + lineHeight + 2, label.prefHeight(-1), 0);
+        assertEquals(14 + 23, label.prefHeight(-1), 0);
     }
 
     @Test public void whenTextIsEmptyAndGraphicIsSetWithBOTTOMContentDisplay_computePrefHeight_ReturnsRightAnswer() {
@@ -1323,8 +1320,7 @@ public class LabelSkinTest {
         label.setGraphicTextGap(2);
         label.setGraphic(r);
         label.setContentDisplay(ContentDisplay.BOTTOM);
-        final double lineHeight = Utils.computeTextHeight(label.getFont(), " ", 0, text.getBoundsType());
-        assertEquals(14 + 23 + lineHeight + 2, label.prefHeight(-1), 0);
+        assertEquals(14 + 23, label.prefHeight(-1), 0);
     }
 
     @Test public void whenTextIsSetAndGraphicIsSetWithBOTTOMContentDisplay_computePrefHeight_ReturnsRightAnswer() {
@@ -1807,8 +1803,7 @@ public class LabelSkinTest {
         label.setGraphicTextGap(2);
         label.setGraphic(r);
         label.setContentDisplay(ContentDisplay.TOP);
-        final double lineHeight = Utils.computeTextHeight(label.getFont(), " ", 0, text.getBoundsType());
-        assertEquals(14 + 23 + lineHeight + 2, label.maxHeight(-1), 0);
+        assertEquals(14 + 23, label.maxHeight(-1), 0);
     }
 
     @Test public void whenTextIsEmptyAndGraphicIsSetWithTOPContentDisplay_computeMaxHeight_ReturnsRightAnswer() {
@@ -1818,8 +1813,7 @@ public class LabelSkinTest {
         label.setGraphicTextGap(2);
         label.setGraphic(r);
         label.setContentDisplay(ContentDisplay.TOP);
-        final double lineHeight = Utils.computeTextHeight(label.getFont(), " ", 0, text.getBoundsType());
-        assertEquals(14 + 23 + lineHeight + 2, label.maxHeight(-1), 0);
+        assertEquals(14 + 23, label.maxHeight(-1), 0);
     }
 
     @Test public void whenTextIsSetAndGraphicIsSetWithTOPContentDisplay_computeMaxHeight_ReturnsRightAnswer() {
@@ -1870,8 +1864,7 @@ public class LabelSkinTest {
         label.setGraphicTextGap(2);
         label.setGraphic(r);
         label.setContentDisplay(ContentDisplay.BOTTOM);
-        final double lineHeight = Utils.computeTextHeight(label.getFont(), " ", 0, text.getBoundsType());
-        assertEquals(14 + 23 + lineHeight + 2, label.maxHeight(-1), 0);
+        assertEquals(14 + 23, label.maxHeight(-1), 0);
     }
 
     @Test public void whenTextIsEmptyAndGraphicIsSetWithBOTTOMContentDisplay_computeMaxHeight_ReturnsRightAnswer() {
@@ -1881,8 +1874,7 @@ public class LabelSkinTest {
         label.setGraphicTextGap(2);
         label.setGraphic(r);
         label.setContentDisplay(ContentDisplay.BOTTOM);
-        final double lineHeight = Utils.computeTextHeight(label.getFont(), " ", 0, text.getBoundsType());
-        assertEquals(14 + 23 + lineHeight + 2, label.maxHeight(-1), 0);
+        assertEquals(14 + 23, label.maxHeight(-1), 0);
     }
 
     @Test public void whenTextIsSetAndGraphicIsSetWithBOTTOMContentDisplay_computeMaxHeight_ReturnsRightAnswer() {


### PR DESCRIPTION
Ignore text condition was not considered in `computePrefHeight` method while calculating the Label height.

Added `isIgnoreText` condition in `computePrefHeight` method while calculating Label height.

Tests are present for all the ContentDisplay types. Modified tests which were failing because of the new height value getting calculated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8230833](https://bugs.openjdk.org/browse/JDK-8230833): LabeledSkinBase computes wrong height with ContentDisplay.GRAPHIC_ONLY


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/996/head:pull/996` \
`$ git checkout pull/996`

Update a local copy of the PR: \
`$ git checkout pull/996` \
`$ git pull https://git.openjdk.org/jfx pull/996/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 996`

View PR using the GUI difftool: \
`$ git pr show -t 996`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/996.diff">https://git.openjdk.org/jfx/pull/996.diff</a>

</details>
