### PR TITLE
8303026: [TextField] IOOBE on setting text with control characters that replaces existing text

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TextInputControl.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TextInputControl.java
@@ -182,8 +182,12 @@ public abstract class TextInputControl extends Control {
                 int start = sel.getStart();
                 int end = sel.getEnd();
                 int length = txt.length();
-                if (end > start + length) end = length;
-                if (start > length - 1) start = end = 0;
+                if (end > start + length) {
+                    end = length;
+                }
+                if (start > length - 1) {
+                    start = end = 0;
+                }
                 selectedText.set(txt.substring(start, end));
             }
         }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TextInputControl.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TextInputControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -181,6 +181,9 @@ public abstract class TextInputControl extends Control {
             } else {
                 int start = sel.getStart();
                 int end = sel.getEnd();
+                int length = txt.length();
+                if (end > start + length) end = length;
+                if (start > length - 1) start = end = 0;
                 selectedText.set(txt.substring(start, end));
             }
         }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -541,6 +541,13 @@ public class TextFieldTest {
         // 3 is removed, therefore we get 100. The value converter above will then add 100 (=200).
         txtField.setText("1300");
         assertEquals("200", txtField.getText());
+    }
+
+    @Test public void stripInvalidCharacters() {
+        txtField.setText("abcdefghijklm");
+        char[] c = new char[]{0x7F, 0xA, 0x9, 0x00, 0x05, 0x10, 0x19};
+        txtField.setText(String.valueOf(c));
+        assertEquals("", txtField.getText());
     }
 
     private Change upperCase(Change change) {


### PR DESCRIPTION
This PR fixes a regression after [JDK-8212102](https://bugs.openjdk.org/browse/JDK-8212102).

When a TextField control has some previous content, and new text with only invalid characters (0x7F, new line, tabs, <0x20) is set, `TextInputControl::filterInput` is used to strip them out, and the new text has length 0.

During the refactoring in JDK-8212102, the checks:
```
int length = txt.length();
if (end > start + length) end = length;
if (start > length-1) start = end = 0;
```
were removed. 

In this particular case, when the new filtered text has length 0, we need those checks, so start and end are set to 0, and txt.substring(start, end) doesn't throw the IOOBE anymore.

A test is added to verify this scenario. It fails with the proposed patch, passes with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303026](https://bugs.openjdk.org/browse/JDK-8303026): [TextField] IOOBE on setting text with control characters that replaces existing text


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Committer)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1043/head:pull/1043` \
`$ git checkout pull/1043`

Update a local copy of the PR: \
`$ git checkout pull/1043` \
`$ git pull https://git.openjdk.org/jfx pull/1043/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1043`

View PR using the GUI difftool: \
`$ git pr show -t 1043`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1043.diff">https://git.openjdk.org/jfx/pull/1043.diff</a>

</details>
