### PR TITLE
8304924: [testbug] Skip failing tests on Linux

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/SliderTooltipNPETest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/SliderTooltipNPETest.java
@@ -27,6 +27,7 @@ package test.robot.javafx.scene;
 
 import java.util.concurrent.CountDownLatch;
 
+import com.sun.javafx.PlatformUtil;
 import javafx.application.Application;
 import javafx.scene.input.MouseButton;
 import javafx.application.Platform;
@@ -44,6 +45,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import test.util.Util;
+
+import static org.junit.Assume.assumeTrue;
 
 /*
  * Test for verifying Slider NPE error.
@@ -72,6 +75,8 @@ public class SliderTooltipNPETest {
 
     @Test
     public void testSliderTooltipNPE() throws Throwable {
+        assumeTrue(!PlatformUtil.isLinux()); // JDK-8304922
+
         Assert.assertTrue(slider.getTooltip().getConsumeAutoHidingEvents());
         dragSliderAfterTooltipDisplayed(DRAG_DISTANCE);
         if (exception != null) {

--- a/tests/system/src/test/java/test/robot/javafx/scene/TabPaneDragPolicyTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TabPaneDragPolicyTest.java
@@ -142,8 +142,8 @@ public class TabPaneDragPolicyTest {
 
     @Test
     public void testReorderTop() {
-        // Disable on Mac until JDK-8213136 is fixed
-        assumeTrue(!PlatformUtil.isMac());
+        // Disable on Mac and Linux until JDK-8213136 is fixed
+        assumeTrue(!PlatformUtil.isMac() && !PlatformUtil.isLinux());
         expectedTab = tabs[1];
         setDragPolicyAndSide(TabPane.TabDragPolicy.REORDER, Side.TOP);
         tabPane.getTabs().addListener(reorderListener);
@@ -157,8 +157,8 @@ public class TabPaneDragPolicyTest {
 
     @Test
     public void testReorderBottom() {
-        // Disable on Mac until JDK-8213136 is fixed
-        assumeTrue(!PlatformUtil.isMac());
+        // Disable on Mac and Linux until JDK-8213136 is fixed
+        assumeTrue(!PlatformUtil.isMac() && !PlatformUtil.isLinux());
         expectedTab = tabs[1];
         setDragPolicyAndSide(TabPane.TabDragPolicy.REORDER, Side.BOTTOM);
         tabPane.getTabs().addListener(reorderListener);
@@ -172,8 +172,8 @@ public class TabPaneDragPolicyTest {
 
     @Test
     public void testReorderLeft() {
-        // Disable on Mac until JDK-8213136 is fixed
-        assumeTrue(!PlatformUtil.isMac());
+        // Disable on Mac and Linux until JDK-8213136 is fixed
+        assumeTrue(!PlatformUtil.isMac() && !PlatformUtil.isLinux());
         expectedTab = tabs[1];
         setDragPolicyAndSide(TabPane.TabDragPolicy.REORDER, Side.LEFT);
         tabPane.getTabs().addListener(reorderListener);
@@ -187,8 +187,8 @@ public class TabPaneDragPolicyTest {
 
     @Test
     public void testReorderRight() {
-        // Disable on Mac until JDK-8213136 is fixed
-        assumeTrue(!PlatformUtil.isMac());
+        // Disable on Mac and Linux until JDK-8213136 is fixed
+        assumeTrue(!PlatformUtil.isMac() && !PlatformUtil.isLinux());
         expectedTab = tabs[1];
         setDragPolicyAndSide(TabPane.TabDragPolicy.REORDER, Side.RIGHT);
         tabPane.getTabs().addListener(reorderListener);

--- a/tests/system/src/test/java/test/robot/javafx/web/PointerEventTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/web/PointerEventTest.java
@@ -25,6 +25,9 @@
 package test.robot.javafx.web;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
+
+import com.sun.javafx.PlatformUtil;
 
 import java.util.concurrent.CountDownLatch;
 
@@ -41,6 +44,7 @@ import javafx.stage.Stage;
 
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -187,6 +191,11 @@ public class PointerEventTest {
     @AfterClass
     public static void exit() {
         Util.shutdown(stage);
+    }
+
+    @Before
+    public void skipOnLinux() {
+        assumeTrue(!PlatformUtil.isLinux()); // JDK-8304923
     }
 
     @After


### PR DESCRIPTION
This PR skips three headful tests on Linux until the issues with the tests can be fixed. These tests consistently fail on our physical Ubuntu 22.04 test machine. This is a step towards getting clean headful test runs. Each of the skipped tests has an associated bug that needs to be fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304924](https://bugs.openjdk.org/browse/JDK-8304924): [testbug] Skip failing tests on Linux


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1068/head:pull/1068` \
`$ git checkout pull/1068`

Update a local copy of the PR: \
`$ git checkout pull/1068` \
`$ git pull https://git.openjdk.org/jfx.git pull/1068/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1068`

View PR using the GUI difftool: \
`$ git pr show -t 1068`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1068.diff">https://git.openjdk.org/jfx/pull/1068.diff</a>

</details>
