### PR TITLE
8293836: Rendering performance degradation at bottom of TableView with many rows

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -3089,7 +3089,6 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
                     oldOffset = oldOffset + newSize - oldSize;
                 }
                 recalculateAndImproveEstimatedSize(0, currentIndex, oldOffset);
-
             }
         }
     }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -1994,8 +1994,6 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             double height = Math.max(getMaxPrefBreadth(), getViewportBreadth());
             cell.resize(fixedCellSizeEnabled ? getFixedCellSize() : Utils.boundedSize(cell.prefWidth(height), cell.minWidth(height), cell.maxWidth(height)), height);
         }
-        // when a cell is resized, our estimate needs to be updated.
-        recalculateAndImproveEstimatedSize(0);
     }
 
     /**
@@ -3079,19 +3077,21 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
      */
     void updateCellSize(T cell) {
         int cellIndex = cell.getIndex();
-        int currentIndex = computeCurrentIndex();
-        double oldOffset = computeViewportOffset(getPosition());
-
 
         if (itemSizeCache.size() > cellIndex) {
             Double oldSize = itemSizeCache.get(cellIndex);
             double newSize = isVertical() ? cell.getLayoutBounds().getHeight() : cell.getLayoutBounds().getWidth();
             itemSizeCache.set(cellIndex, newSize);
-            if ((cellIndex == currentIndex) && (oldSize != null) && (oldOffset != 0)) {
-                oldOffset = oldOffset + newSize - oldSize;
+            if ((oldSize != null) && !oldSize.equals(newSize)) {
+                int currentIndex = computeCurrentIndex();
+                double oldOffset = computeViewportOffset(getPosition());
+                if ((cellIndex == currentIndex) && (oldOffset != 0)) {
+                    oldOffset = oldOffset + newSize - oldSize;
+                }
+                recalculateAndImproveEstimatedSize(0, currentIndex, oldOffset);
+
             }
         }
-        recalculateAndImproveEstimatedSize(0, currentIndex, oldOffset);
     }
 
     /**


### PR DESCRIPTION
Only update the VirtualFlow parameters in case the size of a cell has changed.

The fixes for JDK-8298728 and JDK-8277785 introduced an unconditional recalculation in case the size of a cell is set. This recalculation is only needed in case the size of that specific cell has changed.
Fix for JDK-8293836

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8293836](https://bugs.openjdk.org/browse/JDK-8293836): Rendering performance degradation at bottom of TableView with many rows


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1098/head:pull/1098` \
`$ git checkout pull/1098`

Update a local copy of the PR: \
`$ git checkout pull/1098` \
`$ git pull https://git.openjdk.org/jfx.git pull/1098/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1098`

View PR using the GUI difftool: \
`$ git pr show -t 1098`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1098.diff">https://git.openjdk.org/jfx/pull/1098.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1098#issuecomment-1514639039)