### PR TITLE
8296654: [macos] Crash when launching JavaFX app with JDK that targets SDK 13

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
@@ -263,7 +263,9 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
     (*env)->CallVoidMethod(env, self->jView, jViewNotifyResize, (int)newSize.width, (int)newSize.height);
     GLASS_CHECK_EXCEPTION(env);
 
-    [self->nsView removeTrackingRect:self->trackingRect];
+    if (self->trackingRect) {
+        [self->nsView removeTrackingRect:self->trackingRect];
+    }
     self->trackingRect = [self->nsView addTrackingRect:[self->nsView bounds] owner:self->nsView userData:nil assumeInside:NO];
 }
 
@@ -277,13 +279,17 @@ static jint getSwipeDirFromEvent(NSEvent *theEvent)
     (*env)->CallVoidMethod(env, self->jView, jViewNotifyResize, (int)frameRect.size.width, (int)frameRect.size.height);
     GLASS_CHECK_EXCEPTION(env);
 
-    [self->nsView removeTrackingRect:self->trackingRect];
+    if (self->trackingRect) {
+        [self->nsView removeTrackingRect:self->trackingRect];
+    }
     self->trackingRect = [self->nsView addTrackingRect:[self->nsView bounds] owner:self->nsView userData:nil assumeInside:NO];
 }
 
 - (void)updateTrackingAreas
 {
-    [self->nsView removeTrackingRect:self->trackingRect];
+    if (self->trackingRect) {
+        [self->nsView removeTrackingRect:self->trackingRect];
+    }
     self->trackingRect = [self->nsView addTrackingRect:[self->nsView bounds] owner:self->nsView userData:nil assumeInside:NO];
 }
 


### PR DESCRIPTION
8296654: [macos] Crash when launching JavaFX app with JDK that targets SDK 13

Reviewed-by: aghaisas, jvos, mstrauss

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8296654](https://bugs.openjdk.org/browse/JDK-8296654): [macos] Crash when launching JavaFX app with JDK that targets SDK 13


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1003/head:pull/1003` \
`$ git checkout pull/1003`

Update a local copy of the PR: \
`$ git checkout pull/1003` \
`$ git pull https://git.openjdk.org/jfx pull/1003/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1003`

View PR using the GUI difftool: \
`$ git pr show -t 1003`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1003.diff">https://git.openjdk.org/jfx/pull/1003.diff</a>

</details>
