### PR TITLE
8237505: RadioMenuItem in ToggleGroup: deselected on accelerator

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlAcceleratorSupport.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlAcceleratorSupport.java
@@ -175,7 +175,12 @@ public class ControlAcceleratorSupport {
                         }
                         if (!menuitem.isDisable()) {
                             if (menuitem instanceof RadioMenuItem) {
-                                ((RadioMenuItem)menuitem).setSelected(!((RadioMenuItem)menuitem).isSelected());
+                                if(((RadioMenuItem)menuitem).getToggleGroup() == null){
+                                    ((RadioMenuItem)menuitem).setSelected(!((RadioMenuItem)menuitem).isSelected());
+                                }
+                                else {
+                                    ((RadioMenuItem)menuitem).setSelected(true);
+                                }
                             }
                             else if (menuitem instanceof CheckMenuItem) {
                                 ((CheckMenuItem)menuitem).setSelected(!((CheckMenuItem)menuitem).isSelected());

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlAcceleratorSupport.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ControlAcceleratorSupport.java
@@ -174,12 +174,12 @@ public class ControlAcceleratorSupport {
                             Event.fireEvent(target, new Event(MenuItem.MENU_VALIDATION_EVENT));
                         }
                         if (!menuitem.isDisable()) {
-                            if (menuitem instanceof RadioMenuItem) {
-                                if(((RadioMenuItem)menuitem).getToggleGroup() == null){
-                                    ((RadioMenuItem)menuitem).setSelected(!((RadioMenuItem)menuitem).isSelected());
+                            if (menuitem instanceof RadioMenuItem radioMenuItem) {
+                                if (radioMenuItem.getToggleGroup() == null) {
+                                    radioMenuItem.setSelected(!radioMenuItem.isSelected());
                                 }
                                 else {
-                                    ((RadioMenuItem)menuitem).setSelected(true);
+                                    radioMenuItem.setSelected(true);
                                 }
                             }
                             else if (menuitem instanceof CheckMenuItem) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/RadioMenuItemTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/RadioMenuItemTest.java
@@ -28,6 +28,9 @@ package test.javafx.scene.control;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.*;
 
 import test.com.sun.javafx.pgstub.StubToolkit;
+import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
+import test.com.sun.javafx.scene.control.infrastructure.KeyModifier;
+import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 import com.sun.javafx.tk.Toolkit;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
@@ -36,8 +39,13 @@ import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.scene.Node;
+import javafx.scene.Scene;
 import javafx.scene.control.RadioMenuItem;
 import javafx.scene.control.ToggleGroup;
+import javafx.scene.control.Menu;
+import javafx.scene.control.MenuBar;
+import javafx.scene.input.KeyCombination;
+import javafx.scene.input.KeyCode;
 import javafx.scene.shape.Rectangle;
 import static org.junit.Assert.*;
 
@@ -295,5 +303,27 @@ public class RadioMenuItemTest {
 
        assertTrue(b1.isSelected());
        assertFalse(result8189677);
+    }
+
+    @Test public void testRadioMenuItemSelectionOnAccelerator() {
+       MenuBar menuBar = new MenuBar();
+       Menu menu = new Menu("Submenu");
+       menuBar.getMenus().add(menu);
+
+       ToggleGroup group = new ToggleGroup();
+       RadioMenuItem radioMenuItem = new RadioMenuItem("ONE");
+       radioMenuItem.setToggleGroup(group);
+       radioMenuItem.setAccelerator(KeyCombination.valueOf("alt+1"));
+       menu.getItems().add(radioMenuItem);
+
+       StageLoader s = new StageLoader(menuBar);
+       Scene scene = s.getStage().getScene();
+       KeyEventFirer keyboard = new KeyEventFirer(radioMenuItem, scene);
+
+       keyboard.doKeyPress(KeyCode.DIGIT1, KeyModifier.ALT);
+       assertTrue(radioMenuItem.isSelected());
+
+       keyboard.doKeyPress(KeyCode.DIGIT1, KeyModifier.ALT);
+       assertTrue(radioMenuItem.isSelected());
     }
 }


### PR DESCRIPTION
No check was present in `RadioMenuItem` accelerator to see if it is in a `ToggleGroup` or not.

Made changes to check if `RadioMenuItem` is part of `ToggleGroup` or not. If it is part of a `ToggleGroup`, then it can not be cleared using accelerator.

Added test to validate the change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8237505](https://bugs.openjdk.org/browse/JDK-8237505): RadioMenuItem in ToggleGroup: deselected on accelerator


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Committer)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1002/head:pull/1002` \
`$ git checkout pull/1002`

Update a local copy of the PR: \
`$ git checkout pull/1002` \
`$ git pull https://git.openjdk.org/jfx pull/1002/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1002`

View PR using the GUI difftool: \
`$ git pr show -t 1002`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1002.diff">https://git.openjdk.org/jfx/pull/1002.diff</a>

</details>
