### PR TITLE
8246104: Some complex text doesn't render correctly on macOS

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/CompositeStrike.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/CompositeStrike.java
@@ -116,14 +116,16 @@ public class CompositeStrike implements FontStrike {
             }
 
             if (slot >= strikeSlots.length) {
-                FontStrike[] tmp = new FontStrike[fontResource.getNumSlots()];
+                FontStrike[] tmp = new FontStrike[slot+1];
                 System.arraycopy(strikeSlots, 0, tmp, 0, strikeSlots.length);
                 strikeSlots = tmp;
             }
             if (strikeSlots[slot] == null) {
                 FontResource slotResource = fontResource.getSlotResource(slot);
-                strikeSlots[slot] = slotResource.getStrike(size, transform,
-                                                           getAAMode());
+                if (slotResource != null) {
+                    strikeSlots[slot] = slotResource.getStrike(size, transform,
+                                                               getAAMode());
+                }
             }
             return strikeSlots[slot];
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FallbackResource.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FallbackResource.java
@@ -34,16 +34,17 @@ import com.sun.javafx.geom.transform.BaseTransform;
 
 
 /*
- * Create a singleton fallback resource per style to be shared across
- * all physical fonts. "Per style" refers to the Bold and Italic styles,
- * thus will (eventually) be 4 in all.
+ * Fallback fonts may differ depending on the primary resource.
+ * Additionally it may differ based on style even if it is otherwise
+ * the same for multiple fonts.
  */
 
