### PR TITLE
JDK-8304960: ObservableListBase should defer constructing ListChangeBuilder

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/collections/ObservableListBase.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/ObservableListBase.java
@@ -90,7 +90,7 @@ import javafx.beans.InvalidationListener;
 public abstract class ObservableListBase<E> extends AbstractList<E>  implements ObservableList<E> {
 
     private ListListenerHelper<E> listenerHelper;
-    private final ListChangeBuilder<E> changeBuilder = new ListChangeBuilder<>(this);
+    private ListChangeBuilder<E> changeBuilder;
 
     /**
      * Creates a default {@code ObservableListBase}.
@@ -105,7 +105,7 @@ public abstract class ObservableListBase<E> extends AbstractList<E>  implements 
      * @param pos the position in the list where the updated element resides.
      */
     protected final void nextUpdate(int pos) {
-        changeBuilder.nextUpdate(pos);
+        getListChangeBuilder().nextUpdate(pos);
     }
 
     /**
@@ -117,7 +117,7 @@ public abstract class ObservableListBase<E> extends AbstractList<E>  implements 
      * @param old the old value at the {@code idx} position.
      */
     protected final void nextSet(int idx, E old) {
-        changeBuilder.nextSet(idx, old);
+        getListChangeBuilder().nextSet(idx, old);
     }
 
     /**
@@ -130,7 +130,7 @@ public abstract class ObservableListBase<E> extends AbstractList<E>  implements 
      * @param removed the list of items that were removed
      */
     protected final void nextReplace(int from, int to, List<? extends E> removed) {
-        changeBuilder.nextReplace(from, to, removed);
+        getListChangeBuilder().nextReplace(from, to, removed);
     }
 
     /**
@@ -141,7 +141,7 @@ public abstract class ObservableListBase<E> extends AbstractList<E>  implements 
      * @param removed the list of items that were removed
      */
     protected final void nextRemove(int idx, List<? extends E> removed) {
-        changeBuilder.nextRemove(idx, removed);
+        getListChangeBuilder().nextRemove(idx, removed);
     }
 
     /**
@@ -152,7 +152,7 @@ public abstract class ObservableListBase<E> extends AbstractList<E>  implements 
      * @param removed the item that was removed
      */
     protected final void nextRemove(int idx, E removed) {
-        changeBuilder.nextRemove(idx, removed);
+        getListChangeBuilder().nextRemove(idx, removed);
     }
 
     /**
@@ -168,7 +168,7 @@ public abstract class ObservableListBase<E> extends AbstractList<E>  implements 
      * contain the indexes of the list. Therefore, such permutation would not contain indexes of range {@code (0, from)}
      */
     protected final void nextPermutation(int from, int to, int[] perm) {
-        changeBuilder.nextPermutation(from, to, perm);
+        getListChangeBuilder().nextPermutation(from, to, perm);
     }
 
     /**
@@ -181,7 +181,7 @@ public abstract class ObservableListBase<E> extends AbstractList<E>  implements 
      * @param to marks the end (exclusive) of the range that was added
      */
     protected final void nextAdd(int from, int to) {
-        changeBuilder.nextAdd(from, to);
+        getListChangeBuilder().nextAdd(from, to);
     }
 
     /**
@@ -194,7 +194,7 @@ public abstract class ObservableListBase<E> extends AbstractList<E>  implements 
      * @see #endChange()
      */
     protected final void beginChange() {
-        changeBuilder.beginChange();
+        getListChangeBuilder().beginChange();
     }
 
     /**
@@ -207,7 +207,15 @@ public abstract class ObservableListBase<E> extends AbstractList<E>  implements 
      * @see #beginChange()
      */
     protected final void endChange() {
-        changeBuilder.endChange();
+        getListChangeBuilder().endChange();
+    }
+
+    private ListChangeBuilder<E> getListChangeBuilder() {
+        if (changeBuilder == null) {
+            changeBuilder = new ListChangeBuilder<>(this);
+        }
+
+        return changeBuilder;
     }
 
     @Override


### PR DESCRIPTION
A 1200 Node application sees a 2/3rds reduction of ListChangeBuilder's created.  Every `Node` for example has an `ObservableList` for style classes, and every `Parent` has one for stylesheets, which rarely if ever change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8304960](https://bugs.openjdk.org/browse/JDK-8304960): ObservableListBase should defer constructing ListChangeBuilder


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Committer)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1075/head:pull/1075` \
`$ git checkout pull/1075`

Update a local copy of the PR: \
`$ git checkout pull/1075` \
`$ git pull https://git.openjdk.org/jfx.git pull/1075/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1075`

View PR using the GUI difftool: \
`$ git pr show -t 1075`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1075.diff">https://git.openjdk.org/jfx/pull/1075.diff</a>

</details>
