### PR TITLE
8172849: Non-intuitive baseline alignment for labeled controls with graphics

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/LabeledSkinBase.java
@@ -424,11 +424,14 @@ public abstract class LabeledSkinBase<C extends Labeled> extends SkinBase<C> {
         final Labeled labeled = getSkinnable();
         final Node g = labeled.getGraphic();
         if (!isIgnoreGraphic()) {
+            double graphicHeight = g.prefHeight(-1);
+            double textHeight = text.prefHeight(-1);
             ContentDisplay contentDisplay = labeled.getContentDisplay();
             if (contentDisplay == ContentDisplay.TOP) {
-                h = g.prefHeight(-1) + labeled.getGraphicTextGap() + textBaselineOffset;
-            } else if (contentDisplay == ContentDisplay.LEFT || contentDisplay == RIGHT) {
-                h = textBaselineOffset + (g.prefHeight(-1) - text.prefHeight(-1)) / 2;
+                h = graphicHeight + labeled.getGraphicTextGap() + textBaselineOffset;
+            } else if ((contentDisplay == ContentDisplay.LEFT || contentDisplay == RIGHT)
+                        && (graphicHeight > textHeight)) {
+                h = textBaselineOffset + (graphicHeight - textHeight) / 2;
             }
         }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
@@ -2130,7 +2130,8 @@ public class LabelSkinTest {
 
     /********************************************************************************
      *                                                                              *
-     *                             Helper classes                                   *
+     * Custom skin class implemntation to fetch default skin field values and       *
+     * monitor change in label properties.                                          *
      *                                                                              *
      *******************************************************************************/
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/LabelSkinTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 import com.sun.javafx.scene.control.skin.Utils;
 import javafx.beans.value.ObservableValue;
 import javafx.geometry.Insets;
@@ -41,6 +42,7 @@ import javafx.scene.control.skin.LabelSkin;
 import javafx.scene.control.skin.LabelSkinBaseShim;
 import javafx.scene.control.skin.LabeledSkinBaseShim;
 import javafx.scene.effect.BlendMode;
+import javafx.scene.layout.HBox;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Font;
@@ -2090,6 +2092,47 @@ public class LabelSkinTest {
         skin.updateDisplayedText();
         assertEquals("foo __bar", LabelSkinBaseShim.getText(label).getText());
     }
+
+    /*********************************************************************
+     *
+     * Tests for bug reports                                             *
+     *
+     ********************************************************************/
+
+    //Test for JDK-8172849
+    @Test
+    public void testBaselineAlignmentWhenTextIsSetAndGraphicIsSet() {
+        Label label1 = new Label("Label1");
+        LabelSkinMock label1Skin = new LabelSkinMock(label1);
+        label1.setSkin(label1Skin);
+
+        Label label2 = new Label("Label2");
+        LabelSkinMock label2Skin = new LabelSkinMock(label2);
+        label2.setSkin(label2Skin);
+
+        Rectangle r = new Rectangle(15, 5);
+        label2.setGraphic(r);
+
+        Toolkit tk = Toolkit.getToolkit();
+        HBox hBox = new HBox(label1, label2);
+        hBox.setAlignment(Pos.BASELINE_LEFT);
+        StageLoader sl = new StageLoader(hBox);
+        tk.firePulse();
+
+        double label2Height = label2.getHeight();
+        assertEquals(label1.getBaselineOffset(), label2.getBaselineOffset(), 0);
+        r.setHeight(50);
+        tk.firePulse();
+        assertEquals(label1.getBaselineOffset(), (label2.getBaselineOffset() - (r.getHeight()-label2Height)/2), 0);
+        sl.dispose();
+    }
+
+
+    /********************************************************************************
+     *                                                                              *
+     *                             Helper classes                                   *
+     *                                                                              *
+     *******************************************************************************/
 
     public static final class LabelSkinMock extends LabelSkin {
         boolean propertyChanged = false;


### PR DESCRIPTION
Issue was observed because even when graphic height was less than text height of the Label, graphic height was considered while calculating the baseline offset. This was shifting the baseline offset and resulted in misalignment.

Updated `computeBaselineOffset` to exclude graphic height from baseline offset calculation when graphic height is more than text height.

Added unit test to validate the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8172849](https://bugs.openjdk.org/browse/JDK-8172849): Non-intuitive baseline alignment for labeled controls with graphics


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Committer)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1059/head:pull/1059` \
`$ git checkout pull/1059`

Update a local copy of the PR: \
`$ git checkout pull/1059` \
`$ git pull https://git.openjdk.org/jfx.git pull/1059/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1059`

View PR using the GUI difftool: \
`$ git pr show -t 1059`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1059.diff">https://git.openjdk.org/jfx/pull/1059.diff</a>

</details>
