### PR TITLE
8284542: Missing attribute for state of CheckBox in CheckBoxTreeItem

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/cell/CheckBoxTreeCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/cell/CheckBoxTreeCell.java
@@ -25,6 +25,9 @@
 
 package javafx.scene.control.cell;
 
+import javafx.scene.AccessibleAttribute;
+import javafx.scene.AccessibleRole;
+
 import javafx.scene.control.CheckBoxTreeItem;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
@@ -344,6 +347,7 @@ public class CheckBoxTreeCell<T> extends DefaultTreeCell<T> {
 
         // by default the graphic is null until the cell stops being empty
         setGraphic(null);
+        setAccessibleRole(AccessibleRole.CHECK_BOX_TREE_ITEM);
     }
 
 
@@ -478,5 +482,20 @@ public class CheckBoxTreeCell<T> extends DefaultTreeCell<T> {
         // no-op
         // This was done to resolve RT-33603, but will impact the ability for
         // TreeItem.graphic to change dynamically.
+    }
+
+    /** {@inheritDoc} */
+    @Override public Object queryAccessibleAttribute(AccessibleAttribute attribute, Object... parameters) {
+        switch (attribute) {
+            case TOGGLE_STATE:
+                int state = 0;
+                if (checkBox.isIndeterminate()) {
+                    state = 2;
+                } else if (checkBox.isSelected()) {
+                    state = 1;
+                }
+                return state;
+            default: return super.queryAccessibleAttribute(attribute, parameters);
+        }
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacAccessible.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacAccessible.java
@@ -361,7 +361,13 @@ final class MacAccessible extends Accessible {
             },
             null
         ),
