### PR TITLE
8306424: [testbug] DatePickerUpdateOnAlertCloseTest fails on MacOS

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/DatePickerUpdateOnAlertCloseTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/DatePickerUpdateOnAlertCloseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,11 +53,21 @@ import test.util.Util;
 /*
  * Test for verifying DatePicker update on closing the Alert dialog.
  *
- * There is 1 test in this file.
- * Steps for testDatePickerUpdateOnAlertClose()
- * 1. Create a alert dialog and add date picker to it.
+ * There are 2 tests in this file.
+ * Steps for testDatePickerUpdateOnAlertCloseUsingMouse()
+ * 1. Create an alert dialog and add date picker to it.
  * 2. Add button to scene and show alert dialog on button click.
  * 3. Click on date picker and select a date from popup.
+ * 4. Save the selected date locally.
+ * 5. Click on button and alert to display date picker again.
+ * 6. Select another date from the popup and save locally.
+ * 5. Verify that 2 date selected are not same and
+ *    selected dates are updated in the date picker.
+ *
+ * Steps for testDatePickerUpdateOnAlertCloseUsingKeyboard()
+ * 1. Create an alert dialog and add date picker to it.
+ * 2. Add button to scene and show alert dialog on button click.
+ * 3. Click on date picker and select a date from popup using keyboard.
  * 4. Verify that selected date is updated in the date picker.
  */
 public class DatePickerUpdateOnAlertCloseTest {
@@ -98,7 +108,7 @@ public class DatePickerUpdateOnAlertCloseTest {
     private void selectDatePicker() throws Exception {
         mouseClickOnAlertDialog(datePicker.getLayoutX() + datePicker.getWidth() - 15,
                                     datePicker.getLayoutY() + datePicker.getHeight() / 2);
-        Thread.sleep(400); // Wait for DatePicker popup to display.
+        Thread.sleep(800); // Wait for DatePicker popup to display.
         Util.waitForLatch(onDatePickerShownLatch, 5, "Failed to show DatePicker popup.");
     }
 
@@ -118,7 +128,29 @@ public class DatePickerUpdateOnAlertCloseTest {
     }
 
     @Test
-    public void testDatePickerUpdateOnAlertClose() throws Exception {
+    public void testDatePickerUpdateOnAlertCloseUsingMouse() throws Exception {
+        Thread.sleep(1000); // Wait for stage to layout
+
+        showAlertDialog();
+        selectDatePicker();
+
+        mouseClick(datePicker.getLayoutX() + datePicker.getWidth() / 2,
+                    datePicker.getLayoutY() + datePicker.getHeight() * Y_FACTOR);
+        LocalDate oldDate = datePicker.getValue();
+
+        showAlertDialog();
+        selectDatePicker();
+
+        mouseClick(datePicker.getLayoutX() + datePicker.getWidth() / 3,
+                    (datePicker.getLayoutY() + datePicker.getHeight() * Y_FACTOR));
+        LocalDate newDate = datePicker.getValue();
+
+        Thread.sleep(400); // Wait for date to be selected.
+        Assert.assertNotEquals(oldDate, newDate);
+    }
+
+    @Test
+    public void testDatePickerUpdateOnAlertCloseUsingKeyboard() throws Exception {
         Thread.sleep(1000); // Wait for stage to layout
 
         showAlertDialog();
@@ -134,6 +166,9 @@ public class DatePickerUpdateOnAlertCloseTest {
         Util.runAndWait(() -> {
             datePicker.setOnShown(null);
             datePicker.setOnAction(null);
+            dialog.setOnShown(null);
+            dialog.setOnHidden(null);
+            button.setOnAction(null);
         });
     }
 
@@ -150,6 +185,7 @@ public class DatePickerUpdateOnAlertCloseTest {
 
             dialog = new Alert(AlertType.INFORMATION);
             dialog.initStyle(StageStyle.UNDECORATED);
+            dialog.initOwner(stage);
             dialog.setOnShown(event -> {
                 onAlertShownLatch.countDown();
             });
@@ -159,7 +195,6 @@ public class DatePickerUpdateOnAlertCloseTest {
             });
 
             button.setOnAction(event -> {
-                dialog.initOwner(stage);
                 dialog.getDialogPane().setContent(datePicker);
                 dialog.show();
             });


### PR DESCRIPTION
Test was failing because `CountDownLatch` was not used to make sure that new date is selected and the delay present was not sufficient.
If the current date is on the left edge of the date picker, this test would fail because of the way new date was selected using mouse click.

Added `CountDownLatch` to make sure that alert dialog is closed before asserting the date. Updated the test to select new date using robot `keyType` method instead of mouse click so that the test becomes robust.

Ran the test individually and along with all system tests on Mac. No failure found.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306424](https://bugs.openjdk.org/browse/JDK-8306424): [testbug] DatePickerUpdateOnAlertCloseTest fails on MacOS


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1104/head:pull/1104` \
`$ git checkout pull/1104`

Update a local copy of the PR: \
`$ git checkout pull/1104` \
`$ git pull https://git.openjdk.org/jfx.git pull/1104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1104`

View PR using the GUI difftool: \
`$ git pr show -t 1104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1104.diff">https://git.openjdk.org/jfx/pull/1104.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1104#issuecomment-1516339853)