### PR TITLE
8301797: Pagination control has the wrong size

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/PaginationSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/PaginationSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -194,6 +194,8 @@ public class PaginationSkin extends SkinBase<Pagination> {
         nextStackPane.getStyleClass().add("page");
         nextStackPane.setVisible(false);
 
+        resetIndexes(true);
+
         this.navigation = new NavigationControl();
 
         getChildren().addAll(currentStackPane, nextStackPane, navigation);
@@ -235,7 +237,7 @@ public class PaginationSkin extends SkinBase<Pagination> {
     @Override
     public void install() {
         getSkinnable().setClip(clipRect);
-        resetIndexes(true);
+        getSkinnable().setCurrentPageIndex(currentIndex);
     }
 
 
@@ -649,7 +651,11 @@ public class PaginationSkin extends SkinBase<Pagination> {
         currentStackPane.getChildren().clear();
         nextStackPane.getChildren().clear();
 
-        getSkinnable().setCurrentPageIndex(currentIndex);
+        if (usePageIndex) {
+            // avoid setting skinnable properties in the constructor
+            getSkinnable().setCurrentPageIndex(currentIndex);
+        }
+
         createPage(currentStackPane, currentIndex);
 
         if (isAnimate) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/PaginationSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/PaginationSkin.java
@@ -194,6 +194,7 @@ public class PaginationSkin extends SkinBase<Pagination> {
         nextStackPane.getStyleClass().add("page");
         nextStackPane.setVisible(false);
 
+        // sets the current page index property in control to the same value (no-op)
         resetIndexes(true);
 
         this.navigation = new NavigationControl();
@@ -237,7 +238,6 @@ public class PaginationSkin extends SkinBase<Pagination> {
     @Override
     public void install() {
         getSkinnable().setClip(clipRect);
-        getSkinnable().setCurrentPageIndex(currentIndex);
     }
 
 
@@ -651,11 +651,7 @@ public class PaginationSkin extends SkinBase<Pagination> {
         currentStackPane.getChildren().clear();
         nextStackPane.getChildren().clear();
 
-        if (usePageIndex) {
-            // avoid setting skinnable properties in the constructor
-            getSkinnable().setCurrentPageIndex(currentIndex);
-        }
-
+        getSkinnable().setCurrentPageIndex(currentIndex);
         createPage(currentStackPane, currentIndex);
 
         if (isAnimate) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/PaginationTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/PaginationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -323,5 +323,24 @@ public class PaginationTest {
             box.getChildren().add(l);
         }
         return box;
+    }
+
+    /** JDK-8301797 */
+    @Test
+    public void testInitialPreferredSize() {
+        pagination.setPageCount(150);
+        pagination.setCurrentPageIndex(0);
+        pagination.setMaxPageIndicatorCount(50);
+        Label label = new Label();
+        pagination.setPageFactory(index -> {
+            label.setText("" + (index + 1));
+            return label;
+        });
+
+        root.getChildren().add(pagination);
+        show();
+
+        tk.firePulse();
+        assertTrue("pagination prefWidth() is incorrect", (pagination.prefWidth(-1) > 200));
     }
 }


### PR DESCRIPTION
Fixed regression introduced by JDK-8295754, targeting upstream **jfx20 branch**.

The method PaginationSkin.resetIndexes(true) has been moved to the original position in the constructor, fixing the initialization, while making sure no properties of the control are touched in the constructor (only in install()).

Added a test case.

Tested with the PaginationDisappear.java and the LeakTest app
https://github.com/andy-goryachev-oracle/Test/blob/main/src/goryachev/apps/LeakTestApp.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8301797](https://bugs.openjdk.org/browse/JDK-8301797): Pagination control has the wrong size


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1021/head:pull/1021` \
`$ git checkout pull/1021`

Update a local copy of the PR: \
`$ git checkout pull/1021` \
`$ git pull https://git.openjdk.org/jfx pull/1021/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1021`

View PR using the GUI difftool: \
`$ git pr show -t 1021`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1021.diff">https://git.openjdk.org/jfx/pull/1021.diff</a>

</details>
