### PR TITLE
8303680 Virtual Flow freezes after calling scrollTo and scrollPixels in succession

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -1715,7 +1715,6 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
 
         // Finally, update the scroll bars
         updateScrollBarsAndCells(false);
-        lastPosition = getPosition();
 
         // notify
         return answer;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
@@ -2519,7 +2519,7 @@ public class ListViewTest {
     }
 
     @Test
-    public void fixListViewCrash() {
+    public void fixListViewCrash_JDK_8303680() {
         final ListView<String> listView = new ListView<>();
 
         // add 100 entries

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
@@ -2518,4 +2518,46 @@ public class ListViewTest {
 
     }
 
+    @Test
+    public void fixListViewCrash() {
+        final ListView<String> listView = new ListView<>();
+
+        // add 100 entries
+        listView.setPrefSize(200, 200);
+        for (int i = 0; i < 100; i++) {
+            listView.getItems().add("Item " + i);
+        }
+        StageLoader sl = new StageLoader(new VBox(listView, new Button()));
+
+        // pulse
+        Toolkit.getToolkit().firePulse();
+
+        // get virtual flow
+        VirtualFlow vf = VirtualFlowTestUtils.getVirtualFlow(listView);
+
+        // scroll to 50 and scroll 1 pixel
+        vf.scrollTo(50);
+        vf.scrollPixels(1);
+
+        // another pulse
+        Toolkit.getToolkit().firePulse();
+
+        // scroll to cell
+        IndexedCell<Integer> cell = vf.getCell(50);//VirtualFlowTestUtils.getCell(listView, 70);
+
+        // shouldn't be null
+        assertNotNull(cell);
+
+        // should be visible
+        assertTrue("Cell should be visible", cell.isVisible());
+
+        // should have parent
+        assertNotNull("Cell should have parent", cell.getParent());
+
+        // Note:
+        // We don't check for the position of the cell, because it's currently don't work properly.
+        // But we wan't to ensure, that the VirtualFlow "Doesn't crash" - which was the case before.
+
+    }
+
 }


### PR DESCRIPTION
Possible fix for VirtualFlow freeze.

I encountered the problem when experimenting with VirtualFlow.

Guess @johanvos should take a look.
All tests are still green, so with some luck, this doesn't break anything but fixes some known and unknown bugs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8303680](https://bugs.openjdk.org/browse/JDK-8303680): Virtual Flow freezes after calling scrollTo and scrollPixels in succession


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Committer)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1052/head:pull/1052` \
`$ git checkout pull/1052`

Update a local copy of the PR: \
`$ git checkout pull/1052` \
`$ git pull https://git.openjdk.org/jfx pull/1052/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1052`

View PR using the GUI difftool: \
`$ git pr show -t 1052`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1052.diff">https://git.openjdk.org/jfx/pull/1052.diff</a>

</details>
