### PR TITLE
8303019: cssref.html incorrect internal link in Path

### DIFF
--- a/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
+++ b/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
@@ -2928,7 +2928,7 @@
             <td></td>
         </tr>
         <tr>
-        <th colspan="4" class="parents" scope="row">Also has all properties of <a href="#node">Shape</a></th>
+        <th colspan="4" class="parents" scope="row">Also has all properties of <a href="#shape">Shape</a></th>
         </tr>
         </tbody>
     </table>
@@ -2958,7 +2958,7 @@
             <td></td>
         </tr>
         <tr>
-        <th colspan="4" class="parents" scope="row">Also has all properties of <a href="#node">Shape</a></th>
+        <th colspan="4" class="parents" scope="row">Also has all properties of <a href="#shape">Shape</a></th>
         </tr>
         </tbody>
     </table>
@@ -3068,7 +3068,7 @@
         </tr>
         <tr>
         <th colspan="4" class="parents" scope="row">Also has <a href="#fontprops">font
-            properties</a> and all properties of Shape</th>
+            properties</a> and all properties of <a href="#shape">Shape</a></th>
         </tr>
       </tbody>
     </table>
@@ -6038,7 +6038,7 @@
           <td>&nbsp;</td>
         </tr>
         <tr>
-        <th colspan="4" class="parents" scope="row">Has all properties of <a href="#chart">chart</a></th>
+        <th colspan="4" class="parents" scope="row">Has all properties of <a href="#chart">Chart</a></th>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
documentation change
**targeting jfx20 branch**

- fixed all incorrect references in "Also has all properties of ..."
- added a link to Shape where it was missing
- fixed chart -> Chart

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303019](https://bugs.openjdk.org/browse/JDK-8303019): cssref.html incorrect internal link in Path


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1046/head:pull/1046` \
`$ git checkout pull/1046`

Update a local copy of the PR: \
`$ git checkout pull/1046` \
`$ git pull https://git.openjdk.org/jfx pull/1046/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1046`

View PR using the GUI difftool: \
`$ git pr show -t 1046`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1046.diff">https://git.openjdk.org/jfx/pull/1046.diff</a>

</details>
