### PR TITLE
Content graph

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/LabeledContentList.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/LabeledContentList.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.scene.control;
+
+import javafx.collections.ObservableListBase;
+import javafx.scene.Node;
+import javafx.scene.control.Labeled;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Specialized list that represents the content model of a {@link Labeled} control.
+ * <p>
+ * This list contains any combination or none of the following:
+ * <ul>
+ *     <li>A {@code String} object, representing {@link Labeled#textProperty()}
+ *     <li>A {@code Node} object, representing {@link Labeled#graphicProperty()}
+ * </ul>
+ */
+public final class LabeledContentList extends ObservableListBase<Object> {
+
+    private String text;
+    private Node graphic;
+
+    public void setText(String value) {
+        if (text == null && value == null || text != null && Objects.equals(text, value)) {
+            return;
+        }
+
+        beginChange();
+
+        if (text != null) {
+            if (value != null) {
+                nextReplace(0, 1, List.of(text));
+                text = value;
+            } else {
+                nextRemove(0, text);
+                text = null;
+            }
+        } else {
+            nextAdd(0, 1);
+            text = value;
+        }
+
+        endChange();
+    }
+
+    public void setGraphic(Node value) {
+        if (graphic == value) {
+            return;
+        }
+
+        beginChange();
+
+        if (graphic != null) {
+            if (value != null) {
+                nextReplace(0, 1, List.of(graphic));
+                graphic = value;
+            } else {
+                nextRemove(0, graphic);
+                graphic = null;
+            }
+        } else {
+            nextAdd(0, 1);
+            graphic = value;
+        }
+
+        endChange();
+    }
+
+    @Override
+    public Object get(int index) {
+        Objects.checkIndex(index, size());
+        return switch(index) {
+            case 0 -> text != null ? text : graphic;
+            case 1 -> graphic;
+            default -> throw new IndexOutOfBoundsException(index);
+        };
+    }
+
+    @Override
+    public int size() {
+        if (text != null) {
+            if (graphic != null) {
+                return 2;
+            }
+
+            return 1;
+        } else if (graphic != null) {
+            return 1;
+        }
+
+        return 0;
+    }
+
+}

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ReseatableObservableListAdapter.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ReseatableObservableListAdapter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.scene.control;
+
+import com.sun.javafx.collections.SourceAdapterChange;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.collections.ObservableListBase;
+import javafx.collections.WeakListChangeListener;
+import java.util.Objects;
+
+/**
+ * Thin unmodifiable wrapper around an {@link ObservableList}.
+ * <p>
+ * The wrapped {@code ObservableList} can be changed at any time, allowing an instance of this
+ * class to be used as a stand-in for different backing lists. Change notifications of the wrapped
+ * backing list are forwarded through this list, and swapping out the backing list fires an
+ * appropriate change notification on this list.
+ */
+public final class ReseatableObservableListAdapter<T> extends ObservableListBase<T> implements ListChangeListener<T> {
+
+    private final WeakListChangeListener<T> weakListChangeListener = new WeakListChangeListener<>(this);
+    private ObservableList<T> list;
+
+    public void changeList(ObservableList<T> newList) {
+        ObservableList<T> oldList = this.list;
+        this.list = newList;
+
+        beginChange();
+
+        if (oldList != null) {
+            oldList.removeListener(weakListChangeListener);
+            nextRemove(0, oldList);
+        }
+
+        if (newList != null) {
+            newList.addListener(weakListChangeListener);
+            nextAdd(0, newList.size());
+        }
+
+        endChange();
+    }
+
+    @Override
+    public void onChanged(Change<? extends T> c) {
+        fireChange(new SourceAdapterChange<>(this, c));
+    }
+
+    @Override
+    public T get(int index) {
+        if (list == null) {
+            throw new IndexOutOfBoundsException(index);
+        }
+
+        return list.get(index);
+    }
+
+    @Override
+    public int size() {
+        return list != null ? list.size() : 0;
+    }
+
+}

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/Labeled.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/Labeled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package javafx.scene.control;
 
 import com.sun.javafx.css.StyleManager;
 import com.sun.javafx.scene.NodeHelper;
+import com.sun.javafx.scene.control.LabeledContentList;
 import javafx.css.converter.BooleanConverter;
 import javafx.css.converter.EnumConverter;
 import javafx.css.converter.InsetsConverter;
@@ -96,6 +97,8 @@ public abstract class Labeled extends Control {
 
     private final static String DEFAULT_ELLIPSIS_STRING = "...";
 
+    private final LabeledContentList contentModel = new LabeledContentList();
+
 
     /* *************************************************************************
      *                                                                         *
@@ -106,7 +109,9 @@ public abstract class Labeled extends Control {
     /**
      * Creates a Label with no text and graphic
      */
-    public Labeled() { }
+    public Labeled() {
+        addContentModel(contentModel);
+    }
 
     /**
      * Creates a Label with text
@@ -114,6 +119,7 @@ public abstract class Labeled extends Control {
      */
     public Labeled(String text) {
         setText(text);
+        addContentModel(contentModel);
     }
 
     /**
@@ -124,6 +130,7 @@ public abstract class Labeled extends Control {
     public Labeled(String text, Node graphic) {
         setText(text);
         ((StyleableProperty<Node>)(WritableValue<Node>)graphicProperty()).applyStyle(null, graphic);
+        addContentModel(contentModel);
     }
 
     /* *************************************************************************
@@ -139,7 +146,12 @@ public abstract class Labeled extends Control {
      */
     public final StringProperty textProperty() {
         if (text == null) {
-            text = new SimpleStringProperty(this, "text", "");
+            text = new SimpleStringProperty(this, "text", "") {
+                @Override
+                protected void invalidated() {
+                    contentModel.setText(get());
+                }
+            };
         }
         return text;
     }
@@ -439,6 +451,11 @@ public abstract class Labeled extends Control {
                 @Override
                 public String getName() {
                     return "graphic";
+                }
+
+                @Override
+                protected void invalidated() {
+                    contentModel.setGraphic(get());
                 }
             };
         }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListView.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 
+import com.sun.javafx.scene.control.ReseatableObservableListAdapter;
 import com.sun.javafx.scene.control.Properties;
 import com.sun.javafx.scene.control.behavior.ListCellBehavior;
 import javafx.beans.InvalidationListener;
@@ -337,6 +338,7 @@ public class ListView<T> extends Control {
     // for the ComboBox, this is not desirable, so it can be disabled here.
     private boolean selectFirstRowByDefault = true;
 
+    private final ReseatableObservableListAdapter<T> contentModel = new ReseatableObservableListAdapter<>();
 
 
     /* *************************************************************************
@@ -400,6 +402,8 @@ public class ListView<T> extends Control {
         });
 
         pseudoClassStateChanged(PSEUDO_CLASS_VERTICAL, true);
+
+        addContentModel(contentModel);
     }
 
 
@@ -457,7 +461,12 @@ public class ListView<T> extends Control {
      */
     public final ObjectProperty<ObservableList<T>> itemsProperty() {
         if (items == null) {
-            items = new SimpleObjectProperty<>(this, "items");
+            items = new SimpleObjectProperty<>(this, "items") {
+                @Override
+                protected void invalidated() {
+                    contentModel.changeList(get());
+                }
+            };
         }
         return items;
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/Menu.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/Menu.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -172,6 +172,10 @@ public class Menu extends MenuItem {
                 item.setParentPopup(getParentPopup());
             }
         });
+
+        // We only need to add "items" here, since "text" and "graphic" are already
+        // part of MenuItem's content model.
+        addContentModel(this.items);
     }
 
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/MenuButton.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/MenuButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -173,6 +173,7 @@ public class MenuButton extends ButtonBase {
             getItems().addAll(items);
         }
 
+        addContentModel(this.items);
         getStyleClass().setAll(DEFAULT_STYLE_CLASS);
         setAccessibleRole(AccessibleRole.MENU_BUTTON);
         setMnemonicParsing(true);     // enable mnemonic auto-parsing by default

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/MenuItem.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/MenuItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@ package javafx.scene.control;
 
 import com.sun.javafx.beans.IDProperty;
 import javafx.collections.ObservableSet;
+import javafx.content.ContentParentBase;
 import javafx.css.PseudoClass;
 import javafx.css.Styleable;
 import javafx.css.CssMetaData;
@@ -50,6 +51,7 @@ import javafx.scene.input.KeyCombination;
 
 import com.sun.javafx.event.EventHandlerManager;
 import com.sun.javafx.scene.control.ContextMenuContent;
+import com.sun.javafx.scene.control.LabeledContentList;
 import javafx.scene.control.skin.ContextMenuSkin;
 import java.util.Collections;
 import java.util.HashMap;
@@ -94,7 +96,7 @@ MenuBar menuBar = new MenuBar(menu);</code></pre>
  * @since JavaFX 2.0
  */
 @IDProperty("id")
-public class MenuItem implements EventTarget, Styleable {
+public class MenuItem extends ContentParentBase implements EventTarget, Styleable {
 
     /* *************************************************************************
      *                                                                         *
@@ -130,6 +132,7 @@ public class MenuItem implements EventTarget, Styleable {
         setText(text);
         setGraphic(graphic);
         styleClass.add(DEFAULT_STYLE_CLASS);
+        addContentModel(contentModel);
     }
 
 
@@ -140,6 +143,8 @@ public class MenuItem implements EventTarget, Styleable {
      *                                                                         *
      **************************************************************************/
 
+    private final LabeledContentList contentModel = new LabeledContentList();
+
     private final ObservableList<String> styleClass = FXCollections.observableArrayList();
 
     final EventHandlerManager eventHandlerManager =
@@ -147,6 +152,7 @@ public class MenuItem implements EventTarget, Styleable {
 
     private Object userData;
     private ObservableMap<Object, Object> properties;
+
 
     /* *************************************************************************
      *                                                                         *
@@ -260,7 +266,12 @@ public class MenuItem implements EventTarget, Styleable {
 
     public final StringProperty textProperty() {
         if (text == null) {
-            text = new SimpleStringProperty(this, "text");
+            text = new SimpleStringProperty(this, "text") {
+                @Override
+                protected void invalidated() {
+                    contentModel.setText(get());
+                }
+            };
         }
         return text;
     }
@@ -284,7 +295,12 @@ public class MenuItem implements EventTarget, Styleable {
 
     public final ObjectProperty<Node> graphicProperty() {
         if (graphic == null) {
-            graphic = new SimpleObjectProperty<>(this, "graphic");
+            graphic = new SimpleObjectProperty<>(this, "graphic") {
+                @Override
+                protected void invalidated() {
+                    contentModel.setGraphic(get());
+                }
+            };
         }
         return graphic;
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SplitPane.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SplitPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -232,6 +232,8 @@ public class SplitPane extends Control {
         if (items != null) {
             getItems().addAll(items);
         }
+
+        addContentModel(getItems());
 
         // initialize pseudo-class state
         pseudoClassStateChanged(HORIZONTAL_PSEUDOCLASS_STATE, true);

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/Tab.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/Tab.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package javafx.scene.control;
 import com.sun.javafx.beans.IDProperty;
 import com.sun.javafx.scene.control.ControlAcceleratorSupport;
 import javafx.collections.ObservableSet;
+import javafx.content.ContentParentBase;
 import javafx.css.CssMetaData;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
@@ -76,7 +77,7 @@ import javafx.collections.ObservableMap;
  */
 @DefaultProperty("content")
 @IDProperty("id")
-public class Tab implements EventTarget, Styleable {
+public class Tab extends ContentParentBase implements EventTarget, Styleable {
 
     /* *************************************************************************
      *                                                                         *
@@ -305,7 +306,12 @@ public class Tab implements EventTarget, Styleable {
      */
     public final StringProperty textProperty() {
         if (text == null) {
-            text = new SimpleStringProperty(this, "text");
+            text = new SimpleStringProperty(this, "text") {
+                @Override
+                protected void invalidated() {
+
+                }
+            };
         }
         return text;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/content/ContentChildrenList.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/content/ContentChildrenList.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.content;
+
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.collections.ObservableListBase;
+import javafx.collections.WeakListChangeListener;
+import java.util.Arrays;
+import java.util.Objects;
+
+public final class ContentChildrenList extends ObservableListBase<Object> {
+
+    private final ListChangeListener<Object> listChangeListener;
+    private final ListChangeListener<Object> weakListChangeListener;
+    private ObservableList<?>[] lists;
+    private int size;
+
+    public ContentChildrenList(ObservableList<?>[] lists) {
+        this.lists = lists;
+        this.listChangeListener = this::onListChanged;
+        this.weakListChangeListener = new WeakListChangeListener<>(listChangeListener);
+
+        for (ObservableList<?> list : lists) {
+            list.addListener(weakListChangeListener);
+            size = addSize(list.size());
+        }
+    }
+
+    public void addList(ObservableList<?> list) {
+        lists = Arrays.copyOf(lists, lists.length + 1);
+        lists[lists.length -1 ] = list;
+        list.addListener(weakListChangeListener);
+        int oldSize = size;
+        size = addSize(list.size());
+
+        if (size != oldSize) {
+            beginChange();
+            nextAdd(oldSize, size);
+            endChange();
+        }
+    }
+
+    private int computeListOffset(ObservableList<?> list) {
+        int offset = 0;
+
+        for (ObservableList<?> l : lists) {
+            if (l != list) {
+                offset += l.size();
+            } else {
+                return offset;
+            }
+        }
+
+        throw new IllegalArgumentException("list");
+    }
+
+    private void onListChanged(ListChangeListener.Change<?> change) {
+        int listOffset = computeListOffset(change.getList());
+
+        while (change.next()) {
+            beginChange();
+
+            if (change.wasPermutated()) {
+                onPermutated(change, listOffset);
+            } else if (change.wasUpdated()) {
+                onUpdated(change, listOffset);
+            } else {
+                if (change.wasReplaced()) {
+                    onReplaced(change, listOffset);
+                } else if (change.wasRemoved()) {
+                    onRemoved(change, listOffset);
+                } else if (change.wasAdded()) {
+                    onAdded(change, listOffset);
+                }
+            }
+
+            endChange();
+        }
+    }
+
+    private void onPermutated(ListChangeListener.Change<?> change, int listOffset) {
+        int from = change.getFrom();
+        int to = change.getTo();
+        int[] perm = new int[to - from];
+
+        for (int i = 0, oldIndex = change.getFrom(), max = change.getTo(); oldIndex < max; ++i, ++oldIndex) {
+            int newIndex = change.getPermutation(oldIndex);
+            perm[i] = newIndex + listOffset;
+        }
+
+        nextPermutation(from, to, perm);
+    }
+
+    private void onUpdated(ListChangeListener.Change<?> change, int listOffset) {
+        for (int index = change.getFrom(), max = change.getTo(); index < max; ++index) {
+            nextUpdate(listOffset + index);
+        }
+    }
+
+    private void onReplaced(ListChangeListener.Change<?> change, int listOffset) {
+        int from = change.getFrom(), to = change.getTo();
+        size = addSize(to - from - change.getRemovedSize());
+        nextReplace(listOffset + from, listOffset + to, change.getRemoved());
+    }
+
+    private void onRemoved(ListChangeListener.Change<?> change, int listOffset) {
+        size -= change.getRemovedSize();
+        nextRemove(change.getFrom() + listOffset, change.getRemoved());
+    }
+
+    private void onAdded(ListChangeListener.Change<?> change, int listOffset) {
+        int from = change.getFrom(), to = change.getTo();
+        size = addSize(to - from);
+        nextAdd(from + listOffset, to + listOffset);
+    }
+
+    @Override
+    public Object get(int index) {
+        Objects.checkIndex(index, size);
+        int newIndex = index;
+
+        for (ObservableList<?> list : lists) {
+            int listSize = list.size();
+            if (newIndex >= listSize) {
+                newIndex -= listSize;
+            } else {
+                return list.get(newIndex);
+            }
+        }
+
+        throw new IndexOutOfBoundsException(index);
+    }
+
+    @Override
+    public int size() {
+        return size;
+    }
+
+    private int addSize(int size) {
+        int r = this.size + size;
+        if (((this.size ^ r) & (size ^ r)) < 0) {
+            throw new IndexOutOfBoundsException("Maximum list size exceeded");
+        }
+
+        return r;
+    }
+
+}

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/content/ContentNodeHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/content/ContentNodeHelper.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.content;
+
+import com.sun.javafx.scene.NodeHelper;
+import javafx.content.ContentNode;
+import javafx.content.ContentParent;
+import javafx.content.ContentParentBase;
+import javafx.css.Selector;
+import javafx.css.Styleable;
+import javafx.scene.Node;
+import java.util.LinkedList;
+import java.util.List;
+
+public final class ContentNodeHelper {
+
+    private ContentNodeHelper() {}
+
+    public static void setContentParent(List<?> nodes, ContentParent parent) {
+        for (Object node : nodes) {
+            if (node instanceof Node n) {
+                NodeHelper.setContentParent(n, parent);
+            } else if (node instanceof ContentParentBase n) {
+                ContentParentBaseHelper.setContentParent(n, parent);
+            }
+        }
+    }
+
+    public static List<Styleable> lookupAllContent(ContentNode node, Selector selector, List<Styleable> results) {
+        if (node instanceof Styleable styleable && selector.applies(styleable)) {
+            if (results == null) {
+                results = new LinkedList<>();
+            }
+
+            results.add(styleable);
+        }
+
+        if (node instanceof ContentParent parent) {
+            for (Object child : parent.getContentChildren()) {
+                if (child instanceof ContentNode childNode) {
+                    results = lookupAllContent(childNode, selector, results);
+                }
+            }
+        }
+
+        return results;
+    }
+
+}

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/content/ContentParentBaseHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/content/ContentParentBaseHelper.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.content;
+
+import com.sun.javafx.util.Utils;
+import javafx.content.ContentParent;
+import javafx.content.ContentParentBase;
+
+public final class ContentParentBaseHelper {
+
+    private ContentParentBaseHelper() {}
+
+    private static Accessor accessor;
+
+    static {
+        Utils.forceInit(ContentParentBase.class);
+    }
+
+    public static void setAccessor(Accessor accessor) {
+        ContentParentBaseHelper.accessor = accessor;
+    }
+
+    public static void setContentParent(ContentParentBase node, ContentParent parent) {
+        accessor.setContentParent(node, parent);
+    }
+
+    public interface Accessor {
+        void setContentParent(ContentParentBase node, ContentParent parent);
+    }
+
+}

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/content/ContentParentChangedListener.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/content/ContentParentChangedListener.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.content;
+
+import com.sun.javafx.scene.NodeHelper;
+import javafx.beans.WeakListener;
+import javafx.collections.ListChangeListener;
+import javafx.content.ContentParent;
+import javafx.content.ContentParentBase;
+import javafx.scene.Node;
+import java.lang.ref.WeakReference;
+
+public final class ContentParentChangedListener implements ListChangeListener<Object>, WeakListener {
+
+    private final WeakReference<ContentParent> parent;
+
+    public ContentParentChangedListener(ContentParent parent) {
+        this.parent = new WeakReference<>(parent);
+    }
+
+    @Override
+    public boolean wasGarbageCollected() {
+        return parent.get() != null;
+    }
+
+    @Override
+    public void onChanged(Change<?> c) {
+        while (c.next()) {
+            if (c.wasRemoved()) {
+                for (var node : c.getRemoved()) {
+                    if (node instanceof Node n) {
+                        NodeHelper.setContentParent(n, null);
+                    } else if (node instanceof ContentParentBase n) {
+                        ContentParentBaseHelper.setContentParent(n, null);
+                    }
+                }
+            }
+
+            ContentParent parent = this.parent.get();
+
+            if (parent == null) {
+                c.getList().removeListener(this);
+            } else if (c.wasAdded()) {
+                for (var node : c.getAddedSubList()) {
+                    if (node instanceof Node n) {
+                        NodeHelper.setContentParent(n, parent);
+                    } else if (node instanceof ContentParentBase n) {
+                        ContentParentBaseHelper.setContentParent(n, parent);
+                    }
+                }
+            }
+        }
+    }
+
+}

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/NodeHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/NodeHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import javafx.beans.binding.BooleanExpression;
 import javafx.beans.property.BooleanProperty;
+import javafx.content.ContentParent;
 import javafx.css.CssMetaData;
 import javafx.css.Style;
 import javafx.css.Styleable;
@@ -312,6 +313,10 @@ public abstract class NodeHelper {
         nodeAccessor.requestFocusVisible(node);
     }
 
+    public static void setContentParent(Node node, ContentParent parent) {
+        nodeAccessor.setContentParent(node, parent);
+    }
+
     public static void setNodeAccessor(final NodeAccessor newAccessor) {
         if (nodeAccessor != null) {
             throw new IllegalStateException();
@@ -372,6 +377,7 @@ public abstract class NodeHelper {
         Map<StyleableProperty<?>,List<Style>> findStyles(Node node,
                 Map<StyleableProperty<?>,List<Style>> styleMap);
         void requestFocusVisible(Node node);
+        void setContentParent(Node node, ContentParent parent);
     }
 
 }

--- a/modules/javafx.graphics/src/main/java/javafx/content/ContentNode.java
+++ b/modules/javafx.graphics/src/main/java/javafx/content/ContentNode.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package javafx.content;
+
+import javafx.css.Selector;
+import javafx.css.Styleable;
+import javafx.scene.Node;
+import java.util.Set;
+
+/**
+ * The {@code ContentNode} class represents a node in the content graph, which is the structure that defines
+ * the content model of an application. Although the content graph is primarily composed of {@code ContentNode}
+ * instances, its leaf nodes can also be objects of any kind.
+ * <p>
+ * The content model contains all significant parts of the user interface, for example:
+ * <ul>
+ *     <li>The children of a layout container like {@link javafx.scene.layout.StackPane}.
+ *     <li>The text or graphic of a {@link javafx.scene.control.Button}
+ *     <li>The items of a {@link javafx.scene.control.ListView}
+ *     <li>The menu items of a {@link javafx.scene.control.Menu}
+ *     <li>The title, graphic, and content of a {@link javafx.scene.control.Tab}
+ * </ul>
+ * The content graph does not include nodes created by skins or cell factories, which makes it independent
+ * of an application's visualization. For this reason, the scene graph will usually contain many more nodes
+ * than the content graph.
+ * <p>
+ * Since the content graph is not limited to {@link Node} instances, it can also span across nodes that are
+ * not part of the scene graph.
+ * For example, {@link javafx.scene.control.Tab} or {@link javafx.scene.control.MenuItem} are not scene
+ * graph nodes, but they are included in the content graph.
+ * <p>
+ * While an application will only have a single scene graph, it can have any number of disconnected content
+ * graphs. The main content graph corresponds to the root node of the user interface. Additional content
+ * graphs can appear in several scenarios, for example when a skin creates scene graph nodes. A skin's
+ * content graph is not reachable from the main content graph.
+ *
+ * @since 21
+ */
+public sealed interface ContentNode permits Node, ContentParent {
+
+    /**
+     * Returns the parent of this {@link ContentNode}.
+     *
+     * @return the {@code ContentParent}, or {@code null} if this node has no parent
+     */
+    ContentParent getContentParent();
+
+    /**
+     * Finds this {@code ContentNode}, or the first sub-node, based on the given CSS selector.
+     * If this node is a {@code ContentParent}, then this function will traverse down into the
+     * branch until it finds a match. If more than one sub-node matches the specified selector,
+     * this function returns the first of them.
+     * <p>
+     * For example, if a node is given the id of "myId", then the lookup method can be used to
+     * find this node as follows: <code>scene.lookup("#myId");</code>.
+     *
+     * @param selector The CSS selector of the node to find
+     * @return The first node, starting from this {@code ContentNode}, which matches
+     *         the CSS {@code selector}, {@code null} if none is found.
+     */
+    default Styleable lookupContent(String selector) {
+        if (selector == null || !(this instanceof Styleable styleable)) {
+            return null;
+        }
+
+        Selector s = Selector.createSelector(selector);
+        return s != null && s.applies(styleable) ? styleable : null;
+    }
+
+    /**
+     * Finds all content nodes, including this one and any children, which match the given
+     * CSS selector. If no matches are found, an empty unmodifiable set is returned.
+     * The set is explicitly unordered.
+     *
+     * @param selector The CSS selector of the nodes to find
+     * @return All nodes, starting from and including this {@code ContentNode}, which match
+     *         the CSS {@code selector}. The returned set is always unordered and
+     *         unmodifiable, and never {@code null}.
+     */
+    default Set<Styleable> lookupAllContent(String selector) {
+        Styleable styleable = lookupContent(selector);
+        return styleable != null ? Set.of(styleable) : Set.of();
+    }
+
+}

--- a/modules/javafx.graphics/src/main/java/javafx/content/ContentParent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/content/ContentParent.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package javafx.content;
+
+import com.sun.javafx.collections.UnmodifiableListSet;
+import com.sun.javafx.content.ContentNodeHelper;
+import javafx.collections.ObservableList;
+import javafx.css.Selector;
+import javafx.css.Styleable;
+import javafx.scene.Parent;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Represents a {@link ContentNode} that can have children.
+ *
+ * @since 21
+ */
+public sealed interface ContentParent extends ContentNode permits Parent, ContentParentBase {
+
+    /**
+     * Gets the children of this {@code ContentParent}.
+     *
+     * @return an unmodifiable list of children, which can be objects of any kind
+     */
+    ObservableList<?> getContentChildren();
+
+    @Override
+    default Styleable lookupContent(String selector) {
+        Styleable styleable = ContentNode.super.lookupContent(selector);
+        if (styleable != null) {
+            return styleable;
+        }
+
+        for (Object child : getContentChildren()) {
+            styleable = child instanceof ContentNode node ? node.lookupContent(selector) : null;
+            if (styleable != null) {
+                return styleable;
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    default Set<Styleable> lookupAllContent(String selector) {
+        Selector cssSelector = Selector.createSelector(selector);
+        if (cssSelector == null) {
+            return Set.of();
+        }
+
+        List<Styleable> results = ContentNodeHelper.lookupAllContent(this, cssSelector, null);
+        return results == null ? Set.of() : new UnmodifiableListSet<>(results);
+    }
+
+}

--- a/modules/javafx.graphics/src/main/java/javafx/content/ContentParentBase.java
+++ b/modules/javafx.graphics/src/main/java/javafx/content/ContentParentBase.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package javafx.content;
+
+import com.sun.javafx.content.ContentChildrenList;
+import com.sun.javafx.content.ContentNodeHelper;
+import com.sun.javafx.content.ContentParentBaseHelper;
+import com.sun.javafx.content.ContentParentChangedListener;
+import javafx.beans.property.ReadOnlyObjectProperty;
+import javafx.beans.property.ReadOnlyObjectPropertyBase;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.scene.Node;
+
+/**
+ * Base class for implementations of {@link ContentParent} that are not subclasses of {@link Node}.
+ *
+ * @since 21
+ */
+public non-sealed abstract class ContentParentBase implements ContentParent {
+
+    static {
+        ContentParentBaseHelper.setAccessor(new ContentParentBaseHelper.Accessor() {
+            @Override
+            public void setContentParent(ContentParentBase node, ContentParent parent) {
+                node.setContentParent(parent);
+            }
+        });
+    }
+
+    private final ContentParentChangedListener contentParentChanged = new ContentParentChangedListener(this);
+    private ContentParent contentParent;
+    private ContentParentProperty contentParentProperty;
+    private ContentChildrenList contentChildren;
+    private ObservableList<?> contentChildrenUnmodifiable;
+
+    /**
+     * Adds a content model to this node.
+     * <p>
+     * Derived classes should call this method to add their own content model, which may include
+     * any number of objects. The content model is added to the content models that were added
+     * by base classes.
+     * <p>
+     * See {@link ContentNode} for more information about the content graph.
+     *
+     * @param content an {@code ObservableList} that contains the content model
+     */
+    protected final void addContentModel(ObservableList<?> content) {
+        if (contentChildren == null) {
+            contentChildren = new ContentChildrenList(new ObservableList[] { content });
+            contentChildren.addListener(contentParentChanged);
+            ContentNodeHelper.setContentParent(contentChildren, this);
+        } else {
+            contentChildren.addList(content);
+        }
+    }
+
+    @Override
+    public final ObservableList<?> getContentChildren() {
+        if (contentChildrenUnmodifiable == null) {
+            if (contentChildren == null) {
+                contentChildren = new ContentChildrenList(new ObservableList[0]);
+                contentChildren.addListener(contentParentChanged);
+            }
+
+            contentChildrenUnmodifiable = FXCollections.unmodifiableObservableList(contentChildren);
+        }
+
+        return contentChildrenUnmodifiable;
+    }
+
+    public final ReadOnlyObjectProperty<ContentParent> contentParentProperty() {
+        if (contentParentProperty == null) {
+            contentParentProperty = new ContentParentProperty();
+        }
+
+        return contentParentProperty;
+    }
+
+    @Override
+    public final ContentParent getContentParent() {
+        return contentParent;
+    }
+
+    private void setContentParent(ContentParent parent) {
+        if (contentParent != parent) {
+            contentParent = parent;
+
+            if (contentParentProperty != null) {
+                contentParentProperty.notifyValueChanged();
+            }
+        }
+    }
+
+    private class ContentParentProperty extends ReadOnlyObjectPropertyBase<ContentParent> {
+        @Override
+        public Object getBean() {
+            return ContentParentBase.this;
+        }
+
+        @Override
+        public String getName() {
+            return "contentParent";
+        }
+
+        @Override
+        public ContentParent get() {
+            return contentParent;
+        }
+
+        public void notifyValueChanged() {
+            fireValueChangedEvent();
+        }
+    }
+
+}

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -55,6 +55,8 @@ import javafx.collections.ListChangeListener.Change;
 import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
 import javafx.collections.ObservableSet;
+import javafx.content.ContentNode;
+import javafx.content.ContentParent;
 import javafx.css.CssMetaData;
 import javafx.css.ParsedValue;
 import javafx.css.PseudoClass;
@@ -406,7 +408,7 @@ import com.sun.javafx.logging.PlatformLogger.Level;
  * @since JavaFX 2.0
  */
 @IDProperty("id")
-public abstract class Node implements EventTarget, Styleable {
+public abstract non-sealed class Node implements ContentNode, EventTarget, Styleable {
 
     /*
      * Store the singleton instance of the NodeHelper subclass corresponding
@@ -624,6 +626,11 @@ public abstract class Node implements EventTarget, Styleable {
             @Override
             public void requestFocusVisible(Node node) {
                 node.requestFocusVisible();
+            }
+
+            @Override
+            public void setContentParent(Node node, ContentParent parent) {
+                node.setContentParent(parent);
             }
         });
     }
@@ -928,6 +935,53 @@ public abstract class Node implements EventTarget, Styleable {
      *
      *                                                                        *
      *************************************************************************/
+
+    private ContentParent contentParent;
+    private ContentParentProperty contentParentProperty;
+
+    public final ReadOnlyObjectProperty<ContentParent> contentParentProperty() {
+        if (contentParentProperty == null) {
+            contentParentProperty = new ContentParentProperty();
+        }
+
+        return contentParentProperty;
+    }
+
+    @Override
+    public final ContentParent getContentParent() {
+        return contentParent;
+    }
+
+    private void setContentParent(ContentParent parent) {
+        if (contentParent != parent) {
+            contentParent = parent;
+
+            if (contentParentProperty != null) {
+                contentParentProperty.notifyValueChanged();
+            }
+        }
+    }
+
+    private class ContentParentProperty extends ReadOnlyObjectPropertyBase<ContentParent> {
+        @Override
+        public Object getBean() {
+            return Node.this;
+        }
+
+        @Override
+        public String getName() {
+            return "contentParent";
+        }
+
+        @Override
+        public ContentParent get() {
+            return contentParent;
+        }
+
+        public void notifyValueChanged() {
+            fireValueChangedEvent();
+        }
+    }
 
     /**
      * The parent of this {@code Node}. If this {@code Node} has not been added

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Pane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Pane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,7 +128,9 @@ public class Pane extends Region {
     {
         // To initialize the class helper at the begining each constructor of this class
         PaneHelper.initHelper(this);
+        addContentModel(getChildren());
     }
+
     /**
      * Creates a Pane layout.
      */

--- a/modules/javafx.graphics/src/main/java/module-info.java
+++ b/modules/javafx.graphics/src/main/java/module-info.java
@@ -51,6 +51,7 @@ module javafx.graphics {
     exports javafx.concurrent;
     exports javafx.css;
     exports javafx.css.converter;
+    exports javafx.content;
     exports javafx.geometry;
     exports javafx.print;
     exports javafx.scene;


### PR DESCRIPTION
The content graph is a structure that comprises all content nodes of a scene. Content nodes represent the significant scene content, which exludes nodes contributed by skins, but includes some nodes that are not part of the scene graph (like `Tab` or `MenuItem`).

## API
The content graph consists of two new interfaces that live in the `javafx.content` package:
```java
/**
 * The {@code ContentNode} class represents a node in the content graph, which is the structure that defines
 * the content model of an application. Although the content graph is primarily composed of {@code ContentNode}
 * instances, its leaf nodes can also be objects of any kind.
 * <p>
 * The content model contains all significant parts of the user interface, for example:
 * <ul>
 *     <li>The children of a layout container like {@link javafx.scene.layout.StackPane}.
 *     <li>The text or graphic of a {@link javafx.scene.control.Button}
 *     <li>The items of a {@link javafx.scene.control.ListView}
 *     <li>The menu items of a {@link javafx.scene.control.Menu}
 *     <li>The title, graphic, and content of a {@link javafx.scene.control.Tab}
 * </ul>
 * The content graph does not include nodes created by skins or cell factories, which makes it independent
 * of an application's visualization. For this reason, the scene graph will usually contain many more nodes
 * than the content graph.
 * <p>
 * Since the content graph is not limited to {@link Node} instances, it can also span across nodes that are
 * not part of the scene graph.
 * For example, {@link javafx.scene.control.Tab} or {@link javafx.scene.control.MenuItem} are not scene
 * graph nodes, but they are included in the content graph.
 * <p>
 * While an application will only have a single scene graph, it can have any number of disconnected content
 * graphs. The main content graph corresponds to the root node of the user interface. Additional content
 * graphs can appear in several scenarios, for example when a skin creates scene graph nodes. A skin's
 * content graph is not reachable from the main content graph.
 *
 * @since 21
 */
public interface ContentNode {
    /**
     * Returns the parent of this {@link ContentNode}.
     *
     * @return the {@code ContentParent}, or {@code null} if this node has no parent
     */
    ContentParent getContentParent();

    Styleable lookupContent(String selector);
    Set<Styleable> lookupAllContent(String selector);
}

/**
 * Represents a {@link ContentNode} that can have children.
 *
 * @since 21
 */
public interface ContentParent extends ContentNode {
    /**
     * Gets the children of this {@code ContentParent}.
     *
     * @return an unmodifiable list of children, which can be objects of any kind
     */
    ObservableList<ContentNode> getContentChildren();
}
```

These interfaces are implemented by `javafx.scene.Node` and `javafx.scene.Parent`, but also by other classes like `Tab` or
`MenuItem`. Using these interfaces, the content graph can be traversed in the same way as the scene graph.

## Content graph vs. scene graph
Consider the following program, which creates a simple user interface:
```java
var root = new VBox();
var menuBtn = new MenuButton();
menuBtn.getItems().add(new MenuItem("Item 1"));
menuBtn.getItems().add(new MenuItem("Item 2", new Rectangle()));
root.getChildren().add(menuBtn);
root.getChildren().add(new Button("Button 1", new Rectangle()));
root.getChildren().add(new Button("Button 2", new Circle()));
```

Suppose a method `printSceneGraph(Node root)`, which traverses the scene graph and prints out the nodes it encounters. Here is the output before the UI is shown:
```
javafx.scene.layout.VBox
    javafx.scene.control.MenuButton
    javafx.scene.control.Button
    javafx.scene.control.Button
```

And here's the output of the same method, but after the UI is shown:
```
javafx.scene.layout.VBox
    javafx.scene.control.MenuButton
        javafx.scene.control.skin.MenuButtonSkinBase$MenuLabeledImpl
            com.sun.javafx.scene.control.LabeledText
        javafx.scene.layout.StackPane
            javafx.scene.layout.StackPane
    javafx.scene.control.Button
        javafx.scene.shape.Rectangle
        com.sun.javafx.scene.control.LabeledText
    javafx.scene.control.Button
        javafx.scene.shape.Circle
        com.sun.javafx.scene.control.LabeledText
```

Note that the scene graph contains many more nodes after skins have been inflated, but it still doesn't contain the `MenuItem` instances.

Now also suppose a method `printContentGraph(ContentNode root)`, which does the same as before, but works on the content graph. This is the output of that method:
```
javafx.scene.layout.VBox
    javafx.scene.control.MenuButton
        java.lang.String
        javafx.scene.control.MenuItem
            java.lang.String
        javafx.scene.control.MenuItem
            java.lang.String
            javafx.scene.shape.Rectangle
    javafx.scene.control.Button
        java.lang.String
        javafx.scene.shape.Rectangle
    javafx.scene.control.Button
        java.lang.String
        javafx.scene.shape.Circle
```
Note that the content graph is not affected by skins, and the output is the same whether the method is called before or after skin inflation.

## Defining the content model
Controls can modify their content model by invoking the `addContentModel(ObservableList<?>)` method, which is defined on `Parent` and `ContentParentBase` (base class for content nodes that don't subclass `Node`). Usually a control class will only add a single content model (i.e. a single `ObservableList`) that contains all content objects (content objects can be of any type). It is left to the discretion of the control implementation to define which objects are part of its content model.

For example, a `SplitPane` will add its `items` collection to its content model:
```java
public class SplitPane extends Control {
    public SplitPane(Node... items) {
        addContentModel(getItems());
    }
}
```

In another example, `Labeled` uses a special list to manage its two content objects, "text" and "graphic":
```java
public abstract class Labeled extends Control {
    private final LabeledContentList contentModel = new LabeledContentList();

    public Labeled() {
        addContentModel(contentModel);
    }

    private StringProperty text;

    public final StringProperty textProperty() {
        if (text == null) {
            text = new SimpleStringProperty(this, "text", "") {
                @Override
                protected void invalidated() {
                    contentModel.setText(get());
                }
            };
        }
        return text;
    }
}
```

`LabeledContentList` is not public API. It implements the semantics of a labeled content model: when "text" or "graphic" are set, the objects are included in the LabeledContentList; when they are set to `null`, the values are removed from the list.

In another example, `ListView` modifies its content model when the `items` property is changed:
```java
public class ListView<T> extends Control {
    private final ReseatableObservableListAdapter<T> contentModel =
            new ReseatableObservableListAdapter<>();

    public ListView() {
        addContentModel(contentModel);
    }

    private ObjectProperty<ObservableList<T>> items;

    public final ObjectProperty<ObservableList<T>> itemsProperty() {
        if (items == null) {
            items = new SimpleObjectProperty<>(this, "items") {
                @Override
                protected void invalidated() {
                    contentModel.changeList(get());
                }
            };
        }
        return items;
    }
}
```
`ReseatableObservableListAdapter` is not public API. It is a thin wrapper around a swappable backing list, which allows the content model to respond when the `items` property is set to a new `ObservableList` instance.

## Extending the content model
If a control subclass wants to extend the content model of an existing control, it simply adds a new content model using the `addContentModel(ObservableList<?>)` method. The new content model will be appended to the existing content model of the base control. The content model of a subclass can only be extended, it can't be constrained. This is analogous to how a subclass of `Labeled` can only add new properties, but not remove the existing `Labeled.text` and `Labeled.graphic` properties.

Note that if a custom control is not aware of the content graph and does not add a content model, that's not an issue in itself; it simply means that the custom control will not contribute additional nodes to the content graph.

## Operations on the content graph

The content graph supports query operations on styleable nodes by adding two new lookup methods: `lookupContent` and `lookupAllContent`. This solves a problem that was discussed on the mailing list previously:
https://mail.openjdk.org/pipermail/openjfx-dev/2022-December/037770.html

The particular problem that was described in this email can be fixed simply by using `lookupAllContent` instead of `lookupAll`:
```java
window.getScene().getRoot().lookupAllContent(".split-pane")
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1096/head:pull/1096` \
`$ git checkout pull/1096`

Update a local copy of the PR: \
`$ git checkout pull/1096` \
`$ git pull https://git.openjdk.org/jfx.git pull/1096/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1096`

View PR using the GUI difftool: \
`$ git pr show -t 1096`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1096.diff">https://git.openjdk.org/jfx/pull/1096.diff</a>

</details>
