### PR TITLE
8300640: Update JavaFX release to 19.0.2.1 in jfx/jfx19 branch

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -24,7 +24,7 @@
 [general]
 project=openjfx
 jbs=jdk
-version=openjfx19.0.2
+version=openjfx19.0.2.1
 
 [repository]
 tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9]((\.\d{1,3}){0,2})-((b\d{2,3})|(ga))|[1-9]u(\d{1,3})-((b\d{2,3})|(ga))

--- a/build.properties
+++ b/build.properties
@@ -42,7 +42,7 @@ jfx.release.suffix=-ea
 jfx.release.major.version=19
 jfx.release.minor.version=0
 jfx.release.security.version=2
-jfx.release.patch.version=0
+jfx.release.patch.version=1
 
 # Note: The release version is now calculated in build.gradle as the
 # dot-separated concatenation of the previous four fields with trailing zero


### PR DESCRIPTION
set release version to 19.0.2.1
Fix for JDK-8300640

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300640](https://bugs.openjdk.org/browse/JDK-8300640): Update JavaFX release to 19.0.2.1 in jfx/jfx19 branch


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1001/head:pull/1001` \
`$ git checkout pull/1001`

Update a local copy of the PR: \
`$ git checkout pull/1001` \
`$ git pull https://git.openjdk.org/jfx pull/1001/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1001`

View PR using the GUI difftool: \
`$ git pr show -t 1001`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1001.diff">https://git.openjdk.org/jfx/pull/1001.diff</a>

</details>
