### PR TITLE
8285878: [TestBug] LocalStorageTest and UserDataDirectoryTest don't always cleanup data dirs

### DIFF
--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/LocalStorageTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/LocalStorageTest.java
@@ -28,28 +28,30 @@ package test.javafx.scene.web;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
+
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
 import java.io.File;
 import java.io.IOException;
-
 import javafx.scene.web.WebView;
 import javafx.scene.web.WebEngine;
 
-
 public class LocalStorageTest extends TestBase {
 
-    private static final File LOCAL_STORAGE_DIR_PATH = new File("build/");
     private static final File LOCAL_STORAGE_DIR = new File("build/localstorage");
 
     private static void deleteRecursively(File file) throws IOException {
         if (file.isDirectory()) {
             for (File f : file.listFiles()) {
                 deleteRecursively(f);
-                f.delete();
             }
+        }
+
+        if (!file.delete()) {
+            // If WebKit takes time to close the file, better
+            // delete it during VM shutdown.
+            file.deleteOnExit();
         }
     }
 
@@ -81,7 +83,7 @@ public class LocalStorageTest extends TestBase {
     public void testLocalStorage() throws Exception {
         final WebEngine webEngine = getEngine();
         webEngine.setJavaScriptEnabled(true);
-        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR_PATH);
+        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR);
         checkLocalStorageAfterWindowClose(webEngine);
         webEngine.setUserDataDirectory(null);
     }
@@ -91,7 +93,7 @@ public class LocalStorageTest extends TestBase {
     public void testLocalStorageData() {
         final WebEngine webEngine = getEngine();
         webEngine.setJavaScriptEnabled(true);
-        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR_PATH);
+        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR);
         load(new File("src/test/resources/test/html/localstorage.html"));
         submit(() -> {
             WebView view = getView();
@@ -108,7 +110,7 @@ public class LocalStorageTest extends TestBase {
     public void testLocalStorageSet() {
         final WebEngine webEngine = getEngine();
         webEngine.setJavaScriptEnabled(true);
-        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR_PATH);
+        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR);
         load(new File("src/test/resources/test/html/localstorage.html"));
         submit(() -> {
             WebView view = getView();
@@ -123,7 +125,7 @@ public class LocalStorageTest extends TestBase {
     public void testLocalStoargeClear() {
         final WebEngine webEngine = getEngine();
         webEngine.setJavaScriptEnabled(true);
-        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR_PATH);
+        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR);
         load(new File("src/test/resources/test/html/localstorage.html"));
         submit(() -> {
             WebView view = getView();

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/LocalStorageTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/LocalStorageTest.java
@@ -108,7 +108,6 @@ public class LocalStorageTest extends TestBase {
             //get data
             String s = (String) view.getEngine().executeScript("document.getElementById('key').innerText;");
             assertEquals("1001", s);
-            webEngine.setUserDataDirectory(null);
         });
     }
 
@@ -123,7 +122,6 @@ public class LocalStorageTest extends TestBase {
             view.getEngine().executeScript("test_local_storage_set();");
             String s = (String) view.getEngine().executeScript("document.getElementById('key').innerText;");
             assertEquals("1001", s);
-            webEngine.setUserDataDirectory(null);
         });
     }
 
@@ -140,7 +138,6 @@ public class LocalStorageTest extends TestBase {
             String s = (String) view.getEngine().executeScript("document.getElementById('key').innerText;");
             boolean res = (s == null || s.length() == 0);
             assertTrue(res);
-            webEngine.setUserDataDirectory(null);
         });
     }
 }

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/LocalStorageTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/LocalStorageTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
@@ -40,18 +41,15 @@ import javafx.scene.web.WebEngine;
 
 public class LocalStorageTest extends TestBase {
 
-    private static final File LOCAL_STORAGE_DIR = new File("LocalStorageDir");
+    private static final File LOCAL_STORAGE_DIR_PATH = new File("build/");
+    private static final File LOCAL_STORAGE_DIR = new File("build/localstorage");
 
     private static void deleteRecursively(File file) throws IOException {
         if (file.isDirectory()) {
             for (File f : file.listFiles()) {
                 deleteRecursively(f);
+                f.delete();
             }
-        }
-        if (!file.delete()) {
-            // If WebKit takes time to close the file, better
-            // delete it during VM shutdown.
-            file.deleteOnExit();
         }
     }
 
@@ -69,6 +67,11 @@ public class LocalStorageTest extends TestBase {
         });
     }
 
