### PR TITLE
8302472 WebColorFieldSkin should use precompiled Pattern

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/skin/WebColorFieldSkin.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/skin/WebColorFieldSkin.java
@@ -25,9 +25,10 @@
 
 package com.sun.javafx.scene.control.skin;
 
-import java.util.Locale;
-
 import com.sun.javafx.scene.control.WebColorField;
+
+import java.util.regex.Pattern;
+
 import javafx.beans.InvalidationListener;
 import javafx.geometry.NodeOrientation;
 import javafx.scene.Node;
@@ -36,8 +37,11 @@ import javafx.scene.paint.Color;
 /**
  */
 public class WebColorFieldSkin extends InputFieldSkin {
+    private static final String HEX_DIGIT = "[A-Fa-f0-9]";
+    private static final Pattern PATTERN = Pattern.compile("#?" + HEX_DIGIT + "{6}");
+    private static final Pattern PARTIAL_PATTERN = Pattern.compile("#?" + HEX_DIGIT + "{0,6}");
+
     private InvalidationListener integerFieldValueListener;
-    private boolean noChangeInValue = false;
 
     /**
      * Create a new WebColorFieldSkin.
@@ -80,14 +84,9 @@ public class WebColorFieldSkin extends InputFieldSkin {
         super.dispose();
     }
 
-    //  "^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$";
     @Override
     protected boolean accept(String text) {
-        if (text.length() == 0) return true;
-        if (text.matches("#[a-fA-F0-9]{0,6}") || text.matches("[a-fA-F0-9]{0,6}")) {
-            return true;
-        }
-        return false;
+        return PARTIAL_PATTERN.matcher(text).matches();
     }
 
     @Override
@@ -99,23 +98,18 @@ public class WebColorFieldSkin extends InputFieldSkin {
 
     @Override
     protected void updateValue() {
-        if (noChangeInValue) return;
         Color value = ((WebColorField) control).getValue();
-        String text = getTextField().getText() == null ? "" : getTextField().getText().trim().toUpperCase(Locale.ROOT);
-        if (text.matches("#[A-F0-9]{6}") || text.matches("[A-F0-9]{6}")) {
-            try {
-                Color newValue = (text.charAt(0) == '#')? Color.web(text) : Color.web("#"+text);
-                if (!newValue.equals(value)) {
-                    ((WebColorField) control).setValue(newValue);
-                } else {
-                    // calling setText results in updateValue - so we set this flag to true
-                    // so that when this is true updateValue simply returns.
-                    noChangeInValue = true;
-                    getTextField().setText(Utils.formatHexString(newValue));
-                    noChangeInValue = false;
+        String text = getTextField().getText() == null ? "" : getTextField().getText().trim();
+        if (PATTERN.matcher(text).matches()) {
+            Color newValue = (text.charAt(0) == '#') ? Color.web(text) : Color.web("#" + text);
+            if (!newValue.equals(value)) {
+                ((WebColorField) control).setValue(newValue);
+            } else {
+                String newText = Utils.formatHexString(newValue);
+
+                if (!newText.equals(text)) {
+                    getTextField().setText(newText);
                 }
-            } catch (java.lang.IllegalArgumentException ex) {
-                System.out.println("Failed to parse ["+text+"]");
             }
         }
     }


### PR DESCRIPTION
Split off from https://github.com/openjdk/jfx/pull/837

This uses a precompiled regex pattern and cleans up the code in WebColorFieldSkin a bit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302472](https://bugs.openjdk.org/browse/JDK-8302472): WebColorFieldSkin should use precompiled Pattern


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1032/head:pull/1032` \
`$ git checkout pull/1032`

Update a local copy of the PR: \
`$ git checkout pull/1032` \
`$ git pull https://git.openjdk.org/jfx pull/1032/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1032`

View PR using the GUI difftool: \
`$ git pr show -t 1032`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1032.diff">https://git.openjdk.org/jfx/pull/1032.diff</a>

</details>
