### PR TITLE
8138842: TableViewSelectionModel.selectIndices does not select index 0

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
@@ -2642,7 +2642,7 @@ public class TableView<S> extends Control {
         }
 
         @Override public void selectIndices(int row, int... rows) {
-            if (rows == null) {
+            if (rows == null || rows.length == 0) {
                 select(row);
                 return;
             }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -3009,7 +3009,7 @@ public class TreeTableView<S> extends Control {
         }
 
         @Override public void selectIndices(int row, int... rows) {
-            if (rows == null) {
+            if (rows == null || rows.length == 0) {
                 select(row);
                 return;
             }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -6002,4 +6002,18 @@ public class TableViewTest {
 
         assertNull(result);
     }
+
+    @Test
+    public void testFirstRowSelectionWithEmptyArrayAsParameter() {
+        table.getItems().addAll("1", "2", "3");
+
+        table.getSelectionModel().selectIndices(0, new int[0]);
+        assertEquals(0, table.getSelectionModel().getSelectedIndex());
+
+        table.getSelectionModel().selectIndices(1, new int[0]);
+        assertEquals(1, table.getSelectionModel().getSelectedIndex());
+
+        table.getSelectionModel().selectIndices(2, new int[]{1, 2});
+        assertEquals(2, table.getSelectionModel().getSelectedIndex());
+    }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -6003,6 +6003,7 @@ public class TableViewTest {
         assertNull(result);
     }
 
+    // See JDK-8138842
     @Test
     public void testFirstRowSelectionWithEmptyArrayAsParameter() {
         table.getItems().addAll("1", "2", "3");
@@ -6013,7 +6014,7 @@ public class TableViewTest {
         table.getSelectionModel().selectIndices(1, new int[0]);
         assertEquals(1, table.getSelectionModel().getSelectedIndex());
 
-        table.getSelectionModel().selectIndices(2, new int[]{1, 2});
+        table.getSelectionModel().selectIndices(1, new int[]{1, 2});
         assertEquals(2, table.getSelectionModel().getSelectedIndex());
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -7178,4 +7178,24 @@ public class TreeTableViewTest {
         Object result = treeTableView.queryAccessibleAttribute(AccessibleAttribute.FOCUS_ITEM);
         assertNull(result);
     }
+
+    // See JDK-8138842
+    @Test
+    public void testFirstRowSelectionWithEmptyArrayAsParameter() {
+        treeTableView.setRoot(new TreeItem("Root"));
+        treeTableView.getRoot().setExpanded(true);
+        for (int i = 0; i < 4; i++) {
+            TreeItem parent = new TreeItem("item - " + i);
+            treeTableView.getRoot().getChildren().add(parent);
+        }
+
+        treeTableView.getSelectionModel().selectIndices(0, new int[0]);
+        assertEquals(0, treeTableView.getSelectionModel().getSelectedIndex());
+
+        treeTableView.getSelectionModel().selectIndices(1, new int[0]);
+        assertEquals(1, treeTableView.getSelectionModel().getSelectedIndex());
+
+        treeTableView.getSelectionModel().selectIndices(1, new int[]{1, 2});
+        assertEquals(2, treeTableView.getSelectionModel().getSelectedIndex());
+    }
 }


### PR DESCRIPTION
In `selectIndices` method, zero length array is not considered while ignoring row number given as parameter.

Updated the code to consider both null and zero length array in the condition before ignoring the row value given as parameter.

Added unit test to validate the fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8138842](https://bugs.openjdk.org/browse/JDK-8138842): TableViewSelectionModel.selectIndices does not select index 0


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Committer)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer) 🔄 Re-review required (review applies to [06c1950b](https://git.openjdk.org/jfx/pull/1018/files/06c1950b54d334d677f4fa7c954ccd8970abbf95))
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1018/head:pull/1018` \
`$ git checkout pull/1018`

Update a local copy of the PR: \
`$ git checkout pull/1018` \
`$ git pull https://git.openjdk.org/jfx pull/1018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1018`

View PR using the GUI difftool: \
`$ git pr show -t 1018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1018.diff">https://git.openjdk.org/jfx/pull/1018.diff</a>

</details>
