### PR TITLE
8300954 : HTML default Range input control not rendered

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/css/CSSPrimitiveValueMappings.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/css/CSSPrimitiveValueMappings.h
@@ -490,6 +490,14 @@ template<> inline CSSPrimitiveValue::CSSPrimitiveValue(ControlPart e)
     case SliderVerticalPart:
         m_value.valueID = CSSValueSliderVertical;
         break;
+#if PLATFORM(JAVA)
+    case SliderThumbHorizontalPart:
+        m_value.valueID = CSSValueSliderthumbHorizontal;
+        break;
+    case SliderThumbVerticalPart:
+        m_value.valueID = CSSValueSliderthumbVertical;
+        break;
+#endif
     case SearchFieldPart:
         m_value.valueID = CSSValueSearchfield;
         break;
@@ -527,8 +535,10 @@ template<> inline CSSPrimitiveValue::CSSPrimitiveValue(ControlPart e)
     case SearchFieldResultsDecorationPart:
     case SearchFieldResultsButtonPart:
     case SearchFieldCancelButtonPart:
+#if !PLATFORM(JAVA)
     case SliderThumbHorizontalPart:
     case SliderThumbVerticalPart:
+#endif
         ASSERT_NOT_REACHED();
         m_value.valueID = CSSValueNone;
         break;

--- a/modules/javafx.web/src/main/native/Source/WebCore/css/CSSProperties.json
+++ b/modules/javafx.web/src/main/native/Source/WebCore/css/CSSProperties.json
@@ -5225,7 +5225,6 @@
                 "progress-bar",
                 "slider-horizontal",
                 "slider-vertical",
-                //sliderthumb-horizontal and sliderthumb-vertical need to be defined for PLATFORM(JAVA)
                 "sliderthumb-horizontal",
                 "sliderthumb-vertical",
                 "searchfield",

--- a/modules/javafx.web/src/main/native/Source/WebCore/css/CSSProperties.json
+++ b/modules/javafx.web/src/main/native/Source/WebCore/css/CSSProperties.json
@@ -5225,6 +5225,9 @@
                 "progress-bar",
                 "slider-horizontal",
                 "slider-vertical",
+                //sliderthumb-horizontal and sliderthumb-vertical need to be defined for PLATFORM(JAVA)
+                "sliderthumb-horizontal",
+                "sliderthumb-vertical",
                 "searchfield",
                 "textfield",
                 "-apple-pay-button",

--- a/modules/javafx.web/src/main/native/Source/WebCore/css/CSSValueKeywords.in
+++ b/modules/javafx.web/src/main/native/Source/WebCore/css/CSSValueKeywords.in
@@ -849,6 +849,9 @@ meter
 progress-bar
 slider-horizontal
 slider-vertical
+// sliderthumb-horizontal and sliderthumb-vertical are added for PLATFORM(JAVA)
+sliderthumb-horizontal
+sliderthumb-vertical
 searchfield
 #if defined(ENABLE_APPLE_PAY) && ENABLE_APPLE_PAY
 -apple-pay-button

--- a/modules/javafx.web/src/main/native/Source/WebCore/css/html.css
+++ b/modules/javafx.web/src/main/native/Source/WebCore/css/html.css
@@ -870,6 +870,9 @@ button[type="menu"], button[type="menu"]:active {
 #endif
 
 input[type="range"] {
+    /*This is needed for PLATFORM(JAVA)*/
+    -webkit-appearance: slider-horizontal;
+    appearance: slider-horizontal;
     padding: initial;
     border: initial;
     margin: 2px;
@@ -887,13 +890,14 @@ input[type="range"]::-webkit-slider-container, input[type="range"]::-webkit-medi
 input[type="range"]::-webkit-slider-runnable-track {
     flex: 1;
     align-self: center;
-
     box-sizing: border-box;
     display: block;
 }
 
 input[type="range"]::-webkit-slider-thumb, input[type="range"]::-webkit-media-slider-thumb {
-    appearance: auto;
+    /*This is needed for PLATFORM(JAVA)*/
+    -webkit-appearance: sliderthumb-horizontal;
+    appearance: sliderthumb-horizontal;
     box-sizing: border-box;
     display: block;
 }

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/ThemeTypes.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/ThemeTypes.h
@@ -48,6 +48,10 @@ enum ControlPart {
     ProgressBarPart,
     SliderHorizontalPart,
     SliderVerticalPart,
+#if PLATFORM(JAVA)
+    SliderThumbHorizontalPart,
+    SliderThumbVerticalPart,
+#endif
     SearchFieldPart,
 #if ENABLE(APPLE_PAY)
     ApplePayButtonPart,
@@ -74,8 +78,10 @@ enum ControlPart {
     SearchFieldResultsDecorationPart,
     SearchFieldResultsButtonPart,
     SearchFieldCancelButtonPart,
+#if !PLATFORM(JAVA)
     SliderThumbHorizontalPart,
     SliderThumbVerticalPart
+#endif
 };
 
 #if ENABLE(SERVICE_CONTROLS)

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/FormControlsTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/FormControlsTest.java
@@ -37,7 +37,6 @@ import javafx.scene.Node;
 import javafx.scene.web.WebEngineShim;
 
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized.Parameters;
@@ -89,7 +88,6 @@ public final class FormControlsTest extends TestBase {
             exMessage.contains("Exception") || exMessage.contains("Error"));
     }
 
-    @Ignore("JDK-8300954")
     @Test
     public void testRendering() {
         final Runnable testBody = () -> {


### PR DESCRIPTION
With this fix, default slider of input type: Range is rendered properly.
Verified build and unit tests.DRT tests related to "Range", also pass with this fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8300954](https://bugs.openjdk.org/browse/JDK-8300954): HTML default Range input control not rendered


### Reviewers
 * [Jay Bhaskar](https://openjdk.org/census#jbhaskar) (@jaybhaskar - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1050/head:pull/1050` \
`$ git checkout pull/1050`

Update a local copy of the PR: \
`$ git checkout pull/1050` \
`$ git pull https://git.openjdk.org/jfx pull/1050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1050`

View PR using the GUI difftool: \
`$ git pr show -t 1050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1050.diff">https://git.openjdk.org/jfx/pull/1050.diff</a>

</details>