-        NSAccessibilityRowRole(new AccessibleRole[] {AccessibleRole.LIST_ITEM, AccessibleRole.TABLE_ROW, AccessibleRole.TREE_ITEM, AccessibleRole.TREE_TABLE_ROW},
+        NSAccessibilityRowRole(new AccessibleRole[] {
+                AccessibleRole.LIST_ITEM,
+                AccessibleRole.TABLE_ROW,
+                AccessibleRole.TREE_ITEM,
+                AccessibleRole.CHECK_BOX_TREE_ITEM,
+                AccessibleRole.TREE_TABLE_ROW
+            },
             new MacAttribute[] {
                 MacAttribute.NSAccessibilitySubroleAttribute,
                 MacAttribute.NSAccessibilityIndexAttribute,
@@ -483,7 +489,11 @@ final class MacAccessible extends Accessible {
     private static enum MacSubrole {
         NSAccessibilityTableRowSubrole(AccessibleRole.LIST_ITEM, AccessibleRole.TABLE_ROW),
         NSAccessibilitySecureTextFieldSubrole(AccessibleRole.PASSWORD_FIELD),
-        NSAccessibilityOutlineRowSubrole(new AccessibleRole[] { AccessibleRole.TREE_ITEM, AccessibleRole.TREE_TABLE_ROW },
+        NSAccessibilityOutlineRowSubrole(new AccessibleRole[] {
+                AccessibleRole.TREE_ITEM,
+                AccessibleRole.CHECK_BOX_TREE_ITEM,
+                AccessibleRole.TREE_TABLE_ROW
+            },
             new MacAttribute[] {
                 MacAttribute.NSAccessibilityDisclosedByRowAttribute,
                 MacAttribute.NSAccessibilityDisclosedRowsAttribute,
@@ -748,8 +758,9 @@ final class MacAccessible extends Accessible {
                 }
 
                 AccessibleRole role = (AccessibleRole) getAttribute(ROLE);
-                if (role == AccessibleRole.TREE_ITEM || role == AccessibleRole.TREE_TABLE_ROW) {
-                    AccessibleRole containerRole = role == AccessibleRole.TREE_ITEM ? AccessibleRole.TREE_VIEW : AccessibleRole.TREE_TABLE_VIEW;
+                if (role == AccessibleRole.TREE_ITEM || role == AccessibleRole.CHECK_BOX_TREE_ITEM || role == AccessibleRole.TREE_TABLE_ROW) {
+                    AccessibleRole containerRole = (role == AccessibleRole.TREE_ITEM || role == AccessibleRole.CHECK_BOX_TREE_ITEM) ?
+                                                                                AccessibleRole.TREE_VIEW : AccessibleRole.TREE_TABLE_VIEW;
                     MacAccessible container = (MacAccessible)getContainerAccessible(containerRole);
                     if (container != null) {
                         NSAccessibilityPostNotification(container.getNativeAccessible(), MacNotification.NSAccessibilityRowCountChangedNotification.ptr);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinAccessible.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinAccessible.java
@@ -299,14 +299,16 @@ final class WinAccessible extends Accessible {
                 break;
             }
             case INDETERMINATE: {
-                if (getAttribute(ROLE) == AccessibleRole.CHECK_BOX) {
+                if (getAttribute(ROLE) == AccessibleRole.CHECK_BOX
+                        || getAttribute(ROLE) == AccessibleRole.CHECK_BOX_TREE_ITEM) {
                     notifyToggleState();
                 }
                 break;
             }
             case SELECTED: {
                 Object role = getAttribute(ROLE);
-                if (role == AccessibleRole.CHECK_BOX || role == AccessibleRole.TOGGLE_BUTTON) {
+                if (role == AccessibleRole.CHECK_BOX || role == AccessibleRole.TOGGLE_BUTTON
+                        || role == AccessibleRole.CHECK_BOX_TREE_ITEM) {
                     notifyToggleState();
                     break;
                 }
@@ -431,6 +433,7 @@ final class WinAccessible extends Accessible {
                 case LIST_ITEM: return getContainerAccessible(AccessibleRole.LIST_VIEW);
                 case TAB_ITEM: return getContainerAccessible(AccessibleRole.TAB_PANE);
                 case PAGE_ITEM: return getContainerAccessible(AccessibleRole.PAGINATION);
+                case CHECK_BOX_TREE_ITEM:
                 case TREE_ITEM: return getContainerAccessible(AccessibleRole.TREE_VIEW);
                 case TREE_TABLE_ROW:
                 case TREE_TABLE_CELL: return getContainerAccessible(AccessibleRole.TREE_TABLE_VIEW);
@@ -477,6 +480,7 @@ final class WinAccessible extends Accessible {
             case COMBO_BOX: return UIA_ComboBoxControlTypeId;
             case HYPERLINK: return UIA_HyperlinkControlTypeId;
             case TREE_VIEW: return UIA_TreeControlTypeId;
+            case CHECK_BOX_TREE_ITEM:
             case TREE_ITEM: return UIA_TreeItemControlTypeId;
             case PROGRESS_INDICATOR: return UIA_ProgressBarControlTypeId;
             case TOOL_BAR: return UIA_ToolBarControlTypeId;
@@ -530,6 +534,7 @@ final class WinAccessible extends Accessible {
                 }
                 break;
             }
+            case CHECK_BOX_TREE_ITEM:
             case TREE_ITEM: {
                 Integer index = (Integer)getAttribute(INDEX);
                 if (index != null) {
@@ -627,6 +632,12 @@ final class WinAccessible extends Accessible {
             case TREE_VIEW:
                 impl = patternId == UIA_SelectionPatternId ||
                        patternId == UIA_ScrollPatternId;
+                break;
+            case CHECK_BOX_TREE_ITEM:
+                impl = patternId == UIA_SelectionItemPatternId ||
+                       patternId == UIA_ExpandCollapsePatternId ||
+                       patternId == UIA_ScrollItemPatternId ||
+                       patternId == UIA_TogglePatternId;
                 break;
             case TREE_ITEM:
                 impl = patternId == UIA_SelectionItemPatternId ||
@@ -913,6 +924,15 @@ final class WinAccessible extends Accessible {
                 variant.bstrVal = "JavaFXProvider";
                 break;
             }
+            case UIA_ToggleToggleStatePropertyId: {
+                AccessibleRole role = (AccessibleRole) getAttribute(ROLE);
+                if (role == AccessibleRole.CHECK_BOX_TREE_ITEM) {
+                    variant = new WinVariant();
+                    variant.vt = WinVariant.VT_I4;
+                    variant.lVal = get_ToggleState();
+                }
+                break;
+            }
             default:
         }
         return variant;
@@ -1008,7 +1028,8 @@ final class WinAccessible extends Accessible {
         if (isDisposed()) return 0;
         AccessibleRole role = (AccessibleRole)getAttribute(ROLE);
         /* special case for the tree item hierarchy, as expected by Windows */
-        boolean treeCell = role == AccessibleRole.TREE_ITEM;
+        boolean treeCell = (role == AccessibleRole.TREE_ITEM
+                            || role == AccessibleRole.CHECK_BOX_TREE_ITEM);
         Node node = null;
         switch (direction) {
             case NavigateDirection_Parent: {
@@ -1369,6 +1390,7 @@ final class WinAccessible extends Accessible {
                     executeAction(AccessibleAction.FIRE);
                     break;
                 case LIST_ITEM:
+                case CHECK_BOX_TREE_ITEM:
                 case TREE_ITEM:
                 case TABLE_CELL:
                 case TREE_TABLE_CELL:
@@ -1562,6 +1584,9 @@ final class WinAccessible extends Accessible {
 
     private int get_ToggleState() {
         if (isDisposed()) return 0;
+        if (getAttribute(ROLE) == AccessibleRole.CHECK_BOX_TREE_ITEM) {
+            return (int)getAttribute(TOGGLE_STATE);
+        }
         if (Boolean.TRUE.equals(getAttribute(INDETERMINATE))) {
             return ToggleState_Indeterminate;
         }
@@ -1888,6 +1913,7 @@ final class WinAccessible extends Accessible {
                 }
                 break;
             }
+            case CHECK_BOX_TREE_ITEM:
             case TREE_ITEM: {
                 Integer index = (Integer)getAttribute(INDEX);
                 if (index != null) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleAttribute.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleAttribute.java
@@ -338,6 +338,25 @@ public enum AccessibleAttribute {
     INDETERMINATE(Boolean.class),
 
     /**
+     * Returns toggle state of CheckBox of CheckBoxTreeItem.
+     * <ul>
+     * <li>Used by: CheckBoxTreeItem</li>
+     * <li>Needs notify: yes </li>
+     * <li>Return Type: {@link Integer}
+     *   <ul>
+     *    <li>2: Indeterminate state</li>
+     *    <li>1: Checked state</li>
+     *    <li>0: Unchecked state</li>
+     *   </ul>
+     * </li>
+     * <li>Parameters: </li>
+     * </ul>
+     *
+     * @since 21
+     */
+    TOGGLE_STATE(Integer.class),
+
+    /**
      * Returns the item at the given index.
      * <ul>
      * <li>Used by: TabPane, ListView, and others </li>

--- a/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleRole.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleRole.java
@@ -739,6 +739,33 @@ public enum AccessibleRole {
      */
     TREE_ITEM,
 
+     /**
+     * Check Box Tree Item role.
+     * <p>
+     * Attributes:
+     * <ul>
+     * <li> {@link AccessibleAttribute#TEXT} </li>
+     * <li> {@link AccessibleAttribute#INDEX} </li>
+     * <li> {@link AccessibleAttribute#SELECTED} </li>
+     * <li> {@link AccessibleAttribute#EXPANDED} </li>
+     * <li> {@link AccessibleAttribute#LEAF} </li>
+     * <li> {@link AccessibleAttribute#DISCLOSURE_LEVEL} </li>
+     * <li> {@link AccessibleAttribute#TREE_ITEM_COUNT} </li>
+     * <li> {@link AccessibleAttribute#TREE_ITEM_AT_INDEX} </li>
+     * <li> {@link AccessibleAttribute#TREE_ITEM_PARENT} </li>
+     * <li> {@link AccessibleAttribute#TOGGLE_STATE} </li>
+     * </ul>
+     * Actions:
+     * <ul>
+     * <li> {@link AccessibleAction#EXPAND} </li>
+     * <li> {@link AccessibleAction#COLLAPSE} </li>
+     * <li> {@link AccessibleAction#REQUEST_FOCUS} </li>
+     * </ul>
+     *
+     * @since 21
+     */
+    CHECK_BOX_TREE_ITEM,
+
     /**
      * Tree Table Cell role.
      * <p>


### PR DESCRIPTION
Issue:
CheckBoxTreeItem extends TreeItem and adds a CheckBox.
The state of this CheckBox is not visible to an accessibility client application.
If we analyze a simple program that contains a CheckBoxTreeItem using a windows application "Accessibility Insights for Window", we can notice that toggle state of CheckBox is not exposed.

Fix:
Include the [Toggle Control Pattern](https://learn.microsoft.com/en-us/windows/win32/winauto/uiauto-implementingtoggle) in Accessibility information of a CheckBoxTreeItem in addition to the patterns that are used for a TreeItem.

Verification:
On Windows: Do the following with and without the fix.
1. Run the sample program attached to JBS issue.
2. Launch "Accessibility Insights for Window"
3. Observe that patterns section for each item
4. Select / de-select the CheckBoxes and observe the patterns section for correctness of toggle state.
 