### PR TITLE
JDK-8305885: Use ReadOnly*PropertyBase class where possible

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TextArea.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TextArea.java
@@ -36,7 +36,6 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.SimpleDoubleProperty;
-import javafx.beans.value.ChangeListener;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.css.CssMetaData;
@@ -45,7 +44,6 @@ import javafx.css.StyleableBooleanProperty;
 import javafx.css.StyleableIntegerProperty;
 import javafx.css.StyleableProperty;
 
-import com.sun.javafx.binding.ExpressionHelper;
 import com.sun.javafx.collections.ListListenerHelper;
 import com.sun.javafx.collections.NonIterableChange;
 import javafx.css.converter.SizeConverter;
@@ -84,12 +82,11 @@ import javafx.scene.AccessibleRole;
  */
 public class TextArea extends TextInputControl {
     // Text area content model
-    private static final class TextAreaContent implements Content {
-        private ExpressionHelper<String> helper = null;
-        private ArrayList<StringBuilder> paragraphs = new ArrayList<>();
+    private static final class TextAreaContent extends ContentBase {
+        private final List<StringBuilder> paragraphs = new ArrayList<>();
+        private final ParagraphList paragraphList = new ParagraphList();
+
         private int contentLength = 0;
-        private ParagraphList paragraphList = new ParagraphList();
-        private ListListenerHelper<CharSequence> listenerHelper;
 
         private TextAreaContent() {
             paragraphs.add(new StringBuilder(DEFAULT_PARAGRAPH_CAPACITY));
@@ -214,7 +211,7 @@ public class TextArea extends TextInputControl {
                 // Update content length
                 contentLength += length;
                 if (notifyListeners) {
-                    ExpressionHelper.fireValueChangedEvent(helper);
+                    fireValueChangedEvent();
                 }
             }
         }
@@ -297,7 +294,7 @@ public class TextArea extends TextInputControl {
                 // Update content length
                 contentLength -= length;
                 if (notifyListeners) {
-                    ExpressionHelper.fireValueChangedEvent(helper);
+                    fireValueChangedEvent();
                 }
             }
         }
@@ -310,29 +307,13 @@ public class TextArea extends TextInputControl {
             return get(0, length());
         }
 
-        @Override public void addListener(ChangeListener<? super String> changeListener) {
-            helper = ExpressionHelper.addListener(helper, this, changeListener);
-        }
-
-        @Override public void removeListener(ChangeListener<? super String> changeListener) {
-            helper = ExpressionHelper.removeListener(helper, changeListener);
-        }
-
         @Override public String getValue() {
             return get();
         }
 
-        @Override public void addListener(InvalidationListener listener) {
-            helper = ExpressionHelper.addListener(helper, this, listener);
-        }
-
-        @Override public void removeListener(InvalidationListener listener) {
-            helper = ExpressionHelper.removeListener(helper, listener);
-        }
-
         private void fireParagraphListChangeEvent(int from, int to, List<CharSequence> removed) {
             ParagraphListChange change = new ParagraphListChange(paragraphList, from, to, removed);
-            ListListenerHelper.fireValueChangedEvent(listenerHelper, change);
+            ListListenerHelper.fireValueChangedEvent(paragraphList.listenerHelper, change);
         }
     }
 
@@ -341,6 +322,7 @@ public class TextArea extends TextInputControl {
             implements ObservableList<CharSequence> {
 
         private TextAreaContent content;
+        private ListListenerHelper<CharSequence> listenerHelper;
 
         @Override
         public CharSequence get(int index) {
@@ -374,12 +356,12 @@ public class TextArea extends TextInputControl {
 
         @Override
         public void addListener(ListChangeListener<? super CharSequence> listener) {
-            content.listenerHelper = ListListenerHelper.addListener(content.listenerHelper, listener);
+            listenerHelper = ListListenerHelper.addListener(listenerHelper, listener);
         }
 
         @Override
         public void removeListener(ListChangeListener<? super CharSequence> listener) {
-            content.listenerHelper = ListListenerHelper.removeListener(content.listenerHelper, listener);
+            listenerHelper = ListListenerHelper.removeListener(listenerHelper, listener);
         }
 
         @Override
@@ -399,12 +381,12 @@ public class TextArea extends TextInputControl {
 
         @Override
         public void addListener(InvalidationListener listener) {
-            content.listenerHelper = ListListenerHelper.addListener(content.listenerHelper, listener);
+            listenerHelper = ListListenerHelper.addListener(listenerHelper, listener);
         }
 
         @Override
         public void removeListener(InvalidationListener listener) {
-            content.listenerHelper = ListListenerHelper.removeListener(content.listenerHelper, listener);
+            listenerHelper = ListListenerHelper.removeListener(listenerHelper, listener);
         }
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TextField.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TextField.java
@@ -29,11 +29,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import javafx.beans.InvalidationListener;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ObjectPropertyBase;
-import javafx.beans.value.ChangeListener;
 import javafx.beans.value.WritableValue;
 import javafx.css.CssMetaData;
 import javafx.css.StyleableIntegerProperty;
@@ -44,7 +42,6 @@ import javafx.event.EventHandler;
 import javafx.geometry.Pos;
 import javafx.scene.AccessibleRole;
 
-import com.sun.javafx.binding.ExpressionHelper;
 import javafx.css.converter.EnumConverter;
 import javafx.css.converter.SizeConverter;
 import javafx.scene.control.skin.TextFieldSkin;
@@ -74,9 +71,9 @@ import javafx.css.Styleable;
  * @since JavaFX 2.0
  */
 public class TextField extends TextInputControl {
+
     // Text field content
-    private static final class TextFieldContent implements Content {
-        private ExpressionHelper<String> helper = null;
+    private static final class TextFieldContent extends ContentBase {
         private StringBuilder characters = new StringBuilder();
 
         @Override public String get(int start, int end) {
@@ -88,7 +85,7 @@ public class TextField extends TextInputControl {
             if (!text.isEmpty()) {
                 characters.insert(index, text);
                 if (notifyListeners) {
-                    ExpressionHelper.fireValueChangedEvent(helper);
+                    fireValueChangedEvent();
                 }
             }
         }
@@ -97,7 +94,7 @@ public class TextField extends TextInputControl {
             if (end > start) {
                 characters.delete(start, end);
                 if (notifyListeners) {
-                    ExpressionHelper.fireValueChangedEvent(helper);
+                    fireValueChangedEvent();
                 }
             }
         }
@@ -110,24 +107,8 @@ public class TextField extends TextInputControl {
             return characters.toString();
         }
 
-        @Override public void addListener(ChangeListener<? super String> changeListener) {
-            helper = ExpressionHelper.addListener(helper, this, changeListener);
-        }
-
-        @Override public void removeListener(ChangeListener<? super String> changeListener) {
-            helper = ExpressionHelper.removeListener(helper, changeListener);
-        }
-
         @Override public String getValue() {
             return get();
-        }
-
-        @Override public void addListener(InvalidationListener listener) {
-            helper = ExpressionHelper.addListener(helper, this, listener);
-        }
-
-        @Override public void removeListener(InvalidationListener listener) {
-            helper = ExpressionHelper.removeListener(helper, listener);
         }
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TextInputControl.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TextInputControl.java
@@ -119,6 +119,37 @@ public abstract class TextInputControl extends Control {
         public int length();
     }
 
+    /**
+     * Package private base implementation of Content.
+     */
+    abstract static class ContentBase implements Content {
+        private ExpressionHelper<String> helper;
+
+        @Override
+        public void addListener(ChangeListener<? super String> changeListener) {
+            helper = ExpressionHelper.addListener(helper, this, changeListener);
+        }
+
+        @Override
+        public void removeListener(ChangeListener<? super String> changeListener) {
+            helper = ExpressionHelper.removeListener(helper, changeListener);
+        }
+
+        @Override
+        public void addListener(InvalidationListener listener) {
+            helper = ExpressionHelper.addListener(helper, this, listener);
+        }
+
+        @Override
+        public void removeListener(InvalidationListener listener) {
+            helper = ExpressionHelper.removeListener(helper, listener);
+        }
+
+        protected final void fireValueChangedEvent() {
+            ExpressionHelper.fireValueChangedEvent(helper);
+        }
+    }
+
     private boolean blockSelectedTextUpdate;
 
     /* *************************************************************************

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ProgressIndicatorSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ProgressIndicatorSkin.java
@@ -26,7 +26,7 @@
 package javafx.scene.control.skin;
 
 import com.sun.javafx.scene.NodeHelper;
-import com.sun.javafx.scene.TreeShowingExpression;
+import com.sun.javafx.scene.TreeShowingProperty;
 import com.sun.javafx.scene.control.skin.Utils;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -105,7 +105,7 @@ public class ProgressIndicatorSkin extends SkinBase<ProgressIndicator> {
     private IndeterminateSpinner spinner;
     private DeterminateIndicator determinateIndicator;
     private ProgressIndicator control;
-    private TreeShowingExpression treeShowingExpression;
+    private TreeShowingProperty treeShowingProperty;
 
     Animation indeterminateTransition;
 
@@ -127,13 +127,13 @@ public class ProgressIndicatorSkin extends SkinBase<ProgressIndicator> {
         super(control);
 
         this.control = control;
-        this.treeShowingExpression = new TreeShowingExpression(control);
+        this.treeShowingProperty = new TreeShowingProperty(control);
 
         // register listeners
         registerChangeListener(control.indeterminateProperty(), e -> initialize());
         registerChangeListener(control.progressProperty(), e -> updateProgress());
         registerChangeListener(control.sceneProperty(), e->updateAnimation());
-        registerChangeListener(treeShowingExpression, e -> updateAnimation());
+        registerChangeListener(treeShowingProperty, e -> updateAnimation());
 
         initialize();
         updateAnimation();
@@ -235,7 +235,7 @@ public class ProgressIndicatorSkin extends SkinBase<ProgressIndicator> {
     @Override public void dispose() {
         super.dispose();
 
-        treeShowingExpression.dispose();
+        treeShowingProperty.dispose();
 
         if (indeterminateTransition != null) {
             indeterminateTransition.stop();

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/TreeShowingExpression.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/TreeShowingExpression.java
@@ -25,9 +25,9 @@
 
 package com.sun.javafx.scene;
 
-import com.sun.javafx.binding.ExpressionHelper;
 import javafx.beans.InvalidationListener;
 import javafx.beans.binding.BooleanExpression;
+import javafx.beans.property.ReadOnlyBooleanPropertyBase;
 import javafx.beans.value.ChangeListener;
 import javafx.scene.Node;
 import javafx.scene.Scene;
@@ -41,14 +41,13 @@ import javafx.stage.Window;
  * This class provides the exact same functionality as {@link NodeHelper#isTreeShowing(Node)} in
  * an observable form.
  */
-public class TreeShowingExpression extends BooleanExpression {
+public class TreeShowingExpression extends ReadOnlyBooleanPropertyBase {
     private final ChangeListener<Boolean> windowShowingChangedListener = (obs, old, current) -> updateTreeShowing();
     private final ChangeListener<Window> sceneWindowChangedListener = (obs, old, current) -> windowChanged(old, current);
     private final ChangeListener<Scene> nodeSceneChangedListener = (obs, old, current) -> sceneChanged(old, current);
 
     private final Node node;
 
-    private ExpressionHelper<Boolean> helper;
     private boolean valid;
     private boolean treeShowing;
 
@@ -66,6 +65,16 @@ public class TreeShowingExpression extends BooleanExpression {
         sceneChanged(null, node.getScene());
     }
 
+    @Override
+    public Object getBean() {
+        return node;
+    }
+
+    @Override
+    public String getName() {
+        return "treeShowing";
+    }
+
     /**
      * Cleans up any listeners that this class may have registered on the {@link Node}
      * that was supplied at construction.
@@ -79,30 +88,10 @@ public class TreeShowingExpression extends BooleanExpression {
         sceneChanged(node.getScene(), null);
     }
 
-    @Override
-    public void addListener(InvalidationListener listener) {
-        helper = ExpressionHelper.addListener(helper, this, listener);
-    }
-
-    @Override
-    public void removeListener(InvalidationListener listener) {
-        helper = ExpressionHelper.removeListener(helper, listener);
-    }
-
-    @Override
-    public void addListener(ChangeListener<? super Boolean> listener) {
-        helper = ExpressionHelper.addListener(helper, this, listener);
-    }
-
-    @Override
-    public void removeListener(ChangeListener<? super Boolean> listener) {
-        helper = ExpressionHelper.removeListener(helper, listener);
-    }
-
     protected void invalidate() {
         if (valid) {
             valid = false;
-            ExpressionHelper.fireValueChangedEvent(helper);
+            fireValueChangedEvent();
         }
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/TreeShowingProperty.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/TreeShowingProperty.java
@@ -25,8 +25,6 @@
 
 package com.sun.javafx.scene;
 
-import javafx.beans.InvalidationListener;
-import javafx.beans.binding.BooleanExpression;
 import javafx.beans.property.ReadOnlyBooleanPropertyBase;
 import javafx.beans.value.ChangeListener;
 import javafx.scene.Node;
@@ -41,7 +39,7 @@ import javafx.stage.Window;
  * This class provides the exact same functionality as {@link NodeHelper#isTreeShowing(Node)} in
  * an observable form.
  */
-public class TreeShowingExpression extends ReadOnlyBooleanPropertyBase {
+public class TreeShowingProperty extends ReadOnlyBooleanPropertyBase {
     private final ChangeListener<Boolean> windowShowingChangedListener = (obs, old, current) -> updateTreeShowing();
     private final ChangeListener<Window> sceneWindowChangedListener = (obs, old, current) -> windowChanged(old, current);
     private final ChangeListener<Scene> nodeSceneChangedListener = (obs, old, current) -> sceneChanged(old, current);
@@ -56,7 +54,7 @@ public class TreeShowingExpression extends ReadOnlyBooleanPropertyBase {
      *
      * @param node a {@link Node} for which the tree showing status should be observed, cannot be null
      */
-    public TreeShowingExpression(Node node) {
+    public TreeShowingProperty(Node node) {
         this.node = node;
         this.node.sceneProperty().addListener(nodeSceneChangedListener);
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -8550,7 +8550,7 @@ public abstract class Node implements EventTarget, Styleable {
     }
 
     private boolean treeVisible = true;
-    private TreeVisiblePropertyReadOnly treeVisibleRO;
+    private TreeVisibleProperty treeVisibleProperty;
 
     final void setTreeVisible(boolean value) {
         if (treeVisible != value) {
@@ -8563,7 +8563,9 @@ public abstract class Node implements EventTarget, Styleable {
             if (treeVisible && !isDirtyEmpty()) {
                 addToSceneDirtyList();
             }
-            ((TreeVisiblePropertyReadOnly) treeVisibleProperty()).invalidate();
+            if (treeVisibleProperty != null) {
+                treeVisibleProperty.invalidate();
+            }
             if (Node.this instanceof Parent parent) {
                 for (Node child : parent.getChildren()) {
                     child.updateTreeVisible(true);
@@ -8583,14 +8585,14 @@ public abstract class Node implements EventTarget, Styleable {
         return treeVisibleProperty().get();
     }
 
-    final BooleanExpression treeVisibleProperty() {
-        if (treeVisibleRO == null) {
-            treeVisibleRO = new TreeVisiblePropertyReadOnly();
+    final ReadOnlyBooleanProperty treeVisibleProperty() {
+        if (treeVisibleProperty == null) {
+            treeVisibleProperty = new TreeVisibleProperty();
         }
-        return treeVisibleRO;
+        return treeVisibleProperty;
     }
 
-    class TreeVisiblePropertyReadOnly extends ReadOnlyBooleanPropertyBase {
+    class TreeVisibleProperty extends ReadOnlyBooleanPropertyBase {
 
         private boolean valid;
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -119,7 +119,6 @@ import com.sun.javafx.util.TempState;
 import com.sun.javafx.util.Utils;
 import com.sun.javafx.beans.IDProperty;
 import com.sun.javafx.beans.event.AbstractNotifyListener;
-import com.sun.javafx.binding.ExpressionHelper;
 import com.sun.javafx.collections.TrackableObservableList;
 import com.sun.javafx.collections.UnmodifiableListSet;
 import com.sun.javafx.css.PseudoClassState;
@@ -8591,35 +8590,24 @@ public abstract class Node implements EventTarget, Styleable {
         return treeVisibleRO;
     }
 
-    class TreeVisiblePropertyReadOnly extends BooleanExpression {
+    class TreeVisiblePropertyReadOnly extends ReadOnlyBooleanPropertyBase {
 
-        private ExpressionHelper<Boolean> helper;
         private boolean valid;
 
         @Override
-        public void addListener(InvalidationListener listener) {
-            helper = ExpressionHelper.addListener(helper, this, listener);
+        public Object getBean() {
+            return Node.this;
         }
 
         @Override
-        public void removeListener(InvalidationListener listener) {
-            helper = ExpressionHelper.removeListener(helper, listener);
-        }
-
-        @Override
-        public void addListener(ChangeListener<? super Boolean> listener) {
-            helper = ExpressionHelper.addListener(helper, this, listener);
-        }
-
-        @Override
-        public void removeListener(ChangeListener<? super Boolean> listener) {
-            helper = ExpressionHelper.removeListener(helper, listener);
+        public String getName() {
+            return "treeVisible";
         }
 
         protected void invalidate() {
             if (valid) {
                 valid = false;
-                ExpressionHelper.fireValueChangedEvent(helper);
+                fireValueChangedEvent();
             }
         }
 
@@ -9751,37 +9739,15 @@ public abstract class Node implements EventTarget, Styleable {
     private static final PseudoClass SHOW_MNEMONICS_PSEUDOCLASS_STATE = PseudoClass.getPseudoClass("show-mnemonics");
 
     private static abstract class LazyTransformProperty
-            extends ReadOnlyObjectProperty<Transform> {
+            extends ReadOnlyObjectPropertyBase<Transform> {
 
         protected static final int VALID = 0;
         protected static final int INVALID = 1;
         protected static final int VALIDITY_UNKNOWN = 2;
         protected int valid = INVALID;
 
-        private ExpressionHelper<Transform> helper;
-
         private Transform transform;
         private boolean canReuse = false;
-
-        @Override
-        public void addListener(InvalidationListener listener) {
-            helper = ExpressionHelper.addListener(helper, this, listener);
-        }
-
-        @Override
-        public void removeListener(InvalidationListener listener) {
-            helper = ExpressionHelper.removeListener(helper, listener);
-        }
-
-        @Override
-        public void addListener(ChangeListener<? super Transform> listener) {
-            helper = ExpressionHelper.addListener(helper, this, listener);
-        }
-
-        @Override
-        public void removeListener(ChangeListener<? super Transform> listener) {
-            helper = ExpressionHelper.removeListener(helper, listener);
-        }
 
         protected Transform getInternalValue() {
             if (valid == INVALID ||
@@ -9810,7 +9776,7 @@ public abstract class Node implements EventTarget, Styleable {
         public void invalidate() {
             if (valid != INVALID) {
                 valid = INVALID;
-                ExpressionHelper.fireValueChangedEvent(helper);
+                fireValueChangedEvent();
             }
         }
 
@@ -9820,31 +9786,10 @@ public abstract class Node implements EventTarget, Styleable {
     }
 
     private static abstract class LazyBoundsProperty
-            extends ReadOnlyObjectProperty<Bounds> {
-        private ExpressionHelper<Bounds> helper;
+            extends ReadOnlyObjectPropertyBase<Bounds> {
         private boolean valid;
 
         private Bounds bounds;
-
-        @Override
-        public void addListener(InvalidationListener listener) {
-            helper = ExpressionHelper.addListener(helper, this, listener);
-        }
-
-        @Override
-        public void removeListener(InvalidationListener listener) {
-            helper = ExpressionHelper.removeListener(helper, listener);
-        }
-
-        @Override
-        public void addListener(ChangeListener<? super Bounds> listener) {
-            helper = ExpressionHelper.addListener(helper, this, listener);
-        }
-
-        @Override
-        public void removeListener(ChangeListener<? super Bounds> listener) {
-            helper = ExpressionHelper.removeListener(helper, listener);
-        }
 
         @Override
         public Bounds get() {
@@ -9859,7 +9804,7 @@ public abstract class Node implements EventTarget, Styleable {
         public void invalidate() {
             if (valid) {
                 valid = false;
-                ExpressionHelper.fireValueChangedEvent(helper);
+                fireValueChangedEvent();
             }
         }
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
@@ -33,7 +33,6 @@ import javafx.beans.property.ReadOnlyDoubleProperty;
 import javafx.beans.property.ReadOnlyDoubleWrapper;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.ReadOnlyObjectPropertyBase;
-import javafx.beans.value.ChangeListener;
 import javafx.css.CssMetaData;
 import javafx.css.Styleable;
 import javafx.css.StyleableBooleanProperty;
@@ -61,7 +60,6 @@ import java.util.List;
 import java.util.function.Function;
 import com.sun.javafx.util.Logging;
 import com.sun.javafx.util.TempState;
-import com.sun.javafx.binding.ExpressionHelper;
 import javafx.css.converter.BooleanConverter;
 import javafx.css.converter.InsetsConverter;
 import javafx.css.converter.ShapeConverter;
@@ -913,34 +911,17 @@ public class Region extends Parent {
     private final InsetsProperty insets = new InsetsProperty();
     public final Insets getInsets() { return insets.get(); }
     public final ReadOnlyObjectProperty<Insets> insetsProperty() { return insets; }
-    private final class InsetsProperty extends ReadOnlyObjectProperty<Insets> {
+    private final class InsetsProperty extends ReadOnlyObjectPropertyBase<Insets> {
         private Insets cache = null;
-        private ExpressionHelper<Insets> helper = null;
 
         @Override public Object getBean() { return Region.this; }
         @Override public String getName() { return "insets"; }
-
-        @Override public void addListener(InvalidationListener listener) {
-            helper = ExpressionHelper.addListener(helper, this, listener);
-        }
-
-        @Override public void removeListener(InvalidationListener listener) {
-            helper = ExpressionHelper.removeListener(helper, listener);
-        }
-
-        @Override public void addListener(ChangeListener<? super Insets> listener) {
-            helper = ExpressionHelper.addListener(helper, this, listener);
-        }
-
-        @Override public void removeListener(ChangeListener<? super Insets> listener) {
-            helper = ExpressionHelper.removeListener(helper, listener);
-        }
 
         void fireValueChanged() {
             cache = null;
             updateSnappedInsets();
             requestLayout();
-            ExpressionHelper.fireValueChangedEvent(helper);
+            fireValueChangedEvent();
         }
 
         @Override public Insets get() {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/TilePane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/TilePane.java
@@ -25,7 +25,6 @@
 
 package javafx.scene.layout;
 
-import com.sun.javafx.binding.ExpressionHelper;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -33,6 +32,7 @@ import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyDoubleProperty;
+import javafx.beans.property.ReadOnlyDoublePropertyBase;
 import javafx.css.CssMetaData;
 import javafx.css.StyleableDoubleProperty;
 import javafx.css.StyleableIntegerProperty;
@@ -46,8 +46,6 @@ import javafx.geometry.VPos;
 import javafx.scene.Node;
 import javafx.css.converter.EnumConverter;
 import javafx.css.converter.SizeConverter;
-import javafx.beans.InvalidationListener;
-import javafx.beans.value.ChangeListener;
 import javafx.css.Styleable;
 
 import static javafx.geometry.Orientation.*;
@@ -1201,9 +1199,9 @@ public class TilePane extends Pane {
         return getClassCssMetaData();
     }
 
-    private abstract class TileSizeProperty extends ReadOnlyDoubleProperty {
+    private abstract class TileSizeProperty extends ReadOnlyDoublePropertyBase {
         private final String name;
-        private ExpressionHelper<Number> helper;
+
         private double value;
         private boolean valid;
 
@@ -1225,26 +1223,6 @@ public class TilePane extends Pane {
         }
 
         @Override
-        public void addListener(InvalidationListener listener) {
-            helper = ExpressionHelper.addListener(helper, this, listener);
-        }
-
-        @Override
-        public void removeListener(InvalidationListener listener) {
-            helper = ExpressionHelper.removeListener(helper, listener);
-        }
-
-        @Override
-        public void addListener(ChangeListener<? super Number> listener) {
-            helper = ExpressionHelper.addListener(helper, this, listener);
-        }
-
-        @Override
-        public void removeListener(ChangeListener<? super Number> listener) {
-            helper = ExpressionHelper.removeListener(helper, listener);
-        }
-
-        @Override
         public double get() {
             if (!valid) {
                 value = compute();
@@ -1257,7 +1235,7 @@ public class TilePane extends Pane {
         public void invalidate() {
             if (valid) {
                 valid = false;
-                ExpressionHelper.fireValueChangedEvent(helper);
+                fireValueChangedEvent();
             }
         }
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/transform/Transform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/transform/Transform.java
@@ -671,8 +671,7 @@ public abstract class Transform implements Cloneable, EventTarget {
      * Lazily computed read-only boolean property implementation.
      * Used for type2D and identity properties.
      */
-    private static abstract class LazyBooleanProperty
-            extends ReadOnlyBooleanPropertyBase {
+    private static abstract class LazyBooleanProperty extends ReadOnlyBooleanPropertyBase {
 
         private boolean valid;
         private boolean value;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/transform/Transform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/transform/Transform.java
@@ -33,7 +33,6 @@ import javafx.event.EventDispatchChain;
 import javafx.scene.Node;
 
 import com.sun.javafx.util.WeakReferenceQueue;
-import com.sun.javafx.binding.ExpressionHelper;
 import com.sun.javafx.event.EventHandlerManager;
 import com.sun.javafx.geom.transform.Affine3D;
 import com.sun.javafx.geom.transform.BaseTransform;
@@ -41,11 +40,10 @@ import com.sun.javafx.scene.NodeHelper;
 import com.sun.javafx.scene.transform.TransformHelper;
 import com.sun.javafx.scene.transform.TransformUtils;
 import java.lang.ref.SoftReference;
-import javafx.beans.InvalidationListener;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyBooleanProperty;
+import javafx.beans.property.ReadOnlyBooleanPropertyBase;
 import javafx.beans.property.SimpleObjectProperty;
-import javafx.beans.value.ChangeListener;
 import javafx.event.Event;
 import javafx.event.EventHandler;
 import javafx.event.EventTarget;
@@ -674,31 +672,10 @@ public abstract class Transform implements Cloneable, EventTarget {
      * Used for type2D and identity properties.
      */
     private static abstract class LazyBooleanProperty
-            extends ReadOnlyBooleanProperty {
+            extends ReadOnlyBooleanPropertyBase {
 
-        private ExpressionHelper<Boolean> helper;
         private boolean valid;
         private boolean value;
-
-        @Override
-        public void addListener(InvalidationListener listener) {
-            helper = ExpressionHelper.addListener(helper, this, listener);
-        }
-
-        @Override
-        public void removeListener(InvalidationListener listener) {
-            helper = ExpressionHelper.removeListener(helper, listener);
-        }
-
-        @Override
-        public void addListener(ChangeListener<? super Boolean> listener) {
-            helper = ExpressionHelper.addListener(helper, this, listener);
-        }
-
-        @Override
-        public void removeListener(ChangeListener<? super Boolean> listener) {
-            helper = ExpressionHelper.removeListener(helper, listener);
-        }
 
         @Override
         public boolean get() {
@@ -713,7 +690,7 @@ public abstract class Transform implements Cloneable, EventTarget {
         public void invalidate() {
             if (valid) {
                 valid = false;
-                ExpressionHelper.fireValueChangedEvent(helper);
+                fireValueChangedEvent();
             }
         }
 

--- a/modules/javafx.graphics/src/main/java/javafx/stage/PopupWindow.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/PopupWindow.java
@@ -25,7 +25,7 @@
 
 package javafx.stage;
 
-import com.sun.javafx.scene.TreeShowingExpression;
+import com.sun.javafx.scene.TreeShowingProperty;
 import com.sun.javafx.util.Utils;
 import com.sun.javafx.event.DirectEvent;
 import java.util.ArrayList;
@@ -150,7 +150,7 @@ public abstract class PopupWindow extends Window {
     };
 
     private WeakChangeListener<Boolean> weakOwnerNodeListener = new WeakChangeListener(changeListener);
-    private TreeShowingExpression treeShowingExpression;
+    private TreeShowingProperty treeShowingProperty;
 
     /**
      * Constructor for subclasses to call.
@@ -415,8 +415,8 @@ public abstract class PopupWindow extends Window {
 
         // PopupWindow should disappear when owner node is not visible
         if (ownerNode != null) {
-            treeShowingExpression = new TreeShowingExpression(ownerNode);
-            treeShowingExpression.addListener(weakOwnerNodeListener);
+            treeShowingProperty = new TreeShowingProperty(ownerNode);
+            treeShowingProperty.addListener(weakOwnerNodeListener);
         }
 
         updateWindow(anchorX, anchorY);
@@ -493,10 +493,10 @@ public abstract class PopupWindow extends Window {
 
         // When popup hides, remove listeners; these are added when the popup shows.
         if (getOwnerWindow() != null) getOwnerWindow().showingProperty().removeListener(weakOwnerNodeListener);
-        if (treeShowingExpression != null) {
-            treeShowingExpression.removeListener(weakOwnerNodeListener);
-            treeShowingExpression.dispose();
-            treeShowingExpression = null;
+        if (treeShowingProperty != null) {
+            treeShowingProperty.removeListener(weakOwnerNodeListener);
+            treeShowingProperty.dispose();
+            treeShowingProperty = null;
         }
     }
 


### PR DESCRIPTION
These changes use base classes for custom properties where possible for the `ExpressionHelper` logic instead of duplicating these each time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8305885](https://bugs.openjdk.org/browse/JDK-8305885): Use ReadOnly*PropertyBase class where possible


### Reviewers
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1092/head:pull/1092` \
`$ git checkout pull/1092`

Update a local copy of the PR: \
`$ git checkout pull/1092` \
`$ git pull https://git.openjdk.org/jfx.git pull/1092/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1092`

View PR using the GUI difftool: \
`$ git pr show -t 1092`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1092.diff">https://git.openjdk.org/jfx/pull/1092.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1092#issuecomment-1508134405)