### PR TITLE
8301604: Replace Collections.unmodifiableList with List.of

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/common/ImageDescriptor.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/common/ImageDescriptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,6 @@
 package com.sun.javafx.iio.common;
 
 import com.sun.javafx.iio.ImageFormatDescription;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public class ImageDescriptor implements ImageFormatDescription {
@@ -38,12 +36,9 @@ public class ImageDescriptor implements ImageFormatDescription {
 
     public ImageDescriptor(String formatName, String[] extensions, Signature[] signatures, String[] mimeSubtypes) {
         this.formatName = formatName;
-        this.extensions = Collections.unmodifiableList(
-                                          Arrays.asList(extensions));
-        this.signatures = Collections.unmodifiableList(
-                                          Arrays.asList(signatures));
-        this.mimeSubtypes = Collections.unmodifiableList(
-                                          Arrays.asList(mimeSubtypes));
+        this.extensions = List.of(extensions);
+        this.signatures = List.of(signatures);
+        this.mimeSubtypes = List.of(mimeSubtypes);
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/javafx/stage/FileChooser.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/FileChooser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package javafx.stage;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -113,8 +112,7 @@ public final class FileChooser {
             validateArgs(description, extensions);
 
             this.description = description;
-            this.extensions = Collections.unmodifiableList(
-                                      Arrays.asList(extensions.clone()));
+            this.extensions = List.of(extensions);
         }
 
         /**
@@ -140,8 +138,7 @@ public final class FileChooser {
             validateArgs(description, extensionsArray);
 
             this.description = description;
-            this.extensions = Collections.unmodifiableList(
-                                      Arrays.asList(extensionsArray));
+            this.extensions = List.of(extensionsArray);
         }
 
         /**

--- a/modules/javafx.graphics/src/main/java/javafx/stage/FileChooser.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/FileChooser.java
@@ -85,12 +85,14 @@ import com.sun.javafx.tk.Toolkit;
  * @since JavaFX 2.0
  */
 public final class FileChooser {
+
     /**
      * Defines an extension filter, used for filtering which files can be chosen
      * in a FileDialog based on the file name extensions.
      * @since JavaFX 2.0
      */
     public static final class ExtensionFilter {
+
         private final String description;
         private final List<String> extensions;
 
@@ -108,8 +110,7 @@ public final class FileChooser {
          * @throws IllegalArgumentException if the description or the extensions
          *      are empty
          */
-        public ExtensionFilter(final String description,
-                               final String... extensions) {
+        public ExtensionFilter(final String description, final String... extensions) {
             this(description, List.of(extensions));
         }
 
@@ -127,8 +128,7 @@ public final class FileChooser {
          * @throws IllegalArgumentException if the description or the extensions
          *      are empty
          */
-        public ExtensionFilter(final String description,
-                               final List<String> extensions) {
+        public ExtensionFilter(final String description, final List<String> extensions) {
             var extensionsList = List.copyOf(extensions);
             validateArgs(description, extensionsList);
 
@@ -157,24 +157,20 @@ public final class FileChooser {
             return extensions;
         }
 
-        private static void validateArgs(final String description,
-                                         final List<String> extensions) {
+        private static void validateArgs(final String description, final List<String> extensions) {
             Objects.requireNonNull(description, "Description must not be null");
 
             if (description.isEmpty()) {
-                throw new IllegalArgumentException(
-                        "Description must not be empty");
+                throw new IllegalArgumentException("Description must not be empty");
             }
 
             if (extensions.isEmpty()) {
-                throw new IllegalArgumentException(
-                        "At least one extension must be defined");
+                throw new IllegalArgumentException("At least one extension must be defined");
             }
 
             for (String extension : extensions) {
                 if (extension.isEmpty()) {
-                    throw new IllegalArgumentException(
-                            "Extension must not be empty");
+                    throw new IllegalArgumentException("Extension must not be empty");
                 }
             }
         }

--- a/modules/javafx.graphics/src/main/java/javafx/stage/FileChooser.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/FileChooser.java
@@ -28,6 +28,7 @@ package javafx.stage;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -109,10 +110,7 @@ public final class FileChooser {
          */
         public ExtensionFilter(final String description,
                                final String... extensions) {
-            validateArgs(description, extensions);
-
-            this.description = description;
-            this.extensions = List.of(extensions);
+            this(description, List.of(extensions));
         }
 
         /**
@@ -131,14 +129,11 @@ public final class FileChooser {
          */
         public ExtensionFilter(final String description,
                                final List<String> extensions) {
-            final String[] extensionsArray =
-                    (extensions != null) ? extensions.toArray(
-                                               new String[extensions.size()])
-                                         : null;
-            validateArgs(description, extensionsArray);
+            var extensionsList = List.copyOf(extensions);
+            validateArgs(description, extensionsList);
 
             this.description = description;
-            this.extensions = List.of(extensionsArray);
+            this.extensions = extensionsList;
         }
 
         /**
@@ -163,31 +158,20 @@ public final class FileChooser {
         }
 
         private static void validateArgs(final String description,
-                                         final String[] extensions) {
-            if (description == null) {
-                throw new NullPointerException("Description must not be null");
-            }
+                                         final List<String> extensions) {
+            Objects.requireNonNull(description, "Description must not be null");
 
             if (description.isEmpty()) {
                 throw new IllegalArgumentException(
                         "Description must not be empty");
             }
 
-            if (extensions == null) {
-                throw new NullPointerException("Extensions must not be null");
-            }
-
-            if (extensions.length == 0) {
+            if (extensions.isEmpty()) {
                 throw new IllegalArgumentException(
                         "At least one extension must be defined");
             }
 
             for (String extension : extensions) {
-                if (extension == null) {
-                    throw new NullPointerException(
-                            "Extension must not be null");
-                }
-
                 if (extension.isEmpty()) {
                     throw new IllegalArgumentException(
                             "Extension must not be empty");

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/Media.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/Media.java
@@ -87,20 +87,14 @@ public abstract class Media {
     /**
      * Gets the tracks found in the media. The returned value will be
      * <code>null</code> if no tracks have yet been encountered while scanning
-     * the media. The returned <code>List</code> us unmodifiable.
+     * the media. The returned <code>List</code> is unmodifiable.
      *
      * @return the tracks in the media or <code>null</code> if no tracks found.
      */
     public List<Track> getTracks() {
-        List<Track> returnValue;
         synchronized(tracks) {
-            if (tracks.isEmpty()) {
-                returnValue = null;
-            } else {
-                returnValue = List.copyOf(tracks);
-            }
+            return tracks.isEmpty() ? null : List.copyOf(tracks);
         }
-        return returnValue;
     }
 
     /**

--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/Media.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/Media.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package com.sun.media.jfxmedia;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.ArrayList;
 import java.util.List;
@@ -98,7 +97,7 @@ public abstract class Media {
             if (tracks.isEmpty()) {
                 returnValue = null;
             } else {
-                returnValue = Collections.unmodifiableList(new ArrayList<>(tracks));
+                returnValue = List.copyOf(tracks);
             }
         }
         return returnValue;


### PR DESCRIPTION
`List.of` is cleaner, and can slightly reduce the memory footprint for lists of one or two elements.

Because `List.of` can only store non-null elements, I have only replaced a few usage.

Can someone open an Issue on JBS for me?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301604](https://bugs.openjdk.org/browse/JDK-8301604): Replace Collections.unmodifiableList with List.of


### Reviewers
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1012/head:pull/1012` \
`$ git checkout pull/1012`

Update a local copy of the PR: \
`$ git checkout pull/1012` \
`$ git pull https://git.openjdk.org/jfx pull/1012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1012`

View PR using the GUI difftool: \
`$ git pr show -t 1012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1012.diff">https://git.openjdk.org/jfx/pull/1012.diff</a>

</details>
