### PR TITLE
8154038: Spinner's converter should update its editor

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/Spinner.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/Spinner.java
@@ -34,6 +34,8 @@ import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import javafx.beans.value.WritableValue;
 import javafx.collections.MapChangeListener;
 import javafx.collections.ObservableList;
@@ -513,7 +515,11 @@ public class Spinner<T> extends Control {
         return value;
     }
 
-
+    private final ChangeListener<StringConverter> converterListener = new ChangeListener<StringConverter>() {
+        @Override public void changed(ObservableValue<? extends StringConverter> observable, StringConverter oldValue, StringConverter newRate) {
+            setText(valueProperty().getValue());
+        }
+    };
     // --- valueFactory
     /**
      * The value factory is the model behind the JavaFX Spinner control - without
@@ -533,19 +539,22 @@ public class Spinner<T> extends Control {
      */
     private ObjectProperty<SpinnerValueFactory<T>> valueFactory =
             new SimpleObjectProperty<>(this, "valueFactory") {
+                private SpinnerValueFactory oldFactory;
                 @Override protected void invalidated() {
                     value.unbind();
+                    if(oldFactory != null) {
+                        oldFactory.converterProperty().removeListener(converterListener);
+                    }
 
                     SpinnerValueFactory<T> newFactory = get();
                     if (newFactory != null) {
                         // this binding is what ensures the Spinner.valueProperty()
                         // properly represents the value in the value factory
                         value.bind(newFactory.valueProperty());
-                        // Update the spinner editor when converter is changed.
-                        newFactory.converterProperty().addListener((o, oldValue, newValue) -> {
-                            setText(valueProperty().getValue());
-                        });
+                        // Listener to update the spinner editor when converter is changed.
+                        newFactory.converterProperty().addListener(converterListener);
                     }
+                    oldFactory = newFactory;
                 }
             };
     public final void setValueFactory(SpinnerValueFactory<T> value) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/Spinner.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/Spinner.java
@@ -541,6 +541,10 @@ public class Spinner<T> extends Control {
                         // this binding is what ensures the Spinner.valueProperty()
                         // properly represents the value in the value factory
                         value.bind(newFactory.valueProperty());
+                        // Update the spinner editor when converter is changed.
+                        newFactory.converterProperty().addListener((o, oldValue, newValue) -> {
+                            setText(valueProperty().getValue());
+                        });
                     }
                 }
             };

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
@@ -35,6 +35,7 @@ import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.text.DecimalFormat;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
@@ -53,6 +54,7 @@ import javafx.scene.layout.VBox;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 import javafx.util.Duration;
+import javafx.util.StringConverter;
 
 import test.com.sun.javafx.pgstub.StubToolkit;
 import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
@@ -1522,5 +1524,57 @@ public class SpinnerTest {
     @Test public void testSetValueNull_LocalTimeSpinner() {
         localTimeValueFactory.setValue(null);
         assertNull(localTimeSpinner.getValue());
+    }
+
+    @Test public void testSpinnerEditorUpdateOnConverterChange() {
+        dblSpinner = new Spinner<>(0.0, 1.0, 0.5, 0.01);
+        dblSpinner.setEditable(true);
+
+        intSpinner = new Spinner<>(0, 100, 50, 1);
+        intSpinner.setEditable(true);
+
+        assertEquals("0.5", dblSpinner.getEditor().getText());
+        assertEquals("50", intSpinner.getEditor().getText());
+
+        dblSpinner.getValueFactory().setConverter(new StringConverter<Double>() {
+            private final DecimalFormat df = new DecimalFormat("#.##%");
+
+            @Override
+            public String toString(Double value) {
+                return value == null ? "" : df.format(value);
+            }
+            @Override
+            public Double fromString(String value) {
+                if (value == null) {
+                    return null;
+                }
+
+                try {
+                    return df.parse(value).doubleValue();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+
+        intSpinner.getValueFactory().setConverter(new StringConverter<Integer>() {
+            @Override
+            public String toString(Integer value) {
+                return value == null ? "" : value.toString() + "%";
+            }
+
+            @Override
+            public Integer fromString(String value) {
+                if (value == null) {
+                    return null;
+                }
+
+                String valueWithoutUnits = value.replaceAll("%", "").trim();
+                return valueWithoutUnits.isEmpty() ? 0 : Integer.valueOf(valueWithoutUnits);
+            }
+        });
+
+        assertEquals("50%", dblSpinner.getEditor().getText());
+        assertEquals("50%", intSpinner.getEditor().getText());
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
@@ -1526,15 +1526,11 @@ public class SpinnerTest {
         assertNull(localTimeSpinner.getValue());
     }
 
-    @Test public void testSpinnerEditorUpdateOnConverterChange() {
+    @Test public void testDoubleSpinnerEditorUpdateOnConverterChange() {
         dblSpinner = new Spinner<>(0.0, 1.0, 0.5, 0.01);
         dblSpinner.setEditable(true);
 
-        intSpinner = new Spinner<>(0, 100, 50, 1);
-        intSpinner.setEditable(true);
-
         assertEquals("0.5", dblSpinner.getEditor().getText());
-        assertEquals("50", intSpinner.getEditor().getText());
 
         dblSpinner.getValueFactory().setConverter(new StringConverter<Double>() {
             private final DecimalFormat df = new DecimalFormat("#.##%");
@@ -1557,6 +1553,15 @@ public class SpinnerTest {
             }
         });
 
+        assertEquals("50%", dblSpinner.getEditor().getText());
+    }
+
+    @Test public void testIntegerSpinnerEditorUpdateOnConverterChange() {
+        intSpinner = new Spinner<>(0, 100, 50, 1);
+        intSpinner.setEditable(true);
+
+        assertEquals("50", intSpinner.getEditor().getText());
+
         intSpinner.getValueFactory().setConverter(new StringConverter<Integer>() {
             @Override
             public String toString(Integer value) {
@@ -1574,7 +1579,6 @@ public class SpinnerTest {
             }
         });
 
-        assertEquals("50%", dblSpinner.getEditor().getText());
         assertEquals("50%", intSpinner.getEditor().getText());
     }
 }


### PR DESCRIPTION
When converter was changed, `setText` method of spinner was not invoked to update the spinner text using new converter.

Added a listener to converter property of `SpinnerValueFactory` to call `setText` so that spinner text is updated using new converter.

Added unit test to validate the fix. Along with spinner of Double type, added a spinner of Integer type as well so that the fix is validated using 2 types of spinner.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8154038](https://bugs.openjdk.org/browse/JDK-8154038): Spinner's converter should update its editor


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1057/head:pull/1057` \
`$ git checkout pull/1057`

Update a local copy of the PR: \
`$ git checkout pull/1057` \
`$ git pull https://git.openjdk.org/jfx.git pull/1057/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1057`

View PR using the GUI difftool: \
`$ git pr show -t 1057`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1057.diff">https://git.openjdk.org/jfx/pull/1057.diff</a>

</details>
