### PR TITLE
8282359: Intermittent WebKit build failure on Windows: C1090: PDB API call failed, error code 23

### DIFF
--- a/modules/javafx.web/src/main/native/Source/cmake/OptionsMSVC.cmake
+++ b/modules/javafx.web/src/main/native/Source/cmake/OptionsMSVC.cmake
@@ -113,8 +113,8 @@ if (NOT WTF_CPU_X86)
     # Create pdb files for debugging purposes, also for Release builds
     #add_compile_options(/Zi /GS)
 
-    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG /OPT:ICF /OPT:REF")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG /OPT:ICF /OPT:REF")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /OPT:ICF /OPT:REF")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /OPT:ICF /OPT:REF")
 endif ()
 
 # We do not use exceptions

--- a/modules/javafx.web/src/main/native/Source/cmake/OptionsMSVC.cmake
+++ b/modules/javafx.web/src/main/native/Source/cmake/OptionsMSVC.cmake
@@ -111,7 +111,8 @@ add_compile_options(
 
 if (NOT WTF_CPU_X86)
     if (PORT STREQUAL "Java")
-    # Create pdb files for debugging purposes, also for Release builds
+    # Suppress creation of pdb files for Release builds
+    # FIXME: Need to re-enable the flag for Debug builds
     #add_compile_options(/Zi /GS)
 
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /OPT:ICF /OPT:REF")

--- a/modules/javafx.web/src/main/native/Source/cmake/OptionsMSVC.cmake
+++ b/modules/javafx.web/src/main/native/Source/cmake/OptionsMSVC.cmake
@@ -111,7 +111,7 @@ add_compile_options(
 
 if (NOT WTF_CPU_X86)
     # Create pdb files for debugging purposes, also for Release builds
-    add_compile_options(/Zi /GS)
+    #add_compile_options(/Zi /GS)
 
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG /OPT:ICF /OPT:REF")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG /OPT:ICF /OPT:REF")

--- a/modules/javafx.web/src/main/native/Source/cmake/OptionsMSVC.cmake
+++ b/modules/javafx.web/src/main/native/Source/cmake/OptionsMSVC.cmake
@@ -110,11 +110,19 @@ add_compile_options(
 )
 
 if (NOT WTF_CPU_X86)
+    if (PORT STREQUAL "Java")
     # Create pdb files for debugging purposes, also for Release builds
     #add_compile_options(/Zi /GS)
 
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /OPT:ICF /OPT:REF")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /OPT:ICF /OPT:REF")
+    else()
+    # Create pdb files for debugging purposes, also for Release builds
+    add_compile_options(/Zi /GS)
+
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG /OPT:ICF /OPT:REF")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG /OPT:ICF /OPT:REF")
+    endif() 
 endif ()
 
 # We do not use exceptions

--- a/modules/javafx.web/src/main/native/Source/cmake/OptionsMSVC.cmake
+++ b/modules/javafx.web/src/main/native/Source/cmake/OptionsMSVC.cmake
@@ -122,7 +122,7 @@ if (NOT WTF_CPU_X86)
 
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG /OPT:ICF /OPT:REF")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG /OPT:ICF /OPT:REF")
-    endif() 
+    endif()
 endif ()
 
 # We do not use exceptions


### PR DESCRIPTION
In Jenkins Build, the intermediate failure on windows is observed due to crash in mspdbserv.exe, which generates Program database (.pdb) files.
Disabled the pdb file generation in order to resolve the build failure.
Sanity testing looks fine. Verified build on windows, mac and linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8282359](https://bugs.openjdk.org/browse/JDK-8282359): Intermittent WebKit build failure on Windows: C1090: PDB API call failed, error code 23


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Joeri Sykora](https://openjdk.org/census#sykora) (@tiainen - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1079/head:pull/1079` \
`$ git checkout pull/1079`

Update a local copy of the PR: \
`$ git checkout pull/1079` \
`$ git pull https://git.openjdk.org/jfx.git pull/1079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1079`

View PR using the GUI difftool: \
`$ git pr show -t 1079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1079.diff">https://git.openjdk.org/jfx/pull/1079.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1079#issuecomment-1491483506)