### PR TITLE
8299986: Wrong sublist used in ListChangeListener

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/AccordionBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/AccordionBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -277,7 +277,7 @@ public class AccordionBehavior extends BehaviorBase<Accordion> {
                         tp.focusedProperty().addListener(paneFocusListener);
                     }
                 } else if (c.wasRemoved()) {
-                    for (final TitledPane tp: c.getAddedSubList()) {
+                    for (final TitledPane tp: c.getRemoved()) {
                         tp.focusedProperty().removeListener(paneFocusListener);
                     }
                 }

--- a/modules/javafx.graphics/src/main/java/javafx/css/Rule.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Rule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -266,7 +266,7 @@ final public class Rule {
                         }
 
                         if (c.wasRemoved()) {
-                            List<Selector> removed = c.getAddedSubList();
+                            List<Selector> removed = c.getRemoved();
                             for(int i = 0, max = removed.size(); i < max; i++) {
                                 Selector sel = removed.get(i);
                                 if (sel.getRule() == Observables.this.rule) {


### PR DESCRIPTION
The obvious coding error has been corrected in two places.

No unit tests have been added because
a) the issue did not result in any apparent behavioral changes as it only affects  what is effectively cleanup
b) I found no easy way to construct a unit test without getting deep into implementation code

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299986](https://bugs.openjdk.org/browse/JDK-8299986): Wrong sublist used in ListChangeListener


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1029/head:pull/1029` \
`$ git checkout pull/1029`

Update a local copy of the PR: \
`$ git checkout pull/1029` \
`$ git pull https://git.openjdk.org/jfx pull/1029/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1029`

View PR using the GUI difftool: \
`$ git pr show -t 1029`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1029.diff">https://git.openjdk.org/jfx/pull/1029.diff</a>

</details>
