### PR TITLE
8304441: [macos] Crash when putting invalid unicode char on clipboard

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassPasteboard.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassPasteboard.m
@@ -31,6 +31,12 @@
 #import "GlassPasteboard.h"
 #import "GlassDragSource.h"
 
+// UTF-16 code points for surrogate pairs
+#define HIGH_SURROGATE_START 0xD800
+#define HIGH_SURROGATE_END 0xDBFF
+#define LOW_SURROGATE_START 0xDC00
+#define LOW_SURROGATE_END 0xDFFF
+
 //#define VERBOSE
 #ifndef VERBOSE
     #define LOG(MSG, ...)
@@ -39,6 +45,40 @@
 #endif
 
 static NSInteger lastDragSesionNumber = 0;
+
+// Validate the string. Returns false if the string is nil or if
+// it contains invalid partial surrogate pairs: a high surrogate
+// without an immediately following low surrogate, or conversely,
+// a low surrogate without an immediately preceding high surrogate.
+static BOOL validate(NSString *data)
+{
+    if (data == nil) {
+        return NO;
+    }
+
+    BOOL prevHiSurrogate = NO;
+    NSUInteger i;
+    for (i = 0; i < [data length]; i++) {
+        BOOL hiSurrogate = NO;
+        BOOL loSurrogate = NO;
+        NSUInteger c = [data characterAtIndex:i];
+        if (c >= HIGH_SURROGATE_START && c <= HIGH_SURROGATE_END) {
+            hiSurrogate = YES;
+        } else if (c >= LOW_SURROGATE_START && c <= LOW_SURROGATE_END) {
+            loSurrogate = YES;
+        }
+
+        if (loSurrogate && !prevHiSurrogate ) {
+            return NO;
+        }
+        if (prevHiSurrogate && !loSurrogate) {
+            return NO;
+        }
+
+        prevHiSurrogate = hiSurrogate;
+    }
+    return !prevHiSurrogate;
+}
 
 // Dock puts the data to a custom pasteboard, so dragging from it does not work.
 // Copy the contents of the sender PBoard to the DraggingPBoard
@@ -213,8 +253,11 @@ static inline void SetNSPasteboardItemValueForUtf(JNIEnv *env, NSPasteboardItem 
             string = [NSString stringWithCharacters:(UniChar *)chars length:(NSUInteger)(*env)->GetStringLength(env, jValue)];
             (*env)->ReleaseStringChars(env, jValue, chars);
         }
-        [item setString:string forType:utf];
+
         //NSLog(@"                SetValue(string): %@, ForUtf: %@", string, utf);
+        if (validate(string)) {
+            [item setString:string forType:utf];
+        }
     }
     else
     {
@@ -286,7 +329,14 @@ static inline NSPasteboardItem *NSPasteboardItemFromArray(JNIEnv *env, jobjectAr
                         }
                         (*env)->ReleaseStringChars(env, jUtf, chars);
                     }
-                    SetNSPasteboardItemValueForUtf(env, item, jObject, utf);
+                    // Setting pasteboard can throw exception. It shouldn't
+                    // happen if we validate the data, but in case it does,
+                    // we will catch the exception and log a warning
+                    @try {
+                        SetNSPasteboardItemValueForUtf(env, item, jObject, utf);
+                    } @catch (NSException *exception) {
+                        NSLog(@"WARNING: %@: %@ ",exception.name, exception.reason);
+                    }
                 }
                 else
                 {

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassPasteboard.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassPasteboard.m
@@ -68,7 +68,7 @@ static BOOL validate(NSString *data)
             loSurrogate = YES;
         }
 
-        if (loSurrogate && !prevHiSurrogate ) {
+        if (loSurrogate && !prevHiSurrogate) {
             return NO;
         }
         if (prevHiSurrogate && !loSurrogate) {


### PR DESCRIPTION
A malformed unicode string containing only half of a surrogate pair (either a high or low surrogate without the other half) will cause a native exception in the macOS `NSPasteboardItem setString:forType:` method. This uncaught exception will terminate (crash) the application.

The fix is to validate the string before calling `setString:forType:`. I also added a try / catch that logs a warning, so that if we ever run into other exceptions, they won't be fatal.

I added an automated test that fails on macOS without the fix and passes with the fix. The test is run on other platforms as well, and passes both before and after the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8304441](https://bugs.openjdk.org/browse/JDK-8304441): [macos] Crash when putting invalid unicode char on clipboard


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1074/head:pull/1074` \
`$ git checkout pull/1074`

Update a local copy of the PR: \
`$ git checkout pull/1074` \
`$ git pull https://git.openjdk.org/jfx.git pull/1074/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1074`

View PR using the GUI difftool: \
`$ git pr show -t 1074`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1074.diff">https://git.openjdk.org/jfx/pull/1074.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1074#issuecomment-1487088371)