### PR TITLE
JDK-8245919: Region#padding property rendering error

### DIFF
--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/CssStyleHelperTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/CssStyleHelperTest.java
@@ -611,7 +611,7 @@ public class CssStyleHelperTest {
     }
 
     @Test
-    public void initialNodeWithUserSetValueShouldNotResetValuesOnOtherNodesWithoutOverridenValue() throws IOException {
+    public void initialNodeWithUserSetValueShouldNotResetValuesOnOtherNodesWithoutOverriddenValue() throws IOException {
         Stylesheet stylesheet = new CssParser().parse(
             "initialNodeWithUserSetValueShouldNotResetValuesOnOtherNodesWithoutOverridenValue",
             """

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/CssStyleHelperTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/CssStyleHelperTest.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import javafx.css.CssParser;
 import javafx.css.PseudoClass;
 import javafx.css.Stylesheet;
+import javafx.geometry.Insets;
 import javafx.scene.Scene;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
@@ -607,5 +608,54 @@ public class CssStyleHelperTest {
         assertEquals(Color.BLUE, D.backgroundProperty().getValue().getFills().get(0).getFill());
         assertEquals(Color.BLUE, E.backgroundProperty().getValue().getFills().get(0).getFill());
         assertEquals(Color.BLUE, F.backgroundProperty().getValue().getFills().get(0).getFill());
+    }
+
+    @Test
+    public void initialNodeWithUserSetValueShouldNotResetValuesOnOtherNodesWithoutOverridenValue() throws IOException {
+        Stylesheet stylesheet = new CssParser().parse(
+            "initialNodeWithUserSetValueShouldNotResetValuesOnOtherNodesWithoutOverridenValue",
+            """
+                .pane {
+                    -fx-padding: 4;
+                }
+            """
+        );
+
+        StyleManager.getInstance().setDefaultUserAgentStylesheet(stylesheet);
+        Pane a = new Pane();
+        Pane b = new Pane();
+
+        a.getStyleClass().add("pane");
+        a.setPadding(new Insets(10));
+
+        b.getStyleClass().add("pane");
+
+        root.getChildren().addAll(a, b);
+
+        stage.show();
+        Toolkit.getToolkit().firePulse();
+
+        assertEquals(new Insets(10), a.getPadding());
+        assertEquals(new Insets(4), b.getPadding());
+
+        // When changing a to focused, this will be the first time that the padding
+        // property is seen in the state focused. A new cache entry is created, which
+        // despite the padding value being overridden, should still add the padding value
+        // that comes from the USER_AGENT stylesheet as this entry is shared with
+        // all other nodes with the same property, with the same state at the same nesting level.
+        a.pseudoClassStateChanged(PseudoClass.getPseudoClass("focused"), true);
+        Toolkit.getToolkit().firePulse();
+
+        assertEquals(new Insets(10), a.getPadding());
+        assertEquals(new Insets(4), b.getPadding());
+
+        // When changing b to focused, it should not have its padding changed. If b
+        // padding does change, then the cache entry was incorrect.
+        a.pseudoClassStateChanged(PseudoClass.getPseudoClass("focused"), false);
+        b.pseudoClassStateChanged(PseudoClass.getPseudoClass("focused"), true);
+        Toolkit.getToolkit().firePulse();
+
+        assertEquals(new Insets(10), a.getPadding());
+        assertEquals(new Insets(4), b.getPadding());
     }
 }


### PR DESCRIPTION
Fix bug in CSS caching code that could reset values on unrelated nodes.

The bug occurs due to a cache entry being constructed incorrectly when the initial node that triggered the cache entry creation has user set values. The calculated values for properties with a user set value were omitted in the cache entry, and other nodes that later share the same entry would incorrectly assume the omitted property was unstyled and were therefore reset to their default values.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8245919](https://bugs.openjdk.org/browse/JDK-8245919): Region#padding property rendering error


### Reviewers
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1072/head:pull/1072` \
`$ git checkout pull/1072`

Update a local copy of the PR: \
`$ git checkout pull/1072` \
`$ git pull https://git.openjdk.org/jfx.git pull/1072/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1072`

View PR using the GUI difftool: \
`$ git pr show -t 1072`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1072.diff">https://git.openjdk.org/jfx/pull/1072.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1072#issuecomment-1485980575)