### PR TITLE
8306571: [testbug] Skip Tree/TableViewResizeColumnToFitContentTest with fractional screen scale

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewResizeColumnToFitContentTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewResizeColumnToFitContentTest.java
@@ -96,7 +96,7 @@ public class TableViewResizeColumnToFitContentTest {
                 (colTwoWidth != table.getColumns().get(1).getWidth()));
 
         // Skip this check on platforms with fractional scale until JDK-8299753 gets implemented
-        if (!Util.isFractionalScale(table)) {
+        if (!Util.isFractionalScaleX(table)) {
             colTwoWidth = table.getColumns().get(1).getWidth();
             colThreeWidth = table.getColumns().get(2).getWidth();
             double colsWidthAfterResize = colOneWidth + colTwoWidth + colThreeWidth;

--- a/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewResizeColumnToFitContentTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewResizeColumnToFitContentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,7 @@
 package test.robot.javafx.scene.tableview;
 
 import static org.junit.Assert.fail;
-
 import java.util.concurrent.CountDownLatch;
-
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.beans.property.SimpleObjectProperty;
@@ -40,12 +38,10 @@ import javafx.scene.robot.Robot;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.WindowEvent;
-
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
 import test.util.Util;
 
 /*
@@ -60,6 +56,7 @@ public class TableViewResizeColumnToFitContentTest {
     static volatile Scene scene;
     static final int SCENE_WIDTH = 450;
     static final int SCENE_HEIGHT = 100;
+    private static final double EPSILON = 1e-10;
     static CountDownLatch startupLatch = new CountDownLatch(1);
 
     public static void main(String[] args) {
@@ -97,11 +94,14 @@ public class TableViewResizeColumnToFitContentTest {
         }
         Assert.assertTrue("resizeColumnToFitContent failed",
                 (colTwoWidth != table.getColumns().get(1).getWidth()));
-        colTwoWidth = table.getColumns().get(1).getWidth();
-        colThreeWidth = table.getColumns().get(2).getWidth();
-        double colsWidthAfterResize = colOneWidth + colTwoWidth + colThreeWidth;
-        Assert.assertEquals("TableView.CONSTRAINED_RESIZE_POLICY ignored.",
-                colsWidthBeforeResize, colsWidthAfterResize, 0);
+
+        if (!Util.isFractionalScale(table)) {
+            colTwoWidth = table.getColumns().get(1).getWidth();
+            colThreeWidth = table.getColumns().get(2).getWidth();
+            double colsWidthAfterResize = colOneWidth + colTwoWidth + colThreeWidth;
+            Assert.assertEquals("TableView.CONSTRAINED_RESIZE_POLICY ignored.",
+                    colsWidthBeforeResize, colsWidthAfterResize, EPSILON);
+        }
     }
 
     @BeforeClass
@@ -162,5 +162,4 @@ public class TableViewResizeColumnToFitContentTest {
             this.descriptionProperty = new SimpleObjectProperty<>(description);
         }
     }
-
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewResizeColumnToFitContentTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewResizeColumnToFitContentTest.java
@@ -95,6 +95,7 @@ public class TableViewResizeColumnToFitContentTest {
         Assert.assertTrue("resizeColumnToFitContent failed",
                 (colTwoWidth != table.getColumns().get(1).getWidth()));
 
+        // Skip this check on platforms with fractional scale until JDK-8299753 gets implemented
         if (!Util.isFractionalScale(table)) {
             colTwoWidth = table.getColumns().get(1).getWidth();
             colThreeWidth = table.getColumns().get(2).getWidth();

--- a/tests/system/src/test/java/test/robot/javafx/scene/treetableview/TreeTableViewResizeColumnToFitContentTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/treetableview/TreeTableViewResizeColumnToFitContentTest.java
@@ -95,6 +95,7 @@ public class TreeTableViewResizeColumnToFitContentTest {
         Assert.assertTrue("resizeColumnToFitContent failed",
                 (colTwoWidth != treeTableView.getColumns().get(1).getWidth()));
 
+        // Skip this check on platforms with fractional scale until JDK-8299753 gets implemented
         if (!Util.isFractionalScale(treeTableView)) {
             colTwoWidth = treeTableView.getColumns().get(1).getWidth();
             colThreeWidth = treeTableView.getColumns().get(2).getWidth();

--- a/tests/system/src/test/java/test/robot/javafx/scene/treetableview/TreeTableViewResizeColumnToFitContentTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/treetableview/TreeTableViewResizeColumnToFitContentTest.java
@@ -96,7 +96,7 @@ public class TreeTableViewResizeColumnToFitContentTest {
                 (colTwoWidth != treeTableView.getColumns().get(1).getWidth()));
 
         // Skip this check on platforms with fractional scale until JDK-8299753 gets implemented
-        if (!Util.isFractionalScale(treeTableView)) {
+        if (!Util.isFractionalScaleX(treeTableView)) {
             colTwoWidth = treeTableView.getColumns().get(1).getWidth();
             colThreeWidth = treeTableView.getColumns().get(2).getWidth();
             double colsWidthAfterResize = colOneWidth + colTwoWidth + colThreeWidth;

--- a/tests/system/src/test/java/test/robot/javafx/scene/treetableview/TreeTableViewResizeColumnToFitContentTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/treetableview/TreeTableViewResizeColumnToFitContentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,7 @@
 package test.robot.javafx.scene.treetableview;
 
 import static org.junit.Assert.fail;
-
 import java.util.concurrent.CountDownLatch;
-
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -41,12 +39,10 @@ import javafx.scene.robot.Robot;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.stage.WindowEvent;
-
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
 import test.util.Util;
 
 /*
@@ -61,6 +57,7 @@ public class TreeTableViewResizeColumnToFitContentTest {
     static volatile Scene scene;
     static final int SCENE_WIDTH = 450;
     static final int SCENE_HEIGHT = 100;
+    private static final double EPSILON = 1e-10;
     static CountDownLatch startupLatch = new CountDownLatch(1);
 
     public static void main(String[] args) {
@@ -97,11 +94,14 @@ public class TreeTableViewResizeColumnToFitContentTest {
         }
         Assert.assertTrue("resizeColumnToFitContent failed",
                 (colTwoWidth != treeTableView.getColumns().get(1).getWidth()));
-        colTwoWidth = treeTableView.getColumns().get(1).getWidth();
-        colThreeWidth = treeTableView.getColumns().get(2).getWidth();
-        double colsWidthAfterResize = colOneWidth + colTwoWidth + colThreeWidth;
-        Assert.assertEquals("TreeTableView.CONSTRAINED_RESIZE_POLICY ignored.",
-                colsWidthBeforeResize, colsWidthAfterResize, 0);
+
+        if (!Util.isFractionalScale(treeTableView)) {
+            colTwoWidth = treeTableView.getColumns().get(1).getWidth();
+            colThreeWidth = treeTableView.getColumns().get(2).getWidth();
+            double colsWidthAfterResize = colOneWidth + colTwoWidth + colThreeWidth;
+            Assert.assertEquals("TreeTableView.CONSTRAINED_RESIZE_POLICY ignored.",
+                    colsWidthBeforeResize, colsWidthAfterResize, EPSILON);
+        }
     }
 
     @BeforeClass

--- a/tests/system/src/test/java/test/util/Util.java
+++ b/tests/system/src/test/java/test/util/Util.java
@@ -424,11 +424,10 @@ public class Util {
         }
     }
 
-    /** returns true if either scaleX or scaleY of the specified Node is not integer */
-    public static boolean isFractionalScale(Node n) {
-        return
-            isFractional(n.getScene().getWindow().getRenderScaleX()) ||
-            isFractional(n.getScene().getWindow().getRenderScaleY());
+    /** returns true if scaleX of the specified Node is not integer */
+    public static boolean isFractionalScaleX(Node n) {
+        double scale = n.getScene().getWindow().getRenderScaleX();
+        return isFractional(scale);
     }
 
     private static boolean isFractional(double x) {

--- a/tests/system/src/test/java/test/util/Util.java
+++ b/tests/system/src/test/java/test/util/Util.java
@@ -41,6 +41,7 @@ import java.util.concurrent.TimeUnit;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.geometry.Rectangle2D;
+import javafx.scene.Node;
 import javafx.scene.robot.Robot;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
@@ -421,5 +422,16 @@ public class Util {
         } else {
             runAndWait(park);
         }
+    }
+
+    /** returns true if either scaleX or scaleY of the specified Node is not integer */
+    public static boolean isFractionalScale(Node n) {
+        return
+            isFractional(n.getScene().getWindow().getRenderScaleX()) ||
+            isFractional(n.getScene().getWindow().getRenderScaleY());
+    }
+
+    private static boolean isFractional(double x) {
+        return x != Math.rint(x);
     }
 }


### PR DESCRIPTION
Skipping some checks in Tree/TableViewResizeColumnToFitContentTest on platforms with fractional screen scale, until JDK-8299753 gets implemented.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306571](https://bugs.openjdk.org/browse/JDK-8306571): [testbug] Skip Tree/TableViewResizeColumnToFitContentTest with fractional screen scale


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1105/head:pull/1105` \
`$ git checkout pull/1105`

Update a local copy of the PR: \
`$ git checkout pull/1105` \
`$ git pull https://git.openjdk.org/jfx.git pull/1105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1105`

View PR using the GUI difftool: \
`$ git pr show -t 1105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1105.diff">https://git.openjdk.org/jfx/pull/1105.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1105#issuecomment-1516597963)