### PR TITLE
JDK-8304933: BitSet (used for CSS pseudo class states) listener management is incorrect

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/css/BitSet.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/css/BitSet.java
@@ -601,7 +601,7 @@ abstract class BitSet<T> implements ObservableSet<T> {
     @Override
     public void removeListener(SetChangeListener<? super T> setChangeListener) {
         if (setChangeListener != null) {
-            SetListenerHelper.removeListener(listenerHelper, setChangeListener);
+            listenerHelper = SetListenerHelper.removeListener(listenerHelper, setChangeListener);
         }
     }
 
@@ -615,7 +615,7 @@ abstract class BitSet<T> implements ObservableSet<T> {
     @Override
     public void removeListener(InvalidationListener invalidationListener) {
         if (invalidationListener != null) {
-            SetListenerHelper.removeListener(listenerHelper, invalidationListener);
+            listenerHelper = SetListenerHelper.removeListener(listenerHelper, invalidationListener);
         }
     }
 

--- a/modules/javafx.graphics/src/shims/java/com/sun/javafx/css/BitSetShim.java
+++ b/modules/javafx.graphics/src/shims/java/com/sun/javafx/css/BitSetShim.java
@@ -26,8 +26,17 @@ package com.sun.javafx.css;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
-public class BitSetShim {
+import javafx.beans.InvalidationListener;
+import javafx.collections.SetChangeListener;
+import javafx.css.PseudoClass;
+
+public class BitSetShim<T> {
 
     public static boolean add(BitSet s, Object t) {
         return s.add(t);
@@ -73,4 +82,107 @@ public class BitSetShim {
         return s.size();
     }
 
+    public static BitSetShim<PseudoClass> getPseudoClassInstance() {
+        return new BitSetShim<>(new PseudoClassState());
+    }
+
+    private final BitSet<T> delegate;
+
+    private BitSetShim(BitSet<T> delegate) {
+        this.delegate = delegate;
+    }
+
+    // Generated delegate methods:
+
+    public void forEach(Consumer<? super T> action) {
+        delegate.forEach(action);
+    }
+
+    public int size() {
+        return delegate.size();
+    }
+
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    public Iterator<T> iterator() {
+        return delegate.iterator();
+    }
+
+    public boolean add(T t) {
+        return delegate.add(t);
+    }
+
+    public boolean remove(Object o) {
+        return delegate.remove(o);
+    }
+
+    public boolean contains(Object o) {
+        return delegate.contains(o);
+    }
+
+    public Object[] toArray() {
+        return delegate.toArray();
+    }
+
+    public boolean containsAll(Collection<?> c) {
+        return delegate.containsAll(c);
+    }
+
+    public <T> T[] toArray(T[] a) {
+        return delegate.toArray(a);
+    }
+
+    public boolean addAll(Collection<? extends T> c) {
+        return delegate.addAll(c);
+    }
+
+    public boolean retainAll(Collection<?> c) {
+        return delegate.retainAll(c);
+    }
+
+    public boolean removeAll(Collection<?> c) {
+        return delegate.removeAll(c);
+    }
+
+    public void clear() {
+        delegate.clear();
+    }
+
+    public void addListener(SetChangeListener<? super T> setChangeListener) {
+        delegate.addListener(setChangeListener);
+    }
+
+    public void removeListener(SetChangeListener<? super T> setChangeListener) {
+        delegate.removeListener(setChangeListener);
+    }
+
+    public void addListener(InvalidationListener invalidationListener) {
+        delegate.addListener(invalidationListener);
+    }
+
+    public void removeListener(InvalidationListener invalidationListener) {
+        delegate.removeListener(invalidationListener);
+    }
+
+    public Spliterator<T> spliterator() {
+        return delegate.spliterator();
+    }
+
+    public <T> T[] toArray(IntFunction<T[]> generator) {
+        return delegate.toArray(generator);
+    }
+
+    public boolean removeIf(Predicate<? super T> filter) {
+        return delegate.removeIf(filter);
+    }
+
+    public Stream<T> stream() {
+        return delegate.stream();
+    }
+
+    public Stream<T> parallelStream() {
+        return delegate.parallelStream();
+    }
 }

--- a/modules/javafx.graphics/src/shims/java/com/sun/javafx/css/BitSetShim.java
+++ b/modules/javafx.graphics/src/shims/java/com/sun/javafx/css/BitSetShim.java
@@ -92,7 +92,7 @@ public class BitSetShim<T> {
         this.delegate = delegate;
     }
 
-    // Generated delegate methods:
+    // These delegate methods were generated automatically by an IDE.
 
     public void forEach(Consumer<? super T> action) {
         delegate.forEach(action);

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/BitSetTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/BitSetTest.java
@@ -20,7 +20,7 @@ public class BitSetTest {
     private final PseudoClass c = PseudoClass.getPseudoClass("c");
 
     @Test
-    void setShouldProcssAddAndRemoveCorrectly() {
+    void setShouldProcessAddAndRemoveCorrectly() {
         assertEquals(0, set.size());
         assertTrue(set.isEmpty());
 

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/BitSetTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/BitSetTest.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
 package test.com.sun.javafx.css;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/BitSetTest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/css/BitSetTest.java
@@ -1,0 +1,112 @@
+package test.com.sun.javafx.css;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import com.sun.javafx.css.BitSetShim;
+
+import javafx.beans.InvalidationListener;
+import javafx.collections.SetChangeListener;
+import javafx.css.PseudoClass;
+
+public class BitSetTest {
+    private final BitSetShim<PseudoClass> set = BitSetShim.getPseudoClassInstance();
+    private final PseudoClass a = PseudoClass.getPseudoClass("a");
+    private final PseudoClass b = PseudoClass.getPseudoClass("b");
+    private final PseudoClass c = PseudoClass.getPseudoClass("c");
+
+    @Test
+    void setShouldProcssAddAndRemoveCorrectly() {
+        assertEquals(0, set.size());
+        assertTrue(set.isEmpty());
+
+        set.add(a);
+
+        assertEquals(1, set.size());
+        assertTrue(set.contains(a));
+
+        set.add(b);
+
+        assertEquals(2, set.size());
+        assertTrue(set.contains(a));
+        assertTrue(set.contains(b));
+
+        set.remove(a);
+
+        assertEquals(1, set.size());
+        assertTrue(set.contains(b));
+
+        set.remove(a);
+
+        assertEquals(1, set.size());
+        assertTrue(set.contains(b));
+
+        set.remove(b);
+
+        assertEquals(0, set.size());
+        assertTrue(set.isEmpty());
+
+        set.remove(b);
+
+        assertEquals(0, set.size());
+        assertTrue(set.isEmpty());
+    }
+
+    @Test
+    void listenerManagementForInvalidationListenerShouldWorkCorrectly() {
+        AtomicInteger invalidated = new AtomicInteger();
+
+        InvalidationListener listener = obs -> invalidated.addAndGet(1);
+
+        set.addListener(listener);
+        set.add(a);
+
+        assertEquals(1, invalidated.getAndSet(0));
+
+        set.addListener(listener);  // added listener twice
+        set.add(b);
+
+        assertEquals(2, invalidated.getAndSet(0));  // called twice
+
+        set.removeListener(listener);
+        set.add(c);
+
+        assertEquals(1, invalidated.getAndSet(0));  // called once
+
+        set.removeListener(listener);
+        set.remove(a);
+
+        assertEquals(0, invalidated.getAndSet(0));  // not called
+    }
+
+    @Test
+    void listenerManagementForSetChangeListenerShouldWorkCorrectly() {
+        AtomicInteger changed = new AtomicInteger();
+
+        SetChangeListener<PseudoClass> listener = obs -> changed.addAndGet(1);
+
+        set.addListener(listener);
+        set.add(a);
+
+        assertEquals(1, changed.getAndSet(0));
+
+        set.addListener(listener);  // added listener twice
+        set.add(b);
+
+        assertEquals(2, changed.getAndSet(0));  // called twice
+
+        set.removeListener(listener);
+        set.add(c);
+
+        assertEquals(1, changed.getAndSet(0));  // called once
+
+        set.removeListener(listener);
+        set.remove(a);
+
+        assertEquals(0, changed.getAndSet(0));  // not called
+    }
+}


### PR DESCRIPTION
BitSet uses the SetListenerHelper abstraction to prevent allocating the listener arrays.

When removing listeners, the newly returned listener helper (which may be different from the one called) is not reassigned. This effectively means that removing the listener does not happen.

This fix correctly assigns the potentially changed SetListenerHelper instance to BitSet's helper field after listener removal.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8304933](https://bugs.openjdk.org/browse/JDK-8304933): BitSet (used for CSS pseudo class states) listener management is incorrect


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1071/head:pull/1071` \
`$ git checkout pull/1071`

Update a local copy of the PR: \
`$ git checkout pull/1071` \
`$ git pull https://git.openjdk.org/jfx.git pull/1071/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1071`

View PR using the GUI difftool: \
`$ git pr show -t 1071`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1071.diff">https://git.openjdk.org/jfx/pull/1071.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1071#issuecomment-1485227896)