+    @BeforeClass
+    public static void beforeClass() throws IOException {
+        deleteRecursively(LOCAL_STORAGE_DIR);
+    }
+
     @AfterClass
     public static void afterClass() throws IOException {
         deleteRecursively(LOCAL_STORAGE_DIR);
@@ -78,8 +81,9 @@ public class LocalStorageTest extends TestBase {
     public void testLocalStorage() throws Exception {
         final WebEngine webEngine = getEngine();
         webEngine.setJavaScriptEnabled(true);
-        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR);
+        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR_PATH);
         checkLocalStorageAfterWindowClose(webEngine);
+        webEngine.setUserDataDirectory(null);
     }
 
     /* test localstorage set data before window.close and check data after window.close */
@@ -87,7 +91,7 @@ public class LocalStorageTest extends TestBase {
     public void testLocalStorageData() {
         final WebEngine webEngine = getEngine();
         webEngine.setJavaScriptEnabled(true);
-        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR);
+        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR_PATH);
         load(new File("src/test/resources/test/html/localstorage.html"));
         submit(() -> {
             WebView view = getView();
@@ -96,6 +100,7 @@ public class LocalStorageTest extends TestBase {
             //get data
             String s = (String) view.getEngine().executeScript("document.getElementById('key').innerText;");
             assertEquals("1001", s);
+            webEngine.setUserDataDirectory(null);
         });
     }
 
@@ -103,13 +108,14 @@ public class LocalStorageTest extends TestBase {
     public void testLocalStorageSet() {
         final WebEngine webEngine = getEngine();
         webEngine.setJavaScriptEnabled(true);
-        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR);
+        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR_PATH);
         load(new File("src/test/resources/test/html/localstorage.html"));
         submit(() -> {
             WebView view = getView();
             view.getEngine().executeScript("test_local_storage_set();");
             String s = (String) view.getEngine().executeScript("document.getElementById('key').innerText;");
             assertEquals("1001", s);
+            webEngine.setUserDataDirectory(null);
         });
     }
 
@@ -117,7 +123,7 @@ public class LocalStorageTest extends TestBase {
     public void testLocalStoargeClear() {
         final WebEngine webEngine = getEngine();
         webEngine.setJavaScriptEnabled(true);
-        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR);
+        webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR_PATH);
         load(new File("src/test/resources/test/html/localstorage.html"));
         submit(() -> {
             WebView view = getView();
@@ -126,6 +132,7 @@ public class LocalStorageTest extends TestBase {
             String s = (String) view.getEngine().executeScript("document.getElementById('key').innerText;");
             boolean res = (s == null || s.length() == 0);
             assertTrue(res);
+            webEngine.setUserDataDirectory(null);
         });
     }
 }

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/LocalStorageTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/LocalStorageTest.java
@@ -29,6 +29,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -79,13 +80,18 @@ public class LocalStorageTest extends TestBase {
         deleteRecursively(LOCAL_STORAGE_DIR);
     }
 
+    @After
+    public void after() {
+        final WebEngine webEngine = getEngine();
+        webEngine.setUserDataDirectory(null);
+    }
+
     @Test
     public void testLocalStorage() throws Exception {
         final WebEngine webEngine = getEngine();
         webEngine.setJavaScriptEnabled(true);
         webEngine.setUserDataDirectory(LOCAL_STORAGE_DIR);
         checkLocalStorageAfterWindowClose(webEngine);
-        webEngine.setUserDataDirectory(null);
     }
 
     /* test localstorage set data before window.close and check data after window.close */

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/UserDataDirectoryTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/UserDataDirectoryTest.java
@@ -65,9 +65,9 @@ import org.junit.Test;
 
 public class UserDataDirectoryTest extends TestBase {
 
-    private static final File FOO = new File("foo");
-    private static final File BAR = new File("bar");
-    private static final File PRE_LOCKED = new File("baz");
+    private static final File FOO = new File("build/foo");
+    private static final File BAR = new File("build/bar");
+    private static final File PRE_LOCKED = new File("build/baz");
     private static final File[] DIRS = new File[] {FOO, BAR, PRE_LOCKED};
 
 


### PR DESCRIPTION
Issue: "LocalStorageTest and UserDataDirectoryTest don't always cleanup data dirs"
Solution:
1. All data directories must only be created under the "build" dir. In addition to being a best practice, at least they will be cleaned up by "gradle clean"
2. There should be an @AfterClass method that deletes the data dirs
3. There should be an @BeforeClass method that also deletes the data dirs prior to running the tests in case it wasn't cleaned up previously

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8285878](https://bugs.openjdk.org/browse/JDK-8285878): [TestBug] LocalStorageTest and UserDataDirectoryTest  don't always cleanup data dirs


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1100/head:pull/1100` \
`$ git checkout pull/1100`

Update a local copy of the PR: \
`$ git checkout pull/1100` \
`$ git pull https://git.openjdk.org/jfx.git pull/1100/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1100`

View PR using the GUI difftool: \
`$ git pr show -t 1100`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1100.diff">https://git.openjdk.org/jfx/pull/1100.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1100#issuecomment-1514742158)