### PR TITLE
JDK-8302355: Public API for Toolkit.canStartNestedEventLoop()

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -307,13 +307,13 @@ public abstract class Toolkit {
 
     /**
      * Indicates whether a nested event loop can be started from the current thread in the current state.
-     * Note that a nested event loop is not allowed outside an event handler.
+     * A nested event loop can be started from an event handler or from a {@code Runnable} passed to
+     * {@code Platform.runLater(Runnable}.
      * This method must be called on the JavaFX Application thread.
      *
-     * @return true if a nested event loop can be started, and false otherwise.
+     * @return {@code true} if a nested event loop can be started, and {@code false} otherwise.
      *
-     * @throws IllegalStateException if this method is called on a thread
-     * other than the JavaFX Application Thread.
+     * @throws IllegalStateException if this method is called on a thread other than the JavaFX Application Thread.
      */
     public abstract boolean canStartNestedEventLoop();
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -308,7 +308,7 @@ public abstract class Toolkit {
     /**
      * Indicates whether a nested event loop can be started from the current thread in the current state.
      * A nested event loop can be started from an event handler or from a {@code Runnable} passed to
-     * {@code Platform.runLater(Runnable}.
+     * {@code Platform.runLater(Runnable)}.
      * This method must be called on the JavaFX Application thread.
      *
      * @return {@code true} if a nested event loop can be started, and {@code false} otherwise.

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -306,11 +306,14 @@ public abstract class Toolkit {
     public abstract boolean init();
 
     /**
-     * Indicates whether or not a nested event loop can be started
-     * from the current thread in the current state. Note that a nested
-     * event loop is not allowed outside of an event handler.
+     * Indicates whether a nested event loop can be started from the current thread in the current state.
+     * Note that a nested event loop is not allowed outside an event handler.
+     * This method must be called on the JavaFX Application thread.
      *
-     * @return flag indicating whether a nested event loop can be started.
+     * @return true if a nested event loop can be started, and false otherwise.
+     *
+     * @throws IllegalStateException if this method is called on a thread
+     * other than the JavaFX Application Thread.
      */
     public abstract boolean canStartNestedEventLoop();
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -621,6 +621,8 @@ public final class QuantumToolkit extends Toolkit {
     }
 
     @Override public boolean canStartNestedEventLoop() {
+        checkFxUserThread();
+
         return inPulse == 0;
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -394,8 +394,12 @@ public final class Platform {
     /**
      * Indicates whether a nested event loop can be started from the current thread in the current state.
      * Note that a nested event loop is not allowed outside an event handler.
+     * This method must be called on the JavaFX Application thread.
      *
      * @return true if a nested event loop can be started, and false otherwise.
+     *
+     * @throws IllegalStateException if this method is called on a thread
+     * other than the JavaFX Application Thread.
      *
      * @since 21
      */

--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -393,13 +393,13 @@ public final class Platform {
 
     /**
      * Indicates whether a nested event loop can be started from the current thread in the current state.
-     * Note that a nested event loop is not allowed outside an event handler.
+     * A nested event loop can be started from an event handler or from a {@code Runnable} passed to
+     * {@link #runLater(Runnable)}.
      * This method must be called on the JavaFX Application thread.
      *
-     * @return true if a nested event loop can be started, and false otherwise.
+     * @return {@code true} if a nested event loop can be started, and {@code false} otherwise.
      *
-     * @throws IllegalStateException if this method is called on a thread
-     * other than the JavaFX Application Thread.
+     * @throws IllegalStateException if this method is called on a thread other than the JavaFX Application Thread.
      *
      * @since 21
      */

--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -389,6 +389,18 @@ public final class Platform {
      */
     public static boolean isNestedLoopRunning() {
         return Toolkit.getToolkit().isNestedLoopRunning();
+    }
+
+    /**
+     * Indicates whether a nested event loop can be started from the current thread in the current state.
+     * Note that a nested event loop is not allowed outside an event handler.
+     *
+     * @return true if a nested event loop can be started, and false otherwise.
+     *
+     * @since 21
+     */
+    public static boolean canStartNestedEventLoop() {
+        return Toolkit.getToolkit().canStartNestedEventLoop();
     }
 
     private static ReadOnlyBooleanWrapper accessibilityActiveProperty;

--- a/tests/system/src/test/java/test/javafx/application/PlatformTest.java
+++ b/tests/system/src/test/java/test/javafx/application/PlatformTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.application;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import test.util.Util;
+
+import javafx.animation.KeyFrame;
+import javafx.animation.Timeline;
+import javafx.util.Duration;
+import javafx.application.Platform;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class PlatformTest {
+
+    @BeforeAll
+    public static void initFXOnce() {
+        CountDownLatch startupLatch = new CountDownLatch(1);
+        Platform.setImplicitExit(false);
+
+        Util.startup(startupLatch, startupLatch::countDown);
+    }
+
+    @AfterAll
+    public static void teardownOnce() {
+        Util.shutdown();
+    }
+
+    @Test
+    public void testNestedEventLoopChecks() {
+        // Check on FX Thread.
+        Util.runAndWait(() -> {
+            assertFalse(Platform.isNestedLoopRunning());
+            assertTrue(Platform.canStartNestedEventLoop());
+        });
+    }
+
+    @Test
+    public void testEnterExitNestedEventLoop() {
+        final String key = "key";
+        final String value = "value";
+        final AtomicReference<Throwable> exceptionRef = new AtomicReference<>();
+
+        Util.runAndWait(() -> {
+            // Exit nested event loop after it was started.
+            Platform.runLater(() -> {
+                try {
+                    assertTrue(Platform.isNestedLoopRunning());
+                    assertTrue(Platform.canStartNestedEventLoop());
+                    Platform.exitNestedEventLoop(key, value);
+                } catch (Throwable e) {
+                    exceptionRef.set(e);
+                }
+            });
+
+            Object returnValue = Platform.enterNestedEventLoop(key);
+            assertEquals(value, returnValue);
+        });
+
+        // We do not expect any exception.
+        assertNull(exceptionRef.get(), exceptionRef::toString);
+    }
+
+    @Test
+    public void testNestedEventLoopChecksNotOnFxThread() {
+        assertThrows(IllegalStateException.class, () -> Platform.isNestedLoopRunning());
+        assertThrows(IllegalStateException.class, () -> Platform.canStartNestedEventLoop());
+    }
+
+    @Test
+    public void testEnterExitNestedEventLoopNotOnFxThread() {
+        assertThrows(IllegalStateException.class, () -> Platform.enterNestedEventLoop(null));
+        assertThrows(IllegalStateException.class, () -> Platform.exitNestedEventLoop(null, null));
+    }
+
+    @Test
+    public void testCanNotStartNestedEventLoopInTimeline() {
+        final CountDownLatch timelineDone = new CountDownLatch(1);
+        final AtomicReference<Throwable> exceptionRef = new AtomicReference<>();
+
+        Timeline timeline = new Timeline(new KeyFrame(Duration.millis(50), event -> {
+            try {
+                assertFalse(Platform.canStartNestedEventLoop());
+            } catch (Throwable e) {
+                exceptionRef.set(e);
+            } finally {
+                timelineDone.countDown();
+            }
+        }));
+        timeline.play();
+
+        Util.await(timelineDone);
+
+        // We do not expect any exception.
+        assertNull(exceptionRef.get(), exceptionRef::toString);
+    }
+
+}


### PR DESCRIPTION
This PR adds the last missing method for dealing with nested event loops.
As also written in the ticket, there is currently no (public) way to find out whether it is safe to start an event loop now or not.
Classes like `Dialog` check via `Toolkit.getToolkit().canStartNestedEventLoop()` (sun api), if it safe to start a nested event loop before doing so.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8302355](https://bugs.openjdk.org/browse/JDK-8302355): Public API for Toolkit.canStartNestedEventLoop()


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1031/head:pull/1031` \
`$ git checkout pull/1031`

Update a local copy of the PR: \
`$ git checkout pull/1031` \
`$ git pull https://git.openjdk.org/jfx pull/1031/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1031`

View PR using the GUI difftool: \
`$ git pr show -t 1031`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1031.diff">https://git.openjdk.org/jfx/pull/1031.diff</a>

</details>
