### PR TITLE
8305867: BitSetShim: The type parameter T is hiding the type T warning

### DIFF
--- a/modules/javafx.graphics/src/shims/java/com/sun/javafx/css/BitSetShim.java
+++ b/modules/javafx.graphics/src/shims/java/com/sun/javafx/css/BitSetShim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -130,7 +130,7 @@ public class BitSetShim<T> {
         return delegate.containsAll(c);
     }
 
-    public <T> T[] toArray(T[] a) {
+    public <E> E[] toArray(E[] a) {
         return delegate.toArray(a);
     }
 
@@ -170,7 +170,7 @@ public class BitSetShim<T> {
         return delegate.spliterator();
     }
 
-    public <T> T[] toArray(IntFunction<T[]> generator) {
+    public <E> E[] toArray(IntFunction<E[]> generator) {
         return delegate.toArray(generator);
     }
 


### PR DESCRIPTION
Fixed minor warnings in Eclipse.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305867](https://bugs.openjdk.org/browse/JDK-8305867): BitSetShim: The type parameter T is hiding the type T warning


### Reviewers
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1086/head:pull/1086` \
`$ git checkout pull/1086`

Update a local copy of the PR: \
`$ git checkout pull/1086` \
`$ git pull https://git.openjdk.org/jfx.git pull/1086/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1086`

View PR using the GUI difftool: \
`$ git pr show -t 1086`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1086.diff">https://git.openjdk.org/jfx/pull/1086.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1086#issuecomment-1504074474)