### PR TITLE
JDK-8304705 Parent class contains 6 constants that should be static

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
@@ -1654,12 +1654,12 @@ public abstract class Parent extends Node {
         }
     }
 
-    private final int LEFT_INVALID = 1;
-    private final int TOP_INVALID = 1 << 1;
-    private final int NEAR_INVALID = 1 << 2;
-    private final int RIGHT_INVALID = 1 << 3;
-    private final int BOTTOM_INVALID = 1 << 4;
-    private final int FAR_INVALID = 1 << 5;
+    private static final int LEFT_INVALID = 1;
+    private static final int TOP_INVALID = 1 << 1;
+    private static final int NEAR_INVALID = 1 << 2;
+    private static final int RIGHT_INVALID = 1 << 3;
+    private static final int BOTTOM_INVALID = 1 << 4;
+    private static final int FAR_INVALID = 1 << 5;
 
     private boolean updateCachedBounds(final List<Node> dirtyNodes,
                                        int remainingDirtyNodes) {


### PR DESCRIPTION
Made 6 constants static in `Parent`.  Discovered these with the Java Object Layout tool.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304705](https://bugs.openjdk.org/browse/JDK-8304705): Parent class contains 6 constants that should be static


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1064/head:pull/1064` \
`$ git checkout pull/1064`

Update a local copy of the PR: \
`$ git checkout pull/1064` \
`$ git pull https://git.openjdk.org/jfx.git pull/1064/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1064`

View PR using the GUI difftool: \
`$ git pr show -t 1064`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1064.diff">https://git.openjdk.org/jfx/pull/1064.diff</a>

</details>
