### PR TITLE
8286089: Intermittent WebKit build failure on macOS in JavaScriptCore

### DIFF
--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/CMakeLists.txt
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/CMakeLists.txt
@@ -181,6 +181,32 @@ file(GLOB JavaScriptCore_SCRIPTS_SOURCES ${JavaScriptCore_SCRIPTS_SOURCES_PATHS}
 
 foreach (_file ${JavaScriptCore_SCRIPTS_SOURCES})
     get_filename_component(_script "${_file}" NAME)
+    #the copy_if_different  is failing on Mac OSX 11 platform if build using -j12
+    #Introducing sleep for 1 s and retry file copy 10 times, to prevent copy failing error
+    if (PORT STREQUAL "Java")
+    # introduce one second delay to prevent any lock
+    execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 1)
+    set(copy_success FALSE)
+    set(copy_attempts 0)
+    while(NOT copy_success AND copy_attempts LESS 10)
+        execute_process(
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different ${_file} ${JavaScriptCore_SCRIPTS_DIR}/${_script}
+            RESULT_VARIABLE copy_result
+            OUTPUT_VARIABLE copy_output
+        )
+        if(copy_result)
+            message(WARNING "Failed to copy ${_file} to ${JavaScriptCore_SCRIPTS_DIR}/${_script}: ${copy_output}")
+            # retry the copy after a delay of one second
+            execute_process(COMMAND ${CMAKE_COMMAND} -E sleep 1)
+        else()
+            set(copy_success TRUE)
+        endif()
+        math(EXPR copy_attempts "${copy_attempts}+1")
+    endwhile()
+    if(NOT copy_success)
+        message(FATAL_ERROR "Failed to copy ${_file} after multiple attempts")
+    endif()
+    endif() # end for port "Java"
     add_custom_command(
         OUTPUT ${JavaScriptCore_SCRIPTS_DIR}/${_script}
         MAIN_DEPENDENCY ${_file}


### PR DESCRIPTION
Issue: Error copying file (if different) from Source/JavaScriptCore/Scripts/wkbuiltins/builtins_generate_separate_header.py" to "modules/javafx.web/build/mac/Release/JavaScriptCcripts/builtins_generate_separate_header.py".

Root cause: The number of build threads more than 8, causing a synchronization issue for builtins_generate_separate_header.py, the file needs to be copied before use at build dir

Solution: Use the sleep of 1 second and retry 10 times to copy in CMakeList.txt and execute using the execute_process cmake command

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8286089](https://bugs.openjdk.org/browse/JDK-8286089): Intermittent WebKit build failure on macOS in JavaScriptCore


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Joeri Sykora](https://openjdk.org/census#sykora) (@tiainen - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1073/head:pull/1073` \
`$ git checkout pull/1073`

Update a local copy of the PR: \
`$ git checkout pull/1073` \
`$ git pull https://git.openjdk.org/jfx.git pull/1073/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1073`

View PR using the GUI difftool: \
`$ git pr show -t 1073`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1073.diff">https://git.openjdk.org/jfx/pull/1073.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1073#issuecomment-1486106756)