### PR TITLE
JDK-8090647: Mnemonics : on windows we should cancel the underscore latch when an app loses focus.

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -2123,6 +2123,10 @@ public class Scene implements EventTarget {
         if (windowFocused && accessible != null) {
             accessible.sendNotification(AccessibleAttribute.FOCUS_NODE);
         }
+
+        if (!windowFocused) {
+            getInternalEventDispatcher().getKeyboardShortcutsHandler().setMnemonicsDisplayEnabled(false);
+        }
     }
 
     /**

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/SceneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/SceneTest.java
@@ -25,7 +25,9 @@
 
 package test.javafx.scene;
 
+import com.sun.javafx.scene.KeyboardShortcutsHandler;
 import com.sun.javafx.scene.NodeHelper;
+import com.sun.javafx.scene.SceneEventDispatcher;
 import com.sun.javafx.scene.SceneHelper;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
@@ -1064,5 +1066,30 @@ public class SceneTest {
         pane = null;
 
         JMemoryBuddy.assertCollectable(ref);
+    }
+
+    @Test
+    public void sceneShouldSet_MnemonicsDisplayEnabled_ToFalseWhenWindowFocusIsLost() {
+        Group root = new Group();
+
+        root.setFocusTraversable(true);
+
+        Scene scene = new Scene(root);
+        SceneEventDispatcher dispatcher = (SceneEventDispatcher) scene.getEventDispatcher();
+        KeyboardShortcutsHandler keyboardShortcutsHandler = dispatcher.getKeyboardShortcutsHandler();
+
+        stage.setScene(scene);
+        stage.show();
+        stage.requestFocus();
+
+        assertFalse(keyboardShortcutsHandler.isMnemonicsDisplayEnabled());
+
+        keyboardShortcutsHandler.setMnemonicsDisplayEnabled(true);
+
+        assertTrue(keyboardShortcutsHandler.isMnemonicsDisplayEnabled());
+
+        stage.close();
+
+        assertFalse(keyboardShortcutsHandler.isMnemonicsDisplayEnabled());
     }
 }


### PR DESCRIPTION
This fix hides mnemonics when the Scene's Window loses focus.

Before integration, we need to make sure this is correct behavior for Mac and Linux as well. It is correct for Windows.

How to test:

- Create a control with a mnemonic
- Alt-tab to another window (mnemonics appear when alt is pressed)

Before:
- Window shows visible mnemonic still and reacts on them when returning

After:
- Window hides mnemonics when focus is lost and doesn't react on them when returning

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8090647](https://bugs.openjdk.org/browse/JDK-8090647): Mnemonics : on windows we should cancel the underscore latch when an app loses focus.


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Committer)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1030/head:pull/1030` \
`$ git checkout pull/1030`

Update a local copy of the PR: \
`$ git checkout pull/1030` \
`$ git pull https://git.openjdk.org/jfx pull/1030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1030`

View PR using the GUI difftool: \
`$ git pr show -t 1030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1030.diff">https://git.openjdk.org/jfx/pull/1030.diff</a>

</details>
