### PR TITLE
8299968: Second call to Stage.setScene() create sizing issue with uiScale > 1.0

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Window.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Window.java
@@ -349,6 +349,7 @@ public abstract class Window {
     }
 
     protected abstract boolean _setView(long ptr, View view);
+    protected abstract void _updateViewSize(long ptr);
     public void setView(final View view) {
         Application.checkEventThread();
         checkNotClosed();
@@ -370,6 +371,10 @@ public abstract class Window {
         if (view != null && _setView(this.ptr, view)) {
             this.view = view;
             this.view.setWindow(this);
+            // JDK-8299968: View size update (especially notifyResize event) have to happen
+            // after we call view.setWindow(this); otherwise with UI scaling different than
+            // 100% some platforms might display scenes wrong after Window was shown.
+            _updateViewSize(this.ptr);
             if (this.isDecorated == false) {
                 this.helper = new UndecoratedMoveResizeHelper();
             }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Window.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Window.java
@@ -371,7 +371,7 @@ public abstract class Window {
         if (view != null && _setView(this.ptr, view)) {
             this.view = view;
             this.view.setWindow(this);
-            // JDK-8299968: View size update (especially notifyResize event) have to happen
+            // View size update (especially notifyResize event) has to happen
             // after we call view.setWindow(this); otherwise with UI scaling different than
             // 100% some platforms might display scenes wrong after Window was shown.
             _updateViewSize(this.ptr);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkWindow.java
@@ -46,6 +46,10 @@ class GtkWindow extends Window {
     @Override
     protected native boolean _setView(long ptr, View view);
 
+    // empty - not needed by this implementation
+    @Override
+    protected void _updateViewSize(long ptr) {}
+
     @Override
     protected boolean _setMenubar(long ptr, long menubarPtr) {
         //TODO is it needed?

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosWindow.java
@@ -67,6 +67,10 @@ final class IosWindow extends Window {
     @Override native protected boolean _grabFocus(long ptr);
     @Override native protected void _ungrabFocus(long ptr);
 
+    // empty - not needed by this implementation
+    @Override
+    protected void _updateViewSize(long ptr) {}
+
     //No cursor on iOS. API compatibility call.
     @Override
     protected void _setCursor(long ptr, Cursor cursor) {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacWindow.java
@@ -52,6 +52,8 @@ final class MacWindow extends Window {
     @Override native protected boolean _setMenubar(long ptr, long menubarPtr);
     @Override native protected boolean _minimize(long ptr, boolean minimize);
     @Override native protected boolean _maximize(long ptr, boolean maximize, boolean wasMaximized);
+    // empty - not needed by this implementation
+    @Override protected void _updateViewSize(long ptr) {}
     @Override protected void _setBounds(long ptr,
                                         int x, int y, boolean xSet, boolean ySet,
                                         int w, int h, int cw, int ch,

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleWindow.java
@@ -179,6 +179,10 @@ final class MonocleWindow extends Window {
         return result;
     }
 
+    // empty - not needed by this implementation
+    @Override
+    protected void _updateViewSize(long ptr) {}
+
     /**
      * Returns the handle used to create a rendering context in Prism
      */

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinWindow.java
@@ -260,6 +260,7 @@ class WinWindow extends Window {
     @Override native protected long _createWindow(long ownerPtr, long screenPtr, int mask);
     @Override native protected boolean _close(long ptr);
     @Override native protected boolean _setView(long ptr, View view);
+    @Override native protected void _updateViewSize(long ptr);
     @Override native protected boolean _setMenubar(long ptr, long menubarPtr);
     @Override native protected boolean _minimize(long ptr, boolean minimize);
     @Override native protected boolean _maximize(long ptr, boolean maximize, boolean wasMaximized);

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
@@ -1297,10 +1297,6 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_win_WinWindow__1setView
         }
         pWindow->ResetMouseTracking(hWnd);
         pWindow->SetGlassView(view);
-        // The condition below may be restricted to WS_POPUP windows
-        if (::IsWindowVisible(hWnd)) {
-            pWindow->NotifyViewSize(hWnd);
-        }
     }
     GlassView * view;
     LEAVE_MAIN_THREAD_WITH_hWnd;
@@ -1309,6 +1305,29 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_win_WinWindow__1setView
 
     PERFORM();
     return JNI_TRUE;
+}
+
+/**
+ * Class:     com_sun_glass_ui_win_WinWindow
+ * Method:    _updateViewSize
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_com_sun_glass_ui_win_WinWindow__1updateViewSize
+    (JNIEnv * env, jobject jThis, jlong ptr)
+{
+    ENTER_MAIN_THREAD()
+    {
+        GlassWindow *pWindow = GlassWindow::FromHandle(hWnd);
+
+        // The condition below may be restricted to WS_POPUP windows
+        if (::IsWindowVisible(hWnd)) {
+            pWindow->NotifyViewSize(hWnd);
+        }
+    }
+    GlassView * view;
+    LEAVE_MAIN_THREAD_WITH_hWnd;
+
+    PERFORM();
 }
 
 /*

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.cpp
@@ -1324,7 +1324,6 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_win_WinWindow__1updateViewSize
             pWindow->NotifyViewSize(hWnd);
         }
     }
-    GlassView * view;
     LEAVE_MAIN_THREAD_WITH_hWnd;
 
     PERFORM();

--- a/tests/system/src/test/java/test/javafx/stage/SetSceneScalingTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/SetSceneScalingTest.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.javafx.stage;
+
+import java.util.concurrent.CountDownLatch;
+
+import javafx.application.Platform;
+import javafx.event.ActionEvent;
+import javafx.geometry.Pos;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.input.MouseButton;
+import javafx.scene.layout.VBox;
+import javafx.scene.robot.Robot;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+import javafx.stage.WindowEvent;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import test.util.Util;
+
+public class SetSceneScalingTest {
+    static CountDownLatch startupLatch = new CountDownLatch(1);
+    static Robot robot;
+
+    TestApp app;
+
+
+    public abstract class TestApp {
+        protected Stage stage = new Stage(StageStyle.UNDECORATED);
+        protected Button button;
+        protected boolean wasClicked = false;
+
+        protected void testButtonClick()
+        {
+            robot.mouseMove(400, 400);
+            Util.sleep(2000);
+            robot.mouseClick(MouseButton.PRIMARY);
+        }
+
+        protected Scene createTestScene()
+        {
+            button = new Button("I should be centered");
+            button.setOnAction((ActionEvent e) -> wasClicked = true);
+
+            VBox box = new VBox(button);
+            box.setAlignment(Pos.CENTER);
+            return new Scene(box);
+        }
+
+        protected abstract void test();
+
+        public void runTest() {
+            wasClicked = false;
+            Util.runAndWait(() -> test());
+            Assert.assertTrue(wasClicked);
+        }
+
+        public void start() {
+            stage.setX(200);
+            stage.setY(200);
+            stage.setWidth(400);
+            stage.setHeight(400);
+            stage.addEventHandler(WindowEvent.WINDOW_SHOWN, e ->
+                                    Platform.runLater(startupLatch::countDown));
+        }
+
+        public void hideStage() {
+            stage.hide();
+        }
+    }
+
+    public class TestSetSceneShowApp extends TestApp {
+        @Override
+        protected void test() {
+            testButtonClick();
+        }
+
+        @Override
+        public void start() {
+            super.start();
+            stage.setScene(createTestScene());
+            stage.show();
+        }
+    }
+
+    public class TestShowSetSceneApp extends TestApp {
+        @Override
+        protected void test() {
+            testButtonClick();
+        }
+
+        @Override
+        public void start() {
+            super.start();
+            stage.show();
+            stage.setScene(createTestScene());
+        }
+    }
+
+    public class TestSecondSetSceneApp extends TestApp {
+        @Override
+        protected void test() {
+            testButtonClick();
+
+            stage.setScene(createTestScene());
+            testButtonClick();
+        }
+
+        @Override
+        public void start() {
+            super.start();
+            stage.setScene(createTestScene());
+            stage.show();
+        }
+    }
+
+
+    @BeforeClass
+    public static void initFX() {
+        Platform.setImplicitExit(false);
+        Util.startup(startupLatch, startupLatch::countDown);
+
+        Util.runAndWait(() -> robot = new Robot());
+    }
+
+    @After
+    public void cleanupTest() {
+        if (app != null) {
+            Platform.runLater(() -> app.hideStage());
+        }
+    }
+
+    @AfterClass
+    public static void teardownFX() {
+        Util.shutdown();
+    }
+
+
+    @Test
+    public void testSetSceneAndShow() throws Exception {
+        Util.runAndWait(() -> {
+            app = new TestSetSceneShowApp();
+            app.start();
+        });
+        Util.waitForLatch(startupLatch, 5, "Stage failed to show");
+
+        app.runTest();
+    }
+
+    @Test
+    public void testShowAndSetScene() throws Exception {
+        Util.runAndWait(() -> {
+            app = new TestShowSetSceneApp();
+            app.start();
+        });
+        Util.waitForLatch(startupLatch, 5, "Stage failed to show");
+
+        app.runTest();
+    }
+
+    @Test
+    public void testSecondSetScene() throws Exception {
+        Util.runAndWait(() -> {
+            app = new TestSecondSetSceneApp();
+            app.start();
+        });
+        Util.waitForLatch(startupLatch, 5, "Stage failed to show");
+
+        app.runTest();
+    }
+}

--- a/tests/system/src/test/java/test/robot/javafx/stage/SetSceneScalingTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/SetSceneScalingTest.java
@@ -60,8 +60,12 @@ public class SetSceneScalingTest {
         protected Stage stage;
         protected Button button;
 
+        private final int WIDTH = 400;
+        private final int HEIGHT = 400;
+
         protected void testButtonClick() {
-            robot.mouseMove(400, 400);
+            robot.mouseMove((int)(stage.getX() + stage.getScene().getX()) + (WIDTH / 2),
+                            (int)(stage.getY() + stage.getScene().getY()) + (HEIGHT / 2));
             robot.mousePress(MouseButton.PRIMARY);
             robot.mouseRelease(MouseButton.PRIMARY);
         }
@@ -92,12 +96,9 @@ public class SetSceneScalingTest {
         public void start() {
             Util.runAndWait(() -> {
                 stage = new Stage(StageStyle.UNDECORATED);
-                stage.addEventHandler(WindowEvent.WINDOW_SHOWN, e ->
-                                        Platform.runLater(shownLatch::countDown));
-                stage.setX(200);
-                stage.setY(200);
-                stage.setWidth(400);
-                stage.setHeight(400);
+                stage.setOnShown(e -> Platform.runLater(() -> shownLatch.countDown()));
+                stage.setWidth(WIDTH);
+                stage.setHeight(HEIGHT);
                 stage.setAlwaysOnTop(true);
 
                 sceneShowSetup();

--- a/tests/system/src/test/java/test/robot/javafx/stage/SetSceneScalingTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/SetSceneScalingTest.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package test.javafx.stage;
+package test.robot.javafx.stage;
 
 import java.util.concurrent.CountDownLatch;
 


### PR DESCRIPTION
Issue happened during setting a new Scene - updating a new View was done while the Window reference it kept was null. This caused it to default scaling values to 1.0f (or 100%) while processing a resize notification, which for high DPI screens with scaling different than 100% caused UI issues.

Resolved by splitting `_setView()` native call into two parts - first one sets the view, then back in JVM side we set a correct Window reference, then we trigger the notification. It has to be triggered from native side, because Windows backend of Glass sends back new width/height pulled from WinAPI `::GetClientRect()` call.

In process of working on this issue I also found another scenario causing the same problem - calling `Stage.setScene()` after `Stage.show()`. The patch fixed that case as well.

Added a system test which is supposed to check for above issues. I didn't limit it to run only on platforms with UI scaling enabled because it also serves as a good sanity check in case there are some other changes to code that might move/scale the UI unwantingly. I tested this patch both on macOS Ventura and Windows 11, with `d9c091f` all tests pass while without `d9c091f` on Windows tests `testShowAndSetScene` and `testSecondSetScene` fail as expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8299968](https://bugs.openjdk.org/browse/JDK-8299968): Second call to Stage.setScene() create sizing issue with uiScale &gt; 1.0


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx pull/1054/head:pull/1054` \
`$ git checkout pull/1054`

Update a local copy of the PR: \
`$ git checkout pull/1054` \
`$ git pull https://git.openjdk.org/jfx pull/1054/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1054`

View PR using the GUI difftool: \
`$ git pr show -t 1054`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1054.diff">https://git.openjdk.org/jfx/pull/1054.diff</a>

</details>
