### PR TITLE
8302470: Change JBS version in .jcheck/conf to jfxNN[.0.MM]

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -24,7 +24,7 @@
 [general]
 project=openjfx
 jbs=jdk
-version=openjfx20
+version=jfx20
 
 [repository]
 tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9]((\.\d{1,3}){0,2})-((b\d{2,3})|(ga))|[1-9]u(\d{1,3})-((b\d{2,3})|(ga))

--- a/UPDATING-VERSION.md
+++ b/UPDATING-VERSION.md
@@ -11,7 +11,7 @@ Here are the steps to increment the JavaFX release version number to a new
 feature version (for example, from 13 to 14).
 
 * In `.jcheck/conf`, modify the `version` property in the `[general]`
-section to increment the version number from `openjfx$N` to `openjfx$N+1`.
+section to increment the JBS version number from `jfx$N` to `jfx$N+1`.
 
 * In `build.properties`, modify the following properties to increment the
 feature version number from `N` to `N+1`:
@@ -33,8 +33,8 @@ Here are the steps to increment the JavaFX release version number to a new
 security version (for example, from 13 to 13.0.1).
 
 * In `.jcheck/conf`, modify the `version` property in the `[general]`
-section to increment the version number from `openjfx$N` to `openjfx$N.0.1`
-or from `openjfx$N.0.M` to `openjfx$N.0.$M+1`.
+section to increment the JBS version number from `jfx$N` to `jfx$N.0.1`
+or from `jfx$N.0.M` to `jfx$N.0.$M+1`.
 
 * In `build.properties`, modify the `jfx.release.security.version` property
 to increment the security version number from `M` to `M+1`.


### PR DESCRIPTION
In support of the JBS version change from "openjfxNN[.0.MM]" to "jfxNN[.0.MM]", we need to update the JBS version in .jcheck/conf in each active code line.

The planned cut-over date is Tuesday, Feb 28. I will integrate this PR immediately after the JBS version renaming is done.

NOTE: This PR is targeted to `jfx20`. I also created a separate PR targeted to `master`. This is a necessary exception to the usual rule where a fix goes into one or the other. In this case it needs to go into both so that they can be integrated immediately after the version change. The merge will have conflicts anyway, since the JBS fix versions are already different in the two branches, and doing it this way will allow a trivial resolution of the eventual merge conflict (which doesn't then have to be done urgently).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8302470](https://bugs.openjdk.org/browse/JDK-8302470): Change JBS version in .jcheck/conf to jfxNN[.0.MM]


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1034/head:pull/1034` \
`$ git checkout pull/1034`

Update a local copy of the PR: \
`$ git checkout pull/1034` \
`$ git pull https://git.openjdk.org/jfx pull/1034/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1034`

View PR using the GUI difftool: \
`$ git pr show -t 1034`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1034.diff">https://git.openjdk.org/jfx/pull/1034.diff</a>

</details>
