### PR TITLE
8301832: InputMethodEvents are not enabled for text input controls

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextInputControlSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextInputControlSkin.java
@@ -326,8 +326,6 @@ public abstract class TextInputControlSkin<T extends TextInputControl> extends S
                 }
             });
         }
-
-        control.addEventHandler(InputMethodEvent.INPUT_METHOD_TEXT_CHANGED, inputMethodTextChangedHandler);
     }
 
     @Override
@@ -335,6 +333,11 @@ public abstract class TextInputControlSkin<T extends TextInputControl> extends S
         super.install();
 
         TextInputControl control = getSkinnable();
+
+        // IMPORTANT: both setOnInputMethodTextChanged() and setInputMethodRequests() are required for IME to work
+        if (control.getOnInputMethodTextChanged() == null) {
+            control.setOnInputMethodTextChanged(inputMethodTextChangedHandler);
+        }
 
         if (control.getInputMethodRequests() == null) {
             inputMethodRequests = new ExtendedInputMethodRequests() {
@@ -402,11 +405,14 @@ public abstract class TextInputControlSkin<T extends TextInputControl> extends S
             return;
         }
 
-        getSkinnable().removeEventHandler(InputMethodEvent.INPUT_METHOD_TEXT_CHANGED, inputMethodTextChangedHandler);
-
         if (getSkinnable().getInputMethodRequests() == inputMethodRequests) {
             getSkinnable().setInputMethodRequests(null);
         }
+
+        if (getSkinnable().getOnInputMethodTextChanged() == inputMethodTextChangedHandler) {
+            getSkinnable().setOnInputMethodTextChanged(null);
+        }
+
         super.dispose();
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinCleanupTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/SkinCleanupTest.java
@@ -1348,6 +1348,37 @@ public class SkinCleanupTest {
     }
 
     /**
+     * Test that both inputMethodRequests and onInputMethodTextChanged properties, required for IME to work
+     * (see Scene:2239) are set by a skin, on replacing a skin, and on uninstalling a skin.
+     */
+    @Test
+    public void testTextInput_BothIME() {
+        TextField t = new TextField();
+        installDefaultSkin(t);
+        InputMethodRequests mr1 = t.getInputMethodRequests();
+        EventHandler<? super InputMethodEvent> tc1 = t.getOnInputMethodTextChanged();
+
+        assertNotNull("InputMethodRequests must be set by a skin", mr1);
+        assertNotNull("onInputMethodTextChanged must be set by a skin", tc1);
+
+        replaceSkin(t);
+        InputMethodRequests mr2 = t.getInputMethodRequests();
+        EventHandler<? super InputMethodEvent> tc2 = t.getOnInputMethodTextChanged();
+
+        assertNotNull("InputMethodRequests must be set by a skin 2", mr2);
+        assertNotNull("onInputMethodTextChanged must be set by a skin 2", tc2);
+
+        assertNotEquals("InputMethodRequests set by an old skin must be replaced by the new skin", mr1, mr2);
+        assertNotEquals("onInputMethodTextChanged set by an old skin must be replaced by the new skin", tc1, tc2);
+
+        t.setSkin(null);
+        InputMethodRequests mr3 = t.getInputMethodRequests();
+        EventHandler<? super InputMethodEvent> tc3 = t.getOnInputMethodTextChanged();
+        assertNull("InputMethodRequests must be cleared by uninstalling a skin", mr3);
+        assertNull("onInputMethodTextChanged must be cleared by uninstalling a skin", tc3);
+    }
+
+    /**
      * Test that the user input method requests is not affected by the skin.
      */
     @Test


### PR DESCRIPTION
**Targeting jfx20 branch**

A fix for regression introduced by [JDK-8268877](https://bugs.openjdk.org/browse/JDK-8268877).

For IME to work, both `setOnInputMethodTextChanged()` and `setInputMethodRequests()` needs to be set, see Scene:2242.

The fix involves changing the code back to setting the control properties and doing so in the install() method.

Thank you Martin Fox  for noticing the issue!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8301832](https://bugs.openjdk.org/browse/JDK-8301832): InputMethodEvents are not enabled for text input controls


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1024/head:pull/1024` \
`$ git checkout pull/1024`

Update a local copy of the PR: \
`$ git checkout pull/1024` \
`$ git pull https://git.openjdk.org/jfx pull/1024/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1024`

View PR using the GUI difftool: \
`$ git pr show -t 1024`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1024.diff">https://git.openjdk.org/jfx/pull/1024.diff</a>

</details>
