### PR TITLE
8306447: Adding an element to a long existing list may cause the first visible element to jump

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -855,11 +855,15 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
         private int oldCount = 0;
 
         @Override protected void invalidated() {
+            int oldIndex = computeCurrentIndex();
+            double oldOffset = computeViewportOffset(getPosition());
             int cellCount = get();
             resetSizeEstimates();
             recalculateEstimatedSize();
 
             boolean countChanged = oldCount != cellCount;
+            double boff = computeBaseOffset(oldIndex);
+            absoluteOffset = boff + oldOffset;
             oldCount = cellCount;
 
             // ensure that the virtual scrollbar adjusts in size based on the current
@@ -2976,6 +2980,18 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
         setPosition(newPosition);
         return absoluteOffset - origAbsoluteOffset;
 
+    }
+
+    private double computeBaseOffset(int index) {
+        double baseOffset = 0d;
+        int currentCellCount = getCellCount();
+        double estSize = estimatedSize / currentCellCount;
+        for (int i = 0; i < index; i++) {
+            double nextSize = getCellSize(i);
+            if (nextSize < 0) nextSize = estSize;
+            baseOffset += nextSize;
+        }
+        return baseOffset;
     }
 
     private int computeCurrentIndex() {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -97,7 +97,7 @@ public class VirtualFlowTest {
 
             @Override
             protected double computePrefWidth(double height) {
-                return flow.isVertical() ? (c.getIndex() == 29 ? 200 : 100) : (c.getIndex() == 29 ? 100 : 25);
+                return flow.isVertical() ? (getIndex() == 29 ? 200 : 100) : (getIndex() == 29 ? 100 : 25);
             }
 
             @Override
@@ -112,7 +112,7 @@ public class VirtualFlowTest {
 
             @Override
             protected double computePrefHeight(double width) {
-                return flow.isVertical() ? (c.getIndex() == 29 ? 100 : 25) : (c.getIndex() == 29 ? 200 : 100);
+                return flow.isVertical() ? (getIndex() == 29 ? 100 : 25) : (getIndex() == 29 ? 200 : 100);
             }
         });
         flow.setCellCount(100);
@@ -1221,6 +1221,36 @@ public class VirtualFlowTest {
             assertEquals("Wrong first cell position after inserting " + i + " cells", -10d, cellPosition, 0d);
         }
     }
+
+    @Test
+    // see JDK-8306447
+    public void testPositionCellRemainsConstantWithManyItems() {
+        flow.setVertical(true);
+        flow.setCellCount(100);
+        flow.resize(300, 300);
+        // scroll up and down, to populate the size cache
+        for (int i = 0; i < 20; i++) {
+            flow.scrollPixels(1);
+            pulse();
+            flow.scrollPixels(-1);
+            pulse();
+        }
+        flow.scrollPixels(911);
+        pulse();
+
+        IndexedCell vc = flow.getCell(33);
+        double cellPosition = flow.getCellPosition(vc);
+        // cell 33 should be at (32 x 25 + 1 x 100) - 911 = -11
+        assertEquals("Wrong first cell position", -11d, cellPosition, 0d);
+
+        flow.setCellCount(101);
+        pulse();
+        vc = flow.getCell(33);
+        cellPosition = flow.getCellPosition(vc);
+        assertEquals("First cell position changed after adding cell on large irregular list", -11d, cellPosition, 0d);
+    }
+
+
 
     @Test
     // see JDK-8252811


### PR DESCRIPTION
Calculate position of first visible element before propagating changes.
Make sure to restore the position of said element after the changes are done.

Fix JDK-8306447