### PR TITLE
8090123: Items are no longer visible when collection is changed

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ContextMenuContent.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ContextMenuContent.java
@@ -343,6 +343,15 @@ public class ContextMenuContent extends Region {
         itemsContainer.resize(w,contentHeight);
         itemsContainer.relocate(x, y);
 
+        if(contentHeight < Math.abs(ty)){
+            /*
+             ** This condition occurs when context menu with large number of items
+             ** are replaced by smaller number of items.
+             ** Scroll to the top to display the context menu items.
+             */
+            scroll(Math.abs(ty));
+        }
+
         if (isFirstShow && ty == 0) {
             upArrow.setVisible(false);
             isFirstShow = false;
@@ -808,6 +817,14 @@ public class ContextMenuContent extends Region {
 
     Menu getOpenSubMenu() {
         return openSubmenu;
+    }
+
+    boolean isUpArrowVisible() {
+        return upArrow.isVisible();
+    }
+
+    boolean isDownArrowVisible() {
+        return upArrow.isVisible();
     }
 
     private void createSubmenu() {

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ContextMenuContent.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ContextMenuContent.java
@@ -343,7 +343,7 @@ public class ContextMenuContent extends Region {
         itemsContainer.resize(w,contentHeight);
         itemsContainer.relocate(x, y);
 
-        if(contentHeight < Math.abs(ty)){
+        if (contentHeight < Math.abs(ty)) {
             /*
              ** This condition occurs when context menu with large number of items
              ** are replaced by smaller number of items.
@@ -815,14 +815,17 @@ public class ContextMenuContent extends Region {
         return submenu;
     }
 
+    // For test purpose only
     Menu getOpenSubMenu() {
         return openSubmenu;
     }
 
+    // For test purpose only
     boolean isUpArrowVisible() {
         return upArrow.isVisible();
     }
 
+    // For test purpose only
     boolean isDownArrowVisible() {
         return downArrow.isVisible();
     }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ContextMenuContent.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ContextMenuContent.java
@@ -824,7 +824,7 @@ public class ContextMenuContent extends Region {
     }
 
     boolean isDownArrowVisible() {
-        return upArrow.isVisible();
+        return downArrow.isVisible();
     }
 
     private void createSubmenu() {

--- a/modules/javafx.controls/src/shims/java/com/sun/javafx/scene/control/ContextMenuContentShim.java
+++ b/modules/javafx.controls/src/shims/java/com/sun/javafx/scene/control/ContextMenuContentShim.java
@@ -138,4 +138,14 @@ public class ContextMenuContentShim {
         return null;
     }
 
+    public static boolean isContextMenuUpArrowVisible(ContextMenu menu) {
+        ContextMenuContent content = getMenuContent(menu);
+        return content.isUpArrowVisible();
+    }
+
+    public static boolean isContextMenuDownArrowVisible(ContextMenu menu) {
+        ContextMenuContent content = getMenuContent(menu);
+        return content.isDownArrowVisible();
+    }
+
 }

--- a/modules/javafx.controls/src/shims/java/com/sun/javafx/scene/control/ContextMenuContentShim.java
+++ b/modules/javafx.controls/src/shims/java/com/sun/javafx/scene/control/ContextMenuContentShim.java
@@ -148,4 +148,9 @@ public class ContextMenuContentShim {
         return content.isDownArrowVisible();
     }
 
+    public static double getContextMenuRowHeight(ContextMenu menu) {
+        ContextMenuContent content = getMenuContent(menu);
+        return content.getItemsContainer().getChildren().get(0).prefHeight(-1);
+    }
+
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
@@ -116,7 +116,7 @@ public class ChoiceBoxScrollUpOnCollectionChangeTest {
     }
 
     @Test
-    public void testChoicBoxScrollOnCollectionChange() throws Exception {
+    public void testChoiceBoxScrollOnCollectionChange() throws Exception {
         Util.waitForLatch(startupLatch, 5, "Timeout waiting for stage to load.");
         ContextMenu popup = ChoiceBoxSkinNodesShim.getChoiceBoxPopup((ChoiceBoxSkin<?>) choiceBox.getSkin());
 

--- a/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
@@ -66,6 +66,7 @@ import test.util.Util;
  * 6. Verify that ChoiceBox items are displayed and no scroll
  *    arrows are displayed.
  */
+
 public class ChoiceBoxScrollUpOnCollectionChangeTest {
     static CountDownLatch startupLatch = new CountDownLatch(1);
     static CountDownLatch scrollLatch = new CountDownLatch(1);

--- a/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
@@ -140,8 +140,8 @@ public class ChoiceBoxScrollUpOnCollectionChangeTest {
         Assert.assertTrue(ContextMenuContentShim.isContextMenuDownArrowVisible(popup));
 
         double rowHeight = ContextMenuContentShim.getContextMenuRowHeight(popup);
-        double screenHeight = Math.ceil(Screen.getPrimary().getVisualBounds().getHeight());
-        scrollChoiceBox((int) (screenHeight / rowHeight));
+        double screenHeight = Screen.getPrimary().getVisualBounds().getHeight();
+        scrollChoiceBox((int) Math.ceil(screenHeight / rowHeight));
 
         Util.waitForLatch(choiceBoxHiddenLatch, 5, "Timeout waiting for choicebox to be hidden.");
         Assert.assertTrue(ContextMenuContentShim.isContextMenuUpArrowVisible(popup));

--- a/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
@@ -37,12 +37,12 @@ import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.skin.ChoiceBoxSkin;
 import javafx.scene.control.skin.ChoiceBoxSkinNodesShim;
-import javafx.scene.control.skin.ContextMenuSkin;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;
 import javafx.application.Platform;
 import javafx.scene.robot.Robot;
 import javafx.scene.Scene;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 
@@ -97,9 +97,13 @@ public class ChoiceBoxScrollUpOnCollectionChangeTest {
                 robot.keyType(KeyCode.DOWN);
                 Toolkit.getToolkit().firePulse();
             }
+            scrollLatch.countDown();
+        });
 
-            Util.sleep(400); // Wait for up arrow to get loaded in UI
+        Util.waitForLatch(scrollLatch, 5, "Timeout waiting for choicebox to be hidden.");
+        Thread.sleep(400); // Wait for up arrow to get loaded in UI
 
+        Util.runAndWait(() -> {
             robot.keyType(KeyCode.ENTER);
         });
     }
@@ -130,12 +134,16 @@ public class ChoiceBoxScrollUpOnCollectionChangeTest {
         addChoiceBoxItems(150);
         showChoiceBox();
 
+        Thread.sleep(400); // Small delay to avoid test failure due to slow UI loading.
+
         Assert.assertFalse(ContextMenuContentShim.isContextMenuUpArrowVisible(popup));
         Assert.assertTrue(ContextMenuContentShim.isContextMenuDownArrowVisible(popup));
-        scrollChoiceBox(75);
+
+        double rowHeight = ContextMenuContentShim.getContextMenuRowHeight(popup);
+        double screenHeight = Screen.getPrimary().getBounds().getHeight();
+        scrollChoiceBox((int) (screenHeight / rowHeight));
 
         Util.waitForLatch(choiceBoxHiddenLatch, 5, "Timeout waiting for choicebox to be hidden.");
-        Thread.sleep(400); // Small delay to avoid test failure due to slow UI loading.
         Assert.assertTrue(ContextMenuContentShim.isContextMenuUpArrowVisible(popup));
         Assert.assertTrue(ContextMenuContentShim.isContextMenuDownArrowVisible(popup));
 

--- a/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
@@ -92,14 +92,12 @@ public class ChoiceBoxScrollUpOnCollectionChangeTest {
 
     private void scrollChoiceBox(int scrollAmt) throws Exception {
         Util.runAndWait(() -> {
-            for (int i=0; i<scrollAmt; i++) {
+            for (int i = 0; i < scrollAmt; i++) {
                 robot.keyType(KeyCode.DOWN);
                 Toolkit.getToolkit().firePulse();
             }
 
-            try {
-                Thread.sleep(400); // Wait for up arrow to get loaded in UI
-            } catch (Exception e) {}
+            Util.sleep(400); // Wait for up arrow to get loaded in UI
 
             robot.keyType(KeyCode.ENTER);
         });
@@ -115,7 +113,7 @@ public class ChoiceBoxScrollUpOnCollectionChangeTest {
     private void addChoiceBoxItems(int count) {
         Util.runAndWait(() -> {
             ObservableList<String> items = FXCollections.observableArrayList();
-            for(int i=0 ; i<count ; i++) {
+            for (int i = 0; i < count; i++) {
                 items.add("item " + (i + 1));
             }
             choiceBox.getItems().setAll(items);

--- a/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
@@ -59,7 +59,7 @@ import test.util.Util;
  *
  * There is 1 test in this file.
  * Steps for testChoicBoxScrollOnCollectionChange()
- * 1. Create a ChoiceBox and add 50 items to it.
+ * 1. Create a ChoiceBox and add 150 items to it.
  * 2. Display the ChoiceBox and scroll down.
  * 3. Verify if both up and down scroll arrows are displayed.
  * 4. Replace the ChoiceBox items with 2 items.
@@ -140,7 +140,7 @@ public class ChoiceBoxScrollUpOnCollectionChangeTest {
         Assert.assertTrue(ContextMenuContentShim.isContextMenuDownArrowVisible(popup));
 
         double rowHeight = ContextMenuContentShim.getContextMenuRowHeight(popup);
-        double screenHeight = Screen.getPrimary().getBounds().getHeight();
+        double screenHeight = Math.ceil(Screen.getPrimary().getVisualBounds().getHeight());
         scrollChoiceBox((int) (screenHeight / rowHeight));
 
         Util.waitForLatch(choiceBoxHiddenLatch, 5, "Timeout waiting for choicebox to be hidden.");

--- a/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
@@ -83,9 +83,10 @@ public class ChoiceBoxScrollUpOnCollectionChangeTest {
     static final int SCENE_HEIGHT = SCENE_WIDTH;
 
     private void mouseClick(double x, double y) {
+        int xCoordinate = (int) (scene.getWindow().getX() + scene.getX() + x);
+        int yCoordinate = (int) (scene.getWindow().getY() + scene.getY() + y);
         Util.runAndWait(() -> {
-            robot.mouseMove((int) (scene.getWindow().getX() + scene.getX() + x),
-                                (int) (scene.getWindow().getY() + scene.getY() + y));
+            robot.mouseMove(xCoordinate, yCoordinate);
             robot.mouseClick(MouseButton.PRIMARY);
         });
     }
@@ -104,8 +105,9 @@ public class ChoiceBoxScrollUpOnCollectionChangeTest {
     }
 
     private void showChoiceBox() throws Exception {
-        mouseClick(choiceBox.getLayoutX() + choiceBox.getWidth() / 2,
-                    choiceBox.getLayoutY() + choiceBox.getHeight() / 2);
+        double x = choiceBox.getLayoutX() + choiceBox.getWidth() / 2;
+        double y = choiceBox.getLayoutY() + choiceBox.getHeight() / 2;
+        mouseClick(x, y);
 
         Util.waitForLatch(choiceBoxDisplayLatch, 5, "Timeout waiting for choicebox to be displayed.");
     }

--- a/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
@@ -28,6 +28,7 @@ package test.robot.javafx.scene;
 import java.util.concurrent.CountDownLatch;
 
 import com.sun.javafx.scene.control.ContextMenuContentShim;
+import com.sun.javafx.tk.Toolkit;
 
 import javafx.application.Application;
 import javafx.collections.FXCollections;
@@ -93,7 +94,13 @@ public class ChoiceBoxScrollUpOnCollectionChangeTest {
         Util.runAndWait(() -> {
             for (int i=0; i<scrollAmt; i++) {
                 robot.keyType(KeyCode.DOWN);
+                Toolkit.getToolkit().firePulse();
             }
+
+            try {
+                Thread.sleep(400); // Wait for up arrow to get loaded in UI
+            } catch (Exception e) {}
+
             robot.keyType(KeyCode.ENTER);
         });
     }
@@ -120,21 +127,22 @@ public class ChoiceBoxScrollUpOnCollectionChangeTest {
         Util.waitForLatch(startupLatch, 5, "Timeout waiting for stage to load.");
         ContextMenu popup = ChoiceBoxSkinNodesShim.getChoiceBoxPopup((ChoiceBoxSkin<?>) choiceBox.getSkin());
 
-        addChoiceBoxItems(100);
+        addChoiceBoxItems(150);
         showChoiceBox();
 
         Assert.assertFalse(ContextMenuContentShim.isContextMenuUpArrowVisible(popup));
         Assert.assertTrue(ContextMenuContentShim.isContextMenuDownArrowVisible(popup));
-        scrollChoiceBox(50);
+        scrollChoiceBox(75);
 
         Util.waitForLatch(choiceBoxHiddenLatch, 5, "Timeout waiting for choicebox to be hidden.");
+        Thread.sleep(400); // Small delay to avoid test failure due to slow UI loading.
         Assert.assertTrue(ContextMenuContentShim.isContextMenuUpArrowVisible(popup));
         Assert.assertTrue(ContextMenuContentShim.isContextMenuDownArrowVisible(popup));
 
         addChoiceBoxItems(2);
+        choiceBoxDisplayLatch = new CountDownLatch(1);
         showChoiceBox();
 
-        Util.waitForLatch(choiceBoxDisplayLatch, 5, "Timeout waiting for choicebox to be displayed.");
         Assert.assertFalse(ContextMenuContentShim.isContextMenuUpArrowVisible(popup));
         Assert.assertFalse(ContextMenuContentShim.isContextMenuDownArrowVisible(popup));
     }

--- a/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
@@ -120,8 +120,11 @@ public class ChoiceBoxScrollUpOnCollectionChangeTest {
         Util.waitForLatch(startupLatch, 5, "Timeout waiting for stage to load.");
         ContextMenu popup = ChoiceBoxSkinNodesShim.getChoiceBoxPopup((ChoiceBoxSkin<?>) choiceBox.getSkin());
 
-        addChoiceBoxItems(50);
+        addChoiceBoxItems(100);
         showChoiceBox();
+
+        Assert.assertFalse(ContextMenuContentShim.isContextMenuUpArrowVisible(popup));
+        Assert.assertTrue(ContextMenuContentShim.isContextMenuDownArrowVisible(popup));
         scrollChoiceBox(50);
 
         Util.waitForLatch(choiceBoxHiddenLatch, 5, "Timeout waiting for choicebox to be hidden.");

--- a/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.robot.javafx.scene;
+
+import java.util.concurrent.CountDownLatch;
+
+import com.sun.javafx.scene.control.ContextMenuContentShim;
+
+import javafx.application.Application;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.control.ChoiceBox;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.skin.ChoiceBoxSkin;
+import javafx.scene.control.skin.ChoiceBoxSkinNodesShim;
+import javafx.scene.control.skin.ContextMenuSkin;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.MouseButton;
+import javafx.application.Platform;
+import javafx.scene.robot.Robot;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import test.util.Util;
+
+/*
+ * Test for verifying if ChoiceBox items are displayed after
+ * scrolling large number of items and replacing with 2 items.
+ *
+ * There is 1 test in this file.
+ * Steps for testChoicBoxScrollOnCollectionChange()
+ * 1. Create a ChoiceBox and add 50 items to it.
+ * 2. Display the ChoiceBox and scroll down.
+ * 3. Verify if both up and down scroll arrows are displayed.
+ * 4. Replace the ChoiceBox items with 2 items.
+ * 5. Display the ChoiceBox again.
+ * 6. Verify that ChoiceBox items are displayed and no scroll
+ *    arrows are displayed.
+ */
+public class ChoiceBoxScrollUpOnCollectionChangeTest {
+    static CountDownLatch startupLatch = new CountDownLatch(1);
+    static CountDownLatch scrollLatch = new CountDownLatch(1);
+    static CountDownLatch choiceBoxDisplayLatch = new CountDownLatch(1);
+    static CountDownLatch choiceBoxHiddenLatch = new CountDownLatch(1);
+    static Robot robot;
+    static ChoiceBox<String> choiceBox;
+
+    static volatile Stage stage;
+    static volatile Scene scene;
+
+    static final int SCENE_WIDTH = 250;
+    static final int SCENE_HEIGHT = SCENE_WIDTH;
+
+    private void mouseClick(double x, double y) {
+        Util.runAndWait(() -> {
+            robot.mouseMove((int) (scene.getWindow().getX() + scene.getX() + x),
+                                (int) (scene.getWindow().getY() + scene.getY() + y));
+            robot.mouseClick(MouseButton.PRIMARY);
+        });
+    }
+
+    private void scrollChoiceBox(int scrollAmt) throws Exception {
+        Util.runAndWait(() -> {
+            for (int i=0; i<scrollAmt; i++) {
+                robot.keyType(KeyCode.DOWN);
+            }
+            robot.keyType(KeyCode.ENTER);
+        });
+    }
+
+    private void showChoiceBox() throws Exception {
+        mouseClick(choiceBox.getLayoutX() + choiceBox.getWidth() / 2,
+                    choiceBox.getLayoutY() + choiceBox.getHeight() / 2);
+
+        Util.waitForLatch(choiceBoxDisplayLatch, 5, "Timeout waiting for choicebox to be displayed.");
+    }
+
+    private void addChoiceBoxItems(int count) {
+        Util.runAndWait(() -> {
+            ObservableList<String> items = FXCollections.observableArrayList();
+            for(int i=0 ; i<count ; i++) {
+                items.add("item " + (i + 1));
+            }
+            choiceBox.getItems().setAll(items);
+        });
+    }
+
+    @Test
+    public void testChoicBoxScrollOnCollectionChange() throws Exception {
+        Util.waitForLatch(startupLatch, 5, "Timeout waiting for stage to load.");
+        ContextMenu popup = ChoiceBoxSkinNodesShim.getChoiceBoxPopup((ChoiceBoxSkin<?>) choiceBox.getSkin());
+
+        addChoiceBoxItems(50);
+        showChoiceBox();
+        scrollChoiceBox(50);
+
+        Util.waitForLatch(choiceBoxHiddenLatch, 5, "Timeout waiting for choicebox to be hidden.");
+        Assert.assertTrue(ContextMenuContentShim.isContextMenuUpArrowVisible(popup));
+        Assert.assertTrue(ContextMenuContentShim.isContextMenuDownArrowVisible(popup));
+
+        addChoiceBoxItems(2);
+        showChoiceBox();
+
+        Util.waitForLatch(choiceBoxDisplayLatch, 5, "Timeout waiting for choicebox to be displayed.");
+        Assert.assertFalse(ContextMenuContentShim.isContextMenuUpArrowVisible(popup));
+        Assert.assertFalse(ContextMenuContentShim.isContextMenuDownArrowVisible(popup));
+    }
+
+    @BeforeClass
+    public static void initFX() throws Exception {
+        Util.launch(startupLatch, TestApp.class);
+    }
+
+    @AfterClass
+    public static void exit() {
+        Util.shutdown(stage);
+    }
+
+    public static class TestApp extends Application {
+        @Override
+        public void start(Stage primaryStage) {
+            robot = new Robot();
+            stage = primaryStage;
+
+            choiceBox = new ChoiceBox<String>();
+            choiceBox.setOnShown(event -> {
+                choiceBoxDisplayLatch.countDown();
+            });
+
+            choiceBox.setOnHidden(event -> {
+                choiceBoxHiddenLatch.countDown();
+            });
+
+            scene = new Scene(choiceBox, SCENE_WIDTH, SCENE_HEIGHT);
+            stage.setScene(scene);
+            stage.initStyle(StageStyle.UNDECORATED);
+            stage.setAlwaysOnTop(true);
+            stage.setOnShown(event -> Platform.runLater(startupLatch::countDown));
+            stage.show();
+        }
+    }
+}


### PR DESCRIPTION
When a large number of items were scrolled in the `ChoiceBox`, the scrolled offset was carried forward when the list is replaced with small number of items. Hence the scroll up arrow was displayed with empty popup.

Changed code to scroll to top before popup display when content height of `ChoiceBox` is smaller than the scrolled offset.

Added system test to validate the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8090123](https://bugs.openjdk.org/browse/JDK-8090123): Items are no longer visible when collection is changed


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1039/head:pull/1039` \
`$ git checkout pull/1039`

Update a local copy of the PR: \
`$ git checkout pull/1039` \
`$ git pull https://git.openjdk.org/jfx pull/1039/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1039`

View PR using the GUI difftool: \
`$ git pr show -t 1039`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1039.diff">https://git.openjdk.org/jfx/pull/1039.diff</a>

</details>
