### PR TITLE
8303740 JavaFX - Leak in Logging, Logging remembers last exception

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/Logging.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/Logging.java
@@ -29,6 +29,8 @@ import com.sun.javafx.logging.PlatformLogger;
 
 public class Logging {
 
+    public static boolean keepException = false;
+
     public static ErrorLogger getLogger() {
         return ErrorLogger.INSTANCE;
     }
@@ -50,7 +52,11 @@ public class Logging {
 
             public ErrorLogRecord(Level level, Throwable thrown) {
                 this.level = level;
-                this.thrown = thrown;
+                if (Logging.keepException) {
+                    this.thrown = thrown;
+                } else {
+                    this.thrown = null;
+                }
             }
 
             public Throwable getThrown() {

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/Logging.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/Logging.java
@@ -29,7 +29,23 @@ import com.sun.javafx.logging.PlatformLogger;
 
 public class Logging {
 
-    public static boolean keepException = false;
+    private static boolean keepException = false;
+
+    /**
+     * This is only used for testing purposes.
+     * @param keepException
+     */
+    public static void setKeepException(boolean keepException) {
+        Logging.keepException = keepException;
+    }
+
+    /**
+     * This is only used for testing purposes.
+     * @return
+     */
+    public static boolean getKeepException() {
+        return keepException;
+    }
 
     public static ErrorLogger getLogger() {
         return ErrorLogger.INSTANCE;

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ErrorLoggingUtiltity.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ErrorLoggingUtiltity.java
@@ -38,6 +38,7 @@ public class ErrorLoggingUtiltity {
     private static ErrorLogger errorLogger = Logging.getLogger();
 
     public static void reset() {
+        Logging.keepException = true;
         errorLogger.setErrorLogRecord(null);
     }
 
@@ -60,6 +61,7 @@ public class ErrorLoggingUtiltity {
     }
 
     public static void check(Level expectedLevel, Class<?> expectedException) {
+        assertTrue(Logging.keepException);
         ErrorLogRecord errorLogRecord = errorLogger.getErrorLogRecord();
         assertNotNull(errorLogRecord);
         assertEquals(expectedLevel, errorLogRecord.getLevel());

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ErrorLoggingUtiltity.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/ErrorLoggingUtiltity.java
@@ -38,7 +38,7 @@ public class ErrorLoggingUtiltity {
     private static ErrorLogger errorLogger = Logging.getLogger();
 
     public static void reset() {
-        Logging.keepException = true;
+        Logging.setKeepException(true);
         errorLogger.setErrorLogRecord(null);
     }
 
@@ -61,7 +61,7 @@ public class ErrorLoggingUtiltity {
     }
 
     public static void check(Level expectedLevel, Class<?> expectedException) {
-        assertTrue(Logging.keepException);
+        assertTrue(Logging.getKeepException());
         ErrorLogRecord errorLogRecord = errorLogger.getErrorLogRecord();
         assertNotNull(errorLogRecord);
         assertEquals(expectedLevel, errorLogRecord.getLevel());

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/TestLogging.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/TestLogging.java
@@ -1,0 +1,24 @@
+package test.com.sun.javafx.binding;
+
+import com.sun.javafx.binding.Logging;
+import org.junit.Test;
+import test.util.memory.JMemoryBuddy;
+
+public class TestLogging {
+
+    @Test
+    public void testExceptionCollectableAfterLogging() {
+
+        JMemoryBuddy.memoryTest(checker -> {
+            Throwable e = new Exception();
+
+            // This is the value that is used in the application
+            // other test might set it to true
+            Logging.keepException = false;
+
+            Logging.getLogger().warning("test", e);
+
+            checker.assertCollectable(e);
+        });
+    }
+}

--- a/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/TestLogging.java
+++ b/modules/javafx.base/src/test/java/test/com/sun/javafx/binding/TestLogging.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package test.com.sun.javafx.binding;
 
 import com.sun.javafx.binding.Logging;
@@ -14,7 +39,7 @@ public class TestLogging {
 
             // This is the value that is used in the application
             // other test might set it to true
-            Logging.keepException = false;
+            Logging.setKeepException(false);
 
             Logging.getLogger().warning("test", e);
 


### PR DESCRIPTION
When an exception is logged in JavaFX, then the exception is kept in a reference.
This way, always the last logged exception is retained.

This is a memory-leak.
This was done to write unit-tests to ensure certain error-cases are logged.

A simple fix is, to add a flag, to enable/disable retaining the exception.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8303740](https://bugs.openjdk.org/browse/JDK-8303740): JavaFX - Leak in Logging, Logging remembers last exception


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1053/head:pull/1053` \
`$ git checkout pull/1053`

Update a local copy of the PR: \
`$ git checkout pull/1053` \
`$ git pull https://git.openjdk.org/jfx.git pull/1053/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1053`

View PR using the GUI difftool: \
`$ git pr show -t 1053`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1053.diff">https://git.openjdk.org/jfx/pull/1053.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1053#issuecomment-1458051960)