### PR TITLE
JDK-8305248: TableView not rendered correctly after column is made visible if fixed cell size is set

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
@@ -353,8 +353,8 @@ public abstract class TableRowSkinBase<T,
                 if (fixedCellSizeEnabled && tableCell.getParent() == null) {
                     getChildren().add(tableCell);
                 }
-                // Note: We have to determine the pref width here because the add operation above may trigger the skin
-                // creation first, which is what makes it possible to get a correct value here in the first place.
+                // Note: prefWidth() has to be called only after the tableCell is added to the tableRow, if it wasn't
+                // already. Otherwise, it might not have its skin yet, and its pref width is therefore 0.
                 width = tableCell.prefWidth(height);
 
                 // Added for RT-32700, and then updated for RT-34074.

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -349,12 +349,13 @@ public abstract class TableRowSkinBase<T,
                 height = h;
             }
 
-            width = tableCell.prefWidth(height);
-
             if (isVisible) {
                 if (fixedCellSizeEnabled && tableCell.getParent() == null) {
                     getChildren().add(tableCell);
                 }
+                // Note: We have to determine the pref width here because the add operation above may trigger the skin
+                // creation first, which is what makes it possible to get a correct value here in the first place.
+                width = tableCell.prefWidth(height);
 
                 // Added for RT-32700, and then updated for RT-34074.
                 // We change the alignment from CENTER_LEFT to TOP_LEFT if the
@@ -426,6 +427,7 @@ public abstract class TableRowSkinBase<T,
                 // This does not appear to impact performance...
                 tableCell.requestLayout();
             } else {
+                width = tableCell.prefWidth(height);
                 if (fixedCellSizeEnabled) {
                     // we only add/remove to the scenegraph if the fixed cell
                     // length support is enabled - otherwise we keep all

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableRowSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableRowSkinTest.java
@@ -32,6 +32,7 @@ import javafx.geometry.Insets;
 import javafx.scene.Node;
 import javafx.scene.control.IndexedCell;
 import javafx.scene.control.Skin;
+import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
@@ -39,7 +40,6 @@ import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.control.skin.TableColumnHeader;
 import javafx.scene.control.skin.TableColumnHeaderShim;
 import javafx.scene.control.skin.TableRowSkin;
-import javafx.scene.layout.Region;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -248,7 +248,8 @@ public class TableRowSkinTest {
     }
 
     /**
-     * When we make an invisible column visible we expect the underlying cells to be visible, e.g. as width > 0.
+     * When we set a fixed cell size and make an invisible column visible we expect the underlying cells to be visible,
+     * e.g. width > 0.
      * See also: JDK-8305248
      */
     @Test
@@ -264,9 +265,11 @@ public class TableRowSkinTest {
         Toolkit.getToolkit().firePulse();
 
         IndexedCell<?> row = VirtualFlowTestUtils.getCell(tableView, 0);
-        for (Node cellNode : row.getChildrenUnmodifiable()) {
-            double width = ((Region) cellNode).getWidth();
-            assertNotEquals(0.0, width);
+        for (Node node : row.getChildrenUnmodifiable()) {
+            if (node instanceof TableCell<?, ?> cell) {
+                double width = cell.getWidth();
+                assertNotEquals(0.0, width);
+            }
         }
     }
 
@@ -274,6 +277,7 @@ public class TableRowSkinTest {
     public void testMakeVisibleColumnInvisible() {
         tableView.setFixedCellSize(24);
         TableColumn<Person, ?> firstColumn = tableView.getColumns().get(0);
+        assertTrue(firstColumn.isVisible());
 
         tableView.refresh();
         Toolkit.getToolkit().firePulse();
@@ -282,9 +286,11 @@ public class TableRowSkinTest {
         Toolkit.getToolkit().firePulse();
 
         IndexedCell<?> row = VirtualFlowTestUtils.getCell(tableView, 0);
-        for (Node cellNode : row.getChildrenUnmodifiable()) {
-            double width = ((Region) cellNode).getWidth();
-            assertNotEquals(0.0, width);
+        for (Node node : row.getChildrenUnmodifiable()) {
+            if (node instanceof TableCell<?, ?> cell) {
+                double width = cell.getWidth();
+                assertNotEquals(0.0, width);
+            }
         }
     }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableRowSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableRowSkinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import com.sun.javafx.tk.Toolkit;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
+import javafx.scene.Node;
 import javafx.scene.control.IndexedCell;
 import javafx.scene.control.Skin;
 import javafx.scene.control.TableColumn;
@@ -38,6 +39,7 @@ import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.control.skin.TableColumnHeader;
 import javafx.scene.control.skin.TableColumnHeaderShim;
 import javafx.scene.control.skin.TableRowSkin;
+import javafx.scene.layout.Region;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,6 +48,7 @@ import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
 import test.com.sun.javafx.scene.control.test.Person;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -242,6 +245,47 @@ public class TableRowSkinTest {
         assertEquals(prefHeight, cell.prefHeight(-1), 0);
         assertEquals(maxHeight, cell.maxHeight(-1), 0);
         assertEquals(height, cell.getHeight(), 0);
+    }
+
+    /**
+     * When we make an invisible column visible we expect the underlying cells to be visible, e.g. as width > 0.
+     * See also: JDK-8305248
+     */
+    @Test
+    public void testMakeInvisibleColumnVisible() {
+        tableView.setFixedCellSize(24);
+        TableColumn<Person, ?> firstColumn = tableView.getColumns().get(0);
+        firstColumn.setVisible(false);
+
+        tableView.refresh();
+        Toolkit.getToolkit().firePulse();
+
+        firstColumn.setVisible(true);
+        Toolkit.getToolkit().firePulse();
+
+        IndexedCell<?> row = VirtualFlowTestUtils.getCell(tableView, 0);
+        for (Node cellNode : row.getChildrenUnmodifiable()) {
+            double width = ((Region) cellNode).getWidth();
+            assertNotEquals(0.0, width);
+        }
+    }
+
+    @Test
+    public void testMakeVisibleColumnInvisible() {
+        tableView.setFixedCellSize(24);
+        TableColumn<Person, ?> firstColumn = tableView.getColumns().get(0);
+
+        tableView.refresh();
+        Toolkit.getToolkit().firePulse();
+
+        firstColumn.setVisible(false);
+        Toolkit.getToolkit().firePulse();
+
+        IndexedCell<?> row = VirtualFlowTestUtils.getCell(tableView, 0);
+        for (Node cellNode : row.getChildrenUnmodifiable()) {
+            double width = ((Region) cellNode).getWidth();
+            assertNotEquals(0.0, width);
+        }
     }
 
     @Test

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableRowSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableRowSkinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,13 +29,11 @@ import com.sun.javafx.tk.Toolkit;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
+import javafx.scene.Node;
 import javafx.scene.control.IndexedCell;
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 import javafx.scene.control.Skin;
-import javafx.scene.control.TableRow;
-import javafx.scene.control.TableView;
 import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeTableCell;
 import javafx.scene.control.TreeTableColumn;
 import javafx.scene.control.TreeTableRow;
 import javafx.scene.control.TreeTableView;
@@ -50,6 +48,7 @@ import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
 import test.com.sun.javafx.scene.control.test.Person;
 
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -250,6 +249,53 @@ public class TreeTableRowSkinTest {
         assertEquals(prefHeight, cell.prefHeight(-1), 0);
         assertEquals(maxHeight, cell.maxHeight(-1), 0);
         assertEquals(height, cell.getHeight(), 0);
+    }
+
+    /**
+     * When we set a fixed cell size and make an invisible column visible we expect the underlying cells to be visible,
+     * e.g. width > 0.
+     * See also: JDK-8305248
+     */
+    @Test
+    public void testMakeInvisibleColumnVisible() {
+        treeTableView.setFixedCellSize(24);
+        TreeTableColumn<Person, ?> firstColumn = treeTableView.getColumns().get(0);
+        firstColumn.setVisible(false);
+
+        treeTableView.refresh();
+        Toolkit.getToolkit().firePulse();
+
+        firstColumn.setVisible(true);
+        Toolkit.getToolkit().firePulse();
+
+        IndexedCell<?> row = VirtualFlowTestUtils.getCell(treeTableView, 0);
+        for (Node node : row.getChildrenUnmodifiable()) {
+            if (node instanceof TreeTableCell<?, ?> cell) {
+                double width = cell.getWidth();
+                assertNotEquals(0.0, width);
+            }
+        }
+    }
+
+    @Test
+    public void testMakeVisibleColumnInvisible() {
+        treeTableView.setFixedCellSize(24);
+        TreeTableColumn<Person, ?> firstColumn = treeTableView.getColumns().get(0);
+        assertTrue(firstColumn.isVisible());
+
+        treeTableView.refresh();
+        Toolkit.getToolkit().firePulse();
+
+        firstColumn.setVisible(false);
+        Toolkit.getToolkit().firePulse();
+
+        IndexedCell<?> row = VirtualFlowTestUtils.getCell(treeTableView, 0);
+        for (Node cellNode : row.getChildrenUnmodifiable()) {
+            if (cellNode instanceof TreeTableCell<?, ?> cell) {
+                double width = cell.getWidth();
+                assertNotEquals(0.0, width);
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
The determined `prefWidth` of a `TableCell` could be `0.0` when a `fixedCellSize` is set.
This happened because the `TableCell` may not have a skin since it was never added to the scene graph yet.

The fix is to make sure we get the `prefWidth` after the `TableCell` was added to the scene graph.
That is also the reason why the problem only happened the first time and never again after (skin is then already created).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8305248](https://bugs.openjdk.org/browse/JDK-8305248): TableView not rendered correctly after column is made visible if fixed cell size is set


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Committer)
 * [Jose Pereda](https://openjdk.org/census#jpereda) (@jperedadnr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1077/head:pull/1077` \
`$ git checkout pull/1077`

Update a local copy of the PR: \
`$ git checkout pull/1077` \
`$ git pull https://git.openjdk.org/jfx.git pull/1077/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1077`

View PR using the GUI difftool: \
`$ git pr show -t 1077`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1077.diff">https://git.openjdk.org/jfx/pull/1077.diff</a>

</details>
