### PR TITLE
8301712: [linux] Crash on exit from WebKit 615.1

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/ThreadTimers.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/ThreadTimers.cpp
@@ -26,7 +26,9 @@
 
 #include "config.h"
 #include "ThreadTimers.h"
-
+#if PLATFORM(JAVA)
+#include <wtf/java/JavaEnv.h>
+#endif
 #include "MainThreadSharedTimer.h"
 #include "SharedTimer.h"
 #include "ThreadGlobalData.h"
@@ -63,7 +65,11 @@ void ThreadTimers::setSharedTimer(SharedTimer* sharedTimer)
 
     m_sharedTimer = sharedTimer;
 
+#if PLATFORM(JAVA)
+    if (sharedTimer && !g_ShuttingDown) {
+#else
     if (sharedTimer) {
+#endif
         m_sharedTimer->setFiredFunction([] { threadGlobalData().threadTimers().sharedTimerFiredInternal(); });
         updateSharedTimer();
     }


### PR DESCRIPTION
Issue: [linux] Crash on exit from WebKit 615.1 Crash dump observed on Window exit
Root cause: Accessing local storage data of a thread having client data like font cache during VM shutdown
Solution: Add a shutdown hook to ThreadTimers class, so that no timer class doesn't fire any function during the shutdown.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8301712](https://bugs.openjdk.org/browse/JDK-8301712): [linux] Crash on exit from WebKit 615.1


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Hima Bindu Meda](https://openjdk.org/census#hmeda) (@HimaBinduMeda - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1027/head:pull/1027` \
`$ git checkout pull/1027`

Update a local copy of the PR: \
`$ git checkout pull/1027` \
`$ git pull https://git.openjdk.org/jfx pull/1027/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1027`

View PR using the GUI difftool: \
`$ git pr show -t 1027`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1027.diff">https://git.openjdk.org/jfx/pull/1027.diff</a>

</details>
