### PR TITLE
8283551: ControlAcceleratorSupport menu items listener causes memory leak

### DIFF
--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ExpressionHelperUtility.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ExpressionHelperUtility.java
@@ -50,6 +50,7 @@ public class ExpressionHelperUtility {
     private static final String LIST_EXPRESSION_HELPER_SINGLE_CHANGE       = "com.sun.javafx.binding.ListExpressionHelper$SingleChange";
     private static final String LIST_EXPRESSION_HELPER_SINGLE_LIST_CHANGE  = "com.sun.javafx.binding.ListExpressionHelper$SingleListChange";
     private static final String LIST_EXPRESSION_HELPER_GENERIC             = "com.sun.javafx.binding.ListExpressionHelper$Generic";
+    private static final String LIST_LISTENER_HELPER_GENERIC               = "com.sun.javafx.collections.ListListenerHelper$Generic";
     private static final String MAP_EXPRESSION_HELPER_SINGLE_INVALIDATION  = "com.sun.javafx.binding.MapExpressionHelper$SingleInvalidation";
     private static final String MAP_EXPRESSION_HELPER_SINGLE_CHANGE        = "com.sun.javafx.binding.MapExpressionHelper$SingleChange";
     private static final String MAP_EXPRESSION_HELPER_SINGLE_MAP_CHANGE    = "com.sun.javafx.binding.MapExpressionHelper$SingleMapChange";
@@ -199,9 +200,12 @@ public class ExpressionHelperUtility {
     }
 
     public static <E> List<ListChangeListener<? super E>> getListChangeListeners(ObservableList<E> observable) {
-        final Object helper = getExpressionHelper(observable);
+        Object helper = getExpressionHelper(observable);
         if (helper == null) {
-            return Collections.emptyList();
+            helper = getListExpressionHelper(observable);
+            if (helper == null) {
+                return Collections.emptyList();
+            }
         }
         final Class helperClass = helper.getClass();
 
@@ -226,6 +230,23 @@ public class ExpressionHelperUtility {
                     final ListChangeListener<? super E>[] listeners = (ListChangeListener[])field.get(helper);
                     if (listeners != null) {
                         final Field sizeField = clazz.getDeclaredField("listChangeSize");
+                        sizeField.setAccessible(true);
+                        final int size = sizeField.getInt(helper);
+                        return Arrays.asList(Arrays.copyOf(listeners, size));
+                    }
+                } catch (Exception ex) { }
+            }
+        } catch (ClassNotFoundException ex) { }
+
+        try {
+            final Class clazz = Class.forName(LIST_LISTENER_HELPER_GENERIC);
+            if (clazz.isAssignableFrom(helperClass)) {
+                try {
+                    final Field field = clazz.getDeclaredField("changeListeners");
+                    field.setAccessible(true);
+                    final ListChangeListener<? super E>[] listeners = (ListChangeListener[])field.get(helper);
+                    if (listeners != null) {
+                        final Field sizeField = clazz.getDeclaredField("changeSize");
                         sizeField.setAccessible(true);
                         final int size = sizeField.getInt(helper);
                         return Arrays.asList(Arrays.copyOf(listeners, size));
@@ -323,6 +344,19 @@ public class ExpressionHelperUtility {
                 field.setAccessible(true);
                 return field.get(bean);
             } catch (Exception ex) { }
+            clazz = clazz.getSuperclass();
+        }
+        return null;
+    }
+
+    private static Object getListExpressionHelper(Object bean) {
+        Class clazz = bean.getClass();
+        while (clazz != Object.class) {
+            try {
+                final Field field = clazz.getDeclaredField("listenerHelper");
+                field.setAccessible(true);
+                return field.get(bean);
+            } catch (Exception ex) {}
             clazz = clazz.getSuperclass();
         }
         return null;

--- a/modules/javafx.controls/src/test/addExports
+++ b/modules/javafx.controls/src/test/addExports
@@ -7,6 +7,8 @@
 --add-opens javafx.base/javafx.beans.property=ALL-UNNAMED
 --add-opens javafx.base/com.sun.javafx.binding=ALL-UNNAMED
 --add-exports javafx.base/com.sun.javafx.logging=ALL-UNNAMED
+--add-opens javafx.base/com.sun.javafx.collections=ALL-UNNAMED
+--add-opens javafx.base/javafx.collections=ALL-UNNAMED
 #
 --add-exports javafx.graphics/com.sun.javafx.application=ALL-UNNAMED
 --add-exports javafx.graphics/com.sun.javafx.font=ALL-UNNAMED


### PR DESCRIPTION
Each time a menu would change scenes, a new set of ListChangeListeners would be added to the items in the menu. The bigger problem however is that these list change listeners have a strong reference to the scene which is potentially a much bigger leak.

The first commit was more straightforward, but there are 2 things that might be of concern:

1. The method removeAcceleratorsFromScene takes in a scene parameter, but it'll remove all the ListChangeListeners attached to it, regardless of which scene was passed in. Something similar happens with changeListenerMap already, so I think it's fine.
2. I made the remove method public so that external calls from skins to remove the accelerators would remove the ListChangeListener and also because all the remove methods are public. 

After I wrote more tests I realised using the ObservableLists as keys in the WeakHashMaps was a bad idea. If Java had a WeakIdentityHashMap the fix would be simple. The fix is in the second commit.

There are still more issues that stem from the fact that for each anchor there could be multiple menus and the current code doesn't account for that. For example, swapping context menus on a tab doesn't register change listeners on the new context menu because the TabPane itself had a scene change listener already. These other issues could relate to JDK-8268374 https://bugs.openjdk.org/browse/JDK-8268374 and JDK-8283449 https://bugs.openjdk.org/browse/JDK-8283449. One of the issues is related to the fact that there's no logic to remove listeners when Tab/TableColumn's are removed from their associated control (TabPane, TableView, TreeTableView).

I'm looking at these issues, but I think they're dependent on this fix. Either I can add to this PR or I can wait to see what comes out of this and fix them subsequently.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8283551](https://bugs.openjdk.org/browse/JDK-8283551): ControlAcceleratorSupport menu items listener causes memory leak (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1037/head:pull/1037` \
`$ git checkout pull/1037`

Update a local copy of the PR: \
`$ git checkout pull/1037` \
`$ git pull https://git.openjdk.org/jfx.git pull/1037/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1037`

View PR using the GUI difftool: \
`$ git pr show -t 1037`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1037.diff">https://git.openjdk.org/jfx/pull/1037.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1037#issuecomment-1433255896)