### PR TITLE
8304290: Some JNI calls made without checking exceptions in media

### DIFF
--- a/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/MediaError.java
+++ b/modules/javafx.media/src/main/java/com/sun/media/jfxmedia/MediaError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -150,6 +150,7 @@ public enum MediaError {
     ERROR_JNI_SEND_STOP_REACHED_EVENT(ERROR_BASE_JNI.code()+0x000C),
     ERROR_JNI_SEND_DURATION_UPDATE_EVENT(ERROR_BASE_JNI.code()+0x000D),
     ERROR_JNI_SEND_AUDIO_SPECTRUM_EVENT(ERROR_BASE_JNI.code()+0x000E),
+    ERROR_JNI_UNEXPECTED(ERROR_BASE_JNI.code()+0x000F),
 
     ERROR_OSX_INIT(ERROR_BASE_OSX.code() + 0x0001),
 

--- a/modules/javafx.media/src/main/native/jfxmedia/Locator/Locator.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/Locator/Locator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ jstring CLocator::LocatorGetStringLocation(JNIEnv *env, jobject locator)
 
         mid_toString = env->GetMethodID(klass, "getStringLocation", "()Ljava/lang/String;");
         env->DeleteLocalRef(klass);
-        if (javaEnv.clearException())
+        if (javaEnv.clearException() || mid_toString == NULL)
         {
             return NULL;
         }

--- a/modules/javafx.media/src/main/native/jfxmedia/Locator/Locator.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/Locator/Locator.cpp
@@ -53,23 +53,23 @@ CLocator::LocatorType CLocator::GetType()
 
 jstring CLocator::LocatorGetStringLocation(JNIEnv *env, jobject locator)
 {
-    static jmethodID mid_toString = 0;
+    static jmethodID mid_GetStringLocation = NULL;
     jstring result = NULL;
     CJavaEnvironment javaEnv(env);
 
-    if (mid_toString == 0)
+    if (mid_GetStringLocation == NULL)
     {
         jclass klass = env->GetObjectClass(locator);
 
-        mid_toString = env->GetMethodID(klass, "getStringLocation", "()Ljava/lang/String;");
+        mid_GetStringLocation = env->GetMethodID(klass, "getStringLocation", "()Ljava/lang/String;");
         env->DeleteLocalRef(klass);
-        if (javaEnv.clearException() || mid_toString == NULL)
+        if (javaEnv.clearException() || mid_GetStringLocation == NULL)
         {
             return NULL;
         }
     }
 
-    result = (jstring)env->CallObjectMethod(locator, mid_toString);
+    result = (jstring)env->CallObjectMethod(locator, mid_GetStringLocation);
     if (javaEnv.clearException())
     {
         return NULL;

--- a/modules/javafx.media/src/main/native/jfxmedia/Utils/JavaUtils.h
+++ b/modules/javafx.media/src/main/native/jfxmedia/Utils/JavaUtils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@ extern "C" {
 #endif
 
 NSString *NSStringFromJavaString(JNIEnv *env, jstring js);
-jstring JavaStringFromNSString(JNIEnv *env, NSString *ns);
 
 /*
     Returns a valid JNIEnv, if we had to attach the current thread then attached is set

--- a/modules/javafx.media/src/main/native/jfxmedia/Utils/JavaUtils.m
+++ b/modules/javafx.media/src/main/native/jfxmedia/Utils/JavaUtils.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,38 +36,6 @@ NSString *NSStringFromJavaString(JNIEnv *env, jstring js)
         outString = [NSString stringWithCharacters:(const unichar *)jsChars
                                             length:(*env)->GetStringLength(env, js)];
         (*env)->ReleaseStringChars(env, js, jsChars);
-    }
-
-    return outString;
-}
-
-jstring JavaStringFromNSString(JNIEnv *env, NSString *ns)
-{
-    jstring outString = 0;
-
-    if (NULL != env && nil != ns) {
-        jsize length;
-        if (ns.length > INT32_MAX) {
-            // overflow protection: NSUInteger is 64 bit ulong, jsize is 32 bit int
-            length = INT32_MAX-1;
-        } else {
-            length = (jsize)ns.length;
-        }
-        unichar *strBuf = malloc(length * sizeof(unichar));
-        if (!strBuf) {
-            return 0;
-        }
-
-        @try {
-            [ns getCharacters:strBuf range:NSMakeRange(0, length)];
-        }
-        @catch (NSException *exception) {
-            free(strBuf);
-            return 0;
-        }
-
-        outString = (*env)->NewString(env, strBuf, length);
-        free(strBuf);
     }
 
     return outString;

--- a/modules/javafx.media/src/main/native/jfxmedia/jni/JavaBandsHolder.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/jni/JavaBandsHolder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,7 +82,10 @@ void CJavaBandsHolder::UpdateBands(int size, const float* magnitudes, const floa
 
         if (localMagnitudes && localPhases) {
             pEnv->SetFloatArrayRegion(localMagnitudes, 0, size, magnitudes);
-            pEnv->SetFloatArrayRegion(localPhases, 0, size, phases);
+            if (!jenv.clearException()) {
+                pEnv->SetFloatArrayRegion(localPhases, 0, size, phases);
+                jenv.clearException();
+            }
         }
 
         pEnv->DeleteLocalRef(localMagnitudes);

--- a/modules/javafx.media/src/main/native/jfxmedia/jni/JavaInputStreamCallbacks.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/jni/JavaInputStreamCallbacks.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,11 +65,15 @@ bool CJavaInputStreamCallbacks::Init(JNIEnv *env, jobject jLocator)
         jclass klass = env->GetObjectClass(jLocator);
         createConnectionHolder = env->GetMethodID(klass, "createConnectionHolder", "()Lcom/sun/media/jfxmedia/locator/ConnectionHolder;");
         env->DeleteLocalRef(klass);
-        if (javaEnv.reportException())
+        if (javaEnv.reportException() || createConnectionHolder == 0)
             return false;
     }
 
-    m_ConnectionHolder = env->NewGlobalRef(env->CallObjectMethod(jLocator, createConnectionHolder));
+    jobject connectionHolder = env->CallObjectMethod(jLocator, createConnectionHolder);
+    if (javaEnv.reportException() || NULL == connectionHolder)
+        return false;
+
+    m_ConnectionHolder = env->NewGlobalRef(connectionHolder);
     if (NULL == m_ConnectionHolder)
     {
         javaEnv.reportException();
@@ -83,62 +87,61 @@ bool CJavaInputStreamCallbacks::Init(JNIEnv *env, jobject jLocator)
         // Get the parent abstract class. It's wrong to get method ids from the concrete implementation
         // because it crashes jvm when it tries to call virtual methods.
         // See https://javafx-jira.kenai.com/browse/RT-37115
-        jclass klass = NULL;
-        klass = env->FindClass("com/sun/media/jfxmedia/locator/ConnectionHolder");
-        hasException = javaEnv.reportException();
+        jclass klass = env->FindClass("com/sun/media/jfxmedia/locator/ConnectionHolder");
+        hasException = (javaEnv.reportException() || (NULL == klass));
 
         if (!hasException)
         {
             m_BufferFID = env->GetFieldID(klass, "buffer", "Ljava/nio/ByteBuffer;");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_BufferFID));
         }
 
         if (!hasException)
         {
             m_NeedBufferMID = env->GetMethodID(klass, "needBuffer", "()Z");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_NeedBufferMID));
         }
 
         if (!hasException)
         {
             m_ReadNextBlockMID = env->GetMethodID(klass, "readNextBlock", "()I");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_ReadNextBlockMID));
         }
 
         if (!hasException)
         {
             m_ReadBlockMID = env->GetMethodID(klass, "readBlock", "(JI)I");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_ReadBlockMID));
         }
 
         if (!hasException)
         {
             m_IsSeekableMID = env->GetMethodID(klass, "isSeekable", "()Z");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_IsSeekableMID));
         }
 
         if (!hasException)
         {
             m_IsRandomAccessMID = env->GetMethodID(klass, "isRandomAccess", "()Z");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_IsRandomAccessMID));
         }
 
         if (!hasException)
         {
             m_SeekMID = env->GetMethodID(klass, "seek", "(J)J");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_SeekMID));
         }
 
         if (!hasException)
         {
             m_CloseConnectionMID = env->GetMethodID(klass, "closeConnection", "()V");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_CloseConnectionMID));
         }
 
         if (!hasException)
         {
             m_PropertyMID = env->GetMethodID(klass, "property", "(II)I");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_PropertyMID));
         }
 
         if (NULL != klass)
@@ -179,11 +182,10 @@ int CJavaInputStreamCallbacks::ReadNextBlock()
         jobject connection = pEnv->NewLocalRef(m_ConnectionHolder);
         if (connection) {
             result = pEnv->CallIntMethod(connection, m_ReadNextBlockMID);
+            if (javaEnv.clearException()) {
+                result = -2;
+            }
             pEnv->DeleteLocalRef(connection);
-        }
-
-        if (javaEnv.clearException()) {
-            result = -2;
         }
     }
 
@@ -200,11 +202,10 @@ int CJavaInputStreamCallbacks::ReadBlock(int64_t position, int size)
         jobject connection = pEnv->NewLocalRef(m_ConnectionHolder);
         if (connection) {
             result = pEnv->CallIntMethod(connection, m_ReadBlockMID, position, size);
+            if (javaEnv.clearException()) {
+                result = -2;
+            }
             pEnv->DeleteLocalRef(connection);
-        }
-
-        if (javaEnv.clearException()) {
-            result = -2;
         }
     }
 
@@ -238,10 +239,9 @@ bool CJavaInputStreamCallbacks::IsSeekable()
         jobject connection = pEnv->NewLocalRef(m_ConnectionHolder);
         if (connection) {
             result = (pEnv->CallBooleanMethod(connection, m_IsSeekableMID) == JNI_TRUE);
+            javaEnv.clearException();
             pEnv->DeleteLocalRef(connection);
         }
-
-        javaEnv.reportException();
     }
 
     return result;
@@ -257,10 +257,9 @@ bool CJavaInputStreamCallbacks::IsRandomAccess()
         jobject connection = pEnv->NewLocalRef(m_ConnectionHolder);
         if (connection) {
             result = (pEnv->CallBooleanMethod(connection, m_IsRandomAccessMID) == JNI_TRUE);
+            javaEnv.clearException();
             pEnv->DeleteLocalRef(connection);
         }
-
-        javaEnv.reportException();
     }
 
     return result;
@@ -276,10 +275,9 @@ int64_t CJavaInputStreamCallbacks::Seek(int64_t position)
         jobject connection = pEnv->NewLocalRef(m_ConnectionHolder);
         if (connection) {
             result = pEnv->CallLongMethod(connection, m_SeekMID, (jlong)position);
+            javaEnv.clearException();
             pEnv->DeleteLocalRef(connection);
         }
-
-        javaEnv.reportException();
     }
 
     return (int64_t)result;
@@ -294,9 +292,8 @@ void CJavaInputStreamCallbacks::CloseConnection()
         jobject connection = pEnv->NewLocalRef(m_ConnectionHolder);
         if (connection) {
             pEnv->CallVoidMethod(connection, m_CloseConnectionMID);
+            javaEnv.clearException();
             pEnv->DeleteLocalRef(connection);
-
-            javaEnv.reportException();
         }
 
         pEnv->DeleteGlobalRef(m_ConnectionHolder);
@@ -314,10 +311,9 @@ int CJavaInputStreamCallbacks::Property(int prop, int value)
         jobject connection = pEnv->NewLocalRef(m_ConnectionHolder);
         if (connection) {
             result = pEnv->CallIntMethod(connection, m_PropertyMID, (jint)prop, (jint)value);
+            javaEnv.clearException();
             pEnv->DeleteLocalRef(connection);
         }
-
-        javaEnv.reportException();
     }
 
     return result;

--- a/modules/javafx.media/src/main/native/jfxmedia/jni/JavaInputStreamCallbacks.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/jni/JavaInputStreamCallbacks.cpp
@@ -59,18 +59,18 @@ bool CJavaInputStreamCallbacks::Init(JNIEnv *env, jobject jLocator)
 
     CJavaEnvironment javaEnv(m_jvm);
 
-    static jmethodID createConnectionHolder = 0;
-    if (0 == createConnectionHolder)
+    static jmethodID createConnectionHolder = NULL;
+    if (NULL == createConnectionHolder)
     {
         jclass klass = env->GetObjectClass(jLocator);
         createConnectionHolder = env->GetMethodID(klass, "createConnectionHolder", "()Lcom/sun/media/jfxmedia/locator/ConnectionHolder;");
         env->DeleteLocalRef(klass);
-        if (javaEnv.reportException() || createConnectionHolder == 0)
+        if (javaEnv.reportException() || (NULL == createConnectionHolder))
             return false;
     }
 
     jobject connectionHolder = env->CallObjectMethod(jLocator, createConnectionHolder);
-    if (javaEnv.reportException() || NULL == connectionHolder)
+    if (javaEnv.reportException() || (NULL == connectionHolder))
         return false;
 
     m_ConnectionHolder = env->NewGlobalRef(connectionHolder);
@@ -166,7 +166,7 @@ bool CJavaInputStreamCallbacks::NeedBuffer()
             pEnv->DeleteLocalRef(connection);
         }
 
-        javaEnv.reportException();
+        javaEnv.clearException();
     }
 
     return result;

--- a/modules/javafx.media/src/main/native/jfxmedia/jni/JavaMediaWarningListener.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/jni/JavaMediaWarningListener.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,14 +45,14 @@ void CJavaMediaWarningListener::Warning(int warningCode, const char* warningMess
     JNIEnv *pEnv = javaEnv.getEnvironment();
     if (pEnv) {
         jclass mediaUtilsClass = pEnv->FindClass("com/sun/media/jfxmediaimpl/MediaUtils");
-        if (!javaEnv.clearException()) {
+        if (!javaEnv.clearException() && mediaUtilsClass != NULL) {
             jmethodID errorMethodID = pEnv->GetStaticMethodID(mediaUtilsClass,
                                                               "nativeWarning",
                                                               "(ILjava/lang/String;)V");
-            char* message = NULL == warningMessage ? (char*)"" : (char*)warningMessage;
             if (!javaEnv.clearException()) {
+                char* message = NULL == warningMessage ? (char*)"" : (char*)warningMessage;
                 jstring jmessage = pEnv->NewStringUTF(message);
-                if (!javaEnv.clearException()) {
+                if (!javaEnv.clearException() && jmessage != NULL) {
                     pEnv->CallStaticVoidMethod(mediaUtilsClass, errorMethodID,
                                                (jint)warningCode, jmessage);
                     javaEnv.clearException();

--- a/modules/javafx.media/src/main/native/jfxmedia/jni/JavaMediaWarningListener.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/jni/JavaMediaWarningListener.cpp
@@ -46,14 +46,14 @@ void CJavaMediaWarningListener::Warning(int warningCode, const char* warningMess
     if (pEnv) {
         jclass mediaUtilsClass = pEnv->FindClass("com/sun/media/jfxmediaimpl/MediaUtils");
         if (!javaEnv.clearException() && mediaUtilsClass != NULL) {
-            jmethodID errorMethodID = pEnv->GetStaticMethodID(mediaUtilsClass,
-                                                              "nativeWarning",
-                                                              "(ILjava/lang/String;)V");
+            jmethodID nativeWarningMethodID = pEnv->GetStaticMethodID(mediaUtilsClass,
+                                                                      "nativeWarning",
+                                                                      "(ILjava/lang/String;)V");
             if (!javaEnv.clearException()) {
                 char* message = NULL == warningMessage ? (char*)"" : (char*)warningMessage;
                 jstring jmessage = pEnv->NewStringUTF(message);
                 if (!javaEnv.clearException() && jmessage != NULL) {
-                    pEnv->CallStaticVoidMethod(mediaUtilsClass, errorMethodID,
+                    pEnv->CallStaticVoidMethod(mediaUtilsClass, nativeWarningMethodID,
                                                (jint)warningCode, jmessage);
                     javaEnv.clearException();
                     pEnv->DeleteLocalRef(jmessage);

--- a/modules/javafx.media/src/main/native/jfxmedia/jni/JavaPlayerEventDispatcher.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/jni/JavaPlayerEventDispatcher.cpp
@@ -194,9 +194,8 @@ void CJavaPlayerEventDispatcher::Warning(int warningCode, const char* warningMes
                     pEnv->CallVoidMethod(localPlayer, m_SendWarningMethod,
                                  (jint)warningCode, jmessage);
                     jenv.reportException();
+                    pEnv->DeleteLocalRef(jmessage);
                 }
-
-                pEnv->DeleteLocalRef(jmessage);
             }
 
             pEnv->DeleteLocalRef(localPlayer);

--- a/modules/javafx.media/src/main/native/jfxmedia/jni/JavaPlayerEventDispatcher.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/jni/JavaPlayerEventDispatcher.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,78 +85,78 @@ void CJavaPlayerEventDispatcher::Init(JNIEnv *env, jobject PlayerInstance, CMedi
         jclass klass = env->GetObjectClass(m_PlayerInstance);
 
         m_SendWarningMethod = env->GetMethodID(klass, "sendWarning", "(ILjava/lang/String;)V");
-        hasException = javaEnv.reportException();
+        hasException = (javaEnv.reportException() || (NULL == m_SendWarningMethod));
 
         if (!hasException)
         {
             m_SendPlayerMediaErrorEventMethod = env->GetMethodID(klass, "sendPlayerMediaErrorEvent", "(I)V");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_SendPlayerMediaErrorEventMethod));
         }
 
         if (!hasException)
         {
             m_SendPlayerHaltEventMethod = env->GetMethodID(klass, "sendPlayerHaltEvent", "(Ljava/lang/String;D)V");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_SendPlayerHaltEventMethod));
         }
 
         if (!hasException)
         {
             m_SendPlayerStateEventMethod = env->GetMethodID(klass, "sendPlayerStateEvent", "(ID)V");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_SendPlayerStateEventMethod));
         }
 
         if (!hasException)
         {
             m_SendNewFrameEventMethod = env->GetMethodID(klass, "sendNewFrameEvent", "(J)V");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_SendNewFrameEventMethod));
         }
 
         if (!hasException)
         {
             m_SendFrameSizeChangedEventMethod = env->GetMethodID(klass, "sendFrameSizeChangedEvent", "(II)V");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_SendFrameSizeChangedEventMethod));
         }
 
         if (!hasException)
         {
             m_SendAudioTrackEventMethod = env->GetMethodID(klass, "sendAudioTrack", "(ZJLjava/lang/String;ILjava/lang/String;IIF)V");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_SendAudioTrackEventMethod));
         }
 
         if (!hasException)
         {
             m_SendVideoTrackEventMethod = env->GetMethodID(klass, "sendVideoTrack", "(ZJLjava/lang/String;IIIFZ)V");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_SendVideoTrackEventMethod));
         }
 
         if (!hasException)
         {
             m_SendSubtitleTrackEventMethod = env->GetMethodID(klass, "sendSubtitleTrack", "(ZJLjava/lang/String;ILjava/lang/String;)V");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_SendSubtitleTrackEventMethod));
         }
 
         if (!hasException)
         {
             m_SendMarkerEventMethod = env->GetMethodID(klass, "sendMarkerEvent", "(Ljava/lang/String;D)V");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_SendMarkerEventMethod));
         }
 
         if (!hasException)
         {
             m_SendBufferProgressEventMethod = env->GetMethodID(klass, "sendBufferProgressEvent", "(DJJJ)V");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_SendBufferProgressEventMethod));
         }
 
         if (!hasException)
         {
             m_SendDurationUpdateEventMethod  = env->GetMethodID(klass, "sendDurationUpdateEvent", "(D)V");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_SendDurationUpdateEventMethod));
         }
 
         if (!hasException)
         {
             m_SendAudioSpectrumEventMethod  = env->GetMethodID(klass, "sendAudioSpectrumEvent", "(DDZ)V");
-            hasException = javaEnv.reportException();
+            hasException = (javaEnv.reportException() || (NULL == m_SendAudioSpectrumEventMethod));
         }
 
         env->DeleteLocalRef(klass);
@@ -190,14 +190,12 @@ void CJavaPlayerEventDispatcher::Warning(int warningCode, const char* warningMes
             jstring jmessage = NULL;
             if (warningMessage) {
                 jmessage = pEnv->NewStringUTF(warningMessage);
-                if (!jenv.reportException()) {
+                if (!jenv.reportException() && jmessage != NULL) {
                     pEnv->CallVoidMethod(localPlayer, m_SendWarningMethod,
                                  (jint)warningCode, jmessage);
                     jenv.reportException();
                 }
-            }
 
-            if (jmessage) {
                 pEnv->DeleteLocalRef(jmessage);
             }
 
@@ -234,17 +232,13 @@ bool CJavaPlayerEventDispatcher::SendPlayerHaltEvent(const char* message, double
         if (localPlayer) {
             jstring jmessage = NULL;
             jmessage = pEnv->NewStringUTF(message);
-            if (!jenv.reportException()) {
+            if (!jenv.reportException() && jmessage != NULL) {
                 pEnv->CallVoidMethod(localPlayer, m_SendPlayerHaltEventMethod, jmessage, time);
-            }
-
-            if (jmessage) {
                 pEnv->DeleteLocalRef(jmessage);
+                bSucceeded = !jenv.reportException();
             }
 
             pEnv->DeleteLocalRef(localPlayer);
-
-            bSucceeded = !jenv.reportException();
         }
     }
 
@@ -357,10 +351,10 @@ bool CJavaPlayerEventDispatcher::SendAudioTrackEvent(CAudioTrack* pTrack)
             jstring name = NULL;
             jstring language = NULL;
             name = pEnv->NewStringUTF(pTrack->GetName().c_str());
-            if (!jenv.reportException()) {
+            if (!jenv.reportException() && name != NULL) {
                 language = pEnv->NewStringUTF(pTrack->GetLanguage().c_str());
 
-                if (!jenv.reportException()) {
+                if (!jenv.reportException() && language != NULL) {
                     // Translate channel mask bits from native values to Java values.
                     int nativeChannelMask = pTrack->GetChannelMask();
                     jint javaChannelMask = 0;
@@ -389,20 +383,15 @@ bool CJavaPlayerEventDispatcher::SendAudioTrackEvent(CAudioTrack* pTrack)
                                          pTrack->GetNumChannels(),
                                          javaChannelMask,
                                          pTrack->GetSampleRate());
-                }
-            }
+                    bSucceeded = !jenv.reportException();
 
-            if (name) {
+                    pEnv->DeleteLocalRef(language);
+                }
+
                 pEnv->DeleteLocalRef(name);
             }
 
-            if (language) {
-                pEnv->DeleteLocalRef(language);
-            }
-
             pEnv->DeleteLocalRef(localPlayer);
-
-            bSucceeded = !jenv.reportException();
         }
     }
 
@@ -417,22 +406,18 @@ bool CJavaPlayerEventDispatcher::SendVideoTrackEvent(CVideoTrack* pTrack)
     if (pEnv) {
         jobject localPlayer = pEnv->NewLocalRef(m_PlayerInstance);
         if (localPlayer) {
-            jstring name = NULL;
-            name = pEnv->NewStringUTF(pTrack->GetName().c_str());
-            if (!jenv.reportException()) {
+            jstring name = pEnv->NewStringUTF(pTrack->GetName().c_str());
+            if (!jenv.reportException() && name != NULL) {
                 pEnv->CallVoidMethod(localPlayer, m_SendVideoTrackEventMethod,
                                      (jboolean)pTrack->isEnabled(), (jlong)pTrack->GetTrackID(), name, pTrack->GetEncoding(),
                                      pTrack->GetWidth(), pTrack->GetHeight(),
                                      pTrack->GetFrameRate(), pTrack->HasAlphaChannel());
-            }
+                bSucceeded = !jenv.reportException();
 
-            if (name) {
                 pEnv->DeleteLocalRef(name);
             }
 
             pEnv->DeleteLocalRef(localPlayer);
-
-            bSucceeded = !jenv.reportException();
         }
     }
 
@@ -450,26 +435,21 @@ bool CJavaPlayerEventDispatcher::SendSubtitleTrackEvent(CSubtitleTrack* pTrack)
             jstring name = NULL;
             jstring language = NULL;
             name = pEnv->NewStringUTF(pTrack->GetName().c_str());
-            if (!jenv.reportException()) {
+            if (!jenv.reportException() && name != NULL) {
                 language = pEnv->NewStringUTF(pTrack->GetLanguage().c_str());
-                if (!jenv.reportException()) {
+                if (!jenv.reportException() && language != NULL) {
                     pEnv->CallVoidMethod(localPlayer, m_SendSubtitleTrackEventMethod,
                                          (jboolean)pTrack->isEnabled(), (jlong)pTrack->GetTrackID(),
                                          name, pTrack->GetEncoding(), language);
-                }
-            }
+                    bSucceeded = !jenv.reportException();
 
-            if (name) {
+                    pEnv->DeleteLocalRef(language);
+                }
+
                 pEnv->DeleteLocalRef(name);
             }
 
-            if (language) {
-                pEnv->DeleteLocalRef(language);
-            }
-
             pEnv->DeleteLocalRef(localPlayer);
-
-            bSucceeded = !jenv.reportException();
         }
     }
 
@@ -484,20 +464,16 @@ bool CJavaPlayerEventDispatcher::SendMarkerEvent(string name, double time)
     if (pEnv) {
         jobject localPlayer = pEnv->NewLocalRef(m_PlayerInstance);
         if (localPlayer) {
-            jobject jname = NULL;
-            jname = pEnv->NewStringUTF(name.c_str());
-            if (!jenv.reportException()) {
+            jobject jname = pEnv->NewStringUTF(name.c_str());
+            if (!jenv.reportException() && jname != NULL) {
                 pEnv->CallVoidMethod(localPlayer, m_SendMarkerEventMethod,
                                      jname, time);
-            }
+                bSucceeded = !jenv.reportException();
 
-            if (jname) {
                 pEnv->DeleteLocalRef(jname);
             }
 
             pEnv->DeleteLocalRef(localPlayer);
-
-            bSucceeded = !jenv.reportException();
         }
     }
 
@@ -571,14 +547,15 @@ jobject CJavaPlayerEventDispatcher::CreateObject(JNIEnv *env, jmethodID *cid,
     jclass  classe;
     jobject result;
 
+    CJavaEnvironment jenv(env);
     classe = env->FindClass(class_name);
-    if( classe == NULL )
+    if (jenv.reportException() || classe == NULL)
         return NULL; /* can't find/load the class, exception thrown */
 
-    if( *cid == NULL)
+    if (*cid == NULL)
     {
         *cid = env->GetMethodID(classe, "<init>", signature);
-        if( *cid == NULL )
+        if (jenv.reportException() || *cid == NULL)
         {
             env->DeleteLocalRef(classe);
             return NULL; /* can't find/get the method, exception thrown */
@@ -586,6 +563,7 @@ jobject CJavaPlayerEventDispatcher::CreateObject(JNIEnv *env, jmethodID *cid,
     }
 
     result = env->NewObjectA(classe, *cid, value);
+    jenv.reportException();
 
     env->DeleteLocalRef(classe);
     return result;
@@ -637,14 +615,16 @@ jobject CJavaPlayerEventDispatcher::CreateDuration(JNIEnv *env, jlong duration)
     // We receive duration in nanoseconds, but javafx.util.Duration needs in milliseconds
     jdouble millis = duration/1000000.0;
 
+    CJavaEnvironment jenv(env);
+
     jclass durationClass = env->FindClass("javafx/util/Duration");
-    if (durationClass == NULL)
+    if (jenv.reportException() || durationClass == NULL)
         return NULL; /* can't find/load the class, exception thrown */
 
     if (constructorID == NULL)
     {
         constructorID = env->GetMethodID(durationClass, "<init>", "(D)V");
-        if( constructorID == NULL )
+        if (jenv.reportException() || constructorID == NULL)
         {
             env->DeleteLocalRef(durationClass);
             return NULL; /* can't find/get the method, exception thrown */
@@ -652,6 +632,7 @@ jobject CJavaPlayerEventDispatcher::CreateDuration(JNIEnv *env, jlong duration)
     }
 
     jobject result = env->NewObject(durationClass, constructorID, millis);
+    jenv.reportException();
 
     env->DeleteLocalRef(durationClass);
 

--- a/modules/javafx.media/src/main/native/jfxmedia/jni/JniUtils.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/jni/JniUtils.cpp
@@ -49,15 +49,9 @@ void ThrowJavaException(JNIEnv *env, const char* type, const char* message)
     }
     if (!klass) {
         klass = env->FindClass("java/lang/Exception");
-        if (env->ExceptionCheck() || klass != NULL) {
+        if (env->ExceptionCheck() || klass == NULL) {
             env->ExceptionClear();
             return; // This shouldn't happen...
-        }
-        if (!klass) {
-            if (env->ExceptionCheck()) {
-                env->ExceptionClear();
-            }
-
         }
     }
     env->ThrowNew(klass, message);

--- a/modules/javafx.media/src/main/native/jfxmedia/jni/JniUtils.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/jni/JniUtils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,21 +42,22 @@ void ThrowJavaException(JNIEnv *env, const char* type, const char* message)
     jclass klass = NULL;
     if (type) {
         klass = env->FindClass(type);
-        if (!klass) {
-            // might have caused an exception
-            if (env->ExceptionOccurred()) {
-                env->ExceptionClear();
-            }
+        // might have caused an exception
+        if (env->ExceptionCheck()) {
+            env->ExceptionClear();
         }
     }
     if (!klass) {
         klass = env->FindClass("java/lang/Exception");
+        if (env->ExceptionCheck() || klass != NULL) {
+            env->ExceptionClear();
+            return; // This shouldn't happen...
+        }
         if (!klass) {
-            if (env->ExceptionOccurred()) {
+            if (env->ExceptionCheck()) {
                 env->ExceptionClear();
             }
-            // This shouldn't happen...
-            return;
+
         }
     }
     env->ThrowNew(klass, message);
@@ -100,7 +101,7 @@ bool CJavaEnvironment::reportException()
         if (exc) {
             environment->ExceptionClear(); // Clear current exception
             jclass cid = environment->FindClass("java/lang/Throwable");
-            if (!clearException()) {
+            if (!clearException() && cid != NULL) {
                 jmethodID mid = environment->GetMethodID(cid, "toString", "()Ljava/lang/String;");
                 if (!clearException()) {
                     jstring jmsg = (jstring)environment->CallObjectMethod(exc, mid);

--- a/modules/javafx.media/src/main/native/jfxmedia/jni/NativeAudioEqualizer.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/jni/NativeAudioEqualizer.cpp
@@ -66,22 +66,22 @@ Java_com_sun_media_jfxmediaimpl_NativeAudioEqualizer_nativeAddBand(JNIEnv *env, 
         CEqualizerBand *band = pEqualizer->AddBand(centerFrequency, bandWidth, gain);
         if (NULL != band) {
             jclass bandClass = env->FindClass("com/sun/media/jfxmediaimpl/NativeEqualizerBand");
-            if (jenv.reportException()) {
+            if (jenv.reportException() || bandClass == NULL) {
                 return NULL;
             }
 
             if (NULL == mid_EqualizerBandConstructor)
             {
                 mid_EqualizerBandConstructor = env->GetMethodID(bandClass, "<init>", "(J)V");
-                if (jenv.reportException()) {
+                if (jenv.reportException() || mid_EqualizerBandConstructor == NULL) {
                     env->DeleteLocalRef(bandClass);
                     return NULL;
                 }
             }
 
             jobject band_instance = env->NewObject(bandClass, mid_EqualizerBandConstructor, ptr_to_jlong(band));
-            env->DeleteLocalRef(bandClass);
             jenv.reportException(); // Report exception from NewObject()
+            env->DeleteLocalRef(bandClass);
 
             return band_instance;
         }

--- a/modules/javafx.media/src/main/native/jfxmedia/jni/NativeVideoBuffer.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/jni/NativeVideoBuffer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,12 @@ JNIEXPORT jobject JNICALL Java_com_sun_media_jfxmediaimpl_NativeVideoBuffer_nati
     if (frame) {
         void *dataPtr = frame->GetDataForPlane((int)plane);
         jlong capacity = (jlong)frame->GetSizeForPlane((int)plane);
-        return env->NewDirectByteBuffer(dataPtr, capacity);
+        jobject buffer = env->NewDirectByteBuffer(dataPtr, capacity);
+        if (env->ExceptionCheck()) {
+            env->ExceptionClear();
+            return NULL;
+        }
+        return buffer;
     }
     return NULL;
 }
@@ -209,6 +214,11 @@ JNIEXPORT jintArray JNICALL Java_com_sun_media_jfxmediaimpl_NativeVideoBuffer_na
 
         env->SetIntArrayRegion(strides, 0, count, strideArray);
         delete [] strideArray;
+
+        if (env->ExceptionCheck()) {
+            env->ExceptionClear();
+            return NULL;
+        }
 
         return strides;
     }

--- a/modules/javafx.media/src/main/native/jfxmedia/jni/com_sun_media_jfxmediaimpl_NativeVideoConverter.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/jni/com_sun_media_jfxmediaimpl_NativeVideoConverter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,63 +51,67 @@ static jmethodID formatGetNativeTypeID;     // ()I
 
 static void initialize_jni_methods(JNIEnv *env) {
     if (!klassMethodsInitialized) {
-        jclass vdbClass = env->FindClass("com/sun/media/jfxmedia/control/VideoDataBuffer");
-        jclass formatClass = env->FindClass("com/sun/media/jfxmedia/control/VideoDataBuffer/Format");
+        CJavaEnvironment jenv(env);
 
-        if (!vdbClass) {
+        jclass vdbClass = env->FindClass("com/sun/media/jfxmedia/control/VideoDataBuffer");
+        if (jenv.clearException() || vdbClass == NULL) {
             throw "Internal Error: Can't find VideoDataBuffer class";
         }
-        if (!formatClass) {
+
+        jclass formatClass = env->FindClass("com/sun/media/jfxmedia/control/VideoDataBuffer/Format");
+        if (jenv.clearException() || formatClass == NULL) {
             throw "Internal Error: Can't find VideoDataBuffer.Format class";
         }
 
         vdbCtorID = env->GetMethodID(vdbClass, "<init>", "(Lcom/sun/media/jfxmedia/control/MediaDataDisposer;Ljava/nio/ByteBuffer;DJIIIILcom/sun/media/jfxmedia/VideoDataBuffer$Format;I[I[I)V");
-        if (!vdbCtorID) {
-            throw "Internal Error: Can't get VideoDataBuffer constructor.");
+        if (jenv.clearException() || vdbCtorID == NULL) {
+            throw "Internal Error: Can't get VideoDataBuffer constructor.";
         }
 
         vdbGetBufferID = env->GetMethodID(vdbClass, "getBuffer", "()Ljava/nio/Buffer;");
-        if (!vdbGetBufferID) {
+        if (jenv.clearException() || vdbGetBufferID == NULL) {
             throw "Internal Error: Can't find VideoDataBuffer.getBuffer()";
         }
 
         vdbGetWidthID = env->GetMethodID(vdbClass, "getWidth", "()I");
-        if (!vdbGetWidthID) {
+        if (jenv.clearException() || vdbGetWidthID == NULL) {
             throw "Internal Error: Can't find VideoDataBuffer.getWidth()";
         }
 
         vdbGetHeightID = env->GetMethodID(vdbClass, "getHeight", "()I");
-        if (!vdbGetHeightID) {
+        if (jenv.clearException() || vdbGetHeightID == NULL) {
             throw "Internal Error: Can't find VideoDataBuffer.getHeight()";
         }
 
         vdbGetEncodedWidthID = env->GetMethodID(vdbClass, "getEncodedWidth", "()I");
+        if (jenv.clearException() || vdbGetEncodedWidthID == NULL) {
         if (!vdbGetEncodedWidthID) {
             throw "Internal Error: Can't find VideoDataBuffer.getEncodedWidth()";
         }
 
         vdbGetEncodedHeightID = env->GetMethodID(vdbClass, "getEncodedHeight", "()I");
+        if (jenv.clearException() || vdbGetEncodedWidthID == NULL) {
         if (!vdbGetEncodedHeightID) {
             throw "Internal Error: Can't find VideoDataBuffer.getEncodedHeight()";
         }
 
         vdbGetPlaneCountID = env->GetMethodID(vdbClass, "getPlaneCount", "()I");
-        if (!vdbGetPlaneCountID) {
+        if (jenv.clearException() || vdbGetPlaneCountID == NULL) {
             throw "Internal Error: Can't find VideoDataBuffer.getPlaneCount()";
         }
 
         vdbGetPlaneStridesID = env->GetMethodID(vdbClass, "getPlaneStrides", "()[I");
-        if (!vdbGetPlaneStridesID) {
+        if (jenv.clearException() || vdbGetPlaneStridesID == NULL) {
             throw "Internal Error: Can't find VideoDataBuffer.getPlaneStrides()";
         }
 
         vdbGetFormatID = env->GetMethodID(vdbClass, "getFormat", "()Lcom/sun/media/jfxmedia/control/VideoDataBuffer$Format;");
-        if (!vdbGetFormatID) {
+        if (jenv.clearException() || vdbGetFormatID == NULL) {
             throw "Internal Error: Can't find VideoDataBuffer.getFormat()";
         }
 
         formatGetNativeTypeID = env->GetMethodID(formatClass, "getNativeType", "()I");
-        if (!formatGetNativeTypeID) {
+        if (jenv.clearException() || formatGetNativeTypeID == NULL) {
             throw "Internal Error: Can't find VideoDataBuffer.Format.getNativeType()";
         }
 
@@ -117,9 +121,9 @@ static void initialize_jni_methods(JNIEnv *env) {
 
 static void throw_internal_error_exception(JNIEnv *env, const char *errorString)
 {
+    CJavaEnvironment jenv(env);
     jclass ieeKlass = env->FindClass("java/lang/InternalError");
-    if (ieeKlass) {
-        // FIXME: can we just pass NULL for the message string?
+    if (!jenv.clearException() && ieeKlass != NULL) {
         env->ThrowNew(ieeKlass, (NULL != errorString) ? errorString : "");
         env->DeleteLocalRef(ieeKlass);
     }
@@ -127,7 +131,7 @@ static void throw_internal_error_exception(JNIEnv *env, const char *errorString)
 
 static bool exception_check(JNIEnv *env)
 {
-    if (env->ExceptionOccurred()) {
+    if (env->ExceptionCheck()) {
         env->ExceptionDescribe();
         // Don't clear the exception, let it get back to the JVM
         return true;

--- a/modules/javafx.media/src/main/native/jfxmedia/platform/gstreamer/GstMedia.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/platform/gstreamer/GstMedia.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,6 +115,9 @@ extern "C" {
             {
                 jlong lMediaHandle = (jlong)ptr_to_jlong(pMedia);
                 env->SetLongArrayRegion(jlMediaHandle, 0, 1, &lMediaHandle);
+                if (env->ExceptionCheck()) {
+                    env->ExceptionClear();
+                }
             }
             else
             {

--- a/modules/javafx.media/src/main/native/jfxmedia/platform/gstreamer/GstMediaPlayer.cpp
+++ b/modules/javafx.media/src/main/native/jfxmedia/platform/gstreamer/GstMediaPlayer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -134,6 +134,10 @@ JNIEXPORT jint JNICALL Java_com_sun_media_jfxmediaimpl_platform_gstreamer_GSTMed
         return (jint)uErrCode;
     jlong jlAudioSyncDelay = (jlong)lAudioSyncDelay;
     env->SetLongArrayRegion(jrglAudioSyncDelay, 0, 1, &jlAudioSyncDelay);
+    if (env->ExceptionCheck()) {
+        env->ExceptionClear();
+        return ERROR_JNI_UNEXPECTED;
+    }
 
     LOWLEVELPERF_EXECTIMESTOP("gstGetAudioSyncDelay()");
 
@@ -294,6 +298,10 @@ JNIEXPORT jint JNICALL Java_com_sun_media_jfxmediaimpl_platform_gstreamer_GSTMed
         return uRetCode;
     jfloat jfRate = (jfloat)fRate;
     env->SetFloatArrayRegion (jrgfRate, 0, 1, &jfRate);
+    if (env->ExceptionCheck()) {
+        env->ExceptionClear();
+        return ERROR_JNI_UNEXPECTED;
+    }
 
     LOWLEVELPERF_EXECTIMESTOP("gstGetRate()");
 
@@ -349,6 +357,10 @@ JNIEXPORT jint JNICALL Java_com_sun_media_jfxmediaimpl_platform_gstreamer_GSTMed
         return uRetCode;
     jdouble jdPresentationTime = (double)dPresentationTime;
     env->SetDoubleArrayRegion (jrgdPresentationTime, 0, 1, &jdPresentationTime);
+    if (env->ExceptionCheck()) {
+        env->ExceptionClear();
+        return ERROR_JNI_UNEXPECTED;
+    }
 
     LOWLEVELPERF_EXECTIMESTOP("gstGetPresentationTime()");
 
@@ -379,6 +391,10 @@ JNIEXPORT jint JNICALL Java_com_sun_media_jfxmediaimpl_platform_gstreamer_GSTMed
         return uRetCode;
     jfloat jfVolume = (jfloat)fVolume;
     env->SetFloatArrayRegion (jrgfVolume, 0, 1, &jfVolume);
+    if (env->ExceptionCheck()) {
+        env->ExceptionClear();
+        return ERROR_JNI_UNEXPECTED;
+    }
 
     LOWLEVELPERF_EXECTIMESTOP("gstGetVolume()");
 
@@ -434,6 +450,10 @@ JNIEXPORT jint JNICALL Java_com_sun_media_jfxmediaimpl_platform_gstreamer_GSTMed
         return uErrCode;
     jfloat jfBalance = (jfloat)fBalance;
     env->SetFloatArrayRegion (jrgfBalance, 0, 1, &jfBalance);
+    if (env->ExceptionCheck()) {
+        env->ExceptionClear();
+        return ERROR_JNI_UNEXPECTED;
+    }
 
     LOWLEVELPERF_EXECTIMESTOP("gstGetBalance()");
 
@@ -489,6 +509,10 @@ JNIEXPORT jint JNICALL Java_com_sun_media_jfxmediaimpl_platform_gstreamer_GSTMed
         return uErrCode;
     jdouble jdDuration = (jdouble)dDuration;
     env->SetDoubleArrayRegion (jrgdDuration, 0, 1, &jdDuration);
+    if (env->ExceptionCheck()) {
+        env->ExceptionClear();
+        return ERROR_JNI_UNEXPECTED;
+    }
 
     LOWLEVELPERF_EXECTIMESTOP("gstGetDuration()");
 


### PR DESCRIPTION
- Added missing exception checks for JNI calls.
 - Improved JNI error checking by checking for both exception and return value.
 - Minor code clean up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8304290](https://bugs.openjdk.org/browse/JDK-8304290): Some JNI calls made without checking exceptions in media (**Bug** - P4)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1094/head:pull/1094` \
`$ git checkout pull/1094`

Update a local copy of the PR: \
`$ git checkout pull/1094` \
`$ git pull https://git.openjdk.org/jfx.git pull/1094/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1094`

View PR using the GUI difftool: \
`$ git pr show -t 1094`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1094.diff">https://git.openjdk.org/jfx/pull/1094.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1094#issuecomment-1512337493)