### PR TITLE
fixed reading FIXED_PULSE_LENGTH_PROP from settings

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/AbstractPrimaryTimer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/scenario/animation/AbstractPrimaryTimer.java
@@ -102,7 +102,7 @@ public abstract class AbstractPrimaryTimer {
     // case, instead of advancing time based on the system time (nanos etc) we instead
     // increment each animation by a fixed length of time for each pulse. This is
     // handy while debugging.
-    private final long fixedPulseLength = Boolean.getBoolean(FIXED_PULSE_LENGTH_PROP) ? PULSE_DURATION_NS : 0;
+    private final long fixedPulseLength = Settings.getBoolean(FIXED_PULSE_LENGTH_PROP) ? PULSE_DURATION_NS : 0;
     private long debugNanos = 0;
 
     private final MainLoop theMainLoop = new MainLoop();


### PR DESCRIPTION
converting property name to boolean does not provide the correct result

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1026/head:pull/1026` \
`$ git checkout pull/1026`

Update a local copy of the PR: \
`$ git checkout pull/1026` \
`$ git pull https://git.openjdk.org/jfx pull/1026/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1026`

View PR using the GUI difftool: \
`$ git pr show -t 1026`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1026.diff">https://git.openjdk.org/jfx/pull/1026.diff</a>

</details>