-class FallbackResource implements CompositeFontResource {
+public class FallbackResource implements CompositeFontResource {
 
 
-    private ArrayList<String> linkedFontFiles;
-    private ArrayList<String> linkedFontNames;
+    FontResource primaryResource;
+    private String[] linkedFontFiles;
+    private String[] linkedFontNames;
     private FontResource[] fallbacks;
     private FontResource[] nativeFallbacks;
     private boolean isBold, isItalic;
@@ -56,6 +57,26 @@ class FallbackResource implements CompositeFontResource {
     @Override
     public Map<FontStrikeDesc, WeakReference<FontStrike>> getStrikeMap() {
         return strikeMap;
+    }
+
+    /*
+     * Initially this is used only on macOS where the cascading list for a
+     * resource may include font variations and system fonts that cannot
+     * be directly instantiated. So we need to install resources which already
+     * wrap a native reference to these fonts as we won't be successful
+     * in requesting them from native using name+file.
+     * I hope we should still be able to share these in the global
+     * name->font map so its not too wasteful.
+     */
+    FallbackResource(FontResource primary) {
+        primaryResource = primary;
+        aaMode = primaryResource.getDefaultAAMode();
+        isBold = primaryResource.isBold();
+        isItalic = primaryResource.isItalic();
+    }
+
+    static FallbackResource getFallbackResource(FontResource primaryResource) {
+        return new FallbackResource(primaryResource);
     }
 
     FallbackResource(boolean bold, boolean italic, int aaMode) {
@@ -178,8 +199,7 @@ class FallbackResource implements CompositeFontResource {
         return mapper;
     }
 
-    @Override
-    public int getSlotForFont(String fontName) {
+    private int getSlotForFontNoCreate(String fontName) {
         getLinkedFonts();
         int i = 0;
         for (String linkedFontName : linkedFontNames) {
@@ -196,8 +216,38 @@ class FallbackResource implements CompositeFontResource {
                 i++;
             }
         }
+        return -1;
+    }
 
-        if (i >= 0x7E) {
+    @Override
+    public int getSlotForFont(String fontName) {
+      int slot = getSlotForFontNoCreate(fontName);
+        if (slot >= 0) {
+            return slot;
+        }
+
+        PrismFontFactory factory = PrismFontFactory.getFontFactory();
+        FontResource fr = factory.getFontResource(fontName, null, false);
+
+        if (fr == null) {
+            if (PrismFontFactory.debugFonts) {
+                System.err.println("\t Font name not supported \"" + fontName + "\".");
+            }
+            return -1;
+        }
+        slot = getSlotForFontNoCreate(fr.getFullName());
+        if (slot >= 0) {
+            return slot;
+        }
+
+        /* Add the font to the list of native fallbacks */
+        return addNativeFallback(fr);
+    }
+
+
+    private int addNativeFallback(FontResource fr) {
+        int ns = getNumSlots();
+        if (ns >= 0x7E) {
             /* There are 8bits (0xFF) reserved in a glyph code to store the slot
              * number. The first bit cannot be set to avoid negative values
              * (leaving 0x7F). The extra -1 (leaving 0x7E) is to account for
@@ -208,15 +258,6 @@ class FallbackResource implements CompositeFontResource {
             }
             return -1;
         }
-        PrismFontFactory factory = PrismFontFactory.getFontFactory();
-        FontResource fr = factory.getFontResource(fontName, null, false);
-        if (fr == null) {
-            if (PrismFontFactory.debugFonts) {
-                System.err.println("\t Font name not supported \"" + fontName + "\".");
-            }
-            return -1;
-        }
-
         /* Add the font to the list of native fallbacks */
         FontResource[] tmp;
         if (nativeFallbacks == null) {
@@ -227,41 +268,33 @@ class FallbackResource implements CompositeFontResource {
         }
         tmp[tmp.length - 1] = fr;
         nativeFallbacks = tmp;
-        return i;
+
+        return ns+1;
     }
 
-    /* To start with we will use the exact same fall back list for
-     * everything.
-     */
+    public int addSlotFont(FontResource fr) {
+        int slot = getSlotForFont(fr.getFullName());
+        if (slot >= 0) {
+            return slot;
+        } else {
+            return addNativeFallback(fr);
+        }
+    }
+
     private void getLinkedFonts() {
         if (fallbacks == null) {
-            if (PrismFontFactory.isLinux) {
-                FontConfigManager.FcCompFont font =
-                    FontConfigManager.getFontConfigFont("sans",
-                                                        isBold, isItalic);
-                linkedFontFiles = FontConfigManager.getFileNames(font, false);
-                linkedFontNames = FontConfigManager.getFontNames(font, false);
-                fallbacks = new FontResource[linkedFontFiles.size()];
-            } else {
-                ArrayList<String>[] linkedFontInfo;
-                if (PrismFontFactory.isMacOSX) {
-                    linkedFontInfo =
-                        PrismFontFactory.getLinkedFonts("Arial Unicode MS", true);
-                } else {
-                    linkedFontInfo =
-                        PrismFontFactory.getLinkedFonts("Tahoma", true);
-                }
-                linkedFontFiles = linkedFontInfo[0];
-                linkedFontNames = linkedFontInfo[1];
-                fallbacks = new FontResource[linkedFontFiles.size()];
-            }
+            PrismFontFactory factory = PrismFontFactory.getFontFactory();
+            FontFallbackInfo fallbackInfo = factory.getFallbacks(primaryResource);
+            linkedFontNames = fallbackInfo.getFontNames();
+            linkedFontFiles = fallbackInfo.getFontFiles();
+            fallbacks       = fallbackInfo.getFonts();
         }
     }
 
     @Override
     public int getNumSlots() {
         getLinkedFonts();
-        int num = linkedFontFiles.size();
+        int num = fallbacks.length;
         if (nativeFallbacks != null) {
             num += nativeFallbacks.length;
         }
@@ -296,8 +329,8 @@ class FallbackResource implements CompositeFontResource {
             return nativeFallbacks[slot];
         }
         if (fallbacks[slot] == null) {
-            String file = linkedFontFiles.get(slot);
-            String name = linkedFontNames.get(slot);
+            String file = linkedFontFiles[slot];
+            String name = linkedFontNames[slot];
             fallbacks[slot] =
                 PrismFontFactory.getFontFactory().
                 getFontResource(name, file, false);
@@ -331,5 +364,19 @@ class FallbackResource implements CompositeFontResource {
             strikeMap.put(desc, ref);
         }
         return strike;
+    }
+
+    public String toString() {
+        int ns = getNumSlots();
+        String s = "Fallback resource:\n";
+        for (int i=0;i<ns;i++) {
+          if ((getSlotResource(i)==null)) {
+           s+= "Slot " + i + "=null\n";
+          } else {
+          s += "Slot " + i + "="+getSlotResource(i).getFullName()+"\n";
+          }
+        }
+        s+= "\n";
+       return s;
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FallbackResource.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FallbackResource.java
@@ -369,14 +369,14 @@ public class FallbackResource implements CompositeFontResource {
     public String toString() {
         int ns = getNumSlots();
         String s = "Fallback resource:\n";
-        for (int i=0;i<ns;i++) {
-          if ((getSlotResource(i)==null)) {
-           s+= "Slot " + i + "=null\n";
-          } else {
-          s += "Slot " + i + "="+getSlotResource(i).getFullName()+"\n";
-          }
+        for (int i=0; i<ns; i++) {
+            if ((getSlotResource(i) == null)) {
+                s += "Slot " + i + "=null\n";
+            } else {
+                s += "Slot " + i + "=" + getSlotResource(i).getFullName()+"\n";
+            }
         }
         s+= "\n";
-       return s;
+        return s;
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontConfigManager.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontConfigManager.java
@@ -36,7 +36,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Properties;
 
-class FontConfigManager {
+public class FontConfigManager {
 
     static boolean debugFonts = false;
     static boolean useFontConfig = true;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFallbackInfo.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFallbackInfo.java
@@ -60,7 +60,7 @@ public class FontFallbackInfo {
    public String[] getFontFiles() {
       return linkedFontFiles.toArray(new String[0]);
    }
-  
+
    public FontResource[] getFonts() {
       return linkedFonts.toArray(new FontResource[0]);
    }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFallbackInfo.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFallbackInfo.java
@@ -29,9 +29,9 @@ import java.util.ArrayList;
 
 public class FontFallbackInfo {
 
-   ArrayList<String> linkedFontFiles;
-   ArrayList<String> linkedFontNames;
-   ArrayList<FontResource> linkedFonts;
+   private ArrayList<String> linkedFontFiles;
+   private ArrayList<String> linkedFontNames;
+   private ArrayList<FontResource> linkedFonts;
 
    public FontFallbackInfo() {
       linkedFontFiles = new ArrayList<String>();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFallbackInfo.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FontFallbackInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,27 +25,43 @@
 
 package com.sun.javafx.font;
 
+import java.util.ArrayList;
 
-public interface CompositeFontResource extends FontResource {
+public class FontFallbackInfo {
 
-    public FontResource getSlotResource(int slot);
+   ArrayList<String> linkedFontFiles;
+   ArrayList<String> linkedFontNames;
+   ArrayList<FontResource> linkedFonts;
 
-    public int getNumSlots();
+   public FontFallbackInfo() {
+      linkedFontFiles = new ArrayList<String>();
+      linkedFontNames = new ArrayList<String>();
+      linkedFonts = new ArrayList<FontResource>();
+   }
 
-    default public int addSlotFont(FontResource font) {
-        return -1;
-    }
+   public void add(String name, String file, FontResource font) {
+       linkedFontNames.add(name);
+       linkedFontFiles.add(file);
+       linkedFonts.add(font);
+   }
 
-    /**
-     * Returns the slot for the given font name.
-     * Adds fontName as a new fallback font if needed.
-     */
-    public int getSlotForFont(String fontName);
+   public boolean containsName(String name) {
+       return (name != null) && linkedFontNames.contains(name);
+   }
 
-    default boolean isColorGlyph(int glyphCode) {
-        int slot = (glyphCode >>> 24);
-        int slotglyphCode = glyphCode & CompositeGlyphMapper.GLYPHMASK;
-        FontResource slotResource = getSlotResource(slot);
-        return slotResource.isColorGlyph(slotglyphCode);
-    }
+   public boolean containsFile(String file) {
+       return (file != null) && linkedFontFiles.contains(file);
+   }
+
+   public String[] getFontNames() {
+      return linkedFontNames.toArray(new String[0]);
+   }
+
+   public String[] getFontFiles() {
+      return linkedFontFiles.toArray(new String[0]);
+   }
+  
+   public FontResource[] getFonts() {
+      return linkedFonts.toArray(new FontResource[0]);
+   }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/LogicalFont.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/LogicalFont.java
@@ -420,10 +420,6 @@ public class LogicalFont implements CompositeFontResource {
         int slot = (glyphCode >>> 24);
         int slotglyphCode = glyphCode & CompositeGlyphMapper.GLYPHMASK;
         FontResource slotResource = getSlotResource(slot);
-        if (slotResource == null) {
-            float[] arr = { 0f, 0f, 10f, 10f };
-            return arr;
-        }
         return slotResource.getGlyphBoundingBox(slotglyphCode, size, retArr);
    }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/LogicalFont.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/LogicalFont.java
@@ -203,41 +203,37 @@ public class LogicalFont implements CompositeFontResource {
         return slot0FontResource;
     }
 
-    private ArrayList<String> linkedFontFiles;
-    private ArrayList<String> linkedFontNames;
-    private FontResource[] fallbacks;
-    private FontResource[] nativeFallbacks;
+    volatile private String[] linkedFontNames;
+    volatile private String[] linkedFontFiles;
+    volatile private FontResource[] fallbacks;
+    volatile private FontResource[] nativeFallbacks;
 
     private void getLinkedFonts() {
         if (fallbacks == null) {
-            ArrayList<String>[] linkedFontInfo;
-            if (PrismFontFactory.isLinux) {
-                FontConfigManager.FcCompFont font =
-                    FontConfigManager.getFontConfigFont(familyName,
-                                                        isBold, isItalic);
-                linkedFontFiles = FontConfigManager.getFileNames(font, true);
-                linkedFontNames = FontConfigManager.getFontNames(font, true);
-            } else {
-                linkedFontInfo = PrismFontFactory.getLinkedFonts("Tahoma", true);
-                linkedFontFiles = linkedFontInfo[0];
-                linkedFontNames = linkedFontInfo[1];
-            }
-            fallbacks = new FontResource[linkedFontFiles.size()];
+            PrismFontFactory factory = PrismFontFactory.getFontFactory();
+            FontFallbackInfo fallbackInfo = factory.getFallbacks(getSlot0Resource());
+            linkedFontNames = fallbackInfo.getFontNames();
+            linkedFontFiles = fallbackInfo.getFontFiles();
+            fallbacks       = fallbackInfo.getFonts();
         }
     }
 
     @Override
     public int getNumSlots() {
         getLinkedFonts();
-        int num = linkedFontFiles.size();
+        int num = fallbacks.length;
         if (nativeFallbacks != null) {
             num += nativeFallbacks.length;
         }
         return num + 1;
     }
 
-    @Override
-    public int getSlotForFont(String fontName) {
+    private int getSlotForFontNoCreate(String fontName) {
+
+        if (fontName.equals(getSlot0Resource().getFullName())) {
+            return 0;
+        }
+
         getLinkedFonts();
         int i = 1;
         for (String linkedFontName : linkedFontNames) {
@@ -254,8 +250,36 @@ public class LogicalFont implements CompositeFontResource {
                 i++;
             }
         }
+        return -1;
+    }
 
-        if (i >= 0x7E) {
+    @Override
+    public int getSlotForFont(String fontName) {
+        int slot = getSlotForFontNoCreate(fontName);
+        if (slot >= 0) {
+            return slot;
+        }
+
+        PrismFontFactory factory = PrismFontFactory.getFontFactory();
+        FontResource fr = factory.getFontResource(fontName, null, false);
+        if (fr == null) {
+            if (PrismFontFactory.debugFonts) {
+                System.err.println("\t Font name not supported \"" + fontName + "\".");
+            }
+            return -1;
+        }
+        slot = getSlotForFontNoCreate(fr.getFullName());
+        if (slot >= 0) {
+            return slot;
+        }
+
+        /* Add the font to the list of native fallbacks */
+        return addNativeFallback(fr);
+    }
+
+    private int addNativeFallback(FontResource fr) {
+        int ns = getNumSlots();
+        if (ns >= 0x7E) {
             /* There are 8bits (0xFF) reserved in a glyph code to store the slot
              * number. The first bit cannot be set to avoid negative values
              * (leaving 0x7F). The extra -1 (leaving 0x7E) is to account for
@@ -266,15 +290,6 @@ public class LogicalFont implements CompositeFontResource {
             }
             return -1;
         }
-        PrismFontFactory factory = PrismFontFactory.getFontFactory();
-        FontResource fr = factory.getFontResource(fontName, null, false);
-        if (fr == null) {
-            if (PrismFontFactory.debugFonts) {
-                System.err.println("\t Font name not supported \"" + fontName + "\".");
-            }
-            return -1;
-        }
-
         /* Add the font to the list of native fallbacks */
         FontResource[] tmp;
         if (nativeFallbacks == null) {
@@ -286,7 +301,19 @@ public class LogicalFont implements CompositeFontResource {
         tmp[tmp.length - 1] = fr;
         nativeFallbacks = tmp;
 
-        return i;
+        return ns;
+    }
+
+    public int addSlotFont(FontResource fr) {
+        if (fr == null) {
+            return -1;
+        }
+        int slot = getSlotForFont(fr.getFullName());
+        if (slot >= 0) {
+            return slot;
+        } else {
+            return addNativeFallback(fr);
+        }
     }
 
     @Override
@@ -304,8 +331,8 @@ public class LogicalFont implements CompositeFontResource {
                 return nativeFallbacks[slot];
             }
             if (fallbacks[slot] == null) {
-                String file = linkedFontFiles.get(slot);
-                String name = linkedFontNames.get(slot);
+                String file = linkedFontFiles[slot];
+                String name = linkedFontNames[slot];
                 fallbacks[slot] =
                     PrismFontFactory.getFontFactory().
                           getFontResource(name, file, false);
@@ -393,6 +420,10 @@ public class LogicalFont implements CompositeFontResource {
         int slot = (glyphCode >>> 24);
         int slotglyphCode = glyphCode & CompositeGlyphMapper.GLYPHMASK;
         FontResource slotResource = getSlotResource(slot);
+        if (slotResource == null) {
+            float[] arr = { 0f, 0f, 10f, 10f };
+            return arr;
+        }
         return slotResource.getGlyphBoundingBox(slotglyphCode, size, retArr);
    }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/MacFontFinder.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/MacFontFinder.java
@@ -33,7 +33,7 @@ import java.util.Locale;
 
 import com.sun.glass.utils.NativeLibLoader;
 
-class MacFontFinder {
+public class MacFontFinder {
 
     static {
         @SuppressWarnings("removal")
@@ -109,5 +109,8 @@ class MacFontFinder {
      * @return array of post-script font names
      */
     private native static String[] getFontData();
+
+    public native static String[] getCascadeList(long fontRef);
+    public native static long[] getCascadeListRefs(long fontRef);
 }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismCompositeFontResource.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismCompositeFontResource.java
@@ -53,11 +53,7 @@ class PrismCompositeFontResource implements CompositeFontResource {
             factory.compResourceMap.put(lookupName, this);
         }
         this.primaryResource = primaryResource;
-        int aaMode = primaryResource.getDefaultAAMode();
-        boolean bold = primaryResource.isBold();
-        boolean italic = primaryResource.isItalic();
-        fallbackResource =
-              FallbackResource.getFallbackResource(bold, italic, aaMode);
+        fallbackResource = FallbackResource.getFallbackResource(primaryResource);
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
@@ -242,7 +242,7 @@ public abstract class PrismFontFactory implements FontFactory {
          * macOS: we need to load unique fonts for regular and bold.
          * Probably this should be handled elsewhere
          */
-        if (isMacOSX && name.startsWith("System ")) {
+        if (isMacOSX && (name != null) && name.startsWith("System ")) {
             key += name;
         }
         PrismFontFile fr = fileNameToFontResourceMap.get(key);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
@@ -284,7 +284,7 @@ public abstract class PrismFontFactory implements FontFactory {
              PrismFontFile fr = createFontFile(null, filename, 0, false, false, false, false);
 
              int cnt = fr.getFontCount();
-             if (cnt == 1) {
+             if (cnt == 1 || fr.getFullName().equalsIgnoreCase(targetName)) {
                  return 0;
              }
              int index = 1;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
@@ -238,6 +238,13 @@ public abstract class PrismFontFactory implements FontFactory {
                                              boolean register, boolean embedded,
                                              boolean copy, boolean tracked) {
         String key = (filename+index).toLowerCase();
+        /*
+         * macOS: we need to load unique fonts for regular and bold.
+         * Probably this should be handled elsewhere
+         */
+        if (isMacOSX && name.startsWith("System ")) {
+            key += name;
+        }
         PrismFontFile fr = fileNameToFontResourceMap.get(key);
         if (fr != null) {
             return fr;
@@ -247,6 +254,15 @@ public abstract class PrismFontFactory implements FontFactory {
             fr = createFontFile(name, filename, index, register,
                                 embedded, copy, tracked);
             if (register) {
+                // Although it looks tempting here to store the lookup name
+                // as what we matched, it isn't safe to do so.
+                // We may be iterating over fonts in a TTC, or (some day)
+                // a TTF with font variations. So we don't want to just store the name
+                // But there also times (ie "System Font" on macOS - that's a macOS name
+                // not JavaFX System font) when the name in the font still does
+                // not match what macOS told us but we need to register it anyway
+                // That needs to be handled by the caller of that case - see
+                // createFontResource() below.
                 storeInMap(fr.getFullName(), fr);
                 fileNameToFontResourceMap.put(key, fr);
             }
@@ -259,15 +275,55 @@ public abstract class PrismFontFactory implements FontFactory {
         }
     }
 
+   /*
+    * Whether a ttf or ttc this will find the index of the named font.
+    */
+   public int findFontIndex(String targetName, String filename) {
+
+         try {
+             PrismFontFile fr = createFontFile(null, filename, 0, false, false, false, false);
+
+             int cnt = fr.getFontCount();
+             if (cnt == 1) {
+                 return 0;
+             }
+             int index = 1;
+             do {
+                 fr = createFontFile(null, filename, index, false, false, false, false);
+                 String name = fr.getFullName();
+                 if (name.equalsIgnoreCase(targetName)) {
+                     return index;
+                 }
+             } while (++index < cnt);
+         } catch (Exception e) {
+             if (PrismFontFactory.debugFonts) {
+                 e.printStackTrace();
+             }
+         }
+         return -1;
+   }
+
     private PrismFontFile createFontResource(String name, String filename) {
         PrismFontFile[] pffArr =
             createFontResources(name, filename,
-                                true, false, false, false, false);
+                                true, false, false, false, true);
         if (pffArr == null || pffArr.length == 0) {
            return null;
         } else {
-           return pffArr[0];
+           for (int i = 0; i < pffArr.length; i++) {
+               if (pffArr[i].getFullName().equalsIgnoreCase(name)) {
+                   return pffArr[i];
+               }
+           }
         }
+        // No exact match - we don't want to repeat the look up so
+        // log this, but store the specified name as the key to
+        // match first font in this file
+        storeInMap(name, pffArr[0]);
+        if (PrismFontFactory.debugFonts) {
+            System.err.println("No match for name " + name + " in " + filename);
+        }
+        return pffArr[0];
     }
 
     private PrismFontFile[] createFontResources(String name, String filename,
@@ -350,7 +406,7 @@ public abstract class PrismFontFactory implements FontFactory {
         }
     }
 
-    private void storeInMap(String name, FontResource resource) {
+    protected void storeInMap(String name, FontResource resource) {
         if (name == null || resource == null) {
             return;
         }
@@ -555,7 +611,7 @@ public abstract class PrismFontFactory implements FontFactory {
     public synchronized PGFont createFont(String familyName, boolean bold,
                                           boolean italic, float size) {
         FontResource fr = null;
-        if (familyName != null && !familyName.isEmpty()) {
+        if (familyName != null && !familyName.isEmpty() && !isExcluded(familyName)) {
             PGFont logFont =
                 LogicalFont.getLogicalFont(familyName, bold, italic, size);
             if (logFont != null) {
@@ -575,7 +631,7 @@ public abstract class PrismFontFactory implements FontFactory {
     public synchronized PGFont createFont(String name, float size) {
 
         FontResource fr = null;
-        if (name != null && !name.isEmpty()) {
+        if (name != null && !name.isEmpty() && !isExcluded(name)) {
             PGFont logFont =
                 LogicalFont.getLogicalFont(name, size);
             if (logFont != null) {
@@ -919,106 +975,6 @@ public abstract class PrismFontFactory implements FontFactory {
         }
     }
 
-    /**
-      * This will return an array of size 2, each element being an array
-      * list of <code>String</code>. The first (zeroth) array holds file
-      * names, and, the second array holds the corresponding fontnames.
-      * If the file does not have a corresponding font name, its corresponding
-      * name is assigned an empty string "".
-      * As a further complication, Windows 7 frequently lists a font twice,
-      * once with some scaling values, and again without. We don't use this
-      * so find these and exclude duplicates.
-      */
-    static ArrayList<String> [] getLinkedFonts(String searchFont,
-                                               boolean addSearchFont) {
-
-
-        ArrayList<String> [] fontRegInfo = new ArrayList[2];
-        // index 0 = file names, 1 = font name.
-        // the name is only specified for TTC files.
-        fontRegInfo[0] = new ArrayList<>();
-        fontRegInfo[1] = new ArrayList<>();
-
-        if (isMacOSX) {
-            // Hotkey implementation of fallback font on Mac
-            fontRegInfo[0].add("/Library/Fonts/Arial Unicode.ttf");
-            fontRegInfo[1].add("Arial Unicode MS");
-
-            // Add Lucida Sans Regular to Mac OS X fallback list
-            fontRegInfo[0].add(jreFontDir + jreDefaultFontFile);
-            fontRegInfo[1].add(jreDefaultFont);
-
-            // Add Apple Symbols to Mac OS X fallback list
-            fontRegInfo[0].add("/System/Library/Fonts/Apple Symbols.ttf");
-            fontRegInfo[1].add("Apple Symbols");
-
-            // Add Apple Emoji Symbols to Mac OS X fallback list
-            fontRegInfo[0].add("/System/Library/Fonts/Apple Color Emoji.ttc");
-            fontRegInfo[1].add("Apple Color Emoji");
-
-            // Add CJK Ext B supplementary characters.
-            fontRegInfo[0].add("/System/Library/Fonts/STHeiti Light.ttf");
-            fontRegInfo[1].add("Heiti SC Light");
-
-            return fontRegInfo;
-        }
-        if (!isWindows) {
-            return fontRegInfo;
-        }
-
-        if (addSearchFont) {
-            fontRegInfo[0].add(null);
-            fontRegInfo[1].add(searchFont);
-        }
-
-        String fontRegBuf = regReadFontLink(searchFont);
-        if (fontRegBuf != null && fontRegBuf.length() > 0) {
-            // split registry data into null terminated strings
-            String[] fontRegList = fontRegBuf.split("\u0000");
-            int linkListLen = fontRegList.length;
-            for (int i=0; i < linkListLen; i++) {
-                String[] splitFontData = fontRegList[i].split(",");
-                int len = splitFontData.length;
-                String file = getPathNameWindows(splitFontData[0]);
-                String name = (len > 1) ? splitFontData[1] : null;
-                if (name != null && fontRegInfo[1].contains(name)) {
-                    continue;
-                } else if (name == null && fontRegInfo[0].contains(file)) {
-                    continue;
-                }
-                fontRegInfo[0].add(file);
-                fontRegInfo[1].add(name);
-            }
-        }
-
-        String eudcFontFile = getEUDCFontFile();
-        if (eudcFontFile != null) {
-            fontRegInfo[0].add(eudcFontFile);
-            fontRegInfo[1].add(null);
-        }
-
-        // Add Lucida Sans Regular to Windows fallback list
-        fontRegInfo[0].add(jreFontDir + jreDefaultFontFile);
-        fontRegInfo[1].add(jreDefaultFont);
-
-        if (PlatformUtil.isWinVistaOrLater()) {
-            // CJK Ext B Supplementary character fallbacks.
-            fontRegInfo[0].add(getPathNameWindows("mingliub.ttc"));
-            fontRegInfo[1].add("MingLiU-ExtB");
-
-            if (PlatformUtil.isWin7OrLater()) {
-                // Add Segoe UI Symbol to Windows 7 or later fallback list
-                fontRegInfo[0].add(getPathNameWindows("seguisym.ttf"));
-                fontRegInfo[1].add("Segoe UI Symbol");
-            } else {
-                // Add Cambria Math to Windows Vista fallback list
-                fontRegInfo[0].add(getPathNameWindows("cambria.ttc"));
-                fontRegInfo[1].add("Cambria Math");
-            }
-        }
-        return fontRegInfo;
-    }
-
     /* This is needed since some windows registry names don't match
      * the font names.
      * - UPC styled font names have a double space, but the
@@ -1196,7 +1152,7 @@ public abstract class PrismFontFactory implements FontFactory {
                                      familyToFontListMap,
                                  Locale locale);
 
-    static String getPathNameWindows(final String filename) {
+    protected static String getPathNameWindows(final String filename) {
         if (filename == null) {
             return null;
         }
@@ -1231,6 +1187,16 @@ public abstract class PrismFontFactory implements FontFactory {
         return null; //  shouldn't happen.
     }
 
+    /*
+     * Do not return matching names via public API.
+     * Some names may be needed for internal matching but
+     * never exposed to application code.
+     * Initially this only excludes certain names on macOS.
+     */
+    public boolean isExcluded(String name) {
+        return false;
+    }
+
     private static ArrayList<String> allFamilyNames;
     @Override
     public String[] getFontFamilyNames() {
@@ -1256,7 +1222,9 @@ public abstract class PrismFontFactory implements FontFactory {
             getFullNameToFileMap();
             for (String f : fontToFamilyNameMap.values()) {
                 if (!familyNames.contains(f)) {
-                    familyNames.add(f);
+                    if (!isExcluded(f)) {
+                        familyNames.add(f);
+                    }
                 }
             }
             Collections.sort(familyNames);
@@ -1286,7 +1254,9 @@ public abstract class PrismFontFactory implements FontFactory {
             getFullNameToFileMap();
             for (ArrayList<String> a : familyToFontListMap.values()) {
                 for (String s : a) {
-                    fontNames.add(s);
+                    if (!isExcluded(s)) {
+                        fontNames.add(s);
+                    }
                 }
             }
             Collections.sort(fontNames);
@@ -1298,6 +1268,9 @@ public abstract class PrismFontFactory implements FontFactory {
     @Override
     public String[] getFontFullNames(String family) {
 
+        if (isExcluded(family)) {
+            return STR_ARRAY;
+        }
         // First check if its a logical font family.
         String[] logFonts = LogicalFont.getFontsInFamily(family);
         if (logFonts != null) {
@@ -1748,6 +1721,12 @@ public abstract class PrismFontFactory implements FontFactory {
                                                       familyToFontListMap,
                                                       Locale.ENGLISH);
 
+                if (debugFonts) {
+                    logFontInfo(" *** MACOS LOCATED FONTS:",
+                                tmpFontToFileMap,
+                                fontToFamilyNameMap,
+                                familyToFontListMap);
+                }
             } else if (isLinux) {
                 FontConfigManager.populateMaps(tmpFontToFileMap,
                                                fontToFamilyNameMap,
@@ -1985,4 +1964,6 @@ public abstract class PrismFontFactory implements FontFactory {
 
     /* Called from PrismFontFile which caches the return value */
     static native short getSystemLCID();
+
+    public abstract FontFallbackInfo getFallbacks(FontResource primaryResource);
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFactory.java
@@ -955,8 +955,6 @@ public abstract class PrismFontFactory implements FontFactory {
     private static String userFontDir = null;
 
     private static native byte[] getFontPath();
-    private static native String regReadFontLink(String searchfont);
-    private static native String getEUDCFontFile();
 
     private static void getPlatformFontDirs() {
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFile.java
@@ -64,7 +64,7 @@ public abstract class PrismFontFile implements FontResource, FontConstants {
     // then its really expensive as all font files need to be opened.
     //
     String familyName;           /* Family font name (English) */
-    String fullName;             /* Full font name (English)   */
+    protected String fullName;   /* Full font name (English)   */
     String psName;               /* PostScript font name       */
     String localeFamilyName;
     String localeFullName;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFile.java
@@ -559,6 +559,9 @@ public abstract class PrismFontFile implements FontResource, FontConstants {
             }
 
             DirectoryEntry headDE = getDirectoryEntry(headTag);
+            if (headDE == null) {
+                throw new Exception("No header table - font is invalid.");
+            }
             Buffer headTable = filereader.readBlock(headDE.offset,
                                                     headDE.length);
             // Important font attribute must be set in order to prevent div by zero
@@ -624,7 +627,7 @@ public abstract class PrismFontFile implements FontResource, FontConstants {
                 if (familyName == null) {
                     familyName = fullName != null ? fullName : fontName;
                 }
-                throw new Exception("Font name not found.");
+                throw new Exception("Font name not found in " + filename);
             }
 
             /* update the font resource only if the file was decoded
@@ -764,6 +767,8 @@ public abstract class PrismFontFile implements FontResource, FontConstants {
     }
 
     /* -- ID's used in the 'name' table */
+    public static final int UNICODE_PLATFORM_ID = 0;
+
     public static final int MAC_PLATFORM_ID = 1;
     public static final int MACROMAN_SPECIFIC_ID = 0;
     public static final int MACROMAN_ENGLISH_LANG = 0;
@@ -797,8 +802,9 @@ public abstract class PrismFontFile implements FontResource, FontConstants {
          */
         for (int i=0; i<numRecords; i++) {
             short platformID = buffer.getShort();
-            if (platformID != MS_PLATFORM_ID &&
-                platformID != MAC_PLATFORM_ID) {
+            if ((platformID != UNICODE_PLATFORM_ID) &&
+                (platformID != MS_PLATFORM_ID) &&
+                (platformID != MAC_PLATFORM_ID)) {
                 buffer.skip(10);
                 continue; // skip over this record.
             }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFactory.java
@@ -25,6 +25,11 @@
 
 package com.sun.javafx.font.coretext;
 
+import java.util.ArrayList;
+
+import com.sun.javafx.font.FallbackResource;
+import com.sun.javafx.font.FontFallbackInfo;
+import com.sun.javafx.font.FontResource;
 import com.sun.javafx.font.PrismFontFactory;
 import com.sun.javafx.font.PrismFontFile;
 import com.sun.javafx.text.GlyphLayout;
@@ -36,6 +41,28 @@ public class CTFactory extends PrismFontFactory {
     }
 
     private CTFactory() {
+    }
+
+    /*
+     * This is needed for fonts where the name starts with "."
+     * It isn't just the ".SF" "System Font", but related fallbacks which
+     * layout returns and we need to add as a native fallback to a composite font.
+     */
+    CTFontFile createFontFile(String name, long fontRef) throws Exception {
+        String filename = OS.CTFontCopyURLAttribute(fontRef);
+        int fIndex = findFontIndex(name, filename);
+
+        if (debugFonts) {
+            System.err.println("createFontFile by ref name="+name + " filename="+filename+" index="+fIndex);
+        }
+        if (fIndex == -1) {
+            return null;
+        }
+        CTFontFile font = new CTFontFile(name, filename, fIndex, fontRef);
+        // Store the lookup name in the map.
+        // This should prevent us needing to create new instances.
+        storeInMap(name, font);
+        return font;
     }
 
     @Override
@@ -62,5 +89,67 @@ public class CTFactory extends PrismFontFactory {
             }
         }
         return result;
+    }
+
+    /*
+     * This should prevent enumeration of special fonts, but also should
+     * be used to prevent public lookup of these even if not enumerated
+     */
+    @Override
+    public boolean isExcluded(String name) {
+         return name.startsWith(".") || name.startsWith("System Font");
+    }
+
+    public FontFallbackInfo getFallbacks(FontResource primaryResource) {
+        FontFallbackInfo info = new FontFallbackInfo();
+        ArrayList<String> names;
+        ArrayList<String> files;
+        ArrayList<String> fonts;
+
+        // First add cascading font list.
+        if (primaryResource instanceof CTFontFile ctff) {
+           ctff.getCascadingInfo(info);
+        }
+        // ELSE: REMIND we can get the default cascading list for this case.
+        // Do this only if we find we end up here, which I think unlikely today.
+
+        String name = "System Regular"; // a default
+        boolean bold = false;
+        if (primaryResource != null) {
+            name = primaryResource.getFullName();
+            bold = primaryResource.isBold();
+        }
+
+        // The "." fonts for Japanese, Korean, Simplified Chinese, HK Chinese, TW Chinese
+        // do not report a file, so out of caution, let's add some known fallbacks used
+        // by Arial and Arial Bold for these scripts.
+        // Note: even if "." fonts do report a file, macOS does not like apps looking
+        // them up that way.
+        if (name.startsWith("System ")) {
+           if (!bold) {
+               info.add("Hiragino Sans W3", "/System/Library/Fonts/ヒラギノ角ゴシック W3.ttc", null);
+               info.add("Hiragino Sans GB W3", "/System/Library/Fonts/Hiragino Sans GB.ttc", null);
+               info.add("Apple SD Gothic Neo Regular", "/System/Library/Fonts/AppleSDGothicNeo.ttc", null);
+               info.add("PingFang SC Regular", "/System/Library/Fonts/PingFang.ttc", null);
+               info.add("PingFang TC Regular", "/System/Library/Fonts/PingFang.ttc", null);
+               info.add("PingFang HK Regular", "/System/Library/Fonts/PingFang.ttc", null);
+           } else {
+               info.add("Hiragino Sans W6", "/System/Library/Fonts/ヒラギノ角ゴシック W6.ttc", null);
+               info.add("Hiragino Sans GB W6", "System/Library/Fonts/Hiragino Sans GB.ttc", null);
+               info.add("Apple SD Gothic Neo Bold", "/System/Library/Fonts/AppleSDGothicNeo.ttc", null);
+               info.add("PingFang SC Semibold", "/System/Library/Fonts/PingFang.ttc", null);
+               info.add("PingFang TC Semibold", "/System/Library/Fonts/PingFang.ttc", null);
+               info.add("PingFang HK Semibold", "/System/Library/Fonts/PingFang.ttc", null);
+           }
+        }
+
+        // Now add hardwired fall backs in case of problems with the above.
+        info.add("Apple Symbols", "/System/Library/Fonts/Apple Symbols.ttf", null);
+        info.add("Apple Color Emoji", "/System/Library/Fonts/Apple Color Emoji.ttc", null);
+        info.add("Arial Unicode MS", "/Library/Fonts/Arial Unicode.ttf", null);
+        // Add CJK Ext B supplementary characters.
+        info.add("Heiti SC Light", "/System/Library/Fonts/STHeiti Light.ttc", null);
+
+        return info;
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFactory.java
@@ -50,15 +50,6 @@ public class CTFactory extends PrismFontFactory {
      */
     CTFontFile createFontFile(String name, long fontRef) throws Exception {
         String filename = OS.CTFontCopyURLAttribute(fontRef);
-        // macOS 13 Ventura reports ".ThonburiUI Regular Regular" as the name
-        // of font used for Thai. Per inspection of the font this is incorrect.
-        // Need to do fix up here.
-        if (name.endsWith(" Regular Regular")) {
-            if (debugFonts) {
-                System.err.println("Fix up double use of Regular in name : " + name);
-            }
-            name = name.replaceFirst(" Regular Regular", " Regular");
-        }
         int fIndex = findFontIndex(name, filename);
 
         if (debugFonts) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFactory.java
@@ -52,10 +52,10 @@ public class CTFactory extends PrismFontFactory {
         String filename = OS.CTFontCopyURLAttribute(fontRef);
         // macOS 13 Ventura reports ".ThonburiUI Regular Regular" as the name
         // of font used for Thai. Per inspection of the font this is incorrect.
-        // Need to do fix up here. I 
+        // Need to do fix up here.
         if (name.endsWith(" Regular Regular")) {
-            System.err.println("Fix up double use of Regular in name : " + name);
             if (debugFonts) {
+                System.err.println("Fix up double use of Regular in name : " + name);
             }
             name = name.replaceFirst(" Regular Regular", " Regular");
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFactory.java
@@ -50,6 +50,15 @@ public class CTFactory extends PrismFontFactory {
      */
     CTFontFile createFontFile(String name, long fontRef) throws Exception {
         String filename = OS.CTFontCopyURLAttribute(fontRef);
+        // macOS 13 Ventura reports ".ThonburiUI Regular Regular" as the name
+        // of font used for Thai. Per inspection of the font this is incorrect.
+        // Need to do fix up here. I 
+        if (name.endsWith(" Regular Regular")) {
+            System.err.println("Fix up double use of Regular in name : " + name);
+            if (debugFonts) {
+            }
+            name = name.replaceFirst(" Regular Regular", " Regular");
+        }
         int fIndex = findFontIndex(name, filename);
 
         if (debugFonts) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
@@ -27,7 +27,10 @@ package com.sun.javafx.font.coretext;
 
 import com.sun.javafx.font.Disposer;
 import com.sun.javafx.font.DisposerRecord;
+import com.sun.javafx.font.FontFallbackInfo;
 import com.sun.javafx.font.FontStrikeDesc;
+import com.sun.javafx.font.MacFontFinder;
+import com.sun.javafx.font.PrismFontFactory;
 import com.sun.javafx.font.PrismFontFile;
 import com.sun.javafx.font.PrismFontStrike;
 import com.sun.javafx.geom.Path2D;
@@ -35,7 +38,7 @@ import com.sun.javafx.geom.transform.BaseTransform;
 
 class CTFontFile extends PrismFontFile {
 
-    private final long cgFontRef;
+    private long cgFontRef = 0;
     /* Transform used for outline and bounds */
     private final static CGAffineTransform tx = new CGAffineTransform();
     static {
@@ -44,25 +47,50 @@ class CTFontFile extends PrismFontFile {
     }
 
     private static class SelfDisposerRecord implements DisposerRecord {
-        private long cgFontRef;
+        private long fontRef;
 
-        SelfDisposerRecord(long cgFontRef) {
-            this.cgFontRef = cgFontRef;
+        SelfDisposerRecord(long fontRef) {
+            this.fontRef = fontRef;
         }
 
         @Override
         public synchronized void dispose() {
-            if (cgFontRef != 0) {
-                OS.CFRelease(cgFontRef);
-                cgFontRef = 0;
+            if (fontRef != 0) {
+                OS.CFRelease(fontRef);
+                fontRef = 0;
             }
         }
+    }
+
+    private long ctFontRef = 0;
+    CTFontFile(String name, String filename, int fIndex, long fontRef) throws Exception {
+        super(name, filename, fIndex, false, false, false, false);
+
+        if (fontRef == 0) {
+           throw new InternalError("Zero fontref");
+        }
+        ctFontRef = fontRef;
+        //OS.CFRetain(ctFontRef);
+        Disposer.addRecord(this, new SelfDisposerRecord(ctFontRef));
     }
 
     CTFontFile(String name, String filename, int fIndex, boolean register,
                boolean embedded, boolean copy, boolean tracked) throws Exception {
         super(name, filename, fIndex, register, embedded, copy, tracked);
 
+        // The super-class code that opens and reads the font can't handle font variations,
+        // as used by the macOS "System Font"
+        // So when we see a font from this family, we need to use the original name
+        // passed in here as the full name.
+        // No question, this isn't robust against Apple changing the name of the font
+        // but I think it fairly unlikely.
+
+        if (name != null) {
+            String family = getFamilyName();
+            if (family.equals("System Font")) {
+                fullName = name;
+            }
+        }
         if (embedded) {
             cgFontRef = createCGFontForEmbeddedFont();
             Disposer.addRecord(this, new SelfDisposerRecord(cgFontRef));
@@ -97,7 +125,7 @@ class CTFontFile extends PrismFontFile {
                     OS.kCFAllocatorDefault(), fileNameRef,
                     OS.kCFURLPOSIXPathStyle, false);
             if (url != 0) {
-                final long dataProvider = OS.CGDataProviderCreateWithURL(url);
+                long dataProvider = OS.CGDataProviderCreateWithURL(url);
                 if (dataProvider != 0) {
                     cgFontRef = OS.CGFontCreateWithDataProvider(dataProvider);
                     OS.CFRelease(dataProvider);
@@ -202,4 +230,64 @@ class CTFontFile extends PrismFontFile {
         return new CTFontStrike(this, size, transform, aaMode, desc);
     }
 
+    long getFontRef(float size, CGAffineTransform matrix) {
+      long retRef = 0;
+      if (isEmbeddedFont()) {
+          if (cgFontRef != 0) {
+             retRef = OS.CTFontCreateWithGraphicsFont(cgFontRef, size, matrix, 0);
+             //OS.CFRetain(cgFontRef);
+          }
+      } else if (ctFontRef != 0) {
+           retRef = OS.CTFontCreateCopyWithAttributes(ctFontRef, size, matrix, 0);
+      } else {
+          String psName = getPSName();
+          if (psName.startsWith(".")) {
+               boolean bold = getFullName().indexOf("Bold") > 0;
+               retRef = OS.CTFontCreateUIFontForLanguage(size, matrix, bold);
+          } else {
+              final long psNameRef = OS.CFStringCreate(psName);
+              if (psNameRef != 0) {
+                  retRef = OS.CTFontCreateWithName(psNameRef, size, matrix);
+                  OS.CFRelease(psNameRef);
+              }
+           }
+       }
+        return retRef;
+    }
+
+    void getCascadingInfo(FontFallbackInfo info) {
+        CTFactory factory = (CTFactory)PrismFontFactory.getFontFactory();
+        long ref = getFontRef(0f, null);
+        String[] stringInfo = MacFontFinder.getCascadeList(ref);
+        // stringInfo is displayname and file.
+        // if there's a null file, skip
+        // if there's a non-null file but name starts with ".",
+        // we'd need a fontRef to use it since macOS won't let us create it.
+        // So we need to skip that case too - unless/until I find an answer to that
+        // in which case we could use Factory.createFontFile(name, ref); and
+        // pass a font instead of null.
+        if (PrismFontFactory.debugFonts) {
+            System.err.println("Cascading list for " + getFullName());
+        }
+        for (int i=0; i<stringInfo.length;i+=2) {
+            String name = stringInfo[i];
+            String file = stringInfo[i+1];
+            if (PrismFontFactory.debugFonts) {
+                System.err.print("Entry : name=" + name + " file="+file);
+            }
+            if (file == null || name.startsWith(".")) {
+                if (PrismFontFactory.debugFonts) {
+                    System.err.println(" - *** not using this entry (.font and/or null file)");
+                }
+                continue;
+            }
+            if (PrismFontFactory.debugFonts) {
+                System.err.println();
+            }
+            info.add(name, file, null);
+        }
+        if (PrismFontFactory.debugFonts) {
+             System.err.println("End cascading list");
+        }
+    }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
@@ -102,8 +102,8 @@ class CTFontFile extends PrismFontFile {
     public boolean isBold() {
         // Need to do this until we add font variation support into the super-class
         return fullName.equals("System Font Bold");
-    } 
-       
+    }
+ 
     public static boolean registerFont(String fontfile) {
         if (fontfile == null) return false;
         long alloc = OS.kCFAllocatorDefault();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
@@ -103,7 +103,7 @@ class CTFontFile extends PrismFontFile {
         // Need to do this until we add font variation support into the super-class
         return fullName.equals("System Font Bold");
     }
- 
+
     public static boolean registerFont(String fontfile) {
         if (fontfile == null) return false;
         long alloc = OS.kCFAllocatorDefault();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
@@ -82,8 +82,8 @@ class CTFontFile extends PrismFontFile {
         // as used by the macOS "System Font"
         // So when we see a font from this family, we need to use the original name
         // passed in here as the full name.
-        // No question, this isn't robust against Apple changing the name of the font
-        // but I think it fairly unlikely.
+        // This isn't robust against Apple changing the name of the font
+        // but I think it sufficient until we add support for font variations.
 
         if (name != null) {
             String family = getFamilyName();
@@ -99,6 +99,12 @@ class CTFontFile extends PrismFontFile {
         }
     }
 
+    @Override
+    public boolean isBold() {
+        // Need to do this until we add font variation support into the super-class
+        return fullName.equals("System Font Bold");
+    } 
+       
     public static boolean registerFont(String fontfile) {
         if (fontfile == null) return false;
         long alloc = OS.kCFAllocatorDefault();
@@ -235,7 +241,6 @@ class CTFontFile extends PrismFontFile {
       if (isEmbeddedFont()) {
           if (cgFontRef != 0) {
              retRef = OS.CTFontCreateWithGraphicsFont(cgFontRef, size, matrix, 0);
-             //OS.CFRetain(cgFontRef);
           }
       } else if (ctFontRef != 0) {
            retRef = OS.CTFontCreateCopyWithAttributes(ctFontRef, size, matrix, 0);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
@@ -70,7 +70,6 @@ class CTFontFile extends PrismFontFile {
            throw new InternalError("Zero fontref");
         }
         ctFontRef = fontRef;
-        //OS.CFRetain(ctFontRef);
         Disposer.addRecord(this, new SelfDisposerRecord(ctFontRef));
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
@@ -273,7 +273,7 @@ class CTFontFile extends PrismFontFile {
         if (PrismFontFactory.debugFonts) {
             System.err.println("Cascading list for " + getFullName());
         }
-        for (int i=0; i<stringInfo.length;i+=2) {
+        for (int i=0; i<stringInfo.length; i+=2) {
             String name = stringInfo[i];
             String file = stringInfo[i+1];
             if (PrismFontFactory.debugFonts) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontFile.java
@@ -101,7 +101,7 @@ class CTFontFile extends PrismFontFile {
     @Override
     public boolean isBold() {
         // Need to do this until we add font variation support into the super-class
-        return fullName.equals("System Font Bold");
+        return fullName.equals("System Font Bold") || super.isBold();
     }
 
     public static boolean registerFont(String fontfile) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontStrike.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFontStrike.java
@@ -78,19 +78,7 @@ class CTFontStrike extends PrismFontStrike<CTFontFile> {
             }
         }
 
-        if (fontResource.isEmbeddedFont()) {
-            final long cgFontRef = fontResource.getCGFontRef();
-            if (cgFontRef != 0) {
-                fontRef = OS.CTFontCreateWithGraphicsFont(
-                        cgFontRef, size, matrix, 0);
-            }
-        } else {
-            final long psNameRef = OS.CFStringCreate(fontResource.getPSName());
-            if (psNameRef != 0) {
-                fontRef = OS.CTFontCreateWithName(psNameRef, size, matrix);
-                OS.CFRelease(psNameRef);
-            }
-        }
+        fontRef = fontResource.getFontRef(size, matrix);
         if (fontRef == 0) {
             if (PrismFontFactory.debugFonts) {
                 System.err.println("Failed to create CTFont for " + this);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTGlyphLayout.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTGlyphLayout.java
@@ -80,6 +80,22 @@ class CTGlyphLayout extends GlyphLayout {
         if (!fontName.equalsIgnoreCase(name)) {
             if (fr == null) return -1;
             slot = fr.getSlotForFont(fontName);
+            if (slot == -1) {
+                 CTFontFile newFont = null;
+                 try {
+                     CTFactory factory = (CTFactory)PrismFontFactory.getFontFactory();
+                     long newRef = OS.CTFontCreateCopyWithAttributes(actualFont, 0, null,0);
+                      OS.CFRetain(newRef); // hope not needed ..
+                     newFont = factory.createFontFile(fontName, newRef);
+                     if (newFont != null) {
+                         slot = fr.addSlotFont(newFont);
+                     }
+                 } catch (Exception e) {
+                     if (PrismFontFactory.debugFonts) {
+                         e.printStackTrace();
+                     }
+                 }
+            }
             if (PrismFontFactory.debugFonts) {
                 System.err.println("\tFallback font= "+ fontName + " slot=" + slot);
             }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTGlyphLayout.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTGlyphLayout.java
@@ -79,6 +79,15 @@ class CTGlyphLayout extends GlyphLayout {
         if (fontName == null) return -1;
         if (!fontName.equalsIgnoreCase(name)) {
             if (fr == null) return -1;
+            // macOS 13 Ventura reports ".ThonburiUI Regular Regular" as the name
+            // of font used for Thai. Per inspection of the font this is incorrect.
+            // Need to do fix up here.
+            if (fontName.endsWith(" Regular Regular")) {
+                if (PrismFontFactory.debugFonts) {
+                    System.err.println("Fix up double use of Regular in name : " + fontName);
+                }
+                fontName = fontName.replaceFirst(" Regular Regular", " Regular");
+            }
             slot = fr.getSlotForFont(fontName);
             if (slot == -1) {
                  CTFontFile newFont = null;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/OS.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/OS.java
@@ -64,6 +64,7 @@ class OS {
     static final native Path2D CGPathApply(long path);
     static final native CGRect CGPathGetPathBoundingBox(long path);
     static final native long CFStringCreateWithCharacters(long alloc, char[] chars, long start, long numChars);
+    static final native String CTFontCopyURLAttribute(long font);
     static final native String CTFontCopyAttributeDisplayName(long font);
     static final native void CTFontDrawGlyphs(long font, short glyphs, double x, double y, long context);
     static final native double CTFontGetAdvancesForGlyphs(long font, int orientation, short glyphs, CGSize advances);
@@ -85,6 +86,7 @@ class OS {
     static final native void CFDictionaryAddValue(long theDict, long key, long value);
     static final native long CFDictionaryCreateMutable(long allocator, long capacity, long keyCallBacks, long valueCallBacks);
     static final native long CFDictionaryGetValue(long theDict, long key);
+    static final native void CFRetain(long cf);
     static final native void CFRelease(long cf);
     static final native long CFStringCreateWithCharacters(long alloc, char[] chars, long numChars);
     static final native long CFURLCreateWithFileSystemPath(long allocator, long filePath, long pathStyle, boolean isDirectory);
@@ -104,7 +106,9 @@ class OS {
     static final native long CGFontCreateWithDataProvider(long dataProvider);
     static final native void CGPathRelease(long path);
     static final native long CTFontCreatePathForGlyph(long font, short glyph, CGAffineTransform matrix);
+    static final native long CTFontCreateCopyWithAttributes(long cgFont, double size, CGAffineTransform matrix, long attributes);
     static final native long CTFontCreateWithGraphicsFont(long cgFont, double size, CGAffineTransform matrix, long attributes);
+    static final native long CTFontCreateUIFontForLanguage(double size, CGAffineTransform matrix, boolean bold);
     static final native long CTFontCreateWithName(long name, double size, CGAffineTransform matrix);
     static final native boolean CTFontManagerRegisterFontsForURL(long fontURL, int scope, long error);
     static final native long CTLineCreateWithAttributedString(long string);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/FTFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/FTFactory.java
@@ -25,6 +25,11 @@
 
 package com.sun.javafx.font.freetype;
 
+import java.util.ArrayList;
+
+import com.sun.javafx.font.FontConfigManager;
+import com.sun.javafx.font.FontFallbackInfo;
+import com.sun.javafx.font.FontResource;
 import com.sun.javafx.font.FontStrike;
 import com.sun.javafx.font.PGFont;
 import com.sun.javafx.font.PrismFontFactory;
@@ -122,4 +127,17 @@ public class FTFactory extends PrismFontFactory {
         }
     }
 
+    public FontFallbackInfo getFallbacks(FontResource primaryResource) {
+        boolean isBold = primaryResource.isBold();
+        boolean isItalic = primaryResource.isItalic();
+        FontConfigManager.FcCompFont font =
+            FontConfigManager.getFontConfigFont("sans", isBold, isItalic);
+        ArrayList<String> linkedFontFiles = FontConfigManager.getFileNames(font, false);
+        ArrayList<String> linkedFontNames = FontConfigManager.getFontNames(font, false);
+        FontFallbackInfo info = new FontFallbackInfo();
+        for (int i=0; i<linkedFontNames.size(); i++)  {
+            info.add(linkedFontNames.get(i), linkedFontFiles.get(i), null);
+        }
+        return info;
+    }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/text/ScriptMapper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/text/ScriptMapper.java
@@ -157,16 +157,16 @@ public class ScriptMapper {
         else if (code <= 0x13ff) { // U+13A0 - U+13FF Cherokee
             return true;
         }
-        else if (code < 0x1c50) {
-            return false;
-        }
-        else if (code <= 0x1c7f) { // U+1C50 - U+1C7F Ol Chiki / Santali
-            return true;
-        }
         else if (code < 0x1780) {
             return false;
         }
         else if (code <= 0x17ff) { // 1780 - 17FF Khmer
+            return true;
+        }
+        else if (code < 0x1c50) {
+            return false;
+        }
+        else if (code <= 0x1c7f) { // U+1C50 - U+1C7F Ol Chiki / Santali
             return true;
         }
         else if (code < 0x200c) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/text/ScriptMapper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/text/ScriptMapper.java
@@ -80,7 +80,7 @@ public class ScriptMapper {
      * in the case where the caller interprets 'layout' to mean where
      * one 'char' (ie the java type char) does not map to one glyph
      */
-    private static final int MAX_LAYOUT_CHARCODE = 0x206F;
+    private static final int MAX_LAYOUT_CHARCODE = 0x12550F;
 
     /* If the character code falls into any of a number of unicode ranges
      * where we know that simple left->right layout mapping chars to glyphs
@@ -151,6 +151,18 @@ public class ScriptMapper {
         else if (code <= 0x11ff) { // U+1100 - U+11FF Old Hangul
             return true;
         }
+        else if (code < 0x13a0) {
+            return false;
+        }
+        else if (code <= 0x13ff) { // U+13A0 - U+13FF Cherokee
+            return true;
+        }
+        else if (code < 0x1c50) {
+            return false;
+        }
+        else if (code <= 0x1c7f) { // U+1C50 - U+1C7F Ol Chiki / Santali
+            return true;
+        }
         else if (code < 0x1780) {
             return false;
         }
@@ -167,6 +179,27 @@ public class ScriptMapper {
             return true;
         }
         else if (code >= 0x206a && code <= 0x206f) { // directional control
+            return true;
+        }
+        else if (code < 0xab70) {
+            return false;
+        }
+        else if (code <= 0xabbf) { // U+AB70 - U+ABBF - Cherokee Supplement
+            return true;
+        }
+        else if (code <= 0xabff) { // U+ABC0 - U+ABFF - Meeti Mayek
+            return true;
+        }
+        else if (code < 0x11080) {
+            return false;
+        }
+        else if (code <= 0x110cf) { // Kaithi
+            return true;
+        }
+        else if (code < 0x12000) {
+            return false;
+        }
+        else if (code >= 0x12000 && code <= 0x1254f) { // Cuneiform
             return true;
         }
         return false;

--- a/modules/javafx.graphics/src/main/native-font/MacFontFinder.c
+++ b/modules/javafx.graphics/src/main/native-font/MacFontFinder.c
@@ -184,9 +184,8 @@ JNIEXPORT jobjectArray JNICALL Java_com_sun_javafx_font_MacFontFinder_getFontDat
 
     /* Also add the EmphasizedSystemFont as it might make the bold version
      * for the system font available to JavaFX.
-     * NOTE: Seems to be the exact same font, so this isn't useful.
-     * I think we need to ask for the system font with bold trait.
-     * However Apple is reporting its name as "System Font Bold" !?!?
+     * NOTE: macOS is using font variations for the system font,
+     * so System Font and System Font Bold are in the same .ttf.
      */
     font = CTFontCreateUIFontForLanguage(kCTFontUIFontEmphasizedSystem, 0, NULL);
     fd = CTFontCopyFontDescriptor(font);

--- a/modules/javafx.graphics/src/main/native-font/MacFontFinder.c
+++ b/modules/javafx.graphics/src/main/native-font/MacFontFinder.c
@@ -59,6 +59,7 @@ extern jboolean checkAndClearException(JNIEnv *env);
 
 jstring createJavaString(JNIEnv *env, CFStringRef stringRef)
 {
+    if (stringRef == NULL) return NULL;
     CFIndex length = CFStringGetLength(stringRef);
     UniChar buffer[length];
     CFStringGetCharacters(stringRef, CFRangeMake(0, length), buffer);
@@ -79,7 +80,7 @@ JNIEXPORT jfloat JNICALL Java_com_sun_javafx_font_MacFontFinder_getSystemFontSiz
   (JNIEnv *env, jclass obj)
 {
     CTFontRef font = CTFontCreateUIFontForLanguage(
-                         kCTFontSystemFontType,
+                         kCTFontUIFontSystem,
                          0.0, //get system font with default size
                          NULL);
     jfloat systemFontDefaultSize = (jfloat) CTFontGetSize (font);
@@ -175,7 +176,7 @@ JNIEXPORT jobjectArray JNICALL Java_com_sun_javafx_font_MacFontFinder_getFontDat
      * to the list so JavaFX can find it. If the UI font is added twice it gets
      * handled in Java.
      */
-    CTFontRef font = CTFontCreateUIFontForLanguage(kCTFontSystemFontType, 0, NULL);
+    CTFontRef font = CTFontCreateUIFontForLanguage(kCTFontUIFontSystem, 0, NULL);
     CTFontDescriptorRef fd = CTFontCopyFontDescriptor(font);
     j = addCTFontDescriptor(fd, env, result, j);
     CFRelease(fd);
@@ -183,14 +184,85 @@ JNIEXPORT jobjectArray JNICALL Java_com_sun_javafx_font_MacFontFinder_getFontDat
 
     /* Also add the EmphasizedSystemFont as it might make the bold version
      * for the system font available to JavaFX.
+     * NOTE: Seems to be the exact same font, so this isn't useful.
+     * I think we need to ask for the system font with bold trait.
+     * However Apple is reporting its name as "System Font Bold" !?!?
      */
-    font = CTFontCreateUIFontForLanguage(kCTFontEmphasizedSystemFontType, 0, NULL);
+    font = CTFontCreateUIFontForLanguage(kCTFontUIFontEmphasizedSystem, 0, NULL);
     fd = CTFontCopyFontDescriptor(font);
     j = addCTFontDescriptor(fd, env, result, j);
     CFRelease(fd);
     CFRelease(font);
 
     return result;
+}
+
+JNIEXPORT jobjectArray JNICALL
+Java_com_sun_javafx_font_MacFontFinder_getCascadeList
+(JNIEnv *env, jclass cls, jlong fontRef)
+{
+    CTFontRef ctFontRef = (CTFontRef)fontRef;
+
+    CFArrayRef codes = CFLocaleCopyISOLanguageCodes();
+    CFArrayRef fds = CTFontCopyDefaultCascadeListForLanguages(ctFontRef, codes);
+    CFRelease(codes);
+
+    CFIndex cnt = CFArrayGetCount(fds);
+    jclass jStringClass = (*env)->FindClass(env, "java/lang/String");
+    int SPE = 2;
+    jobjectArray names = (*env)->NewObjectArray(env, cnt*SPE, jStringClass, NULL);
+    if (names == NULL) {
+        CFRelease(fds);
+        return NULL;
+    }
+    for (CFIndex i=0; i<cnt; i++) {
+        CTFontDescriptorRef ref = CFArrayGetValueAtIndex(fds, i);
+        CFStringRef fontname = CTFontDescriptorCopyAttribute(ref, kCTFontNameAttribute);
+        CFStringRef displayName = CTFontDescriptorCopyAttribute(ref, kCTFontDisplayNameAttribute);
+        CFURLRef url = CTFontDescriptorCopyAttribute(ref, kCTFontURLAttribute);
+        CFStringRef file = url ? CFURLCopyFileSystemPath(url, kCFURLPOSIXPathStyle) : NULL;
+
+        jstring jFontDisplayName = createJavaString(env, displayName);
+        CFRelease(displayName);
+        jstring jFile = createJavaString(env, file);
+        if (file != NULL) CFRelease(file);
+
+        (*env)->SetObjectArrayElement(env, names, (i*SPE)+0, jFontDisplayName);
+        (*env)->SetObjectArrayElement(env, names, (i*SPE)+1, jFile);
+
+        (*env)->DeleteLocalRef(env, jFontDisplayName);
+        if (jFile != NULL) (*env)->DeleteLocalRef(env, jFile);
+    }
+    CFRelease(fds);
+    return names;
+}
+
+JNIEXPORT jlongArray JNICALL
+Java_com_sun_javafx_font_MacFontFinder_getCascadeListRefs
+(JNIEnv *env, jclass cls, jlong fontRef)
+{
+    CTFontRef ctFontRef = (CTFontRef)fontRef;
+
+    CFArrayRef codes = CFLocaleCopyISOLanguageCodes();
+    CFArrayRef fds = CTFontCopyDefaultCascadeListForLanguages(ctFontRef, codes);
+    CFRelease(codes);
+
+    CFIndex cnt = CFArrayGetCount(fds);
+    jlongArray refs = (*env)->NewLongArray(env, cnt);
+    if (refs == NULL) {
+        CFRelease(fds);
+        return NULL;
+    }
+    jlong *refArr = calloc(cnt, sizeof(jlong));
+    for (CFIndex i=0; i<cnt; i++) {
+        CTFontDescriptorRef descRef = CFArrayGetValueAtIndex(fds, i);
+        CTFontRef ref = CTFontCreateWithFontDescriptor(descRef, 0.0, NULL);
+        refArr[i] = (jlong)ref;
+    }
+    (*env)->SetLongArrayRegion(env, refs, 0, cnt, refArr);
+    free(refArr);
+    CFRelease(fds);
+    return refs;
 }
 
 #endif /* __APPLE__ */

--- a/modules/javafx.graphics/src/main/native-font/MacFontFinder.c
+++ b/modules/javafx.graphics/src/main/native-font/MacFontFinder.c
@@ -253,6 +253,11 @@ Java_com_sun_javafx_font_MacFontFinder_getCascadeListRefs
         return NULL;
     }
     jlong *refArr = calloc(cnt, sizeof(jlong));
+    if (refArr == NULL) {
+        CFRelease(fds);
+        (*env)->DeleteLocalRef(env, refs); // not strictly needed.
+        return NULL;
+    }
     for (CFIndex i=0; i<cnt; i++) {
         CTFontDescriptorRef descRef = CFArrayGetValueAtIndex(fds, i);
         CTFontRef ref = CTFontCreateWithFontDescriptor(descRef, 0.0, NULL);

--- a/modules/javafx.graphics/src/main/native-font/coretext.c
+++ b/modules/javafx.graphics/src/main/native-font/coretext.c
@@ -370,6 +370,25 @@ JNIEXPORT void JNICALL OS_NATIVE(CFRelease)
     CFRelease((CFTypeRef)arg0);
 }
 
+JNIEXPORT void JNICALL OS_NATIVE(CFRetain)
+    (JNIEnv *env, jclass that, jlong arg0)
+{
+    CFRetain((CFTypeRef)arg0);
+}
+
+JNIEXPORT jlong JNICALL OS_NATIVE(CTFontCreateCopyWithAttributes)
+    (JNIEnv *env, jclass that, jlong ctfont, jdouble size, jobject matrix, jlong attributes)
+{
+    CGAffineTransform transform;
+    if (matrix) {
+        getCGAffineTransformFields(env, matrix, &transform);
+    } else {
+        transform = CGAffineTransformIdentity;
+    }
+    return (jlong)CTFontCreateCopyWithAttributes((CTFontRef)ctfont, (CGFloat)size,
+                                                 &transform, (CTFontDescriptorRef)attributes);
+}
+
 JNIEXPORT jlong JNICALL OS_NATIVE(CTFontCreateWithGraphicsFont)
     (JNIEnv *env, jclass that, jlong cgFont, jdouble size, jobject matrix, jlong attributes)
 {
@@ -380,6 +399,23 @@ JNIEXPORT jlong JNICALL OS_NATIVE(CTFontCreateWithGraphicsFont)
         transform = CGAffineTransformIdentity;
     }
     return (jlong)CTFontCreateWithGraphicsFont((CGFontRef)cgFont, (CGFloat)size, &transform, (CTFontDescriptorRef)attributes);
+}
+
+JNIEXPORT jlong JNICALL OS_NATIVE(CTFontCreateUIFontForLanguage)
+    (JNIEnv *env, jclass that, jdouble size, jobject matrix, jboolean bold) {
+
+    CGAffineTransform _matrix, *lpmatrix=NULL;
+    CTFontUIFontType fType = bold ? kCTFontUIFontEmphasizedSystem : kCTFontUIFontSystem;
+    CTFontRef font = CTFontCreateUIFontForLanguage(fType, (CGFloat)size, NULL);
+    if (matrix == NULL) {
+        return (jlong)font;
+    }
+    if ((lpmatrix = getCGAffineTransformFields(env, matrix, &_matrix)) == NULL) {
+         return (jlong)font;
+    }
+    jlong txfont = (jlong)CTFontCreateCopyWithAttributes(font, (CGFloat)size, (CGAffineTransform*)lpmatrix, NULL);
+    CFRelease(font);
+    return txfont;
 }
 
 JNIEXPORT jlong JNICALL OS_NATIVE(CTFontCreateWithName)
@@ -754,6 +790,21 @@ JNIEXPORT jint JNICALL OS_NATIVE(CTRunGetStringIndices)
         }
     }
     return i;
+}
+
+JNIEXPORT jstring JNICALL OS_NATIVE(CTFontCopyURLAttribute)
+    (JNIEnv *env, jclass that, jlong arg0)
+{
+    CFURLRef urlRef = CTFontCopyAttribute((CTFontRef)arg0, kCTFontURLAttribute);
+    if (urlRef == NULL) return NULL;
+    CFStringRef stringRef = CFURLCopyFileSystemPath(urlRef, kCFURLPOSIXPathStyle);
+    CFRelease(urlRef);
+    if (stringRef == NULL) return NULL;
+    CFIndex length = CFStringGetLength(stringRef);
+    UniChar buffer[length];
+    CFStringGetCharacters(stringRef, CFRangeMake(0, length), buffer);
+    CFRelease(stringRef);
+    return (*env)->NewString(env, (jchar *)buffer, length);
 }
 
 JNIEXPORT jstring JNICALL OS_NATIVE(CTFontCopyAttributeDisplayName)

--- a/modules/javafx.graphics/src/main/native-font/fontpath.c
+++ b/modules/javafx.graphics/src/main/native-font/fontpath.c
@@ -713,7 +713,7 @@ Java_com_sun_javafx_font_PrismFontFactory_populateFontFileNameMap
 }
 
 JNIEXPORT jstring JNICALL
-Java_com_sun_javafx_font_PrismFontFactory_regReadFontLink(JNIEnv *env, jclass obj, jstring lpFontName)
+Java_com_sun_javafx_font_directwrite_DWFactory_regReadFontLink(JNIEnv *env, jclass obj, jstring lpFontName)
 {
     LONG lResult;
     BYTE* buf;
@@ -780,7 +780,7 @@ static const wchar_t EUDCKEY_DEFAULT[] = L"EUDC\\1252";
 
 
 JNIEXPORT jstring JNICALL
-Java_com_sun_javafx_font_PrismFontFactory_getEUDCFontFile(JNIEnv *env, jclass cl) {
+Java_com_sun_javafx_font_directwrite_DWFactory_getEUDCFontFile(JNIEnv *env, jclass cl) {
     int    rc;
     HKEY   key;
     DWORD  type;


### PR DESCRIPTION
This PR addresses some font problems on macOS.
(1) Garbled Arabic with the System font
(2) Non-ideal fallback fonts for all fonts
(3) No bold for System font.

In particular the standard System Font was garbling Arabic text - random glyphs from another font.
The root of this issue is that several releases ago macOS introduced UI fonts that are hidden from
enumeration. must be loaded by a special API and cannot be loaded by name, even if you extract
the name from the core text font loaded by that special API.
These fonts usually have a name that begins with "." such as the postscript name ".AppleUISystemFont"
and "name" for the main instance of this will be "System Font Regular". These live in files called "SFNS.ttf"
and "SFArabic.ttf" and similar.

JavaFX has its own "System" font family logical name and in order to map to the macOS system font,
several releases ago we started using the special API referenced above.

Normally we have our own list of fall back fonts for other scripts.
But when we encounter complex scripts such as Arabic, and ask CoreText to layout the glyphs,
it may use other system fonts for Arabic (eg ".SFArabic") and the FX code dynamically adds
this new font to its fallback list - by name.
But this new font can't be directly referenced by name either, but that's what used to work and the FX code tries.

So to fix this we need to grab the reference to the font that was returned by CoreText and use
that to create the PrismFont we add as a fall back.
The code that first recognises it needs to go this route is in CTGlyphLayout.java when
"getSlotForFont(String name") fails.
Instead it calls new code in CTFactory which in turn calls a new constructor and supporting code in CTFontFile.java.
There's also supporting changes in native code - coretext.c

Additionally to support that when we ask the platform to enumerate fallbacks, we might get such "." fonts,
we need to make some more changes
Now on to more "fallback" enhancements.
Prior to this fix, on macOS we had a short, hard-coded global list.
This fix calls the macOS API to get the cascading fallback list for a font.
This improves the fallback behaviour in respect to providing
(1) More appropriate styles, (2) More supported code pointd, (3) Code point support coming from a preferred font.
There was some desirable re-factoring as part of this, as the location of fallbacks was pushed from
"if <windows> else if <linux> else <mac> in shared code, down into the appropriate platform factory

This also made it easier to do some required changes to allow fallbacks to be pre-initialised with the
native font resource, not just a name+ file. The new class FontFallbackInfo encapsulates this and changes
were made to follow it.
In practice on macOS it seems that some "." cascading fallbacks for the "." system font come with a "NULL"
file name. Without being able to identify the file we aren't able to use the font to skip them.
More changes would be needed to provide a PrismFont subclass that can handle this case.
Fortunately that isn't happening for any of the fallbacks we get from complex text layout.

The final thing this fixes is that "System Bold" was the same as "System Regular".
The needed name getting lost along the way to constructing the native font.

The work done here also highlighted that we really need to add code that at least recognises OpenType variation fonts.
And some day after that we could expose API that allows apps to request non-named variations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8246104](https://bugs.openjdk.org/browse/JDK-8246104): Some complex text doesn't render correctly on macOS


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1067/head:pull/1067` \
`$ git checkout pull/1067`

Update a local copy of the PR: \
`$ git checkout pull/1067` \
`$ git pull https://git.openjdk.org/jfx.git pull/1067/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1067`

View PR using the GUI difftool: \
`$ git pr show -t 1067`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1067.diff">https://git.openjdk.org/jfx/pull/1067.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1067#issuecomment-1495073794)