### PR TITLE
8306464: [testbug] CustomSecurityManagerTest full screen tests fails on MacOS intermittently

### DIFF
--- a/tests/system/src/test/java/test/robot/helloworld/CustomSecurityManagerTest.java
+++ b/tests/system/src/test/java/test/robot/helloworld/CustomSecurityManagerTest.java
@@ -153,8 +153,8 @@ public class CustomSecurityManagerTest extends VisualTestBase {
         final AtomicInteger screenWidth = new AtomicInteger();
         final AtomicInteger screenHeight = new AtomicInteger();
         runAndWait(() -> {
-            screenWidth.set((int)Screen.getPrimary().getBounds().getWidth());
-            screenHeight.set((int)Screen.getPrimary().getBounds().getHeight());
+            screenWidth.set((int)Screen.getPrimary().getVisualBounds().getWidth());
+            screenHeight.set((int)Screen.getPrimary().getVisualBounds().getHeight());
         });
 
         System.setSecurityManager(sm);
@@ -201,11 +201,11 @@ public class CustomSecurityManagerTest extends VisualTestBase {
                     // avoid the top area as it might contain OS-specific UI (Macs with a notch)
                     y = h / 3;
                 } else {
-                    y = h - 2;
+                    y = h - 5;
                 }
 
                 for (int col = 0; col < 2; col++) {
-                    int x = col == 0 ? 1 : screenWidth.get() - 2;
+                    int x = col == 0 ? 1 : screenWidth.get() - 5;
                     Color color = getColor(x, y);
                     if (expectedFullScreen) {
                         assertColorEquals(Color.LIME, color, TOLERANCE);

--- a/tests/system/src/test/java/test/robot/helloworld/CustomSecurityManagerTest.java
+++ b/tests/system/src/test/java/test/robot/helloworld/CustomSecurityManagerTest.java
@@ -32,6 +32,7 @@ import java.security.AllPermission;
 import java.security.Permission;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import javafx.geometry.Rectangle2D;
 import javafx.scene.Group;
 import javafx.scene.Scene;
 import javafx.scene.paint.Color;
@@ -61,6 +62,8 @@ public class CustomSecurityManagerTest extends VisualTestBase {
 
     private static final int WIDTH = 400;
     private static final int HEIGHT = 300;
+
+    Rectangle2D screenBounds;
 
     @SuppressWarnings("removal")
     static class MySecurityManager extends SecurityManager {
@@ -150,11 +153,8 @@ public class CustomSecurityManagerTest extends VisualTestBase {
         // Readback of FullScreen window is not stable on Linux
         assumeTrue(!PlatformUtil.isLinux());
 
-        final AtomicInteger screenWidth = new AtomicInteger();
-        final AtomicInteger screenHeight = new AtomicInteger();
         runAndWait(() -> {
-            screenWidth.set((int)Screen.getPrimary().getVisualBounds().getWidth());
-            screenHeight.set((int)Screen.getPrimary().getVisualBounds().getHeight());
+            screenBounds = Screen.getPrimary().getVisualBounds();
         });
 
         System.setSecurityManager(sm);
@@ -168,8 +168,8 @@ public class CustomSecurityManagerTest extends VisualTestBase {
                 if (initFullScreen) {
                     testStage1.setFullScreen(true);
                 }
-                testStage1.setX((screenWidth.get() - WIDTH) / 2);
-                testStage1.setY((screenHeight.get() - HEIGHT) / 2);
+                testStage1.setX(((int)screenBounds.getWidth() - WIDTH) / 2);
+                testStage1.setY(((int)screenBounds.getHeight() - HEIGHT) / 2);
                 testStage1.show();
                 testStage1.toFront();
             });
@@ -194,18 +194,18 @@ public class CustomSecurityManagerTest extends VisualTestBase {
             } else {
                 assertFalse(propertyState);
             }
+            final int offset = 10;
             for (int row = 0; row < 2; row++) {
-                int h = screenHeight.get();
                 int y;
                 if (row == 0) {
                     // avoid the top area as it might contain OS-specific UI (Macs with a notch)
-                    y = h / 3;
+                    y = (int)screenBounds.getMinY() + offset;
                 } else {
-                    y = h - 5;
+                    y = (int)screenBounds.getMaxY() - offset - 1;
                 }
 
                 for (int col = 0; col < 2; col++) {
-                    int x = col == 0 ? 1 : screenWidth.get() - 5;
+                    int x = col == 0 ? (int)screenBounds.getMinX() + offset : (int)screenBounds.getMaxX() - offset - 1;
                     Color color = getColor(x, y);
                     if (expectedFullScreen) {
                         assertColorEquals(Color.LIME, color, TOLERANCE);

--- a/tests/system/src/test/java/test/robot/helloworld/CustomSecurityManagerTest.java
+++ b/tests/system/src/test/java/test/robot/helloworld/CustomSecurityManagerTest.java
@@ -168,8 +168,8 @@ public class CustomSecurityManagerTest extends VisualTestBase {
                 if (initFullScreen) {
                     testStage1.setFullScreen(true);
                 }
-                testStage1.setX(((int)screenBounds.getWidth() - WIDTH) / 2);
-                testStage1.setY(((int)screenBounds.getHeight() - HEIGHT) / 2);
+                testStage1.setX((screenBounds.getWidth() - WIDTH) / 2);
+                testStage1.setY((screenBounds.getHeight() - HEIGHT) / 2);
                 testStage1.show();
                 testStage1.toFront();
             });
@@ -196,13 +196,7 @@ public class CustomSecurityManagerTest extends VisualTestBase {
             }
             final int offset = 10;
             for (int row = 0; row < 2; row++) {
-                int y;
-                if (row == 0) {
-                    // avoid the top area as it might contain OS-specific UI (Macs with a notch)
-                    y = (int)screenBounds.getMinY() + offset;
-                } else {
-                    y = (int)screenBounds.getMaxY() - offset - 1;
-                }
+                int y = row == 0 ? (int)screenBounds.getMinY() + offset : (int)screenBounds.getMaxY() - offset - 1;
 
                 for (int col = 0; col < 2; col++) {
                     int x = col == 0 ? (int)screenBounds.getMinX() + offset : (int)screenBounds.getMaxX() - offset - 1;


### PR DESCRIPTION
Usage of `getBounds()` method instead `getVisualBounds()` was giving unreliable screen bound values and color value was read very close to the edge of the window.

Updated the code to use `getVisualBounds()` instead of `getBounds()` and moved the coordinates inside the window from where the color value is read.

Ran the tests individually and along with all system tests in following systems. No failure found after the fix.
Mac M1 with Ventura 13.3
Window 11

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306464](https://bugs.openjdk.org/browse/JDK-8306464): [testbug] CustomSecurityManagerTest full screen tests fails on MacOS intermittently


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1103/head:pull/1103` \
`$ git checkout pull/1103`

Update a local copy of the PR: \
`$ git checkout pull/1103` \
`$ git pull https://git.openjdk.org/jfx.git pull/1103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1103`

View PR using the GUI difftool: \
`$ git pr show -t 1103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1103.diff">https://git.openjdk.org/jfx/pull/1103.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1103#issuecomment-1515951829)