### PR TITLE
8088594: NullPointerException on showing submenu of a contextmenu

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ContextMenuContent.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ContextMenuContent.java
@@ -326,6 +326,7 @@ public class ContextMenuContent extends Region {
         Skin<?> skin = menu.getSkin();
         if (skin == null) return;
 
+        menu.showingProperty().removeListener(subMenuShowingListener);
         ContextMenuContent cmContent = (ContextMenuContent)skin.getNode();
         if (cmContent == null) return;
 
@@ -744,6 +745,13 @@ public class ContextMenuContent extends Region {
         return offset;
     }
 
+    public void disposeListeners() {
+        if(contextMenu != null) {
+            disposeBinds();
+            contextMenu.showingProperty().removeListener(weakPopupShowingListener);
+        }
+    }
+
     private void setUpBinds() {
         updateMenuShowingListeners(contextMenu.getItems(), true);
         contextMenu.getItems().addListener(contextMenuItemsListener);
@@ -830,27 +838,29 @@ public class ContextMenuContent extends Region {
         return downArrow.isVisible();
     }
 
+    private ChangeListener<Boolean> subMenuShowingListener = (observable, wasShowing, isShowing) -> {
+        ReadOnlyBooleanProperty isShowingProperty = (ReadOnlyBooleanProperty) observable;
+        ContextMenu subMenu = (ContextMenu) isShowingProperty.getBean();
+
+        if (!subMenu.isShowing()) {
+            // Maybe user clicked outside or typed ESCAPE.
+            // Make sure menus are in sync.
+            for (Node node : itemsContainer.getChildren()) {
+                if (node instanceof MenuItemContainer
+                        && ((MenuItemContainer)node).item instanceof Menu) {
+                    Menu menu = (Menu)((MenuItemContainer)node).item;
+                    if (menu.isShowing()) {
+                        menu.hide();
+                    }
+                }
+            }
+        }
+    };
+
     private void createSubmenu() {
         if (submenu == null) {
             submenu = new ContextMenu();
-            submenu.showingProperty().addListener(new ChangeListener<Boolean>() {
-                @Override public void changed(ObservableValue<? extends Boolean> observable,
-                                              Boolean oldValue, Boolean newValue) {
-                    if (!submenu.isShowing()) {
-                        // Maybe user clicked outside or typed ESCAPE.
-                        // Make sure menus are in sync.
-                        for (Node node : itemsContainer.getChildren()) {
-                            if (node instanceof MenuItemContainer
-                                  && ((MenuItemContainer)node).item instanceof Menu) {
-                                Menu menu = (Menu)((MenuItemContainer)node).item;
-                                if (menu.isShowing()) {
-                                    menu.hide();
-                                }
-                            }
-                        }
-                    }
-                }
-            });
+            submenu.showingProperty().addListener(subMenuShowingListener);
         }
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ContextMenuSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ContextMenuSkin.java
@@ -201,6 +201,9 @@ public class ContextMenuSkin implements Skin<ContextMenu> {
     @Override public void dispose() {
         root.idProperty().unbind();
         root.styleProperty().unbind();
+        if(root instanceof ContextMenuContent) {
+            ((ContextMenuContent)root).disposeListeners();
+        }
         if (tlFocus != null) tlFocus.dispose();
     }
 

--- a/tests/system/src/test/java/test/robot/javafx/customSkins/ContextMenuCustomSkin.java
+++ b/tests/system/src/test/java/test/robot/javafx/customSkins/ContextMenuCustomSkin.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.robot.javafx.customSkins;
+
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.skin.ContextMenuSkin;
+
+public class ContextMenuCustomSkin extends ContextMenuSkin {
+    public ContextMenuCustomSkin(ContextMenu menu) {
+        super(menu);
+    }
+}

--- a/tests/system/src/test/java/test/robot/javafx/scene/ContextMenuNPETest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ContextMenuNPETest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.robot.javafx.scene;
+
+import java.util.concurrent.CountDownLatch;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Scene;
+import javafx.scene.control.MenuButton;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.MouseButton;
+import javafx.scene.Parent;
+import javafx.scene.robot.Robot;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+import javafx.stage.WindowEvent;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.sun.javafx.PlatformUtil;
+import com.sun.javafx.tk.Toolkit;
+
+import test.util.Util;
+
+/*
+ * Test for verifying context menu NPE error
+ *
+ * There is 1 test in this file.
+ * Steps for testContextMenuNPE()
+ * 1. Create a menu button.
+ * 2. Load a custom skin which extends ContextMenuSkin class.
+ * 3. Add menu items and sub menu.
+ * 4. Click on MenuButton to open context menu.
+ * 5. Got to the first item and select first item of submenu.
+ * 6. Repeat step 4 and 5 and check if NPE is thrown on second attempt.
+ */
+
+public class ContextMenuNPETest {
+    static CountDownLatch startupLatch = new CountDownLatch(1);
+    static Robot robot;
+    static MenuButton menuButton;
+    static Parent fxmlContent;
+
+    static volatile Throwable exception;
+    static volatile Stage stage;
+    static volatile Scene scene;
+
+    CountDownLatch onShownLatch;
+    CountDownLatch onHiddenLatch;
+
+    private void mouseClick(double x, double y) {
+        Util.runAndWait(() -> {
+            robot.mouseMove((int) (scene.getWindow().getX() + scene.getX() + x),
+                    (int) (scene.getWindow().getY() + scene.getY() + y));
+            robot.mousePress(MouseButton.PRIMARY);
+            robot.mouseRelease(MouseButton.PRIMARY);
+        });
+    }
+
+    private void showMenuButtonContextMenu() throws Exception {
+        onShownLatch = new CountDownLatch(1);
+        mouseClick(menuButton.getLayoutX() + menuButton.getWidth() / 2,
+                    menuButton.getLayoutY() + menuButton.getHeight() / 2);
+        Thread.sleep(200); // Small delay to wait for context menu to display.
+        Util.waitForLatch(onShownLatch, 10, "Failed to show context menu.");
+    }
+
+    private void selectSubmenuItem() throws Exception {
+        onHiddenLatch = new CountDownLatch(1);
+        Util.runAndWait(() -> {
+            robot.keyType(KeyCode.DOWN);
+            robot.keyType(KeyCode.RIGHT);
+            robot.keyType(KeyCode.ENTER);
+            Toolkit.getToolkit().firePulse();
+
+        });
+        Thread.sleep(200); // Small delay to wait for context menu to close.
+        Util.waitForLatch(onHiddenLatch, 10, "Failed to hide context menu.");
+    }
+
+    @Test
+    public void testContextMenuNPE() throws Throwable {
+        showMenuButtonContextMenu();
+        selectSubmenuItem();
+
+        showMenuButtonContextMenu();
+        selectSubmenuItem();
+        if (exception != null) {
+            exception.printStackTrace();
+            throw exception;
+        }
+
+        Assert.assertEquals(0, onHiddenLatch.getCount());
+    }
+
+    @After
+    public void resetUI() {
+        Platform.runLater(() -> {
+            menuButton.setOnShown(null);
+            menuButton.setOnHidden(null);
+        });
+    }
+
+    @Before
+    public void setupUI() {
+        Platform.runLater(() -> {
+            menuButton.setOnShown(e -> {
+                onShownLatch.countDown();
+            });
+            menuButton.setOnHidden(e -> {
+                onHiddenLatch.countDown();
+            });
+        });
+    }
+
+    @BeforeClass
+    public static void initFX() throws Exception {
+        Util.launch(startupLatch, TestApp.class);
+    }
+
+    @AfterClass
+    public static void exit() {
+        Util.shutdown(stage);
+    }
+
+    public static class TestApp extends Application {
+        @Override
+        public void start(Stage primaryStage) {
+            robot = new Robot();
+            try {
+                fxmlContent = FXMLLoader.load(getClass().getResource("ContextMenuNPEDemo.fxml"));
+                scene = new Scene(fxmlContent);
+                stage = primaryStage;
+                stage.setScene(scene);
+                menuButton = (MenuButton) scene.lookup("#idMenuButton");
+            }
+            catch (Exception e) {
+                e.printStackTrace();
+            }
+            stage.initStyle(StageStyle.UNDECORATED);
+            stage.addEventHandler(WindowEvent.WINDOW_SHOWN, e ->
+                                    Platform.runLater(startupLatch::countDown));
+            stage.setAlwaysOnTop(true);
+            stage.show();
+
+            Thread.currentThread().setUncaughtExceptionHandler((t2, e) -> {
+                exception = e;
+            });
+        }
+    }
+}

--- a/tests/system/src/test/resources/test/robot/javafx/scene/ContextMenuNPEDemo.fxml
+++ b/tests/system/src/test/resources/test/robot/javafx/scene/ContextMenuNPEDemo.fxml
@@ -1,5 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!--
+Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+This code is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License version 2 only, as
+published by the Free Software Foundation.  Oracle designates this
+particular file as subject to the "Classpath" exception as provided
+by Oracle in the LICENSE file that accompanied this code.
+
+This code is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+version 2 for more details (a copy is included in the LICENSE file that
+accompanied this code).
+
+You should have received a copy of the GNU General Public License version
+2 along with this work; if not, write to the Free Software Foundation,
+Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+or visit www.oracle.com if you need additional information or have any
+questions.
+-->
+
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuButton?>
 <?import javafx.scene.control.MenuItem?>

--- a/tests/system/src/test/resources/test/robot/javafx/scene/ContextMenuNPEDemo.fxml
+++ b/tests/system/src/test/resources/test/robot/javafx/scene/ContextMenuNPEDemo.fxml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.Menu?>
+<?import javafx.scene.control.MenuButton?>
+<?import javafx.scene.control.MenuItem?>
+<?import javafx.scene.layout.AnchorPane?>
+
+
+<AnchorPane prefHeight="200.0" prefWidth="300.0" stylesheets="@ContextMenuStyleSheet.css" xmlns:fx="http://javafx.com/fxml">
+    <children>
+        <MenuButton fx:id="idMenuButton" mnemonicParsing="false" text="MenuButton" AnchorPane.leftAnchor="50.0" AnchorPane.topAnchor="50.0">
+            <items>
+                <Menu mnemonicParsing="false" text="Action 1">
+                    <items>
+                        <MenuItem mnemonicParsing="false" text="Sub Action 1" />
+                        <MenuItem mnemonicParsing="false" text="Sub Action 2" />
+                        <MenuItem mnemonicParsing="false" text="Sub Action 3" />
+                    </items>
+                </Menu>
+                <MenuItem mnemonicParsing="false" text="Action 2" />
+                <MenuItem mnemonicParsing="false" text="Action 3" />
+            </items>
+        </MenuButton>
+    </children>
+</AnchorPane>

--- a/tests/system/src/test/resources/test/robot/javafx/scene/ContextMenuStyleSheet.css
+++ b/tests/system/src/test/resources/test/robot/javafx/scene/ContextMenuStyleSheet.css
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+.context-menu {
+-fx-skin: "test.robot.javafx.customSkins.ContextMenuCustomSkin";
+}


### PR DESCRIPTION
When custom skin was loaded, the listeners added in `ContextMenuContent` class while loading the default skin were not removed. This was causing the NPE when outdated listeners were invoked.

Updated the code to dispose listeners in the `dispose` method of `ContextMenuSkin` so that when new skin is loaded, listeners added in the old skin are removed.

Added system test to validate the fix.