### PR TITLE
8270319: Define an intermediate superclass for Transitions with a duration property

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/animation/FadeTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/FadeTransition.java
@@ -27,7 +27,6 @@ package javafx.animation;
 
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.ObjectPropertyBase;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.Node;
@@ -81,7 +80,7 @@ import javafx.util.Duration;
  *
  * @since JavaFX 2.0
  */
-public final class FadeTransition extends Transition {
+public final class FadeTransition extends TimedTransition {
     private static final double EPSILON = 1e-12;
 
     private double start;
@@ -116,68 +115,6 @@ public final class FadeTransition extends Transition {
     }
 
     private Node cachedNode;
-
-    /**
-     * The duration of this {@code FadeTransition}.
-     * <p>
-     * It is not possible to change the {@code duration} of a running
-     * {@code FadeTransition}. If the value of {@code duration} is changed for a
-     * running {@code FadeTransition}, the animation has to be stopped and
-     * started again to pick up the new value.
-     * <p>
-     * Note: While the unit of {@code duration} is a millisecond, the
-     * granularity depends on the underlying operating system and will in
-     * general be larger. For example animations on desktop systems usually run
-     * with a maximum of 60fps which gives a granularity of ~17 ms.
-     *
-     * Setting duration to value lower than {@link Duration#ZERO} will result
-     * in {@link IllegalArgumentException}.
-     *
-     * @defaultValue 400ms
-     */
-    private ObjectProperty<Duration> duration;
-    private static final Duration DEFAULT_DURATION = Duration.millis(400);
-
-    public final void setDuration(Duration value) {
-        if ((duration != null) || (!DEFAULT_DURATION.equals(value))) {
-            durationProperty().set(value);
-        }
-    }
-
-    public final Duration getDuration() {
-        return (duration == null)? DEFAULT_DURATION : duration.get();
-    }
-
-    public final ObjectProperty<Duration> durationProperty() {
-        if (duration == null) {
-            duration = new ObjectPropertyBase<Duration>(DEFAULT_DURATION) {
-
-                @Override
-                public void invalidated() {
-                    try {
-                        setCycleDuration(getDuration());
-                    } catch (IllegalArgumentException e) {
-                        if (isBound()) {
-                            unbind();
-                        }
-                        set(getCycleDuration());
-                        throw e;
-                    }
-                }
-
-                @Override
-                public Object getBean() {
-                    return FadeTransition.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "duration";
-                }
-            };
-        }
-        return duration;
-    }
 
     /**
      * Specifies the start opacity value for this {@code FadeTransition}.
@@ -296,7 +233,6 @@ public final class FadeTransition extends Transition {
      * The constructor of {@code FadeTransition}
      */
     public FadeTransition() {
-        this(DEFAULT_DURATION, null);
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/animation/FillTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/FillTransition.java
@@ -26,7 +26,6 @@
 package javafx.animation;
 
 import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.ObjectPropertyBase;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.Node;
 import javafx.scene.paint.Color;
@@ -75,7 +74,7 @@ import javafx.util.Duration;
  *
  * @since JavaFX 2.0
  */
-public final class FillTransition extends Transition {
+public final class FillTransition extends TimedTransition {
 
     private Color start;
     private Color end;
@@ -109,68 +108,6 @@ public final class FillTransition extends Transition {
     }
 
     private Shape cachedShape;
-
-    /**
-     * The duration of this {@code FillTransition}.
-     * <p>
-     * It is not possible to change the {@code duration} of a running
-     * {@code FillTransition}. If the value of {@code duration} is changed for a
-     * running {@code FillTransition}, the animation has to be stopped and
-     * started again to pick up the new value.
-     * <p>
-     * Note: While the unit of {@code duration} is a millisecond, the
-     * granularity depends on the underlying operating system and will in
-     * general be larger. For example animations on desktop systems usually run
-     * with a maximum of 60fps which gives a granularity of ~17 ms.
-     *
-     * Setting duration to value lower than {@link Duration#ZERO} will result
-     * in {@link IllegalArgumentException}.
-     *
-     * @defaultValue 400ms
-     */
-    private ObjectProperty<Duration> duration;
-    private static final Duration DEFAULT_DURATION = Duration.millis(400);
-
-    public final void setDuration(Duration value) {
-        if ((duration != null) || (!DEFAULT_DURATION.equals(value))) {
-            durationProperty().set(value);
-        }
-    }
-
-    public final Duration getDuration() {
-        return (duration == null)? DEFAULT_DURATION : duration.get();
-    }
-
-    public final ObjectProperty<Duration> durationProperty() {
-        if (duration == null) {
-            duration = new ObjectPropertyBase<Duration>(DEFAULT_DURATION) {
-
-                @Override
-                public void invalidated() {
-                    try {
-                        setCycleDuration(getDuration());
-                    } catch (IllegalArgumentException e) {
-                        if (isBound()) {
-                            unbind();
-                        }
-                        set(getCycleDuration());
-                        throw e;
-                    }
-                }
-
-                @Override
-                public Object getBean() {
-                    return FillTransition.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "duration";
-                }
-            };
-        }
-        return duration;
-    }
 
     /**
      * Specifies the start color value for this {@code FillTransition}.
@@ -284,7 +221,6 @@ public final class FillTransition extends Transition {
      * The constructor of {@code FillTransition}
      */
     public FillTransition() {
-        this(DEFAULT_DURATION, null);
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/animation/PathTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/PathTransition.java
@@ -26,7 +26,6 @@
 package javafx.animation;
 
 import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.ObjectPropertyBase;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.Node;
 import javafx.scene.shape.Shape;
@@ -86,7 +85,7 @@ import java.util.ArrayList;
  *
  * @since JavaFX 2.0
  */
-public final class PathTransition extends Transition {
+public final class PathTransition extends TimedTransition {
 
     /**
      * The target node of this {@code PathTransition}.
@@ -121,68 +120,6 @@ public final class PathTransition extends Transition {
     }
 
     private Node cachedNode;
-
-    /**
-     * The duration of this {@code Transition}.
-     * <p>
-     * It is not possible to change the {@code duration} of a running
-     * {@code PathTransition}. If the value of {@code duration} is changed for a
-     * running {@code PathTransition}, the animation has to be stopped and
-     * started again to pick up the new value.
-     * <p>
-     * Note: While the unit of {@code duration} is a millisecond, the
-     * granularity depends on the underlying operating system and will in
-     * general be larger. For example animations on desktop systems usually run
-     * with a maximum of 60fps which gives a granularity of ~17 ms.
-     *
-     * Setting duration to value lower than {@link Duration#ZERO} will result
-     * in {@link IllegalArgumentException}.
-     *
-     * @defaultValue 400ms
-     */
-    private ObjectProperty<Duration> duration;
-    private static final Duration DEFAULT_DURATION = Duration.millis(400);
-
-    public final void setDuration(Duration value) {
-        if ((duration != null) || (!DEFAULT_DURATION.equals(value))) {
-            durationProperty().set(value);
-        }
-    }
-
-    public final Duration getDuration() {
-        return (duration == null)? DEFAULT_DURATION : duration.get();
-    }
-
-    public final ObjectProperty<Duration> durationProperty() {
-        if (duration == null) {
-            duration = new ObjectPropertyBase<Duration>(DEFAULT_DURATION) {
-
-                @Override
-                public void invalidated() {
-                    try {
-                        setCycleDuration(getDuration());
-                    } catch (IllegalArgumentException e) {
-                        if (isBound()) {
-                            unbind();
-                        }
-                        set(getCycleDuration());
-                        throw e;
-                    }
-                }
-
-                @Override
-                public Object getBean() {
-                    return PathTransition.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "duration";
-                }
-            };
-        }
-        return duration;
-    }
 
     /**
      * The shape on which outline the node should be animated.
@@ -299,7 +236,6 @@ public final class PathTransition extends Transition {
      * The constructor of {@code PathTransition}.
      */
     public PathTransition() {
-        this(DEFAULT_DURATION, null, null);
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/animation/PauseTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/PauseTransition.java
@@ -25,8 +25,6 @@
 
 package javafx.animation;
 
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.ObjectPropertyBase;
 import javafx.util.Duration;
 
 /**
@@ -69,69 +67,7 @@ import javafx.util.Duration;
  *
  * @since JavaFX 2.0
  */
-public final class PauseTransition extends Transition {
-
-    /**
-     * The duration of this {@code Transition}.
-     * <p>
-     * It is not possible to change the {@code duration} of a running
-     * {@code PauseTransition}. If the value of {@code duration} is changed for a
-     * running {@code PauseTransition}, the animation has to be stopped and started again to
-     * pick up the new value.
-     * <p>
-     * Note: While the unit of {@code duration} is a millisecond, the
-     * granularity depends on the underlying operating system and will in
-     * general be larger. For example animations on desktop systems usually run
-     * with a maximum of 60fps which gives a granularity of ~17 ms.
-     *
-     * Setting duration to value lower than {@link Duration#ZERO} will result
-     * in {@link IllegalArgumentException}.
-     *
-     * @defaultValue 400ms
-     */
-    private ObjectProperty<Duration> duration;
-    private static final Duration DEFAULT_DURATION = Duration.millis(400);
-
-    public final void setDuration(Duration value) {
-        if ((duration != null) || (!DEFAULT_DURATION.equals(value))) {
-            durationProperty().set(value);
-        }
-    }
-
-    public final Duration getDuration() {
-        return (duration == null)? DEFAULT_DURATION : duration.get();
-    }
-
-    public final ObjectProperty<Duration> durationProperty() {
-        if (duration == null) {
-            duration = new ObjectPropertyBase<Duration>(DEFAULT_DURATION) {
-
-                @Override
-                public void invalidated() {
-                    try {
-                        setCycleDuration(getDuration());
-                    } catch (IllegalArgumentException e) {
-                        if (isBound()) {
-                            unbind();
-                        }
-                        set(getCycleDuration());
-                        throw e;
-                    }
-                }
-
-                @Override
-                public Object getBean() {
-                    return PauseTransition.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "duration";
-                }
-            };
-        }
-        return duration;
-    }
+public final class PauseTransition extends TimedTransition {
 
     /**
      * The constructor of {@code PauseTransition}.
@@ -148,7 +84,6 @@ public final class PauseTransition extends Transition {
      * The constructor of {@code PauseTransition}
      */
     public PauseTransition() {
-        this(DEFAULT_DURATION);
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/animation/RotateTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/RotateTransition.java
@@ -27,7 +27,6 @@ package javafx.animation;
 
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.ObjectPropertyBase;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.geometry.Point3D;
@@ -81,7 +80,7 @@ import javafx.util.Duration;
  *
  * @since JavaFX 2.0
  */
-public final class RotateTransition extends Transition {
+public final class RotateTransition extends TimedTransition {
 
     private static final double EPSILON = 1e-12;
 
@@ -117,68 +116,6 @@ public final class RotateTransition extends Transition {
     }
 
     private Node cachedNode;
-
-    /**
-     * The duration of this {@code RotateTransition}.
-     * <p>
-     * It is not possible to change the {@code duration} of a running
-     * {@code RotateTransition}. If the value of {@code duration} is changed for
-     * a running {@code RotateTransition}, the animation has to be stopped and
-     * started again to pick up the new value.
-     * <p>
-     * Note: While the unit of {@code duration} is a millisecond, the
-     * granularity depends on the underlying operating system and will in
-     * general be larger. For example animations on desktop systems usually run
-     * with a maximum of 60fps which gives a granularity of ~17 ms.
-     *
-     * Setting duration to value lower than {@link Duration#ZERO} will result
-     * in {@link IllegalArgumentException}.
-     *
-     * @defaultValue 400ms
-     */
-    private ObjectProperty<Duration> duration;
-    private static final Duration DEFAULT_DURATION = Duration.millis(400);
-
-    public final void setDuration(Duration value) {
-        if ((duration != null) || (!DEFAULT_DURATION.equals(value))) {
-            durationProperty().set(value);
-        }
-    }
-
-    public final Duration getDuration() {
-        return (duration == null)? DEFAULT_DURATION : duration.get();
-    }
-
-    public final ObjectProperty<Duration> durationProperty() {
-        if (duration == null) {
-            duration = new ObjectPropertyBase<Duration>(DEFAULT_DURATION) {
-
-                @Override
-                public void invalidated() {
-                    try {
-                        setCycleDuration(getDuration());
-                    } catch (IllegalArgumentException e) {
-                        if (isBound()) {
-                            unbind();
-                        }
-                        set(getCycleDuration());
-                        throw e;
-                    }
-                }
-
-                @Override
-                public Object getBean() {
-                    return RotateTransition.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "duration";
-                }
-            };
-        }
-        return duration;
-    }
 
     /**
      * Specifies the axis of rotation for this {@code RotateTransition}. Use
@@ -330,7 +267,6 @@ public final class RotateTransition extends Transition {
      *
      */
     public RotateTransition() {
-        this(DEFAULT_DURATION, null);
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/animation/ScaleTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/ScaleTransition.java
@@ -27,7 +27,6 @@ package javafx.animation;
 
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.ObjectPropertyBase;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.Node;
@@ -85,7 +84,7 @@ import javafx.util.Duration;
  *
  * @since JavaFX 2.0
  */
-public final class ScaleTransition extends Transition {
+public final class ScaleTransition extends TimedTransition {
 
     private static final double EPSILON = 1e-12;
     private double startX;
@@ -124,68 +123,6 @@ public final class ScaleTransition extends Transition {
     }
 
     private Node cachedNode;
-
-    /**
-     * The duration of this {@code ScaleTransition}.
-     * <p>
-     * It is not possible to change the {@code duration} of a running
-     * {@code ScaleTransition}. If the value of {@code duration} is changed for
-     * a running {@code ScaleTransition}, the animation has to be stopped and
-     * started again to pick up the new value.
-     * <p>
-     * Note: While the unit of {@code duration} is a millisecond, the
-     * granularity depends on the underlying operating system and will in
-     * general be larger. For example animations on desktop systems usually run
-     * with a maximum of 60fps which gives a granularity of ~17 ms.
-     *
-     * Setting duration to value lower than {@link Duration#ZERO} will result
-     * in {@link IllegalArgumentException}.
-     *
-     * @defaultValue 400ms
-     */
-    private ObjectProperty<Duration> duration;
-    private static final Duration DEFAULT_DURATION = Duration.millis(400);
-
-    public final void setDuration(Duration value) {
-        if ((duration != null) || (!DEFAULT_DURATION.equals(value))) {
-            durationProperty().set(value);
-        }
-    }
-
-    public final Duration getDuration() {
-        return (duration == null)? DEFAULT_DURATION : duration.get();
-    }
-
-    public final ObjectProperty<Duration> durationProperty() {
-        if (duration == null) {
-            duration = new ObjectPropertyBase<Duration>(DEFAULT_DURATION) {
-
-                @Override
-                public void invalidated() {
-                    try {
-                        setCycleDuration(getDuration());
-                    } catch (IllegalArgumentException e) {
-                        if (isBound()) {
-                            unbind();
-                        }
-                        set(getCycleDuration());
-                        throw e;
-                    }
-                }
-
-                @Override
-                public Object getBean() {
-                    return ScaleTransition.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "duration";
-                }
-            };
-        }
-        return duration;
-    }
 
     /**
      * Specifies the start X scale value of this {@code ScaleTransition}.
@@ -482,7 +419,6 @@ public final class ScaleTransition extends Transition {
      * The constructor of {@code ScaleTransition}
      */
     public ScaleTransition() {
-        this(DEFAULT_DURATION, null);
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/animation/StrokeTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/StrokeTransition.java
@@ -26,7 +26,6 @@
 package javafx.animation;
 
 import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.ObjectPropertyBase;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.Node;
 import javafx.scene.paint.Color;
@@ -76,7 +75,7 @@ import javafx.util.Duration;
  *
  * @since JavaFX 2.0
  */
-public final class StrokeTransition extends Transition {
+public final class StrokeTransition extends TimedTransition {
 
     private Color start;
     private Color end;
@@ -110,68 +109,6 @@ public final class StrokeTransition extends Transition {
     }
 
     private Shape cachedShape;
-
-    /**
-     * The duration of this {@code StrokeTransition}.
-     * <p>
-     * It is not possible to change the {@code duration} of a running
-     * {@code StrokeTransition}. If the value of {@code duration} is changed for
-     * a running {@code StrokeTransition}, the animation has to be stopped and
-     * started again to pick up the new value.
-     * <p>
-     * Note: While the unit of {@code duration} is a millisecond, the
-     * granularity depends on the underlying operating system and will in
-     * general be larger. For example animations on desktop systems usually run
-     * with a maximum of 60fps which gives a granularity of ~17 ms.
-     *
-     * Setting duration to value lower than {@link Duration#ZERO} will result
-     * in {@link IllegalArgumentException}.
-     *
-     * @defaultValue 400ms
-     */
-    private ObjectProperty<Duration> duration;
-    private static final Duration DEFAULT_DURATION = Duration.millis(400);
-
-    public final void setDuration(Duration value) {
-        if ((duration != null) || (!DEFAULT_DURATION.equals(value))) {
-            durationProperty().set(value);
-        }
-    }
-
-    public final Duration getDuration() {
-        return (duration == null)? DEFAULT_DURATION : duration.get();
-    }
-
-    public final ObjectProperty<Duration> durationProperty() {
-        if (duration == null) {
-            duration = new ObjectPropertyBase<Duration>(DEFAULT_DURATION) {
-
-                @Override
-                public void invalidated() {
-                    try {
-                        setCycleDuration(getDuration());
-                    } catch (IllegalArgumentException e) {
-                        if (isBound()) {
-                            unbind();
-                        }
-                        set(getCycleDuration());
-                        throw e;
-                    }
-                }
-
-                @Override
-                public Object getBean() {
-                    return StrokeTransition.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "duration";
-                }
-            };
-        }
-        return duration;
-    }
 
     /**
      * Specifies the start color value for this {@code StrokeTransition}.
@@ -285,7 +222,6 @@ public final class StrokeTransition extends Transition {
      * The constructor of {@code StrokeTransition}
      */
     public StrokeTransition() {
-        this(DEFAULT_DURATION, null);
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/animation/TimedTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/TimedTransition.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package javafx.animation;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ObjectPropertyBase;
+import javafx.util.Duration;
+
+/**
+ * An abstract class that extends {@link Transition} and adds the {@link #durationProperty() duration} property.
+ * The {@link #durationProperty() duration} property defines the duration of a Transition-Animation.
+ *
+ * @see Transition
+ * @see Animation
+ *
+ * @since 21
+ */
+public abstract class TimedTransition extends Transition {
+
+    public TimedTransition() {
+        setCycleDuration(getDuration());
+    }
+
+    /**
+     * The duration of this {@code TranslateTransition}.
+     * <p>
+     * It is not possible to change the {@code duration} of a running
+     * {@code TimedTransition}. If the value of {@code duration} is changed
+     * for a running {@code TimedTransition}, the animation has to be
+     * stopped and started again to pick up the new value.
+     * <p>
+     * Note: While the unit of {@code duration} is a millisecond, the
+     * granularity depends on the underlying operating system and will in
+     * general be larger. For example animations on desktop systems usually run
+     * with a maximum of 60fps which gives a granularity of ~17 ms.
+     *
+     * Setting duration to value lower than {@link Duration#ZERO} will result
+     * in {@link IllegalArgumentException}.
+     *
+     * @defaultValue 400ms
+     */
+    private ObjectProperty<Duration> duration;
+    private static final Duration DEFAULT_DURATION = Duration.millis(400);
+
+    public final void setDuration(Duration value) {
+        if (duration != null || !DEFAULT_DURATION.equals(value)) {
+            durationProperty().set(value);
+        }
+    }
+
+    public final Duration getDuration() {
+        return duration == null ? DEFAULT_DURATION : duration.get();
+    }
+
+    public final ObjectProperty<Duration> durationProperty() {
+        if (duration == null) {
+            duration = new ObjectPropertyBase<>(DEFAULT_DURATION) {
+
+                @Override
+                public void invalidated() {
+                    try {
+                        setCycleDuration(getDuration());
+                    } catch (IllegalArgumentException e) {
+                        if (isBound()) {
+                            unbind();
+                        }
+                        set(getCycleDuration());
+                        throw e;
+                    }
+                }
+
+                @Override
+                public Object getBean() {
+                    return TimedTransition.this;
+                }
+
+                @Override
+                public String getName() {
+                    return "duration";
+                }
+            };
+        }
+        return duration;
+    }
+}

--- a/modules/javafx.graphics/src/main/java/javafx/animation/Transition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/Transition.java
@@ -42,8 +42,8 @@ import javafx.scene.Node;
  * <p>
  * In addition, an extending class needs to set the duration of a single cycle
  * with {@link Animation#setCycleDuration(javafx.util.Duration)}. This duration
- * is usually set by the user via a duration property (as in
- * {@link FadeTransition#durationProperty() duration}) for example. But it can also be calculated
+ * is usually set by the user via a duration property (as defined in
+ * {@link TimedTransition#durationProperty() duration}) for example. But it can also be calculated
  * by the extending class as is done in {@link ParallelTransition} and
  * {@link FadeTransition}.
  * <p>
@@ -118,7 +118,7 @@ public abstract class Transition extends Animation {
      * {@code Transition} was started.
      *
      * Changing the {@link #interpolatorProperty() interpolator} of a running {@code Transition} should
-     * have no immediate effect. Instead the running {@code Transition} should
+     * have no immediate effect. Instead, the running {@code Transition} should
      * continue to use the original {@code Interpolator} until it is stopped and
      * started again.
      *

--- a/modules/javafx.graphics/src/main/java/javafx/animation/TranslateTransition.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/TranslateTransition.java
@@ -27,7 +27,6 @@ package javafx.animation;
 
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.ObjectPropertyBase;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.scene.Node;
@@ -83,7 +82,7 @@ import javafx.util.Duration;
  *
  * @since JavaFX 2.0
  */
-public final class TranslateTransition extends Transition {
+public final class TranslateTransition extends TimedTransition {
 
     private static final double EPSILON = 1e-12;
     private double startX;
@@ -122,68 +121,6 @@ public final class TranslateTransition extends Transition {
     }
 
     private Node cachedNode;
-
-    /**
-     * The duration of this {@code TranslateTransition}.
-     * <p>
-     * It is not possible to change the {@code duration} of a running
-     * {@code TranslateTransition}. If the value of {@code duration} is changed
-     * for a running {@code TranslateTransition}, the animation has to be
-     * stopped and started again to pick up the new value.
-     * <p>
-     * Note: While the unit of {@code duration} is a millisecond, the
-     * granularity depends on the underlying operating system and will in
-     * general be larger. For example animations on desktop systems usually run
-     * with a maximum of 60fps which gives a granularity of ~17 ms.
-     *
-     * Setting duration to value lower than {@link Duration#ZERO} will result
-     * in {@link IllegalArgumentException}.
-     *
-     * @defaultValue 400ms
-     */
-    private ObjectProperty<Duration> duration;
-    private static final Duration DEFAULT_DURATION = Duration.millis(400);
-
-    public final void setDuration(Duration value) {
-        if ((duration != null) || (!DEFAULT_DURATION.equals(value))) {
-            durationProperty().set(value);
-        }
-    }
-
-    public final Duration getDuration() {
-        return (duration == null)? DEFAULT_DURATION : duration.get();
-    }
-
-    public final ObjectProperty<Duration> durationProperty() {
-        if (duration == null) {
-            duration = new ObjectPropertyBase<Duration>(DEFAULT_DURATION) {
-
-                @Override
-                public void invalidated() {
-                    try {
-                        setCycleDuration(getDuration());
-                    } catch (IllegalArgumentException e) {
-                        if (isBound()) {
-                            unbind();
-                        }
-                        set(getCycleDuration());
-                        throw e;
-                    }
-                }
-
-                @Override
-                public Object getBean() {
-                    return TranslateTransition.this;
-                }
-
-                @Override
-                public String getName() {
-                    return "duration";
-                }
-            };
-        }
-        return duration;
-    }
 
     /**
      * Specifies the start X coordinate value of this
@@ -483,7 +420,6 @@ public final class TranslateTransition extends Transition {
      * The constructor of {@code TranslateTransition}
      */
     public TranslateTransition() {
-        this(DEFAULT_DURATION, null);
     }
 
     /**

--- a/modules/javafx.graphics/src/test/java/test/javafx/animation/TimedTransitionTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/animation/TimedTransitionTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.animation;
+
+import javafx.animation.*;
+import javafx.util.Duration;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TimedTransitionTest {
+
+    @ParameterizedTest
+    @MethodSource(value = "getTimedTransitionsWithDefaultTime")
+    public void testDefaultDuration(TimedTransition transition) {
+        assertEquals(Duration.millis(400), transition.getDuration());
+        assertEquals(Duration.millis(400), transition.getCycleDuration());
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "getTimedTransitionsWithDefaultTime")
+    public void testCustomDuration(TimedTransition transition) {
+        transition.setDuration(Duration.millis(600));
+        assertEquals(Duration.millis(600), transition.getDuration());
+        assertEquals(Duration.millis(600), transition.getCycleDuration());
+    }
+
+    @ParameterizedTest
+    @MethodSource(value = "getTimedTransitionsWithCustomTime")
+    public void testCustomFromConstructorDuration(TimedTransition transition) {
+        assertEquals(Duration.millis(500), transition.getDuration());
+        assertEquals(Duration.millis(500), transition.getCycleDuration());
+
+        transition.setDuration(Duration.millis(600));
+
+        assertEquals(Duration.millis(600), transition.getDuration());
+        assertEquals(Duration.millis(600), transition.getCycleDuration());
+    }
+
+    static Stream<TimedTransition> getTimedTransitionsWithDefaultTime() {
+        return Stream.of(
+                new FadeTransition(),
+                new FillTransition(),
+                new PathTransition(),
+                new PauseTransition(),
+                new RotateTransition(),
+                new ScaleTransition(),
+                new StrokeTransition(),
+                new TranslateTransition()
+        );
+    }
+
+    static Stream<TimedTransition> getTimedTransitionsWithCustomTime() {
+        return Stream.of(
+                new FadeTransition(Duration.millis(500)),
+                new FillTransition(Duration.millis(500)),
+                new PathTransition(Duration.millis(500), null),
+                new PauseTransition(Duration.millis(500)),
+                new RotateTransition(Duration.millis(500)),
+                new ScaleTransition(Duration.millis(500)),
+                new StrokeTransition(Duration.millis(500)),
+                new TranslateTransition(Duration.millis(500))
+        );
+    }
+
+}


### PR DESCRIPTION
Created an abstract intermediate superclass called `TimedTransition`. The duration-functionality has been extracted from the multiple transition subclasses and is now handled by the superclass, which the other transitions like `RotateTransition` now extend.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion jfx22 to be approved (needs to be created)
- [ ] Change must be properly reviewed (3 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 2 [Authors](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8270319](https://bugs.openjdk.org/browse/JDK-8270319): Define an intermediate superclass for Transitions with a duration property (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1061/head:pull/1061` \
`$ git checkout pull/1061`

Update a local copy of the PR: \
`$ git checkout pull/1061` \
`$ git pull https://git.openjdk.org/jfx.git pull/1061/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1061`

View PR using the GUI difftool: \
`$ git pr show -t 1061`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1061.diff">https://git.openjdk.org/jfx/pull/1061.diff</a>

</details>
