### PR TITLE
8306115 : Update libxml2 to 2.10.4

### DIFF
--- a/modules/javafx.web/src/main/legal/libxml2.md
+++ b/modules/javafx.web/src/main/legal/libxml2.md
@@ -1,4 +1,4 @@
-## xmlsoft.org: libxml2 v2.10.3
+## xmlsoft.org: libxml2 v2.10.4
 
 ### libxml2 License
 ```

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/config.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/config.h
@@ -160,7 +160,7 @@
 #define PACKAGE_NAME "libxml2"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libxml2 2.10.3"
+#define PACKAGE_STRING "libxml2 2.10.4"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libxml2"
@@ -169,7 +169,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.10.3"
+#define PACKAGE_VERSION "2.10.4"
 
 /* Type cast for the send() function 2nd arg */
 #define SEND_ARG2_CAST /**/
@@ -186,7 +186,7 @@
 #define VA_LIST_IS_ARRAY 1
 
 /* Version number of package */
-#define VERSION "2.10.3"
+#define VERSION "2.10.4"
 
 /* Determine what socket length (socklen_t) data type is */
 #define XML_SOCKLEN_T socklen_t

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/include/libxml/xmlversion.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/linux/include/libxml/xmlversion.h
@@ -29,21 +29,21 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.10.3"
+#define LIBXML_DOTTED_VERSION "2.10.4"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 21003
+#define LIBXML_VERSION 21004
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "21003"
+#define LIBXML_VERSION_STRING "21004"
 
 /**
  * LIBXML_VERSION_EXTRA:
@@ -58,7 +58,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(21003);
+#define LIBXML_TEST_VERSION xmlCheckVersion(21004);
 
 #ifndef VMS
 #if 0

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/config.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/config.h
@@ -160,7 +160,7 @@
 #define PACKAGE_NAME "libxml2"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libxml2 2.10.3"
+#define PACKAGE_STRING "libxml2 2.10.4"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libxml2"
@@ -169,7 +169,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "2.10.3"
+#define PACKAGE_VERSION "2.10.4"
 
 /* Type cast for the send() function 2nd arg */
 #define SEND_ARG2_CAST /**/
@@ -186,7 +186,7 @@
 #define VA_LIST_IS_ARRAY 1
 
 /* Version number of package */
-#define VERSION "2.10.3"
+#define VERSION "2.10.4"
 
 /* Determine what socket length (socklen_t) data type is */
 #define XML_SOCKLEN_T socklen_t

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/include/libxml/xmlversion.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/mac/include/libxml/xmlversion.h
@@ -29,21 +29,21 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.10.3"
+#define LIBXML_DOTTED_VERSION "2.10.4"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 21003
+#define LIBXML_VERSION 21004
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "21003"
+#define LIBXML_VERSION_STRING "21004"
 
 /**
  * LIBXML_VERSION_EXTRA:
@@ -58,7 +58,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(21003);
+#define LIBXML_TEST_VERSION xmlCheckVersion(21004);
 
 #ifndef VMS
 #if 0

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/NEWS
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/NEWS
@@ -1,5 +1,19 @@
 NEWS file for libxml2
 
+v2.10.4: Apr 11 2023
+
+### Security
+
+- [CVE-2023-29469] Hashing of empty dict strings isn't deterministic
+- [CVE-2023-28484] Fix null deref in xmlSchemaFixupComplexType
+- schemas: Fix null-pointer-deref in xmlSchemaCheckCOSSTDerivedOK
+
+### Regressions
+
+- SAX2: Ignore namespaces in HTML documents
+- io: Fix "buffer full" error with certain buffer sizes
+
+
 v2.10.3: Oct 14 2022
 
 ### Security
@@ -59,6 +73,47 @@ v2.10.1: Aug 25 2022
 
 
 v2.10.0: Aug 17 2022
+
+### Breaking changes
+
+The Docbook parser module and all related symbols habe been removed completely.
+This was experimental code which never worked and generated a deprecation
+warning for 15+ years. The library's soname wasn't changed in order to allow
+seamless upgrades to later versions. If this concerns you, consider bumping
+soname yourself.
+
+Some other modules are now disabled by default and will eventually be removed
+completely:
+
+- Support for XPointer locations (ranges and points): This was based on
+  a W3C specification which never got beyond Working Draft status. To my
+  knowledge, there's no software supporting this spec which is still
+  maintained. You now have to enable this code by passing the
+  `--with-xptr-locs` configuration option. Be warned that this part of
+  the code base is buggy and had many security issues in the past.
+
+- Support for the built-in FTP client (`--with-ftp`).
+
+- Support for "legacy" functions (`--with-legacy`).
+
+If you're concerned about ABI stability and haven't disabled these modules
+already, add the following configuration options or bump soname yourself:
+
+    --with-ftp
+    --with-legacy
+    --with-xptr-locs
+
+Several functions of the public API were deprecated. Most of them should be
+completely unused and will generate a deprecation warning now.
+
+The autoconf build now uses the sysconfdir variable for the location of
+the default catalog file. The path changed from hardcoded /etc/xml/catalog
+to ${sysconfdir}/xml/catalog. The sysconfdir variable defaults to
+${prefix}/etc, prefix defaults to /usr/local, so without other options
+the path becomes /usr/local/etc/xml/catalog. If you want the old behavior,
+configure with
+
+    --sysconfdir=/etc
 
 ### Security
 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/SAX2.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/SAX2.c
@@ -41,9 +41,9 @@
  *> values "system" and "public".  I have made the default be "system" to
  *> match yours.
  */
-#define TODO                                                            \
-    xmlGenericError(xmlGenericErrorContext,                             \
-            "Unimplemented block at %s:%d\n",                           \
+#define TODO								\
+    xmlGenericError(xmlGenericErrorContext,				\
+	    "Unimplemented block at %s:%d\n",				\
             __FILE__, __LINE__);
 
 /*
@@ -57,25 +57,25 @@ xmlSAX2ErrMemory(xmlParserCtxtPtr ctxt, const char *msg) {
     const char *str1 = "out of memory\n";
 
     if (ctxt != NULL) {
-        ctxt->errNo = XML_ERR_NO_MEMORY;
-        if ((ctxt->sax != NULL) && (ctxt->sax->initialized == XML_SAX2_MAGIC))
-            schannel = ctxt->sax->serror;
-        __xmlRaiseError(schannel,
-                        ctxt->vctxt.error, ctxt->vctxt.userData,
-                        ctxt, NULL, XML_FROM_PARSER, XML_ERR_NO_MEMORY,
-                        XML_ERR_ERROR, NULL, 0, (const char *) str1,
-                        NULL, NULL, 0, 0,
-                        msg, (const char *) str1, NULL);
-        ctxt->errNo = XML_ERR_NO_MEMORY;
-        ctxt->instate = XML_PARSER_EOF;
-        ctxt->disableSAX = 1;
+	ctxt->errNo = XML_ERR_NO_MEMORY;
+	if ((ctxt->sax != NULL) && (ctxt->sax->initialized == XML_SAX2_MAGIC))
+	    schannel = ctxt->sax->serror;
+	__xmlRaiseError(schannel,
+			ctxt->vctxt.error, ctxt->vctxt.userData,
+			ctxt, NULL, XML_FROM_PARSER, XML_ERR_NO_MEMORY,
+			XML_ERR_ERROR, NULL, 0, (const char *) str1,
+			NULL, NULL, 0, 0,
+			msg, (const char *) str1, NULL);
+	ctxt->errNo = XML_ERR_NO_MEMORY;
+	ctxt->instate = XML_PARSER_EOF;
+	ctxt->disableSAX = 1;
     } else {
-        __xmlRaiseError(schannel,
-                        NULL, NULL,
-                        ctxt, NULL, XML_FROM_PARSER, XML_ERR_NO_MEMORY,
-                        XML_ERR_ERROR, NULL, 0, (const char *) str1,
-                        NULL, NULL, 0, 0,
-                        msg, (const char *) str1, NULL);
+	__xmlRaiseError(schannel,
+			NULL, NULL,
+			ctxt, NULL, XML_FROM_PARSER, XML_ERR_NO_MEMORY,
+			XML_ERR_ERROR, NULL, 0, (const char *) str1,
+			NULL, NULL, 0, 0,
+			msg, (const char *) str1, NULL);
     }
 }
 
@@ -97,25 +97,25 @@ xmlErrValid(xmlParserCtxtPtr ctxt, xmlParserErrors error,
 
     if ((ctxt != NULL) && (ctxt->disableSAX != 0) &&
         (ctxt->instate == XML_PARSER_EOF))
-        return;
+	return;
     if (ctxt != NULL) {
-        ctxt->errNo = error;
-        if ((ctxt->sax != NULL) && (ctxt->sax->initialized == XML_SAX2_MAGIC))
-            schannel = ctxt->sax->serror;
-        __xmlRaiseError(schannel,
-                        ctxt->vctxt.error, ctxt->vctxt.userData,
-                        ctxt, NULL, XML_FROM_DTD, error,
-                        XML_ERR_ERROR, NULL, 0, (const char *) str1,
-                        (const char *) str2, NULL, 0, 0,
-                        msg, (const char *) str1, (const char *) str2);
-        ctxt->valid = 0;
+	ctxt->errNo = error;
+	if ((ctxt->sax != NULL) && (ctxt->sax->initialized == XML_SAX2_MAGIC))
+	    schannel = ctxt->sax->serror;
+	__xmlRaiseError(schannel,
+			ctxt->vctxt.error, ctxt->vctxt.userData,
+			ctxt, NULL, XML_FROM_DTD, error,
+			XML_ERR_ERROR, NULL, 0, (const char *) str1,
+			(const char *) str2, NULL, 0, 0,
+			msg, (const char *) str1, (const char *) str2);
+	ctxt->valid = 0;
     } else {
-        __xmlRaiseError(schannel,
-                        NULL, NULL,
-                        ctxt, NULL, XML_FROM_DTD, error,
-                        XML_ERR_ERROR, NULL, 0, (const char *) str1,
-                        (const char *) str2, NULL, 0, 0,
-                        msg, (const char *) str1, (const char *) str2);
+	__xmlRaiseError(schannel,
+			NULL, NULL,
+			ctxt, NULL, XML_FROM_DTD, error,
+			XML_ERR_ERROR, NULL, 0, (const char *) str1,
+			(const char *) str2, NULL, 0, 0,
+			msg, (const char *) str1, (const char *) str2);
     }
 }
 
@@ -135,18 +135,18 @@ xmlFatalErrMsg(xmlParserCtxtPtr ctxt, xmlParserErrors error,
 {
     if ((ctxt != NULL) && (ctxt->disableSAX != 0) &&
         (ctxt->instate == XML_PARSER_EOF))
-        return;
+	return;
     if (ctxt != NULL)
-        ctxt->errNo = error;
+	ctxt->errNo = error;
     __xmlRaiseError(NULL, NULL, NULL, ctxt, NULL, XML_FROM_PARSER, error,
                     XML_ERR_FATAL, NULL, 0,
-                    (const char *) str1, (const char *) str2,
-                    NULL, 0, 0, msg, str1, str2);
+		    (const char *) str1, (const char *) str2,
+		    NULL, 0, 0, msg, str1, str2);
     if (ctxt != NULL) {
-        ctxt->wellFormed = 0;
-        ctxt->valid = 0;
-        if (ctxt->recovery == 0)
-            ctxt->disableSAX = 1;
+	ctxt->wellFormed = 0;
+	ctxt->valid = 0;
+	if (ctxt->recovery == 0)
+	    ctxt->disableSAX = 1;
     }
 }
 
@@ -166,13 +166,13 @@ xmlWarnMsg(xmlParserCtxtPtr ctxt, xmlParserErrors error,
 {
     if ((ctxt != NULL) && (ctxt->disableSAX != 0) &&
         (ctxt->instate == XML_PARSER_EOF))
-        return;
+	return;
     if (ctxt != NULL)
-        ctxt->errNo = error;
+	ctxt->errNo = error;
     __xmlRaiseError(NULL, NULL, NULL, ctxt, NULL, XML_FROM_PARSER, error,
                     XML_ERR_WARNING, NULL, 0,
-                    (const char *) str1, NULL,
-                    NULL, 0, 0, msg, str1);
+		    (const char *) str1, NULL,
+		    NULL, 0, 0, msg, str1);
 }
 
 /**
@@ -190,13 +190,13 @@ xmlNsWarnMsg(xmlParserCtxtPtr ctxt, xmlParserErrors error,
 {
     if ((ctxt != NULL) && (ctxt->disableSAX != 0) &&
         (ctxt->instate == XML_PARSER_EOF))
-        return;
+	return;
     if (ctxt != NULL)
-        ctxt->errNo = error;
+	ctxt->errNo = error;
     __xmlRaiseError(NULL, NULL, NULL, ctxt, NULL, XML_FROM_NAMESPACE, error,
                     XML_ERR_WARNING, NULL, 0,
-                    (const char *) str1, (const char *) str2,
-                    NULL, 0, 0, msg, str1, str2);
+		    (const char *) str1, (const char *) str2,
+		    NULL, 0, 0, msg, str1, str2);
 }
 
 /**
@@ -322,29 +322,29 @@ xmlSAX2HasExternalSubset(void *ctx)
  */
 void
 xmlSAX2InternalSubset(void *ctx, const xmlChar *name,
-               const xmlChar *ExternalID, const xmlChar *SystemID)
+	       const xmlChar *ExternalID, const xmlChar *SystemID)
 {
     xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx;
     xmlDtdPtr dtd;
     if (ctx == NULL) return;
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-            "SAX.xmlSAX2InternalSubset(%s, %s, %s)\n",
+	    "SAX.xmlSAX2InternalSubset(%s, %s, %s)\n",
             name, ExternalID, SystemID);
 #endif
 
     if (ctxt->myDoc == NULL)
-        return;
+	return;
     dtd = xmlGetIntSubset(ctxt->myDoc);
     if (dtd != NULL) {
-        if (ctxt->html)
-            return;
-        xmlUnlinkNode((xmlNodePtr) dtd);
-        xmlFreeDtd(dtd);
-        ctxt->myDoc->intSubset = NULL;
+	if (ctxt->html)
+	    return;
+	xmlUnlinkNode((xmlNodePtr) dtd);
+	xmlFreeDtd(dtd);
+	ctxt->myDoc->intSubset = NULL;
     }
     ctxt->myDoc->intSubset =
-        xmlCreateIntSubset(ctxt->myDoc, name, ExternalID, SystemID);
+	xmlCreateIntSubset(ctxt->myDoc, name, ExternalID, SystemID);
     if (ctxt->myDoc->intSubset == NULL)
         xmlSAX2ErrMemory(ctxt, "xmlSAX2InternalSubset");
 }
@@ -360,114 +360,114 @@ xmlSAX2InternalSubset(void *ctx, const xmlChar *name,
  */
 void
 xmlSAX2ExternalSubset(void *ctx, const xmlChar *name,
-               const xmlChar *ExternalID, const xmlChar *SystemID)
+	       const xmlChar *ExternalID, const xmlChar *SystemID)
 {
     xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx;
     if (ctx == NULL) return;
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-            "SAX.xmlSAX2ExternalSubset(%s, %s, %s)\n",
+	    "SAX.xmlSAX2ExternalSubset(%s, %s, %s)\n",
             name, ExternalID, SystemID);
 #endif
     if (((ExternalID != NULL) || (SystemID != NULL)) &&
         (((ctxt->validate) || (ctxt->loadsubset != 0)) &&
-         (ctxt->wellFormed && ctxt->myDoc))) {
-        /*
-         * Try to fetch and parse the external subset.
-         */
-        xmlParserInputPtr oldinput;
-        int oldinputNr;
-        int oldinputMax;
-        xmlParserInputPtr *oldinputTab;
-        xmlParserInputPtr input = NULL;
-        xmlCharEncoding enc;
-        int oldcharset;
-        const xmlChar *oldencoding;
+	 (ctxt->wellFormed && ctxt->myDoc))) {
+	/*
+	 * Try to fetch and parse the external subset.
+	 */
+	xmlParserInputPtr oldinput;
+	int oldinputNr;
+	int oldinputMax;
+	xmlParserInputPtr *oldinputTab;
+	xmlParserInputPtr input = NULL;
+	xmlCharEncoding enc;
+	int oldcharset;
+	const xmlChar *oldencoding;
+
+	/*
+	 * Ask the Entity resolver to load the damn thing
+	 */
+	if ((ctxt->sax != NULL) && (ctxt->sax->resolveEntity != NULL))
+	    input = ctxt->sax->resolveEntity(ctxt->userData, ExternalID,
+	                                        SystemID);
+	if (input == NULL) {
+	    return;
+	}
+
+	xmlNewDtd(ctxt->myDoc, name, ExternalID, SystemID);
+
+	/*
+	 * make sure we won't destroy the main document context
+	 */
+	oldinput = ctxt->input;
+	oldinputNr = ctxt->inputNr;
+	oldinputMax = ctxt->inputMax;
+	oldinputTab = ctxt->inputTab;
+	oldcharset = ctxt->charset;
+	oldencoding = ctxt->encoding;
+	ctxt->encoding = NULL;
+
+	ctxt->inputTab = (xmlParserInputPtr *)
+	                 xmlMalloc(5 * sizeof(xmlParserInputPtr));
+	if (ctxt->inputTab == NULL) {
+	    xmlSAX2ErrMemory(ctxt, "xmlSAX2ExternalSubset");
+	    ctxt->input = oldinput;
+	    ctxt->inputNr = oldinputNr;
+	    ctxt->inputMax = oldinputMax;
+	    ctxt->inputTab = oldinputTab;
+	    ctxt->charset = oldcharset;
+	    ctxt->encoding = oldencoding;
+	    return;
+	}
+	ctxt->inputNr = 0;
+	ctxt->inputMax = 5;
+	ctxt->input = NULL;
+	xmlPushInput(ctxt, input);
+
+	/*
+	 * On the fly encoding conversion if needed
+	 */
+	if (ctxt->input->length >= 4) {
+	    enc = xmlDetectCharEncoding(ctxt->input->cur, 4);
+	    xmlSwitchEncoding(ctxt, enc);
+	}
+
+	if (input->filename == NULL)
+	    input->filename = (char *) xmlCanonicPath(SystemID);
+	input->line = 1;
+	input->col = 1;
+	input->base = ctxt->input->cur;
+	input->cur = ctxt->input->cur;
+	input->free = NULL;
+
+	/*
+	 * let's parse that entity knowing it's an external subset.
+	 */
+	xmlParseExternalSubset(ctxt, ExternalID, SystemID);
 
         /*
-         * Ask the Entity resolver to load the damn thing
-         */
-        if ((ctxt->sax != NULL) && (ctxt->sax->resolveEntity != NULL))
-            input = ctxt->sax->resolveEntity(ctxt->userData, ExternalID,
-                                                SystemID);
-        if (input == NULL) {
-            return;
-        }
+	 * Free up the external entities
+	 */
 
-        xmlNewDtd(ctxt->myDoc, name, ExternalID, SystemID);
-
-        /*
-         * make sure we won't destroy the main document context
-         */
-        oldinput = ctxt->input;
-        oldinputNr = ctxt->inputNr;
-        oldinputMax = ctxt->inputMax;
-        oldinputTab = ctxt->inputTab;
-        oldcharset = ctxt->charset;
-        oldencoding = ctxt->encoding;
-        ctxt->encoding = NULL;
-
-        ctxt->inputTab = (xmlParserInputPtr *)
-                         xmlMalloc(5 * sizeof(xmlParserInputPtr));
-        if (ctxt->inputTab == NULL) {
-            xmlSAX2ErrMemory(ctxt, "xmlSAX2ExternalSubset");
-            ctxt->input = oldinput;
-            ctxt->inputNr = oldinputNr;
-            ctxt->inputMax = oldinputMax;
-            ctxt->inputTab = oldinputTab;
-            ctxt->charset = oldcharset;
-            ctxt->encoding = oldencoding;
-            return;
-        }
-        ctxt->inputNr = 0;
-        ctxt->inputMax = 5;
-        ctxt->input = NULL;
-        xmlPushInput(ctxt, input);
-
-        /*
-         * On the fly encoding conversion if needed
-         */
-        if (ctxt->input->length >= 4) {
-            enc = xmlDetectCharEncoding(ctxt->input->cur, 4);
-            xmlSwitchEncoding(ctxt, enc);
-        }
-
-        if (input->filename == NULL)
-            input->filename = (char *) xmlCanonicPath(SystemID);
-        input->line = 1;
-        input->col = 1;
-        input->base = ctxt->input->cur;
-        input->cur = ctxt->input->cur;
-        input->free = NULL;
-
-        /*
-         * let's parse that entity knowing it's an external subset.
-         */
-        xmlParseExternalSubset(ctxt, ExternalID, SystemID);
-
-        /*
-         * Free up the external entities
-         */
-
-        while (ctxt->inputNr > 1)
-            xmlPopInput(ctxt);
-        xmlFreeInputStream(ctxt->input);
+	while (ctxt->inputNr > 1)
+	    xmlPopInput(ctxt);
+	xmlFreeInputStream(ctxt->input);
         xmlFree(ctxt->inputTab);
 
-        /*
-         * Restore the parsing context of the main entity
-         */
-        ctxt->input = oldinput;
-        ctxt->inputNr = oldinputNr;
-        ctxt->inputMax = oldinputMax;
-        ctxt->inputTab = oldinputTab;
-        ctxt->charset = oldcharset;
-        if ((ctxt->encoding != NULL) &&
-            ((ctxt->dict == NULL) ||
-             (!xmlDictOwns(ctxt->dict, ctxt->encoding))))
-            xmlFree((xmlChar *) ctxt->encoding);
-        ctxt->encoding = oldencoding;
-        /* ctxt->wellFormed = oldwellFormed; */
+	/*
+	 * Restore the parsing context of the main entity
+	 */
+	ctxt->input = oldinput;
+	ctxt->inputNr = oldinputNr;
+	ctxt->inputMax = oldinputMax;
+	ctxt->inputTab = oldinputTab;
+	ctxt->charset = oldcharset;
+	if ((ctxt->encoding != NULL) &&
+	    ((ctxt->dict == NULL) ||
+	     (!xmlDictOwns(ctxt->dict, ctxt->encoding))))
+	    xmlFree((xmlChar *) ctxt->encoding);
+	ctxt->encoding = oldencoding;
+	/* ctxt->wellFormed = oldwellFormed; */
     }
 }
 
@@ -495,21 +495,21 @@ xmlSAX2ResolveEntity(void *ctx, const xmlChar *publicId, const xmlChar *systemId
 
     if (ctx == NULL) return(NULL);
     if (ctxt->input != NULL)
-        base = ctxt->input->filename;
+	base = ctxt->input->filename;
     if (base == NULL)
-        base = ctxt->directory;
+	base = ctxt->directory;
 
     URI = xmlBuildURI(systemId, (const xmlChar *) base);
 
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-            "SAX.xmlSAX2ResolveEntity(%s, %s)\n", publicId, systemId);
+	    "SAX.xmlSAX2ResolveEntity(%s, %s)\n", publicId, systemId);
 #endif
 
     ret = xmlLoadExternalEntity((const char *) URI,
-                                (const char *) publicId, ctxt);
+				(const char *) publicId, ctxt);
     if (URI != NULL)
-        xmlFree(URI);
+	xmlFree(URI);
     return(ret);
 }
 
@@ -531,34 +531,34 @@ xmlSAX2GetEntity(void *ctx, const xmlChar *name)
     if (ctx == NULL) return(NULL);
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-            "SAX.xmlSAX2GetEntity(%s)\n", name);
+	    "SAX.xmlSAX2GetEntity(%s)\n", name);
 #endif
 
     if (ctxt->inSubset == 0) {
-        ret = xmlGetPredefinedEntity(name);
-        if (ret != NULL)
-            return(ret);
+	ret = xmlGetPredefinedEntity(name);
+	if (ret != NULL)
+	    return(ret);
     }
     if ((ctxt->myDoc != NULL) && (ctxt->myDoc->standalone == 1)) {
-        if (ctxt->inSubset == 2) {
-            ctxt->myDoc->standalone = 0;
-            ret = xmlGetDocEntity(ctxt->myDoc, name);
-            ctxt->myDoc->standalone = 1;
-        } else {
-            ret = xmlGetDocEntity(ctxt->myDoc, name);
-            if (ret == NULL) {
-                ctxt->myDoc->standalone = 0;
-                ret = xmlGetDocEntity(ctxt->myDoc, name);
-                if (ret != NULL) {
-                    xmlFatalErrMsg(ctxt, XML_ERR_NOT_STANDALONE,
-         "Entity(%s) document marked standalone but requires external subset\n",
-                                   name, NULL);
-                }
-                ctxt->myDoc->standalone = 1;
-            }
-        }
+	if (ctxt->inSubset == 2) {
+	    ctxt->myDoc->standalone = 0;
+	    ret = xmlGetDocEntity(ctxt->myDoc, name);
+	    ctxt->myDoc->standalone = 1;
+	} else {
+	    ret = xmlGetDocEntity(ctxt->myDoc, name);
+	    if (ret == NULL) {
+		ctxt->myDoc->standalone = 0;
+		ret = xmlGetDocEntity(ctxt->myDoc, name);
+		if (ret != NULL) {
+		    xmlFatalErrMsg(ctxt, XML_ERR_NOT_STANDALONE,
+	 "Entity(%s) document marked standalone but requires external subset\n",
+				   name, NULL);
+		}
+		ctxt->myDoc->standalone = 1;
+	    }
+	}
     } else {
-        ret = xmlGetDocEntity(ctxt->myDoc, name);
+	ret = xmlGetDocEntity(ctxt->myDoc, name);
     }
     return(ret);
 }
@@ -581,7 +581,7 @@ xmlSAX2GetParameterEntity(void *ctx, const xmlChar *name)
     if (ctx == NULL) return(NULL);
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-            "SAX.xmlSAX2GetParameterEntity(%s)\n", name);
+	    "SAX.xmlSAX2GetParameterEntity(%s)\n", name);
 #endif
 
     ret = xmlGetParameterEntity(ctxt->myDoc, name);
@@ -610,51 +610,51 @@ xmlSAX2EntityDecl(void *ctx, const xmlChar *name, int type,
     if (ctx == NULL) return;
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-            "SAX.xmlSAX2EntityDecl(%s, %d, %s, %s, %s)\n",
+	    "SAX.xmlSAX2EntityDecl(%s, %d, %s, %s, %s)\n",
             name, type, publicId, systemId, content);
 #endif
     if (ctxt->inSubset == 1) {
-        ent = xmlAddDocEntity(ctxt->myDoc, name, type, publicId,
-                              systemId, content);
-        if ((ent == NULL) && (ctxt->pedantic))
-            xmlWarnMsg(ctxt, XML_WAR_ENTITY_REDEFINED,
-             "Entity(%s) already defined in the internal subset\n",
-                       name);
-        if ((ent != NULL) && (ent->URI == NULL) && (systemId != NULL)) {
-            xmlChar *URI;
-            const char *base = NULL;
+	ent = xmlAddDocEntity(ctxt->myDoc, name, type, publicId,
+		              systemId, content);
+	if ((ent == NULL) && (ctxt->pedantic))
+	    xmlWarnMsg(ctxt, XML_WAR_ENTITY_REDEFINED,
+	     "Entity(%s) already defined in the internal subset\n",
+	               name);
+	if ((ent != NULL) && (ent->URI == NULL) && (systemId != NULL)) {
+	    xmlChar *URI;
+	    const char *base = NULL;
 
-            if (ctxt->input != NULL)
-                base = ctxt->input->filename;
-            if (base == NULL)
-                base = ctxt->directory;
+	    if (ctxt->input != NULL)
+		base = ctxt->input->filename;
+	    if (base == NULL)
+		base = ctxt->directory;
 
-            URI = xmlBuildURI(systemId, (const xmlChar *) base);
-            ent->URI = URI;
-        }
+	    URI = xmlBuildURI(systemId, (const xmlChar *) base);
+	    ent->URI = URI;
+	}
     } else if (ctxt->inSubset == 2) {
-        ent = xmlAddDtdEntity(ctxt->myDoc, name, type, publicId,
-                              systemId, content);
-        if ((ent == NULL) && (ctxt->pedantic) &&
-            (ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
-            ctxt->sax->warning(ctxt->userData,
-             "Entity(%s) already defined in the external subset\n", name);
-        if ((ent != NULL) && (ent->URI == NULL) && (systemId != NULL)) {
-            xmlChar *URI;
-            const char *base = NULL;
+	ent = xmlAddDtdEntity(ctxt->myDoc, name, type, publicId,
+		              systemId, content);
+	if ((ent == NULL) && (ctxt->pedantic) &&
+	    (ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
+	    ctxt->sax->warning(ctxt->userData,
+	     "Entity(%s) already defined in the external subset\n", name);
+	if ((ent != NULL) && (ent->URI == NULL) && (systemId != NULL)) {
+	    xmlChar *URI;
+	    const char *base = NULL;
 
-            if (ctxt->input != NULL)
-                base = ctxt->input->filename;
-            if (base == NULL)
-                base = ctxt->directory;
+	    if (ctxt->input != NULL)
+		base = ctxt->input->filename;
+	    if (base == NULL)
+		base = ctxt->directory;
 
-            URI = xmlBuildURI(systemId, (const xmlChar *) base);
-            ent->URI = URI;
-        }
+	    URI = xmlBuildURI(systemId, (const xmlChar *) base);
+	    ent->URI = URI;
+	}
     } else {
-        xmlFatalErrMsg(ctxt, XML_ERR_ENTITY_PROCESSING,
-                       "SAX.xmlSAX2EntityDecl(%s) called while not in subset\n",
-                       name, NULL);
+	xmlFatalErrMsg(ctxt, XML_ERR_ENTITY_PROCESSING,
+	               "SAX.xmlSAX2EntityDecl(%s) called while not in subset\n",
+		       name, NULL);
     }
 }
 
@@ -673,7 +673,7 @@ xmlSAX2EntityDecl(void *ctx, const xmlChar *name, int type,
 void
 xmlSAX2AttributeDecl(void *ctx, const xmlChar *elem, const xmlChar *fullname,
               int type, int def, const xmlChar *defaultValue,
-              xmlEnumerationPtr tree)
+	      xmlEnumerationPtr tree)
 {
     xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx;
     xmlAttributePtr attr;
@@ -687,50 +687,50 @@ xmlSAX2AttributeDecl(void *ctx, const xmlChar *elem, const xmlChar *fullname,
 
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-            "SAX.xmlSAX2AttributeDecl(%s, %s, %d, %d, %s, ...)\n",
+	    "SAX.xmlSAX2AttributeDecl(%s, %s, %d, %d, %s, ...)\n",
             elem, fullname, type, def, defaultValue);
 #endif
     if ((xmlStrEqual(fullname, BAD_CAST "xml:id")) &&
         (type != XML_ATTRIBUTE_ID)) {
-        /*
-         * Raise the error but keep the validity flag
-         */
-        int tmp = ctxt->valid;
-        xmlErrValid(ctxt, XML_DTD_XMLID_TYPE,
-              "xml:id : attribute type should be ID\n", NULL, NULL);
-        ctxt->valid = tmp;
+	/*
+	 * Raise the error but keep the validity flag
+	 */
+	int tmp = ctxt->valid;
+	xmlErrValid(ctxt, XML_DTD_XMLID_TYPE,
+	      "xml:id : attribute type should be ID\n", NULL, NULL);
+	ctxt->valid = tmp;
     }
     /* TODO: optimize name/prefix allocation */
     name = xmlSplitQName(ctxt, fullname, &prefix);
     ctxt->vctxt.valid = 1;
     if (ctxt->inSubset == 1)
-        attr = xmlAddAttributeDecl(&ctxt->vctxt, ctxt->myDoc->intSubset, elem,
-               name, prefix, (xmlAttributeType) type,
-               (xmlAttributeDefault) def, defaultValue, tree);
+	attr = xmlAddAttributeDecl(&ctxt->vctxt, ctxt->myDoc->intSubset, elem,
+	       name, prefix, (xmlAttributeType) type,
+	       (xmlAttributeDefault) def, defaultValue, tree);
     else if (ctxt->inSubset == 2)
-        attr = xmlAddAttributeDecl(&ctxt->vctxt, ctxt->myDoc->extSubset, elem,
-           name, prefix, (xmlAttributeType) type,
-           (xmlAttributeDefault) def, defaultValue, tree);
+	attr = xmlAddAttributeDecl(&ctxt->vctxt, ctxt->myDoc->extSubset, elem,
+	   name, prefix, (xmlAttributeType) type,
+	   (xmlAttributeDefault) def, defaultValue, tree);
     else {
         xmlFatalErrMsg(ctxt, XML_ERR_INTERNAL_ERROR,
-             "SAX.xmlSAX2AttributeDecl(%s) called while not in subset\n",
-                       name, NULL);
-        xmlFree(name);
-        xmlFreeEnumeration(tree);
-        return;
+	     "SAX.xmlSAX2AttributeDecl(%s) called while not in subset\n",
+	               name, NULL);
+	xmlFree(name);
+	xmlFreeEnumeration(tree);
+	return;
     }
 #ifdef LIBXML_VALID_ENABLED
     if (ctxt->vctxt.valid == 0)
-        ctxt->valid = 0;
+	ctxt->valid = 0;
     if ((attr != NULL) && (ctxt->validate) && (ctxt->wellFormed) &&
         (ctxt->myDoc->intSubset != NULL))
-        ctxt->valid &= xmlValidateAttributeDecl(&ctxt->vctxt, ctxt->myDoc,
-                                                attr);
+	ctxt->valid &= xmlValidateAttributeDecl(&ctxt->vctxt, ctxt->myDoc,
+	                                        attr);
 #endif /* LIBXML_VALID_ENABLED */
     if (prefix != NULL)
-        xmlFree(prefix);
+	xmlFree(prefix);
     if (name != NULL)
-        xmlFree(name);
+	xmlFree(name);
 }
 
 /**
@@ -768,8 +768,8 @@ xmlSAX2ElementDecl(void *ctx, const xmlChar * name, int type,
                                  name, (xmlElementTypeVal) type, content);
     else {
         xmlFatalErrMsg(ctxt, XML_ERR_INTERNAL_ERROR,
-             "SAX.xmlSAX2ElementDecl(%s) called while not in subset\n",
-                       name, NULL);
+	     "SAX.xmlSAX2ElementDecl(%s) called while not in subset\n",
+	               name, NULL);
         return;
     }
 #ifdef LIBXML_VALID_ENABLED
@@ -793,7 +793,7 @@ xmlSAX2ElementDecl(void *ctx, const xmlChar * name, int type,
  */
 void
 xmlSAX2NotationDecl(void *ctx, const xmlChar *name,
-             const xmlChar *publicId, const xmlChar *systemId)
+	     const xmlChar *publicId, const xmlChar *systemId)
 {
     xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx;
     xmlNotationPtr nota = NULL;
@@ -806,32 +806,32 @@ xmlSAX2NotationDecl(void *ctx, const xmlChar *name,
 
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-            "SAX.xmlSAX2NotationDecl(%s, %s, %s)\n", name, publicId, systemId);
+	    "SAX.xmlSAX2NotationDecl(%s, %s, %s)\n", name, publicId, systemId);
 #endif
 
     if ((publicId == NULL) && (systemId == NULL)) {
-        xmlFatalErrMsg(ctxt, XML_ERR_NOTATION_PROCESSING,
-             "SAX.xmlSAX2NotationDecl(%s) externalID or PublicID missing\n",
-                       name, NULL);
-        return;
+	xmlFatalErrMsg(ctxt, XML_ERR_NOTATION_PROCESSING,
+	     "SAX.xmlSAX2NotationDecl(%s) externalID or PublicID missing\n",
+	               name, NULL);
+	return;
     } else if (ctxt->inSubset == 1)
-        nota = xmlAddNotationDecl(&ctxt->vctxt, ctxt->myDoc->intSubset, name,
+	nota = xmlAddNotationDecl(&ctxt->vctxt, ctxt->myDoc->intSubset, name,
                               publicId, systemId);
     else if (ctxt->inSubset == 2)
-        nota = xmlAddNotationDecl(&ctxt->vctxt, ctxt->myDoc->extSubset, name,
+	nota = xmlAddNotationDecl(&ctxt->vctxt, ctxt->myDoc->extSubset, name,
                               publicId, systemId);
     else {
-        xmlFatalErrMsg(ctxt, XML_ERR_NOTATION_PROCESSING,
-             "SAX.xmlSAX2NotationDecl(%s) called while not in subset\n",
-                       name, NULL);
-        return;
+	xmlFatalErrMsg(ctxt, XML_ERR_NOTATION_PROCESSING,
+	     "SAX.xmlSAX2NotationDecl(%s) called while not in subset\n",
+	               name, NULL);
+	return;
     }
 #ifdef LIBXML_VALID_ENABLED
     if (nota == NULL) ctxt->valid = 0;
     if ((ctxt->validate) && (ctxt->wellFormed) &&
         (ctxt->myDoc->intSubset != NULL))
-        ctxt->valid &= xmlValidateNotationDecl(&ctxt->vctxt, ctxt->myDoc,
-                                               nota);
+	ctxt->valid &= xmlValidateNotationDecl(&ctxt->vctxt, ctxt->myDoc,
+	                                       nota);
 #endif /* LIBXML_VALID_ENABLED */
 }
 
@@ -847,61 +847,61 @@ xmlSAX2NotationDecl(void *ctx, const xmlChar *name,
  */
 void
 xmlSAX2UnparsedEntityDecl(void *ctx, const xmlChar *name,
-                   const xmlChar *publicId, const xmlChar *systemId,
-                   const xmlChar *notationName)
+		   const xmlChar *publicId, const xmlChar *systemId,
+		   const xmlChar *notationName)
 {
     xmlEntityPtr ent;
     xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx;
     if (ctx == NULL) return;
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-            "SAX.xmlSAX2UnparsedEntityDecl(%s, %s, %s, %s)\n",
+	    "SAX.xmlSAX2UnparsedEntityDecl(%s, %s, %s, %s)\n",
             name, publicId, systemId, notationName);
 #endif
     if (ctxt->inSubset == 1) {
-        ent = xmlAddDocEntity(ctxt->myDoc, name,
-                        XML_EXTERNAL_GENERAL_UNPARSED_ENTITY,
-                        publicId, systemId, notationName);
-        if ((ent == NULL) && (ctxt->pedantic) &&
-            (ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
-            ctxt->sax->warning(ctxt->userData,
-             "Entity(%s) already defined in the internal subset\n", name);
-        if ((ent != NULL) && (ent->URI == NULL) && (systemId != NULL)) {
-            xmlChar *URI;
-            const char *base = NULL;
+	ent = xmlAddDocEntity(ctxt->myDoc, name,
+			XML_EXTERNAL_GENERAL_UNPARSED_ENTITY,
+			publicId, systemId, notationName);
+	if ((ent == NULL) && (ctxt->pedantic) &&
+	    (ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
+	    ctxt->sax->warning(ctxt->userData,
+	     "Entity(%s) already defined in the internal subset\n", name);
+	if ((ent != NULL) && (ent->URI == NULL) && (systemId != NULL)) {
+	    xmlChar *URI;
+	    const char *base = NULL;
 
-            if (ctxt->input != NULL)
-                base = ctxt->input->filename;
-            if (base == NULL)
-                base = ctxt->directory;
+	    if (ctxt->input != NULL)
+		base = ctxt->input->filename;
+	    if (base == NULL)
+		base = ctxt->directory;
 
-            URI = xmlBuildURI(systemId, (const xmlChar *) base);
-            ent->URI = URI;
-        }
+	    URI = xmlBuildURI(systemId, (const xmlChar *) base);
+	    ent->URI = URI;
+	}
     } else if (ctxt->inSubset == 2) {
-        ent = xmlAddDtdEntity(ctxt->myDoc, name,
-                        XML_EXTERNAL_GENERAL_UNPARSED_ENTITY,
-                        publicId, systemId, notationName);
-        if ((ent == NULL) && (ctxt->pedantic) &&
-            (ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
-            ctxt->sax->warning(ctxt->userData,
-             "Entity(%s) already defined in the external subset\n", name);
-        if ((ent != NULL) && (ent->URI == NULL) && (systemId != NULL)) {
-            xmlChar *URI;
-            const char *base = NULL;
+	ent = xmlAddDtdEntity(ctxt->myDoc, name,
+			XML_EXTERNAL_GENERAL_UNPARSED_ENTITY,
+			publicId, systemId, notationName);
+	if ((ent == NULL) && (ctxt->pedantic) &&
+	    (ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
+	    ctxt->sax->warning(ctxt->userData,
+	     "Entity(%s) already defined in the external subset\n", name);
+	if ((ent != NULL) && (ent->URI == NULL) && (systemId != NULL)) {
+	    xmlChar *URI;
+	    const char *base = NULL;
 
-            if (ctxt->input != NULL)
-                base = ctxt->input->filename;
-            if (base == NULL)
-                base = ctxt->directory;
+	    if (ctxt->input != NULL)
+		base = ctxt->input->filename;
+	    if (base == NULL)
+		base = ctxt->directory;
 
-            URI = xmlBuildURI(systemId, (const xmlChar *) base);
-            ent->URI = URI;
-        }
+	    URI = xmlBuildURI(systemId, (const xmlChar *) base);
+	    ent->URI = URI;
+	}
     } else {
         xmlFatalErrMsg(ctxt, XML_ERR_INTERNAL_ERROR,
-             "SAX.xmlSAX2UnparsedEntityDecl(%s) called while not in subset\n",
-                       name, NULL);
+	     "SAX.xmlSAX2UnparsedEntityDecl(%s) called while not in subset\n",
+	               name, NULL);
     }
 }
 
@@ -919,7 +919,7 @@ xmlSAX2SetDocumentLocator(void *ctx ATTRIBUTE_UNUSED, xmlSAXLocatorPtr loc ATTRI
     /* xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx; */
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-            "SAX.xmlSAX2SetDocumentLocator()\n");
+	    "SAX.xmlSAX2SetDocumentLocator()\n");
 #endif
 }
 
@@ -939,52 +939,52 @@ xmlSAX2StartDocument(void *ctx)
 
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-            "SAX.xmlSAX2StartDocument()\n");
+	    "SAX.xmlSAX2StartDocument()\n");
 #endif
     if (ctxt->html) {
 #ifdef LIBXML_HTML_ENABLED
-        if (ctxt->myDoc == NULL)
-            ctxt->myDoc = htmlNewDocNoDtD(NULL, NULL);
-        if (ctxt->myDoc == NULL) {
-            xmlSAX2ErrMemory(ctxt, "xmlSAX2StartDocument");
-            return;
-        }
-        ctxt->myDoc->properties = XML_DOC_HTML;
-        ctxt->myDoc->parseFlags = ctxt->options;
+	if (ctxt->myDoc == NULL)
+	    ctxt->myDoc = htmlNewDocNoDtD(NULL, NULL);
+	if (ctxt->myDoc == NULL) {
+	    xmlSAX2ErrMemory(ctxt, "xmlSAX2StartDocument");
+	    return;
+	}
+	ctxt->myDoc->properties = XML_DOC_HTML;
+	ctxt->myDoc->parseFlags = ctxt->options;
 #else
         xmlGenericError(xmlGenericErrorContext,
-                "libxml2 built without HTML support\n");
-        ctxt->errNo = XML_ERR_INTERNAL_ERROR;
-        ctxt->instate = XML_PARSER_EOF;
-        ctxt->disableSAX = 1;
-        return;
+		"libxml2 built without HTML support\n");
+	ctxt->errNo = XML_ERR_INTERNAL_ERROR;
+	ctxt->instate = XML_PARSER_EOF;
+	ctxt->disableSAX = 1;
+	return;
 #endif
     } else {
-        doc = ctxt->myDoc = xmlNewDoc(ctxt->version);
-        if (doc != NULL) {
-            doc->properties = 0;
-            if (ctxt->options & XML_PARSE_OLD10)
-                doc->properties |= XML_DOC_OLD10;
-            doc->parseFlags = ctxt->options;
-            if (ctxt->encoding != NULL)
-                doc->encoding = xmlStrdup(ctxt->encoding);
-            else
-                doc->encoding = NULL;
-            doc->standalone = ctxt->standalone;
-        } else {
-            xmlSAX2ErrMemory(ctxt, "xmlSAX2StartDocument");
-            return;
-        }
-        if ((ctxt->dictNames) && (doc != NULL)) {
-            doc->dict = ctxt->dict;
-            xmlDictReference(doc->dict);
-        }
+	doc = ctxt->myDoc = xmlNewDoc(ctxt->version);
+	if (doc != NULL) {
+	    doc->properties = 0;
+	    if (ctxt->options & XML_PARSE_OLD10)
+	        doc->properties |= XML_DOC_OLD10;
+	    doc->parseFlags = ctxt->options;
+	    if (ctxt->encoding != NULL)
+		doc->encoding = xmlStrdup(ctxt->encoding);
+	    else
+		doc->encoding = NULL;
+	    doc->standalone = ctxt->standalone;
+	} else {
+	    xmlSAX2ErrMemory(ctxt, "xmlSAX2StartDocument");
+	    return;
+	}
+	if ((ctxt->dictNames) && (doc != NULL)) {
+	    doc->dict = ctxt->dict;
+	    xmlDictReference(doc->dict);
+	}
     }
     if ((ctxt->myDoc != NULL) && (ctxt->myDoc->URL == NULL) &&
-        (ctxt->input != NULL) && (ctxt->input->filename != NULL)) {
-        ctxt->myDoc->URL = xmlPathToURI((const xmlChar *)ctxt->input->filename);
-        if (ctxt->myDoc->URL == NULL)
-            xmlSAX2ErrMemory(ctxt, "xmlSAX2StartDocument");
+	(ctxt->input != NULL) && (ctxt->input->filename != NULL)) {
+	ctxt->myDoc->URL = xmlPathToURI((const xmlChar *)ctxt->input->filename);
+	if (ctxt->myDoc->URL == NULL)
+	    xmlSAX2ErrMemory(ctxt, "xmlSAX2StartDocument");
     }
 }
 
@@ -1000,32 +1000,32 @@ xmlSAX2EndDocument(void *ctx)
     xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx;
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-            "SAX.xmlSAX2EndDocument()\n");
+	    "SAX.xmlSAX2EndDocument()\n");
 #endif
     if (ctx == NULL) return;
 #ifdef LIBXML_VALID_ENABLED
     if (ctxt->validate && ctxt->wellFormed &&
         ctxt->myDoc && ctxt->myDoc->intSubset)
-        ctxt->valid &= xmlValidateDocumentFinal(&ctxt->vctxt, ctxt->myDoc);
+	ctxt->valid &= xmlValidateDocumentFinal(&ctxt->vctxt, ctxt->myDoc);
 #endif /* LIBXML_VALID_ENABLED */
 
     /*
      * Grab the encoding if it was added on-the-fly
      */
     if ((ctxt->encoding != NULL) && (ctxt->myDoc != NULL) &&
-        (ctxt->myDoc->encoding == NULL)) {
-        ctxt->myDoc->encoding = ctxt->encoding;
-        ctxt->encoding = NULL;
+	(ctxt->myDoc->encoding == NULL)) {
+	ctxt->myDoc->encoding = ctxt->encoding;
+	ctxt->encoding = NULL;
     }
     if ((ctxt->inputTab != NULL) &&
         (ctxt->inputNr > 0) && (ctxt->inputTab[0] != NULL) &&
         (ctxt->inputTab[0]->encoding != NULL) && (ctxt->myDoc != NULL) &&
-        (ctxt->myDoc->encoding == NULL)) {
-        ctxt->myDoc->encoding = xmlStrdup(ctxt->inputTab[0]->encoding);
+	(ctxt->myDoc->encoding == NULL)) {
+	ctxt->myDoc->encoding = xmlStrdup(ctxt->inputTab[0]->encoding);
     }
     if ((ctxt->charset != XML_CHAR_ENCODING_NONE) && (ctxt->myDoc != NULL) &&
-        (ctxt->myDoc->charset == XML_CHAR_ENCODING_NONE)) {
-        ctxt->myDoc->charset = ctxt->charset;
+	(ctxt->myDoc->charset == XML_CHAR_ENCODING_NONE)) {
+	ctxt->myDoc->charset = ctxt->charset;
     }
 }
 
@@ -1046,13 +1046,13 @@ xmlNsErrMsg(xmlParserCtxtPtr ctxt, xmlParserErrors error,
 {
     if ((ctxt != NULL) && (ctxt->disableSAX != 0) &&
         (ctxt->instate == XML_PARSER_EOF))
-        return;
+	return;
     if (ctxt != NULL)
-        ctxt->errNo = error;
+	ctxt->errNo = error;
     __xmlRaiseError(NULL, NULL, NULL, ctxt, NULL, XML_FROM_NAMESPACE, error,
                     XML_ERR_ERROR, NULL, 0,
-                    (const char *) str1, (const char *) str2,
-                    NULL, 0, 0, msg, str1, str2);
+		    (const char *) str1, (const char *) str2,
+		    NULL, 0, 0, msg, str1, str2);
 }
 
 /**
@@ -1079,36 +1079,36 @@ xmlSAX2AttributeInternal(void *ctx, const xmlChar *fullname,
     xmlNsPtr namespace;
 
     if (ctxt->html) {
-        name = xmlStrdup(fullname);
-        ns = NULL;
-        namespace = NULL;
+	name = xmlStrdup(fullname);
+	ns = NULL;
+	namespace = NULL;
     } else {
-        /*
-         * Split the full name into a namespace prefix and the tag name
-         */
-        name = xmlSplitQName(ctxt, fullname, &ns);
-        if ((name != NULL) && (name[0] == 0)) {
-            if (xmlStrEqual(ns, BAD_CAST "xmlns")) {
-                xmlNsErrMsg(ctxt, XML_ERR_NS_DECL_ERROR,
-                            "invalid namespace declaration '%s'\n",
-                            fullname, NULL);
-            } else {
-                xmlNsWarnMsg(ctxt, XML_WAR_NS_COLUMN,
-                             "Avoid attribute ending with ':' like '%s'\n",
-                             fullname, NULL);
-            }
-            if (ns != NULL)
-                xmlFree(ns);
-            ns = NULL;
-            xmlFree(name);
-            name = xmlStrdup(fullname);
-        }
+	/*
+	 * Split the full name into a namespace prefix and the tag name
+	 */
+	name = xmlSplitQName(ctxt, fullname, &ns);
+	if ((name != NULL) && (name[0] == 0)) {
+	    if (xmlStrEqual(ns, BAD_CAST "xmlns")) {
+		xmlNsErrMsg(ctxt, XML_ERR_NS_DECL_ERROR,
+			    "invalid namespace declaration '%s'\n",
+			    fullname, NULL);
+	    } else {
+		xmlNsWarnMsg(ctxt, XML_WAR_NS_COLUMN,
+			     "Avoid attribute ending with ':' like '%s'\n",
+			     fullname, NULL);
+	    }
+	    if (ns != NULL)
+		xmlFree(ns);
+	    ns = NULL;
+	    xmlFree(name);
+	    name = xmlStrdup(fullname);
+	}
     }
     if (name == NULL) {
         xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
-        if (ns != NULL)
-            xmlFree(ns);
-        return;
+	if (ns != NULL)
+	    xmlFree(ns);
+	return;
     }
 
 #ifdef LIBXML_HTML_ENABLED
@@ -1145,145 +1145,145 @@ xmlSAX2AttributeInternal(void *ctx, const xmlChar *fullname,
     if ((!ctxt->html) && (ns == NULL) &&
         (name[0] == 'x') && (name[1] == 'm') && (name[2] == 'l') &&
         (name[3] == 'n') && (name[4] == 's') && (name[5] == 0)) {
-        xmlNsPtr nsret;
-        xmlChar *val;
+	xmlNsPtr nsret;
+	xmlChar *val;
 
         /* Avoid unused variable warning if features are disabled. */
         (void) nsret;
 
         if (!ctxt->replaceEntities) {
-            ctxt->depth++;
-            val = xmlStringDecodeEntities(ctxt, value, XML_SUBSTITUTE_REF,
-                                          0,0,0);
-            ctxt->depth--;
-            if (val == NULL) {
-                xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
-                if (name != NULL)
-                    xmlFree(name);
+	    ctxt->depth++;
+	    val = xmlStringDecodeEntities(ctxt, value, XML_SUBSTITUTE_REF,
+		                          0,0,0);
+	    ctxt->depth--;
+	    if (val == NULL) {
+	        xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
+		if (name != NULL)
+		    xmlFree(name);
                 if (nval != NULL)
                     xmlFree(nval);
-                return;
-            }
-        } else {
-            val = (xmlChar *) value;
-        }
+		return;
+	    }
+	} else {
+	    val = (xmlChar *) value;
+	}
 
-        if (val[0] != 0) {
-            xmlURIPtr uri;
+	if (val[0] != 0) {
+	    xmlURIPtr uri;
 
-            uri = xmlParseURI((const char *)val);
-            if (uri == NULL) {
-                if ((ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
-                    ctxt->sax->warning(ctxt->userData,
-                         "xmlns: %s not a valid URI\n", val);
-            } else {
-                if (uri->scheme == NULL) {
-                    if ((ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
-                        ctxt->sax->warning(ctxt->userData,
-                             "xmlns: URI %s is not absolute\n", val);
-                }
-                xmlFreeURI(uri);
-            }
-        }
+	    uri = xmlParseURI((const char *)val);
+	    if (uri == NULL) {
+		if ((ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
+		    ctxt->sax->warning(ctxt->userData,
+			 "xmlns: %s not a valid URI\n", val);
+	    } else {
+		if (uri->scheme == NULL) {
+		    if ((ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
+			ctxt->sax->warning(ctxt->userData,
+			     "xmlns: URI %s is not absolute\n", val);
+		}
+		xmlFreeURI(uri);
+	    }
+	}
 
-        /* a default namespace definition */
-        nsret = xmlNewNs(ctxt->node, val, NULL);
+	/* a default namespace definition */
+	nsret = xmlNewNs(ctxt->node, val, NULL);
 
 #ifdef LIBXML_VALID_ENABLED
-        /*
-         * Validate also for namespace decls, they are attributes from
-         * an XML-1.0 perspective
-         */
+	/*
+	 * Validate also for namespace decls, they are attributes from
+	 * an XML-1.0 perspective
+	 */
         if (nsret != NULL && ctxt->validate && ctxt->wellFormed &&
-            ctxt->myDoc && ctxt->myDoc->intSubset)
-            ctxt->valid &= xmlValidateOneNamespace(&ctxt->vctxt, ctxt->myDoc,
-                                           ctxt->node, prefix, nsret, val);
+	    ctxt->myDoc && ctxt->myDoc->intSubset)
+	    ctxt->valid &= xmlValidateOneNamespace(&ctxt->vctxt, ctxt->myDoc,
+					   ctxt->node, prefix, nsret, val);
 #endif /* LIBXML_VALID_ENABLED */
-        if (name != NULL)
-            xmlFree(name);
-        if (nval != NULL)
-            xmlFree(nval);
-        if (val != value)
-            xmlFree(val);
-        return;
+	if (name != NULL)
+	    xmlFree(name);
+	if (nval != NULL)
+	    xmlFree(nval);
+	if (val != value)
+	    xmlFree(val);
+	return;
     }
     if ((!ctxt->html) &&
-        (ns != NULL) && (ns[0] == 'x') && (ns[1] == 'm') && (ns[2] == 'l') &&
+	(ns != NULL) && (ns[0] == 'x') && (ns[1] == 'm') && (ns[2] == 'l') &&
         (ns[3] == 'n') && (ns[4] == 's') && (ns[5] == 0)) {
-        xmlNsPtr nsret;
-        xmlChar *val;
+	xmlNsPtr nsret;
+	xmlChar *val;
 
         /* Avoid unused variable warning if features are disabled. */
         (void) nsret;
 
         if (!ctxt->replaceEntities) {
-            ctxt->depth++;
-            val = xmlStringDecodeEntities(ctxt, value, XML_SUBSTITUTE_REF,
-                                          0,0,0);
-            ctxt->depth--;
-            if (val == NULL) {
-                xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
-                xmlFree(ns);
-                if (name != NULL)
-                    xmlFree(name);
+	    ctxt->depth++;
+	    val = xmlStringDecodeEntities(ctxt, value, XML_SUBSTITUTE_REF,
+		                          0,0,0);
+	    ctxt->depth--;
+	    if (val == NULL) {
+	        xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
+	        xmlFree(ns);
+		if (name != NULL)
+		    xmlFree(name);
                 if (nval != NULL)
                     xmlFree(nval);
-                return;
-            }
-        } else {
-            val = (xmlChar *) value;
-        }
+		return;
+	    }
+	} else {
+	    val = (xmlChar *) value;
+	}
 
-        if (val[0] == 0) {
-            xmlNsErrMsg(ctxt, XML_NS_ERR_EMPTY,
-                        "Empty namespace name for prefix %s\n", name, NULL);
-        }
-        if ((ctxt->pedantic != 0) && (val[0] != 0)) {
-            xmlURIPtr uri;
+	if (val[0] == 0) {
+	    xmlNsErrMsg(ctxt, XML_NS_ERR_EMPTY,
+		        "Empty namespace name for prefix %s\n", name, NULL);
+	}
+	if ((ctxt->pedantic != 0) && (val[0] != 0)) {
+	    xmlURIPtr uri;
 
-            uri = xmlParseURI((const char *)val);
-            if (uri == NULL) {
-                xmlNsWarnMsg(ctxt, XML_WAR_NS_URI,
-                         "xmlns:%s: %s not a valid URI\n", name, value);
-            } else {
-                if (uri->scheme == NULL) {
-                    xmlNsWarnMsg(ctxt, XML_WAR_NS_URI_RELATIVE,
-                           "xmlns:%s: URI %s is not absolute\n", name, value);
-                }
-                xmlFreeURI(uri);
-            }
-        }
+	    uri = xmlParseURI((const char *)val);
+	    if (uri == NULL) {
+	        xmlNsWarnMsg(ctxt, XML_WAR_NS_URI,
+			 "xmlns:%s: %s not a valid URI\n", name, value);
+	    } else {
+		if (uri->scheme == NULL) {
+		    xmlNsWarnMsg(ctxt, XML_WAR_NS_URI_RELATIVE,
+			   "xmlns:%s: URI %s is not absolute\n", name, value);
+		}
+		xmlFreeURI(uri);
+	    }
+	}
 
-        /* a standard namespace definition */
-        nsret = xmlNewNs(ctxt->node, val, name);
-        xmlFree(ns);
+	/* a standard namespace definition */
+	nsret = xmlNewNs(ctxt->node, val, name);
+	xmlFree(ns);
 #ifdef LIBXML_VALID_ENABLED
-        /*
-         * Validate also for namespace decls, they are attributes from
-         * an XML-1.0 perspective
-         */
+	/*
+	 * Validate also for namespace decls, they are attributes from
+	 * an XML-1.0 perspective
+	 */
         if (nsret != NULL && ctxt->validate && ctxt->wellFormed &&
-            ctxt->myDoc && ctxt->myDoc->intSubset)
-            ctxt->valid &= xmlValidateOneNamespace(&ctxt->vctxt, ctxt->myDoc,
-                                           ctxt->node, prefix, nsret, value);
+	    ctxt->myDoc && ctxt->myDoc->intSubset)
+	    ctxt->valid &= xmlValidateOneNamespace(&ctxt->vctxt, ctxt->myDoc,
+					   ctxt->node, prefix, nsret, value);
 #endif /* LIBXML_VALID_ENABLED */
-        if (name != NULL)
-            xmlFree(name);
-        if (nval != NULL)
-            xmlFree(nval);
-        if (val != value)
-            xmlFree(val);
-        return;
+	if (name != NULL)
+	    xmlFree(name);
+	if (nval != NULL)
+	    xmlFree(nval);
+	if (val != value)
+	    xmlFree(val);
+	return;
     }
 
     if (ns != NULL) {
-        namespace = xmlSearchNs(ctxt->myDoc, ctxt->node, ns);
+	namespace = xmlSearchNs(ctxt->myDoc, ctxt->node, ns);
 
-        if (namespace == NULL) {
-            xmlNsErrMsg(ctxt, XML_NS_ERR_UNDEFINED_NAMESPACE,
-                    "Namespace prefix %s of attribute %s is not defined\n",
-                             ns, name);
-        } else {
+	if (namespace == NULL) {
+	    xmlNsErrMsg(ctxt, XML_NS_ERR_UNDEFINED_NAMESPACE,
+		    "Namespace prefix %s of attribute %s is not defined\n",
+		             ns, name);
+	} else {
             xmlAttrPtr prop;
 
             prop = ctxt->node->properties;
@@ -1306,7 +1306,7 @@ xmlSAX2AttributeInternal(void *ctx, const xmlChar *fullname,
             }
         }
     } else {
-        namespace = NULL;
+	namespace = NULL;
     }
 
     /* !!!!!! <a toto:arg="" xmlns:toto="http://toto.com"> */
@@ -1314,103 +1314,103 @@ xmlSAX2AttributeInternal(void *ctx, const xmlChar *fullname,
 
     if (ret != NULL) {
         if ((ctxt->replaceEntities == 0) && (!ctxt->html)) {
-            xmlNodePtr tmp;
+	    xmlNodePtr tmp;
 
-            ret->children = xmlStringGetNodeList(ctxt->myDoc, value);
-            tmp = ret->children;
-            while (tmp != NULL) {
-                tmp->parent = (xmlNodePtr) ret;
-                if (tmp->next == NULL)
-                    ret->last = tmp;
-                tmp = tmp->next;
-            }
-        } else if (value != NULL) {
-            ret->children = xmlNewDocText(ctxt->myDoc, value);
-            ret->last = ret->children;
-            if (ret->children != NULL)
-                ret->children->parent = (xmlNodePtr) ret;
-        }
+	    ret->children = xmlStringGetNodeList(ctxt->myDoc, value);
+	    tmp = ret->children;
+	    while (tmp != NULL) {
+		tmp->parent = (xmlNodePtr) ret;
+		if (tmp->next == NULL)
+		    ret->last = tmp;
+		tmp = tmp->next;
+	    }
+	} else if (value != NULL) {
+	    ret->children = xmlNewDocText(ctxt->myDoc, value);
+	    ret->last = ret->children;
+	    if (ret->children != NULL)
+		ret->children->parent = (xmlNodePtr) ret;
+	}
     }
 
 #ifdef LIBXML_VALID_ENABLED
     if ((!ctxt->html) && ctxt->validate && ctxt->wellFormed &&
         ctxt->myDoc && ctxt->myDoc->intSubset) {
 
-        /*
-         * If we don't substitute entities, the validation should be
-         * done on a value with replaced entities anyway.
-         */
+	/*
+	 * If we don't substitute entities, the validation should be
+	 * done on a value with replaced entities anyway.
+	 */
         if (!ctxt->replaceEntities) {
-            xmlChar *val;
+	    xmlChar *val;
 
-            ctxt->depth++;
-            val = xmlStringDecodeEntities(ctxt, value, XML_SUBSTITUTE_REF,
-                                          0,0,0);
-            ctxt->depth--;
+	    ctxt->depth++;
+	    val = xmlStringDecodeEntities(ctxt, value, XML_SUBSTITUTE_REF,
+		                          0,0,0);
+	    ctxt->depth--;
 
-            if (val == NULL)
-                ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
-                                ctxt->myDoc, ctxt->node, ret, value);
-            else {
-                xmlChar *nvalnorm;
+	    if (val == NULL)
+		ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
+				ctxt->myDoc, ctxt->node, ret, value);
+	    else {
+		xmlChar *nvalnorm;
 
-                /*
-                 * Do the last stage of the attribute normalization
-                 * It need to be done twice ... it's an extra burden related
-                 * to the ability to keep xmlSAX2References in attributes
-                 */
-                nvalnorm = xmlValidNormalizeAttributeValue(ctxt->myDoc,
-                                            ctxt->node, fullname, val);
-                if (nvalnorm != NULL) {
-                    xmlFree(val);
-                    val = nvalnorm;
-                }
+		/*
+		 * Do the last stage of the attribute normalization
+		 * It need to be done twice ... it's an extra burden related
+		 * to the ability to keep xmlSAX2References in attributes
+		 */
+		nvalnorm = xmlValidNormalizeAttributeValue(ctxt->myDoc,
+					    ctxt->node, fullname, val);
+		if (nvalnorm != NULL) {
+		    xmlFree(val);
+		    val = nvalnorm;
+		}
 
-                ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
-                                ctxt->myDoc, ctxt->node, ret, val);
+		ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
+			        ctxt->myDoc, ctxt->node, ret, val);
                 xmlFree(val);
-            }
-        } else {
-            ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt, ctxt->myDoc,
-                                               ctxt->node, ret, value);
-        }
+	    }
+	} else {
+	    ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt, ctxt->myDoc,
+					       ctxt->node, ret, value);
+	}
     } else
 #endif /* LIBXML_VALID_ENABLED */
            if (((ctxt->loadsubset & XML_SKIP_IDS) == 0) &&
-               (((ctxt->replaceEntities == 0) && (ctxt->external != 2)) ||
-                ((ctxt->replaceEntities != 0) && (ctxt->inSubset == 0))) &&
+	       (((ctxt->replaceEntities == 0) && (ctxt->external != 2)) ||
+	        ((ctxt->replaceEntities != 0) && (ctxt->inSubset == 0))) &&
                /* Don't create IDs containing entity references */
                (ret->children != NULL) &&
                (ret->children->type == XML_TEXT_NODE) &&
                (ret->children->next == NULL)) {
         xmlChar *content = ret->children->content;
         /*
-         * when validating, the ID registration is done at the attribute
-         * validation level. Otherwise we have to do specific handling here.
-         */
-        if (xmlStrEqual(fullname, BAD_CAST "xml:id")) {
-            /*
-             * Add the xml:id value
-             *
-             * Open issue: normalization of the value.
-             */
-            if (xmlValidateNCName(content, 1) != 0) {
-                xmlErrValid(ctxt, XML_DTD_XMLID_VALUE,
-                      "xml:id : attribute value %s is not an NCName\n",
-                            (const char *) content, NULL);
-            }
-            xmlAddID(&ctxt->vctxt, ctxt->myDoc, content, ret);
-        } else if (xmlIsID(ctxt->myDoc, ctxt->node, ret))
-            xmlAddID(&ctxt->vctxt, ctxt->myDoc, content, ret);
-        else if (xmlIsRef(ctxt->myDoc, ctxt->node, ret))
-            xmlAddRef(&ctxt->vctxt, ctxt->myDoc, content, ret);
+	 * when validating, the ID registration is done at the attribute
+	 * validation level. Otherwise we have to do specific handling here.
+	 */
+	if (xmlStrEqual(fullname, BAD_CAST "xml:id")) {
+	    /*
+	     * Add the xml:id value
+	     *
+	     * Open issue: normalization of the value.
+	     */
+	    if (xmlValidateNCName(content, 1) != 0) {
+	        xmlErrValid(ctxt, XML_DTD_XMLID_VALUE,
+		      "xml:id : attribute value %s is not an NCName\n",
+			    (const char *) content, NULL);
+	    }
+	    xmlAddID(&ctxt->vctxt, ctxt->myDoc, content, ret);
+	} else if (xmlIsID(ctxt->myDoc, ctxt->node, ret))
+	    xmlAddID(&ctxt->vctxt, ctxt->myDoc, content, ret);
+	else if (xmlIsRef(ctxt->myDoc, ctxt->node, ret))
+	    xmlAddRef(&ctxt->vctxt, ctxt->myDoc, content, ret);
     }
 
 error:
     if (nval != NULL)
-        xmlFree(nval);
+	xmlFree(nval);
     if (ns != NULL)
-        xmlFree(ns);
+	xmlFree(ns);
 }
 
 /*
@@ -1420,7 +1420,7 @@ error:
  */
 static void
 xmlCheckDefaultedAttributes(xmlParserCtxtPtr ctxt, const xmlChar *name,
-        const xmlChar *prefix, const xmlChar **atts) {
+	const xmlChar *prefix, const xmlChar **atts) {
     xmlElementPtr elemDecl;
     const xmlChar *att;
     int internal = 1;
@@ -1428,141 +1428,141 @@ xmlCheckDefaultedAttributes(xmlParserCtxtPtr ctxt, const xmlChar *name,
 
     elemDecl = xmlGetDtdQElementDesc(ctxt->myDoc->intSubset, name, prefix);
     if (elemDecl == NULL) {
-        elemDecl = xmlGetDtdQElementDesc(ctxt->myDoc->extSubset, name, prefix);
-        internal = 0;
+	elemDecl = xmlGetDtdQElementDesc(ctxt->myDoc->extSubset, name, prefix);
+	internal = 0;
     }
 
 process_external_subset:
 
     if (elemDecl != NULL) {
-        xmlAttributePtr attr = elemDecl->attributes;
-        /*
-         * Check against defaulted attributes from the external subset
-         * if the document is stamped as standalone
-         */
-        if ((ctxt->myDoc->standalone == 1) &&
-            (ctxt->myDoc->extSubset != NULL) &&
-            (ctxt->validate)) {
-            while (attr != NULL) {
-                if ((attr->defaultValue != NULL) &&
-                    (xmlGetDtdQAttrDesc(ctxt->myDoc->extSubset,
-                                        attr->elem, attr->name,
-                                        attr->prefix) == attr) &&
-                    (xmlGetDtdQAttrDesc(ctxt->myDoc->intSubset,
-                                        attr->elem, attr->name,
-                                        attr->prefix) == NULL)) {
-                    xmlChar *fulln;
+	xmlAttributePtr attr = elemDecl->attributes;
+	/*
+	 * Check against defaulted attributes from the external subset
+	 * if the document is stamped as standalone
+	 */
+	if ((ctxt->myDoc->standalone == 1) &&
+	    (ctxt->myDoc->extSubset != NULL) &&
+	    (ctxt->validate)) {
+	    while (attr != NULL) {
+		if ((attr->defaultValue != NULL) &&
+		    (xmlGetDtdQAttrDesc(ctxt->myDoc->extSubset,
+					attr->elem, attr->name,
+					attr->prefix) == attr) &&
+		    (xmlGetDtdQAttrDesc(ctxt->myDoc->intSubset,
+					attr->elem, attr->name,
+					attr->prefix) == NULL)) {
+		    xmlChar *fulln;
 
-                    if (attr->prefix != NULL) {
-                        fulln = xmlStrdup(attr->prefix);
-                        fulln = xmlStrcat(fulln, BAD_CAST ":");
-                        fulln = xmlStrcat(fulln, attr->name);
-                    } else {
-                        fulln = xmlStrdup(attr->name);
-                    }
+		    if (attr->prefix != NULL) {
+			fulln = xmlStrdup(attr->prefix);
+			fulln = xmlStrcat(fulln, BAD_CAST ":");
+			fulln = xmlStrcat(fulln, attr->name);
+		    } else {
+			fulln = xmlStrdup(attr->name);
+		    }
                     if (fulln == NULL) {
                         xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
                         break;
                     }
 
-                    /*
-                     * Check that the attribute is not declared in the
-                     * serialization
-                     */
-                    att = NULL;
-                    if (atts != NULL) {
-                        i = 0;
-                        att = atts[i];
-                        while (att != NULL) {
-                            if (xmlStrEqual(att, fulln))
-                                break;
-                            i += 2;
-                            att = atts[i];
-                        }
-                    }
-                    if (att == NULL) {
-                        xmlErrValid(ctxt, XML_DTD_STANDALONE_DEFAULTED,
+		    /*
+		     * Check that the attribute is not declared in the
+		     * serialization
+		     */
+		    att = NULL;
+		    if (atts != NULL) {
+			i = 0;
+			att = atts[i];
+			while (att != NULL) {
+			    if (xmlStrEqual(att, fulln))
+				break;
+			    i += 2;
+			    att = atts[i];
+			}
+		    }
+		    if (att == NULL) {
+		        xmlErrValid(ctxt, XML_DTD_STANDALONE_DEFAULTED,
       "standalone: attribute %s on %s defaulted from external subset\n",
-                                    (const char *)fulln,
-                                    (const char *)attr->elem);
-                    }
+				    (const char *)fulln,
+				    (const char *)attr->elem);
+		    }
                     xmlFree(fulln);
-                }
-                attr = attr->nexth;
-            }
-        }
+		}
+		attr = attr->nexth;
+	    }
+	}
 
-        /*
-         * Actually insert defaulted values when needed
-         */
-        attr = elemDecl->attributes;
-        while (attr != NULL) {
-            /*
-             * Make sure that attributes redefinition occurring in the
-             * internal subset are not overridden by definitions in the
-             * external subset.
-             */
-            if (attr->defaultValue != NULL) {
-                /*
-                 * the element should be instantiated in the tree if:
-                 *  - this is a namespace prefix
-                 *  - the user required for completion in the tree
-                 *    like XSLT
-                 *  - there isn't already an attribute definition
-                 *    in the internal subset overriding it.
-                 */
-                if (((attr->prefix != NULL) &&
-                     (xmlStrEqual(attr->prefix, BAD_CAST "xmlns"))) ||
-                    ((attr->prefix == NULL) &&
-                     (xmlStrEqual(attr->name, BAD_CAST "xmlns"))) ||
-                    (ctxt->loadsubset & XML_COMPLETE_ATTRS)) {
-                    xmlAttributePtr tst;
+	/*
+	 * Actually insert defaulted values when needed
+	 */
+	attr = elemDecl->attributes;
+	while (attr != NULL) {
+	    /*
+	     * Make sure that attributes redefinition occurring in the
+	     * internal subset are not overridden by definitions in the
+	     * external subset.
+	     */
+	    if (attr->defaultValue != NULL) {
+		/*
+		 * the element should be instantiated in the tree if:
+		 *  - this is a namespace prefix
+		 *  - the user required for completion in the tree
+		 *    like XSLT
+		 *  - there isn't already an attribute definition
+		 *    in the internal subset overriding it.
+		 */
+		if (((attr->prefix != NULL) &&
+		     (xmlStrEqual(attr->prefix, BAD_CAST "xmlns"))) ||
+		    ((attr->prefix == NULL) &&
+		     (xmlStrEqual(attr->name, BAD_CAST "xmlns"))) ||
+		    (ctxt->loadsubset & XML_COMPLETE_ATTRS)) {
+		    xmlAttributePtr tst;
 
-                    tst = xmlGetDtdQAttrDesc(ctxt->myDoc->intSubset,
-                                             attr->elem, attr->name,
-                                             attr->prefix);
-                    if ((tst == attr) || (tst == NULL)) {
-                        xmlChar fn[50];
-                        xmlChar *fulln;
+		    tst = xmlGetDtdQAttrDesc(ctxt->myDoc->intSubset,
+					     attr->elem, attr->name,
+					     attr->prefix);
+		    if ((tst == attr) || (tst == NULL)) {
+		        xmlChar fn[50];
+			xmlChar *fulln;
 
                         fulln = xmlBuildQName(attr->name, attr->prefix, fn, 50);
-                        if (fulln == NULL) {
-                            xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
-                            return;
-                        }
+			if (fulln == NULL) {
+			    xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
+			    return;
+			}
 
-                        /*
-                         * Check that the attribute is not declared in the
-                         * serialization
-                         */
-                        att = NULL;
-                        if (atts != NULL) {
-                            i = 0;
-                            att = atts[i];
-                            while (att != NULL) {
-                                if (xmlStrEqual(att, fulln))
-                                    break;
-                                i += 2;
-                                att = atts[i];
-                            }
-                        }
-                        if (att == NULL) {
-                            xmlSAX2AttributeInternal(ctxt, fulln,
-                                                 attr->defaultValue, prefix);
-                        }
-                        if ((fulln != fn) && (fulln != attr->name))
-                            xmlFree(fulln);
-                    }
-                }
-            }
-            attr = attr->nexth;
-        }
-        if (internal == 1) {
-            elemDecl = xmlGetDtdQElementDesc(ctxt->myDoc->extSubset,
-                                             name, prefix);
-            internal = 0;
-            goto process_external_subset;
-        }
+			/*
+			 * Check that the attribute is not declared in the
+			 * serialization
+			 */
+			att = NULL;
+			if (atts != NULL) {
+			    i = 0;
+			    att = atts[i];
+			    while (att != NULL) {
+				if (xmlStrEqual(att, fulln))
+				    break;
+				i += 2;
+				att = atts[i];
+			    }
+			}
+			if (att == NULL) {
+			    xmlSAX2AttributeInternal(ctxt, fulln,
+						 attr->defaultValue, prefix);
+			}
+			if ((fulln != fn) && (fulln != attr->name))
+			    xmlFree(fulln);
+		    }
+		}
+	    }
+	    attr = attr->nexth;
+	}
+	if (internal == 1) {
+	    elemDecl = xmlGetDtdQElementDesc(ctxt->myDoc->extSubset,
+		                             name, prefix);
+	    internal = 0;
+	    goto process_external_subset;
+	}
     }
 }
 
@@ -1591,7 +1591,7 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
     parent = ctxt->node;
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-            "SAX.xmlSAX2StartElement(%s)\n", fullname);
+	    "SAX.xmlSAX2StartElement(%s)\n", fullname);
 #endif
 
     /*
@@ -1599,21 +1599,24 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
      */
     if (ctxt->validate && (ctxt->myDoc->extSubset == NULL) &&
         ((ctxt->myDoc->intSubset == NULL) ||
-         ((ctxt->myDoc->intSubset->notations == NULL) &&
-          (ctxt->myDoc->intSubset->elements == NULL) &&
-          (ctxt->myDoc->intSubset->attributes == NULL) &&
-          (ctxt->myDoc->intSubset->entities == NULL)))) {
-        xmlErrValid(ctxt, XML_ERR_NO_DTD,
-          "Validation failed: no DTD found !", NULL, NULL);
-        ctxt->validate = 0;
+	 ((ctxt->myDoc->intSubset->notations == NULL) &&
+	  (ctxt->myDoc->intSubset->elements == NULL) &&
+	  (ctxt->myDoc->intSubset->attributes == NULL) &&
+	  (ctxt->myDoc->intSubset->entities == NULL)))) {
+	xmlErrValid(ctxt, XML_ERR_NO_DTD,
+	  "Validation failed: no DTD found !", NULL, NULL);
+	ctxt->validate = 0;
     }
 
-
-    /*
-     * Split the full name into a namespace prefix and the tag name
-     */
-    name = xmlSplitQName(ctxt, fullname, &prefix);
-
+    if (ctxt->html) {
+        prefix = NULL;
+        name = xmlStrdup(fullname);
+    } else {
+        /*
+         * Split the full name into a namespace prefix and the tag name
+         */
+        name = xmlSplitQName(ctxt, fullname, &prefix);
+    }
 
     /*
      * Note : the namespace resolution is deferred until the end of the
@@ -1623,13 +1626,13 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
     ret = xmlNewDocNodeEatName(ctxt->myDoc, NULL, name, NULL);
     if (ret == NULL) {
         if (prefix != NULL)
-            xmlFree(prefix);
-        xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
+	    xmlFree(prefix);
+	xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
         return;
     }
     if (ctxt->myDoc->children == NULL) {
 #ifdef DEBUG_SAX_TREE
-        xmlGenericError(xmlGenericErrorContext, "Setting %s as root\n", name);
+	xmlGenericError(xmlGenericErrorContext, "Setting %s as root\n", name);
 #endif
         xmlAddChild((xmlNodePtr) ctxt->myDoc, (xmlNodePtr) ret);
     } else if (parent == NULL) {
@@ -1637,12 +1640,12 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
     }
     ctxt->nodemem = -1;
     if (ctxt->linenumbers) {
-        if (ctxt->input != NULL) {
-            if (ctxt->input->line < USHRT_MAX)
-                ret->line = (unsigned short) ctxt->input->line;
-            else
-                ret->line = USHRT_MAX;
-        }
+	if (ctxt->input != NULL) {
+	    if (ctxt->input->line < USHRT_MAX)
+		ret->line = (unsigned short) ctxt->input->line;
+	    else
+	        ret->line = USHRT_MAX;
+	}
     }
 
     /*
@@ -1665,18 +1668,18 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
     if (parent != NULL) {
         if (parent->type == XML_ELEMENT_NODE) {
 #ifdef DEBUG_SAX_TREE
-            xmlGenericError(xmlGenericErrorContext,
-                    "adding child %s to %s\n", name, parent->name);
+	    xmlGenericError(xmlGenericErrorContext,
+		    "adding child %s to %s\n", name, parent->name);
 #endif
-            xmlAddChild(parent, ret);
-        } else {
+	    xmlAddChild(parent, ret);
+	} else {
 #ifdef DEBUG_SAX_TREE
-            xmlGenericError(xmlGenericErrorContext,
-                    "adding sibling %s to ", name);
-            xmlDebugDumpOneNode(stderr, parent, 0);
+	    xmlGenericError(xmlGenericErrorContext,
+		    "adding sibling %s to ", name);
+	    xmlDebugDumpOneNode(stderr, parent, 0);
 #endif
-            xmlAddSibling(parent, ret);
-        }
+	    xmlAddSibling(parent, ret);
+	}
     }
 
     if (!ctxt->html) {
@@ -1696,14 +1699,14 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
             i = 0;
             att = atts[i++];
             value = atts[i++];
-            while ((att != NULL) && (value != NULL)) {
-                if ((att[0] == 'x') && (att[1] == 'm') && (att[2] == 'l') &&
-                    (att[3] == 'n') && (att[4] == 's'))
-                    xmlSAX2AttributeInternal(ctxt, att, value, prefix);
+	    while ((att != NULL) && (value != NULL)) {
+		if ((att[0] == 'x') && (att[1] == 'm') && (att[2] == 'l') &&
+		    (att[3] == 'n') && (att[4] == 's'))
+		    xmlSAX2AttributeInternal(ctxt, att, value, prefix);
 
-                att = atts[i++];
-                value = atts[i++];
-            }
+		att = atts[i++];
+		value = atts[i++];
+	    }
         }
 
         /*
@@ -1734,27 +1737,27 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
      */
     if (atts != NULL) {
         i = 0;
-        att = atts[i++];
-        value = atts[i++];
-        if (ctxt->html) {
-            while (att != NULL) {
-                xmlSAX2AttributeInternal(ctxt, att, value, NULL);
-                att = atts[i++];
-                value = atts[i++];
-            }
-        } else {
-            while ((att != NULL) && (value != NULL)) {
-                if ((att[0] != 'x') || (att[1] != 'm') || (att[2] != 'l') ||
-                    (att[3] != 'n') || (att[4] != 's'))
-                    xmlSAX2AttributeInternal(ctxt, att, value, NULL);
+	att = atts[i++];
+	value = atts[i++];
+	if (ctxt->html) {
+	    while (att != NULL) {
+		xmlSAX2AttributeInternal(ctxt, att, value, NULL);
+		att = atts[i++];
+		value = atts[i++];
+	    }
+	} else {
+	    while ((att != NULL) && (value != NULL)) {
+		if ((att[0] != 'x') || (att[1] != 'm') || (att[2] != 'l') ||
+		    (att[3] != 'n') || (att[4] != 's'))
+		    xmlSAX2AttributeInternal(ctxt, att, value, NULL);
 
-                /*
-                 * Next ones
-                 */
-                att = atts[i++];
-                value = atts[i++];
-            }
-        }
+		/*
+		 * Next ones
+		 */
+		att = atts[i++];
+		value = atts[i++];
+	    }
+	}
     }
 
 #ifdef LIBXML_VALID_ENABLED
@@ -1764,20 +1767,20 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
      */
     if ((ctxt->validate) &&
         ((ctxt->vctxt.flags & XML_VCTXT_DTD_VALIDATED) == 0)) {
-        int chk;
+	int chk;
 
-        chk = xmlValidateDtdFinal(&ctxt->vctxt, ctxt->myDoc);
-        if (chk <= 0)
-            ctxt->valid = 0;
-        if (chk < 0)
-            ctxt->wellFormed = 0;
-        ctxt->valid &= xmlValidateRoot(&ctxt->vctxt, ctxt->myDoc);
-        ctxt->vctxt.flags |= XML_VCTXT_DTD_VALIDATED;
+	chk = xmlValidateDtdFinal(&ctxt->vctxt, ctxt->myDoc);
+	if (chk <= 0)
+	    ctxt->valid = 0;
+	if (chk < 0)
+	    ctxt->wellFormed = 0;
+	ctxt->valid &= xmlValidateRoot(&ctxt->vctxt, ctxt->myDoc);
+	ctxt->vctxt.flags |= XML_VCTXT_DTD_VALIDATED;
     }
 #endif /* LIBXML_VALID_ENABLED */
 
     if (prefix != NULL)
-        xmlFree(prefix);
+	xmlFree(prefix);
 
 }
 
@@ -1800,7 +1803,7 @@ xmlSAX2EndElement(void *ctx, const xmlChar *name ATTRIBUTE_UNUSED)
     if (name == NULL)
         xmlGenericError(xmlGenericErrorContext, "SAX.xmlSAX2EndElement(NULL)\n");
     else
-        xmlGenericError(xmlGenericErrorContext, "SAX.xmlSAX2EndElement(%s)\n", name);
+	xmlGenericError(xmlGenericErrorContext, "SAX.xmlSAX2EndElement(%s)\n", name);
 #endif
 
     /* Capture end position and add node */
@@ -1816,7 +1819,7 @@ xmlSAX2EndElement(void *ctx, const xmlChar *name ATTRIBUTE_UNUSED)
     if (ctxt->validate && ctxt->wellFormed &&
         ctxt->myDoc && ctxt->myDoc->intSubset)
         ctxt->valid &= xmlValidateOneElement(&ctxt->vctxt, ctxt->myDoc,
-                                             cur);
+					     cur);
 #endif /* LIBXML_VALID_ENABLED */
 
 
@@ -1849,15 +1852,15 @@ xmlSAX2TextNode(xmlParserCtxtPtr ctxt, const xmlChar *str, int len) {
      * Allocate
      */
     if (ctxt->freeElems != NULL) {
-        ret = ctxt->freeElems;
-        ctxt->freeElems = ret->next;
-        ctxt->freeElemsNr--;
+	ret = ctxt->freeElems;
+	ctxt->freeElems = ret->next;
+	ctxt->freeElemsNr--;
     } else {
-        ret = (xmlNodePtr) xmlMalloc(sizeof(xmlNode));
+	ret = (xmlNodePtr) xmlMalloc(sizeof(xmlNode));
     }
     if (ret == NULL) {
         xmlErrMemory(ctxt, "xmlSAX2Characters");
-        return(NULL);
+	return(NULL);
     }
     memset(ret, 0, sizeof(xmlNode));
     /*
@@ -1867,54 +1870,54 @@ xmlSAX2TextNode(xmlParserCtxtPtr ctxt, const xmlChar *str, int len) {
     if (ctxt->dictNames) {
         xmlChar cur = str[len];
 
-        if ((len < (int) (2 * sizeof(void *))) &&
-            (ctxt->options & XML_PARSE_COMPACT)) {
-            /* store the string in the node overriding properties and nsDef */
-            xmlChar *tmp = (xmlChar *) &(ret->properties);
-            memcpy(tmp, str, len);
-            tmp[len] = 0;
-            intern = tmp;
-        } else if ((len <= 3) && ((cur == '"') || (cur == '\'') ||
-            ((cur == '<') && (str[len + 1] != '!')))) {
-            intern = xmlDictLookup(ctxt->dict, str, len);
-        } else if (IS_BLANK_CH(*str) && (len < 60) && (cur == '<') &&
-                   (str[len + 1] != '!')) {
-            int i;
+	if ((len < (int) (2 * sizeof(void *))) &&
+	    (ctxt->options & XML_PARSE_COMPACT)) {
+	    /* store the string in the node overriding properties and nsDef */
+	    xmlChar *tmp = (xmlChar *) &(ret->properties);
+	    memcpy(tmp, str, len);
+	    tmp[len] = 0;
+	    intern = tmp;
+	} else if ((len <= 3) && ((cur == '"') || (cur == '\'') ||
+	    ((cur == '<') && (str[len + 1] != '!')))) {
+	    intern = xmlDictLookup(ctxt->dict, str, len);
+	} else if (IS_BLANK_CH(*str) && (len < 60) && (cur == '<') &&
+	           (str[len + 1] != '!')) {
+	    int i;
 
-            for (i = 1;i < len;i++) {
-                if (!IS_BLANK_CH(str[i])) goto skip;
-            }
-            intern = xmlDictLookup(ctxt->dict, str, len);
-        }
+	    for (i = 1;i < len;i++) {
+		if (!IS_BLANK_CH(str[i])) goto skip;
+	    }
+	    intern = xmlDictLookup(ctxt->dict, str, len);
+	}
     }
 skip:
     ret->type = XML_TEXT_NODE;
 
     ret->name = xmlStringText;
     if (intern == NULL) {
-        ret->content = xmlStrndup(str, len);
-        if (ret->content == NULL) {
-            xmlSAX2ErrMemory(ctxt, "xmlSAX2TextNode");
-            xmlFree(ret);
-            return(NULL);
-        }
+	ret->content = xmlStrndup(str, len);
+	if (ret->content == NULL) {
+	    xmlSAX2ErrMemory(ctxt, "xmlSAX2TextNode");
+	    xmlFree(ret);
+	    return(NULL);
+	}
     } else
-        ret->content = (xmlChar *) intern;
+	ret->content = (xmlChar *) intern;
 
     if (ctxt->linenumbers) {
-        if (ctxt->input != NULL) {
-            if (ctxt->input->line < USHRT_MAX)
-                ret->line = (unsigned short) ctxt->input->line;
-            else {
-                ret->line = USHRT_MAX;
-                if (ctxt->options & XML_PARSE_BIG_LINES)
-                    ret->psvi = (void *) (ptrdiff_t) ctxt->input->line;
-            }
-        }
+	if (ctxt->input != NULL) {
+	    if (ctxt->input->line < USHRT_MAX)
+		ret->line = (unsigned short) ctxt->input->line;
+	    else {
+	        ret->line = USHRT_MAX;
+		if (ctxt->options & XML_PARSE_BIG_LINES)
+		    ret->psvi = (void *) (ptrdiff_t) ctxt->input->line;
+	    }
+	}
     }
 
     if ((__xmlRegisterCallbacks) && (xmlRegisterNodeDefaultValue))
-        xmlRegisterNodeDefaultValue(ret);
+	xmlRegisterNodeDefaultValue(ret);
     return(ret);
 }
 
@@ -1938,12 +1941,12 @@ xmlSAX2DecodeAttrEntities(xmlParserCtxtPtr ctxt, const xmlChar *str,
     in = str;
     while (in < end)
         if (*in++ == '&')
-            goto decode;
+	    goto decode;
     return(NULL);
 decode:
     ctxt->depth++;
     ret = xmlStringLenDecodeEntities(ctxt, str, end - str,
-                                     XML_SUBSTITUTE_REF, 0,0,0);
+				     XML_SUBSTITUTE_REF, 0,0,0);
     ctxt->depth--;
     return(ret);
 }
@@ -1967,8 +1970,8 @@ static void
 xmlSAX2AttributeNs(xmlParserCtxtPtr ctxt,
                    const xmlChar * localname,
                    const xmlChar * prefix,
-                   const xmlChar * value,
-                   const xmlChar * valueend)
+		   const xmlChar * value,
+		   const xmlChar * valueend)
 {
     xmlAttrPtr ret;
     xmlNsPtr namespace = NULL;
@@ -1978,200 +1981,200 @@ xmlSAX2AttributeNs(xmlParserCtxtPtr ctxt,
      * Note: if prefix == NULL, the attribute is not in the default namespace
      */
     if (prefix != NULL)
-        namespace = xmlSearchNs(ctxt->myDoc, ctxt->node, prefix);
+	namespace = xmlSearchNs(ctxt->myDoc, ctxt->node, prefix);
 
     /*
      * allocate the node
      */
     if (ctxt->freeAttrs != NULL) {
         ret = ctxt->freeAttrs;
-        ctxt->freeAttrs = ret->next;
-        ctxt->freeAttrsNr--;
-        memset(ret, 0, sizeof(xmlAttr));
-        ret->type = XML_ATTRIBUTE_NODE;
+	ctxt->freeAttrs = ret->next;
+	ctxt->freeAttrsNr--;
+	memset(ret, 0, sizeof(xmlAttr));
+	ret->type = XML_ATTRIBUTE_NODE;
 
-        ret->parent = ctxt->node;
-        ret->doc = ctxt->myDoc;
-        ret->ns = namespace;
+	ret->parent = ctxt->node;
+	ret->doc = ctxt->myDoc;
+	ret->ns = namespace;
 
-        if (ctxt->dictNames)
-            ret->name = localname;
-        else
-            ret->name = xmlStrdup(localname);
+	if (ctxt->dictNames)
+	    ret->name = localname;
+	else
+	    ret->name = xmlStrdup(localname);
 
         /* link at the end to preserve order, TODO speed up with a last */
-        if (ctxt->node->properties == NULL) {
-            ctxt->node->properties = ret;
-        } else {
-            xmlAttrPtr prev = ctxt->node->properties;
+	if (ctxt->node->properties == NULL) {
+	    ctxt->node->properties = ret;
+	} else {
+	    xmlAttrPtr prev = ctxt->node->properties;
 
-            while (prev->next != NULL) prev = prev->next;
-            prev->next = ret;
-            ret->prev = prev;
-        }
+	    while (prev->next != NULL) prev = prev->next;
+	    prev->next = ret;
+	    ret->prev = prev;
+	}
 
-        if ((__xmlRegisterCallbacks) && (xmlRegisterNodeDefaultValue))
-            xmlRegisterNodeDefaultValue((xmlNodePtr)ret);
+	if ((__xmlRegisterCallbacks) && (xmlRegisterNodeDefaultValue))
+	    xmlRegisterNodeDefaultValue((xmlNodePtr)ret);
     } else {
-        if (ctxt->dictNames)
-            ret = xmlNewNsPropEatName(ctxt->node, namespace,
-                                      (xmlChar *) localname, NULL);
-        else
-            ret = xmlNewNsProp(ctxt->node, namespace, localname, NULL);
-        if (ret == NULL) {
-            xmlErrMemory(ctxt, "xmlSAX2AttributeNs");
-            return;
-        }
+	if (ctxt->dictNames)
+	    ret = xmlNewNsPropEatName(ctxt->node, namespace,
+	                              (xmlChar *) localname, NULL);
+	else
+	    ret = xmlNewNsProp(ctxt->node, namespace, localname, NULL);
+	if (ret == NULL) {
+	    xmlErrMemory(ctxt, "xmlSAX2AttributeNs");
+	    return;
+	}
     }
 
     if ((ctxt->replaceEntities == 0) && (!ctxt->html)) {
-        xmlNodePtr tmp;
+	xmlNodePtr tmp;
 
-        /*
-         * We know that if there is an entity reference, then
-         * the string has been dup'ed and terminates with 0
-         * otherwise with ' or "
-         */
-        if (*valueend != 0) {
-            tmp = xmlSAX2TextNode(ctxt, value, valueend - value);
-            ret->children = tmp;
-            ret->last = tmp;
-            if (tmp != NULL) {
-                tmp->doc = ret->doc;
-                tmp->parent = (xmlNodePtr) ret;
-            }
-        } else {
-            ret->children = xmlStringLenGetNodeList(ctxt->myDoc, value,
-                                                    valueend - value);
-            tmp = ret->children;
-            while (tmp != NULL) {
-                tmp->doc = ret->doc;
-                tmp->parent = (xmlNodePtr) ret;
-                if (tmp->next == NULL)
-                    ret->last = tmp;
-                tmp = tmp->next;
-            }
-        }
+	/*
+	 * We know that if there is an entity reference, then
+	 * the string has been dup'ed and terminates with 0
+	 * otherwise with ' or "
+	 */
+	if (*valueend != 0) {
+	    tmp = xmlSAX2TextNode(ctxt, value, valueend - value);
+	    ret->children = tmp;
+	    ret->last = tmp;
+	    if (tmp != NULL) {
+		tmp->doc = ret->doc;
+		tmp->parent = (xmlNodePtr) ret;
+	    }
+	} else {
+	    ret->children = xmlStringLenGetNodeList(ctxt->myDoc, value,
+						    valueend - value);
+	    tmp = ret->children;
+	    while (tmp != NULL) {
+	        tmp->doc = ret->doc;
+		tmp->parent = (xmlNodePtr) ret;
+		if (tmp->next == NULL)
+		    ret->last = tmp;
+		tmp = tmp->next;
+	    }
+	}
     } else if (value != NULL) {
-        xmlNodePtr tmp;
+	xmlNodePtr tmp;
 
-        tmp = xmlSAX2TextNode(ctxt, value, valueend - value);
-        ret->children = tmp;
-        ret->last = tmp;
-        if (tmp != NULL) {
-            tmp->doc = ret->doc;
-            tmp->parent = (xmlNodePtr) ret;
-        }
+	tmp = xmlSAX2TextNode(ctxt, value, valueend - value);
+	ret->children = tmp;
+	ret->last = tmp;
+	if (tmp != NULL) {
+	    tmp->doc = ret->doc;
+	    tmp->parent = (xmlNodePtr) ret;
+	}
     }
 
 #ifdef LIBXML_VALID_ENABLED
     if ((!ctxt->html) && ctxt->validate && ctxt->wellFormed &&
         ctxt->myDoc && ctxt->myDoc->intSubset) {
-        /*
-         * If we don't substitute entities, the validation should be
-         * done on a value with replaced entities anyway.
-         */
+	/*
+	 * If we don't substitute entities, the validation should be
+	 * done on a value with replaced entities anyway.
+	 */
         if (!ctxt->replaceEntities) {
-            dup = xmlSAX2DecodeAttrEntities(ctxt, value, valueend);
-            if (dup == NULL) {
-                if (*valueend == 0) {
-                    ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
-                                    ctxt->myDoc, ctxt->node, ret, value);
-                } else {
-                    /*
-                     * That should already be normalized.
-                     * cheaper to finally allocate here than duplicate
-                     * entry points in the full validation code
-                     */
-                    dup = xmlStrndup(value, valueend - value);
+	    dup = xmlSAX2DecodeAttrEntities(ctxt, value, valueend);
+	    if (dup == NULL) {
+	        if (*valueend == 0) {
+		    ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
+				    ctxt->myDoc, ctxt->node, ret, value);
+		} else {
+		    /*
+		     * That should already be normalized.
+		     * cheaper to finally allocate here than duplicate
+		     * entry points in the full validation code
+		     */
+		    dup = xmlStrndup(value, valueend - value);
 
-                    ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
-                                    ctxt->myDoc, ctxt->node, ret, dup);
-                }
-            } else {
-                /*
-                 * dup now contains a string of the flattened attribute
-                 * content with entities substituted. Check if we need to
-                 * apply an extra layer of normalization.
-                 * It need to be done twice ... it's an extra burden related
-                 * to the ability to keep references in attributes
-                 */
-                if (ctxt->attsSpecial != NULL) {
-                    xmlChar *nvalnorm;
-                    xmlChar fn[50];
-                    xmlChar *fullname;
+		    ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
+				    ctxt->myDoc, ctxt->node, ret, dup);
+		}
+	    } else {
+	        /*
+		 * dup now contains a string of the flattened attribute
+		 * content with entities substituted. Check if we need to
+		 * apply an extra layer of normalization.
+		 * It need to be done twice ... it's an extra burden related
+		 * to the ability to keep references in attributes
+		 */
+		if (ctxt->attsSpecial != NULL) {
+		    xmlChar *nvalnorm;
+		    xmlChar fn[50];
+		    xmlChar *fullname;
 
-                    fullname = xmlBuildQName(localname, prefix, fn, 50);
-                    if (fullname != NULL) {
-                        ctxt->vctxt.valid = 1;
-                        nvalnorm = xmlValidCtxtNormalizeAttributeValue(
-                                         &ctxt->vctxt, ctxt->myDoc,
-                                         ctxt->node, fullname, dup);
-                        if (ctxt->vctxt.valid != 1)
-                            ctxt->valid = 0;
+		    fullname = xmlBuildQName(localname, prefix, fn, 50);
+		    if (fullname != NULL) {
+			ctxt->vctxt.valid = 1;
+		        nvalnorm = xmlValidCtxtNormalizeAttributeValue(
+			                 &ctxt->vctxt, ctxt->myDoc,
+					 ctxt->node, fullname, dup);
+			if (ctxt->vctxt.valid != 1)
+			    ctxt->valid = 0;
 
-                        if ((fullname != fn) && (fullname != localname))
-                            xmlFree(fullname);
-                        if (nvalnorm != NULL) {
-                            xmlFree(dup);
-                            dup = nvalnorm;
-                        }
-                    }
-                }
+			if ((fullname != fn) && (fullname != localname))
+			    xmlFree(fullname);
+			if (nvalnorm != NULL) {
+			    xmlFree(dup);
+			    dup = nvalnorm;
+			}
+		    }
+		}
 
-                ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
-                                ctxt->myDoc, ctxt->node, ret, dup);
-            }
-        } else {
-            /*
-             * if entities already have been substituted, then
-             * the attribute as passed is already normalized
-             */
-            dup = xmlStrndup(value, valueend - value);
+		ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
+			        ctxt->myDoc, ctxt->node, ret, dup);
+	    }
+	} else {
+	    /*
+	     * if entities already have been substituted, then
+	     * the attribute as passed is already normalized
+	     */
+	    dup = xmlStrndup(value, valueend - value);
 
-            ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
-                                     ctxt->myDoc, ctxt->node, ret, dup);
-        }
+	    ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
+	                             ctxt->myDoc, ctxt->node, ret, dup);
+	}
     } else
 #endif /* LIBXML_VALID_ENABLED */
            if (((ctxt->loadsubset & XML_SKIP_IDS) == 0) &&
-               (((ctxt->replaceEntities == 0) && (ctxt->external != 2)) ||
-                ((ctxt->replaceEntities != 0) && (ctxt->inSubset == 0))) &&
+	       (((ctxt->replaceEntities == 0) && (ctxt->external != 2)) ||
+	        ((ctxt->replaceEntities != 0) && (ctxt->inSubset == 0))) &&
                /* Don't create IDs containing entity references */
                (ret->children != NULL) &&
                (ret->children->type == XML_TEXT_NODE) &&
                (ret->children->next == NULL)) {
         xmlChar *content = ret->children->content;
         /*
-         * when validating, the ID registration is done at the attribute
-         * validation level. Otherwise we have to do specific handling here.
-         */
+	 * when validating, the ID registration is done at the attribute
+	 * validation level. Otherwise we have to do specific handling here.
+	 */
         if ((prefix == ctxt->str_xml) &&
-                   (localname[0] == 'i') && (localname[1] == 'd') &&
-                   (localname[2] == 0)) {
-            /*
-             * Add the xml:id value
-             *
-             * Open issue: normalization of the value.
-             */
+	           (localname[0] == 'i') && (localname[1] == 'd') &&
+		   (localname[2] == 0)) {
+	    /*
+	     * Add the xml:id value
+	     *
+	     * Open issue: normalization of the value.
+	     */
 #if defined(LIBXML_SAX1_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_WRITER_ENABLED) || defined(LIBXML_LEGACY_ENABLED)
 #ifdef LIBXML_VALID_ENABLED
-            if (xmlValidateNCName(content, 1) != 0) {
-                xmlErrValid(ctxt, XML_DTD_XMLID_VALUE,
-                      "xml:id : attribute value %s is not an NCName\n",
-                            (const char *) content, NULL);
-            }
+	    if (xmlValidateNCName(content, 1) != 0) {
+	        xmlErrValid(ctxt, XML_DTD_XMLID_VALUE,
+		      "xml:id : attribute value %s is not an NCName\n",
+			    (const char *) content, NULL);
+	    }
 #endif
 #endif
-            xmlAddID(&ctxt->vctxt, ctxt->myDoc, content, ret);
-        } else if (xmlIsID(ctxt->myDoc, ctxt->node, ret)) {
-            xmlAddID(&ctxt->vctxt, ctxt->myDoc, content, ret);
-        } else if (xmlIsRef(ctxt->myDoc, ctxt->node, ret)) {
-            xmlAddRef(&ctxt->vctxt, ctxt->myDoc, content, ret);
-        }
+	    xmlAddID(&ctxt->vctxt, ctxt->myDoc, content, ret);
+	} else if (xmlIsID(ctxt->myDoc, ctxt->node, ret)) {
+	    xmlAddID(&ctxt->vctxt, ctxt->myDoc, content, ret);
+	} else if (xmlIsRef(ctxt->myDoc, ctxt->node, ret)) {
+	    xmlAddRef(&ctxt->vctxt, ctxt->myDoc, content, ret);
+	}
     }
     if (dup != NULL)
-        xmlFree(dup);
+	xmlFree(dup);
 }
 
 /**
@@ -2194,13 +2197,13 @@ xmlSAX2AttributeNs(xmlParserCtxtPtr ctxt,
 void
 xmlSAX2StartElementNs(void *ctx,
                       const xmlChar *localname,
-                      const xmlChar *prefix,
-                      const xmlChar *URI,
-                      int nb_namespaces,
-                      const xmlChar **namespaces,
-                      int nb_attributes,
-                      int nb_defaulted,
-                      const xmlChar **attributes)
+		      const xmlChar *prefix,
+		      const xmlChar *URI,
+		      int nb_namespaces,
+		      const xmlChar **namespaces,
+		      int nb_attributes,
+		      int nb_defaulted,
+		      const xmlChar **attributes)
 {
     xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx;
     xmlNodePtr ret;
@@ -2217,13 +2220,13 @@ xmlSAX2StartElementNs(void *ctx,
      */
     if (ctxt->validate && (ctxt->myDoc->extSubset == NULL) &&
         ((ctxt->myDoc->intSubset == NULL) ||
-         ((ctxt->myDoc->intSubset->notations == NULL) &&
-          (ctxt->myDoc->intSubset->elements == NULL) &&
-          (ctxt->myDoc->intSubset->attributes == NULL) &&
-          (ctxt->myDoc->intSubset->entities == NULL)))) {
-        xmlErrValid(ctxt, XML_DTD_NO_DTD,
-          "Validation failed: no DTD found !", NULL, NULL);
-        ctxt->validate = 0;
+	 ((ctxt->myDoc->intSubset->notations == NULL) &&
+	  (ctxt->myDoc->intSubset->elements == NULL) &&
+	  (ctxt->myDoc->intSubset->attributes == NULL) &&
+	  (ctxt->myDoc->intSubset->entities == NULL)))) {
+	xmlErrValid(ctxt, XML_DTD_NO_DTD,
+	  "Validation failed: no DTD found !", NULL, NULL);
+	ctxt->validate = 0;
     }
 
     /*
@@ -2231,61 +2234,61 @@ xmlSAX2StartElementNs(void *ctx,
      */
     if ((prefix != NULL) && (URI == NULL)) {
         if (ctxt->dictNames) {
-            const xmlChar *fullname;
+	    const xmlChar *fullname;
 
-            fullname = xmlDictQLookup(ctxt->dict, prefix, localname);
-            if (fullname != NULL)
-                localname = fullname;
-        } else {
-            lname = xmlBuildQName(localname, prefix, NULL, 0);
-        }
+	    fullname = xmlDictQLookup(ctxt->dict, prefix, localname);
+	    if (fullname != NULL)
+	        localname = fullname;
+	} else {
+	    lname = xmlBuildQName(localname, prefix, NULL, 0);
+	}
     }
     /*
      * allocate the node
      */
     if (ctxt->freeElems != NULL) {
         ret = ctxt->freeElems;
-        ctxt->freeElems = ret->next;
-        ctxt->freeElemsNr--;
-        memset(ret, 0, sizeof(xmlNode));
+	ctxt->freeElems = ret->next;
+	ctxt->freeElemsNr--;
+	memset(ret, 0, sizeof(xmlNode));
         ret->doc = ctxt->myDoc;
-        ret->type = XML_ELEMENT_NODE;
+	ret->type = XML_ELEMENT_NODE;
 
-        if (ctxt->dictNames)
-            ret->name = localname;
-        else {
-            if (lname == NULL)
-                ret->name = xmlStrdup(localname);
-            else
-                ret->name = lname;
-            if (ret->name == NULL) {
-                xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElementNs");
-                return;
-            }
-        }
-        if ((__xmlRegisterCallbacks) && (xmlRegisterNodeDefaultValue))
-            xmlRegisterNodeDefaultValue(ret);
+	if (ctxt->dictNames)
+	    ret->name = localname;
+	else {
+	    if (lname == NULL)
+		ret->name = xmlStrdup(localname);
+	    else
+	        ret->name = lname;
+	    if (ret->name == NULL) {
+	        xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElementNs");
+		return;
+	    }
+	}
+	if ((__xmlRegisterCallbacks) && (xmlRegisterNodeDefaultValue))
+	    xmlRegisterNodeDefaultValue(ret);
     } else {
-        if (ctxt->dictNames)
-            ret = xmlNewDocNodeEatName(ctxt->myDoc, NULL,
-                                       (xmlChar *) localname, NULL);
-        else if (lname == NULL)
-            ret = xmlNewDocNode(ctxt->myDoc, NULL, localname, NULL);
-        else
-            ret = xmlNewDocNodeEatName(ctxt->myDoc, NULL,
-                                       (xmlChar *) lname, NULL);
-        if (ret == NULL) {
-            xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElementNs");
-            return;
-        }
+	if (ctxt->dictNames)
+	    ret = xmlNewDocNodeEatName(ctxt->myDoc, NULL,
+	                               (xmlChar *) localname, NULL);
+	else if (lname == NULL)
+	    ret = xmlNewDocNode(ctxt->myDoc, NULL, localname, NULL);
+	else
+	    ret = xmlNewDocNodeEatName(ctxt->myDoc, NULL,
+	                               (xmlChar *) lname, NULL);
+	if (ret == NULL) {
+	    xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElementNs");
+	    return;
+	}
     }
     if (ctxt->linenumbers) {
-        if (ctxt->input != NULL) {
-            if (ctxt->input->line < USHRT_MAX)
-                ret->line = (unsigned short) ctxt->input->line;
-            else
-                ret->line = USHRT_MAX;
-        }
+	if (ctxt->input != NULL) {
+	    if (ctxt->input->line < USHRT_MAX)
+		ret->line = (unsigned short) ctxt->input->line;
+	    else
+	        ret->line = USHRT_MAX;
+	}
     }
 
     if (parent == NULL) {
@@ -2296,31 +2299,31 @@ xmlSAX2StartElementNs(void *ctx,
      */
     for (i = 0,j = 0;j < nb_namespaces;j++) {
         pref = namespaces[i++];
-        uri = namespaces[i++];
-        ns = xmlNewNs(NULL, uri, pref);
-        if (ns != NULL) {
-            if (last == NULL) {
-                ret->nsDef = last = ns;
-            } else {
-                last->next = ns;
-                last = ns;
-            }
-            if ((URI != NULL) && (prefix == pref))
-                ret->ns = ns;
-        } else {
+	uri = namespaces[i++];
+	ns = xmlNewNs(NULL, uri, pref);
+	if (ns != NULL) {
+	    if (last == NULL) {
+	        ret->nsDef = last = ns;
+	    } else {
+	        last->next = ns;
+		last = ns;
+	    }
+	    if ((URI != NULL) && (prefix == pref))
+		ret->ns = ns;
+	} else {
             /*
              * any out of memory error would already have been raised
              * but we can't be guaranteed it's the actual error due to the
              * API, best is to skip in this case
              */
-            continue;
-        }
+	    continue;
+	}
 #ifdef LIBXML_VALID_ENABLED
-        if ((!ctxt->html) && ctxt->validate && ctxt->wellFormed &&
-            ctxt->myDoc && ctxt->myDoc->intSubset) {
-            ctxt->valid &= xmlValidateOneNamespace(&ctxt->vctxt, ctxt->myDoc,
-                                                   ret, prefix, ns, uri);
-        }
+	if ((!ctxt->html) && ctxt->validate && ctxt->wellFormed &&
+	    ctxt->myDoc && ctxt->myDoc->intSubset) {
+	    ctxt->valid &= xmlValidateOneNamespace(&ctxt->vctxt, ctxt->myDoc,
+	                                           ret, prefix, ns, uri);
+	}
 #endif /* LIBXML_VALID_ENABLED */
     }
     ctxt->nodemem = -1;
@@ -2339,10 +2342,10 @@ xmlSAX2StartElementNs(void *ctx,
      */
     if (parent != NULL) {
         if (parent->type == XML_ELEMENT_NODE) {
-            xmlAddChild(parent, ret);
-        } else {
-            xmlAddSibling(parent, ret);
-        }
+	    xmlAddChild(parent, ret);
+	} else {
+	    xmlAddSibling(parent, ret);
+	}
     }
 
     /*
@@ -2350,7 +2353,7 @@ xmlSAX2StartElementNs(void *ctx,
      */
     if ((nb_defaulted != 0) &&
         ((ctxt->loadsubset & XML_COMPLETE_ATTRS) == 0))
-        nb_attributes -= nb_defaulted;
+	nb_attributes -= nb_defaulted;
 
     /*
      * Search the namespace if it wasn't already found
@@ -2358,16 +2361,16 @@ xmlSAX2StartElementNs(void *ctx,
      */
     if ((URI != NULL) && (ret->ns == NULL)) {
         ret->ns = xmlSearchNs(ctxt->myDoc, parent, prefix);
-        if ((ret->ns == NULL) && (xmlStrEqual(prefix, BAD_CAST "xml"))) {
-            ret->ns = xmlSearchNs(ctxt->myDoc, ret, prefix);
-        }
-        if (ret->ns == NULL) {
-            ns = xmlNewNs(ret, NULL, prefix);
-            if (ns == NULL) {
+	if ((ret->ns == NULL) && (xmlStrEqual(prefix, BAD_CAST "xml"))) {
+	    ret->ns = xmlSearchNs(ctxt->myDoc, ret, prefix);
+	}
+	if (ret->ns == NULL) {
+	    ns = xmlNewNs(ret, NULL, prefix);
+	    if (ns == NULL) {
 
-                xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElementNs");
-                return;
-            }
+	        xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElementNs");
+		return;
+	    }
             if (prefix != NULL)
                 xmlNsWarnMsg(ctxt, XML_NS_ERR_UNDEFINED_NAMESPACE,
                              "Namespace prefix %s was not found\n",
@@ -2376,7 +2379,7 @@ xmlSAX2StartElementNs(void *ctx,
                 xmlNsWarnMsg(ctxt, XML_NS_ERR_UNDEFINED_NAMESPACE,
                              "Namespace default prefix was not found\n",
                              NULL, NULL);
-        }
+	}
     }
 
     /*
@@ -2384,34 +2387,34 @@ xmlSAX2StartElementNs(void *ctx,
      */
     if (nb_attributes > 0) {
         for (j = 0,i = 0;i < nb_attributes;i++,j+=5) {
-            /*
-             * Handle the rare case of an undefined attribute prefix
-             */
-            if ((attributes[j+1] != NULL) && (attributes[j+2] == NULL)) {
-                if (ctxt->dictNames) {
-                    const xmlChar *fullname;
+	    /*
+	     * Handle the rare case of an undefined attribute prefix
+	     */
+	    if ((attributes[j+1] != NULL) && (attributes[j+2] == NULL)) {
+		if (ctxt->dictNames) {
+		    const xmlChar *fullname;
 
-                    fullname = xmlDictQLookup(ctxt->dict, attributes[j+1],
-                                              attributes[j]);
-                    if (fullname != NULL) {
-                        xmlSAX2AttributeNs(ctxt, fullname, NULL,
-                                           attributes[j+3], attributes[j+4]);
-                        continue;
-                    }
-                } else {
-                    lname = xmlBuildQName(attributes[j], attributes[j+1],
-                                          NULL, 0);
-                    if (lname != NULL) {
-                        xmlSAX2AttributeNs(ctxt, lname, NULL,
-                                           attributes[j+3], attributes[j+4]);
-                        xmlFree(lname);
-                        continue;
-                    }
-                }
-            }
-            xmlSAX2AttributeNs(ctxt, attributes[j], attributes[j+1],
-                               attributes[j+3], attributes[j+4]);
-        }
+		    fullname = xmlDictQLookup(ctxt->dict, attributes[j+1],
+		                              attributes[j]);
+		    if (fullname != NULL) {
+			xmlSAX2AttributeNs(ctxt, fullname, NULL,
+			                   attributes[j+3], attributes[j+4]);
+		        continue;
+		    }
+		} else {
+		    lname = xmlBuildQName(attributes[j], attributes[j+1],
+		                          NULL, 0);
+		    if (lname != NULL) {
+			xmlSAX2AttributeNs(ctxt, lname, NULL,
+			                   attributes[j+3], attributes[j+4]);
+			xmlFree(lname);
+		        continue;
+		    }
+		}
+	    }
+	    xmlSAX2AttributeNs(ctxt, attributes[j], attributes[j+1],
+			       attributes[j+3], attributes[j+4]);
+	}
     }
 
 #ifdef LIBXML_VALID_ENABLED
@@ -2421,15 +2424,15 @@ xmlSAX2StartElementNs(void *ctx,
      */
     if ((ctxt->validate) &&
         ((ctxt->vctxt.flags & XML_VCTXT_DTD_VALIDATED) == 0)) {
-        int chk;
+	int chk;
 
-        chk = xmlValidateDtdFinal(&ctxt->vctxt, ctxt->myDoc);
-        if (chk <= 0)
-            ctxt->valid = 0;
-        if (chk < 0)
-            ctxt->wellFormed = 0;
-        ctxt->valid &= xmlValidateRoot(&ctxt->vctxt, ctxt->myDoc);
-        ctxt->vctxt.flags |= XML_VCTXT_DTD_VALIDATED;
+	chk = xmlValidateDtdFinal(&ctxt->vctxt, ctxt->myDoc);
+	if (chk <= 0)
+	    ctxt->valid = 0;
+	if (chk < 0)
+	    ctxt->wellFormed = 0;
+	ctxt->valid &= xmlValidateRoot(&ctxt->vctxt, ctxt->myDoc);
+	ctxt->vctxt.flags |= XML_VCTXT_DTD_VALIDATED;
     }
 #endif /* LIBXML_VALID_ENABLED */
 }
@@ -2448,7 +2451,7 @@ void
 xmlSAX2EndElementNs(void *ctx,
                     const xmlChar * localname ATTRIBUTE_UNUSED,
                     const xmlChar * prefix ATTRIBUTE_UNUSED,
-                    const xmlChar * URI ATTRIBUTE_UNUSED)
+		    const xmlChar * URI ATTRIBUTE_UNUSED)
 {
     xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx;
     xmlParserNodeInfo node_info;
@@ -2493,15 +2496,15 @@ xmlSAX2Reference(void *ctx, const xmlChar *name)
     if (ctx == NULL) return;
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-            "SAX.xmlSAX2Reference(%s)\n", name);
+	    "SAX.xmlSAX2Reference(%s)\n", name);
 #endif
     if (name[0] == '#')
-        ret = xmlNewCharRef(ctxt->myDoc, name);
+	ret = xmlNewCharRef(ctxt->myDoc, name);
     else
-        ret = xmlNewReference(ctxt->myDoc, name);
+	ret = xmlNewReference(ctxt->myDoc, name);
 #ifdef DEBUG_SAX_TREE
     xmlGenericError(xmlGenericErrorContext,
-            "add xmlSAX2Reference %s to %s \n", name, ctxt->node->name);
+	    "add xmlSAX2Reference %s to %s \n", name, ctxt->node->name);
 #endif
     if (xmlAddChild(ctxt->node, ret) == NULL) {
         xmlFreeNode(ret);
@@ -2526,7 +2529,7 @@ xmlSAX2Text(xmlParserCtxtPtr ctxt, const xmlChar *ch, int len,
     if (ctxt == NULL) return;
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-            "SAX.xmlSAX2Characters(%.30s, %d)\n", ch, len);
+	    "SAX.xmlSAX2Characters(%.30s, %d)\n", ch, len);
 #endif
     /*
      * Handle the data if any. If there is no child
@@ -2536,15 +2539,15 @@ xmlSAX2Text(xmlParserCtxtPtr ctxt, const xmlChar *ch, int len,
 
     if (ctxt->node == NULL) {
 #ifdef DEBUG_SAX_TREE
-        xmlGenericError(xmlGenericErrorContext,
-                "add chars: ctxt->node == NULL !\n");
+	xmlGenericError(xmlGenericErrorContext,
+		"add chars: ctxt->node == NULL !\n");
 #endif
         return;
     }
     lastChild = ctxt->node->last;
 #ifdef DEBUG_SAX_TREE
     xmlGenericError(xmlGenericErrorContext,
-            "add chars to %s \n", ctxt->node->name);
+	    "add chars to %s \n", ctxt->node->name);
 #endif
 
     /*
@@ -2556,92 +2559,92 @@ xmlSAX2Text(xmlParserCtxtPtr ctxt, const xmlChar *ch, int len,
             lastChild = xmlSAX2TextNode(ctxt, ch, len);
         else
             lastChild = xmlNewCDataBlock(ctxt->myDoc, ch, len);
-        if (lastChild != NULL) {
-            ctxt->node->children = lastChild;
-            ctxt->node->last = lastChild;
-            lastChild->parent = ctxt->node;
-            lastChild->doc = ctxt->node->doc;
-            ctxt->nodelen = len;
-            ctxt->nodemem = len + 1;
-        } else {
-            xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters");
-            return;
-        }
+	if (lastChild != NULL) {
+	    ctxt->node->children = lastChild;
+	    ctxt->node->last = lastChild;
+	    lastChild->parent = ctxt->node;
+	    lastChild->doc = ctxt->node->doc;
+	    ctxt->nodelen = len;
+	    ctxt->nodemem = len + 1;
+	} else {
+	    xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters");
+	    return;
+	}
     } else {
-        int coalesceText = (lastChild != NULL) &&
-            (lastChild->type == type) &&
-            ((type != XML_TEXT_NODE) ||
+	int coalesceText = (lastChild != NULL) &&
+	    (lastChild->type == type) &&
+	    ((type != XML_TEXT_NODE) ||
              (lastChild->name == xmlStringText));
-        if ((coalesceText) && (ctxt->nodemem != 0)) {
-            /*
-             * The whole point of maintaining nodelen and nodemem,
-             * xmlTextConcat is too costly, i.e. compute length,
-             * reallocate a new buffer, move data, append ch. Here
-             * We try to minimize realloc() uses and avoid copying
-             * and recomputing length over and over.
-             */
-            if (lastChild->content == (xmlChar *)&(lastChild->properties)) {
-                lastChild->content = xmlStrdup(lastChild->content);
-                lastChild->properties = NULL;
-            } else if ((ctxt->nodemem == ctxt->nodelen + 1) &&
-                       (xmlDictOwns(ctxt->dict, lastChild->content))) {
-                lastChild->content = xmlStrdup(lastChild->content);
-            }
-            if (lastChild->content == NULL) {
-                xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters: xmlStrdup returned NULL");
-                return;
-            }
-            if (ctxt->nodelen > INT_MAX - len) {
+	if ((coalesceText) && (ctxt->nodemem != 0)) {
+	    /*
+	     * The whole point of maintaining nodelen and nodemem,
+	     * xmlTextConcat is too costly, i.e. compute length,
+	     * reallocate a new buffer, move data, append ch. Here
+	     * We try to minimize realloc() uses and avoid copying
+	     * and recomputing length over and over.
+	     */
+	    if (lastChild->content == (xmlChar *)&(lastChild->properties)) {
+		lastChild->content = xmlStrdup(lastChild->content);
+		lastChild->properties = NULL;
+	    } else if ((ctxt->nodemem == ctxt->nodelen + 1) &&
+	               (xmlDictOwns(ctxt->dict, lastChild->content))) {
+		lastChild->content = xmlStrdup(lastChild->content);
+	    }
+	    if (lastChild->content == NULL) {
+		xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters: xmlStrdup returned NULL");
+		return;
+ 	    }
+	    if (ctxt->nodelen > INT_MAX - len) {
                 xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters overflow prevented");
                 return;
-            }
+	    }
             if ((ctxt->nodelen + len > XML_MAX_TEXT_LENGTH) &&
                 ((ctxt->options & XML_PARSE_HUGE) == 0)) {
                 xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters: huge text node");
                 return;
             }
-            if (ctxt->nodelen + len >= ctxt->nodemem) {
-                xmlChar *newbuf;
-                int size;
+	    if (ctxt->nodelen + len >= ctxt->nodemem) {
+		xmlChar *newbuf;
+		int size;
 
-                size = ctxt->nodemem > INT_MAX - len ?
+		size = ctxt->nodemem > INT_MAX - len ?
                        INT_MAX :
                        ctxt->nodemem + len;
-                size = size > INT_MAX / 2 ? INT_MAX : size * 2;
+		size = size > INT_MAX / 2 ? INT_MAX : size * 2;
                 newbuf = (xmlChar *) xmlRealloc(lastChild->content,size);
-                if (newbuf == NULL) {
-                    xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters");
-                    return;
-                }
-                ctxt->nodemem = size;
-                lastChild->content = newbuf;
-            }
-            memcpy(&lastChild->content[ctxt->nodelen], ch, len);
-            ctxt->nodelen += len;
-            lastChild->content[ctxt->nodelen] = 0;
-        } else if (coalesceText) {
-            if (xmlTextConcat(lastChild, ch, len)) {
-                xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters");
-            }
-            if (ctxt->node->children != NULL) {
-                ctxt->nodelen = xmlStrlen(lastChild->content);
-                ctxt->nodemem = ctxt->nodelen + 1;
-            }
-        } else {
-            /* Mixed content, first time */
+		if (newbuf == NULL) {
+		    xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters");
+		    return;
+		}
+		ctxt->nodemem = size;
+		lastChild->content = newbuf;
+	    }
+	    memcpy(&lastChild->content[ctxt->nodelen], ch, len);
+	    ctxt->nodelen += len;
+	    lastChild->content[ctxt->nodelen] = 0;
+	} else if (coalesceText) {
+	    if (xmlTextConcat(lastChild, ch, len)) {
+		xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters");
+	    }
+	    if (ctxt->node->children != NULL) {
+		ctxt->nodelen = xmlStrlen(lastChild->content);
+		ctxt->nodemem = ctxt->nodelen + 1;
+	    }
+	} else {
+	    /* Mixed content, first time */
             if (type == XML_TEXT_NODE) {
                 lastChild = xmlSAX2TextNode(ctxt, ch, len);
                 lastChild->doc = ctxt->myDoc;
             } else
                 lastChild = xmlNewCDataBlock(ctxt->myDoc, ch, len);
-            if (lastChild != NULL) {
-                xmlAddChild(ctxt->node, lastChild);
-                if (ctxt->node->children != NULL) {
-                    ctxt->nodelen = len;
-                    ctxt->nodemem = len + 1;
-                }
-            }
-        }
+	    if (lastChild != NULL) {
+		xmlAddChild(ctxt->node, lastChild);
+		if (ctxt->node->children != NULL) {
+		    ctxt->nodelen = len;
+		    ctxt->nodemem = len + 1;
+		}
+	    }
+	}
     }
 }
 
@@ -2674,7 +2677,7 @@ xmlSAX2IgnorableWhitespace(void *ctx ATTRIBUTE_UNUSED, const xmlChar *ch ATTRIBU
     /* xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx; */
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-            "SAX.xmlSAX2IgnorableWhitespace(%.30s, %d)\n", ch, len);
+	    "SAX.xmlSAX2IgnorableWhitespace(%.30s, %d)\n", ch, len);
 #endif
 }
 
@@ -2698,48 +2701,48 @@ xmlSAX2ProcessingInstruction(void *ctx, const xmlChar *target,
     parent = ctxt->node;
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-            "SAX.xmlSAX2ProcessingInstruction(%s, %s)\n", target, data);
+	    "SAX.xmlSAX2ProcessingInstruction(%s, %s)\n", target, data);
 #endif
 
     ret = xmlNewDocPI(ctxt->myDoc, target, data);
     if (ret == NULL) return;
 
     if (ctxt->linenumbers) {
-        if (ctxt->input != NULL) {
-            if (ctxt->input->line < USHRT_MAX)
-                ret->line = (unsigned short) ctxt->input->line;
-            else
-                ret->line = USHRT_MAX;
-        }
+	if (ctxt->input != NULL) {
+	    if (ctxt->input->line < USHRT_MAX)
+		ret->line = (unsigned short) ctxt->input->line;
+	    else
+	        ret->line = USHRT_MAX;
+	}
     }
     if (ctxt->inSubset == 1) {
-        xmlAddChild((xmlNodePtr) ctxt->myDoc->intSubset, ret);
-        return;
+	xmlAddChild((xmlNodePtr) ctxt->myDoc->intSubset, ret);
+	return;
     } else if (ctxt->inSubset == 2) {
-        xmlAddChild((xmlNodePtr) ctxt->myDoc->extSubset, ret);
-        return;
+	xmlAddChild((xmlNodePtr) ctxt->myDoc->extSubset, ret);
+	return;
     }
     if (parent == NULL) {
 #ifdef DEBUG_SAX_TREE
-            xmlGenericError(xmlGenericErrorContext,
-                    "Setting PI %s as root\n", target);
+	    xmlGenericError(xmlGenericErrorContext,
+		    "Setting PI %s as root\n", target);
 #endif
         xmlAddChild((xmlNodePtr) ctxt->myDoc, (xmlNodePtr) ret);
-        return;
+	return;
     }
     if (parent->type == XML_ELEMENT_NODE) {
 #ifdef DEBUG_SAX_TREE
-        xmlGenericError(xmlGenericErrorContext,
-                "adding PI %s child to %s\n", target, parent->name);
+	xmlGenericError(xmlGenericErrorContext,
+		"adding PI %s child to %s\n", target, parent->name);
 #endif
-        xmlAddChild(parent, ret);
+	xmlAddChild(parent, ret);
     } else {
 #ifdef DEBUG_SAX_TREE
-        xmlGenericError(xmlGenericErrorContext,
-                "adding PI %s sibling to ", target);
-        xmlDebugDumpOneNode(stderr, parent, 0);
+	xmlGenericError(xmlGenericErrorContext,
+		"adding PI %s sibling to ", target);
+	xmlDebugDumpOneNode(stderr, parent, 0);
 #endif
-        xmlAddSibling(parent, ret);
+	xmlAddSibling(parent, ret);
     }
 }
 
@@ -2765,42 +2768,42 @@ xmlSAX2Comment(void *ctx, const xmlChar *value)
     ret = xmlNewDocComment(ctxt->myDoc, value);
     if (ret == NULL) return;
     if (ctxt->linenumbers) {
-        if (ctxt->input != NULL) {
-            if (ctxt->input->line < USHRT_MAX)
-                ret->line = (unsigned short) ctxt->input->line;
-            else
-                ret->line = USHRT_MAX;
-        }
+	if (ctxt->input != NULL) {
+	    if (ctxt->input->line < USHRT_MAX)
+		ret->line = (unsigned short) ctxt->input->line;
+	    else
+	        ret->line = USHRT_MAX;
+	}
     }
 
     if (ctxt->inSubset == 1) {
-        xmlAddChild((xmlNodePtr) ctxt->myDoc->intSubset, ret);
-        return;
+	xmlAddChild((xmlNodePtr) ctxt->myDoc->intSubset, ret);
+	return;
     } else if (ctxt->inSubset == 2) {
-        xmlAddChild((xmlNodePtr) ctxt->myDoc->extSubset, ret);
-        return;
+	xmlAddChild((xmlNodePtr) ctxt->myDoc->extSubset, ret);
+	return;
     }
     if (parent == NULL) {
 #ifdef DEBUG_SAX_TREE
-            xmlGenericError(xmlGenericErrorContext,
-                    "Setting xmlSAX2Comment as root\n");
+	    xmlGenericError(xmlGenericErrorContext,
+		    "Setting xmlSAX2Comment as root\n");
 #endif
         xmlAddChild((xmlNodePtr) ctxt->myDoc, (xmlNodePtr) ret);
-        return;
+	return;
     }
     if (parent->type == XML_ELEMENT_NODE) {
 #ifdef DEBUG_SAX_TREE
-        xmlGenericError(xmlGenericErrorContext,
-                "adding xmlSAX2Comment child to %s\n", parent->name);
+	xmlGenericError(xmlGenericErrorContext,
+		"adding xmlSAX2Comment child to %s\n", parent->name);
 #endif
-        xmlAddChild(parent, ret);
+	xmlAddChild(parent, ret);
     } else {
 #ifdef DEBUG_SAX_TREE
-        xmlGenericError(xmlGenericErrorContext,
-                "adding xmlSAX2Comment sibling to ");
-        xmlDebugDumpOneNode(stderr, parent, 0);
+	xmlGenericError(xmlGenericErrorContext,
+		"adding xmlSAX2Comment sibling to ");
+	xmlDebugDumpOneNode(stderr, parent, 0);
 #endif
-        xmlAddSibling(parent, ret);
+	xmlAddSibling(parent, ret);
     }
 }
 
@@ -2859,17 +2862,17 @@ xmlSAXVersion(xmlSAXHandler *hdlr, int version)
 {
     if (hdlr == NULL) return(-1);
     if (version == 2) {
-        hdlr->startElement = NULL;
-        hdlr->endElement = NULL;
-        hdlr->startElementNs = xmlSAX2StartElementNs;
-        hdlr->endElementNs = xmlSAX2EndElementNs;
-        hdlr->serror = NULL;
-        hdlr->initialized = XML_SAX2_MAGIC;
+	hdlr->startElement = NULL;
+	hdlr->endElement = NULL;
+	hdlr->startElementNs = xmlSAX2StartElementNs;
+	hdlr->endElementNs = xmlSAX2EndElementNs;
+	hdlr->serror = NULL;
+	hdlr->initialized = XML_SAX2_MAGIC;
 #ifdef LIBXML_SAX1_ENABLED
     } else if (version == 1) {
-        hdlr->startElement = xmlSAX2StartElement;
-        hdlr->endElement = xmlSAX2EndElement;
-        hdlr->initialized = 1;
+	hdlr->startElement = xmlSAX2StartElement;
+	hdlr->endElement = xmlSAX2EndElement;
+	hdlr->initialized = 1;
 #endif /* LIBXML_SAX1_ENABLED */
     } else
         return(-1);
@@ -2913,13 +2916,13 @@ void
 xmlSAX2InitDefaultSAXHandler(xmlSAXHandler *hdlr, int warning)
 {
     if ((hdlr == NULL) || (hdlr->initialized != 0))
-        return;
+	return;
 
     xmlSAXVersion(hdlr, xmlSAX2DefaultVersionValue);
     if (warning == 0)
-        hdlr->warning = NULL;
+	hdlr->warning = NULL;
     else
-        hdlr->warning = xmlParserWarning;
+	hdlr->warning = xmlParserWarning;
 }
 
 /**
@@ -2950,7 +2953,7 @@ void
 xmlSAX2InitHtmlDefaultSAXHandler(xmlSAXHandler *hdlr)
 {
     if ((hdlr == NULL) || (hdlr->initialized != 0))
-        return;
+	return;
 
     hdlr->internalSubset = xmlSAX2InternalSubset;
     hdlr->externalSubset = NULL;

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/SAX2.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/SAX2.c
@@ -41,9 +41,9 @@
  *> values "system" and "public".  I have made the default be "system" to
  *> match yours.
  */
-#define TODO								\
-    xmlGenericError(xmlGenericErrorContext,				\
-	    "Unimplemented block at %s:%d\n",				\
+#define TODO                                                            \
+    xmlGenericError(xmlGenericErrorContext,                             \
+            "Unimplemented block at %s:%d\n",                           \
             __FILE__, __LINE__);
 
 /*
@@ -57,25 +57,25 @@ xmlSAX2ErrMemory(xmlParserCtxtPtr ctxt, const char *msg) {
     const char *str1 = "out of memory\n";
 
     if (ctxt != NULL) {
-	ctxt->errNo = XML_ERR_NO_MEMORY;
-	if ((ctxt->sax != NULL) && (ctxt->sax->initialized == XML_SAX2_MAGIC))
-	    schannel = ctxt->sax->serror;
-	__xmlRaiseError(schannel,
-			ctxt->vctxt.error, ctxt->vctxt.userData,
-			ctxt, NULL, XML_FROM_PARSER, XML_ERR_NO_MEMORY,
-			XML_ERR_ERROR, NULL, 0, (const char *) str1,
-			NULL, NULL, 0, 0,
-			msg, (const char *) str1, NULL);
-	ctxt->errNo = XML_ERR_NO_MEMORY;
-	ctxt->instate = XML_PARSER_EOF;
-	ctxt->disableSAX = 1;
+        ctxt->errNo = XML_ERR_NO_MEMORY;
+        if ((ctxt->sax != NULL) && (ctxt->sax->initialized == XML_SAX2_MAGIC))
+            schannel = ctxt->sax->serror;
+        __xmlRaiseError(schannel,
+                        ctxt->vctxt.error, ctxt->vctxt.userData,
+                        ctxt, NULL, XML_FROM_PARSER, XML_ERR_NO_MEMORY,
+                        XML_ERR_ERROR, NULL, 0, (const char *) str1,
+                        NULL, NULL, 0, 0,
+                        msg, (const char *) str1, NULL);
+        ctxt->errNo = XML_ERR_NO_MEMORY;
+        ctxt->instate = XML_PARSER_EOF;
+        ctxt->disableSAX = 1;
     } else {
-	__xmlRaiseError(schannel,
-			NULL, NULL,
-			ctxt, NULL, XML_FROM_PARSER, XML_ERR_NO_MEMORY,
-			XML_ERR_ERROR, NULL, 0, (const char *) str1,
-			NULL, NULL, 0, 0,
-			msg, (const char *) str1, NULL);
+        __xmlRaiseError(schannel,
+                        NULL, NULL,
+                        ctxt, NULL, XML_FROM_PARSER, XML_ERR_NO_MEMORY,
+                        XML_ERR_ERROR, NULL, 0, (const char *) str1,
+                        NULL, NULL, 0, 0,
+                        msg, (const char *) str1, NULL);
     }
 }
 
@@ -97,25 +97,25 @@ xmlErrValid(xmlParserCtxtPtr ctxt, xmlParserErrors error,
 
     if ((ctxt != NULL) && (ctxt->disableSAX != 0) &&
         (ctxt->instate == XML_PARSER_EOF))
-	return;
+        return;
     if (ctxt != NULL) {
-	ctxt->errNo = error;
-	if ((ctxt->sax != NULL) && (ctxt->sax->initialized == XML_SAX2_MAGIC))
-	    schannel = ctxt->sax->serror;
-	__xmlRaiseError(schannel,
-			ctxt->vctxt.error, ctxt->vctxt.userData,
-			ctxt, NULL, XML_FROM_DTD, error,
-			XML_ERR_ERROR, NULL, 0, (const char *) str1,
-			(const char *) str2, NULL, 0, 0,
-			msg, (const char *) str1, (const char *) str2);
-	ctxt->valid = 0;
+        ctxt->errNo = error;
+        if ((ctxt->sax != NULL) && (ctxt->sax->initialized == XML_SAX2_MAGIC))
+            schannel = ctxt->sax->serror;
+        __xmlRaiseError(schannel,
+                        ctxt->vctxt.error, ctxt->vctxt.userData,
+                        ctxt, NULL, XML_FROM_DTD, error,
+                        XML_ERR_ERROR, NULL, 0, (const char *) str1,
+                        (const char *) str2, NULL, 0, 0,
+                        msg, (const char *) str1, (const char *) str2);
+        ctxt->valid = 0;
     } else {
-	__xmlRaiseError(schannel,
-			NULL, NULL,
-			ctxt, NULL, XML_FROM_DTD, error,
-			XML_ERR_ERROR, NULL, 0, (const char *) str1,
-			(const char *) str2, NULL, 0, 0,
-			msg, (const char *) str1, (const char *) str2);
+        __xmlRaiseError(schannel,
+                        NULL, NULL,
+                        ctxt, NULL, XML_FROM_DTD, error,
+                        XML_ERR_ERROR, NULL, 0, (const char *) str1,
+                        (const char *) str2, NULL, 0, 0,
+                        msg, (const char *) str1, (const char *) str2);
     }
 }
 
@@ -135,18 +135,18 @@ xmlFatalErrMsg(xmlParserCtxtPtr ctxt, xmlParserErrors error,
 {
     if ((ctxt != NULL) && (ctxt->disableSAX != 0) &&
         (ctxt->instate == XML_PARSER_EOF))
-	return;
+        return;
     if (ctxt != NULL)
-	ctxt->errNo = error;
+        ctxt->errNo = error;
     __xmlRaiseError(NULL, NULL, NULL, ctxt, NULL, XML_FROM_PARSER, error,
                     XML_ERR_FATAL, NULL, 0,
-		    (const char *) str1, (const char *) str2,
-		    NULL, 0, 0, msg, str1, str2);
+                    (const char *) str1, (const char *) str2,
+                    NULL, 0, 0, msg, str1, str2);
     if (ctxt != NULL) {
-	ctxt->wellFormed = 0;
-	ctxt->valid = 0;
-	if (ctxt->recovery == 0)
-	    ctxt->disableSAX = 1;
+        ctxt->wellFormed = 0;
+        ctxt->valid = 0;
+        if (ctxt->recovery == 0)
+            ctxt->disableSAX = 1;
     }
 }
 
@@ -166,13 +166,13 @@ xmlWarnMsg(xmlParserCtxtPtr ctxt, xmlParserErrors error,
 {
     if ((ctxt != NULL) && (ctxt->disableSAX != 0) &&
         (ctxt->instate == XML_PARSER_EOF))
-	return;
+        return;
     if (ctxt != NULL)
-	ctxt->errNo = error;
+        ctxt->errNo = error;
     __xmlRaiseError(NULL, NULL, NULL, ctxt, NULL, XML_FROM_PARSER, error,
                     XML_ERR_WARNING, NULL, 0,
-		    (const char *) str1, NULL,
-		    NULL, 0, 0, msg, str1);
+                    (const char *) str1, NULL,
+                    NULL, 0, 0, msg, str1);
 }
 
 /**
@@ -190,13 +190,13 @@ xmlNsWarnMsg(xmlParserCtxtPtr ctxt, xmlParserErrors error,
 {
     if ((ctxt != NULL) && (ctxt->disableSAX != 0) &&
         (ctxt->instate == XML_PARSER_EOF))
-	return;
+        return;
     if (ctxt != NULL)
-	ctxt->errNo = error;
+        ctxt->errNo = error;
     __xmlRaiseError(NULL, NULL, NULL, ctxt, NULL, XML_FROM_NAMESPACE, error,
                     XML_ERR_WARNING, NULL, 0,
-		    (const char *) str1, (const char *) str2,
-		    NULL, 0, 0, msg, str1, str2);
+                    (const char *) str1, (const char *) str2,
+                    NULL, 0, 0, msg, str1, str2);
 }
 
 /**
@@ -322,29 +322,29 @@ xmlSAX2HasExternalSubset(void *ctx)
  */
 void
 xmlSAX2InternalSubset(void *ctx, const xmlChar *name,
-	       const xmlChar *ExternalID, const xmlChar *SystemID)
+               const xmlChar *ExternalID, const xmlChar *SystemID)
 {
     xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx;
     xmlDtdPtr dtd;
     if (ctx == NULL) return;
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-	    "SAX.xmlSAX2InternalSubset(%s, %s, %s)\n",
+            "SAX.xmlSAX2InternalSubset(%s, %s, %s)\n",
             name, ExternalID, SystemID);
 #endif
 
     if (ctxt->myDoc == NULL)
-	return;
+        return;
     dtd = xmlGetIntSubset(ctxt->myDoc);
     if (dtd != NULL) {
-	if (ctxt->html)
-	    return;
-	xmlUnlinkNode((xmlNodePtr) dtd);
-	xmlFreeDtd(dtd);
-	ctxt->myDoc->intSubset = NULL;
+        if (ctxt->html)
+            return;
+        xmlUnlinkNode((xmlNodePtr) dtd);
+        xmlFreeDtd(dtd);
+        ctxt->myDoc->intSubset = NULL;
     }
     ctxt->myDoc->intSubset =
-	xmlCreateIntSubset(ctxt->myDoc, name, ExternalID, SystemID);
+        xmlCreateIntSubset(ctxt->myDoc, name, ExternalID, SystemID);
     if (ctxt->myDoc->intSubset == NULL)
         xmlSAX2ErrMemory(ctxt, "xmlSAX2InternalSubset");
 }
@@ -360,114 +360,114 @@ xmlSAX2InternalSubset(void *ctx, const xmlChar *name,
  */
 void
 xmlSAX2ExternalSubset(void *ctx, const xmlChar *name,
-	       const xmlChar *ExternalID, const xmlChar *SystemID)
+               const xmlChar *ExternalID, const xmlChar *SystemID)
 {
     xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx;
     if (ctx == NULL) return;
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-	    "SAX.xmlSAX2ExternalSubset(%s, %s, %s)\n",
+            "SAX.xmlSAX2ExternalSubset(%s, %s, %s)\n",
             name, ExternalID, SystemID);
 #endif
     if (((ExternalID != NULL) || (SystemID != NULL)) &&
         (((ctxt->validate) || (ctxt->loadsubset != 0)) &&
-	 (ctxt->wellFormed && ctxt->myDoc))) {
-	/*
-	 * Try to fetch and parse the external subset.
-	 */
-	xmlParserInputPtr oldinput;
-	int oldinputNr;
-	int oldinputMax;
-	xmlParserInputPtr *oldinputTab;
-	xmlParserInputPtr input = NULL;
-	xmlCharEncoding enc;
-	int oldcharset;
-	const xmlChar *oldencoding;
-
-	/*
-	 * Ask the Entity resolver to load the damn thing
-	 */
-	if ((ctxt->sax != NULL) && (ctxt->sax->resolveEntity != NULL))
-	    input = ctxt->sax->resolveEntity(ctxt->userData, ExternalID,
-	                                        SystemID);
-	if (input == NULL) {
-	    return;
-	}
-
-	xmlNewDtd(ctxt->myDoc, name, ExternalID, SystemID);
-
-	/*
-	 * make sure we won't destroy the main document context
-	 */
-	oldinput = ctxt->input;
-	oldinputNr = ctxt->inputNr;
-	oldinputMax = ctxt->inputMax;
-	oldinputTab = ctxt->inputTab;
-	oldcharset = ctxt->charset;
-	oldencoding = ctxt->encoding;
-	ctxt->encoding = NULL;
-
-	ctxt->inputTab = (xmlParserInputPtr *)
-	                 xmlMalloc(5 * sizeof(xmlParserInputPtr));
-	if (ctxt->inputTab == NULL) {
-	    xmlSAX2ErrMemory(ctxt, "xmlSAX2ExternalSubset");
-	    ctxt->input = oldinput;
-	    ctxt->inputNr = oldinputNr;
-	    ctxt->inputMax = oldinputMax;
-	    ctxt->inputTab = oldinputTab;
-	    ctxt->charset = oldcharset;
-	    ctxt->encoding = oldencoding;
-	    return;
-	}
-	ctxt->inputNr = 0;
-	ctxt->inputMax = 5;
-	ctxt->input = NULL;
-	xmlPushInput(ctxt, input);
-
-	/*
-	 * On the fly encoding conversion if needed
-	 */
-	if (ctxt->input->length >= 4) {
-	    enc = xmlDetectCharEncoding(ctxt->input->cur, 4);
-	    xmlSwitchEncoding(ctxt, enc);
-	}
-
-	if (input->filename == NULL)
-	    input->filename = (char *) xmlCanonicPath(SystemID);
-	input->line = 1;
-	input->col = 1;
-	input->base = ctxt->input->cur;
-	input->cur = ctxt->input->cur;
-	input->free = NULL;
-
-	/*
-	 * let's parse that entity knowing it's an external subset.
-	 */
-	xmlParseExternalSubset(ctxt, ExternalID, SystemID);
+         (ctxt->wellFormed && ctxt->myDoc))) {
+        /*
+         * Try to fetch and parse the external subset.
+         */
+        xmlParserInputPtr oldinput;
+        int oldinputNr;
+        int oldinputMax;
+        xmlParserInputPtr *oldinputTab;
+        xmlParserInputPtr input = NULL;
+        xmlCharEncoding enc;
+        int oldcharset;
+        const xmlChar *oldencoding;
 
         /*
-	 * Free up the external entities
-	 */
+         * Ask the Entity resolver to load the damn thing
+         */
+        if ((ctxt->sax != NULL) && (ctxt->sax->resolveEntity != NULL))
+            input = ctxt->sax->resolveEntity(ctxt->userData, ExternalID,
+                                                SystemID);
+        if (input == NULL) {
+            return;
+        }
 
-	while (ctxt->inputNr > 1)
-	    xmlPopInput(ctxt);
-	xmlFreeInputStream(ctxt->input);
+        xmlNewDtd(ctxt->myDoc, name, ExternalID, SystemID);
+
+        /*
+         * make sure we won't destroy the main document context
+         */
+        oldinput = ctxt->input;
+        oldinputNr = ctxt->inputNr;
+        oldinputMax = ctxt->inputMax;
+        oldinputTab = ctxt->inputTab;
+        oldcharset = ctxt->charset;
+        oldencoding = ctxt->encoding;
+        ctxt->encoding = NULL;
+
+        ctxt->inputTab = (xmlParserInputPtr *)
+                         xmlMalloc(5 * sizeof(xmlParserInputPtr));
+        if (ctxt->inputTab == NULL) {
+            xmlSAX2ErrMemory(ctxt, "xmlSAX2ExternalSubset");
+            ctxt->input = oldinput;
+            ctxt->inputNr = oldinputNr;
+            ctxt->inputMax = oldinputMax;
+            ctxt->inputTab = oldinputTab;
+            ctxt->charset = oldcharset;
+            ctxt->encoding = oldencoding;
+            return;
+        }
+        ctxt->inputNr = 0;
+        ctxt->inputMax = 5;
+        ctxt->input = NULL;
+        xmlPushInput(ctxt, input);
+
+        /*
+         * On the fly encoding conversion if needed
+         */
+        if (ctxt->input->length >= 4) {
+            enc = xmlDetectCharEncoding(ctxt->input->cur, 4);
+            xmlSwitchEncoding(ctxt, enc);
+        }
+
+        if (input->filename == NULL)
+            input->filename = (char *) xmlCanonicPath(SystemID);
+        input->line = 1;
+        input->col = 1;
+        input->base = ctxt->input->cur;
+        input->cur = ctxt->input->cur;
+        input->free = NULL;
+
+        /*
+         * let's parse that entity knowing it's an external subset.
+         */
+        xmlParseExternalSubset(ctxt, ExternalID, SystemID);
+
+        /*
+         * Free up the external entities
+         */
+
+        while (ctxt->inputNr > 1)
+            xmlPopInput(ctxt);
+        xmlFreeInputStream(ctxt->input);
         xmlFree(ctxt->inputTab);
 
-	/*
-	 * Restore the parsing context of the main entity
-	 */
-	ctxt->input = oldinput;
-	ctxt->inputNr = oldinputNr;
-	ctxt->inputMax = oldinputMax;
-	ctxt->inputTab = oldinputTab;
-	ctxt->charset = oldcharset;
-	if ((ctxt->encoding != NULL) &&
-	    ((ctxt->dict == NULL) ||
-	     (!xmlDictOwns(ctxt->dict, ctxt->encoding))))
-	    xmlFree((xmlChar *) ctxt->encoding);
-	ctxt->encoding = oldencoding;
-	/* ctxt->wellFormed = oldwellFormed; */
+        /*
+         * Restore the parsing context of the main entity
+         */
+        ctxt->input = oldinput;
+        ctxt->inputNr = oldinputNr;
+        ctxt->inputMax = oldinputMax;
+        ctxt->inputTab = oldinputTab;
+        ctxt->charset = oldcharset;
+        if ((ctxt->encoding != NULL) &&
+            ((ctxt->dict == NULL) ||
+             (!xmlDictOwns(ctxt->dict, ctxt->encoding))))
+            xmlFree((xmlChar *) ctxt->encoding);
+        ctxt->encoding = oldencoding;
+        /* ctxt->wellFormed = oldwellFormed; */
     }
 }
 
@@ -495,21 +495,21 @@ xmlSAX2ResolveEntity(void *ctx, const xmlChar *publicId, const xmlChar *systemId
 
     if (ctx == NULL) return(NULL);
     if (ctxt->input != NULL)
-	base = ctxt->input->filename;
+        base = ctxt->input->filename;
     if (base == NULL)
-	base = ctxt->directory;
+        base = ctxt->directory;
 
     URI = xmlBuildURI(systemId, (const xmlChar *) base);
 
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-	    "SAX.xmlSAX2ResolveEntity(%s, %s)\n", publicId, systemId);
+            "SAX.xmlSAX2ResolveEntity(%s, %s)\n", publicId, systemId);
 #endif
 
     ret = xmlLoadExternalEntity((const char *) URI,
-				(const char *) publicId, ctxt);
+                                (const char *) publicId, ctxt);
     if (URI != NULL)
-	xmlFree(URI);
+        xmlFree(URI);
     return(ret);
 }
 
@@ -531,34 +531,34 @@ xmlSAX2GetEntity(void *ctx, const xmlChar *name)
     if (ctx == NULL) return(NULL);
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-	    "SAX.xmlSAX2GetEntity(%s)\n", name);
+            "SAX.xmlSAX2GetEntity(%s)\n", name);
 #endif
 
     if (ctxt->inSubset == 0) {
-	ret = xmlGetPredefinedEntity(name);
-	if (ret != NULL)
-	    return(ret);
+        ret = xmlGetPredefinedEntity(name);
+        if (ret != NULL)
+            return(ret);
     }
     if ((ctxt->myDoc != NULL) && (ctxt->myDoc->standalone == 1)) {
-	if (ctxt->inSubset == 2) {
-	    ctxt->myDoc->standalone = 0;
-	    ret = xmlGetDocEntity(ctxt->myDoc, name);
-	    ctxt->myDoc->standalone = 1;
-	} else {
-	    ret = xmlGetDocEntity(ctxt->myDoc, name);
-	    if (ret == NULL) {
-		ctxt->myDoc->standalone = 0;
-		ret = xmlGetDocEntity(ctxt->myDoc, name);
-		if (ret != NULL) {
-		    xmlFatalErrMsg(ctxt, XML_ERR_NOT_STANDALONE,
-	 "Entity(%s) document marked standalone but requires external subset\n",
-				   name, NULL);
-		}
-		ctxt->myDoc->standalone = 1;
-	    }
-	}
+        if (ctxt->inSubset == 2) {
+            ctxt->myDoc->standalone = 0;
+            ret = xmlGetDocEntity(ctxt->myDoc, name);
+            ctxt->myDoc->standalone = 1;
+        } else {
+            ret = xmlGetDocEntity(ctxt->myDoc, name);
+            if (ret == NULL) {
+                ctxt->myDoc->standalone = 0;
+                ret = xmlGetDocEntity(ctxt->myDoc, name);
+                if (ret != NULL) {
+                    xmlFatalErrMsg(ctxt, XML_ERR_NOT_STANDALONE,
+         "Entity(%s) document marked standalone but requires external subset\n",
+                                   name, NULL);
+                }
+                ctxt->myDoc->standalone = 1;
+            }
+        }
     } else {
-	ret = xmlGetDocEntity(ctxt->myDoc, name);
+        ret = xmlGetDocEntity(ctxt->myDoc, name);
     }
     return(ret);
 }
@@ -581,7 +581,7 @@ xmlSAX2GetParameterEntity(void *ctx, const xmlChar *name)
     if (ctx == NULL) return(NULL);
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-	    "SAX.xmlSAX2GetParameterEntity(%s)\n", name);
+            "SAX.xmlSAX2GetParameterEntity(%s)\n", name);
 #endif
 
     ret = xmlGetParameterEntity(ctxt->myDoc, name);
@@ -610,51 +610,51 @@ xmlSAX2EntityDecl(void *ctx, const xmlChar *name, int type,
     if (ctx == NULL) return;
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-	    "SAX.xmlSAX2EntityDecl(%s, %d, %s, %s, %s)\n",
+            "SAX.xmlSAX2EntityDecl(%s, %d, %s, %s, %s)\n",
             name, type, publicId, systemId, content);
 #endif
     if (ctxt->inSubset == 1) {
-	ent = xmlAddDocEntity(ctxt->myDoc, name, type, publicId,
-		              systemId, content);
-	if ((ent == NULL) && (ctxt->pedantic))
-	    xmlWarnMsg(ctxt, XML_WAR_ENTITY_REDEFINED,
-	     "Entity(%s) already defined in the internal subset\n",
-	               name);
-	if ((ent != NULL) && (ent->URI == NULL) && (systemId != NULL)) {
-	    xmlChar *URI;
-	    const char *base = NULL;
+        ent = xmlAddDocEntity(ctxt->myDoc, name, type, publicId,
+                              systemId, content);
+        if ((ent == NULL) && (ctxt->pedantic))
+            xmlWarnMsg(ctxt, XML_WAR_ENTITY_REDEFINED,
+             "Entity(%s) already defined in the internal subset\n",
+                       name);
+        if ((ent != NULL) && (ent->URI == NULL) && (systemId != NULL)) {
+            xmlChar *URI;
+            const char *base = NULL;
 
-	    if (ctxt->input != NULL)
-		base = ctxt->input->filename;
-	    if (base == NULL)
-		base = ctxt->directory;
+            if (ctxt->input != NULL)
+                base = ctxt->input->filename;
+            if (base == NULL)
+                base = ctxt->directory;
 
-	    URI = xmlBuildURI(systemId, (const xmlChar *) base);
-	    ent->URI = URI;
-	}
+            URI = xmlBuildURI(systemId, (const xmlChar *) base);
+            ent->URI = URI;
+        }
     } else if (ctxt->inSubset == 2) {
-	ent = xmlAddDtdEntity(ctxt->myDoc, name, type, publicId,
-		              systemId, content);
-	if ((ent == NULL) && (ctxt->pedantic) &&
-	    (ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
-	    ctxt->sax->warning(ctxt->userData,
-	     "Entity(%s) already defined in the external subset\n", name);
-	if ((ent != NULL) && (ent->URI == NULL) && (systemId != NULL)) {
-	    xmlChar *URI;
-	    const char *base = NULL;
+        ent = xmlAddDtdEntity(ctxt->myDoc, name, type, publicId,
+                              systemId, content);
+        if ((ent == NULL) && (ctxt->pedantic) &&
+            (ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
+            ctxt->sax->warning(ctxt->userData,
+             "Entity(%s) already defined in the external subset\n", name);
+        if ((ent != NULL) && (ent->URI == NULL) && (systemId != NULL)) {
+            xmlChar *URI;
+            const char *base = NULL;
 
-	    if (ctxt->input != NULL)
-		base = ctxt->input->filename;
-	    if (base == NULL)
-		base = ctxt->directory;
+            if (ctxt->input != NULL)
+                base = ctxt->input->filename;
+            if (base == NULL)
+                base = ctxt->directory;
 
-	    URI = xmlBuildURI(systemId, (const xmlChar *) base);
-	    ent->URI = URI;
-	}
+            URI = xmlBuildURI(systemId, (const xmlChar *) base);
+            ent->URI = URI;
+        }
     } else {
-	xmlFatalErrMsg(ctxt, XML_ERR_ENTITY_PROCESSING,
-	               "SAX.xmlSAX2EntityDecl(%s) called while not in subset\n",
-		       name, NULL);
+        xmlFatalErrMsg(ctxt, XML_ERR_ENTITY_PROCESSING,
+                       "SAX.xmlSAX2EntityDecl(%s) called while not in subset\n",
+                       name, NULL);
     }
 }
 
@@ -673,7 +673,7 @@ xmlSAX2EntityDecl(void *ctx, const xmlChar *name, int type,
 void
 xmlSAX2AttributeDecl(void *ctx, const xmlChar *elem, const xmlChar *fullname,
               int type, int def, const xmlChar *defaultValue,
-	      xmlEnumerationPtr tree)
+              xmlEnumerationPtr tree)
 {
     xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx;
     xmlAttributePtr attr;
@@ -687,50 +687,50 @@ xmlSAX2AttributeDecl(void *ctx, const xmlChar *elem, const xmlChar *fullname,
 
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-	    "SAX.xmlSAX2AttributeDecl(%s, %s, %d, %d, %s, ...)\n",
+            "SAX.xmlSAX2AttributeDecl(%s, %s, %d, %d, %s, ...)\n",
             elem, fullname, type, def, defaultValue);
 #endif
     if ((xmlStrEqual(fullname, BAD_CAST "xml:id")) &&
         (type != XML_ATTRIBUTE_ID)) {
-	/*
-	 * Raise the error but keep the validity flag
-	 */
-	int tmp = ctxt->valid;
-	xmlErrValid(ctxt, XML_DTD_XMLID_TYPE,
-	      "xml:id : attribute type should be ID\n", NULL, NULL);
-	ctxt->valid = tmp;
+        /*
+         * Raise the error but keep the validity flag
+         */
+        int tmp = ctxt->valid;
+        xmlErrValid(ctxt, XML_DTD_XMLID_TYPE,
+              "xml:id : attribute type should be ID\n", NULL, NULL);
+        ctxt->valid = tmp;
     }
     /* TODO: optimize name/prefix allocation */
     name = xmlSplitQName(ctxt, fullname, &prefix);
     ctxt->vctxt.valid = 1;
     if (ctxt->inSubset == 1)
-	attr = xmlAddAttributeDecl(&ctxt->vctxt, ctxt->myDoc->intSubset, elem,
-	       name, prefix, (xmlAttributeType) type,
-	       (xmlAttributeDefault) def, defaultValue, tree);
+        attr = xmlAddAttributeDecl(&ctxt->vctxt, ctxt->myDoc->intSubset, elem,
+               name, prefix, (xmlAttributeType) type,
+               (xmlAttributeDefault) def, defaultValue, tree);
     else if (ctxt->inSubset == 2)
-	attr = xmlAddAttributeDecl(&ctxt->vctxt, ctxt->myDoc->extSubset, elem,
-	   name, prefix, (xmlAttributeType) type,
-	   (xmlAttributeDefault) def, defaultValue, tree);
+        attr = xmlAddAttributeDecl(&ctxt->vctxt, ctxt->myDoc->extSubset, elem,
+           name, prefix, (xmlAttributeType) type,
+           (xmlAttributeDefault) def, defaultValue, tree);
     else {
         xmlFatalErrMsg(ctxt, XML_ERR_INTERNAL_ERROR,
-	     "SAX.xmlSAX2AttributeDecl(%s) called while not in subset\n",
-	               name, NULL);
-	xmlFree(name);
-	xmlFreeEnumeration(tree);
-	return;
+             "SAX.xmlSAX2AttributeDecl(%s) called while not in subset\n",
+                       name, NULL);
+        xmlFree(name);
+        xmlFreeEnumeration(tree);
+        return;
     }
 #ifdef LIBXML_VALID_ENABLED
     if (ctxt->vctxt.valid == 0)
-	ctxt->valid = 0;
+        ctxt->valid = 0;
     if ((attr != NULL) && (ctxt->validate) && (ctxt->wellFormed) &&
         (ctxt->myDoc->intSubset != NULL))
-	ctxt->valid &= xmlValidateAttributeDecl(&ctxt->vctxt, ctxt->myDoc,
-	                                        attr);
+        ctxt->valid &= xmlValidateAttributeDecl(&ctxt->vctxt, ctxt->myDoc,
+                                                attr);
 #endif /* LIBXML_VALID_ENABLED */
     if (prefix != NULL)
-	xmlFree(prefix);
+        xmlFree(prefix);
     if (name != NULL)
-	xmlFree(name);
+        xmlFree(name);
 }
 
 /**
@@ -768,8 +768,8 @@ xmlSAX2ElementDecl(void *ctx, const xmlChar * name, int type,
                                  name, (xmlElementTypeVal) type, content);
     else {
         xmlFatalErrMsg(ctxt, XML_ERR_INTERNAL_ERROR,
-	     "SAX.xmlSAX2ElementDecl(%s) called while not in subset\n",
-	               name, NULL);
+             "SAX.xmlSAX2ElementDecl(%s) called while not in subset\n",
+                       name, NULL);
         return;
     }
 #ifdef LIBXML_VALID_ENABLED
@@ -793,7 +793,7 @@ xmlSAX2ElementDecl(void *ctx, const xmlChar * name, int type,
  */
 void
 xmlSAX2NotationDecl(void *ctx, const xmlChar *name,
-	     const xmlChar *publicId, const xmlChar *systemId)
+             const xmlChar *publicId, const xmlChar *systemId)
 {
     xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx;
     xmlNotationPtr nota = NULL;
@@ -806,32 +806,32 @@ xmlSAX2NotationDecl(void *ctx, const xmlChar *name,
 
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-	    "SAX.xmlSAX2NotationDecl(%s, %s, %s)\n", name, publicId, systemId);
+            "SAX.xmlSAX2NotationDecl(%s, %s, %s)\n", name, publicId, systemId);
 #endif
 
     if ((publicId == NULL) && (systemId == NULL)) {
-	xmlFatalErrMsg(ctxt, XML_ERR_NOTATION_PROCESSING,
-	     "SAX.xmlSAX2NotationDecl(%s) externalID or PublicID missing\n",
-	               name, NULL);
-	return;
+        xmlFatalErrMsg(ctxt, XML_ERR_NOTATION_PROCESSING,
+             "SAX.xmlSAX2NotationDecl(%s) externalID or PublicID missing\n",
+                       name, NULL);
+        return;
     } else if (ctxt->inSubset == 1)
-	nota = xmlAddNotationDecl(&ctxt->vctxt, ctxt->myDoc->intSubset, name,
+        nota = xmlAddNotationDecl(&ctxt->vctxt, ctxt->myDoc->intSubset, name,
                               publicId, systemId);
     else if (ctxt->inSubset == 2)
-	nota = xmlAddNotationDecl(&ctxt->vctxt, ctxt->myDoc->extSubset, name,
+        nota = xmlAddNotationDecl(&ctxt->vctxt, ctxt->myDoc->extSubset, name,
                               publicId, systemId);
     else {
-	xmlFatalErrMsg(ctxt, XML_ERR_NOTATION_PROCESSING,
-	     "SAX.xmlSAX2NotationDecl(%s) called while not in subset\n",
-	               name, NULL);
-	return;
+        xmlFatalErrMsg(ctxt, XML_ERR_NOTATION_PROCESSING,
+             "SAX.xmlSAX2NotationDecl(%s) called while not in subset\n",
+                       name, NULL);
+        return;
     }
 #ifdef LIBXML_VALID_ENABLED
     if (nota == NULL) ctxt->valid = 0;
     if ((ctxt->validate) && (ctxt->wellFormed) &&
         (ctxt->myDoc->intSubset != NULL))
-	ctxt->valid &= xmlValidateNotationDecl(&ctxt->vctxt, ctxt->myDoc,
-	                                       nota);
+        ctxt->valid &= xmlValidateNotationDecl(&ctxt->vctxt, ctxt->myDoc,
+                                               nota);
 #endif /* LIBXML_VALID_ENABLED */
 }
 
@@ -847,61 +847,61 @@ xmlSAX2NotationDecl(void *ctx, const xmlChar *name,
  */
 void
 xmlSAX2UnparsedEntityDecl(void *ctx, const xmlChar *name,
-		   const xmlChar *publicId, const xmlChar *systemId,
-		   const xmlChar *notationName)
+                   const xmlChar *publicId, const xmlChar *systemId,
+                   const xmlChar *notationName)
 {
     xmlEntityPtr ent;
     xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx;
     if (ctx == NULL) return;
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-	    "SAX.xmlSAX2UnparsedEntityDecl(%s, %s, %s, %s)\n",
+            "SAX.xmlSAX2UnparsedEntityDecl(%s, %s, %s, %s)\n",
             name, publicId, systemId, notationName);
 #endif
     if (ctxt->inSubset == 1) {
-	ent = xmlAddDocEntity(ctxt->myDoc, name,
-			XML_EXTERNAL_GENERAL_UNPARSED_ENTITY,
-			publicId, systemId, notationName);
-	if ((ent == NULL) && (ctxt->pedantic) &&
-	    (ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
-	    ctxt->sax->warning(ctxt->userData,
-	     "Entity(%s) already defined in the internal subset\n", name);
-	if ((ent != NULL) && (ent->URI == NULL) && (systemId != NULL)) {
-	    xmlChar *URI;
-	    const char *base = NULL;
+        ent = xmlAddDocEntity(ctxt->myDoc, name,
+                        XML_EXTERNAL_GENERAL_UNPARSED_ENTITY,
+                        publicId, systemId, notationName);
+        if ((ent == NULL) && (ctxt->pedantic) &&
+            (ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
+            ctxt->sax->warning(ctxt->userData,
+             "Entity(%s) already defined in the internal subset\n", name);
+        if ((ent != NULL) && (ent->URI == NULL) && (systemId != NULL)) {
+            xmlChar *URI;
+            const char *base = NULL;
 
-	    if (ctxt->input != NULL)
-		base = ctxt->input->filename;
-	    if (base == NULL)
-		base = ctxt->directory;
+            if (ctxt->input != NULL)
+                base = ctxt->input->filename;
+            if (base == NULL)
+                base = ctxt->directory;
 
-	    URI = xmlBuildURI(systemId, (const xmlChar *) base);
-	    ent->URI = URI;
-	}
+            URI = xmlBuildURI(systemId, (const xmlChar *) base);
+            ent->URI = URI;
+        }
     } else if (ctxt->inSubset == 2) {
-	ent = xmlAddDtdEntity(ctxt->myDoc, name,
-			XML_EXTERNAL_GENERAL_UNPARSED_ENTITY,
-			publicId, systemId, notationName);
-	if ((ent == NULL) && (ctxt->pedantic) &&
-	    (ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
-	    ctxt->sax->warning(ctxt->userData,
-	     "Entity(%s) already defined in the external subset\n", name);
-	if ((ent != NULL) && (ent->URI == NULL) && (systemId != NULL)) {
-	    xmlChar *URI;
-	    const char *base = NULL;
+        ent = xmlAddDtdEntity(ctxt->myDoc, name,
+                        XML_EXTERNAL_GENERAL_UNPARSED_ENTITY,
+                        publicId, systemId, notationName);
+        if ((ent == NULL) && (ctxt->pedantic) &&
+            (ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
+            ctxt->sax->warning(ctxt->userData,
+             "Entity(%s) already defined in the external subset\n", name);
+        if ((ent != NULL) && (ent->URI == NULL) && (systemId != NULL)) {
+            xmlChar *URI;
+            const char *base = NULL;
 
-	    if (ctxt->input != NULL)
-		base = ctxt->input->filename;
-	    if (base == NULL)
-		base = ctxt->directory;
+            if (ctxt->input != NULL)
+                base = ctxt->input->filename;
+            if (base == NULL)
+                base = ctxt->directory;
 
-	    URI = xmlBuildURI(systemId, (const xmlChar *) base);
-	    ent->URI = URI;
-	}
+            URI = xmlBuildURI(systemId, (const xmlChar *) base);
+            ent->URI = URI;
+        }
     } else {
         xmlFatalErrMsg(ctxt, XML_ERR_INTERNAL_ERROR,
-	     "SAX.xmlSAX2UnparsedEntityDecl(%s) called while not in subset\n",
-	               name, NULL);
+             "SAX.xmlSAX2UnparsedEntityDecl(%s) called while not in subset\n",
+                       name, NULL);
     }
 }
 
@@ -919,7 +919,7 @@ xmlSAX2SetDocumentLocator(void *ctx ATTRIBUTE_UNUSED, xmlSAXLocatorPtr loc ATTRI
     /* xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx; */
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-	    "SAX.xmlSAX2SetDocumentLocator()\n");
+            "SAX.xmlSAX2SetDocumentLocator()\n");
 #endif
 }
 
@@ -939,52 +939,52 @@ xmlSAX2StartDocument(void *ctx)
 
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-	    "SAX.xmlSAX2StartDocument()\n");
+            "SAX.xmlSAX2StartDocument()\n");
 #endif
     if (ctxt->html) {
 #ifdef LIBXML_HTML_ENABLED
-	if (ctxt->myDoc == NULL)
-	    ctxt->myDoc = htmlNewDocNoDtD(NULL, NULL);
-	if (ctxt->myDoc == NULL) {
-	    xmlSAX2ErrMemory(ctxt, "xmlSAX2StartDocument");
-	    return;
-	}
-	ctxt->myDoc->properties = XML_DOC_HTML;
-	ctxt->myDoc->parseFlags = ctxt->options;
+        if (ctxt->myDoc == NULL)
+            ctxt->myDoc = htmlNewDocNoDtD(NULL, NULL);
+        if (ctxt->myDoc == NULL) {
+            xmlSAX2ErrMemory(ctxt, "xmlSAX2StartDocument");
+            return;
+        }
+        ctxt->myDoc->properties = XML_DOC_HTML;
+        ctxt->myDoc->parseFlags = ctxt->options;
 #else
         xmlGenericError(xmlGenericErrorContext,
-		"libxml2 built without HTML support\n");
-	ctxt->errNo = XML_ERR_INTERNAL_ERROR;
-	ctxt->instate = XML_PARSER_EOF;
-	ctxt->disableSAX = 1;
-	return;
+                "libxml2 built without HTML support\n");
+        ctxt->errNo = XML_ERR_INTERNAL_ERROR;
+        ctxt->instate = XML_PARSER_EOF;
+        ctxt->disableSAX = 1;
+        return;
 #endif
     } else {
-	doc = ctxt->myDoc = xmlNewDoc(ctxt->version);
-	if (doc != NULL) {
-	    doc->properties = 0;
-	    if (ctxt->options & XML_PARSE_OLD10)
-	        doc->properties |= XML_DOC_OLD10;
-	    doc->parseFlags = ctxt->options;
-	    if (ctxt->encoding != NULL)
-		doc->encoding = xmlStrdup(ctxt->encoding);
-	    else
-		doc->encoding = NULL;
-	    doc->standalone = ctxt->standalone;
-	} else {
-	    xmlSAX2ErrMemory(ctxt, "xmlSAX2StartDocument");
-	    return;
-	}
-	if ((ctxt->dictNames) && (doc != NULL)) {
-	    doc->dict = ctxt->dict;
-	    xmlDictReference(doc->dict);
-	}
+        doc = ctxt->myDoc = xmlNewDoc(ctxt->version);
+        if (doc != NULL) {
+            doc->properties = 0;
+            if (ctxt->options & XML_PARSE_OLD10)
+                doc->properties |= XML_DOC_OLD10;
+            doc->parseFlags = ctxt->options;
+            if (ctxt->encoding != NULL)
+                doc->encoding = xmlStrdup(ctxt->encoding);
+            else
+                doc->encoding = NULL;
+            doc->standalone = ctxt->standalone;
+        } else {
+            xmlSAX2ErrMemory(ctxt, "xmlSAX2StartDocument");
+            return;
+        }
+        if ((ctxt->dictNames) && (doc != NULL)) {
+            doc->dict = ctxt->dict;
+            xmlDictReference(doc->dict);
+        }
     }
     if ((ctxt->myDoc != NULL) && (ctxt->myDoc->URL == NULL) &&
-	(ctxt->input != NULL) && (ctxt->input->filename != NULL)) {
-	ctxt->myDoc->URL = xmlPathToURI((const xmlChar *)ctxt->input->filename);
-	if (ctxt->myDoc->URL == NULL)
-	    xmlSAX2ErrMemory(ctxt, "xmlSAX2StartDocument");
+        (ctxt->input != NULL) && (ctxt->input->filename != NULL)) {
+        ctxt->myDoc->URL = xmlPathToURI((const xmlChar *)ctxt->input->filename);
+        if (ctxt->myDoc->URL == NULL)
+            xmlSAX2ErrMemory(ctxt, "xmlSAX2StartDocument");
     }
 }
 
@@ -1000,32 +1000,32 @@ xmlSAX2EndDocument(void *ctx)
     xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx;
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-	    "SAX.xmlSAX2EndDocument()\n");
+            "SAX.xmlSAX2EndDocument()\n");
 #endif
     if (ctx == NULL) return;
 #ifdef LIBXML_VALID_ENABLED
     if (ctxt->validate && ctxt->wellFormed &&
         ctxt->myDoc && ctxt->myDoc->intSubset)
-	ctxt->valid &= xmlValidateDocumentFinal(&ctxt->vctxt, ctxt->myDoc);
+        ctxt->valid &= xmlValidateDocumentFinal(&ctxt->vctxt, ctxt->myDoc);
 #endif /* LIBXML_VALID_ENABLED */
 
     /*
      * Grab the encoding if it was added on-the-fly
      */
     if ((ctxt->encoding != NULL) && (ctxt->myDoc != NULL) &&
-	(ctxt->myDoc->encoding == NULL)) {
-	ctxt->myDoc->encoding = ctxt->encoding;
-	ctxt->encoding = NULL;
+        (ctxt->myDoc->encoding == NULL)) {
+        ctxt->myDoc->encoding = ctxt->encoding;
+        ctxt->encoding = NULL;
     }
     if ((ctxt->inputTab != NULL) &&
         (ctxt->inputNr > 0) && (ctxt->inputTab[0] != NULL) &&
         (ctxt->inputTab[0]->encoding != NULL) && (ctxt->myDoc != NULL) &&
-	(ctxt->myDoc->encoding == NULL)) {
-	ctxt->myDoc->encoding = xmlStrdup(ctxt->inputTab[0]->encoding);
+        (ctxt->myDoc->encoding == NULL)) {
+        ctxt->myDoc->encoding = xmlStrdup(ctxt->inputTab[0]->encoding);
     }
     if ((ctxt->charset != XML_CHAR_ENCODING_NONE) && (ctxt->myDoc != NULL) &&
-	(ctxt->myDoc->charset == XML_CHAR_ENCODING_NONE)) {
-	ctxt->myDoc->charset = ctxt->charset;
+        (ctxt->myDoc->charset == XML_CHAR_ENCODING_NONE)) {
+        ctxt->myDoc->charset = ctxt->charset;
     }
 }
 
@@ -1046,13 +1046,13 @@ xmlNsErrMsg(xmlParserCtxtPtr ctxt, xmlParserErrors error,
 {
     if ((ctxt != NULL) && (ctxt->disableSAX != 0) &&
         (ctxt->instate == XML_PARSER_EOF))
-	return;
+        return;
     if (ctxt != NULL)
-	ctxt->errNo = error;
+        ctxt->errNo = error;
     __xmlRaiseError(NULL, NULL, NULL, ctxt, NULL, XML_FROM_NAMESPACE, error,
                     XML_ERR_ERROR, NULL, 0,
-		    (const char *) str1, (const char *) str2,
-		    NULL, 0, 0, msg, str1, str2);
+                    (const char *) str1, (const char *) str2,
+                    NULL, 0, 0, msg, str1, str2);
 }
 
 /**
@@ -1079,36 +1079,36 @@ xmlSAX2AttributeInternal(void *ctx, const xmlChar *fullname,
     xmlNsPtr namespace;
 
     if (ctxt->html) {
-	name = xmlStrdup(fullname);
-	ns = NULL;
-	namespace = NULL;
+        name = xmlStrdup(fullname);
+        ns = NULL;
+        namespace = NULL;
     } else {
-	/*
-	 * Split the full name into a namespace prefix and the tag name
-	 */
-	name = xmlSplitQName(ctxt, fullname, &ns);
-	if ((name != NULL) && (name[0] == 0)) {
-	    if (xmlStrEqual(ns, BAD_CAST "xmlns")) {
-		xmlNsErrMsg(ctxt, XML_ERR_NS_DECL_ERROR,
-			    "invalid namespace declaration '%s'\n",
-			    fullname, NULL);
-	    } else {
-		xmlNsWarnMsg(ctxt, XML_WAR_NS_COLUMN,
-			     "Avoid attribute ending with ':' like '%s'\n",
-			     fullname, NULL);
-	    }
-	    if (ns != NULL)
-		xmlFree(ns);
-	    ns = NULL;
-	    xmlFree(name);
-	    name = xmlStrdup(fullname);
-	}
+        /*
+         * Split the full name into a namespace prefix and the tag name
+         */
+        name = xmlSplitQName(ctxt, fullname, &ns);
+        if ((name != NULL) && (name[0] == 0)) {
+            if (xmlStrEqual(ns, BAD_CAST "xmlns")) {
+                xmlNsErrMsg(ctxt, XML_ERR_NS_DECL_ERROR,
+                            "invalid namespace declaration '%s'\n",
+                            fullname, NULL);
+            } else {
+                xmlNsWarnMsg(ctxt, XML_WAR_NS_COLUMN,
+                             "Avoid attribute ending with ':' like '%s'\n",
+                             fullname, NULL);
+            }
+            if (ns != NULL)
+                xmlFree(ns);
+            ns = NULL;
+            xmlFree(name);
+            name = xmlStrdup(fullname);
+        }
     }
     if (name == NULL) {
         xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
-	if (ns != NULL)
-	    xmlFree(ns);
-	return;
+        if (ns != NULL)
+            xmlFree(ns);
+        return;
     }
 
 #ifdef LIBXML_HTML_ENABLED
@@ -1145,145 +1145,145 @@ xmlSAX2AttributeInternal(void *ctx, const xmlChar *fullname,
     if ((!ctxt->html) && (ns == NULL) &&
         (name[0] == 'x') && (name[1] == 'm') && (name[2] == 'l') &&
         (name[3] == 'n') && (name[4] == 's') && (name[5] == 0)) {
-	xmlNsPtr nsret;
-	xmlChar *val;
+        xmlNsPtr nsret;
+        xmlChar *val;
 
         /* Avoid unused variable warning if features are disabled. */
         (void) nsret;
 
         if (!ctxt->replaceEntities) {
-	    ctxt->depth++;
-	    val = xmlStringDecodeEntities(ctxt, value, XML_SUBSTITUTE_REF,
-		                          0,0,0);
-	    ctxt->depth--;
-	    if (val == NULL) {
-	        xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
-		if (name != NULL)
-		    xmlFree(name);
+            ctxt->depth++;
+            val = xmlStringDecodeEntities(ctxt, value, XML_SUBSTITUTE_REF,
+                                          0,0,0);
+            ctxt->depth--;
+            if (val == NULL) {
+                xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
+                if (name != NULL)
+                    xmlFree(name);
                 if (nval != NULL)
                     xmlFree(nval);
-		return;
-	    }
-	} else {
-	    val = (xmlChar *) value;
-	}
+                return;
+            }
+        } else {
+            val = (xmlChar *) value;
+        }
 
-	if (val[0] != 0) {
-	    xmlURIPtr uri;
+        if (val[0] != 0) {
+            xmlURIPtr uri;
 
-	    uri = xmlParseURI((const char *)val);
-	    if (uri == NULL) {
-		if ((ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
-		    ctxt->sax->warning(ctxt->userData,
-			 "xmlns: %s not a valid URI\n", val);
-	    } else {
-		if (uri->scheme == NULL) {
-		    if ((ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
-			ctxt->sax->warning(ctxt->userData,
-			     "xmlns: URI %s is not absolute\n", val);
-		}
-		xmlFreeURI(uri);
-	    }
-	}
+            uri = xmlParseURI((const char *)val);
+            if (uri == NULL) {
+                if ((ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
+                    ctxt->sax->warning(ctxt->userData,
+                         "xmlns: %s not a valid URI\n", val);
+            } else {
+                if (uri->scheme == NULL) {
+                    if ((ctxt->sax != NULL) && (ctxt->sax->warning != NULL))
+                        ctxt->sax->warning(ctxt->userData,
+                             "xmlns: URI %s is not absolute\n", val);
+                }
+                xmlFreeURI(uri);
+            }
+        }
 
-	/* a default namespace definition */
-	nsret = xmlNewNs(ctxt->node, val, NULL);
+        /* a default namespace definition */
+        nsret = xmlNewNs(ctxt->node, val, NULL);
 
 #ifdef LIBXML_VALID_ENABLED
-	/*
-	 * Validate also for namespace decls, they are attributes from
-	 * an XML-1.0 perspective
-	 */
+        /*
+         * Validate also for namespace decls, they are attributes from
+         * an XML-1.0 perspective
+         */
         if (nsret != NULL && ctxt->validate && ctxt->wellFormed &&
-	    ctxt->myDoc && ctxt->myDoc->intSubset)
-	    ctxt->valid &= xmlValidateOneNamespace(&ctxt->vctxt, ctxt->myDoc,
-					   ctxt->node, prefix, nsret, val);
+            ctxt->myDoc && ctxt->myDoc->intSubset)
+            ctxt->valid &= xmlValidateOneNamespace(&ctxt->vctxt, ctxt->myDoc,
+                                           ctxt->node, prefix, nsret, val);
 #endif /* LIBXML_VALID_ENABLED */
-	if (name != NULL)
-	    xmlFree(name);
-	if (nval != NULL)
-	    xmlFree(nval);
-	if (val != value)
-	    xmlFree(val);
-	return;
+        if (name != NULL)
+            xmlFree(name);
+        if (nval != NULL)
+            xmlFree(nval);
+        if (val != value)
+            xmlFree(val);
+        return;
     }
     if ((!ctxt->html) &&
-	(ns != NULL) && (ns[0] == 'x') && (ns[1] == 'm') && (ns[2] == 'l') &&
+        (ns != NULL) && (ns[0] == 'x') && (ns[1] == 'm') && (ns[2] == 'l') &&
         (ns[3] == 'n') && (ns[4] == 's') && (ns[5] == 0)) {
-	xmlNsPtr nsret;
-	xmlChar *val;
+        xmlNsPtr nsret;
+        xmlChar *val;
 
         /* Avoid unused variable warning if features are disabled. */
         (void) nsret;
 
         if (!ctxt->replaceEntities) {
-	    ctxt->depth++;
-	    val = xmlStringDecodeEntities(ctxt, value, XML_SUBSTITUTE_REF,
-		                          0,0,0);
-	    ctxt->depth--;
-	    if (val == NULL) {
-	        xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
-	        xmlFree(ns);
-		if (name != NULL)
-		    xmlFree(name);
+            ctxt->depth++;
+            val = xmlStringDecodeEntities(ctxt, value, XML_SUBSTITUTE_REF,
+                                          0,0,0);
+            ctxt->depth--;
+            if (val == NULL) {
+                xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
+                xmlFree(ns);
+                if (name != NULL)
+                    xmlFree(name);
                 if (nval != NULL)
                     xmlFree(nval);
-		return;
-	    }
-	} else {
-	    val = (xmlChar *) value;
-	}
+                return;
+            }
+        } else {
+            val = (xmlChar *) value;
+        }
 
-	if (val[0] == 0) {
-	    xmlNsErrMsg(ctxt, XML_NS_ERR_EMPTY,
-		        "Empty namespace name for prefix %s\n", name, NULL);
-	}
-	if ((ctxt->pedantic != 0) && (val[0] != 0)) {
-	    xmlURIPtr uri;
+        if (val[0] == 0) {
+            xmlNsErrMsg(ctxt, XML_NS_ERR_EMPTY,
+                        "Empty namespace name for prefix %s\n", name, NULL);
+        }
+        if ((ctxt->pedantic != 0) && (val[0] != 0)) {
+            xmlURIPtr uri;
 
-	    uri = xmlParseURI((const char *)val);
-	    if (uri == NULL) {
-	        xmlNsWarnMsg(ctxt, XML_WAR_NS_URI,
-			 "xmlns:%s: %s not a valid URI\n", name, value);
-	    } else {
-		if (uri->scheme == NULL) {
-		    xmlNsWarnMsg(ctxt, XML_WAR_NS_URI_RELATIVE,
-			   "xmlns:%s: URI %s is not absolute\n", name, value);
-		}
-		xmlFreeURI(uri);
-	    }
-	}
+            uri = xmlParseURI((const char *)val);
+            if (uri == NULL) {
+                xmlNsWarnMsg(ctxt, XML_WAR_NS_URI,
+                         "xmlns:%s: %s not a valid URI\n", name, value);
+            } else {
+                if (uri->scheme == NULL) {
+                    xmlNsWarnMsg(ctxt, XML_WAR_NS_URI_RELATIVE,
+                           "xmlns:%s: URI %s is not absolute\n", name, value);
+                }
+                xmlFreeURI(uri);
+            }
+        }
 
-	/* a standard namespace definition */
-	nsret = xmlNewNs(ctxt->node, val, name);
-	xmlFree(ns);
+        /* a standard namespace definition */
+        nsret = xmlNewNs(ctxt->node, val, name);
+        xmlFree(ns);
 #ifdef LIBXML_VALID_ENABLED
-	/*
-	 * Validate also for namespace decls, they are attributes from
-	 * an XML-1.0 perspective
-	 */
+        /*
+         * Validate also for namespace decls, they are attributes from
+         * an XML-1.0 perspective
+         */
         if (nsret != NULL && ctxt->validate && ctxt->wellFormed &&
-	    ctxt->myDoc && ctxt->myDoc->intSubset)
-	    ctxt->valid &= xmlValidateOneNamespace(&ctxt->vctxt, ctxt->myDoc,
-					   ctxt->node, prefix, nsret, value);
+            ctxt->myDoc && ctxt->myDoc->intSubset)
+            ctxt->valid &= xmlValidateOneNamespace(&ctxt->vctxt, ctxt->myDoc,
+                                           ctxt->node, prefix, nsret, value);
 #endif /* LIBXML_VALID_ENABLED */
-	if (name != NULL)
-	    xmlFree(name);
-	if (nval != NULL)
-	    xmlFree(nval);
-	if (val != value)
-	    xmlFree(val);
-	return;
+        if (name != NULL)
+            xmlFree(name);
+        if (nval != NULL)
+            xmlFree(nval);
+        if (val != value)
+            xmlFree(val);
+        return;
     }
 
     if (ns != NULL) {
-	namespace = xmlSearchNs(ctxt->myDoc, ctxt->node, ns);
+        namespace = xmlSearchNs(ctxt->myDoc, ctxt->node, ns);
 
-	if (namespace == NULL) {
-	    xmlNsErrMsg(ctxt, XML_NS_ERR_UNDEFINED_NAMESPACE,
-		    "Namespace prefix %s of attribute %s is not defined\n",
-		             ns, name);
-	} else {
+        if (namespace == NULL) {
+            xmlNsErrMsg(ctxt, XML_NS_ERR_UNDEFINED_NAMESPACE,
+                    "Namespace prefix %s of attribute %s is not defined\n",
+                             ns, name);
+        } else {
             xmlAttrPtr prop;
 
             prop = ctxt->node->properties;
@@ -1306,7 +1306,7 @@ xmlSAX2AttributeInternal(void *ctx, const xmlChar *fullname,
             }
         }
     } else {
-	namespace = NULL;
+        namespace = NULL;
     }
 
     /* !!!!!! <a toto:arg="" xmlns:toto="http://toto.com"> */
@@ -1314,103 +1314,103 @@ xmlSAX2AttributeInternal(void *ctx, const xmlChar *fullname,
 
     if (ret != NULL) {
         if ((ctxt->replaceEntities == 0) && (!ctxt->html)) {
-	    xmlNodePtr tmp;
+            xmlNodePtr tmp;
 
-	    ret->children = xmlStringGetNodeList(ctxt->myDoc, value);
-	    tmp = ret->children;
-	    while (tmp != NULL) {
-		tmp->parent = (xmlNodePtr) ret;
-		if (tmp->next == NULL)
-		    ret->last = tmp;
-		tmp = tmp->next;
-	    }
-	} else if (value != NULL) {
-	    ret->children = xmlNewDocText(ctxt->myDoc, value);
-	    ret->last = ret->children;
-	    if (ret->children != NULL)
-		ret->children->parent = (xmlNodePtr) ret;
-	}
+            ret->children = xmlStringGetNodeList(ctxt->myDoc, value);
+            tmp = ret->children;
+            while (tmp != NULL) {
+                tmp->parent = (xmlNodePtr) ret;
+                if (tmp->next == NULL)
+                    ret->last = tmp;
+                tmp = tmp->next;
+            }
+        } else if (value != NULL) {
+            ret->children = xmlNewDocText(ctxt->myDoc, value);
+            ret->last = ret->children;
+            if (ret->children != NULL)
+                ret->children->parent = (xmlNodePtr) ret;
+        }
     }
 
 #ifdef LIBXML_VALID_ENABLED
     if ((!ctxt->html) && ctxt->validate && ctxt->wellFormed &&
         ctxt->myDoc && ctxt->myDoc->intSubset) {
 
-	/*
-	 * If we don't substitute entities, the validation should be
-	 * done on a value with replaced entities anyway.
-	 */
+        /*
+         * If we don't substitute entities, the validation should be
+         * done on a value with replaced entities anyway.
+         */
         if (!ctxt->replaceEntities) {
-	    xmlChar *val;
+            xmlChar *val;
 
-	    ctxt->depth++;
-	    val = xmlStringDecodeEntities(ctxt, value, XML_SUBSTITUTE_REF,
-		                          0,0,0);
-	    ctxt->depth--;
+            ctxt->depth++;
+            val = xmlStringDecodeEntities(ctxt, value, XML_SUBSTITUTE_REF,
+                                          0,0,0);
+            ctxt->depth--;
 
-	    if (val == NULL)
-		ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
-				ctxt->myDoc, ctxt->node, ret, value);
-	    else {
-		xmlChar *nvalnorm;
+            if (val == NULL)
+                ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
+                                ctxt->myDoc, ctxt->node, ret, value);
+            else {
+                xmlChar *nvalnorm;
 
-		/*
-		 * Do the last stage of the attribute normalization
-		 * It need to be done twice ... it's an extra burden related
-		 * to the ability to keep xmlSAX2References in attributes
-		 */
-		nvalnorm = xmlValidNormalizeAttributeValue(ctxt->myDoc,
-					    ctxt->node, fullname, val);
-		if (nvalnorm != NULL) {
-		    xmlFree(val);
-		    val = nvalnorm;
-		}
+                /*
+                 * Do the last stage of the attribute normalization
+                 * It need to be done twice ... it's an extra burden related
+                 * to the ability to keep xmlSAX2References in attributes
+                 */
+                nvalnorm = xmlValidNormalizeAttributeValue(ctxt->myDoc,
+                                            ctxt->node, fullname, val);
+                if (nvalnorm != NULL) {
+                    xmlFree(val);
+                    val = nvalnorm;
+                }
 
-		ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
-			        ctxt->myDoc, ctxt->node, ret, val);
+                ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
+                                ctxt->myDoc, ctxt->node, ret, val);
                 xmlFree(val);
-	    }
-	} else {
-	    ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt, ctxt->myDoc,
-					       ctxt->node, ret, value);
-	}
+            }
+        } else {
+            ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt, ctxt->myDoc,
+                                               ctxt->node, ret, value);
+        }
     } else
 #endif /* LIBXML_VALID_ENABLED */
            if (((ctxt->loadsubset & XML_SKIP_IDS) == 0) &&
-	       (((ctxt->replaceEntities == 0) && (ctxt->external != 2)) ||
-	        ((ctxt->replaceEntities != 0) && (ctxt->inSubset == 0))) &&
+               (((ctxt->replaceEntities == 0) && (ctxt->external != 2)) ||
+                ((ctxt->replaceEntities != 0) && (ctxt->inSubset == 0))) &&
                /* Don't create IDs containing entity references */
                (ret->children != NULL) &&
                (ret->children->type == XML_TEXT_NODE) &&
                (ret->children->next == NULL)) {
         xmlChar *content = ret->children->content;
         /*
-	 * when validating, the ID registration is done at the attribute
-	 * validation level. Otherwise we have to do specific handling here.
-	 */
-	if (xmlStrEqual(fullname, BAD_CAST "xml:id")) {
-	    /*
-	     * Add the xml:id value
-	     *
-	     * Open issue: normalization of the value.
-	     */
-	    if (xmlValidateNCName(content, 1) != 0) {
-	        xmlErrValid(ctxt, XML_DTD_XMLID_VALUE,
-		      "xml:id : attribute value %s is not an NCName\n",
-			    (const char *) content, NULL);
-	    }
-	    xmlAddID(&ctxt->vctxt, ctxt->myDoc, content, ret);
-	} else if (xmlIsID(ctxt->myDoc, ctxt->node, ret))
-	    xmlAddID(&ctxt->vctxt, ctxt->myDoc, content, ret);
-	else if (xmlIsRef(ctxt->myDoc, ctxt->node, ret))
-	    xmlAddRef(&ctxt->vctxt, ctxt->myDoc, content, ret);
+         * when validating, the ID registration is done at the attribute
+         * validation level. Otherwise we have to do specific handling here.
+         */
+        if (xmlStrEqual(fullname, BAD_CAST "xml:id")) {
+            /*
+             * Add the xml:id value
+             *
+             * Open issue: normalization of the value.
+             */
+            if (xmlValidateNCName(content, 1) != 0) {
+                xmlErrValid(ctxt, XML_DTD_XMLID_VALUE,
+                      "xml:id : attribute value %s is not an NCName\n",
+                            (const char *) content, NULL);
+            }
+            xmlAddID(&ctxt->vctxt, ctxt->myDoc, content, ret);
+        } else if (xmlIsID(ctxt->myDoc, ctxt->node, ret))
+            xmlAddID(&ctxt->vctxt, ctxt->myDoc, content, ret);
+        else if (xmlIsRef(ctxt->myDoc, ctxt->node, ret))
+            xmlAddRef(&ctxt->vctxt, ctxt->myDoc, content, ret);
     }
 
 error:
     if (nval != NULL)
-	xmlFree(nval);
+        xmlFree(nval);
     if (ns != NULL)
-	xmlFree(ns);
+        xmlFree(ns);
 }
 
 /*
@@ -1420,7 +1420,7 @@ error:
  */
 static void
 xmlCheckDefaultedAttributes(xmlParserCtxtPtr ctxt, const xmlChar *name,
-	const xmlChar *prefix, const xmlChar **atts) {
+        const xmlChar *prefix, const xmlChar **atts) {
     xmlElementPtr elemDecl;
     const xmlChar *att;
     int internal = 1;
@@ -1428,141 +1428,141 @@ xmlCheckDefaultedAttributes(xmlParserCtxtPtr ctxt, const xmlChar *name,
 
     elemDecl = xmlGetDtdQElementDesc(ctxt->myDoc->intSubset, name, prefix);
     if (elemDecl == NULL) {
-	elemDecl = xmlGetDtdQElementDesc(ctxt->myDoc->extSubset, name, prefix);
-	internal = 0;
+        elemDecl = xmlGetDtdQElementDesc(ctxt->myDoc->extSubset, name, prefix);
+        internal = 0;
     }
 
 process_external_subset:
 
     if (elemDecl != NULL) {
-	xmlAttributePtr attr = elemDecl->attributes;
-	/*
-	 * Check against defaulted attributes from the external subset
-	 * if the document is stamped as standalone
-	 */
-	if ((ctxt->myDoc->standalone == 1) &&
-	    (ctxt->myDoc->extSubset != NULL) &&
-	    (ctxt->validate)) {
-	    while (attr != NULL) {
-		if ((attr->defaultValue != NULL) &&
-		    (xmlGetDtdQAttrDesc(ctxt->myDoc->extSubset,
-					attr->elem, attr->name,
-					attr->prefix) == attr) &&
-		    (xmlGetDtdQAttrDesc(ctxt->myDoc->intSubset,
-					attr->elem, attr->name,
-					attr->prefix) == NULL)) {
-		    xmlChar *fulln;
+        xmlAttributePtr attr = elemDecl->attributes;
+        /*
+         * Check against defaulted attributes from the external subset
+         * if the document is stamped as standalone
+         */
+        if ((ctxt->myDoc->standalone == 1) &&
+            (ctxt->myDoc->extSubset != NULL) &&
+            (ctxt->validate)) {
+            while (attr != NULL) {
+                if ((attr->defaultValue != NULL) &&
+                    (xmlGetDtdQAttrDesc(ctxt->myDoc->extSubset,
+                                        attr->elem, attr->name,
+                                        attr->prefix) == attr) &&
+                    (xmlGetDtdQAttrDesc(ctxt->myDoc->intSubset,
+                                        attr->elem, attr->name,
+                                        attr->prefix) == NULL)) {
+                    xmlChar *fulln;
 
-		    if (attr->prefix != NULL) {
-			fulln = xmlStrdup(attr->prefix);
-			fulln = xmlStrcat(fulln, BAD_CAST ":");
-			fulln = xmlStrcat(fulln, attr->name);
-		    } else {
-			fulln = xmlStrdup(attr->name);
-		    }
+                    if (attr->prefix != NULL) {
+                        fulln = xmlStrdup(attr->prefix);
+                        fulln = xmlStrcat(fulln, BAD_CAST ":");
+                        fulln = xmlStrcat(fulln, attr->name);
+                    } else {
+                        fulln = xmlStrdup(attr->name);
+                    }
                     if (fulln == NULL) {
                         xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
                         break;
                     }
 
-		    /*
-		     * Check that the attribute is not declared in the
-		     * serialization
-		     */
-		    att = NULL;
-		    if (atts != NULL) {
-			i = 0;
-			att = atts[i];
-			while (att != NULL) {
-			    if (xmlStrEqual(att, fulln))
-				break;
-			    i += 2;
-			    att = atts[i];
-			}
-		    }
-		    if (att == NULL) {
-		        xmlErrValid(ctxt, XML_DTD_STANDALONE_DEFAULTED,
+                    /*
+                     * Check that the attribute is not declared in the
+                     * serialization
+                     */
+                    att = NULL;
+                    if (atts != NULL) {
+                        i = 0;
+                        att = atts[i];
+                        while (att != NULL) {
+                            if (xmlStrEqual(att, fulln))
+                                break;
+                            i += 2;
+                            att = atts[i];
+                        }
+                    }
+                    if (att == NULL) {
+                        xmlErrValid(ctxt, XML_DTD_STANDALONE_DEFAULTED,
       "standalone: attribute %s on %s defaulted from external subset\n",
-				    (const char *)fulln,
-				    (const char *)attr->elem);
-		    }
+                                    (const char *)fulln,
+                                    (const char *)attr->elem);
+                    }
                     xmlFree(fulln);
-		}
-		attr = attr->nexth;
-	    }
-	}
+                }
+                attr = attr->nexth;
+            }
+        }
 
-	/*
-	 * Actually insert defaulted values when needed
-	 */
-	attr = elemDecl->attributes;
-	while (attr != NULL) {
-	    /*
-	     * Make sure that attributes redefinition occurring in the
-	     * internal subset are not overridden by definitions in the
-	     * external subset.
-	     */
-	    if (attr->defaultValue != NULL) {
-		/*
-		 * the element should be instantiated in the tree if:
-		 *  - this is a namespace prefix
-		 *  - the user required for completion in the tree
-		 *    like XSLT
-		 *  - there isn't already an attribute definition
-		 *    in the internal subset overriding it.
-		 */
-		if (((attr->prefix != NULL) &&
-		     (xmlStrEqual(attr->prefix, BAD_CAST "xmlns"))) ||
-		    ((attr->prefix == NULL) &&
-		     (xmlStrEqual(attr->name, BAD_CAST "xmlns"))) ||
-		    (ctxt->loadsubset & XML_COMPLETE_ATTRS)) {
-		    xmlAttributePtr tst;
+        /*
+         * Actually insert defaulted values when needed
+         */
+        attr = elemDecl->attributes;
+        while (attr != NULL) {
+            /*
+             * Make sure that attributes redefinition occurring in the
+             * internal subset are not overridden by definitions in the
+             * external subset.
+             */
+            if (attr->defaultValue != NULL) {
+                /*
+                 * the element should be instantiated in the tree if:
+                 *  - this is a namespace prefix
+                 *  - the user required for completion in the tree
+                 *    like XSLT
+                 *  - there isn't already an attribute definition
+                 *    in the internal subset overriding it.
+                 */
+                if (((attr->prefix != NULL) &&
+                     (xmlStrEqual(attr->prefix, BAD_CAST "xmlns"))) ||
+                    ((attr->prefix == NULL) &&
+                     (xmlStrEqual(attr->name, BAD_CAST "xmlns"))) ||
+                    (ctxt->loadsubset & XML_COMPLETE_ATTRS)) {
+                    xmlAttributePtr tst;
 
-		    tst = xmlGetDtdQAttrDesc(ctxt->myDoc->intSubset,
-					     attr->elem, attr->name,
-					     attr->prefix);
-		    if ((tst == attr) || (tst == NULL)) {
-		        xmlChar fn[50];
-			xmlChar *fulln;
+                    tst = xmlGetDtdQAttrDesc(ctxt->myDoc->intSubset,
+                                             attr->elem, attr->name,
+                                             attr->prefix);
+                    if ((tst == attr) || (tst == NULL)) {
+                        xmlChar fn[50];
+                        xmlChar *fulln;
 
                         fulln = xmlBuildQName(attr->name, attr->prefix, fn, 50);
-			if (fulln == NULL) {
-			    xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
-			    return;
-			}
+                        if (fulln == NULL) {
+                            xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
+                            return;
+                        }
 
-			/*
-			 * Check that the attribute is not declared in the
-			 * serialization
-			 */
-			att = NULL;
-			if (atts != NULL) {
-			    i = 0;
-			    att = atts[i];
-			    while (att != NULL) {
-				if (xmlStrEqual(att, fulln))
-				    break;
-				i += 2;
-				att = atts[i];
-			    }
-			}
-			if (att == NULL) {
-			    xmlSAX2AttributeInternal(ctxt, fulln,
-						 attr->defaultValue, prefix);
-			}
-			if ((fulln != fn) && (fulln != attr->name))
-			    xmlFree(fulln);
-		    }
-		}
-	    }
-	    attr = attr->nexth;
-	}
-	if (internal == 1) {
-	    elemDecl = xmlGetDtdQElementDesc(ctxt->myDoc->extSubset,
-		                             name, prefix);
-	    internal = 0;
-	    goto process_external_subset;
-	}
+                        /*
+                         * Check that the attribute is not declared in the
+                         * serialization
+                         */
+                        att = NULL;
+                        if (atts != NULL) {
+                            i = 0;
+                            att = atts[i];
+                            while (att != NULL) {
+                                if (xmlStrEqual(att, fulln))
+                                    break;
+                                i += 2;
+                                att = atts[i];
+                            }
+                        }
+                        if (att == NULL) {
+                            xmlSAX2AttributeInternal(ctxt, fulln,
+                                                 attr->defaultValue, prefix);
+                        }
+                        if ((fulln != fn) && (fulln != attr->name))
+                            xmlFree(fulln);
+                    }
+                }
+            }
+            attr = attr->nexth;
+        }
+        if (internal == 1) {
+            elemDecl = xmlGetDtdQElementDesc(ctxt->myDoc->extSubset,
+                                             name, prefix);
+            internal = 0;
+            goto process_external_subset;
+        }
     }
 }
 
@@ -1591,7 +1591,7 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
     parent = ctxt->node;
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-	    "SAX.xmlSAX2StartElement(%s)\n", fullname);
+            "SAX.xmlSAX2StartElement(%s)\n", fullname);
 #endif
 
     /*
@@ -1599,13 +1599,13 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
      */
     if (ctxt->validate && (ctxt->myDoc->extSubset == NULL) &&
         ((ctxt->myDoc->intSubset == NULL) ||
-	 ((ctxt->myDoc->intSubset->notations == NULL) &&
-	  (ctxt->myDoc->intSubset->elements == NULL) &&
-	  (ctxt->myDoc->intSubset->attributes == NULL) &&
-	  (ctxt->myDoc->intSubset->entities == NULL)))) {
-	xmlErrValid(ctxt, XML_ERR_NO_DTD,
-	  "Validation failed: no DTD found !", NULL, NULL);
-	ctxt->validate = 0;
+         ((ctxt->myDoc->intSubset->notations == NULL) &&
+          (ctxt->myDoc->intSubset->elements == NULL) &&
+          (ctxt->myDoc->intSubset->attributes == NULL) &&
+          (ctxt->myDoc->intSubset->entities == NULL)))) {
+        xmlErrValid(ctxt, XML_ERR_NO_DTD,
+          "Validation failed: no DTD found !", NULL, NULL);
+        ctxt->validate = 0;
     }
 
     if (ctxt->html) {
@@ -1626,13 +1626,13 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
     ret = xmlNewDocNodeEatName(ctxt->myDoc, NULL, name, NULL);
     if (ret == NULL) {
         if (prefix != NULL)
-	    xmlFree(prefix);
-	xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
+            xmlFree(prefix);
+        xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElement");
         return;
     }
     if (ctxt->myDoc->children == NULL) {
 #ifdef DEBUG_SAX_TREE
-	xmlGenericError(xmlGenericErrorContext, "Setting %s as root\n", name);
+        xmlGenericError(xmlGenericErrorContext, "Setting %s as root\n", name);
 #endif
         xmlAddChild((xmlNodePtr) ctxt->myDoc, (xmlNodePtr) ret);
     } else if (parent == NULL) {
@@ -1640,12 +1640,12 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
     }
     ctxt->nodemem = -1;
     if (ctxt->linenumbers) {
-	if (ctxt->input != NULL) {
-	    if (ctxt->input->line < USHRT_MAX)
-		ret->line = (unsigned short) ctxt->input->line;
-	    else
-	        ret->line = USHRT_MAX;
-	}
+        if (ctxt->input != NULL) {
+            if (ctxt->input->line < USHRT_MAX)
+                ret->line = (unsigned short) ctxt->input->line;
+            else
+                ret->line = USHRT_MAX;
+        }
     }
 
     /*
@@ -1668,18 +1668,18 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
     if (parent != NULL) {
         if (parent->type == XML_ELEMENT_NODE) {
 #ifdef DEBUG_SAX_TREE
-	    xmlGenericError(xmlGenericErrorContext,
-		    "adding child %s to %s\n", name, parent->name);
+            xmlGenericError(xmlGenericErrorContext,
+                    "adding child %s to %s\n", name, parent->name);
 #endif
-	    xmlAddChild(parent, ret);
-	} else {
+            xmlAddChild(parent, ret);
+        } else {
 #ifdef DEBUG_SAX_TREE
-	    xmlGenericError(xmlGenericErrorContext,
-		    "adding sibling %s to ", name);
-	    xmlDebugDumpOneNode(stderr, parent, 0);
+            xmlGenericError(xmlGenericErrorContext,
+                    "adding sibling %s to ", name);
+            xmlDebugDumpOneNode(stderr, parent, 0);
 #endif
-	    xmlAddSibling(parent, ret);
-	}
+            xmlAddSibling(parent, ret);
+        }
     }
 
     if (!ctxt->html) {
@@ -1699,14 +1699,14 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
             i = 0;
             att = atts[i++];
             value = atts[i++];
-	    while ((att != NULL) && (value != NULL)) {
-		if ((att[0] == 'x') && (att[1] == 'm') && (att[2] == 'l') &&
-		    (att[3] == 'n') && (att[4] == 's'))
-		    xmlSAX2AttributeInternal(ctxt, att, value, prefix);
+            while ((att != NULL) && (value != NULL)) {
+                if ((att[0] == 'x') && (att[1] == 'm') && (att[2] == 'l') &&
+                    (att[3] == 'n') && (att[4] == 's'))
+                    xmlSAX2AttributeInternal(ctxt, att, value, prefix);
 
-		att = atts[i++];
-		value = atts[i++];
-	    }
+                att = atts[i++];
+                value = atts[i++];
+            }
         }
 
         /*
@@ -1737,27 +1737,27 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
      */
     if (atts != NULL) {
         i = 0;
-	att = atts[i++];
-	value = atts[i++];
-	if (ctxt->html) {
-	    while (att != NULL) {
-		xmlSAX2AttributeInternal(ctxt, att, value, NULL);
-		att = atts[i++];
-		value = atts[i++];
-	    }
-	} else {
-	    while ((att != NULL) && (value != NULL)) {
-		if ((att[0] != 'x') || (att[1] != 'm') || (att[2] != 'l') ||
-		    (att[3] != 'n') || (att[4] != 's'))
-		    xmlSAX2AttributeInternal(ctxt, att, value, NULL);
+        att = atts[i++];
+        value = atts[i++];
+        if (ctxt->html) {
+            while (att != NULL) {
+                xmlSAX2AttributeInternal(ctxt, att, value, NULL);
+                att = atts[i++];
+                value = atts[i++];
+            }
+        } else {
+            while ((att != NULL) && (value != NULL)) {
+                if ((att[0] != 'x') || (att[1] != 'm') || (att[2] != 'l') ||
+                    (att[3] != 'n') || (att[4] != 's'))
+                    xmlSAX2AttributeInternal(ctxt, att, value, NULL);
 
-		/*
-		 * Next ones
-		 */
-		att = atts[i++];
-		value = atts[i++];
-	    }
-	}
+                /*
+                 * Next ones
+                 */
+                att = atts[i++];
+                value = atts[i++];
+            }
+        }
     }
 
 #ifdef LIBXML_VALID_ENABLED
@@ -1767,20 +1767,20 @@ xmlSAX2StartElement(void *ctx, const xmlChar *fullname, const xmlChar **atts)
      */
     if ((ctxt->validate) &&
         ((ctxt->vctxt.flags & XML_VCTXT_DTD_VALIDATED) == 0)) {
-	int chk;
+        int chk;
 
-	chk = xmlValidateDtdFinal(&ctxt->vctxt, ctxt->myDoc);
-	if (chk <= 0)
-	    ctxt->valid = 0;
-	if (chk < 0)
-	    ctxt->wellFormed = 0;
-	ctxt->valid &= xmlValidateRoot(&ctxt->vctxt, ctxt->myDoc);
-	ctxt->vctxt.flags |= XML_VCTXT_DTD_VALIDATED;
+        chk = xmlValidateDtdFinal(&ctxt->vctxt, ctxt->myDoc);
+        if (chk <= 0)
+            ctxt->valid = 0;
+        if (chk < 0)
+            ctxt->wellFormed = 0;
+        ctxt->valid &= xmlValidateRoot(&ctxt->vctxt, ctxt->myDoc);
+        ctxt->vctxt.flags |= XML_VCTXT_DTD_VALIDATED;
     }
 #endif /* LIBXML_VALID_ENABLED */
 
     if (prefix != NULL)
-	xmlFree(prefix);
+        xmlFree(prefix);
 
 }
 
@@ -1803,7 +1803,7 @@ xmlSAX2EndElement(void *ctx, const xmlChar *name ATTRIBUTE_UNUSED)
     if (name == NULL)
         xmlGenericError(xmlGenericErrorContext, "SAX.xmlSAX2EndElement(NULL)\n");
     else
-	xmlGenericError(xmlGenericErrorContext, "SAX.xmlSAX2EndElement(%s)\n", name);
+        xmlGenericError(xmlGenericErrorContext, "SAX.xmlSAX2EndElement(%s)\n", name);
 #endif
 
     /* Capture end position and add node */
@@ -1819,7 +1819,7 @@ xmlSAX2EndElement(void *ctx, const xmlChar *name ATTRIBUTE_UNUSED)
     if (ctxt->validate && ctxt->wellFormed &&
         ctxt->myDoc && ctxt->myDoc->intSubset)
         ctxt->valid &= xmlValidateOneElement(&ctxt->vctxt, ctxt->myDoc,
-					     cur);
+                                             cur);
 #endif /* LIBXML_VALID_ENABLED */
 
 
@@ -1852,15 +1852,15 @@ xmlSAX2TextNode(xmlParserCtxtPtr ctxt, const xmlChar *str, int len) {
      * Allocate
      */
     if (ctxt->freeElems != NULL) {
-	ret = ctxt->freeElems;
-	ctxt->freeElems = ret->next;
-	ctxt->freeElemsNr--;
+        ret = ctxt->freeElems;
+        ctxt->freeElems = ret->next;
+        ctxt->freeElemsNr--;
     } else {
-	ret = (xmlNodePtr) xmlMalloc(sizeof(xmlNode));
+        ret = (xmlNodePtr) xmlMalloc(sizeof(xmlNode));
     }
     if (ret == NULL) {
         xmlErrMemory(ctxt, "xmlSAX2Characters");
-	return(NULL);
+        return(NULL);
     }
     memset(ret, 0, sizeof(xmlNode));
     /*
@@ -1870,54 +1870,54 @@ xmlSAX2TextNode(xmlParserCtxtPtr ctxt, const xmlChar *str, int len) {
     if (ctxt->dictNames) {
         xmlChar cur = str[len];
 
-	if ((len < (int) (2 * sizeof(void *))) &&
-	    (ctxt->options & XML_PARSE_COMPACT)) {
-	    /* store the string in the node overriding properties and nsDef */
-	    xmlChar *tmp = (xmlChar *) &(ret->properties);
-	    memcpy(tmp, str, len);
-	    tmp[len] = 0;
-	    intern = tmp;
-	} else if ((len <= 3) && ((cur == '"') || (cur == '\'') ||
-	    ((cur == '<') && (str[len + 1] != '!')))) {
-	    intern = xmlDictLookup(ctxt->dict, str, len);
-	} else if (IS_BLANK_CH(*str) && (len < 60) && (cur == '<') &&
-	           (str[len + 1] != '!')) {
-	    int i;
+        if ((len < (int) (2 * sizeof(void *))) &&
+            (ctxt->options & XML_PARSE_COMPACT)) {
+            /* store the string in the node overriding properties and nsDef */
+            xmlChar *tmp = (xmlChar *) &(ret->properties);
+            memcpy(tmp, str, len);
+            tmp[len] = 0;
+            intern = tmp;
+        } else if ((len <= 3) && ((cur == '"') || (cur == '\'') ||
+            ((cur == '<') && (str[len + 1] != '!')))) {
+            intern = xmlDictLookup(ctxt->dict, str, len);
+        } else if (IS_BLANK_CH(*str) && (len < 60) && (cur == '<') &&
+                   (str[len + 1] != '!')) {
+            int i;
 
-	    for (i = 1;i < len;i++) {
-		if (!IS_BLANK_CH(str[i])) goto skip;
-	    }
-	    intern = xmlDictLookup(ctxt->dict, str, len);
-	}
+            for (i = 1;i < len;i++) {
+                if (!IS_BLANK_CH(str[i])) goto skip;
+            }
+            intern = xmlDictLookup(ctxt->dict, str, len);
+        }
     }
 skip:
     ret->type = XML_TEXT_NODE;
 
     ret->name = xmlStringText;
     if (intern == NULL) {
-	ret->content = xmlStrndup(str, len);
-	if (ret->content == NULL) {
-	    xmlSAX2ErrMemory(ctxt, "xmlSAX2TextNode");
-	    xmlFree(ret);
-	    return(NULL);
-	}
+        ret->content = xmlStrndup(str, len);
+        if (ret->content == NULL) {
+            xmlSAX2ErrMemory(ctxt, "xmlSAX2TextNode");
+            xmlFree(ret);
+            return(NULL);
+        }
     } else
-	ret->content = (xmlChar *) intern;
+        ret->content = (xmlChar *) intern;
 
     if (ctxt->linenumbers) {
-	if (ctxt->input != NULL) {
-	    if (ctxt->input->line < USHRT_MAX)
-		ret->line = (unsigned short) ctxt->input->line;
-	    else {
-	        ret->line = USHRT_MAX;
-		if (ctxt->options & XML_PARSE_BIG_LINES)
-		    ret->psvi = (void *) (ptrdiff_t) ctxt->input->line;
-	    }
-	}
+        if (ctxt->input != NULL) {
+            if (ctxt->input->line < USHRT_MAX)
+                ret->line = (unsigned short) ctxt->input->line;
+            else {
+                ret->line = USHRT_MAX;
+                if (ctxt->options & XML_PARSE_BIG_LINES)
+                    ret->psvi = (void *) (ptrdiff_t) ctxt->input->line;
+            }
+        }
     }
 
     if ((__xmlRegisterCallbacks) && (xmlRegisterNodeDefaultValue))
-	xmlRegisterNodeDefaultValue(ret);
+        xmlRegisterNodeDefaultValue(ret);
     return(ret);
 }
 
@@ -1941,12 +1941,12 @@ xmlSAX2DecodeAttrEntities(xmlParserCtxtPtr ctxt, const xmlChar *str,
     in = str;
     while (in < end)
         if (*in++ == '&')
-	    goto decode;
+            goto decode;
     return(NULL);
 decode:
     ctxt->depth++;
     ret = xmlStringLenDecodeEntities(ctxt, str, end - str,
-				     XML_SUBSTITUTE_REF, 0,0,0);
+                                     XML_SUBSTITUTE_REF, 0,0,0);
     ctxt->depth--;
     return(ret);
 }
@@ -1970,8 +1970,8 @@ static void
 xmlSAX2AttributeNs(xmlParserCtxtPtr ctxt,
                    const xmlChar * localname,
                    const xmlChar * prefix,
-		   const xmlChar * value,
-		   const xmlChar * valueend)
+                   const xmlChar * value,
+                   const xmlChar * valueend)
 {
     xmlAttrPtr ret;
     xmlNsPtr namespace = NULL;
@@ -1981,200 +1981,200 @@ xmlSAX2AttributeNs(xmlParserCtxtPtr ctxt,
      * Note: if prefix == NULL, the attribute is not in the default namespace
      */
     if (prefix != NULL)
-	namespace = xmlSearchNs(ctxt->myDoc, ctxt->node, prefix);
+        namespace = xmlSearchNs(ctxt->myDoc, ctxt->node, prefix);
 
     /*
      * allocate the node
      */
     if (ctxt->freeAttrs != NULL) {
         ret = ctxt->freeAttrs;
-	ctxt->freeAttrs = ret->next;
-	ctxt->freeAttrsNr--;
-	memset(ret, 0, sizeof(xmlAttr));
-	ret->type = XML_ATTRIBUTE_NODE;
+        ctxt->freeAttrs = ret->next;
+        ctxt->freeAttrsNr--;
+        memset(ret, 0, sizeof(xmlAttr));
+        ret->type = XML_ATTRIBUTE_NODE;
 
-	ret->parent = ctxt->node;
-	ret->doc = ctxt->myDoc;
-	ret->ns = namespace;
+        ret->parent = ctxt->node;
+        ret->doc = ctxt->myDoc;
+        ret->ns = namespace;
 
-	if (ctxt->dictNames)
-	    ret->name = localname;
-	else
-	    ret->name = xmlStrdup(localname);
+        if (ctxt->dictNames)
+            ret->name = localname;
+        else
+            ret->name = xmlStrdup(localname);
 
         /* link at the end to preserve order, TODO speed up with a last */
-	if (ctxt->node->properties == NULL) {
-	    ctxt->node->properties = ret;
-	} else {
-	    xmlAttrPtr prev = ctxt->node->properties;
+        if (ctxt->node->properties == NULL) {
+            ctxt->node->properties = ret;
+        } else {
+            xmlAttrPtr prev = ctxt->node->properties;
 
-	    while (prev->next != NULL) prev = prev->next;
-	    prev->next = ret;
-	    ret->prev = prev;
-	}
+            while (prev->next != NULL) prev = prev->next;
+            prev->next = ret;
+            ret->prev = prev;
+        }
 
-	if ((__xmlRegisterCallbacks) && (xmlRegisterNodeDefaultValue))
-	    xmlRegisterNodeDefaultValue((xmlNodePtr)ret);
+        if ((__xmlRegisterCallbacks) && (xmlRegisterNodeDefaultValue))
+            xmlRegisterNodeDefaultValue((xmlNodePtr)ret);
     } else {
-	if (ctxt->dictNames)
-	    ret = xmlNewNsPropEatName(ctxt->node, namespace,
-	                              (xmlChar *) localname, NULL);
-	else
-	    ret = xmlNewNsProp(ctxt->node, namespace, localname, NULL);
-	if (ret == NULL) {
-	    xmlErrMemory(ctxt, "xmlSAX2AttributeNs");
-	    return;
-	}
+        if (ctxt->dictNames)
+            ret = xmlNewNsPropEatName(ctxt->node, namespace,
+                                      (xmlChar *) localname, NULL);
+        else
+            ret = xmlNewNsProp(ctxt->node, namespace, localname, NULL);
+        if (ret == NULL) {
+            xmlErrMemory(ctxt, "xmlSAX2AttributeNs");
+            return;
+        }
     }
 
     if ((ctxt->replaceEntities == 0) && (!ctxt->html)) {
-	xmlNodePtr tmp;
+        xmlNodePtr tmp;
 
-	/*
-	 * We know that if there is an entity reference, then
-	 * the string has been dup'ed and terminates with 0
-	 * otherwise with ' or "
-	 */
-	if (*valueend != 0) {
-	    tmp = xmlSAX2TextNode(ctxt, value, valueend - value);
-	    ret->children = tmp;
-	    ret->last = tmp;
-	    if (tmp != NULL) {
-		tmp->doc = ret->doc;
-		tmp->parent = (xmlNodePtr) ret;
-	    }
-	} else {
-	    ret->children = xmlStringLenGetNodeList(ctxt->myDoc, value,
-						    valueend - value);
-	    tmp = ret->children;
-	    while (tmp != NULL) {
-	        tmp->doc = ret->doc;
-		tmp->parent = (xmlNodePtr) ret;
-		if (tmp->next == NULL)
-		    ret->last = tmp;
-		tmp = tmp->next;
-	    }
-	}
+        /*
+         * We know that if there is an entity reference, then
+         * the string has been dup'ed and terminates with 0
+         * otherwise with ' or "
+         */
+        if (*valueend != 0) {
+            tmp = xmlSAX2TextNode(ctxt, value, valueend - value);
+            ret->children = tmp;
+            ret->last = tmp;
+            if (tmp != NULL) {
+                tmp->doc = ret->doc;
+                tmp->parent = (xmlNodePtr) ret;
+            }
+        } else {
+            ret->children = xmlStringLenGetNodeList(ctxt->myDoc, value,
+                                                    valueend - value);
+            tmp = ret->children;
+            while (tmp != NULL) {
+                tmp->doc = ret->doc;
+                tmp->parent = (xmlNodePtr) ret;
+                if (tmp->next == NULL)
+                    ret->last = tmp;
+                tmp = tmp->next;
+            }
+        }
     } else if (value != NULL) {
-	xmlNodePtr tmp;
+        xmlNodePtr tmp;
 
-	tmp = xmlSAX2TextNode(ctxt, value, valueend - value);
-	ret->children = tmp;
-	ret->last = tmp;
-	if (tmp != NULL) {
-	    tmp->doc = ret->doc;
-	    tmp->parent = (xmlNodePtr) ret;
-	}
+        tmp = xmlSAX2TextNode(ctxt, value, valueend - value);
+        ret->children = tmp;
+        ret->last = tmp;
+        if (tmp != NULL) {
+            tmp->doc = ret->doc;
+            tmp->parent = (xmlNodePtr) ret;
+        }
     }
 
 #ifdef LIBXML_VALID_ENABLED
     if ((!ctxt->html) && ctxt->validate && ctxt->wellFormed &&
         ctxt->myDoc && ctxt->myDoc->intSubset) {
-	/*
-	 * If we don't substitute entities, the validation should be
-	 * done on a value with replaced entities anyway.
-	 */
+        /*
+         * If we don't substitute entities, the validation should be
+         * done on a value with replaced entities anyway.
+         */
         if (!ctxt->replaceEntities) {
-	    dup = xmlSAX2DecodeAttrEntities(ctxt, value, valueend);
-	    if (dup == NULL) {
-	        if (*valueend == 0) {
-		    ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
-				    ctxt->myDoc, ctxt->node, ret, value);
-		} else {
-		    /*
-		     * That should already be normalized.
-		     * cheaper to finally allocate here than duplicate
-		     * entry points in the full validation code
-		     */
-		    dup = xmlStrndup(value, valueend - value);
+            dup = xmlSAX2DecodeAttrEntities(ctxt, value, valueend);
+            if (dup == NULL) {
+                if (*valueend == 0) {
+                    ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
+                                    ctxt->myDoc, ctxt->node, ret, value);
+                } else {
+                    /*
+                     * That should already be normalized.
+                     * cheaper to finally allocate here than duplicate
+                     * entry points in the full validation code
+                     */
+                    dup = xmlStrndup(value, valueend - value);
 
-		    ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
-				    ctxt->myDoc, ctxt->node, ret, dup);
-		}
-	    } else {
-	        /*
-		 * dup now contains a string of the flattened attribute
-		 * content with entities substituted. Check if we need to
-		 * apply an extra layer of normalization.
-		 * It need to be done twice ... it's an extra burden related
-		 * to the ability to keep references in attributes
-		 */
-		if (ctxt->attsSpecial != NULL) {
-		    xmlChar *nvalnorm;
-		    xmlChar fn[50];
-		    xmlChar *fullname;
+                    ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
+                                    ctxt->myDoc, ctxt->node, ret, dup);
+                }
+            } else {
+                /*
+                 * dup now contains a string of the flattened attribute
+                 * content with entities substituted. Check if we need to
+                 * apply an extra layer of normalization.
+                 * It need to be done twice ... it's an extra burden related
+                 * to the ability to keep references in attributes
+                 */
+                if (ctxt->attsSpecial != NULL) {
+                    xmlChar *nvalnorm;
+                    xmlChar fn[50];
+                    xmlChar *fullname;
 
-		    fullname = xmlBuildQName(localname, prefix, fn, 50);
-		    if (fullname != NULL) {
-			ctxt->vctxt.valid = 1;
-		        nvalnorm = xmlValidCtxtNormalizeAttributeValue(
-			                 &ctxt->vctxt, ctxt->myDoc,
-					 ctxt->node, fullname, dup);
-			if (ctxt->vctxt.valid != 1)
-			    ctxt->valid = 0;
+                    fullname = xmlBuildQName(localname, prefix, fn, 50);
+                    if (fullname != NULL) {
+                        ctxt->vctxt.valid = 1;
+                        nvalnorm = xmlValidCtxtNormalizeAttributeValue(
+                                         &ctxt->vctxt, ctxt->myDoc,
+                                         ctxt->node, fullname, dup);
+                        if (ctxt->vctxt.valid != 1)
+                            ctxt->valid = 0;
 
-			if ((fullname != fn) && (fullname != localname))
-			    xmlFree(fullname);
-			if (nvalnorm != NULL) {
-			    xmlFree(dup);
-			    dup = nvalnorm;
-			}
-		    }
-		}
+                        if ((fullname != fn) && (fullname != localname))
+                            xmlFree(fullname);
+                        if (nvalnorm != NULL) {
+                            xmlFree(dup);
+                            dup = nvalnorm;
+                        }
+                    }
+                }
 
-		ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
-			        ctxt->myDoc, ctxt->node, ret, dup);
-	    }
-	} else {
-	    /*
-	     * if entities already have been substituted, then
-	     * the attribute as passed is already normalized
-	     */
-	    dup = xmlStrndup(value, valueend - value);
+                ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
+                                ctxt->myDoc, ctxt->node, ret, dup);
+            }
+        } else {
+            /*
+             * if entities already have been substituted, then
+             * the attribute as passed is already normalized
+             */
+            dup = xmlStrndup(value, valueend - value);
 
-	    ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
-	                             ctxt->myDoc, ctxt->node, ret, dup);
-	}
+            ctxt->valid &= xmlValidateOneAttribute(&ctxt->vctxt,
+                                     ctxt->myDoc, ctxt->node, ret, dup);
+        }
     } else
 #endif /* LIBXML_VALID_ENABLED */
            if (((ctxt->loadsubset & XML_SKIP_IDS) == 0) &&
-	       (((ctxt->replaceEntities == 0) && (ctxt->external != 2)) ||
-	        ((ctxt->replaceEntities != 0) && (ctxt->inSubset == 0))) &&
+               (((ctxt->replaceEntities == 0) && (ctxt->external != 2)) ||
+                ((ctxt->replaceEntities != 0) && (ctxt->inSubset == 0))) &&
                /* Don't create IDs containing entity references */
                (ret->children != NULL) &&
                (ret->children->type == XML_TEXT_NODE) &&
                (ret->children->next == NULL)) {
         xmlChar *content = ret->children->content;
         /*
-	 * when validating, the ID registration is done at the attribute
-	 * validation level. Otherwise we have to do specific handling here.
-	 */
+         * when validating, the ID registration is done at the attribute
+         * validation level. Otherwise we have to do specific handling here.
+         */
         if ((prefix == ctxt->str_xml) &&
-	           (localname[0] == 'i') && (localname[1] == 'd') &&
-		   (localname[2] == 0)) {
-	    /*
-	     * Add the xml:id value
-	     *
-	     * Open issue: normalization of the value.
-	     */
+                   (localname[0] == 'i') && (localname[1] == 'd') &&
+                   (localname[2] == 0)) {
+            /*
+             * Add the xml:id value
+             *
+             * Open issue: normalization of the value.
+             */
 #if defined(LIBXML_SAX1_ENABLED) || defined(LIBXML_HTML_ENABLED) || defined(LIBXML_WRITER_ENABLED) || defined(LIBXML_LEGACY_ENABLED)
 #ifdef LIBXML_VALID_ENABLED
-	    if (xmlValidateNCName(content, 1) != 0) {
-	        xmlErrValid(ctxt, XML_DTD_XMLID_VALUE,
-		      "xml:id : attribute value %s is not an NCName\n",
-			    (const char *) content, NULL);
-	    }
+            if (xmlValidateNCName(content, 1) != 0) {
+                xmlErrValid(ctxt, XML_DTD_XMLID_VALUE,
+                      "xml:id : attribute value %s is not an NCName\n",
+                            (const char *) content, NULL);
+            }
 #endif
 #endif
-	    xmlAddID(&ctxt->vctxt, ctxt->myDoc, content, ret);
-	} else if (xmlIsID(ctxt->myDoc, ctxt->node, ret)) {
-	    xmlAddID(&ctxt->vctxt, ctxt->myDoc, content, ret);
-	} else if (xmlIsRef(ctxt->myDoc, ctxt->node, ret)) {
-	    xmlAddRef(&ctxt->vctxt, ctxt->myDoc, content, ret);
-	}
+            xmlAddID(&ctxt->vctxt, ctxt->myDoc, content, ret);
+        } else if (xmlIsID(ctxt->myDoc, ctxt->node, ret)) {
+            xmlAddID(&ctxt->vctxt, ctxt->myDoc, content, ret);
+        } else if (xmlIsRef(ctxt->myDoc, ctxt->node, ret)) {
+            xmlAddRef(&ctxt->vctxt, ctxt->myDoc, content, ret);
+        }
     }
     if (dup != NULL)
-	xmlFree(dup);
+        xmlFree(dup);
 }
 
 /**
@@ -2197,13 +2197,13 @@ xmlSAX2AttributeNs(xmlParserCtxtPtr ctxt,
 void
 xmlSAX2StartElementNs(void *ctx,
                       const xmlChar *localname,
-		      const xmlChar *prefix,
-		      const xmlChar *URI,
-		      int nb_namespaces,
-		      const xmlChar **namespaces,
-		      int nb_attributes,
-		      int nb_defaulted,
-		      const xmlChar **attributes)
+                      const xmlChar *prefix,
+                      const xmlChar *URI,
+                      int nb_namespaces,
+                      const xmlChar **namespaces,
+                      int nb_attributes,
+                      int nb_defaulted,
+                      const xmlChar **attributes)
 {
     xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx;
     xmlNodePtr ret;
@@ -2220,13 +2220,13 @@ xmlSAX2StartElementNs(void *ctx,
      */
     if (ctxt->validate && (ctxt->myDoc->extSubset == NULL) &&
         ((ctxt->myDoc->intSubset == NULL) ||
-	 ((ctxt->myDoc->intSubset->notations == NULL) &&
-	  (ctxt->myDoc->intSubset->elements == NULL) &&
-	  (ctxt->myDoc->intSubset->attributes == NULL) &&
-	  (ctxt->myDoc->intSubset->entities == NULL)))) {
-	xmlErrValid(ctxt, XML_DTD_NO_DTD,
-	  "Validation failed: no DTD found !", NULL, NULL);
-	ctxt->validate = 0;
+         ((ctxt->myDoc->intSubset->notations == NULL) &&
+          (ctxt->myDoc->intSubset->elements == NULL) &&
+          (ctxt->myDoc->intSubset->attributes == NULL) &&
+          (ctxt->myDoc->intSubset->entities == NULL)))) {
+        xmlErrValid(ctxt, XML_DTD_NO_DTD,
+          "Validation failed: no DTD found !", NULL, NULL);
+        ctxt->validate = 0;
     }
 
     /*
@@ -2234,61 +2234,61 @@ xmlSAX2StartElementNs(void *ctx,
      */
     if ((prefix != NULL) && (URI == NULL)) {
         if (ctxt->dictNames) {
-	    const xmlChar *fullname;
+            const xmlChar *fullname;
 
-	    fullname = xmlDictQLookup(ctxt->dict, prefix, localname);
-	    if (fullname != NULL)
-	        localname = fullname;
-	} else {
-	    lname = xmlBuildQName(localname, prefix, NULL, 0);
-	}
+            fullname = xmlDictQLookup(ctxt->dict, prefix, localname);
+            if (fullname != NULL)
+                localname = fullname;
+        } else {
+            lname = xmlBuildQName(localname, prefix, NULL, 0);
+        }
     }
     /*
      * allocate the node
      */
     if (ctxt->freeElems != NULL) {
         ret = ctxt->freeElems;
-	ctxt->freeElems = ret->next;
-	ctxt->freeElemsNr--;
-	memset(ret, 0, sizeof(xmlNode));
+        ctxt->freeElems = ret->next;
+        ctxt->freeElemsNr--;
+        memset(ret, 0, sizeof(xmlNode));
         ret->doc = ctxt->myDoc;
-	ret->type = XML_ELEMENT_NODE;
+        ret->type = XML_ELEMENT_NODE;
 
-	if (ctxt->dictNames)
-	    ret->name = localname;
-	else {
-	    if (lname == NULL)
-		ret->name = xmlStrdup(localname);
-	    else
-	        ret->name = lname;
-	    if (ret->name == NULL) {
-	        xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElementNs");
-		return;
-	    }
-	}
-	if ((__xmlRegisterCallbacks) && (xmlRegisterNodeDefaultValue))
-	    xmlRegisterNodeDefaultValue(ret);
+        if (ctxt->dictNames)
+            ret->name = localname;
+        else {
+            if (lname == NULL)
+                ret->name = xmlStrdup(localname);
+            else
+                ret->name = lname;
+            if (ret->name == NULL) {
+                xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElementNs");
+                return;
+            }
+        }
+        if ((__xmlRegisterCallbacks) && (xmlRegisterNodeDefaultValue))
+            xmlRegisterNodeDefaultValue(ret);
     } else {
-	if (ctxt->dictNames)
-	    ret = xmlNewDocNodeEatName(ctxt->myDoc, NULL,
-	                               (xmlChar *) localname, NULL);
-	else if (lname == NULL)
-	    ret = xmlNewDocNode(ctxt->myDoc, NULL, localname, NULL);
-	else
-	    ret = xmlNewDocNodeEatName(ctxt->myDoc, NULL,
-	                               (xmlChar *) lname, NULL);
-	if (ret == NULL) {
-	    xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElementNs");
-	    return;
-	}
+        if (ctxt->dictNames)
+            ret = xmlNewDocNodeEatName(ctxt->myDoc, NULL,
+                                       (xmlChar *) localname, NULL);
+        else if (lname == NULL)
+            ret = xmlNewDocNode(ctxt->myDoc, NULL, localname, NULL);
+        else
+            ret = xmlNewDocNodeEatName(ctxt->myDoc, NULL,
+                                       (xmlChar *) lname, NULL);
+        if (ret == NULL) {
+            xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElementNs");
+            return;
+        }
     }
     if (ctxt->linenumbers) {
-	if (ctxt->input != NULL) {
-	    if (ctxt->input->line < USHRT_MAX)
-		ret->line = (unsigned short) ctxt->input->line;
-	    else
-	        ret->line = USHRT_MAX;
-	}
+        if (ctxt->input != NULL) {
+            if (ctxt->input->line < USHRT_MAX)
+                ret->line = (unsigned short) ctxt->input->line;
+            else
+                ret->line = USHRT_MAX;
+        }
     }
 
     if (parent == NULL) {
@@ -2299,31 +2299,31 @@ xmlSAX2StartElementNs(void *ctx,
      */
     for (i = 0,j = 0;j < nb_namespaces;j++) {
         pref = namespaces[i++];
-	uri = namespaces[i++];
-	ns = xmlNewNs(NULL, uri, pref);
-	if (ns != NULL) {
-	    if (last == NULL) {
-	        ret->nsDef = last = ns;
-	    } else {
-	        last->next = ns;
-		last = ns;
-	    }
-	    if ((URI != NULL) && (prefix == pref))
-		ret->ns = ns;
-	} else {
+        uri = namespaces[i++];
+        ns = xmlNewNs(NULL, uri, pref);
+        if (ns != NULL) {
+            if (last == NULL) {
+                ret->nsDef = last = ns;
+            } else {
+                last->next = ns;
+                last = ns;
+            }
+            if ((URI != NULL) && (prefix == pref))
+                ret->ns = ns;
+        } else {
             /*
              * any out of memory error would already have been raised
              * but we can't be guaranteed it's the actual error due to the
              * API, best is to skip in this case
              */
-	    continue;
-	}
+            continue;
+        }
 #ifdef LIBXML_VALID_ENABLED
-	if ((!ctxt->html) && ctxt->validate && ctxt->wellFormed &&
-	    ctxt->myDoc && ctxt->myDoc->intSubset) {
-	    ctxt->valid &= xmlValidateOneNamespace(&ctxt->vctxt, ctxt->myDoc,
-	                                           ret, prefix, ns, uri);
-	}
+        if ((!ctxt->html) && ctxt->validate && ctxt->wellFormed &&
+            ctxt->myDoc && ctxt->myDoc->intSubset) {
+            ctxt->valid &= xmlValidateOneNamespace(&ctxt->vctxt, ctxt->myDoc,
+                                                   ret, prefix, ns, uri);
+        }
 #endif /* LIBXML_VALID_ENABLED */
     }
     ctxt->nodemem = -1;
@@ -2342,10 +2342,10 @@ xmlSAX2StartElementNs(void *ctx,
      */
     if (parent != NULL) {
         if (parent->type == XML_ELEMENT_NODE) {
-	    xmlAddChild(parent, ret);
-	} else {
-	    xmlAddSibling(parent, ret);
-	}
+            xmlAddChild(parent, ret);
+        } else {
+            xmlAddSibling(parent, ret);
+        }
     }
 
     /*
@@ -2353,7 +2353,7 @@ xmlSAX2StartElementNs(void *ctx,
      */
     if ((nb_defaulted != 0) &&
         ((ctxt->loadsubset & XML_COMPLETE_ATTRS) == 0))
-	nb_attributes -= nb_defaulted;
+        nb_attributes -= nb_defaulted;
 
     /*
      * Search the namespace if it wasn't already found
@@ -2361,16 +2361,16 @@ xmlSAX2StartElementNs(void *ctx,
      */
     if ((URI != NULL) && (ret->ns == NULL)) {
         ret->ns = xmlSearchNs(ctxt->myDoc, parent, prefix);
-	if ((ret->ns == NULL) && (xmlStrEqual(prefix, BAD_CAST "xml"))) {
-	    ret->ns = xmlSearchNs(ctxt->myDoc, ret, prefix);
-	}
-	if (ret->ns == NULL) {
-	    ns = xmlNewNs(ret, NULL, prefix);
-	    if (ns == NULL) {
+        if ((ret->ns == NULL) && (xmlStrEqual(prefix, BAD_CAST "xml"))) {
+            ret->ns = xmlSearchNs(ctxt->myDoc, ret, prefix);
+        }
+        if (ret->ns == NULL) {
+            ns = xmlNewNs(ret, NULL, prefix);
+            if (ns == NULL) {
 
-	        xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElementNs");
-		return;
-	    }
+                xmlSAX2ErrMemory(ctxt, "xmlSAX2StartElementNs");
+                return;
+            }
             if (prefix != NULL)
                 xmlNsWarnMsg(ctxt, XML_NS_ERR_UNDEFINED_NAMESPACE,
                              "Namespace prefix %s was not found\n",
@@ -2379,7 +2379,7 @@ xmlSAX2StartElementNs(void *ctx,
                 xmlNsWarnMsg(ctxt, XML_NS_ERR_UNDEFINED_NAMESPACE,
                              "Namespace default prefix was not found\n",
                              NULL, NULL);
-	}
+        }
     }
 
     /*
@@ -2387,34 +2387,34 @@ xmlSAX2StartElementNs(void *ctx,
      */
     if (nb_attributes > 0) {
         for (j = 0,i = 0;i < nb_attributes;i++,j+=5) {
-	    /*
-	     * Handle the rare case of an undefined attribute prefix
-	     */
-	    if ((attributes[j+1] != NULL) && (attributes[j+2] == NULL)) {
-		if (ctxt->dictNames) {
-		    const xmlChar *fullname;
+            /*
+             * Handle the rare case of an undefined attribute prefix
+             */
+            if ((attributes[j+1] != NULL) && (attributes[j+2] == NULL)) {
+                if (ctxt->dictNames) {
+                    const xmlChar *fullname;
 
-		    fullname = xmlDictQLookup(ctxt->dict, attributes[j+1],
-		                              attributes[j]);
-		    if (fullname != NULL) {
-			xmlSAX2AttributeNs(ctxt, fullname, NULL,
-			                   attributes[j+3], attributes[j+4]);
-		        continue;
-		    }
-		} else {
-		    lname = xmlBuildQName(attributes[j], attributes[j+1],
-		                          NULL, 0);
-		    if (lname != NULL) {
-			xmlSAX2AttributeNs(ctxt, lname, NULL,
-			                   attributes[j+3], attributes[j+4]);
-			xmlFree(lname);
-		        continue;
-		    }
-		}
-	    }
-	    xmlSAX2AttributeNs(ctxt, attributes[j], attributes[j+1],
-			       attributes[j+3], attributes[j+4]);
-	}
+                    fullname = xmlDictQLookup(ctxt->dict, attributes[j+1],
+                                              attributes[j]);
+                    if (fullname != NULL) {
+                        xmlSAX2AttributeNs(ctxt, fullname, NULL,
+                                           attributes[j+3], attributes[j+4]);
+                        continue;
+                    }
+                } else {
+                    lname = xmlBuildQName(attributes[j], attributes[j+1],
+                                          NULL, 0);
+                    if (lname != NULL) {
+                        xmlSAX2AttributeNs(ctxt, lname, NULL,
+                                           attributes[j+3], attributes[j+4]);
+                        xmlFree(lname);
+                        continue;
+                    }
+                }
+            }
+            xmlSAX2AttributeNs(ctxt, attributes[j], attributes[j+1],
+                               attributes[j+3], attributes[j+4]);
+        }
     }
 
 #ifdef LIBXML_VALID_ENABLED
@@ -2424,15 +2424,15 @@ xmlSAX2StartElementNs(void *ctx,
      */
     if ((ctxt->validate) &&
         ((ctxt->vctxt.flags & XML_VCTXT_DTD_VALIDATED) == 0)) {
-	int chk;
+        int chk;
 
-	chk = xmlValidateDtdFinal(&ctxt->vctxt, ctxt->myDoc);
-	if (chk <= 0)
-	    ctxt->valid = 0;
-	if (chk < 0)
-	    ctxt->wellFormed = 0;
-	ctxt->valid &= xmlValidateRoot(&ctxt->vctxt, ctxt->myDoc);
-	ctxt->vctxt.flags |= XML_VCTXT_DTD_VALIDATED;
+        chk = xmlValidateDtdFinal(&ctxt->vctxt, ctxt->myDoc);
+        if (chk <= 0)
+            ctxt->valid = 0;
+        if (chk < 0)
+            ctxt->wellFormed = 0;
+        ctxt->valid &= xmlValidateRoot(&ctxt->vctxt, ctxt->myDoc);
+        ctxt->vctxt.flags |= XML_VCTXT_DTD_VALIDATED;
     }
 #endif /* LIBXML_VALID_ENABLED */
 }
@@ -2451,7 +2451,7 @@ void
 xmlSAX2EndElementNs(void *ctx,
                     const xmlChar * localname ATTRIBUTE_UNUSED,
                     const xmlChar * prefix ATTRIBUTE_UNUSED,
-		    const xmlChar * URI ATTRIBUTE_UNUSED)
+                    const xmlChar * URI ATTRIBUTE_UNUSED)
 {
     xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx;
     xmlParserNodeInfo node_info;
@@ -2496,15 +2496,15 @@ xmlSAX2Reference(void *ctx, const xmlChar *name)
     if (ctx == NULL) return;
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-	    "SAX.xmlSAX2Reference(%s)\n", name);
+            "SAX.xmlSAX2Reference(%s)\n", name);
 #endif
     if (name[0] == '#')
-	ret = xmlNewCharRef(ctxt->myDoc, name);
+        ret = xmlNewCharRef(ctxt->myDoc, name);
     else
-	ret = xmlNewReference(ctxt->myDoc, name);
+        ret = xmlNewReference(ctxt->myDoc, name);
 #ifdef DEBUG_SAX_TREE
     xmlGenericError(xmlGenericErrorContext,
-	    "add xmlSAX2Reference %s to %s \n", name, ctxt->node->name);
+            "add xmlSAX2Reference %s to %s \n", name, ctxt->node->name);
 #endif
     if (xmlAddChild(ctxt->node, ret) == NULL) {
         xmlFreeNode(ret);
@@ -2529,7 +2529,7 @@ xmlSAX2Text(xmlParserCtxtPtr ctxt, const xmlChar *ch, int len,
     if (ctxt == NULL) return;
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-	    "SAX.xmlSAX2Characters(%.30s, %d)\n", ch, len);
+            "SAX.xmlSAX2Characters(%.30s, %d)\n", ch, len);
 #endif
     /*
      * Handle the data if any. If there is no child
@@ -2539,15 +2539,15 @@ xmlSAX2Text(xmlParserCtxtPtr ctxt, const xmlChar *ch, int len,
 
     if (ctxt->node == NULL) {
 #ifdef DEBUG_SAX_TREE
-	xmlGenericError(xmlGenericErrorContext,
-		"add chars: ctxt->node == NULL !\n");
+        xmlGenericError(xmlGenericErrorContext,
+                "add chars: ctxt->node == NULL !\n");
 #endif
         return;
     }
     lastChild = ctxt->node->last;
 #ifdef DEBUG_SAX_TREE
     xmlGenericError(xmlGenericErrorContext,
-	    "add chars to %s \n", ctxt->node->name);
+            "add chars to %s \n", ctxt->node->name);
 #endif
 
     /*
@@ -2559,92 +2559,92 @@ xmlSAX2Text(xmlParserCtxtPtr ctxt, const xmlChar *ch, int len,
             lastChild = xmlSAX2TextNode(ctxt, ch, len);
         else
             lastChild = xmlNewCDataBlock(ctxt->myDoc, ch, len);
-	if (lastChild != NULL) {
-	    ctxt->node->children = lastChild;
-	    ctxt->node->last = lastChild;
-	    lastChild->parent = ctxt->node;
-	    lastChild->doc = ctxt->node->doc;
-	    ctxt->nodelen = len;
-	    ctxt->nodemem = len + 1;
-	} else {
-	    xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters");
-	    return;
-	}
+        if (lastChild != NULL) {
+            ctxt->node->children = lastChild;
+            ctxt->node->last = lastChild;
+            lastChild->parent = ctxt->node;
+            lastChild->doc = ctxt->node->doc;
+            ctxt->nodelen = len;
+            ctxt->nodemem = len + 1;
+        } else {
+            xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters");
+            return;
+        }
     } else {
-	int coalesceText = (lastChild != NULL) &&
-	    (lastChild->type == type) &&
-	    ((type != XML_TEXT_NODE) ||
+        int coalesceText = (lastChild != NULL) &&
+            (lastChild->type == type) &&
+            ((type != XML_TEXT_NODE) ||
              (lastChild->name == xmlStringText));
-	if ((coalesceText) && (ctxt->nodemem != 0)) {
-	    /*
-	     * The whole point of maintaining nodelen and nodemem,
-	     * xmlTextConcat is too costly, i.e. compute length,
-	     * reallocate a new buffer, move data, append ch. Here
-	     * We try to minimize realloc() uses and avoid copying
-	     * and recomputing length over and over.
-	     */
-	    if (lastChild->content == (xmlChar *)&(lastChild->properties)) {
-		lastChild->content = xmlStrdup(lastChild->content);
-		lastChild->properties = NULL;
-	    } else if ((ctxt->nodemem == ctxt->nodelen + 1) &&
-	               (xmlDictOwns(ctxt->dict, lastChild->content))) {
-		lastChild->content = xmlStrdup(lastChild->content);
-	    }
-	    if (lastChild->content == NULL) {
-		xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters: xmlStrdup returned NULL");
-		return;
- 	    }
-	    if (ctxt->nodelen > INT_MAX - len) {
+        if ((coalesceText) && (ctxt->nodemem != 0)) {
+            /*
+             * The whole point of maintaining nodelen and nodemem,
+             * xmlTextConcat is too costly, i.e. compute length,
+             * reallocate a new buffer, move data, append ch. Here
+             * We try to minimize realloc() uses and avoid copying
+             * and recomputing length over and over.
+             */
+            if (lastChild->content == (xmlChar *)&(lastChild->properties)) {
+                lastChild->content = xmlStrdup(lastChild->content);
+                lastChild->properties = NULL;
+            } else if ((ctxt->nodemem == ctxt->nodelen + 1) &&
+                       (xmlDictOwns(ctxt->dict, lastChild->content))) {
+                lastChild->content = xmlStrdup(lastChild->content);
+            }
+            if (lastChild->content == NULL) {
+                xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters: xmlStrdup returned NULL");
+                return;
+            }
+            if (ctxt->nodelen > INT_MAX - len) {
                 xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters overflow prevented");
                 return;
-	    }
+            }
             if ((ctxt->nodelen + len > XML_MAX_TEXT_LENGTH) &&
                 ((ctxt->options & XML_PARSE_HUGE) == 0)) {
                 xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters: huge text node");
                 return;
             }
-	    if (ctxt->nodelen + len >= ctxt->nodemem) {
-		xmlChar *newbuf;
-		int size;
+            if (ctxt->nodelen + len >= ctxt->nodemem) {
+                xmlChar *newbuf;
+                int size;
 
-		size = ctxt->nodemem > INT_MAX - len ?
+                size = ctxt->nodemem > INT_MAX - len ?
                        INT_MAX :
                        ctxt->nodemem + len;
-		size = size > INT_MAX / 2 ? INT_MAX : size * 2;
+                size = size > INT_MAX / 2 ? INT_MAX : size * 2;
                 newbuf = (xmlChar *) xmlRealloc(lastChild->content,size);
-		if (newbuf == NULL) {
-		    xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters");
-		    return;
-		}
-		ctxt->nodemem = size;
-		lastChild->content = newbuf;
-	    }
-	    memcpy(&lastChild->content[ctxt->nodelen], ch, len);
-	    ctxt->nodelen += len;
-	    lastChild->content[ctxt->nodelen] = 0;
-	} else if (coalesceText) {
-	    if (xmlTextConcat(lastChild, ch, len)) {
-		xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters");
-	    }
-	    if (ctxt->node->children != NULL) {
-		ctxt->nodelen = xmlStrlen(lastChild->content);
-		ctxt->nodemem = ctxt->nodelen + 1;
-	    }
-	} else {
-	    /* Mixed content, first time */
+                if (newbuf == NULL) {
+                    xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters");
+                    return;
+                }
+                ctxt->nodemem = size;
+                lastChild->content = newbuf;
+            }
+            memcpy(&lastChild->content[ctxt->nodelen], ch, len);
+            ctxt->nodelen += len;
+            lastChild->content[ctxt->nodelen] = 0;
+        } else if (coalesceText) {
+            if (xmlTextConcat(lastChild, ch, len)) {
+                xmlSAX2ErrMemory(ctxt, "xmlSAX2Characters");
+            }
+            if (ctxt->node->children != NULL) {
+                ctxt->nodelen = xmlStrlen(lastChild->content);
+                ctxt->nodemem = ctxt->nodelen + 1;
+            }
+        } else {
+            /* Mixed content, first time */
             if (type == XML_TEXT_NODE) {
                 lastChild = xmlSAX2TextNode(ctxt, ch, len);
                 lastChild->doc = ctxt->myDoc;
             } else
                 lastChild = xmlNewCDataBlock(ctxt->myDoc, ch, len);
-	    if (lastChild != NULL) {
-		xmlAddChild(ctxt->node, lastChild);
-		if (ctxt->node->children != NULL) {
-		    ctxt->nodelen = len;
-		    ctxt->nodemem = len + 1;
-		}
-	    }
-	}
+            if (lastChild != NULL) {
+                xmlAddChild(ctxt->node, lastChild);
+                if (ctxt->node->children != NULL) {
+                    ctxt->nodelen = len;
+                    ctxt->nodemem = len + 1;
+                }
+            }
+        }
     }
 }
 
@@ -2677,7 +2677,7 @@ xmlSAX2IgnorableWhitespace(void *ctx ATTRIBUTE_UNUSED, const xmlChar *ch ATTRIBU
     /* xmlParserCtxtPtr ctxt = (xmlParserCtxtPtr) ctx; */
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-	    "SAX.xmlSAX2IgnorableWhitespace(%.30s, %d)\n", ch, len);
+            "SAX.xmlSAX2IgnorableWhitespace(%.30s, %d)\n", ch, len);
 #endif
 }
 
@@ -2701,48 +2701,48 @@ xmlSAX2ProcessingInstruction(void *ctx, const xmlChar *target,
     parent = ctxt->node;
 #ifdef DEBUG_SAX
     xmlGenericError(xmlGenericErrorContext,
-	    "SAX.xmlSAX2ProcessingInstruction(%s, %s)\n", target, data);
+            "SAX.xmlSAX2ProcessingInstruction(%s, %s)\n", target, data);
 #endif
 
     ret = xmlNewDocPI(ctxt->myDoc, target, data);
     if (ret == NULL) return;
 
     if (ctxt->linenumbers) {
-	if (ctxt->input != NULL) {
-	    if (ctxt->input->line < USHRT_MAX)
-		ret->line = (unsigned short) ctxt->input->line;
-	    else
-	        ret->line = USHRT_MAX;
-	}
+        if (ctxt->input != NULL) {
+            if (ctxt->input->line < USHRT_MAX)
+                ret->line = (unsigned short) ctxt->input->line;
+            else
+                ret->line = USHRT_MAX;
+        }
     }
     if (ctxt->inSubset == 1) {
-	xmlAddChild((xmlNodePtr) ctxt->myDoc->intSubset, ret);
-	return;
+        xmlAddChild((xmlNodePtr) ctxt->myDoc->intSubset, ret);
+        return;
     } else if (ctxt->inSubset == 2) {
-	xmlAddChild((xmlNodePtr) ctxt->myDoc->extSubset, ret);
-	return;
+        xmlAddChild((xmlNodePtr) ctxt->myDoc->extSubset, ret);
+        return;
     }
     if (parent == NULL) {
 #ifdef DEBUG_SAX_TREE
-	    xmlGenericError(xmlGenericErrorContext,
-		    "Setting PI %s as root\n", target);
+            xmlGenericError(xmlGenericErrorContext,
+                    "Setting PI %s as root\n", target);
 #endif
         xmlAddChild((xmlNodePtr) ctxt->myDoc, (xmlNodePtr) ret);
-	return;
+        return;
     }
     if (parent->type == XML_ELEMENT_NODE) {
 #ifdef DEBUG_SAX_TREE
-	xmlGenericError(xmlGenericErrorContext,
-		"adding PI %s child to %s\n", target, parent->name);
+        xmlGenericError(xmlGenericErrorContext,
+                "adding PI %s child to %s\n", target, parent->name);
 #endif
-	xmlAddChild(parent, ret);
+        xmlAddChild(parent, ret);
     } else {
 #ifdef DEBUG_SAX_TREE
-	xmlGenericError(xmlGenericErrorContext,
-		"adding PI %s sibling to ", target);
-	xmlDebugDumpOneNode(stderr, parent, 0);
+        xmlGenericError(xmlGenericErrorContext,
+                "adding PI %s sibling to ", target);
+        xmlDebugDumpOneNode(stderr, parent, 0);
 #endif
-	xmlAddSibling(parent, ret);
+        xmlAddSibling(parent, ret);
     }
 }
 
@@ -2768,42 +2768,42 @@ xmlSAX2Comment(void *ctx, const xmlChar *value)
     ret = xmlNewDocComment(ctxt->myDoc, value);
     if (ret == NULL) return;
     if (ctxt->linenumbers) {
-	if (ctxt->input != NULL) {
-	    if (ctxt->input->line < USHRT_MAX)
-		ret->line = (unsigned short) ctxt->input->line;
-	    else
-	        ret->line = USHRT_MAX;
-	}
+        if (ctxt->input != NULL) {
+            if (ctxt->input->line < USHRT_MAX)
+                ret->line = (unsigned short) ctxt->input->line;
+            else
+                ret->line = USHRT_MAX;
+        }
     }
 
     if (ctxt->inSubset == 1) {
-	xmlAddChild((xmlNodePtr) ctxt->myDoc->intSubset, ret);
-	return;
+        xmlAddChild((xmlNodePtr) ctxt->myDoc->intSubset, ret);
+        return;
     } else if (ctxt->inSubset == 2) {
-	xmlAddChild((xmlNodePtr) ctxt->myDoc->extSubset, ret);
-	return;
+        xmlAddChild((xmlNodePtr) ctxt->myDoc->extSubset, ret);
+        return;
     }
     if (parent == NULL) {
 #ifdef DEBUG_SAX_TREE
-	    xmlGenericError(xmlGenericErrorContext,
-		    "Setting xmlSAX2Comment as root\n");
+            xmlGenericError(xmlGenericErrorContext,
+                    "Setting xmlSAX2Comment as root\n");
 #endif
         xmlAddChild((xmlNodePtr) ctxt->myDoc, (xmlNodePtr) ret);
-	return;
+        return;
     }
     if (parent->type == XML_ELEMENT_NODE) {
 #ifdef DEBUG_SAX_TREE
-	xmlGenericError(xmlGenericErrorContext,
-		"adding xmlSAX2Comment child to %s\n", parent->name);
+        xmlGenericError(xmlGenericErrorContext,
+                "adding xmlSAX2Comment child to %s\n", parent->name);
 #endif
-	xmlAddChild(parent, ret);
+        xmlAddChild(parent, ret);
     } else {
 #ifdef DEBUG_SAX_TREE
-	xmlGenericError(xmlGenericErrorContext,
-		"adding xmlSAX2Comment sibling to ");
-	xmlDebugDumpOneNode(stderr, parent, 0);
+        xmlGenericError(xmlGenericErrorContext,
+                "adding xmlSAX2Comment sibling to ");
+        xmlDebugDumpOneNode(stderr, parent, 0);
 #endif
-	xmlAddSibling(parent, ret);
+        xmlAddSibling(parent, ret);
     }
 }
 
@@ -2862,17 +2862,17 @@ xmlSAXVersion(xmlSAXHandler *hdlr, int version)
 {
     if (hdlr == NULL) return(-1);
     if (version == 2) {
-	hdlr->startElement = NULL;
-	hdlr->endElement = NULL;
-	hdlr->startElementNs = xmlSAX2StartElementNs;
-	hdlr->endElementNs = xmlSAX2EndElementNs;
-	hdlr->serror = NULL;
-	hdlr->initialized = XML_SAX2_MAGIC;
+        hdlr->startElement = NULL;
+        hdlr->endElement = NULL;
+        hdlr->startElementNs = xmlSAX2StartElementNs;
+        hdlr->endElementNs = xmlSAX2EndElementNs;
+        hdlr->serror = NULL;
+        hdlr->initialized = XML_SAX2_MAGIC;
 #ifdef LIBXML_SAX1_ENABLED
     } else if (version == 1) {
-	hdlr->startElement = xmlSAX2StartElement;
-	hdlr->endElement = xmlSAX2EndElement;
-	hdlr->initialized = 1;
+        hdlr->startElement = xmlSAX2StartElement;
+        hdlr->endElement = xmlSAX2EndElement;
+        hdlr->initialized = 1;
 #endif /* LIBXML_SAX1_ENABLED */
     } else
         return(-1);
@@ -2916,13 +2916,13 @@ void
 xmlSAX2InitDefaultSAXHandler(xmlSAXHandler *hdlr, int warning)
 {
     if ((hdlr == NULL) || (hdlr->initialized != 0))
-	return;
+        return;
 
     xmlSAXVersion(hdlr, xmlSAX2DefaultVersionValue);
     if (warning == 0)
-	hdlr->warning = NULL;
+        hdlr->warning = NULL;
     else
-	hdlr->warning = xmlParserWarning;
+        hdlr->warning = xmlParserWarning;
 }
 
 /**
@@ -2953,7 +2953,7 @@ void
 xmlSAX2InitHtmlDefaultSAXHandler(xmlSAXHandler *hdlr)
 {
     if ((hdlr == NULL) || (hdlr->initialized != 0))
-	return;
+        return;
 
     hdlr->internalSubset = xmlSAX2InternalSubset;
     hdlr->externalSubset = NULL;

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/configure.ac
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/configure.ac
@@ -3,7 +3,7 @@ AC_PREREQ([2.63])
 
 m4_define([MAJOR_VERSION], 2)
 m4_define([MINOR_VERSION], 10)
-m4_define([MICRO_VERSION], 3)
+m4_define([MICRO_VERSION], 4)
 
 AC_INIT([libxml2],[MAJOR_VERSION.MINOR_VERSION.MICRO_VERSION])
 AC_CONFIG_SRCDIR([entities.c])

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/dict.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/dict.c
@@ -72,7 +72,7 @@ typedef unsigned __int32 uint32_t;
     (((prefix) == NULL) ?                                               \
       (xmlDictComputeKey(dict, name, len)) :                             \
       (((dict)->size == MIN_DICT_SIZE) ?                                \
-       xmlDictComputeFastQKey(prefix, plen, name, len, (dict)->seed) :  \
+       xmlDictComputeFastQKey(prefix, plen, name, len, (dict)->seed) :	\
        xmlDictComputeBigQKey(prefix, plen, name, len, (dict)->seed)))
 
 #else /* !WITH_BIG_KEY */
@@ -252,11 +252,11 @@ xmlDictAddString(xmlDictPtr dict, const xmlChar *name, unsigned int namelen) {
 #endif
     pool = dict->strings;
     while (pool != NULL) {
-        if ((size_t)(pool->end - pool->free) > namelen)
-            goto found_pool;
-        if (pool->size > size) size = pool->size;
+	if ((size_t)(pool->end - pool->free) > namelen)
+	    goto found_pool;
+	if (pool->size > size) size = pool->size;
         limit += pool->size;
-        pool = pool->next;
+	pool = pool->next;
     }
     /*
      * Not found, need to allocate
@@ -267,18 +267,18 @@ xmlDictAddString(xmlDictPtr dict, const xmlChar *name, unsigned int namelen) {
         }
 
         if (size == 0) size = 1000;
-        else size *= 4; /* exponential growth */
+	else size *= 4; /* exponential growth */
         if (size < 4 * namelen)
-            size = 4 * namelen; /* just in case ! */
-        pool = (xmlDictStringsPtr) xmlMalloc(sizeof(xmlDictStrings) + size);
-        if (pool == NULL)
-            return(NULL);
-        pool->size = size;
-        pool->nbStrings = 0;
-        pool->free = &pool->array[0];
-        pool->end = &pool->array[size];
-        pool->next = dict->strings;
-        dict->strings = pool;
+	    size = 4 * namelen; /* just in case ! */
+	pool = (xmlDictStringsPtr) xmlMalloc(sizeof(xmlDictStrings) + size);
+	if (pool == NULL)
+	    return(NULL);
+	pool->size = size;
+	pool->nbStrings = 0;
+	pool->free = &pool->array[0];
+	pool->end = &pool->array[size];
+	pool->next = dict->strings;
+	dict->strings = pool;
 #ifdef DICT_DEBUG_PATTERNS
         fprintf(stderr, "+");
 #endif
@@ -320,11 +320,11 @@ xmlDictAddQString(xmlDictPtr dict, const xmlChar *prefix, unsigned int plen,
 #endif
     pool = dict->strings;
     while (pool != NULL) {
-        if ((size_t)(pool->end - pool->free) > namelen + plen + 1)
-            goto found_pool;
-        if (pool->size > size) size = pool->size;
+	if ((size_t)(pool->end - pool->free) > namelen + plen + 1)
+	    goto found_pool;
+	if (pool->size > size) size = pool->size;
         limit += pool->size;
-        pool = pool->next;
+	pool = pool->next;
     }
     /*
      * Not found, need to allocate
@@ -335,18 +335,18 @@ xmlDictAddQString(xmlDictPtr dict, const xmlChar *prefix, unsigned int plen,
         }
 
         if (size == 0) size = 1000;
-        else size *= 4; /* exponential growth */
+	else size *= 4; /* exponential growth */
         if (size < 4 * (namelen + plen + 1))
-            size = 4 * (namelen + plen + 1); /* just in case ! */
-        pool = (xmlDictStringsPtr) xmlMalloc(sizeof(xmlDictStrings) + size);
-        if (pool == NULL)
-            return(NULL);
-        pool->size = size;
-        pool->nbStrings = 0;
-        pool->free = &pool->array[0];
-        pool->end = &pool->array[size];
-        pool->next = dict->strings;
-        dict->strings = pool;
+	    size = 4 * (namelen + plen + 1); /* just in case ! */
+	pool = (xmlDictStringsPtr) xmlMalloc(sizeof(xmlDictStrings) + size);
+	if (pool == NULL)
+	    return(NULL);
+	pool->size = size;
+	pool->nbStrings = 0;
+	pool->free = &pool->array[0];
+	pool->end = &pool->array[size];
+	pool->next = dict->strings;
+	dict->strings = pool;
 #ifdef DICT_DEBUG_PATTERNS
         fprintf(stderr, "+");
 #endif
@@ -388,8 +388,8 @@ xmlDictComputeBigKey(const xmlChar* data, int namelen, int seed) {
 
     for (i = 0;i < namelen; i++) {
         hash += data[i];
-        hash += (hash << 10);
-        hash ^= (hash >> 6);
+	hash += (hash << 10);
+	hash ^= (hash >> 6);
     }
     hash += (hash << 3);
     hash ^= (hash >> 11);
@@ -423,8 +423,8 @@ xmlDictComputeBigQKey(const xmlChar *prefix, int plen,
 
     for (i = 0;i < plen; i++) {
         hash += prefix[i];
-        hash += (hash << 10);
-        hash ^= (hash >> 6);
+	hash += (hash << 10);
+	hash ^= (hash >> 6);
     }
     hash += ':';
     hash += (hash << 10);
@@ -432,8 +432,8 @@ xmlDictComputeBigQKey(const xmlChar *prefix, int plen,
 
     for (i = 0;i < len; i++) {
         hash += name[i];
-        hash += (hash << 10);
-        hash ^= (hash >> 6);
+	hash += (hash << 10);
+	hash ^= (hash >> 6);
     }
     hash += (hash << 3);
     hash ^= (hash >> 11);
@@ -453,7 +453,8 @@ static unsigned long
 xmlDictComputeFastKey(const xmlChar *name, int namelen, int seed) {
     unsigned long value = seed;
 
-    if (name == NULL) return(0);
+    if ((name == NULL) || (namelen <= 0))
+        return(value);
     value += *name;
     value <<= 5;
     if (namelen > 10) {
@@ -499,18 +500,18 @@ xmlDictComputeFastQKey(const xmlChar *prefix, int plen,
     unsigned long value = (unsigned long) seed;
 
     if (plen == 0)
-        value += 30 * (unsigned long) ':';
+	value += 30 * (unsigned long) ':';
     else
-        value += 30 * (*prefix);
+	value += 30 * (*prefix);
 
     if (len > 10) {
         int offset = len - (plen + 1 + 1);
-        if (offset < 0)
-            offset = len - (10 + 1);
-        value += name[offset];
+	if (offset < 0)
+	    offset = len - (10 + 1);
+	value += name[offset];
         len = 10;
-        if (plen > 10)
-            plen = 10;
+	if (plen > 10)
+	    plen = 10;
     }
     switch (plen) {
         case 10: value += prefix[9];
@@ -538,7 +539,7 @@ xmlDictComputeFastQKey(const xmlChar *prefix, int plen,
     len -= plen;
     if (len > 0) {
         value += (unsigned long) ':';
-        len--;
+	len--;
     }
     switch (len) {
         case 10: value += name[9];
@@ -591,18 +592,18 @@ xmlDictCreate(void) {
         dict->limit = 0;
 
         dict->size = MIN_DICT_SIZE;
-        dict->nbElems = 0;
+	dict->nbElems = 0;
         dict->dict = xmlMalloc(MIN_DICT_SIZE * sizeof(xmlDictEntry));
-        dict->strings = NULL;
-        dict->subdict = NULL;
+	dict->strings = NULL;
+	dict->subdict = NULL;
         if (dict->dict) {
-            memset(dict->dict, 0, MIN_DICT_SIZE * sizeof(xmlDictEntry));
+	    memset(dict->dict, 0, MIN_DICT_SIZE * sizeof(xmlDictEntry));
 #ifdef DICT_RANDOMIZATION
             dict->seed = __xmlRandom();
 #else
             dict->seed = 0;
 #endif
-            return(dict);
+	    return(dict);
         }
         xmlFree(dict);
     }
@@ -630,7 +631,7 @@ xmlDictCreateSub(xmlDictPtr sub) {
 #endif
         dict->seed = sub->seed;
         dict->subdict = sub;
-        xmlDictReference(dict->subdict);
+	xmlDictReference(dict->subdict);
     }
     return(dict);
 }
@@ -678,11 +679,11 @@ xmlDictGrow(xmlDictPtr dict, size_t size) {
     int keep_keys = 1;
 
     if (dict == NULL)
-        return(-1);
+	return(-1);
     if (size < 8)
         return(-1);
     if (size > 8 * 2048)
-        return(-1);
+	return(-1);
 
 #ifdef DICT_DEBUG_PATTERNS
     fprintf(stderr, "*");
@@ -697,95 +698,95 @@ xmlDictGrow(xmlDictPtr dict, size_t size) {
 
     dict->dict = xmlMalloc(size * sizeof(xmlDictEntry));
     if (dict->dict == NULL) {
-        dict->dict = olddict;
-        return(-1);
+	dict->dict = olddict;
+	return(-1);
     }
     memset(dict->dict, 0, size * sizeof(xmlDictEntry));
     dict->size = size;
 
-    /*  If the two loops are merged, there would be situations where
-        a new entry needs to allocated and data copied into it from
-        the main dict. It is nicer to run through the array twice, first
-        copying all the elements in the main array (less probability of
-        allocate) and then the rest, so we only free in the second loop.
+    /*	If the two loops are merged, there would be situations where
+	a new entry needs to allocated and data copied into it from
+	the main dict. It is nicer to run through the array twice, first
+	copying all the elements in the main array (less probability of
+	allocate) and then the rest, so we only free in the second loop.
     */
     for (i = 0; i < oldsize; i++) {
-        if (olddict[i].valid == 0)
-            continue;
+	if (olddict[i].valid == 0)
+	    continue;
 
-        if (keep_keys)
-            okey = olddict[i].okey;
-        else
-            okey = xmlDictComputeKey(dict, olddict[i].name, olddict[i].len);
-        key = okey % dict->size;
+	if (keep_keys)
+	    okey = olddict[i].okey;
+	else
+	    okey = xmlDictComputeKey(dict, olddict[i].name, olddict[i].len);
+	key = okey % dict->size;
 
-        if (dict->dict[key].valid == 0) {
-            memcpy(&(dict->dict[key]), &(olddict[i]), sizeof(xmlDictEntry));
-            dict->dict[key].next = NULL;
-            dict->dict[key].okey = okey;
-        } else {
-            xmlDictEntryPtr entry;
+	if (dict->dict[key].valid == 0) {
+	    memcpy(&(dict->dict[key]), &(olddict[i]), sizeof(xmlDictEntry));
+	    dict->dict[key].next = NULL;
+	    dict->dict[key].okey = okey;
+	} else {
+	    xmlDictEntryPtr entry;
 
-            entry = xmlMalloc(sizeof(xmlDictEntry));
-            if (entry != NULL) {
-                entry->name = olddict[i].name;
-                entry->len = olddict[i].len;
-                entry->okey = okey;
-                entry->next = dict->dict[key].next;
-                entry->valid = 1;
-                dict->dict[key].next = entry;
-            } else {
-                /*
-                 * we don't have much ways to alert from here
-                 * result is losing an entry and unicity guarantee
-                 */
-                ret = -1;
-            }
-        }
+	    entry = xmlMalloc(sizeof(xmlDictEntry));
+	    if (entry != NULL) {
+		entry->name = olddict[i].name;
+		entry->len = olddict[i].len;
+		entry->okey = okey;
+		entry->next = dict->dict[key].next;
+		entry->valid = 1;
+		dict->dict[key].next = entry;
+	    } else {
+	        /*
+		 * we don't have much ways to alert from here
+		 * result is losing an entry and unicity guarantee
+		 */
+	        ret = -1;
+	    }
+	}
 #ifdef DEBUG_GROW
-        nbElem++;
+	nbElem++;
 #endif
     }
 
     for (i = 0; i < oldsize; i++) {
-        iter = olddict[i].next;
-        while (iter) {
-            next = iter->next;
+	iter = olddict[i].next;
+	while (iter) {
+	    next = iter->next;
 
-            /*
-             * put back the entry in the new dict
-             */
+	    /*
+	     * put back the entry in the new dict
+	     */
 
-            if (keep_keys)
-                okey = iter->okey;
-            else
-                okey = xmlDictComputeKey(dict, iter->name, iter->len);
-            key = okey % dict->size;
-            if (dict->dict[key].valid == 0) {
-                memcpy(&(dict->dict[key]), iter, sizeof(xmlDictEntry));
-                dict->dict[key].next = NULL;
-                dict->dict[key].valid = 1;
-                dict->dict[key].okey = okey;
-                xmlFree(iter);
-            } else {
-                iter->next = dict->dict[key].next;
-                iter->okey = okey;
-                dict->dict[key].next = iter;
-            }
+	    if (keep_keys)
+		okey = iter->okey;
+	    else
+		okey = xmlDictComputeKey(dict, iter->name, iter->len);
+	    key = okey % dict->size;
+	    if (dict->dict[key].valid == 0) {
+		memcpy(&(dict->dict[key]), iter, sizeof(xmlDictEntry));
+		dict->dict[key].next = NULL;
+		dict->dict[key].valid = 1;
+		dict->dict[key].okey = okey;
+		xmlFree(iter);
+	    } else {
+		iter->next = dict->dict[key].next;
+		iter->okey = okey;
+		dict->dict[key].next = iter;
+	    }
 
 #ifdef DEBUG_GROW
-            nbElem++;
+	    nbElem++;
 #endif
 
-            iter = next;
-        }
+	    iter = next;
+	}
     }
 
     xmlFree(olddict);
 
 #ifdef DEBUG_GROW
     xmlGenericError(xmlGenericErrorContext,
-            "xmlDictGrow : from %lu to %lu, %u elems\n", oldsize, size, nbElem);
+	    "xmlDictGrow : from %lu to %lu, %u elems\n", oldsize, size, nbElem);
 #endif
 
     return(ret);
@@ -807,7 +808,7 @@ xmlDictFree(xmlDictPtr dict) {
     xmlDictStringsPtr pool, nextp;
 
     if (dict == NULL)
-        return;
+	return;
 
     if (!xmlDictInitialized)
         if (!__xmlInitializeDict())
@@ -828,27 +829,27 @@ xmlDictFree(xmlDictPtr dict) {
     }
 
     if (dict->dict) {
-        for(i = 0; ((i < dict->size) && (dict->nbElems > 0)); i++) {
-            iter = &(dict->dict[i]);
-            if (iter->valid == 0)
-                continue;
-            inside_dict = 1;
-            while (iter) {
-                next = iter->next;
-                if (!inside_dict)
-                    xmlFree(iter);
-                dict->nbElems--;
-                inside_dict = 0;
-                iter = next;
-            }
-        }
-        xmlFree(dict->dict);
+	for(i = 0; ((i < dict->size) && (dict->nbElems > 0)); i++) {
+	    iter = &(dict->dict[i]);
+	    if (iter->valid == 0)
+		continue;
+	    inside_dict = 1;
+	    while (iter) {
+		next = iter->next;
+		if (!inside_dict)
+		    xmlFree(iter);
+		dict->nbElems--;
+		inside_dict = 0;
+		iter = next;
+	    }
+	}
+	xmlFree(dict->dict);
     }
     pool = dict->strings;
     while (pool != NULL) {
         nextp = pool->next;
-        xmlFree(pool);
-        pool = nextp;
+	xmlFree(pool);
+	pool = nextp;
     }
     xmlFree(dict);
 }
@@ -872,7 +873,7 @@ xmlDictLookup(xmlDictPtr dict, const xmlChar *name, int len) {
     unsigned int l;
 
     if ((dict == NULL) || (name == NULL))
-        return(NULL);
+	return(NULL);
 
     if (len < 0)
         l = strlen((const char *) name);
@@ -889,31 +890,31 @@ xmlDictLookup(xmlDictPtr dict, const xmlChar *name, int len) {
     okey = xmlDictComputeKey(dict, name, l);
     key = okey % dict->size;
     if (dict->dict[key].valid == 0) {
-        insert = NULL;
+	insert = NULL;
     } else {
-        for (insert = &(dict->dict[key]); insert->next != NULL;
-             insert = insert->next) {
+	for (insert = &(dict->dict[key]); insert->next != NULL;
+	     insert = insert->next) {
 #ifdef __GNUC__
-            if ((insert->okey == okey) && (insert->len == l)) {
-                if (!memcmp(insert->name, name, l))
-                    return(insert->name);
-            }
+	    if ((insert->okey == okey) && (insert->len == l)) {
+		if (!memcmp(insert->name, name, l))
+		    return(insert->name);
+	    }
 #else
-            if ((insert->okey == okey) && (insert->len == l) &&
-                (!xmlStrncmp(insert->name, name, l)))
-                return(insert->name);
+	    if ((insert->okey == okey) && (insert->len == l) &&
+	        (!xmlStrncmp(insert->name, name, l)))
+		return(insert->name);
 #endif
-            nbi++;
-        }
+	    nbi++;
+	}
 #ifdef __GNUC__
-        if ((insert->okey == okey) && (insert->len == l)) {
-            if (!memcmp(insert->name, name, l))
-                return(insert->name);
-        }
+	if ((insert->okey == okey) && (insert->len == l)) {
+	    if (!memcmp(insert->name, name, l))
+		return(insert->name);
+	}
 #else
-        if ((insert->okey == okey) && (insert->len == l) &&
-            (!xmlStrncmp(insert->name, name, l)))
-            return(insert->name);
+	if ((insert->okey == okey) && (insert->len == l) &&
+	    (!xmlStrncmp(insert->name, name, l)))
+	    return(insert->name);
 #endif
     }
 
@@ -922,54 +923,54 @@ xmlDictLookup(xmlDictPtr dict, const xmlChar *name, int len) {
 
         /* we cannot always reuse the same okey for the subdict */
         if (((dict->size == MIN_DICT_SIZE) &&
-             (dict->subdict->size != MIN_DICT_SIZE)) ||
+	     (dict->subdict->size != MIN_DICT_SIZE)) ||
             ((dict->size != MIN_DICT_SIZE) &&
-             (dict->subdict->size == MIN_DICT_SIZE)))
-            skey = xmlDictComputeKey(dict->subdict, name, l);
-        else
-            skey = okey;
+	     (dict->subdict->size == MIN_DICT_SIZE)))
+	    skey = xmlDictComputeKey(dict->subdict, name, l);
+	else
+	    skey = okey;
 
-        key = skey % dict->subdict->size;
-        if (dict->subdict->dict[key].valid != 0) {
-            xmlDictEntryPtr tmp;
+	key = skey % dict->subdict->size;
+	if (dict->subdict->dict[key].valid != 0) {
+	    xmlDictEntryPtr tmp;
 
-            for (tmp = &(dict->subdict->dict[key]); tmp->next != NULL;
-                 tmp = tmp->next) {
+	    for (tmp = &(dict->subdict->dict[key]); tmp->next != NULL;
+		 tmp = tmp->next) {
 #ifdef __GNUC__
-                if ((tmp->okey == skey) && (tmp->len == l)) {
-                    if (!memcmp(tmp->name, name, l))
-                        return(tmp->name);
-                }
+		if ((tmp->okey == skey) && (tmp->len == l)) {
+		    if (!memcmp(tmp->name, name, l))
+			return(tmp->name);
+		}
 #else
-                if ((tmp->okey == skey) && (tmp->len == l) &&
-                    (!xmlStrncmp(tmp->name, name, l)))
-                    return(tmp->name);
+		if ((tmp->okey == skey) && (tmp->len == l) &&
+		    (!xmlStrncmp(tmp->name, name, l)))
+		    return(tmp->name);
 #endif
-                nbi++;
-            }
+		nbi++;
+	    }
 #ifdef __GNUC__
-            if ((tmp->okey == skey) && (tmp->len == l)) {
-                if (!memcmp(tmp->name, name, l))
-                    return(tmp->name);
-            }
+	    if ((tmp->okey == skey) && (tmp->len == l)) {
+		if (!memcmp(tmp->name, name, l))
+		    return(tmp->name);
+	    }
 #else
-            if ((tmp->okey == skey) && (tmp->len == l) &&
-                (!xmlStrncmp(tmp->name, name, l)))
-                return(tmp->name);
+	    if ((tmp->okey == skey) && (tmp->len == l) &&
+		(!xmlStrncmp(tmp->name, name, l)))
+		return(tmp->name);
 #endif
-        }
-        key = okey % dict->size;
+	}
+	key = okey % dict->size;
     }
 
     ret = xmlDictAddString(dict, name, l);
     if (ret == NULL)
         return(NULL);
     if (insert == NULL) {
-        entry = &(dict->dict[key]);
+	entry = &(dict->dict[key]);
     } else {
-        entry = xmlMalloc(sizeof(xmlDictEntry));
-        if (entry == NULL)
-             return(NULL);
+	entry = xmlMalloc(sizeof(xmlDictEntry));
+	if (entry == NULL)
+	     return(NULL);
     }
     entry->name = ret;
     entry->len = l;
@@ -979,14 +980,14 @@ xmlDictLookup(xmlDictPtr dict, const xmlChar *name, int len) {
 
 
     if (insert != NULL)
-        insert->next = entry;
+	insert->next = entry;
 
     dict->nbElems++;
 
     if ((nbi > MAX_HASH_LEN) &&
         (dict->size <= ((MAX_DICT_HASH / 2) / MAX_HASH_LEN))) {
-        if (xmlDictGrow(dict, MAX_HASH_LEN * 2 * dict->size) != 0)
-            return(NULL);
+	if (xmlDictGrow(dict, MAX_HASH_LEN * 2 * dict->size) != 0)
+	    return(NULL);
     }
     /* Note that entry may have been freed at this point by xmlDictGrow */
 
@@ -1010,7 +1011,7 @@ xmlDictExists(xmlDictPtr dict, const xmlChar *name, int len) {
     unsigned int l;
 
     if ((dict == NULL) || (name == NULL))
-        return(NULL);
+	return(NULL);
 
     if (len < 0)
         l = strlen((const char *) name);
@@ -1026,31 +1027,31 @@ xmlDictExists(xmlDictPtr dict, const xmlChar *name, int len) {
     okey = xmlDictComputeKey(dict, name, l);
     key = okey % dict->size;
     if (dict->dict[key].valid == 0) {
-        insert = NULL;
+	insert = NULL;
     } else {
-        for (insert = &(dict->dict[key]); insert->next != NULL;
-             insert = insert->next) {
+	for (insert = &(dict->dict[key]); insert->next != NULL;
+	     insert = insert->next) {
 #ifdef __GNUC__
-            if ((insert->okey == okey) && (insert->len == l)) {
-                if (!memcmp(insert->name, name, l))
-                    return(insert->name);
-            }
+	    if ((insert->okey == okey) && (insert->len == l)) {
+		if (!memcmp(insert->name, name, l))
+		    return(insert->name);
+	    }
 #else
-            if ((insert->okey == okey) && (insert->len == l) &&
-                (!xmlStrncmp(insert->name, name, l)))
-                return(insert->name);
+	    if ((insert->okey == okey) && (insert->len == l) &&
+	        (!xmlStrncmp(insert->name, name, l)))
+		return(insert->name);
 #endif
-            nbi++;
-        }
+	    nbi++;
+	}
 #ifdef __GNUC__
-        if ((insert->okey == okey) && (insert->len == l)) {
-            if (!memcmp(insert->name, name, l))
-                return(insert->name);
-        }
+	if ((insert->okey == okey) && (insert->len == l)) {
+	    if (!memcmp(insert->name, name, l))
+		return(insert->name);
+	}
 #else
-        if ((insert->okey == okey) && (insert->len == l) &&
-            (!xmlStrncmp(insert->name, name, l)))
-            return(insert->name);
+	if ((insert->okey == okey) && (insert->len == l) &&
+	    (!xmlStrncmp(insert->name, name, l)))
+	    return(insert->name);
 #endif
     }
 
@@ -1059,42 +1060,42 @@ xmlDictExists(xmlDictPtr dict, const xmlChar *name, int len) {
 
         /* we cannot always reuse the same okey for the subdict */
         if (((dict->size == MIN_DICT_SIZE) &&
-             (dict->subdict->size != MIN_DICT_SIZE)) ||
+	     (dict->subdict->size != MIN_DICT_SIZE)) ||
             ((dict->size != MIN_DICT_SIZE) &&
-             (dict->subdict->size == MIN_DICT_SIZE)))
-            skey = xmlDictComputeKey(dict->subdict, name, l);
-        else
-            skey = okey;
+	     (dict->subdict->size == MIN_DICT_SIZE)))
+	    skey = xmlDictComputeKey(dict->subdict, name, l);
+	else
+	    skey = okey;
 
-        key = skey % dict->subdict->size;
-        if (dict->subdict->dict[key].valid != 0) {
-            xmlDictEntryPtr tmp;
+	key = skey % dict->subdict->size;
+	if (dict->subdict->dict[key].valid != 0) {
+	    xmlDictEntryPtr tmp;
 
-            for (tmp = &(dict->subdict->dict[key]); tmp->next != NULL;
-                 tmp = tmp->next) {
+	    for (tmp = &(dict->subdict->dict[key]); tmp->next != NULL;
+		 tmp = tmp->next) {
 #ifdef __GNUC__
-                if ((tmp->okey == skey) && (tmp->len == l)) {
-                    if (!memcmp(tmp->name, name, l))
-                        return(tmp->name);
-                }
+		if ((tmp->okey == skey) && (tmp->len == l)) {
+		    if (!memcmp(tmp->name, name, l))
+			return(tmp->name);
+		}
 #else
-                if ((tmp->okey == skey) && (tmp->len == l) &&
-                    (!xmlStrncmp(tmp->name, name, l)))
-                    return(tmp->name);
+		if ((tmp->okey == skey) && (tmp->len == l) &&
+		    (!xmlStrncmp(tmp->name, name, l)))
+		    return(tmp->name);
 #endif
-                nbi++;
-            }
+		nbi++;
+	    }
 #ifdef __GNUC__
-            if ((tmp->okey == skey) && (tmp->len == l)) {
-                if (!memcmp(tmp->name, name, l))
-                    return(tmp->name);
-            }
+	    if ((tmp->okey == skey) && (tmp->len == l)) {
+		if (!memcmp(tmp->name, name, l))
+		    return(tmp->name);
+	    }
 #else
-            if ((tmp->okey == skey) && (tmp->len == l) &&
-                (!xmlStrncmp(tmp->name, name, l)))
-                return(tmp->name);
+	    if ((tmp->okey == skey) && (tmp->len == l) &&
+		(!xmlStrncmp(tmp->name, name, l)))
+		return(tmp->name);
 #endif
-        }
+	}
     }
 
     /* not found */
@@ -1120,7 +1121,7 @@ xmlDictQLookup(xmlDictPtr dict, const xmlChar *prefix, const xmlChar *name) {
     unsigned int len, plen, l;
 
     if ((dict == NULL) || (name == NULL))
-        return(NULL);
+	return(NULL);
     if (prefix == NULL)
         return(xmlDictLookup(dict, name, -1));
 
@@ -1134,18 +1135,18 @@ xmlDictQLookup(xmlDictPtr dict, const xmlChar *prefix, const xmlChar *name) {
     okey = xmlDictComputeQKey(dict, prefix, plen, name, l);
     key = okey % dict->size;
     if (dict->dict[key].valid == 0) {
-        insert = NULL;
+	insert = NULL;
     } else {
-        for (insert = &(dict->dict[key]); insert->next != NULL;
-             insert = insert->next) {
-            if ((insert->okey == okey) && (insert->len == len) &&
-                (xmlStrQEqual(prefix, name, insert->name)))
-                return(insert->name);
-            nbi++;
-        }
-        if ((insert->okey == okey) && (insert->len == len) &&
-            (xmlStrQEqual(prefix, name, insert->name)))
-            return(insert->name);
+	for (insert = &(dict->dict[key]); insert->next != NULL;
+	     insert = insert->next) {
+	    if ((insert->okey == okey) && (insert->len == len) &&
+	        (xmlStrQEqual(prefix, name, insert->name)))
+		return(insert->name);
+	    nbi++;
+	}
+	if ((insert->okey == okey) && (insert->len == len) &&
+	    (xmlStrQEqual(prefix, name, insert->name)))
+	    return(insert->name);
     }
 
     if (dict->subdict) {
@@ -1153,39 +1154,39 @@ xmlDictQLookup(xmlDictPtr dict, const xmlChar *prefix, const xmlChar *name) {
 
         /* we cannot always reuse the same okey for the subdict */
         if (((dict->size == MIN_DICT_SIZE) &&
-             (dict->subdict->size != MIN_DICT_SIZE)) ||
+	     (dict->subdict->size != MIN_DICT_SIZE)) ||
             ((dict->size != MIN_DICT_SIZE) &&
-             (dict->subdict->size == MIN_DICT_SIZE)))
-            skey = xmlDictComputeQKey(dict->subdict, prefix, plen, name, l);
-        else
-            skey = okey;
+	     (dict->subdict->size == MIN_DICT_SIZE)))
+	    skey = xmlDictComputeQKey(dict->subdict, prefix, plen, name, l);
+	else
+	    skey = okey;
 
-        key = skey % dict->subdict->size;
-        if (dict->subdict->dict[key].valid != 0) {
-            xmlDictEntryPtr tmp;
-            for (tmp = &(dict->subdict->dict[key]); tmp->next != NULL;
-                 tmp = tmp->next) {
-                if ((tmp->okey == skey) && (tmp->len == len) &&
-                    (xmlStrQEqual(prefix, name, tmp->name)))
-                    return(tmp->name);
-                nbi++;
-            }
-            if ((tmp->okey == skey) && (tmp->len == len) &&
-                (xmlStrQEqual(prefix, name, tmp->name)))
-                return(tmp->name);
-        }
-        key = okey % dict->size;
+	key = skey % dict->subdict->size;
+	if (dict->subdict->dict[key].valid != 0) {
+	    xmlDictEntryPtr tmp;
+	    for (tmp = &(dict->subdict->dict[key]); tmp->next != NULL;
+		 tmp = tmp->next) {
+		if ((tmp->okey == skey) && (tmp->len == len) &&
+		    (xmlStrQEqual(prefix, name, tmp->name)))
+		    return(tmp->name);
+		nbi++;
+	    }
+	    if ((tmp->okey == skey) && (tmp->len == len) &&
+		(xmlStrQEqual(prefix, name, tmp->name)))
+		return(tmp->name);
+	}
+	key = okey % dict->size;
     }
 
     ret = xmlDictAddQString(dict, prefix, plen, name, l);
     if (ret == NULL)
         return(NULL);
     if (insert == NULL) {
-        entry = &(dict->dict[key]);
+	entry = &(dict->dict[key]);
     } else {
-        entry = xmlMalloc(sizeof(xmlDictEntry));
-        if (entry == NULL)
-             return(NULL);
+	entry = xmlMalloc(sizeof(xmlDictEntry));
+	if (entry == NULL)
+	     return(NULL);
     }
     entry->name = ret;
     entry->len = len;
@@ -1194,13 +1195,13 @@ xmlDictQLookup(xmlDictPtr dict, const xmlChar *prefix, const xmlChar *name) {
     entry->okey = okey;
 
     if (insert != NULL)
-        insert->next = entry;
+	insert->next = entry;
 
     dict->nbElems++;
 
     if ((nbi > MAX_HASH_LEN) &&
         (dict->size <= ((MAX_DICT_HASH / 2) / MAX_HASH_LEN)))
-        xmlDictGrow(dict, MAX_HASH_LEN * 2 * dict->size);
+	xmlDictGrow(dict, MAX_HASH_LEN * 2 * dict->size);
     /* Note that entry may have been freed at this point by xmlDictGrow */
 
     return(ret);
@@ -1221,12 +1222,12 @@ xmlDictOwns(xmlDictPtr dict, const xmlChar *str) {
     xmlDictStringsPtr pool;
 
     if ((dict == NULL) || (str == NULL))
-        return(-1);
+	return(-1);
     pool = dict->strings;
     while (pool != NULL) {
         if ((str >= &pool->array[0]) && (str <= pool->free))
-            return(1);
-        pool = pool->next;
+	    return(1);
+	pool = pool->next;
     }
     if (dict->subdict)
         return(xmlDictOwns(dict->subdict, str));
@@ -1245,7 +1246,7 @@ xmlDictOwns(xmlDictPtr dict, const xmlChar *str) {
 int
 xmlDictSize(xmlDictPtr dict) {
     if (dict == NULL)
-        return(-1);
+	return(-1);
     if (dict->subdict)
         return(dict->nbElems + dict->subdict->nbElems);
     return(dict->nbElems);
@@ -1266,7 +1267,7 @@ xmlDictSetLimit(xmlDictPtr dict, size_t limit) {
     size_t ret;
 
     if (dict == NULL)
-        return(0);
+	return(0);
     ret = dict->limit;
     dict->limit = limit;
     return(ret);
@@ -1287,11 +1288,11 @@ xmlDictGetUsage(xmlDictPtr dict) {
     size_t limit = 0;
 
     if (dict == NULL)
-        return(0);
+	return(0);
     pool = dict->strings;
     while (pool != NULL) {
         limit += pool->size;
-        pool = pool->next;
+	pool = pool->next;
     }
     return(limit);
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/dict.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/dict.c
@@ -72,7 +72,7 @@ typedef unsigned __int32 uint32_t;
     (((prefix) == NULL) ?                                               \
       (xmlDictComputeKey(dict, name, len)) :                             \
       (((dict)->size == MIN_DICT_SIZE) ?                                \
-       xmlDictComputeFastQKey(prefix, plen, name, len, (dict)->seed) :	\
+       xmlDictComputeFastQKey(prefix, plen, name, len, (dict)->seed) :  \
        xmlDictComputeBigQKey(prefix, plen, name, len, (dict)->seed)))
 
 #else /* !WITH_BIG_KEY */
@@ -252,11 +252,11 @@ xmlDictAddString(xmlDictPtr dict, const xmlChar *name, unsigned int namelen) {
 #endif
     pool = dict->strings;
     while (pool != NULL) {
-	if ((size_t)(pool->end - pool->free) > namelen)
-	    goto found_pool;
-	if (pool->size > size) size = pool->size;
+        if ((size_t)(pool->end - pool->free) > namelen)
+            goto found_pool;
+        if (pool->size > size) size = pool->size;
         limit += pool->size;
-	pool = pool->next;
+        pool = pool->next;
     }
     /*
      * Not found, need to allocate
@@ -267,18 +267,18 @@ xmlDictAddString(xmlDictPtr dict, const xmlChar *name, unsigned int namelen) {
         }
 
         if (size == 0) size = 1000;
-	else size *= 4; /* exponential growth */
+        else size *= 4; /* exponential growth */
         if (size < 4 * namelen)
-	    size = 4 * namelen; /* just in case ! */
-	pool = (xmlDictStringsPtr) xmlMalloc(sizeof(xmlDictStrings) + size);
-	if (pool == NULL)
-	    return(NULL);
-	pool->size = size;
-	pool->nbStrings = 0;
-	pool->free = &pool->array[0];
-	pool->end = &pool->array[size];
-	pool->next = dict->strings;
-	dict->strings = pool;
+            size = 4 * namelen; /* just in case ! */
+        pool = (xmlDictStringsPtr) xmlMalloc(sizeof(xmlDictStrings) + size);
+        if (pool == NULL)
+            return(NULL);
+        pool->size = size;
+        pool->nbStrings = 0;
+        pool->free = &pool->array[0];
+        pool->end = &pool->array[size];
+        pool->next = dict->strings;
+        dict->strings = pool;
 #ifdef DICT_DEBUG_PATTERNS
         fprintf(stderr, "+");
 #endif
@@ -320,11 +320,11 @@ xmlDictAddQString(xmlDictPtr dict, const xmlChar *prefix, unsigned int plen,
 #endif
     pool = dict->strings;
     while (pool != NULL) {
-	if ((size_t)(pool->end - pool->free) > namelen + plen + 1)
-	    goto found_pool;
-	if (pool->size > size) size = pool->size;
+        if ((size_t)(pool->end - pool->free) > namelen + plen + 1)
+            goto found_pool;
+        if (pool->size > size) size = pool->size;
         limit += pool->size;
-	pool = pool->next;
+        pool = pool->next;
     }
     /*
      * Not found, need to allocate
@@ -335,18 +335,18 @@ xmlDictAddQString(xmlDictPtr dict, const xmlChar *prefix, unsigned int plen,
         }
 
         if (size == 0) size = 1000;
-	else size *= 4; /* exponential growth */
+        else size *= 4; /* exponential growth */
         if (size < 4 * (namelen + plen + 1))
-	    size = 4 * (namelen + plen + 1); /* just in case ! */
-	pool = (xmlDictStringsPtr) xmlMalloc(sizeof(xmlDictStrings) + size);
-	if (pool == NULL)
-	    return(NULL);
-	pool->size = size;
-	pool->nbStrings = 0;
-	pool->free = &pool->array[0];
-	pool->end = &pool->array[size];
-	pool->next = dict->strings;
-	dict->strings = pool;
+            size = 4 * (namelen + plen + 1); /* just in case ! */
+        pool = (xmlDictStringsPtr) xmlMalloc(sizeof(xmlDictStrings) + size);
+        if (pool == NULL)
+            return(NULL);
+        pool->size = size;
+        pool->nbStrings = 0;
+        pool->free = &pool->array[0];
+        pool->end = &pool->array[size];
+        pool->next = dict->strings;
+        dict->strings = pool;
 #ifdef DICT_DEBUG_PATTERNS
         fprintf(stderr, "+");
 #endif
@@ -388,8 +388,8 @@ xmlDictComputeBigKey(const xmlChar* data, int namelen, int seed) {
 
     for (i = 0;i < namelen; i++) {
         hash += data[i];
-	hash += (hash << 10);
-	hash ^= (hash >> 6);
+        hash += (hash << 10);
+        hash ^= (hash >> 6);
     }
     hash += (hash << 3);
     hash ^= (hash >> 11);
@@ -423,8 +423,8 @@ xmlDictComputeBigQKey(const xmlChar *prefix, int plen,
 
     for (i = 0;i < plen; i++) {
         hash += prefix[i];
-	hash += (hash << 10);
-	hash ^= (hash >> 6);
+        hash += (hash << 10);
+        hash ^= (hash >> 6);
     }
     hash += ':';
     hash += (hash << 10);
@@ -432,8 +432,8 @@ xmlDictComputeBigQKey(const xmlChar *prefix, int plen,
 
     for (i = 0;i < len; i++) {
         hash += name[i];
-	hash += (hash << 10);
-	hash ^= (hash >> 6);
+        hash += (hash << 10);
+        hash ^= (hash >> 6);
     }
     hash += (hash << 3);
     hash ^= (hash >> 11);
@@ -500,18 +500,18 @@ xmlDictComputeFastQKey(const xmlChar *prefix, int plen,
     unsigned long value = (unsigned long) seed;
 
     if (plen == 0)
-	value += 30 * (unsigned long) ':';
+        value += 30 * (unsigned long) ':';
     else
-	value += 30 * (*prefix);
+        value += 30 * (*prefix);
 
     if (len > 10) {
         int offset = len - (plen + 1 + 1);
-	if (offset < 0)
-	    offset = len - (10 + 1);
-	value += name[offset];
+        if (offset < 0)
+            offset = len - (10 + 1);
+        value += name[offset];
         len = 10;
-	if (plen > 10)
-	    plen = 10;
+        if (plen > 10)
+            plen = 10;
     }
     switch (plen) {
         case 10: value += prefix[9];
@@ -539,7 +539,7 @@ xmlDictComputeFastQKey(const xmlChar *prefix, int plen,
     len -= plen;
     if (len > 0) {
         value += (unsigned long) ':';
-	len--;
+        len--;
     }
     switch (len) {
         case 10: value += name[9];
@@ -592,18 +592,18 @@ xmlDictCreate(void) {
         dict->limit = 0;
 
         dict->size = MIN_DICT_SIZE;
-	dict->nbElems = 0;
+        dict->nbElems = 0;
         dict->dict = xmlMalloc(MIN_DICT_SIZE * sizeof(xmlDictEntry));
-	dict->strings = NULL;
-	dict->subdict = NULL;
+        dict->strings = NULL;
+        dict->subdict = NULL;
         if (dict->dict) {
-	    memset(dict->dict, 0, MIN_DICT_SIZE * sizeof(xmlDictEntry));
+            memset(dict->dict, 0, MIN_DICT_SIZE * sizeof(xmlDictEntry));
 #ifdef DICT_RANDOMIZATION
             dict->seed = __xmlRandom();
 #else
             dict->seed = 0;
 #endif
-	    return(dict);
+            return(dict);
         }
         xmlFree(dict);
     }
@@ -631,7 +631,7 @@ xmlDictCreateSub(xmlDictPtr sub) {
 #endif
         dict->seed = sub->seed;
         dict->subdict = sub;
-	xmlDictReference(dict->subdict);
+        xmlDictReference(dict->subdict);
     }
     return(dict);
 }
@@ -679,11 +679,11 @@ xmlDictGrow(xmlDictPtr dict, size_t size) {
     int keep_keys = 1;
 
     if (dict == NULL)
-	return(-1);
+        return(-1);
     if (size < 8)
         return(-1);
     if (size > 8 * 2048)
-	return(-1);
+        return(-1);
 
 #ifdef DICT_DEBUG_PATTERNS
     fprintf(stderr, "*");
@@ -698,95 +698,95 @@ xmlDictGrow(xmlDictPtr dict, size_t size) {
 
     dict->dict = xmlMalloc(size * sizeof(xmlDictEntry));
     if (dict->dict == NULL) {
-	dict->dict = olddict;
-	return(-1);
+        dict->dict = olddict;
+        return(-1);
     }
     memset(dict->dict, 0, size * sizeof(xmlDictEntry));
     dict->size = size;
 
-    /*	If the two loops are merged, there would be situations where
-	a new entry needs to allocated and data copied into it from
-	the main dict. It is nicer to run through the array twice, first
-	copying all the elements in the main array (less probability of
-	allocate) and then the rest, so we only free in the second loop.
+    /*  If the two loops are merged, there would be situations where
+        a new entry needs to allocated and data copied into it from
+        the main dict. It is nicer to run through the array twice, first
+        copying all the elements in the main array (less probability of
+        allocate) and then the rest, so we only free in the second loop.
     */
     for (i = 0; i < oldsize; i++) {
-	if (olddict[i].valid == 0)
-	    continue;
+        if (olddict[i].valid == 0)
+            continue;
 
-	if (keep_keys)
-	    okey = olddict[i].okey;
-	else
-	    okey = xmlDictComputeKey(dict, olddict[i].name, olddict[i].len);
-	key = okey % dict->size;
+        if (keep_keys)
+            okey = olddict[i].okey;
+        else
+            okey = xmlDictComputeKey(dict, olddict[i].name, olddict[i].len);
+        key = okey % dict->size;
 
-	if (dict->dict[key].valid == 0) {
-	    memcpy(&(dict->dict[key]), &(olddict[i]), sizeof(xmlDictEntry));
-	    dict->dict[key].next = NULL;
-	    dict->dict[key].okey = okey;
-	} else {
-	    xmlDictEntryPtr entry;
+        if (dict->dict[key].valid == 0) {
+            memcpy(&(dict->dict[key]), &(olddict[i]), sizeof(xmlDictEntry));
+            dict->dict[key].next = NULL;
+            dict->dict[key].okey = okey;
+        } else {
+            xmlDictEntryPtr entry;
 
-	    entry = xmlMalloc(sizeof(xmlDictEntry));
-	    if (entry != NULL) {
-		entry->name = olddict[i].name;
-		entry->len = olddict[i].len;
-		entry->okey = okey;
-		entry->next = dict->dict[key].next;
-		entry->valid = 1;
-		dict->dict[key].next = entry;
-	    } else {
-	        /*
-		 * we don't have much ways to alert from here
-		 * result is losing an entry and unicity guarantee
-		 */
-	        ret = -1;
-	    }
-	}
+            entry = xmlMalloc(sizeof(xmlDictEntry));
+            if (entry != NULL) {
+                entry->name = olddict[i].name;
+                entry->len = olddict[i].len;
+                entry->okey = okey;
+                entry->next = dict->dict[key].next;
+                entry->valid = 1;
+                dict->dict[key].next = entry;
+            } else {
+                /*
+                 * we don't have much ways to alert from here
+                 * result is losing an entry and unicity guarantee
+                 */
+                ret = -1;
+            }
+        }
 #ifdef DEBUG_GROW
-	nbElem++;
+        nbElem++;
 #endif
     }
 
     for (i = 0; i < oldsize; i++) {
-	iter = olddict[i].next;
-	while (iter) {
-	    next = iter->next;
+        iter = olddict[i].next;
+        while (iter) {
+            next = iter->next;
 
-	    /*
-	     * put back the entry in the new dict
-	     */
+            /*
+             * put back the entry in the new dict
+             */
 
-	    if (keep_keys)
-		okey = iter->okey;
-	    else
-		okey = xmlDictComputeKey(dict, iter->name, iter->len);
-	    key = okey % dict->size;
-	    if (dict->dict[key].valid == 0) {
-		memcpy(&(dict->dict[key]), iter, sizeof(xmlDictEntry));
-		dict->dict[key].next = NULL;
-		dict->dict[key].valid = 1;
-		dict->dict[key].okey = okey;
-		xmlFree(iter);
-	    } else {
-		iter->next = dict->dict[key].next;
-		iter->okey = okey;
-		dict->dict[key].next = iter;
-	    }
+            if (keep_keys)
+                okey = iter->okey;
+            else
+                okey = xmlDictComputeKey(dict, iter->name, iter->len);
+            key = okey % dict->size;
+            if (dict->dict[key].valid == 0) {
+                memcpy(&(dict->dict[key]), iter, sizeof(xmlDictEntry));
+                dict->dict[key].next = NULL;
+                dict->dict[key].valid = 1;
+                dict->dict[key].okey = okey;
+                xmlFree(iter);
+            } else {
+                iter->next = dict->dict[key].next;
+                iter->okey = okey;
+                dict->dict[key].next = iter;
+            }
 
 #ifdef DEBUG_GROW
-	    nbElem++;
+            nbElem++;
 #endif
 
-	    iter = next;
-	}
+            iter = next;
+        }
     }
 
     xmlFree(olddict);
 
 #ifdef DEBUG_GROW
     xmlGenericError(xmlGenericErrorContext,
-	    "xmlDictGrow : from %lu to %lu, %u elems\n", oldsize, size, nbElem);
+            "xmlDictGrow : from %lu to %lu, %u elems\n", oldsize, size, nbElem);
 #endif
 
     return(ret);
@@ -808,7 +808,7 @@ xmlDictFree(xmlDictPtr dict) {
     xmlDictStringsPtr pool, nextp;
 
     if (dict == NULL)
-	return;
+        return;
 
     if (!xmlDictInitialized)
         if (!__xmlInitializeDict())
@@ -829,27 +829,27 @@ xmlDictFree(xmlDictPtr dict) {
     }
 
     if (dict->dict) {
-	for(i = 0; ((i < dict->size) && (dict->nbElems > 0)); i++) {
-	    iter = &(dict->dict[i]);
-	    if (iter->valid == 0)
-		continue;
-	    inside_dict = 1;
-	    while (iter) {
-		next = iter->next;
-		if (!inside_dict)
-		    xmlFree(iter);
-		dict->nbElems--;
-		inside_dict = 0;
-		iter = next;
-	    }
-	}
-	xmlFree(dict->dict);
+        for(i = 0; ((i < dict->size) && (dict->nbElems > 0)); i++) {
+            iter = &(dict->dict[i]);
+            if (iter->valid == 0)
+                continue;
+            inside_dict = 1;
+            while (iter) {
+                next = iter->next;
+                if (!inside_dict)
+                    xmlFree(iter);
+                dict->nbElems--;
+                inside_dict = 0;
+                iter = next;
+            }
+        }
+        xmlFree(dict->dict);
     }
     pool = dict->strings;
     while (pool != NULL) {
         nextp = pool->next;
-	xmlFree(pool);
-	pool = nextp;
+        xmlFree(pool);
+        pool = nextp;
     }
     xmlFree(dict);
 }
@@ -873,7 +873,7 @@ xmlDictLookup(xmlDictPtr dict, const xmlChar *name, int len) {
     unsigned int l;
 
     if ((dict == NULL) || (name == NULL))
-	return(NULL);
+        return(NULL);
 
     if (len < 0)
         l = strlen((const char *) name);
@@ -890,31 +890,31 @@ xmlDictLookup(xmlDictPtr dict, const xmlChar *name, int len) {
     okey = xmlDictComputeKey(dict, name, l);
     key = okey % dict->size;
     if (dict->dict[key].valid == 0) {
-	insert = NULL;
+        insert = NULL;
     } else {
-	for (insert = &(dict->dict[key]); insert->next != NULL;
-	     insert = insert->next) {
+        for (insert = &(dict->dict[key]); insert->next != NULL;
+             insert = insert->next) {
 #ifdef __GNUC__
-	    if ((insert->okey == okey) && (insert->len == l)) {
-		if (!memcmp(insert->name, name, l))
-		    return(insert->name);
-	    }
+            if ((insert->okey == okey) && (insert->len == l)) {
+                if (!memcmp(insert->name, name, l))
+                    return(insert->name);
+            }
 #else
-	    if ((insert->okey == okey) && (insert->len == l) &&
-	        (!xmlStrncmp(insert->name, name, l)))
-		return(insert->name);
+            if ((insert->okey == okey) && (insert->len == l) &&
+                (!xmlStrncmp(insert->name, name, l)))
+                return(insert->name);
 #endif
-	    nbi++;
-	}
+            nbi++;
+        }
 #ifdef __GNUC__
-	if ((insert->okey == okey) && (insert->len == l)) {
-	    if (!memcmp(insert->name, name, l))
-		return(insert->name);
-	}
+        if ((insert->okey == okey) && (insert->len == l)) {
+            if (!memcmp(insert->name, name, l))
+                return(insert->name);
+        }
 #else
-	if ((insert->okey == okey) && (insert->len == l) &&
-	    (!xmlStrncmp(insert->name, name, l)))
-	    return(insert->name);
+        if ((insert->okey == okey) && (insert->len == l) &&
+            (!xmlStrncmp(insert->name, name, l)))
+            return(insert->name);
 #endif
     }
 
@@ -923,54 +923,54 @@ xmlDictLookup(xmlDictPtr dict, const xmlChar *name, int len) {
 
         /* we cannot always reuse the same okey for the subdict */
         if (((dict->size == MIN_DICT_SIZE) &&
-	     (dict->subdict->size != MIN_DICT_SIZE)) ||
+             (dict->subdict->size != MIN_DICT_SIZE)) ||
             ((dict->size != MIN_DICT_SIZE) &&
-	     (dict->subdict->size == MIN_DICT_SIZE)))
-	    skey = xmlDictComputeKey(dict->subdict, name, l);
-	else
-	    skey = okey;
+             (dict->subdict->size == MIN_DICT_SIZE)))
+            skey = xmlDictComputeKey(dict->subdict, name, l);
+        else
+            skey = okey;
 
-	key = skey % dict->subdict->size;
-	if (dict->subdict->dict[key].valid != 0) {
-	    xmlDictEntryPtr tmp;
+        key = skey % dict->subdict->size;
+        if (dict->subdict->dict[key].valid != 0) {
+            xmlDictEntryPtr tmp;
 
-	    for (tmp = &(dict->subdict->dict[key]); tmp->next != NULL;
-		 tmp = tmp->next) {
+            for (tmp = &(dict->subdict->dict[key]); tmp->next != NULL;
+                 tmp = tmp->next) {
 #ifdef __GNUC__
-		if ((tmp->okey == skey) && (tmp->len == l)) {
-		    if (!memcmp(tmp->name, name, l))
-			return(tmp->name);
-		}
+                if ((tmp->okey == skey) && (tmp->len == l)) {
+                    if (!memcmp(tmp->name, name, l))
+                        return(tmp->name);
+                }
 #else
-		if ((tmp->okey == skey) && (tmp->len == l) &&
-		    (!xmlStrncmp(tmp->name, name, l)))
-		    return(tmp->name);
+                if ((tmp->okey == skey) && (tmp->len == l) &&
+                    (!xmlStrncmp(tmp->name, name, l)))
+                    return(tmp->name);
 #endif
-		nbi++;
-	    }
+                nbi++;
+            }
 #ifdef __GNUC__
-	    if ((tmp->okey == skey) && (tmp->len == l)) {
-		if (!memcmp(tmp->name, name, l))
-		    return(tmp->name);
-	    }
+            if ((tmp->okey == skey) && (tmp->len == l)) {
+                if (!memcmp(tmp->name, name, l))
+                    return(tmp->name);
+            }
 #else
-	    if ((tmp->okey == skey) && (tmp->len == l) &&
-		(!xmlStrncmp(tmp->name, name, l)))
-		return(tmp->name);
+            if ((tmp->okey == skey) && (tmp->len == l) &&
+                (!xmlStrncmp(tmp->name, name, l)))
+                return(tmp->name);
 #endif
-	}
-	key = okey % dict->size;
+        }
+        key = okey % dict->size;
     }
 
     ret = xmlDictAddString(dict, name, l);
     if (ret == NULL)
         return(NULL);
     if (insert == NULL) {
-	entry = &(dict->dict[key]);
+        entry = &(dict->dict[key]);
     } else {
-	entry = xmlMalloc(sizeof(xmlDictEntry));
-	if (entry == NULL)
-	     return(NULL);
+        entry = xmlMalloc(sizeof(xmlDictEntry));
+        if (entry == NULL)
+             return(NULL);
     }
     entry->name = ret;
     entry->len = l;
@@ -980,14 +980,14 @@ xmlDictLookup(xmlDictPtr dict, const xmlChar *name, int len) {
 
 
     if (insert != NULL)
-	insert->next = entry;
+        insert->next = entry;
 
     dict->nbElems++;
 
     if ((nbi > MAX_HASH_LEN) &&
         (dict->size <= ((MAX_DICT_HASH / 2) / MAX_HASH_LEN))) {
-	if (xmlDictGrow(dict, MAX_HASH_LEN * 2 * dict->size) != 0)
-	    return(NULL);
+        if (xmlDictGrow(dict, MAX_HASH_LEN * 2 * dict->size) != 0)
+            return(NULL);
     }
     /* Note that entry may have been freed at this point by xmlDictGrow */
 
@@ -1011,7 +1011,7 @@ xmlDictExists(xmlDictPtr dict, const xmlChar *name, int len) {
     unsigned int l;
 
     if ((dict == NULL) || (name == NULL))
-	return(NULL);
+        return(NULL);
 
     if (len < 0)
         l = strlen((const char *) name);
@@ -1027,31 +1027,31 @@ xmlDictExists(xmlDictPtr dict, const xmlChar *name, int len) {
     okey = xmlDictComputeKey(dict, name, l);
     key = okey % dict->size;
     if (dict->dict[key].valid == 0) {
-	insert = NULL;
+        insert = NULL;
     } else {
-	for (insert = &(dict->dict[key]); insert->next != NULL;
-	     insert = insert->next) {
+        for (insert = &(dict->dict[key]); insert->next != NULL;
+             insert = insert->next) {
 #ifdef __GNUC__
-	    if ((insert->okey == okey) && (insert->len == l)) {
-		if (!memcmp(insert->name, name, l))
-		    return(insert->name);
-	    }
+            if ((insert->okey == okey) && (insert->len == l)) {
+                if (!memcmp(insert->name, name, l))
+                    return(insert->name);
+            }
 #else
-	    if ((insert->okey == okey) && (insert->len == l) &&
-	        (!xmlStrncmp(insert->name, name, l)))
-		return(insert->name);
+            if ((insert->okey == okey) && (insert->len == l) &&
+                (!xmlStrncmp(insert->name, name, l)))
+                return(insert->name);
 #endif
-	    nbi++;
-	}
+            nbi++;
+        }
 #ifdef __GNUC__
-	if ((insert->okey == okey) && (insert->len == l)) {
-	    if (!memcmp(insert->name, name, l))
-		return(insert->name);
-	}
+        if ((insert->okey == okey) && (insert->len == l)) {
+            if (!memcmp(insert->name, name, l))
+                return(insert->name);
+        }
 #else
-	if ((insert->okey == okey) && (insert->len == l) &&
-	    (!xmlStrncmp(insert->name, name, l)))
-	    return(insert->name);
+        if ((insert->okey == okey) && (insert->len == l) &&
+            (!xmlStrncmp(insert->name, name, l)))
+            return(insert->name);
 #endif
     }
 
@@ -1060,42 +1060,42 @@ xmlDictExists(xmlDictPtr dict, const xmlChar *name, int len) {
 
         /* we cannot always reuse the same okey for the subdict */
         if (((dict->size == MIN_DICT_SIZE) &&
-	     (dict->subdict->size != MIN_DICT_SIZE)) ||
+             (dict->subdict->size != MIN_DICT_SIZE)) ||
             ((dict->size != MIN_DICT_SIZE) &&
-	     (dict->subdict->size == MIN_DICT_SIZE)))
-	    skey = xmlDictComputeKey(dict->subdict, name, l);
-	else
-	    skey = okey;
+             (dict->subdict->size == MIN_DICT_SIZE)))
+            skey = xmlDictComputeKey(dict->subdict, name, l);
+        else
+            skey = okey;
 
-	key = skey % dict->subdict->size;
-	if (dict->subdict->dict[key].valid != 0) {
-	    xmlDictEntryPtr tmp;
+        key = skey % dict->subdict->size;
+        if (dict->subdict->dict[key].valid != 0) {
+            xmlDictEntryPtr tmp;
 
-	    for (tmp = &(dict->subdict->dict[key]); tmp->next != NULL;
-		 tmp = tmp->next) {
+            for (tmp = &(dict->subdict->dict[key]); tmp->next != NULL;
+                 tmp = tmp->next) {
 #ifdef __GNUC__
-		if ((tmp->okey == skey) && (tmp->len == l)) {
-		    if (!memcmp(tmp->name, name, l))
-			return(tmp->name);
-		}
+                if ((tmp->okey == skey) && (tmp->len == l)) {
+                    if (!memcmp(tmp->name, name, l))
+                        return(tmp->name);
+                }
 #else
-		if ((tmp->okey == skey) && (tmp->len == l) &&
-		    (!xmlStrncmp(tmp->name, name, l)))
-		    return(tmp->name);
+                if ((tmp->okey == skey) && (tmp->len == l) &&
+                    (!xmlStrncmp(tmp->name, name, l)))
+                    return(tmp->name);
 #endif
-		nbi++;
-	    }
+                nbi++;
+            }
 #ifdef __GNUC__
-	    if ((tmp->okey == skey) && (tmp->len == l)) {
-		if (!memcmp(tmp->name, name, l))
-		    return(tmp->name);
-	    }
+            if ((tmp->okey == skey) && (tmp->len == l)) {
+                if (!memcmp(tmp->name, name, l))
+                    return(tmp->name);
+            }
 #else
-	    if ((tmp->okey == skey) && (tmp->len == l) &&
-		(!xmlStrncmp(tmp->name, name, l)))
-		return(tmp->name);
+            if ((tmp->okey == skey) && (tmp->len == l) &&
+                (!xmlStrncmp(tmp->name, name, l)))
+                return(tmp->name);
 #endif
-	}
+        }
     }
 
     /* not found */
@@ -1121,7 +1121,7 @@ xmlDictQLookup(xmlDictPtr dict, const xmlChar *prefix, const xmlChar *name) {
     unsigned int len, plen, l;
 
     if ((dict == NULL) || (name == NULL))
-	return(NULL);
+        return(NULL);
     if (prefix == NULL)
         return(xmlDictLookup(dict, name, -1));
 
@@ -1135,18 +1135,18 @@ xmlDictQLookup(xmlDictPtr dict, const xmlChar *prefix, const xmlChar *name) {
     okey = xmlDictComputeQKey(dict, prefix, plen, name, l);
     key = okey % dict->size;
     if (dict->dict[key].valid == 0) {
-	insert = NULL;
+        insert = NULL;
     } else {
-	for (insert = &(dict->dict[key]); insert->next != NULL;
-	     insert = insert->next) {
-	    if ((insert->okey == okey) && (insert->len == len) &&
-	        (xmlStrQEqual(prefix, name, insert->name)))
-		return(insert->name);
-	    nbi++;
-	}
-	if ((insert->okey == okey) && (insert->len == len) &&
-	    (xmlStrQEqual(prefix, name, insert->name)))
-	    return(insert->name);
+        for (insert = &(dict->dict[key]); insert->next != NULL;
+             insert = insert->next) {
+            if ((insert->okey == okey) && (insert->len == len) &&
+                (xmlStrQEqual(prefix, name, insert->name)))
+                return(insert->name);
+            nbi++;
+        }
+        if ((insert->okey == okey) && (insert->len == len) &&
+            (xmlStrQEqual(prefix, name, insert->name)))
+            return(insert->name);
     }
 
     if (dict->subdict) {
@@ -1154,39 +1154,39 @@ xmlDictQLookup(xmlDictPtr dict, const xmlChar *prefix, const xmlChar *name) {
 
         /* we cannot always reuse the same okey for the subdict */
         if (((dict->size == MIN_DICT_SIZE) &&
-	     (dict->subdict->size != MIN_DICT_SIZE)) ||
+             (dict->subdict->size != MIN_DICT_SIZE)) ||
             ((dict->size != MIN_DICT_SIZE) &&
-	     (dict->subdict->size == MIN_DICT_SIZE)))
-	    skey = xmlDictComputeQKey(dict->subdict, prefix, plen, name, l);
-	else
-	    skey = okey;
+             (dict->subdict->size == MIN_DICT_SIZE)))
+            skey = xmlDictComputeQKey(dict->subdict, prefix, plen, name, l);
+        else
+            skey = okey;
 
-	key = skey % dict->subdict->size;
-	if (dict->subdict->dict[key].valid != 0) {
-	    xmlDictEntryPtr tmp;
-	    for (tmp = &(dict->subdict->dict[key]); tmp->next != NULL;
-		 tmp = tmp->next) {
-		if ((tmp->okey == skey) && (tmp->len == len) &&
-		    (xmlStrQEqual(prefix, name, tmp->name)))
-		    return(tmp->name);
-		nbi++;
-	    }
-	    if ((tmp->okey == skey) && (tmp->len == len) &&
-		(xmlStrQEqual(prefix, name, tmp->name)))
-		return(tmp->name);
-	}
-	key = okey % dict->size;
+        key = skey % dict->subdict->size;
+        if (dict->subdict->dict[key].valid != 0) {
+            xmlDictEntryPtr tmp;
+            for (tmp = &(dict->subdict->dict[key]); tmp->next != NULL;
+                 tmp = tmp->next) {
+                if ((tmp->okey == skey) && (tmp->len == len) &&
+                    (xmlStrQEqual(prefix, name, tmp->name)))
+                    return(tmp->name);
+                nbi++;
+            }
+            if ((tmp->okey == skey) && (tmp->len == len) &&
+                (xmlStrQEqual(prefix, name, tmp->name)))
+                return(tmp->name);
+        }
+        key = okey % dict->size;
     }
 
     ret = xmlDictAddQString(dict, prefix, plen, name, l);
     if (ret == NULL)
         return(NULL);
     if (insert == NULL) {
-	entry = &(dict->dict[key]);
+        entry = &(dict->dict[key]);
     } else {
-	entry = xmlMalloc(sizeof(xmlDictEntry));
-	if (entry == NULL)
-	     return(NULL);
+        entry = xmlMalloc(sizeof(xmlDictEntry));
+        if (entry == NULL)
+             return(NULL);
     }
     entry->name = ret;
     entry->len = len;
@@ -1195,13 +1195,13 @@ xmlDictQLookup(xmlDictPtr dict, const xmlChar *prefix, const xmlChar *name) {
     entry->okey = okey;
 
     if (insert != NULL)
-	insert->next = entry;
+        insert->next = entry;
 
     dict->nbElems++;
 
     if ((nbi > MAX_HASH_LEN) &&
         (dict->size <= ((MAX_DICT_HASH / 2) / MAX_HASH_LEN)))
-	xmlDictGrow(dict, MAX_HASH_LEN * 2 * dict->size);
+        xmlDictGrow(dict, MAX_HASH_LEN * 2 * dict->size);
     /* Note that entry may have been freed at this point by xmlDictGrow */
 
     return(ret);
@@ -1222,12 +1222,12 @@ xmlDictOwns(xmlDictPtr dict, const xmlChar *str) {
     xmlDictStringsPtr pool;
 
     if ((dict == NULL) || (str == NULL))
-	return(-1);
+        return(-1);
     pool = dict->strings;
     while (pool != NULL) {
         if ((str >= &pool->array[0]) && (str <= pool->free))
-	    return(1);
-	pool = pool->next;
+            return(1);
+        pool = pool->next;
     }
     if (dict->subdict)
         return(xmlDictOwns(dict->subdict, str));
@@ -1246,7 +1246,7 @@ xmlDictOwns(xmlDictPtr dict, const xmlChar *str) {
 int
 xmlDictSize(xmlDictPtr dict) {
     if (dict == NULL)
-	return(-1);
+        return(-1);
     if (dict->subdict)
         return(dict->nbElems + dict->subdict->nbElems);
     return(dict->nbElems);
@@ -1267,7 +1267,7 @@ xmlDictSetLimit(xmlDictPtr dict, size_t limit) {
     size_t ret;
 
     if (dict == NULL)
-	return(0);
+        return(0);
     ret = dict->limit;
     dict->limit = limit;
     return(ret);
@@ -1288,11 +1288,11 @@ xmlDictGetUsage(xmlDictPtr dict) {
     size_t limit = 0;
 
     if (dict == NULL)
-	return(0);
+        return(0);
     pool = dict->strings;
     while (pool != NULL) {
         limit += pool->size;
-	pool = pool->next;
+        pool = pool->next;
     }
     return(limit);
 }

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/libxml2.spec
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/libxml2.spec
@@ -2,7 +2,7 @@
 
 Summary: Library providing XML and HTML support
 Name: libxml2
-Version: 2.10.3
+Version: 2.10.4
 Release: 1%{?dist}%{?extra_release}
 License: MIT
 Group: Development/Libraries
@@ -203,6 +203,6 @@ rm -fr %{buildroot}
 %endif # with_python3
 
 %changelog
-* Thu Mar  9 2023 Daniel Veillard <veillard@redhat.com>
-- upstream release 2.10.3
+* Thu Apr 20 2023 Daniel Veillard <veillard@redhat.com>
+- upstream release 2.10.4
 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xmlIO.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xmlIO.c
@@ -117,69 +117,69 @@ xmlAllocOutputBufferInternal(xmlCharEncodingHandlerPtr encoder);
 #endif /* LIBXML_OUTPUT_ENABLED */
 
 /************************************************************************
- *                                                                      *
- *              Tree memory error handler                               *
- *                                                                      *
+ *									*
+ *		Tree memory error handler				*
+ *									*
  ************************************************************************/
 
 static const char* const IOerr[] = {
     "Unknown IO error",         /* UNKNOWN */
-    "Permission denied",        /* EACCES */
+    "Permission denied",	/* EACCES */
     "Resource temporarily unavailable",/* EAGAIN */
-    "Bad file descriptor",      /* EBADF */
-    "Bad message",              /* EBADMSG */
-    "Resource busy",            /* EBUSY */
-    "Operation canceled",       /* ECANCELED */
-    "No child processes",       /* ECHILD */
+    "Bad file descriptor",	/* EBADF */
+    "Bad message",		/* EBADMSG */
+    "Resource busy",		/* EBUSY */
+    "Operation canceled",	/* ECANCELED */
+    "No child processes",	/* ECHILD */
     "Resource deadlock avoided",/* EDEADLK */
-    "Domain error",             /* EDOM */
-    "File exists",              /* EEXIST */
-    "Bad address",              /* EFAULT */
-    "File too large",           /* EFBIG */
-    "Operation in progress",    /* EINPROGRESS */
+    "Domain error",		/* EDOM */
+    "File exists",		/* EEXIST */
+    "Bad address",		/* EFAULT */
+    "File too large",		/* EFBIG */
+    "Operation in progress",	/* EINPROGRESS */
     "Interrupted function call",/* EINTR */
-    "Invalid argument",         /* EINVAL */
-    "Input/output error",       /* EIO */
-    "Is a directory",           /* EISDIR */
-    "Too many open files",      /* EMFILE */
-    "Too many links",           /* EMLINK */
+    "Invalid argument",		/* EINVAL */
+    "Input/output error",	/* EIO */
+    "Is a directory",		/* EISDIR */
+    "Too many open files",	/* EMFILE */
+    "Too many links",		/* EMLINK */
     "Inappropriate message buffer length",/* EMSGSIZE */
-    "Filename too long",        /* ENAMETOOLONG */
+    "Filename too long",	/* ENAMETOOLONG */
     "Too many open files in system",/* ENFILE */
-    "No such device",           /* ENODEV */
+    "No such device",		/* ENODEV */
     "No such file or directory",/* ENOENT */
-    "Exec format error",        /* ENOEXEC */
-    "No locks available",       /* ENOLCK */
-    "Not enough space",         /* ENOMEM */
-    "No space left on device",  /* ENOSPC */
-    "Function not implemented", /* ENOSYS */
-    "Not a directory",          /* ENOTDIR */
-    "Directory not empty",      /* ENOTEMPTY */
-    "Not supported",            /* ENOTSUP */
+    "Exec format error",	/* ENOEXEC */
+    "No locks available",	/* ENOLCK */
+    "Not enough space",		/* ENOMEM */
+    "No space left on device",	/* ENOSPC */
+    "Function not implemented",	/* ENOSYS */
+    "Not a directory",		/* ENOTDIR */
+    "Directory not empty",	/* ENOTEMPTY */
+    "Not supported",		/* ENOTSUP */
     "Inappropriate I/O control operation",/* ENOTTY */
     "No such device or address",/* ENXIO */
-    "Operation not permitted",  /* EPERM */
-    "Broken pipe",              /* EPIPE */
-    "Result too large",         /* ERANGE */
-    "Read-only file system",    /* EROFS */
-    "Invalid seek",             /* ESPIPE */
-    "No such process",          /* ESRCH */
-    "Operation timed out",      /* ETIMEDOUT */
-    "Improper link",            /* EXDEV */
+    "Operation not permitted",	/* EPERM */
+    "Broken pipe",		/* EPIPE */
+    "Result too large",		/* ERANGE */
+    "Read-only file system",	/* EROFS */
+    "Invalid seek",		/* ESPIPE */
+    "No such process",		/* ESRCH */
+    "Operation timed out",	/* ETIMEDOUT */
+    "Improper link",		/* EXDEV */
     "Attempt to load network entity %s", /* XML_IO_NETWORK_ATTEMPT */
-    "encoder error",            /* XML_IO_ENCODER */
+    "encoder error",		/* XML_IO_ENCODER */
     "flush error",
     "write error",
     "no input",
     "buffer full",
     "loading error",
-    "not a socket",             /* ENOTSOCK */
-    "already connected",        /* EISCONN */
-    "connection refused",       /* ECONNREFUSED */
-    "unreachable network",      /* ENETUNREACH */
-    "address in use",           /* EADDRINUSE */
-    "already in use",           /* EALREADY */
-    "unknown address family",   /* EAFNOSUPPORT */
+    "not a socket",		/* ENOTSOCK */
+    "already connected",	/* EISCONN */
+    "connection refused",	/* ECONNREFUSED */
+    "unreachable network",	/* ENETUNREACH */
+    "address in use",		/* EADDRINUSE */
+    "already in use",		/* EALREADY */
+    "unknown address family",	/* EAFNOSUPPORT */
 };
 
 #if defined(_WIN32)
@@ -240,7 +240,7 @@ __xmlIOErr(int domain, int code, const char *extra)
     unsigned int idx;
 
     if (code == 0) {
-        if (errno == 0) code = 0;
+	if (errno == 0) code = 0;
 #ifdef EACCES
         else if (errno == EACCES) code = XML_IO_EACCES;
 #endif
@@ -434,30 +434,30 @@ __xmlLoaderErr(void *ctx, const char *msg, const char *filename)
 
     if ((ctxt != NULL) && (ctxt->disableSAX != 0) &&
         (ctxt->instate == XML_PARSER_EOF))
-        return;
+	return;
     if ((ctxt != NULL) && (ctxt->sax != NULL)) {
         if (ctxt->validate) {
-            channel = ctxt->sax->error;
-            level = XML_ERR_ERROR;
-        } else {
-            channel = ctxt->sax->warning;
-            level = XML_ERR_WARNING;
-        }
-        if (ctxt->sax->initialized == XML_SAX2_MAGIC)
-            schannel = ctxt->sax->serror;
-        data = ctxt->userData;
+	    channel = ctxt->sax->error;
+	    level = XML_ERR_ERROR;
+	} else {
+	    channel = ctxt->sax->warning;
+	    level = XML_ERR_WARNING;
+	}
+	if (ctxt->sax->initialized == XML_SAX2_MAGIC)
+	    schannel = ctxt->sax->serror;
+	data = ctxt->userData;
     }
     __xmlRaiseError(schannel, channel, data, ctxt, NULL, XML_FROM_IO,
                     XML_IO_LOAD_ERROR, level, NULL, 0,
-                    filename, NULL, NULL, 0, 0,
-                    msg, filename);
+		    filename, NULL, NULL, 0, 0,
+		    msg, filename);
 
 }
 
 /************************************************************************
- *                                                                      *
- *              Tree memory error handler                               *
- *                                                                      *
+ *									*
+ *		Tree memory error handler				*
+ *									*
  ************************************************************************/
 /**
  * xmlNormalizeWindowsPath:
@@ -580,9 +580,9 @@ xmlPopOutputCallbacks(void)
 #endif /* LIBXML_OUTPUT_ENABLED */
 
 /************************************************************************
- *                                                                      *
- *              Standard I/O for file accesses                          *
- *                                                                      *
+ *									*
+ *		Standard I/O for file accesses				*
+ *									*
  ************************************************************************/
 
 #if defined(_WIN32)
@@ -628,13 +628,13 @@ xmlWrapGzOpenUtf8(const char *path, const char *mode)
     wPath = __xmlIOWin32UTF8ToWChar(path);
     if(wPath)
     {
-        int d, m = (strstr(mode, "r") ? O_RDONLY : O_RDWR);
+	int d, m = (strstr(mode, "r") ? O_RDONLY : O_RDWR);
 #ifdef _O_BINARY
         m |= (strstr(mode, "b") ? _O_BINARY : 0);
 #endif
-        d = _wopen(wPath, m);
-        if (d >= 0)
-            fd = gzdopen(d, mode);
+	d = _wopen(wPath, m);
+	if (d >= 0)
+	    fd = gzdopen(d, mode);
         xmlFree(wPath);
     }
 
@@ -693,7 +693,7 @@ xmlCheckFilename (const char *path)
 #endif
 #endif
     if (path == NULL)
-        return(0);
+	return(0);
 
 #ifdef HAVE_STAT
 #if defined(_WIN32)
@@ -702,8 +702,8 @@ xmlCheckFilename (const char *path)
      * which start with '\\?\'
      */
     if ((path[0] == '\\') && (path[1] == '\\') && (path[2] == '?') &&
-        (path[3] == '\\') )
-            return 1;
+	(path[3] == '\\') )
+	    return 1;
 
     if (xmlWrapStatUtf8(path, &stat_buffer) == -1)
         return 0;
@@ -768,8 +768,8 @@ xmlFdWrite (void * context, const char * buffer, int len) {
     int ret = 0;
 
     if (len > 0) {
-        ret = write((int) (ptrdiff_t) context, &buffer[0], len);
-        if (ret < 0) xmlIOErr(0, "write()");
+	ret = write((int) (ptrdiff_t) context, &buffer[0], len);
+	if (ret < 0) xmlIOErr(0, "write()");
     }
     return(ret);
 }
@@ -822,28 +822,28 @@ xmlFileOpen_real (const char *filename) {
         return(NULL);
 
     if (!strcmp(filename, "-")) {
-        fd = stdin;
-        return((void *) fd);
+	fd = stdin;
+	return((void *) fd);
     }
 
     if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file://localhost/", 17)) {
 #if defined (_WIN32)
-        path = &filename[17];
+	path = &filename[17];
 #else
-        path = &filename[16];
+	path = &filename[16];
 #endif
     } else if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file:///", 8)) {
 #if defined (_WIN32)
-        path = &filename[8];
+	path = &filename[8];
 #else
-        path = &filename[7];
+	path = &filename[7];
 #endif
     } else if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file:/", 6)) {
         /* lots of generators seems to lazy to read RFC 1738 */
 #if defined (_WIN32)
-        path = &filename[6];
+	path = &filename[6];
 #else
-        path = &filename[5];
+	path = &filename[5];
 #endif
     }
 
@@ -878,11 +878,11 @@ xmlFileOpen (const char *filename) {
 
     retval = xmlFileOpen_real(filename);
     if (retval == NULL) {
-        unescaped = xmlURIUnescapeString(filename, 0, NULL);
-        if (unescaped != NULL) {
-            retval = xmlFileOpen_real(unescaped);
-            xmlFree(unescaped);
-        }
+	unescaped = xmlURIUnescapeString(filename, 0, NULL);
+	if (unescaped != NULL) {
+	    retval = xmlFileOpen_real(unescaped);
+	    xmlFree(unescaped);
+	}
     }
 
     return retval;
@@ -904,27 +904,27 @@ xmlFileOpenW (const char *filename) {
     FILE *fd;
 
     if (!strcmp(filename, "-")) {
-        fd = stdout;
-        return((void *) fd);
+	fd = stdout;
+	return((void *) fd);
     }
 
     if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file://localhost/", 17))
 #if defined (_WIN32)
-        path = &filename[17];
+	path = &filename[17];
 #else
-        path = &filename[16];
+	path = &filename[16];
 #endif
     else if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file:///", 8)) {
 #if defined (_WIN32)
-        path = &filename[8];
+	path = &filename[8];
 #else
-        path = &filename[7];
+	path = &filename[7];
 #endif
     } else
-        path = filename;
+	path = filename;
 
     if (path == NULL)
-        return(NULL);
+	return(NULL);
 
 #if defined(_WIN32)
     fd = xmlWrapOpenUtf8(path, 1);
@@ -979,7 +979,7 @@ xmlFileWrite (void * context, const char * buffer, int len) {
     items = fwrite(&buffer[0], len, 1, (FILE *) context);
     if ((items == 0) && (ferror((FILE *) context))) {
         xmlIOErr(0, "fwrite()");
-        return(-1);
+	return(-1);
     }
     return(items * len);
 }
@@ -1003,12 +1003,12 @@ xmlFileClose (void * context) {
     fil = (FILE *) context;
     if ((fil == stdout) || (fil == stderr)) {
         ret = fflush(fil);
-        if (ret < 0)
-            xmlIOErr(0, "fflush()");
-        return(0);
+	if (ret < 0)
+	    xmlIOErr(0, "fflush()");
+	return(0);
     }
     if (fil == stdin)
-        return(0);
+	return(0);
     ret = ( fclose((FILE *) context) == EOF ) ? -1 : 0;
     if (ret < 0)
         xmlIOErr(0, "fclose()");
@@ -1057,9 +1057,9 @@ xmlBufferWrite (void * context, const char * buffer, int len) {
 
 #ifdef LIBXML_ZLIB_ENABLED
 /************************************************************************
- *                                                                      *
- *              I/O for compressed file accesses                        *
- *                                                                      *
+ *									*
+ *		I/O for compressed file accesses			*
+ *									*
  ************************************************************************/
 /**
  * xmlGzfileMatch:
@@ -1095,26 +1095,26 @@ xmlGzfileOpen_real (const char *filename) {
             close(duped_fd);  /* gzdOpen() does not close on failure */
         }
 
-        return((void *) fd);
+	return((void *) fd);
     }
 
     if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file://localhost/", 17))
 #if defined (_WIN32)
-        path = &filename[17];
+	path = &filename[17];
 #else
-        path = &filename[16];
+	path = &filename[16];
 #endif
     else if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file:///", 8)) {
 #if defined (_WIN32)
-        path = &filename[8];
+	path = &filename[8];
 #else
-        path = &filename[7];
+	path = &filename[7];
 #endif
     } else
-        path = filename;
+	path = filename;
 
     if (path == NULL)
-        return(NULL);
+	return(NULL);
     if (!xmlCheckFilename(path))
         return(NULL);
 
@@ -1140,11 +1140,11 @@ xmlGzfileOpen (const char *filename) {
 
     retval = xmlGzfileOpen_real(filename);
     if (retval == NULL) {
-        unescaped = xmlURIUnescapeString(filename, 0, NULL);
-        if (unescaped != NULL) {
-            retval = xmlGzfileOpen_real(unescaped);
-        }
-        xmlFree(unescaped);
+	unescaped = xmlURIUnescapeString(filename, 0, NULL);
+	if (unescaped != NULL) {
+	    retval = xmlGzfileOpen_real(unescaped);
+	}
+	xmlFree(unescaped);
     }
     return retval;
 }
@@ -1174,26 +1174,26 @@ xmlGzfileOpenW (const char *filename, int compression) {
             close(duped_fd);  /* gzdOpen() does not close on failure */
         }
 
-        return((void *) fd);
+	return((void *) fd);
     }
 
     if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file://localhost/", 17))
 #if defined (_WIN32)
-        path = &filename[17];
+	path = &filename[17];
 #else
-        path = &filename[16];
+	path = &filename[16];
 #endif
     else if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file:///", 8)) {
 #if defined (_WIN32)
-        path = &filename[8];
+	path = &filename[8];
 #else
-        path = &filename[7];
+	path = &filename[7];
 #endif
     } else
-        path = filename;
+	path = filename;
 
     if (path == NULL)
-        return(NULL);
+	return(NULL);
 
 #if defined(_WIN32)
     fd = xmlWrapGzOpenUtf8(path, mode);
@@ -1262,9 +1262,9 @@ xmlGzfileClose (void * context) {
 
 #ifdef LIBXML_LZMA_ENABLED
 /************************************************************************
- *                                                                      *
- *              I/O for compressed file accesses                        *
- *                                                                      *
+ *									*
+ *		I/O for compressed file accesses			*
+ *									*
  ************************************************************************/
 #include "xzlib.h"
 /**
@@ -1296,21 +1296,21 @@ xmlXzfileOpen_real (const char *filename) {
 
     if (!strcmp(filename, "-")) {
         fd = __libxml2_xzdopen(dup(fileno(stdin)), "rb");
-        return((void *) fd);
+	return((void *) fd);
     }
 
     if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file://localhost/", 17)) {
-        path = &filename[16];
+	path = &filename[16];
     } else if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file:///", 8)) {
-        path = &filename[7];
+	path = &filename[7];
     } else if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file:/", 6)) {
         /* lots of generators seems to lazy to read RFC 1738 */
-        path = &filename[5];
+	path = &filename[5];
     } else
-        path = filename;
+	path = filename;
 
     if (path == NULL)
-        return(NULL);
+	return(NULL);
     if (!xmlCheckFilename(path))
         return(NULL);
 
@@ -1334,11 +1334,11 @@ xmlXzfileOpen (const char *filename) {
 
     retval = xmlXzfileOpen_real(filename);
     if (retval == NULL) {
-        unescaped = xmlURIUnescapeString(filename, 0, NULL);
-        if (unescaped != NULL) {
-            retval = xmlXzfileOpen_real(unescaped);
-        }
-        xmlFree(unescaped);
+	unescaped = xmlURIUnescapeString(filename, 0, NULL);
+	if (unescaped != NULL) {
+	    retval = xmlXzfileOpen_real(unescaped);
+	}
+	xmlFree(unescaped);
     }
 
     return retval;
@@ -1381,31 +1381,31 @@ xmlXzfileClose (void * context) {
 
 #ifdef LIBXML_HTTP_ENABLED
 /************************************************************************
- *                                                                      *
- *                      I/O for HTTP file accesses                      *
- *                                                                      *
+ *									*
+ *			I/O for HTTP file accesses			*
+ *									*
  ************************************************************************/
 
 #ifdef LIBXML_OUTPUT_ENABLED
 typedef struct xmlIOHTTPWriteCtxt_
 {
-    int                 compression;
+    int			compression;
 
-    char *              uri;
+    char *		uri;
 
-    void *              doc_buff;
+    void *		doc_buff;
 
 } xmlIOHTTPWriteCtxt, *xmlIOHTTPWriteCtxtPtr;
 
 #ifdef LIBXML_ZLIB_ENABLED
 
-#define DFLT_WBITS              ( -15 )
-#define DFLT_MEM_LVL            ( 8 )
-#define GZ_MAGIC1               ( 0x1f )
-#define GZ_MAGIC2               ( 0x8b )
-#define LXML_ZLIB_OS_CODE       ( 0x03 )
-#define INIT_HTTP_BUFF_SIZE     ( 32768 )
-#define DFLT_ZLIB_RATIO         ( 5 )
+#define DFLT_WBITS		( -15 )
+#define DFLT_MEM_LVL		( 8 )
+#define GZ_MAGIC1		( 0x1f )
+#define GZ_MAGIC2		( 0x8b )
+#define LXML_ZLIB_OS_CODE	( 0x03 )
+#define INIT_HTTP_BUFF_SIZE	( 32768 )
+#define DFLT_ZLIB_RATIO		( 5 )
 
 /*
 **  Data structure and functions to work with sending compressed data
@@ -1414,11 +1414,11 @@ typedef struct xmlIOHTTPWriteCtxt_
 
 typedef struct xmlZMemBuff_
 {
-   unsigned long        size;
-   unsigned long        crc;
+   unsigned long	size;
+   unsigned long	crc;
 
-   unsigned char *      zbuff;
-   z_stream             zctrl;
+   unsigned char *	zbuff;
+   z_stream		zctrl;
 
 } xmlZMemBuff, *xmlZMemBuffPtr;
 
@@ -1433,10 +1433,10 @@ typedef struct xmlZMemBuff_
 static void
 append_reverse_ulong( xmlZMemBuff * buff, unsigned long data ) {
 
-    int         idx;
+    int		idx;
 
     if ( buff == NULL )
-        return;
+	return;
 
     /*
     **  This is plagiarized from putLong in gzio.c (zlib source) where
@@ -1446,9 +1446,9 @@ append_reverse_ulong( xmlZMemBuff * buff, unsigned long data ) {
     */
 
     for ( idx = 0; idx < 4; idx++ ) {
-        *buff->zctrl.next_out = ( data & 0xff );
-        data >>= 8;
-        buff->zctrl.next_out++;
+	*buff->zctrl.next_out = ( data & 0xff );
+	data >>= 8;
+	buff->zctrl.next_out++;
     }
 
     return;
@@ -1469,15 +1469,15 @@ xmlFreeZMemBuff( xmlZMemBuffPtr buff ) {
 #endif
 
     if ( buff == NULL )
-        return;
+	return;
 
     xmlFree( buff->zbuff );
 #ifdef DEBUG_HTTP
     z_err = deflateEnd( &buff->zctrl );
     if ( z_err != Z_OK )
-        xmlGenericError( xmlGenericErrorContext,
-                        "xmlFreeZMemBuff:  Error releasing zlib context:  %d\n",
-                        z_err );
+	xmlGenericError( xmlGenericErrorContext,
+			"xmlFreeZMemBuff:  Error releasing zlib context:  %d\n",
+			z_err );
 #else
     deflateEnd( &buff->zctrl );
 #endif
@@ -1488,7 +1488,7 @@ xmlFreeZMemBuff( xmlZMemBuffPtr buff ) {
 
 /**
  * xmlCreateZMemBuff
- *@compression: Compression value to use
+ *@compression:	Compression value to use
  *
  * Create a memory buffer to hold the compressed XML document.  The
  * compressed document in memory will end up being identical to what
@@ -1499,50 +1499,50 @@ xmlFreeZMemBuff( xmlZMemBuffPtr buff ) {
 static void *
 xmlCreateZMemBuff( int compression ) {
 
-    int                 z_err;
-    int                 hdr_lgth;
-    xmlZMemBuffPtr      buff = NULL;
+    int			z_err;
+    int			hdr_lgth;
+    xmlZMemBuffPtr	buff = NULL;
 
     if ( ( compression < 1 ) || ( compression > 9 ) )
-        return ( NULL );
+	return ( NULL );
 
     /*  Create the control and data areas  */
 
     buff = xmlMalloc( sizeof( xmlZMemBuff ) );
     if ( buff == NULL ) {
-        xmlIOErrMemory("creating buffer context");
-        return ( NULL );
+	xmlIOErrMemory("creating buffer context");
+	return ( NULL );
     }
 
     (void)memset( buff, 0, sizeof( xmlZMemBuff ) );
     buff->size = INIT_HTTP_BUFF_SIZE;
     buff->zbuff = xmlMalloc( buff->size );
     if ( buff->zbuff == NULL ) {
-        xmlFreeZMemBuff( buff );
-        xmlIOErrMemory("creating buffer");
-        return ( NULL );
+	xmlFreeZMemBuff( buff );
+	xmlIOErrMemory("creating buffer");
+	return ( NULL );
     }
 
     z_err = deflateInit2( &buff->zctrl, compression, Z_DEFLATED,
-                            DFLT_WBITS, DFLT_MEM_LVL, Z_DEFAULT_STRATEGY );
+			    DFLT_WBITS, DFLT_MEM_LVL, Z_DEFAULT_STRATEGY );
     if ( z_err != Z_OK ) {
-        xmlChar msg[500];
-        xmlFreeZMemBuff( buff );
-        buff = NULL;
-        xmlStrPrintf(msg, 500,
-                    "xmlCreateZMemBuff:  %s %d\n",
-                    "Error initializing compression context.  ZLIB error:",
-                    z_err );
-        xmlIOErr(XML_IO_WRITE, (const char *) msg);
-        return ( NULL );
+	xmlChar msg[500];
+	xmlFreeZMemBuff( buff );
+	buff = NULL;
+	xmlStrPrintf(msg, 500,
+		    "xmlCreateZMemBuff:  %s %d\n",
+		    "Error initializing compression context.  ZLIB error:",
+		    z_err );
+	xmlIOErr(XML_IO_WRITE, (const char *) msg);
+	return ( NULL );
     }
 
     /*  Set the header data.  The CRC will be needed for the trailer  */
     buff->crc = crc32( 0L, NULL, 0 );
     hdr_lgth = snprintf( (char *)buff->zbuff, buff->size,
-                        "%c%c%c%c%c%c%c%c%c%c",
-                        GZ_MAGIC1, GZ_MAGIC2, Z_DEFLATED,
-                        0, 0, 0, 0, 0, 0, LXML_ZLIB_OS_CODE );
+			"%c%c%c%c%c%c%c%c%c%c",
+			GZ_MAGIC1, GZ_MAGIC2, Z_DEFLATED,
+			0, 0, 0, 0, 0, 0, LXML_ZLIB_OS_CODE );
     buff->zctrl.next_out  = buff->zbuff + hdr_lgth;
     buff->zctrl.avail_out = buff->size - hdr_lgth;
 
@@ -1563,45 +1563,45 @@ xmlCreateZMemBuff( int compression ) {
 static int
 xmlZMemBuffExtend( xmlZMemBuffPtr buff, size_t ext_amt ) {
 
-    int                 rc = -1;
-    size_t              new_size;
-    size_t              cur_used;
+    int			rc = -1;
+    size_t		new_size;
+    size_t		cur_used;
 
-    unsigned char *     tmp_ptr = NULL;
+    unsigned char *	tmp_ptr = NULL;
 
     if ( buff == NULL )
-        return ( -1 );
+	return ( -1 );
 
     else if ( ext_amt == 0 )
-        return ( 0 );
+	return ( 0 );
 
     cur_used = buff->zctrl.next_out - buff->zbuff;
     new_size = buff->size + ext_amt;
 
 #ifdef DEBUG_HTTP
     if ( cur_used > new_size )
-        xmlGenericError( xmlGenericErrorContext,
-                        "xmlZMemBuffExtend:  %s\n%s %d bytes.\n",
-                        "Buffer overwrite detected during compressed memory",
-                        "buffer extension.  Overflowed by",
-                        (cur_used - new_size ) );
+	xmlGenericError( xmlGenericErrorContext,
+			"xmlZMemBuffExtend:  %s\n%s %d bytes.\n",
+			"Buffer overwrite detected during compressed memory",
+			"buffer extension.  Overflowed by",
+			(cur_used - new_size ) );
 #endif
 
     tmp_ptr = xmlRealloc( buff->zbuff, new_size );
     if ( tmp_ptr != NULL ) {
-        rc = 0;
-        buff->size  = new_size;
-        buff->zbuff = tmp_ptr;
-        buff->zctrl.next_out  = tmp_ptr + cur_used;
-        buff->zctrl.avail_out = new_size - cur_used;
+	rc = 0;
+	buff->size  = new_size;
+	buff->zbuff = tmp_ptr;
+	buff->zctrl.next_out  = tmp_ptr + cur_used;
+	buff->zctrl.avail_out = new_size - cur_used;
     }
     else {
-        xmlChar msg[500];
-        xmlStrPrintf(msg, 500,
-                    "xmlZMemBuffExtend:  %s %lu bytes.\n",
-                    "Allocation failure extending output buffer to",
-                    (unsigned long) new_size );
-        xmlIOErr(XML_IO_WRITE, (const char *) msg);
+	xmlChar msg[500];
+	xmlStrPrintf(msg, 500,
+		    "xmlZMemBuffExtend:  %s %lu bytes.\n",
+		    "Allocation failure extending output buffer to",
+		    (unsigned long) new_size );
+	xmlIOErr(XML_IO_WRITE, (const char *) msg);
     }
 
     return ( rc );
@@ -1621,35 +1621,35 @@ xmlZMemBuffExtend( xmlZMemBuffPtr buff, size_t ext_amt ) {
 static int
 xmlZMemBuffAppend( xmlZMemBuffPtr buff, const char * src, int len ) {
 
-    int         z_err;
-    size_t      min_accept;
+    int		z_err;
+    size_t	min_accept;
 
     if ( ( buff == NULL ) || ( src == NULL ) )
-        return ( -1 );
+	return ( -1 );
 
     buff->zctrl.avail_in = len;
     buff->zctrl.next_in  = (unsigned char *)src;
     while ( buff->zctrl.avail_in > 0 ) {
-        /*
-        **  Extend the buffer prior to deflate call if a reasonable amount
-        **  of output buffer space is not available.
-        */
-        min_accept = buff->zctrl.avail_in / DFLT_ZLIB_RATIO;
-        if ( buff->zctrl.avail_out <= min_accept ) {
-            if ( xmlZMemBuffExtend( buff, buff->size ) == -1 )
-                return ( -1 );
-        }
+	/*
+	**  Extend the buffer prior to deflate call if a reasonable amount
+	**  of output buffer space is not available.
+	*/
+	min_accept = buff->zctrl.avail_in / DFLT_ZLIB_RATIO;
+	if ( buff->zctrl.avail_out <= min_accept ) {
+	    if ( xmlZMemBuffExtend( buff, buff->size ) == -1 )
+		return ( -1 );
+	}
 
-        z_err = deflate( &buff->zctrl, Z_NO_FLUSH );
-        if ( z_err != Z_OK ) {
-            xmlChar msg[500];
-            xmlStrPrintf(msg, 500,
-                        "xmlZMemBuffAppend:  %s %d %s - %d",
-                        "Compression error while appending",
-                        len, "bytes to buffer.  ZLIB error", z_err );
-            xmlIOErr(XML_IO_WRITE, (const char *) msg);
-            return ( -1 );
-        }
+	z_err = deflate( &buff->zctrl, Z_NO_FLUSH );
+	if ( z_err != Z_OK ) {
+	    xmlChar msg[500];
+	    xmlStrPrintf(msg, 500,
+			"xmlZMemBuffAppend:  %s %d %s - %d",
+			"Compression error while appending",
+			len, "bytes to buffer.  ZLIB error", z_err );
+	    xmlIOErr(XML_IO_WRITE, (const char *) msg);
+	    return ( -1 );
+	}
     }
 
     buff->crc = crc32( buff->crc, (unsigned char *)src, len );
@@ -1671,23 +1671,23 @@ xmlZMemBuffAppend( xmlZMemBuffPtr buff, const char * src, int len ) {
 static int
 xmlZMemBuffGetContent( xmlZMemBuffPtr buff, char ** data_ref ) {
 
-    int         zlgth = -1;
-    int         z_err;
+    int		zlgth = -1;
+    int		z_err;
 
     if ( ( buff == NULL ) || ( data_ref == NULL ) )
-        return ( -1 );
+	return ( -1 );
 
     /*  Need to loop until compression output buffers are flushed  */
 
     do
     {
-        z_err = deflate( &buff->zctrl, Z_FINISH );
-        if ( z_err == Z_OK ) {
-            /*  In this case Z_OK means more buffer space needed  */
+	z_err = deflate( &buff->zctrl, Z_FINISH );
+	if ( z_err == Z_OK ) {
+	    /*  In this case Z_OK means more buffer space needed  */
 
-            if ( xmlZMemBuffExtend( buff, buff->size ) == -1 )
-                return ( -1 );
-        }
+	    if ( xmlZMemBuffExtend( buff, buff->size ) == -1 )
+		return ( -1 );
+	}
     }
     while ( z_err == Z_OK );
 
@@ -1695,31 +1695,31 @@ xmlZMemBuffGetContent( xmlZMemBuffPtr buff, char ** data_ref ) {
 
     if ( z_err == Z_STREAM_END ) {
 
-        /*  Need to append the gzip data trailer  */
+	/*  Need to append the gzip data trailer  */
 
-        if ( buff->zctrl.avail_out < ( 2 * sizeof( unsigned long ) ) ) {
-            if ( xmlZMemBuffExtend(buff, (2 * sizeof(unsigned long))) == -1 )
-                return ( -1 );
-        }
+	if ( buff->zctrl.avail_out < ( 2 * sizeof( unsigned long ) ) ) {
+	    if ( xmlZMemBuffExtend(buff, (2 * sizeof(unsigned long))) == -1 )
+		return ( -1 );
+	}
 
-        /*
-        **  For whatever reason, the CRC and length data are pushed out
-        **  in reverse byte order.  So a memcpy can't be used here.
-        */
+	/*
+	**  For whatever reason, the CRC and length data are pushed out
+	**  in reverse byte order.  So a memcpy can't be used here.
+	*/
 
-        append_reverse_ulong( buff, buff->crc );
-        append_reverse_ulong( buff, buff->zctrl.total_in );
+	append_reverse_ulong( buff, buff->crc );
+	append_reverse_ulong( buff, buff->zctrl.total_in );
 
-        zlgth = buff->zctrl.next_out - buff->zbuff;
-        *data_ref = (char *)buff->zbuff;
+	zlgth = buff->zctrl.next_out - buff->zbuff;
+	*data_ref = (char *)buff->zbuff;
     }
 
     else {
-        xmlChar msg[500];
-        xmlStrPrintf(msg, 500,
-                    "xmlZMemBuffGetContent:  %s - %d\n",
-                    "Error flushing zlib buffers.  Error code", z_err );
-        xmlIOErr(XML_IO_WRITE, (const char *) msg);
+	xmlChar msg[500];
+	xmlStrPrintf(msg, 500,
+		    "xmlZMemBuffGetContent:  %s - %d\n",
+		    "Error flushing zlib buffers.  Error code", z_err );
+	xmlIOErr(XML_IO_WRITE, (const char *) msg);
     }
 
     return ( zlgth );
@@ -1740,19 +1740,19 @@ static void
 xmlFreeHTTPWriteCtxt( xmlIOHTTPWriteCtxtPtr ctxt )
 {
     if ( ctxt->uri != NULL )
-        xmlFree( ctxt->uri );
+	xmlFree( ctxt->uri );
 
     if ( ctxt->doc_buff != NULL ) {
 
 #ifdef LIBXML_ZLIB_ENABLED
-        if ( ctxt->compression > 0 ) {
-            xmlFreeZMemBuff( ctxt->doc_buff );
-        }
-        else
+	if ( ctxt->compression > 0 ) {
+	    xmlFreeZMemBuff( ctxt->doc_buff );
+	}
+	else
 #endif
-        {
-            xmlOutputBufferClose( ctxt->doc_buff );
-        }
+	{
+	    xmlOutputBufferClose( ctxt->doc_buff );
+	}
     }
 
     xmlFree( ctxt );
@@ -1772,7 +1772,7 @@ xmlFreeHTTPWriteCtxt( xmlIOHTTPWriteCtxtPtr ctxt )
 int
 xmlIOHTTPMatch (const char *filename) {
     if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "http://", 7))
-        return(1);
+	return(1);
     return(0);
 }
 
@@ -1812,7 +1812,7 @@ xmlIOHTTPOpenW(const char *post_uri, int compression ATTRIBUTE_UNUSED)
 
     ctxt = xmlMalloc(sizeof(xmlIOHTTPWriteCtxt));
     if (ctxt == NULL) {
-        xmlIOErrMemory("creating HTTP output context");
+	xmlIOErrMemory("creating HTTP output context");
         return (NULL);
     }
 
@@ -1820,7 +1820,7 @@ xmlIOHTTPOpenW(const char *post_uri, int compression ATTRIBUTE_UNUSED)
 
     ctxt->uri = (char *) xmlStrdup((const xmlChar *)post_uri);
     if (ctxt->uri == NULL) {
-        xmlIOErrMemory("copying URI");
+	xmlIOErrMemory("copying URI");
         xmlFreeHTTPWriteCtxt(ctxt);
         return (NULL);
     }
@@ -1902,32 +1902,32 @@ xmlIOHTTPRead(void * context, char * buffer, int len) {
 static int
 xmlIOHTTPWrite( void * context, const char * buffer, int len ) {
 
-    xmlIOHTTPWriteCtxtPtr       ctxt = context;
+    xmlIOHTTPWriteCtxtPtr	ctxt = context;
 
     if ( ( ctxt == NULL ) || ( ctxt->doc_buff == NULL ) || ( buffer == NULL ) )
-        return ( -1 );
+	return ( -1 );
 
     if ( len > 0 ) {
 
-        /*  Use gzwrite or fwrite as previously setup in the open call  */
+	/*  Use gzwrite or fwrite as previously setup in the open call  */
 
 #ifdef LIBXML_ZLIB_ENABLED
-        if ( ctxt->compression > 0 )
-            len = xmlZMemBuffAppend( ctxt->doc_buff, buffer, len );
+	if ( ctxt->compression > 0 )
+	    len = xmlZMemBuffAppend( ctxt->doc_buff, buffer, len );
 
-        else
+	else
 #endif
-            len = xmlOutputBufferWrite( ctxt->doc_buff, len, buffer );
+	    len = xmlOutputBufferWrite( ctxt->doc_buff, len, buffer );
 
-        if ( len < 0 ) {
-            xmlChar msg[500];
-            xmlStrPrintf(msg, 500,
-                        "xmlIOHTTPWrite:  %s\n%s '%s'.\n",
-                        "Error appending to internal buffer.",
-                        "Error sending document to URI",
-                        ctxt->uri );
-            xmlIOErr(XML_IO_WRITE, (const char *) msg);
-        }
+	if ( len < 0 ) {
+	    xmlChar msg[500];
+	    xmlStrPrintf(msg, 500,
+			"xmlIOHTTPWrite:  %s\n%s '%s'.\n",
+			"Error appending to internal buffer.",
+			"Error sending document to URI",
+			ctxt->uri );
+	    xmlIOErr(XML_IO_WRITE, (const char *) msg);
+	}
     }
 
     return ( len );
@@ -1960,122 +1960,122 @@ xmlIOHTTPClose (void * context) {
 static int
 xmlIOHTTPCloseWrite( void * context, const char * http_mthd ) {
 
-    int                         close_rc = -1;
-    int                         http_rtn = 0;
-    int                         content_lgth = 0;
-    xmlIOHTTPWriteCtxtPtr       ctxt = context;
+    int				close_rc = -1;
+    int				http_rtn = 0;
+    int				content_lgth = 0;
+    xmlIOHTTPWriteCtxtPtr	ctxt = context;
 
-    char *                      http_content = NULL;
-    char *                      content_encoding = NULL;
-    char *                      content_type = (char *) "text/xml";
-    void *                      http_ctxt = NULL;
+    char *			http_content = NULL;
+    char *			content_encoding = NULL;
+    char *			content_type = (char *) "text/xml";
+    void *			http_ctxt = NULL;
 
     if ( ( ctxt == NULL ) || ( http_mthd == NULL ) )
-        return ( -1 );
+	return ( -1 );
 
     /*  Retrieve the content from the appropriate buffer  */
 
 #ifdef LIBXML_ZLIB_ENABLED
 
     if ( ctxt->compression > 0 ) {
-        content_lgth = xmlZMemBuffGetContent( ctxt->doc_buff, &http_content );
-        content_encoding = (char *) "Content-Encoding: gzip";
+	content_lgth = xmlZMemBuffGetContent( ctxt->doc_buff, &http_content );
+	content_encoding = (char *) "Content-Encoding: gzip";
     }
     else
 #endif
     {
-        /*  Pull the data out of the memory output buffer  */
+	/*  Pull the data out of the memory output buffer  */
 
-        xmlOutputBufferPtr      dctxt = ctxt->doc_buff;
-        http_content = (char *) xmlBufContent(dctxt->buffer);
-        content_lgth = xmlBufUse(dctxt->buffer);
+	xmlOutputBufferPtr	dctxt = ctxt->doc_buff;
+	http_content = (char *) xmlBufContent(dctxt->buffer);
+	content_lgth = xmlBufUse(dctxt->buffer);
     }
 
     if ( http_content == NULL ) {
-        xmlChar msg[500];
-        xmlStrPrintf(msg, 500,
-                     "xmlIOHTTPCloseWrite:  %s '%s' %s '%s'.\n",
-                     "Error retrieving content.\nUnable to",
-                     http_mthd, "data to URI", ctxt->uri );
-        xmlIOErr(XML_IO_WRITE, (const char *) msg);
+	xmlChar msg[500];
+	xmlStrPrintf(msg, 500,
+		     "xmlIOHTTPCloseWrite:  %s '%s' %s '%s'.\n",
+		     "Error retrieving content.\nUnable to",
+		     http_mthd, "data to URI", ctxt->uri );
+	xmlIOErr(XML_IO_WRITE, (const char *) msg);
     }
 
     else {
 
-        http_ctxt = xmlNanoHTTPMethod( ctxt->uri, http_mthd, http_content,
-                                        &content_type, content_encoding,
-                                        content_lgth );
+	http_ctxt = xmlNanoHTTPMethod( ctxt->uri, http_mthd, http_content,
+					&content_type, content_encoding,
+					content_lgth );
 
-        if ( http_ctxt != NULL ) {
+	if ( http_ctxt != NULL ) {
 #ifdef DEBUG_HTTP
-            /*  If testing/debugging - dump reply with request content  */
+	    /*  If testing/debugging - dump reply with request content  */
 
-            FILE *      tst_file = NULL;
-            char        buffer[ 4096 ];
-            char *      dump_name = NULL;
-            int         avail;
+	    FILE *	tst_file = NULL;
+	    char	buffer[ 4096 ];
+	    char *	dump_name = NULL;
+	    int		avail;
 
-            xmlGenericError( xmlGenericErrorContext,
-                        "xmlNanoHTTPCloseWrite:  HTTP %s to\n%s returned %d.\n",
-                        http_mthd, ctxt->uri,
-                        xmlNanoHTTPReturnCode( http_ctxt ) );
+	    xmlGenericError( xmlGenericErrorContext,
+			"xmlNanoHTTPCloseWrite:  HTTP %s to\n%s returned %d.\n",
+			http_mthd, ctxt->uri,
+			xmlNanoHTTPReturnCode( http_ctxt ) );
 
-            /*
-            **  Since either content or reply may be gzipped,
-            **  dump them to separate files instead of the
-            **  standard error context.
-            */
+	    /*
+	    **  Since either content or reply may be gzipped,
+	    **  dump them to separate files instead of the
+	    **  standard error context.
+	    */
 
-            dump_name = tempnam( NULL, "lxml" );
-            if ( dump_name != NULL ) {
-                (void)snprintf( buffer, sizeof(buffer), "%s.content", dump_name );
+	    dump_name = tempnam( NULL, "lxml" );
+	    if ( dump_name != NULL ) {
+		(void)snprintf( buffer, sizeof(buffer), "%s.content", dump_name );
 
-                tst_file = fopen( buffer, "wb" );
-                if ( tst_file != NULL ) {
-                    xmlGenericError( xmlGenericErrorContext,
-                        "Transmitted content saved in file:  %s\n", buffer );
+		tst_file = fopen( buffer, "wb" );
+		if ( tst_file != NULL ) {
+		    xmlGenericError( xmlGenericErrorContext,
+			"Transmitted content saved in file:  %s\n", buffer );
 
-                    fwrite( http_content, sizeof( char ),
-                                        content_lgth, tst_file );
-                    fclose( tst_file );
-                }
+		    fwrite( http_content, sizeof( char ),
+					content_lgth, tst_file );
+		    fclose( tst_file );
+		}
 
-                (void)snprintf( buffer, sizeof(buffer), "%s.reply", dump_name );
-                tst_file = fopen( buffer, "wb" );
-                if ( tst_file != NULL ) {
-                    xmlGenericError( xmlGenericErrorContext,
-                        "Reply content saved in file:  %s\n", buffer );
+		(void)snprintf( buffer, sizeof(buffer), "%s.reply", dump_name );
+		tst_file = fopen( buffer, "wb" );
+		if ( tst_file != NULL ) {
+		    xmlGenericError( xmlGenericErrorContext,
+			"Reply content saved in file:  %s\n", buffer );
 
 
-                    while ( (avail = xmlNanoHTTPRead( http_ctxt,
-                                        buffer, sizeof( buffer ) )) > 0 ) {
+		    while ( (avail = xmlNanoHTTPRead( http_ctxt,
+					buffer, sizeof( buffer ) )) > 0 ) {
 
-                        fwrite( buffer, sizeof( char ), avail, tst_file );
-                    }
+			fwrite( buffer, sizeof( char ), avail, tst_file );
+		    }
 
-                    fclose( tst_file );
-                }
+		    fclose( tst_file );
+		}
 
-                free( dump_name );
-            }
+		free( dump_name );
+	    }
 #endif  /*  DEBUG_HTTP  */
 
-            http_rtn = xmlNanoHTTPReturnCode( http_ctxt );
-            if ( ( http_rtn >= 200 ) && ( http_rtn < 300 ) )
-                close_rc = 0;
-            else {
+	    http_rtn = xmlNanoHTTPReturnCode( http_ctxt );
+	    if ( ( http_rtn >= 200 ) && ( http_rtn < 300 ) )
+		close_rc = 0;
+	    else {
                 xmlChar msg[500];
                 xmlStrPrintf(msg, 500,
                       "xmlIOHTTPCloseWrite: HTTP '%s' of %d %s\n'%s' %s %d\n",
-                            http_mthd, content_lgth,
-                            "bytes to URI", ctxt->uri,
-                            "failed.  HTTP return code:", http_rtn );
-                xmlIOErr(XML_IO_WRITE, (const char *) msg);
+			    http_mthd, content_lgth,
+			    "bytes to URI", ctxt->uri,
+			    "failed.  HTTP return code:", http_rtn );
+		xmlIOErr(XML_IO_WRITE, (const char *) msg);
             }
 
-            xmlNanoHTTPClose( http_ctxt );
-            xmlFree( content_type );
-        }
+	    xmlNanoHTTPClose( http_ctxt );
+	    xmlFree( content_type );
+	}
     }
 
     /*  Final cleanups  */
@@ -2117,9 +2117,9 @@ xmlIOHTTPClosePost( void * ctxt ) {
 
 #ifdef LIBXML_FTP_ENABLED
 /************************************************************************
- *                                                                      *
- *                      I/O for FTP file accesses                       *
- *                                                                      *
+ *									*
+ *			I/O for FTP file accesses			*
+ *									*
  ************************************************************************/
 /**
  * xmlIOFTPMatch:
@@ -2132,7 +2132,7 @@ xmlIOHTTPClosePost( void * ctxt ) {
 int
 xmlIOFTPMatch (const char *filename) {
     if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "ftp://", 6))
-        return(1);
+	return(1);
     return(0);
 }
 
@@ -2193,10 +2193,10 @@ xmlIOFTPClose (void * context) {
  */
 int
 xmlRegisterInputCallbacks(xmlInputMatchCallback matchFunc,
-        xmlInputOpenCallback openFunc, xmlInputReadCallback readFunc,
-        xmlInputCloseCallback closeFunc) {
+	xmlInputOpenCallback openFunc, xmlInputReadCallback readFunc,
+	xmlInputCloseCallback closeFunc) {
     if (xmlInputCallbackNr >= MAX_INPUT_CALLBACK) {
-        return(-1);
+	return(-1);
     }
     xmlInputCallbackTable[xmlInputCallbackNr].matchcallback = matchFunc;
     xmlInputCallbackTable[xmlInputCallbackNr].opencallback = openFunc;
@@ -2220,10 +2220,10 @@ xmlRegisterInputCallbacks(xmlInputMatchCallback matchFunc,
  */
 int
 xmlRegisterOutputCallbacks(xmlOutputMatchCallback matchFunc,
-        xmlOutputOpenCallback openFunc, xmlOutputWriteCallback writeFunc,
-        xmlOutputCloseCallback closeFunc) {
+	xmlOutputOpenCallback openFunc, xmlOutputWriteCallback writeFunc,
+	xmlOutputCloseCallback closeFunc) {
     if (xmlOutputCallbackNr >= MAX_OUTPUT_CALLBACK) {
-        return(-1);
+	return(-1);
     }
     xmlOutputCallbackTable[xmlOutputCallbackNr].matchcallback = matchFunc;
     xmlOutputCallbackTable[xmlOutputCallbackNr].opencallback = openFunc;
@@ -2242,27 +2242,27 @@ xmlRegisterOutputCallbacks(xmlOutputMatchCallback matchFunc,
 void
 xmlRegisterDefaultInputCallbacks(void) {
     if (xmlInputCallbackInitialized)
-        return;
+	return;
 
     xmlRegisterInputCallbacks(xmlFileMatch, xmlFileOpen,
-                              xmlFileRead, xmlFileClose);
+	                      xmlFileRead, xmlFileClose);
 #ifdef LIBXML_ZLIB_ENABLED
     xmlRegisterInputCallbacks(xmlGzfileMatch, xmlGzfileOpen,
-                              xmlGzfileRead, xmlGzfileClose);
+	                      xmlGzfileRead, xmlGzfileClose);
 #endif /* LIBXML_ZLIB_ENABLED */
 #ifdef LIBXML_LZMA_ENABLED
     xmlRegisterInputCallbacks(xmlXzfileMatch, xmlXzfileOpen,
-                              xmlXzfileRead, xmlXzfileClose);
+	                      xmlXzfileRead, xmlXzfileClose);
 #endif /* LIBXML_LZMA_ENABLED */
 
 #ifdef LIBXML_HTTP_ENABLED
     xmlRegisterInputCallbacks(xmlIOHTTPMatch, xmlIOHTTPOpen,
-                              xmlIOHTTPRead, xmlIOHTTPClose);
+	                      xmlIOHTTPRead, xmlIOHTTPClose);
 #endif /* LIBXML_HTTP_ENABLED */
 
 #ifdef LIBXML_FTP_ENABLED
     xmlRegisterInputCallbacks(xmlIOFTPMatch, xmlIOFTPOpen,
-                              xmlIOFTPRead, xmlIOFTPClose);
+	                      xmlIOFTPRead, xmlIOFTPClose);
 #endif /* LIBXML_FTP_ENABLED */
     xmlInputCallbackInitialized = 1;
 }
@@ -2276,14 +2276,14 @@ xmlRegisterDefaultInputCallbacks(void) {
 void
 xmlRegisterDefaultOutputCallbacks (void) {
     if (xmlOutputCallbackInitialized)
-        return;
+	return;
 
     xmlRegisterOutputCallbacks(xmlFileMatch, xmlFileOpenW,
-                              xmlFileWrite, xmlFileClose);
+	                      xmlFileWrite, xmlFileClose);
 
 #ifdef LIBXML_HTTP_ENABLED
     xmlRegisterOutputCallbacks(xmlIOHTTPMatch, xmlIOHTTPDfltOpenW,
-                               xmlIOHTTPWrite, xmlIOHTTPClosePut);
+	                       xmlIOHTTPWrite, xmlIOHTTPClosePut);
 #endif
 
 /*********************************
@@ -2293,13 +2293,13 @@ xmlRegisterDefaultOutputCallbacks (void) {
 
 #ifdef LIBXML_ZLIB_ENABLED
     xmlRegisterOutputCallbacks(xmlGzfileMatch, xmlGzfileOpen,
-                               xmlGzfileWrite, xmlGzfileClose);
+	                       xmlGzfileWrite, xmlGzfileClose);
 #endif
 
  Nor FTP PUT ....
 #ifdef LIBXML_FTP_ENABLED
     xmlRegisterOutputCallbacks(xmlIOFTPMatch, xmlIOFTPOpen,
-                               xmlIOFTPWrite, xmlIOFTPClose);
+	                       xmlIOFTPWrite, xmlIOFTPClose);
 #endif
  **********************************/
     xmlOutputCallbackInitialized = 1;
@@ -2320,10 +2320,10 @@ xmlRegisterHTTPPostCallbacks( void ) {
     /*  Register defaults if not done previously  */
 
     if ( xmlOutputCallbackInitialized == 0 )
-        xmlRegisterDefaultOutputCallbacks( );
+	xmlRegisterDefaultOutputCallbacks( );
 
     xmlRegisterOutputCallbacks(xmlIOHTTPMatch, xmlIOHTTPDfltOpenW,
-                               xmlIOHTTPWrite, xmlIOHTTPClosePost);
+	                       xmlIOHTTPWrite, xmlIOHTTPClosePost);
     return;
 }
 #endif
@@ -2343,14 +2343,14 @@ xmlAllocParserInputBuffer(xmlCharEncoding enc) {
 
     ret = (xmlParserInputBufferPtr) xmlMalloc(sizeof(xmlParserInputBuffer));
     if (ret == NULL) {
-        xmlIOErrMemory("creating input buffer");
-        return(NULL);
+	xmlIOErrMemory("creating input buffer");
+	return(NULL);
     }
     memset(ret, 0, (size_t) sizeof(xmlParserInputBuffer));
     ret->buffer = xmlBufCreateSize(2 * xmlDefaultBufferSize);
     if (ret->buffer == NULL) {
         xmlFree(ret);
-        return(NULL);
+	return(NULL);
     }
     xmlBufSetAllocationScheme(ret->buffer, XML_BUFFER_ALLOC_DOUBLEIT);
     ret->encoder = xmlGetCharEncodingHandler(enc);
@@ -2382,30 +2382,30 @@ xmlAllocOutputBuffer(xmlCharEncodingHandlerPtr encoder) {
 
     ret = (xmlOutputBufferPtr) xmlMalloc(sizeof(xmlOutputBuffer));
     if (ret == NULL) {
-        xmlIOErrMemory("creating output buffer");
-        return(NULL);
+	xmlIOErrMemory("creating output buffer");
+	return(NULL);
     }
     memset(ret, 0, (size_t) sizeof(xmlOutputBuffer));
     ret->buffer = xmlBufCreate();
     if (ret->buffer == NULL) {
         xmlFree(ret);
-        return(NULL);
+	return(NULL);
     }
     xmlBufSetAllocationScheme(ret->buffer, XML_BUFFER_ALLOC_DOUBLEIT);
 
     ret->encoder = encoder;
     if (encoder != NULL) {
         ret->conv = xmlBufCreateSize(4000);
-        if (ret->conv == NULL) {
+	if (ret->conv == NULL) {
             xmlBufFree(ret->buffer);
-            xmlFree(ret);
-            return(NULL);
-        }
+	    xmlFree(ret);
+	    return(NULL);
+	}
 
-        /*
-         * This call is designed to initiate the encoder state
-         */
-        xmlCharEncOutput(ret, 1);
+	/*
+	 * This call is designed to initiate the encoder state
+	 */
+	xmlCharEncOutput(ret, 1);
     } else
         ret->conv = NULL;
     ret->writecallback = NULL;
@@ -2430,14 +2430,14 @@ xmlAllocOutputBufferInternal(xmlCharEncodingHandlerPtr encoder) {
 
     ret = (xmlOutputBufferPtr) xmlMalloc(sizeof(xmlOutputBuffer));
     if (ret == NULL) {
-        xmlIOErrMemory("creating output buffer");
-        return(NULL);
+	xmlIOErrMemory("creating output buffer");
+	return(NULL);
     }
     memset(ret, 0, (size_t) sizeof(xmlOutputBuffer));
     ret->buffer = xmlBufCreate();
     if (ret->buffer == NULL) {
         xmlFree(ret);
-        return(NULL);
+	return(NULL);
     }
 
 
@@ -2449,15 +2449,15 @@ xmlAllocOutputBufferInternal(xmlCharEncodingHandlerPtr encoder) {
     ret->encoder = encoder;
     if (encoder != NULL) {
         ret->conv = xmlBufCreateSize(4000);
-        if (ret->conv == NULL) {
+	if (ret->conv == NULL) {
             xmlBufFree(ret->buffer);
-            xmlFree(ret);
-            return(NULL);
-        }
+	    xmlFree(ret);
+	    return(NULL);
+	}
 
-        /*
-         * This call is designed to initiate the encoder state
-         */
+	/*
+	 * This call is designed to initiate the encoder state
+	 */
         xmlCharEncOutput(ret, 1);
     } else
         ret->conv = NULL;
@@ -2483,17 +2483,17 @@ xmlFreeParserInputBuffer(xmlParserInputBufferPtr in) {
 
     if (in->raw) {
         xmlBufFree(in->raw);
-        in->raw = NULL;
+	in->raw = NULL;
     }
     if (in->encoder != NULL) {
         xmlCharEncCloseFunc(in->encoder);
     }
     if (in->closecallback != NULL) {
-        in->closecallback(in->context);
+	in->closecallback(in->context);
     }
     if (in->buffer != NULL) {
         xmlBufFree(in->buffer);
-        in->buffer = NULL;
+	in->buffer = NULL;
     }
 
     xmlFree(in);
@@ -2549,7 +2549,7 @@ __xmlParserInputBufferCreateFilename(const char *URI, xmlCharEncoding enc) {
     void *context = NULL;
 
     if (xmlInputCallbackInitialized == 0)
-        xmlRegisterDefaultInputCallbacks();
+	xmlRegisterDefaultInputCallbacks();
 
     if (URI == NULL) return(NULL);
 
@@ -2558,18 +2558,18 @@ __xmlParserInputBufferCreateFilename(const char *URI, xmlCharEncoding enc) {
      * Go in reverse to give precedence to user defined handlers.
      */
     if (context == NULL) {
-        for (i = xmlInputCallbackNr - 1;i >= 0;i--) {
-            if ((xmlInputCallbackTable[i].matchcallback != NULL) &&
-                (xmlInputCallbackTable[i].matchcallback(URI) != 0)) {
-                context = xmlInputCallbackTable[i].opencallback(URI);
-                if (context != NULL) {
-                    break;
-                }
-            }
-        }
+	for (i = xmlInputCallbackNr - 1;i >= 0;i--) {
+	    if ((xmlInputCallbackTable[i].matchcallback != NULL) &&
+		(xmlInputCallbackTable[i].matchcallback(URI) != 0)) {
+		context = xmlInputCallbackTable[i].opencallback(URI);
+		if (context != NULL) {
+		    break;
+		}
+	    }
+	}
     }
     if (context == NULL) {
-        return(NULL);
+	return(NULL);
     }
 
     /*
@@ -2577,34 +2577,34 @@ __xmlParserInputBufferCreateFilename(const char *URI, xmlCharEncoding enc) {
      */
     ret = xmlAllocParserInputBuffer(enc);
     if (ret != NULL) {
-        ret->context = context;
-        ret->readcallback = xmlInputCallbackTable[i].readcallback;
-        ret->closecallback = xmlInputCallbackTable[i].closecallback;
+	ret->context = context;
+	ret->readcallback = xmlInputCallbackTable[i].readcallback;
+	ret->closecallback = xmlInputCallbackTable[i].closecallback;
 #ifdef LIBXML_ZLIB_ENABLED
-        if ((xmlInputCallbackTable[i].opencallback == xmlGzfileOpen) &&
-                (strcmp(URI, "-") != 0)) {
+	if ((xmlInputCallbackTable[i].opencallback == xmlGzfileOpen) &&
+		(strcmp(URI, "-") != 0)) {
 #if defined(ZLIB_VERNUM) && ZLIB_VERNUM >= 0x1230
             ret->compressed = !gzdirect(context);
 #else
-            if (((z_stream *)context)->avail_in > 4) {
-                char *cptr, buff4[4];
-                cptr = (char *) ((z_stream *)context)->next_in;
-                if (gzread(context, buff4, 4) == 4) {
-                    if (strncmp(buff4, cptr, 4) == 0)
-                        ret->compressed = 0;
-                    else
-                        ret->compressed = 1;
-                    gzrewind(context);
-                }
-            }
+	    if (((z_stream *)context)->avail_in > 4) {
+	        char *cptr, buff4[4];
+		cptr = (char *) ((z_stream *)context)->next_in;
+		if (gzread(context, buff4, 4) == 4) {
+		    if (strncmp(buff4, cptr, 4) == 0)
+		        ret->compressed = 0;
+		    else
+		        ret->compressed = 1;
+		    gzrewind(context);
+		}
+	    }
 #endif
-        }
+	}
 #endif
 #ifdef LIBXML_LZMA_ENABLED
-        if ((xmlInputCallbackTable[i].opencallback == xmlXzfileOpen) &&
-                (strcmp(URI, "-") != 0)) {
+	if ((xmlInputCallbackTable[i].opencallback == xmlXzfileOpen) &&
+		(strcmp(URI, "-") != 0)) {
             ret->compressed = __libxml2_xzcompressed(context);
-        }
+	}
 #endif
     }
     else
@@ -2629,9 +2629,9 @@ __xmlParserInputBufferCreateFilename(const char *URI, xmlCharEncoding enc) {
 xmlParserInputBufferPtr
 xmlParserInputBufferCreateFilename(const char *URI, xmlCharEncoding enc) {
     if ((xmlParserInputBufferCreateFilenameValue)) {
-                return xmlParserInputBufferCreateFilenameValue(URI, enc);
-        }
-        return __xmlParserInputBufferCreateFilename(URI, enc);
+		return xmlParserInputBufferCreateFilenameValue(URI, enc);
+	}
+	return __xmlParserInputBufferCreateFilename(URI, enc);
 }
 
 #ifdef LIBXML_OUTPUT_ENABLED
@@ -2649,7 +2649,7 @@ __xmlOutputBufferCreateFilename(const char *URI,
 #endif
 
     if (xmlOutputCallbackInitialized == 0)
-        xmlRegisterDefaultOutputCallbacks();
+	xmlRegisterDefaultOutputCallbacks();
 
     if (URI == NULL) return(NULL);
 
@@ -2657,16 +2657,16 @@ __xmlOutputBufferCreateFilename(const char *URI,
     if (puri != NULL) {
 #ifdef LIBXML_ZLIB_ENABLED
         if ((puri->scheme != NULL) &&
-            (!xmlStrEqual(BAD_CAST puri->scheme, BAD_CAST "file")))
-            is_file_uri = 0;
+	    (!xmlStrEqual(BAD_CAST puri->scheme, BAD_CAST "file")))
+	    is_file_uri = 0;
 #endif
-        /*
-         * try to limit the damages of the URI unescaping code.
-         */
-        if ((puri->scheme == NULL) ||
-            (xmlStrEqual(BAD_CAST puri->scheme, BAD_CAST "file")))
-            unescaped = xmlURIUnescapeString(URI, 0, NULL);
-        xmlFreeURI(puri);
+	/*
+	 * try to limit the damages of the URI unescaping code.
+	 */
+	if ((puri->scheme == NULL) ||
+	    (xmlStrEqual(BAD_CAST puri->scheme, BAD_CAST "file")))
+	    unescaped = xmlURIUnescapeString(URI, 0, NULL);
+	xmlFreeURI(puri);
     }
 
     /*
@@ -2676,35 +2676,35 @@ __xmlOutputBufferCreateFilename(const char *URI,
      */
     if (unescaped != NULL) {
 #ifdef LIBXML_ZLIB_ENABLED
-        if ((compression > 0) && (compression <= 9) && (is_file_uri == 1)) {
-            context = xmlGzfileOpenW(unescaped, compression);
-            if (context != NULL) {
-                ret = xmlAllocOutputBufferInternal(encoder);
-                if (ret != NULL) {
-                    ret->context = context;
-                    ret->writecallback = xmlGzfileWrite;
-                    ret->closecallback = xmlGzfileClose;
-                }
-                xmlFree(unescaped);
-                return(ret);
-            }
-        }
+	if ((compression > 0) && (compression <= 9) && (is_file_uri == 1)) {
+	    context = xmlGzfileOpenW(unescaped, compression);
+	    if (context != NULL) {
+		ret = xmlAllocOutputBufferInternal(encoder);
+		if (ret != NULL) {
+		    ret->context = context;
+		    ret->writecallback = xmlGzfileWrite;
+		    ret->closecallback = xmlGzfileClose;
+		}
+		xmlFree(unescaped);
+		return(ret);
+	    }
+	}
 #endif
-        for (i = xmlOutputCallbackNr - 1;i >= 0;i--) {
-            if ((xmlOutputCallbackTable[i].matchcallback != NULL) &&
-                (xmlOutputCallbackTable[i].matchcallback(unescaped) != 0)) {
+	for (i = xmlOutputCallbackNr - 1;i >= 0;i--) {
+	    if ((xmlOutputCallbackTable[i].matchcallback != NULL) &&
+		(xmlOutputCallbackTable[i].matchcallback(unescaped) != 0)) {
 #if defined(LIBXML_HTTP_ENABLED) && defined(LIBXML_ZLIB_ENABLED)
-                /*  Need to pass compression parameter into HTTP open calls  */
-                if (xmlOutputCallbackTable[i].matchcallback == xmlIOHTTPMatch)
-                    context = xmlIOHTTPOpenW(unescaped, compression);
-                else
+		/*  Need to pass compression parameter into HTTP open calls  */
+		if (xmlOutputCallbackTable[i].matchcallback == xmlIOHTTPMatch)
+		    context = xmlIOHTTPOpenW(unescaped, compression);
+		else
 #endif
-                    context = xmlOutputCallbackTable[i].opencallback(unescaped);
-                if (context != NULL)
-                    break;
-            }
-        }
-        xmlFree(unescaped);
+		    context = xmlOutputCallbackTable[i].opencallback(unescaped);
+		if (context != NULL)
+		    break;
+	    }
+	}
+	xmlFree(unescaped);
     }
 
     /*
@@ -2713,39 +2713,39 @@ __xmlOutputBufferCreateFilename(const char *URI,
      */
     if (context == NULL) {
 #ifdef LIBXML_ZLIB_ENABLED
-        if ((compression > 0) && (compression <= 9) && (is_file_uri == 1)) {
-            context = xmlGzfileOpenW(URI, compression);
-            if (context != NULL) {
-                ret = xmlAllocOutputBufferInternal(encoder);
-                if (ret != NULL) {
-                    ret->context = context;
-                    ret->writecallback = xmlGzfileWrite;
-                    ret->closecallback = xmlGzfileClose;
-                }
-                else
-                    xmlGzfileClose(context);
-                return(ret);
-            }
-        }
+	if ((compression > 0) && (compression <= 9) && (is_file_uri == 1)) {
+	    context = xmlGzfileOpenW(URI, compression);
+	    if (context != NULL) {
+		ret = xmlAllocOutputBufferInternal(encoder);
+		if (ret != NULL) {
+		    ret->context = context;
+		    ret->writecallback = xmlGzfileWrite;
+		    ret->closecallback = xmlGzfileClose;
+		}
+		else
+		    xmlGzfileClose(context);
+		return(ret);
+	    }
+	}
 #endif
-        for (i = xmlOutputCallbackNr - 1;i >= 0;i--) {
-            if ((xmlOutputCallbackTable[i].matchcallback != NULL) &&
-                (xmlOutputCallbackTable[i].matchcallback(URI) != 0)) {
+	for (i = xmlOutputCallbackNr - 1;i >= 0;i--) {
+	    if ((xmlOutputCallbackTable[i].matchcallback != NULL) &&
+		(xmlOutputCallbackTable[i].matchcallback(URI) != 0)) {
 #if defined(LIBXML_HTTP_ENABLED) && defined(LIBXML_ZLIB_ENABLED)
-                /*  Need to pass compression parameter into HTTP open calls  */
-                if (xmlOutputCallbackTable[i].matchcallback == xmlIOHTTPMatch)
-                    context = xmlIOHTTPOpenW(URI, compression);
-                else
+		/*  Need to pass compression parameter into HTTP open calls  */
+		if (xmlOutputCallbackTable[i].matchcallback == xmlIOHTTPMatch)
+		    context = xmlIOHTTPOpenW(URI, compression);
+		else
 #endif
-                    context = xmlOutputCallbackTable[i].opencallback(URI);
-                if (context != NULL)
-                    break;
-            }
-        }
+		    context = xmlOutputCallbackTable[i].opencallback(URI);
+		if (context != NULL)
+		    break;
+	    }
+	}
     }
 
     if (context == NULL) {
-        return(NULL);
+	return(NULL);
     }
 
     /*
@@ -2753,9 +2753,9 @@ __xmlOutputBufferCreateFilename(const char *URI,
      */
     ret = xmlAllocOutputBufferInternal(encoder);
     if (ret != NULL) {
-        ret->context = context;
-        ret->writecallback = xmlOutputCallbackTable[i].writecallback;
-        ret->closecallback = xmlOutputCallbackTable[i].closecallback;
+	ret->context = context;
+	ret->writecallback = xmlOutputCallbackTable[i].writecallback;
+	ret->closecallback = xmlOutputCallbackTable[i].closecallback;
     }
     return(ret);
 }
@@ -2780,9 +2780,9 @@ xmlOutputBufferCreateFilename(const char *URI,
                               xmlCharEncodingHandlerPtr encoder,
                               int compression ATTRIBUTE_UNUSED) {
     if ((xmlOutputBufferCreateFilenameValue)) {
-                return xmlOutputBufferCreateFilenameValue(URI, encoder, compression);
-        }
-        return __xmlOutputBufferCreateFilename(URI, encoder, compression);
+		return xmlOutputBufferCreateFilenameValue(URI, encoder, compression);
+	}
+	return __xmlOutputBufferCreateFilename(URI, encoder, compression);
 }
 #endif /* LIBXML_OUTPUT_ENABLED */
 
@@ -2801,15 +2801,15 @@ xmlParserInputBufferCreateFile(FILE *file, xmlCharEncoding enc) {
     xmlParserInputBufferPtr ret;
 
     if (xmlInputCallbackInitialized == 0)
-        xmlRegisterDefaultInputCallbacks();
+	xmlRegisterDefaultInputCallbacks();
 
     if (file == NULL) return(NULL);
 
     ret = xmlAllocParserInputBuffer(enc);
     if (ret != NULL) {
         ret->context = file;
-        ret->readcallback = xmlFileRead;
-        ret->closecallback = xmlFileFlush;
+	ret->readcallback = xmlFileRead;
+	ret->closecallback = xmlFileFlush;
     }
 
     return(ret);
@@ -2831,15 +2831,15 @@ xmlOutputBufferCreateFile(FILE *file, xmlCharEncodingHandlerPtr encoder) {
     xmlOutputBufferPtr ret;
 
     if (xmlOutputCallbackInitialized == 0)
-        xmlRegisterDefaultOutputCallbacks();
+	xmlRegisterDefaultOutputCallbacks();
 
     if (file == NULL) return(NULL);
 
     ret = xmlAllocOutputBufferInternal(encoder);
     if (ret != NULL) {
         ret->context = file;
-        ret->writecallback = xmlFileWrite;
-        ret->closecallback = xmlFileFlush;
+	ret->writecallback = xmlFileWrite;
+	ret->closecallback = xmlFileFlush;
     }
 
     return(ret);
@@ -2921,8 +2921,8 @@ xmlParserInputBufferCreateFd(int fd, xmlCharEncoding enc) {
     ret = xmlAllocParserInputBuffer(enc);
     if (ret != NULL) {
         ret->context = (void *) (ptrdiff_t) fd;
-        ret->readcallback = xmlFdRead;
-        ret->closecallback = xmlFdClose;
+	ret->readcallback = xmlFdRead;
+	ret->closecallback = xmlFdClose;
     }
 
     return(ret);
@@ -2950,13 +2950,13 @@ xmlParserInputBufferCreateMem(const char *mem, int size, xmlCharEncoding enc) {
     ret = xmlAllocParserInputBuffer(enc);
     if (ret != NULL) {
         ret->context = (void *) mem;
-        ret->readcallback = xmlInputReadCallbackNop;
-        ret->closecallback = NULL;
-        errcode = xmlBufAdd(ret->buffer, (const xmlChar *) mem, size);
-        if (errcode != 0) {
-            xmlFree(ret);
-            return(NULL);
-        }
+	ret->readcallback = xmlInputReadCallbackNop;
+	ret->closecallback = NULL;
+	errcode = xmlBufAdd(ret->buffer, (const xmlChar *) mem, size);
+	if (errcode != 0) {
+	    xmlFree(ret);
+	    return(NULL);
+	}
     }
 
     return(ret);
@@ -2985,14 +2985,14 @@ xmlParserInputBufferCreateStatic(const char *mem, int size,
 
     ret = (xmlParserInputBufferPtr) xmlMalloc(sizeof(xmlParserInputBuffer));
     if (ret == NULL) {
-        xmlIOErrMemory("creating input buffer");
-        return(NULL);
+	xmlIOErrMemory("creating input buffer");
+	return(NULL);
     }
     memset(ret, 0, (size_t) sizeof(xmlParserInputBuffer));
     ret->buffer = xmlBufCreateStatic((void *)mem, (size_t) size);
     if (ret->buffer == NULL) {
         xmlFree(ret);
-        return(NULL);
+	return(NULL);
     }
     ret->encoder = xmlGetCharEncodingHandler(enc);
     if (ret->encoder != NULL)
@@ -3027,8 +3027,8 @@ xmlOutputBufferCreateFd(int fd, xmlCharEncodingHandlerPtr encoder) {
     ret = xmlAllocOutputBufferInternal(encoder);
     if (ret != NULL) {
         ret->context = (void *) (ptrdiff_t) fd;
-        ret->writecallback = xmlFdWrite;
-        ret->closecallback = NULL;
+	ret->writecallback = xmlFdWrite;
+	ret->closecallback = NULL;
     }
 
     return(ret);
@@ -3049,7 +3049,7 @@ xmlOutputBufferCreateFd(int fd, xmlCharEncodingHandlerPtr encoder) {
  */
 xmlParserInputBufferPtr
 xmlParserInputBufferCreateIO(xmlInputReadCallback   ioread,
-         xmlInputCloseCallback  ioclose, void *ioctx, xmlCharEncoding enc) {
+	 xmlInputCloseCallback  ioclose, void *ioctx, xmlCharEncoding enc) {
     xmlParserInputBufferPtr ret;
 
     if (ioread == NULL) return(NULL);
@@ -3057,8 +3057,8 @@ xmlParserInputBufferCreateIO(xmlInputReadCallback   ioread,
     ret = xmlAllocParserInputBuffer(enc);
     if (ret != NULL) {
         ret->context = (void *) ioctx;
-        ret->readcallback = ioread;
-        ret->closecallback = ioclose;
+	ret->readcallback = ioread;
+	ret->closecallback = ioclose;
     }
 
     return(ret);
@@ -3079,8 +3079,8 @@ xmlParserInputBufferCreateIO(xmlInputReadCallback   ioread,
  */
 xmlOutputBufferPtr
 xmlOutputBufferCreateIO(xmlOutputWriteCallback   iowrite,
-         xmlOutputCloseCallback  ioclose, void *ioctx,
-         xmlCharEncodingHandlerPtr encoder) {
+	 xmlOutputCloseCallback  ioclose, void *ioctx,
+	 xmlCharEncodingHandlerPtr encoder) {
     xmlOutputBufferPtr ret;
 
     if (iowrite == NULL) return(NULL);
@@ -3088,8 +3088,8 @@ xmlOutputBufferCreateIO(xmlOutputWriteCallback   iowrite,
     ret = xmlAllocOutputBufferInternal(encoder);
     if (ret != NULL) {
         ret->context = (void *) ioctx;
-        ret->writecallback = iowrite;
-        ret->closecallback = ioclose;
+	ret->writecallback = iowrite;
+	ret->closecallback = ioclose;
     }
 
     return(ret);
@@ -3109,8 +3109,8 @@ xmlParserInputBufferCreateFilenameDefault(xmlParserInputBufferCreateFilenameFunc
 {
     xmlParserInputBufferCreateFilenameFunc old = xmlParserInputBufferCreateFilenameValue;
     if (old == NULL) {
-                old = __xmlParserInputBufferCreateFilename;
-        }
+		old = __xmlParserInputBufferCreateFilename;
+	}
 
     xmlParserInputBufferCreateFilenameValue = func;
     return(old);
@@ -3130,8 +3130,8 @@ xmlOutputBufferCreateFilenameDefault(xmlOutputBufferCreateFilenameFunc func)
     xmlOutputBufferCreateFilenameFunc old = xmlOutputBufferCreateFilenameValue;
 #ifdef LIBXML_OUTPUT_ENABLED
     if (old == NULL) {
-                old = __xmlOutputBufferCreateFilename;
-        }
+		old = __xmlOutputBufferCreateFilename;
+	}
 #endif
     xmlOutputBufferCreateFilenameValue = func;
     return(old);
@@ -3152,7 +3152,7 @@ xmlOutputBufferCreateFilenameDefault(xmlOutputBufferCreateFilenameFunc func)
  */
 int
 xmlParserInputBufferPush(xmlParserInputBufferPtr in,
-                         int len, const char *buf) {
+	                 int len, const char *buf) {
     int nbchars = 0;
     int ret;
 
@@ -3162,35 +3162,35 @@ xmlParserInputBufferPush(xmlParserInputBufferPtr in,
         unsigned int use;
 
         /*
-         * Store the data in the incoming raw buffer
-         */
+	 * Store the data in the incoming raw buffer
+	 */
         if (in->raw == NULL) {
-            in->raw = xmlBufCreate();
-        }
-        ret = xmlBufAdd(in->raw, (const xmlChar *) buf, len);
-        if (ret != 0)
-            return(-1);
+	    in->raw = xmlBufCreate();
+	}
+	ret = xmlBufAdd(in->raw, (const xmlChar *) buf, len);
+	if (ret != 0)
+	    return(-1);
 
-        /*
-         * convert as much as possible to the parser reading buffer.
-         */
-        use = xmlBufUse(in->raw);
-        nbchars = xmlCharEncInput(in, 1);
-        if (nbchars < 0) {
-            xmlIOErr(XML_IO_ENCODER, NULL);
-            in->error = XML_IO_ENCODER;
-            return(-1);
-        }
-        in->rawconsumed += (use - xmlBufUse(in->raw));
+	/*
+	 * convert as much as possible to the parser reading buffer.
+	 */
+	use = xmlBufUse(in->raw);
+	nbchars = xmlCharEncInput(in, 1);
+	if (nbchars < 0) {
+	    xmlIOErr(XML_IO_ENCODER, NULL);
+	    in->error = XML_IO_ENCODER;
+	    return(-1);
+	}
+	in->rawconsumed += (use - xmlBufUse(in->raw));
     } else {
-        nbchars = len;
+	nbchars = len;
         ret = xmlBufAdd(in->buffer, (xmlChar *) buf, nbchars);
-        if (ret != 0)
-            return(-1);
+	if (ret != 0)
+	    return(-1);
     }
 #ifdef DEBUG_INPUT
     xmlGenericError(xmlGenericErrorContext,
-            "I/O: pushed %d chars, buffer %d/%d\n",
+	    "I/O: pushed %d chars, buffer %d/%d\n",
             nbchars, xmlBufUse(in->buffer), xmlBufLength(in->buffer));
 #endif
     return(nbchars);
@@ -3204,8 +3204,8 @@ xmlParserInputBufferPush(xmlParserInputBufferPtr in,
  */
 static int
 endOfInput (void * context ATTRIBUTE_UNUSED,
-            char * buffer ATTRIBUTE_UNUSED,
-            int len ATTRIBUTE_UNUSED) {
+	    char * buffer ATTRIBUTE_UNUSED,
+	    int len ATTRIBUTE_UNUSED) {
     return(0);
 }
 
@@ -3234,12 +3234,6 @@ xmlParserInputBufferGrow(xmlParserInputBufferPtr in, int len) {
     if ((len <= MINLEN) && (len != 4))
         len = MINLEN;
 
-    if (xmlBufAvail(in->buffer) <= 0) {
-        xmlIOErr(XML_IO_BUFFER_FULL, NULL);
-        in->error = XML_IO_BUFFER_FULL;
-        return(-1);
-    }
-
     if (xmlBufGrow(in->buffer, len + 1) < 0) {
         xmlIOErrMemory("growing input buffer");
         in->error = XML_ERR_NO_MEMORY;
@@ -3251,16 +3245,16 @@ xmlParserInputBufferGrow(xmlParserInputBufferPtr in, int len) {
      * Call the read method for this I/O type.
      */
     if (in->readcallback != NULL) {
-        res = in->readcallback(in->context, &buffer[0], len);
-        if (res <= 0)
-            in->readcallback = endOfInput;
+	res = in->readcallback(in->context, &buffer[0], len);
+	if (res <= 0)
+	    in->readcallback = endOfInput;
     } else {
-        xmlIOErr(XML_IO_NO_INPUT, NULL);
-        in->error = XML_IO_NO_INPUT;
-        return(-1);
+	xmlIOErr(XML_IO_NO_INPUT, NULL);
+	in->error = XML_IO_NO_INPUT;
+	return(-1);
     }
     if (res < 0) {
-        return(-1);
+	return(-1);
     }
 
     /*
@@ -3268,7 +3262,7 @@ xmlParserInputBufferGrow(xmlParserInputBufferPtr in, int len) {
      */
     if (in->compressed == -1) {
 #ifdef LIBXML_LZMA_ENABLED
-        if (in->readcallback == xmlXzfileRead)
+	if (in->readcallback == xmlXzfileRead)
             in->compressed = __libxml2_xzcompressed(in->context);
 #endif
     }
@@ -3278,33 +3272,33 @@ xmlParserInputBufferGrow(xmlParserInputBufferPtr in, int len) {
         unsigned int use;
 
         /*
-         * Store the data in the incoming raw buffer
-         */
+	 * Store the data in the incoming raw buffer
+	 */
         if (in->raw == NULL) {
-            in->raw = xmlBufCreate();
-        }
-        res = xmlBufAdd(in->raw, (const xmlChar *) buffer, len);
-        if (res != 0)
-            return(-1);
+	    in->raw = xmlBufCreate();
+	}
+	res = xmlBufAdd(in->raw, (const xmlChar *) buffer, len);
+	if (res != 0)
+	    return(-1);
 
-        /*
-         * convert as much as possible to the parser reading buffer.
-         */
-        use = xmlBufUse(in->raw);
-        nbchars = xmlCharEncInput(in, 1);
-        if (nbchars < 0) {
-            xmlIOErr(XML_IO_ENCODER, NULL);
-            in->error = XML_IO_ENCODER;
-            return(-1);
-        }
-        in->rawconsumed += (use - xmlBufUse(in->raw));
+	/*
+	 * convert as much as possible to the parser reading buffer.
+	 */
+	use = xmlBufUse(in->raw);
+	nbchars = xmlCharEncInput(in, 1);
+	if (nbchars < 0) {
+	    xmlIOErr(XML_IO_ENCODER, NULL);
+	    in->error = XML_IO_ENCODER;
+	    return(-1);
+	}
+	in->rawconsumed += (use - xmlBufUse(in->raw));
     } else {
-        nbchars = len;
+	nbchars = len;
         xmlBufAddLen(in->buffer, nbchars);
     }
 #ifdef DEBUG_INPUT
     xmlGenericError(xmlGenericErrorContext,
-            "I/O: read %d chars, buffer %d\n",
+	    "I/O: read %d chars, buffer %d\n",
             nbchars, xmlBufUse(in->buffer));
 #endif
     return(nbchars);
@@ -3326,9 +3320,9 @@ int
 xmlParserInputBufferRead(xmlParserInputBufferPtr in, int len) {
     if ((in == NULL) || (in->error)) return(-1);
     if (in->readcallback != NULL)
-        return(xmlParserInputBufferGrow(in, len));
+	return(xmlParserInputBufferGrow(in, len));
     else if (xmlBufGetAllocationScheme(in->buffer) == XML_BUFFER_ALLOC_IMMUTABLE)
-        return(0);
+	return(0);
     else
         return(-1);
 }
@@ -3360,87 +3354,87 @@ xmlOutputBufferWrite(xmlOutputBufferPtr out, int len, const char *buf) {
     if (out->error) return(-1);
 
     do {
-        chunk = len;
-        if (chunk > 4 * MINLEN)
-            chunk = 4 * MINLEN;
+	chunk = len;
+	if (chunk > 4 * MINLEN)
+	    chunk = 4 * MINLEN;
 
-        /*
-         * first handle encoding stuff.
-         */
-        if (out->encoder != NULL) {
-            /*
-             * Store the data in the incoming raw buffer
-             */
-            if (out->conv == NULL) {
-                out->conv = xmlBufCreate();
-            }
-            ret = xmlBufAdd(out->buffer, (const xmlChar *) buf, chunk);
-            if (ret != 0)
-                return(-1);
+	/*
+	 * first handle encoding stuff.
+	 */
+	if (out->encoder != NULL) {
+	    /*
+	     * Store the data in the incoming raw buffer
+	     */
+	    if (out->conv == NULL) {
+		out->conv = xmlBufCreate();
+	    }
+	    ret = xmlBufAdd(out->buffer, (const xmlChar *) buf, chunk);
+	    if (ret != 0)
+	        return(-1);
 
-            if ((xmlBufUse(out->buffer) < MINLEN) && (chunk == len))
-                goto done;
+	    if ((xmlBufUse(out->buffer) < MINLEN) && (chunk == len))
+		goto done;
 
-            /*
-             * convert as much as possible to the parser reading buffer.
-             */
-            ret = xmlCharEncOutput(out, 0);
-            if ((ret < 0) && (ret != -3)) {
-                xmlIOErr(XML_IO_ENCODER, NULL);
-                out->error = XML_IO_ENCODER;
-                return(-1);
-            }
+	    /*
+	     * convert as much as possible to the parser reading buffer.
+	     */
+	    ret = xmlCharEncOutput(out, 0);
+	    if ((ret < 0) && (ret != -3)) {
+		xmlIOErr(XML_IO_ENCODER, NULL);
+		out->error = XML_IO_ENCODER;
+		return(-1);
+	    }
             if (out->writecallback)
-                nbchars = xmlBufUse(out->conv);
+	        nbchars = xmlBufUse(out->conv);
             else
                 nbchars = ret >= 0 ? ret : 0;
-        } else {
-            ret = xmlBufAdd(out->buffer, (const xmlChar *) buf, chunk);
-            if (ret != 0)
-                return(-1);
+	} else {
+	    ret = xmlBufAdd(out->buffer, (const xmlChar *) buf, chunk);
+	    if (ret != 0)
+	        return(-1);
             if (out->writecallback)
-                nbchars = xmlBufUse(out->buffer);
+	        nbchars = xmlBufUse(out->buffer);
             else
                 nbchars = chunk;
-        }
-        buf += chunk;
-        len -= chunk;
+	}
+	buf += chunk;
+	len -= chunk;
 
-        if (out->writecallback) {
+	if (out->writecallback) {
             if ((nbchars < MINLEN) && (len <= 0))
                 goto done;
 
-            /*
-             * second write the stuff to the I/O channel
-             */
-            if (out->encoder != NULL) {
-                ret = out->writecallback(out->context,
+	    /*
+	     * second write the stuff to the I/O channel
+	     */
+	    if (out->encoder != NULL) {
+		ret = out->writecallback(out->context,
                            (const char *)xmlBufContent(out->conv), nbchars);
-                if (ret >= 0)
-                    xmlBufShrink(out->conv, ret);
-            } else {
-                ret = out->writecallback(out->context,
+		if (ret >= 0)
+		    xmlBufShrink(out->conv, ret);
+	    } else {
+		ret = out->writecallback(out->context,
                            (const char *)xmlBufContent(out->buffer), nbchars);
-                if (ret >= 0)
-                    xmlBufShrink(out->buffer, ret);
-            }
-            if (ret < 0) {
-                xmlIOErr(XML_IO_WRITE, NULL);
-                out->error = XML_IO_WRITE;
-                return(ret);
-            }
+		if (ret >= 0)
+		    xmlBufShrink(out->buffer, ret);
+	    }
+	    if (ret < 0) {
+		xmlIOErr(XML_IO_WRITE, NULL);
+		out->error = XML_IO_WRITE;
+		return(ret);
+	    }
             if (out->written > INT_MAX - ret)
                 out->written = INT_MAX;
             else
                 out->written += ret;
-        }
-        written += nbchars;
+	}
+	written += nbchars;
     } while (len > 0);
 
 done:
 #ifdef DEBUG_INPUT
     xmlGenericError(xmlGenericErrorContext,
-            "I/O: wrote %d chars\n", written);
+	    "I/O: wrote %d chars\n", written);
 #endif
     return(written);
 }
@@ -3469,36 +3463,36 @@ xmlEscapeContent(unsigned char* out, int *outlen,
     inend = in + (*inlen);
 
     while ((in < inend) && (out < outend)) {
-        if (*in == '<') {
-            if (outend - out < 4) break;
-            *out++ = '&';
-            *out++ = 'l';
-            *out++ = 't';
-            *out++ = ';';
-        } else if (*in == '>') {
-            if (outend - out < 4) break;
-            *out++ = '&';
-            *out++ = 'g';
-            *out++ = 't';
-            *out++ = ';';
-        } else if (*in == '&') {
-            if (outend - out < 5) break;
-            *out++ = '&';
-            *out++ = 'a';
-            *out++ = 'm';
-            *out++ = 'p';
-            *out++ = ';';
-        } else if (*in == '\r') {
-            if (outend - out < 5) break;
-            *out++ = '&';
-            *out++ = '#';
-            *out++ = '1';
-            *out++ = '3';
-            *out++ = ';';
-        } else {
-            *out++ = (unsigned char) *in;
-        }
-        ++in;
+	if (*in == '<') {
+	    if (outend - out < 4) break;
+	    *out++ = '&';
+	    *out++ = 'l';
+	    *out++ = 't';
+	    *out++ = ';';
+	} else if (*in == '>') {
+	    if (outend - out < 4) break;
+	    *out++ = '&';
+	    *out++ = 'g';
+	    *out++ = 't';
+	    *out++ = ';';
+	} else if (*in == '&') {
+	    if (outend - out < 5) break;
+	    *out++ = '&';
+	    *out++ = 'a';
+	    *out++ = 'm';
+	    *out++ = 'p';
+	    *out++ = ';';
+	} else if (*in == '\r') {
+	    if (outend - out < 5) break;
+	    *out++ = '&';
+	    *out++ = '#';
+	    *out++ = '1';
+	    *out++ = '3';
+	    *out++ = ';';
+	} else {
+	    *out++ = (unsigned char) *in;
+	}
+	++in;
     }
     *outlen = out - outstart;
     *inlen = in - base;
@@ -3533,7 +3527,7 @@ xmlOutputBufferWriteEscape(xmlOutputBufferPtr out, const xmlChar *str,
 
     if ((out == NULL) || (out->error) || (str == NULL) ||
         (out->buffer == NULL) ||
-        (xmlBufGetAllocationScheme(out->buffer) == XML_BUFFER_ALLOC_IMMUTABLE))
+	(xmlBufGetAllocationScheme(out->buffer) == XML_BUFFER_ALLOC_IMMUTABLE))
         return(-1);
     len = strlen((const char *)str);
     if (len < 0) return(0);
@@ -3544,104 +3538,104 @@ xmlOutputBufferWriteEscape(xmlOutputBufferPtr out, const xmlChar *str,
         oldwritten = written;
 
         /*
-         * how many bytes to consume and how many bytes to store.
-         */
-        cons = len;
-        chunk = xmlBufAvail(out->buffer);
+	 * how many bytes to consume and how many bytes to store.
+	 */
+	cons = len;
+	chunk = xmlBufAvail(out->buffer);
 
         /*
-         * make sure we have enough room to save first, if this is
-         * not the case force a flush, but make sure we stay in the loop
-         */
-        if (chunk < 40) {
-            if (xmlBufGrow(out->buffer, 100) < 0)
-                return(-1);
+	 * make sure we have enough room to save first, if this is
+	 * not the case force a flush, but make sure we stay in the loop
+	 */
+	if (chunk < 40) {
+	    if (xmlBufGrow(out->buffer, 100) < 0)
+	        return(-1);
             oldwritten = -1;
-            continue;
-        }
+	    continue;
+	}
 
-        /*
-         * first handle encoding stuff.
-         */
-        if (out->encoder != NULL) {
-            /*
-             * Store the data in the incoming raw buffer
-             */
-            if (out->conv == NULL) {
-                out->conv = xmlBufCreate();
-            }
-            ret = escaping(xmlBufEnd(out->buffer) ,
-                           &chunk, str, &cons);
-            if ((ret < 0) || (chunk == 0)) /* chunk==0 => nothing done */
-                return(-1);
+	/*
+	 * first handle encoding stuff.
+	 */
+	if (out->encoder != NULL) {
+	    /*
+	     * Store the data in the incoming raw buffer
+	     */
+	    if (out->conv == NULL) {
+		out->conv = xmlBufCreate();
+	    }
+	    ret = escaping(xmlBufEnd(out->buffer) ,
+	                   &chunk, str, &cons);
+	    if ((ret < 0) || (chunk == 0)) /* chunk==0 => nothing done */
+	        return(-1);
             xmlBufAddLen(out->buffer, chunk);
 
-            if ((xmlBufUse(out->buffer) < MINLEN) && (cons == len))
-                goto done;
+	    if ((xmlBufUse(out->buffer) < MINLEN) && (cons == len))
+		goto done;
 
-            /*
-             * convert as much as possible to the output buffer.
-             */
-            ret = xmlCharEncOutput(out, 0);
-            if ((ret < 0) && (ret != -3)) {
-                xmlIOErr(XML_IO_ENCODER, NULL);
-                out->error = XML_IO_ENCODER;
-                return(-1);
-            }
+	    /*
+	     * convert as much as possible to the output buffer.
+	     */
+	    ret = xmlCharEncOutput(out, 0);
+	    if ((ret < 0) && (ret != -3)) {
+		xmlIOErr(XML_IO_ENCODER, NULL);
+		out->error = XML_IO_ENCODER;
+		return(-1);
+	    }
             if (out->writecallback)
-                nbchars = xmlBufUse(out->conv);
+	        nbchars = xmlBufUse(out->conv);
             else
                 nbchars = ret >= 0 ? ret : 0;
-        } else {
-            ret = escaping(xmlBufEnd(out->buffer), &chunk, str, &cons);
-            if ((ret < 0) || (chunk == 0)) /* chunk==0 => nothing done */
-                return(-1);
+	} else {
+	    ret = escaping(xmlBufEnd(out->buffer), &chunk, str, &cons);
+	    if ((ret < 0) || (chunk == 0)) /* chunk==0 => nothing done */
+	        return(-1);
             xmlBufAddLen(out->buffer, chunk);
             if (out->writecallback)
-                nbchars = xmlBufUse(out->buffer);
+	        nbchars = xmlBufUse(out->buffer);
             else
                 nbchars = chunk;
-        }
-        str += cons;
-        len -= cons;
+	}
+	str += cons;
+	len -= cons;
 
-        if (out->writecallback) {
+	if (out->writecallback) {
             if ((nbchars < MINLEN) && (len <= 0))
                 goto done;
 
-            /*
-             * second write the stuff to the I/O channel
-             */
-            if (out->encoder != NULL) {
-                ret = out->writecallback(out->context,
+	    /*
+	     * second write the stuff to the I/O channel
+	     */
+	    if (out->encoder != NULL) {
+		ret = out->writecallback(out->context,
                            (const char *)xmlBufContent(out->conv), nbchars);
-                if (ret >= 0)
-                    xmlBufShrink(out->conv, ret);
-            } else {
-                ret = out->writecallback(out->context,
+		if (ret >= 0)
+		    xmlBufShrink(out->conv, ret);
+	    } else {
+		ret = out->writecallback(out->context,
                            (const char *)xmlBufContent(out->buffer), nbchars);
-                if (ret >= 0)
-                    xmlBufShrink(out->buffer, ret);
-            }
-            if (ret < 0) {
-                xmlIOErr(XML_IO_WRITE, NULL);
-                out->error = XML_IO_WRITE;
-                return(ret);
-            }
+		if (ret >= 0)
+		    xmlBufShrink(out->buffer, ret);
+	    }
+	    if (ret < 0) {
+		xmlIOErr(XML_IO_WRITE, NULL);
+		out->error = XML_IO_WRITE;
+		return(ret);
+	    }
             if (out->written > INT_MAX - ret)
                 out->written = INT_MAX;
             else
                 out->written += ret;
-        } else if (xmlBufAvail(out->buffer) < MINLEN) {
-            xmlBufGrow(out->buffer, MINLEN);
-        }
-        written += nbchars;
+	} else if (xmlBufAvail(out->buffer) < MINLEN) {
+	    xmlBufGrow(out->buffer, MINLEN);
+	}
+	written += nbchars;
     } while ((len > 0) && (oldwritten != written));
 
 done:
 #ifdef DEBUG_INPUT
     xmlGenericError(xmlGenericErrorContext,
-            "I/O: wrote %d chars\n", written);
+	    "I/O: wrote %d chars\n", written);
 #endif
     return(written);
 }
@@ -3669,7 +3663,7 @@ xmlOutputBufferWriteString(xmlOutputBufferPtr out, const char *str) {
     len = strlen(str);
 
     if (len > 0)
-        return(xmlOutputBufferWrite(out, len, str));
+	return(xmlOutputBufferWrite(out, len, str));
     return(len);
 }
 
@@ -3690,40 +3684,40 @@ xmlOutputBufferFlush(xmlOutputBufferPtr out) {
      * first handle encoding stuff.
      */
     if ((out->conv != NULL) && (out->encoder != NULL)) {
-        /*
-         * convert as much as possible to the parser output buffer.
-         */
-        do {
-            nbchars = xmlCharEncOutput(out, 0);
-            if (nbchars < 0) {
-                xmlIOErr(XML_IO_ENCODER, NULL);
-                out->error = XML_IO_ENCODER;
-                return(-1);
-            }
-        } while (nbchars);
+	/*
+	 * convert as much as possible to the parser output buffer.
+	 */
+	do {
+	    nbchars = xmlCharEncOutput(out, 0);
+	    if (nbchars < 0) {
+		xmlIOErr(XML_IO_ENCODER, NULL);
+		out->error = XML_IO_ENCODER;
+		return(-1);
+	    }
+	} while (nbchars);
     }
 
     /*
      * second flush the stuff to the I/O channel
      */
     if ((out->conv != NULL) && (out->encoder != NULL) &&
-        (out->writecallback != NULL)) {
-        ret = out->writecallback(out->context,
+	(out->writecallback != NULL)) {
+	ret = out->writecallback(out->context,
                                  (const char *)xmlBufContent(out->conv),
                                  xmlBufUse(out->conv));
-        if (ret >= 0)
-            xmlBufShrink(out->conv, ret);
+	if (ret >= 0)
+	    xmlBufShrink(out->conv, ret);
     } else if (out->writecallback != NULL) {
-        ret = out->writecallback(out->context,
+	ret = out->writecallback(out->context,
                                  (const char *)xmlBufContent(out->buffer),
                                  xmlBufUse(out->buffer));
-        if (ret >= 0)
-            xmlBufShrink(out->buffer, ret);
+	if (ret >= 0)
+	    xmlBufShrink(out->buffer, ret);
     }
     if (ret < 0) {
-        xmlIOErr(XML_IO_FLUSH, NULL);
-        out->error = XML_IO_FLUSH;
-        return(ret);
+	xmlIOErr(XML_IO_FLUSH, NULL);
+	out->error = XML_IO_FLUSH;
+	return(ret);
     }
     if (out->written > INT_MAX - ret)
         out->written = INT_MAX;
@@ -3732,7 +3726,7 @@ xmlOutputBufferFlush(xmlOutputBufferPtr out) {
 
 #ifdef DEBUG_INPUT
     xmlGenericError(xmlGenericErrorContext,
-            "I/O: flushed %d chars\n", ret);
+	    "I/O: flushed %d chars\n", ret);
 #endif
     return(ret);
 }
@@ -3753,7 +3747,7 @@ xmlParserGetDirectory(const char *filename) {
     char *cur;
 
     if (xmlInputCallbackInitialized == 0)
-        xmlRegisterDefaultInputCallbacks();
+	xmlRegisterDefaultInputCallbacks();
 
     if (filename == NULL) return(NULL);
 
@@ -3768,26 +3762,26 @@ xmlParserGetDirectory(const char *filename) {
     cur = &dir[strlen(dir)];
     while (cur > dir) {
          if (IS_XMLPGD_SEP(*cur)) break;
-         cur --;
+	 cur --;
     }
     if (IS_XMLPGD_SEP(*cur)) {
         if (cur == dir) dir[1] = 0;
-        else *cur = 0;
-        ret = xmlMemStrdup(dir);
+	else *cur = 0;
+	ret = xmlMemStrdup(dir);
     } else {
         if (getcwd(dir, 1024) != NULL) {
-            dir[1023] = 0;
-            ret = xmlMemStrdup(dir);
-        }
+	    dir[1023] = 0;
+	    ret = xmlMemStrdup(dir);
+	}
     }
     return(ret);
 #undef IS_XMLPGD_SEP
 }
 
 /****************************************************************
- *                                                              *
- *              External entities loading                       *
- *                                                              *
+ *								*
+ *		External entities loading			*
+ *								*
  ****************************************************************/
 
 /**
@@ -3819,11 +3813,11 @@ xmlCheckHTTPInput(xmlParserCtxtPtr ctxt, xmlParserInputPtr ret) {
         code = xmlNanoHTTPReturnCode(ret->buf->context);
         if (code >= 400) {
             /* fatal error */
-            if (ret->filename != NULL)
-                __xmlLoaderErr(ctxt, "failed to load HTTP resource \"%s\"\n",
+	    if (ret->filename != NULL)
+		__xmlLoaderErr(ctxt, "failed to load HTTP resource \"%s\"\n",
                          (const char *) ret->filename);
-            else
-                __xmlLoaderErr(ctxt, "failed to load HTTP resource\n", NULL);
+	    else
+		__xmlLoaderErr(ctxt, "failed to load HTTP resource\n", NULL);
             xmlFreeInputStream(ret);
             ret = NULL;
         } else {
@@ -3871,22 +3865,22 @@ static int xmlNoNetExists(const char *URL) {
     const char *path;
 
     if (URL == NULL)
-        return(0);
+	return(0);
 
     if (!xmlStrncasecmp(BAD_CAST URL, BAD_CAST "file://localhost/", 17))
 #if defined (_WIN32)
-        path = &URL[17];
+	path = &URL[17];
 #else
-        path = &URL[16];
+	path = &URL[16];
 #endif
     else if (!xmlStrncasecmp(BAD_CAST URL, BAD_CAST "file:///", 8)) {
 #if defined (_WIN32)
-        path = &URL[8];
+	path = &URL[8];
 #else
-        path = &URL[7];
+	path = &URL[7];
 #endif
     } else
-        path = URL;
+	path = URL;
 
     return xmlCheckFilename(path);
 }
@@ -3918,50 +3912,50 @@ xmlResolveResourceFromCatalog(const char *URL, const char *ID,
     pref = xmlCatalogGetDefaults();
 
     if ((pref != XML_CATA_ALLOW_NONE) && (!xmlNoNetExists(URL))) {
-        /*
-         * Do a local lookup
-         */
-        if ((ctxt != NULL) && (ctxt->catalogs != NULL) &&
-            ((pref == XML_CATA_ALLOW_ALL) ||
-             (pref == XML_CATA_ALLOW_DOCUMENT))) {
-            resource = xmlCatalogLocalResolve(ctxt->catalogs,
-                                              (const xmlChar *)ID,
-                                              (const xmlChar *)URL);
+	/*
+	 * Do a local lookup
+	 */
+	if ((ctxt != NULL) && (ctxt->catalogs != NULL) &&
+	    ((pref == XML_CATA_ALLOW_ALL) ||
+	     (pref == XML_CATA_ALLOW_DOCUMENT))) {
+	    resource = xmlCatalogLocalResolve(ctxt->catalogs,
+					      (const xmlChar *)ID,
+					      (const xmlChar *)URL);
         }
-        /*
-         * Try a global lookup
-         */
-        if ((resource == NULL) &&
-            ((pref == XML_CATA_ALLOW_ALL) ||
-             (pref == XML_CATA_ALLOW_GLOBAL))) {
-            resource = xmlCatalogResolve((const xmlChar *)ID,
-                                         (const xmlChar *)URL);
-        }
-        if ((resource == NULL) && (URL != NULL))
-            resource = xmlStrdup((const xmlChar *) URL);
+	/*
+	 * Try a global lookup
+	 */
+	if ((resource == NULL) &&
+	    ((pref == XML_CATA_ALLOW_ALL) ||
+	     (pref == XML_CATA_ALLOW_GLOBAL))) {
+	    resource = xmlCatalogResolve((const xmlChar *)ID,
+					 (const xmlChar *)URL);
+	}
+	if ((resource == NULL) && (URL != NULL))
+	    resource = xmlStrdup((const xmlChar *) URL);
 
-        /*
-         * TODO: do an URI lookup on the reference
-         */
-        if ((resource != NULL) && (!xmlNoNetExists((const char *)resource))) {
-            xmlChar *tmp = NULL;
+	/*
+	 * TODO: do an URI lookup on the reference
+	 */
+	if ((resource != NULL) && (!xmlNoNetExists((const char *)resource))) {
+	    xmlChar *tmp = NULL;
 
-            if ((ctxt != NULL) && (ctxt->catalogs != NULL) &&
-                ((pref == XML_CATA_ALLOW_ALL) ||
-                 (pref == XML_CATA_ALLOW_DOCUMENT))) {
-                tmp = xmlCatalogLocalResolveURI(ctxt->catalogs, resource);
-            }
-            if ((tmp == NULL) &&
-                ((pref == XML_CATA_ALLOW_ALL) ||
-                 (pref == XML_CATA_ALLOW_GLOBAL))) {
-                tmp = xmlCatalogResolveURI(resource);
-            }
+	    if ((ctxt != NULL) && (ctxt->catalogs != NULL) &&
+		((pref == XML_CATA_ALLOW_ALL) ||
+		 (pref == XML_CATA_ALLOW_DOCUMENT))) {
+		tmp = xmlCatalogLocalResolveURI(ctxt->catalogs, resource);
+	    }
+	    if ((tmp == NULL) &&
+		((pref == XML_CATA_ALLOW_ALL) ||
+	         (pref == XML_CATA_ALLOW_GLOBAL))) {
+		tmp = xmlCatalogResolveURI(resource);
+	    }
 
-            if (tmp != NULL) {
-                xmlFree(resource);
-                resource = tmp;
-            }
-        }
+	    if (tmp != NULL) {
+		xmlFree(resource);
+		resource = tmp;
+	    }
+	}
     }
 
     return resource;
@@ -3993,10 +3987,10 @@ xmlDefaultExternalEntityLoader(const char *URL, const char *ID,
     if ((ctxt != NULL) && (ctxt->options & XML_PARSE_NONET)) {
         int options = ctxt->options;
 
-        ctxt->options -= XML_PARSE_NONET;
+	ctxt->options -= XML_PARSE_NONET;
         ret = xmlNoNetExternalEntityLoader(URL, ID, ctxt);
-        ctxt->options = options;
-        return(ret);
+	ctxt->options = options;
+	return(ret);
     }
 #ifdef LIBXML_CATALOG_ENABLED
     resource = xmlResolveResourceFromCatalog(URL, ID, ctxt);
@@ -4058,26 +4052,26 @@ xmlParserInputPtr
 xmlLoadExternalEntity(const char *URL, const char *ID,
                       xmlParserCtxtPtr ctxt) {
     if ((URL != NULL) && (xmlNoNetExists(URL) == 0)) {
-        char *canonicFilename;
-        xmlParserInputPtr ret;
+	char *canonicFilename;
+	xmlParserInputPtr ret;
 
-        canonicFilename = (char *) xmlCanonicPath((const xmlChar *) URL);
-        if (canonicFilename == NULL) {
+	canonicFilename = (char *) xmlCanonicPath((const xmlChar *) URL);
+	if (canonicFilename == NULL) {
             xmlIOErrMemory("building canonical path\n");
-            return(NULL);
-        }
+	    return(NULL);
+	}
 
-        ret = xmlCurrentExternalEntityLoader(canonicFilename, ID, ctxt);
-        xmlFree(canonicFilename);
-        return(ret);
+	ret = xmlCurrentExternalEntityLoader(canonicFilename, ID, ctxt);
+	xmlFree(canonicFilename);
+	return(ret);
     }
     return(xmlCurrentExternalEntityLoader(URL, ID, ctxt));
 }
 
 /************************************************************************
- *                                                                      *
- *              Disabling Network access                                *
- *                                                                      *
+ *									*
+ *		Disabling Network access				*
+ *									*
  ************************************************************************/
 
 /**
@@ -4102,20 +4096,20 @@ xmlNoNetExternalEntityLoader(const char *URL, const char *ID,
 #endif
 
     if (resource == NULL)
-        resource = (xmlChar *) URL;
+	resource = (xmlChar *) URL;
 
     if (resource != NULL) {
         if ((!xmlStrncasecmp(BAD_CAST resource, BAD_CAST "ftp://", 6)) ||
             (!xmlStrncasecmp(BAD_CAST resource, BAD_CAST "http://", 7))) {
             xmlIOErr(XML_IO_NETWORK_ATTEMPT, (const char *) resource);
-            if (resource != (xmlChar *) URL)
-                xmlFree(resource);
-            return(NULL);
-        }
+	    if (resource != (xmlChar *) URL)
+		xmlFree(resource);
+	    return(NULL);
+	}
     }
     input = xmlDefaultExternalEntityLoader((const char *) resource, ID, ctxt);
     if (resource != (xmlChar *) URL)
-        xmlFree(resource);
+	xmlFree(resource);
     return(input);
 }
 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xmlIO.c
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/src/xmlIO.c
@@ -117,69 +117,69 @@ xmlAllocOutputBufferInternal(xmlCharEncodingHandlerPtr encoder);
 #endif /* LIBXML_OUTPUT_ENABLED */
 
 /************************************************************************
- *									*
- *		Tree memory error handler				*
- *									*
+ *                                                                      *
+ *              Tree memory error handler                               *
+ *                                                                      *
  ************************************************************************/
 
 static const char* const IOerr[] = {
     "Unknown IO error",         /* UNKNOWN */
-    "Permission denied",	/* EACCES */
+    "Permission denied",        /* EACCES */
     "Resource temporarily unavailable",/* EAGAIN */
-    "Bad file descriptor",	/* EBADF */
-    "Bad message",		/* EBADMSG */
-    "Resource busy",		/* EBUSY */
-    "Operation canceled",	/* ECANCELED */
-    "No child processes",	/* ECHILD */
+    "Bad file descriptor",      /* EBADF */
+    "Bad message",              /* EBADMSG */
+    "Resource busy",            /* EBUSY */
+    "Operation canceled",       /* ECANCELED */
+    "No child processes",       /* ECHILD */
     "Resource deadlock avoided",/* EDEADLK */
-    "Domain error",		/* EDOM */
-    "File exists",		/* EEXIST */
-    "Bad address",		/* EFAULT */
-    "File too large",		/* EFBIG */
-    "Operation in progress",	/* EINPROGRESS */
+    "Domain error",             /* EDOM */
+    "File exists",              /* EEXIST */
+    "Bad address",              /* EFAULT */
+    "File too large",           /* EFBIG */
+    "Operation in progress",    /* EINPROGRESS */
     "Interrupted function call",/* EINTR */
-    "Invalid argument",		/* EINVAL */
-    "Input/output error",	/* EIO */
-    "Is a directory",		/* EISDIR */
-    "Too many open files",	/* EMFILE */
-    "Too many links",		/* EMLINK */
+    "Invalid argument",         /* EINVAL */
+    "Input/output error",       /* EIO */
+    "Is a directory",           /* EISDIR */
+    "Too many open files",      /* EMFILE */
+    "Too many links",           /* EMLINK */
     "Inappropriate message buffer length",/* EMSGSIZE */
-    "Filename too long",	/* ENAMETOOLONG */
+    "Filename too long",        /* ENAMETOOLONG */
     "Too many open files in system",/* ENFILE */
-    "No such device",		/* ENODEV */
+    "No such device",           /* ENODEV */
     "No such file or directory",/* ENOENT */
-    "Exec format error",	/* ENOEXEC */
-    "No locks available",	/* ENOLCK */
-    "Not enough space",		/* ENOMEM */
-    "No space left on device",	/* ENOSPC */
-    "Function not implemented",	/* ENOSYS */
-    "Not a directory",		/* ENOTDIR */
-    "Directory not empty",	/* ENOTEMPTY */
-    "Not supported",		/* ENOTSUP */
+    "Exec format error",        /* ENOEXEC */
+    "No locks available",       /* ENOLCK */
+    "Not enough space",         /* ENOMEM */
+    "No space left on device",  /* ENOSPC */
+    "Function not implemented", /* ENOSYS */
+    "Not a directory",          /* ENOTDIR */
+    "Directory not empty",      /* ENOTEMPTY */
+    "Not supported",            /* ENOTSUP */
     "Inappropriate I/O control operation",/* ENOTTY */
     "No such device or address",/* ENXIO */
-    "Operation not permitted",	/* EPERM */
-    "Broken pipe",		/* EPIPE */
-    "Result too large",		/* ERANGE */
-    "Read-only file system",	/* EROFS */
-    "Invalid seek",		/* ESPIPE */
-    "No such process",		/* ESRCH */
-    "Operation timed out",	/* ETIMEDOUT */
-    "Improper link",		/* EXDEV */
+    "Operation not permitted",  /* EPERM */
+    "Broken pipe",              /* EPIPE */
+    "Result too large",         /* ERANGE */
+    "Read-only file system",    /* EROFS */
+    "Invalid seek",             /* ESPIPE */
+    "No such process",          /* ESRCH */
+    "Operation timed out",      /* ETIMEDOUT */
+    "Improper link",            /* EXDEV */
     "Attempt to load network entity %s", /* XML_IO_NETWORK_ATTEMPT */
-    "encoder error",		/* XML_IO_ENCODER */
+    "encoder error",            /* XML_IO_ENCODER */
     "flush error",
     "write error",
     "no input",
     "buffer full",
     "loading error",
-    "not a socket",		/* ENOTSOCK */
-    "already connected",	/* EISCONN */
-    "connection refused",	/* ECONNREFUSED */
-    "unreachable network",	/* ENETUNREACH */
-    "address in use",		/* EADDRINUSE */
-    "already in use",		/* EALREADY */
-    "unknown address family",	/* EAFNOSUPPORT */
+    "not a socket",             /* ENOTSOCK */
+    "already connected",        /* EISCONN */
+    "connection refused",       /* ECONNREFUSED */
+    "unreachable network",      /* ENETUNREACH */
+    "address in use",           /* EADDRINUSE */
+    "already in use",           /* EALREADY */
+    "unknown address family",   /* EAFNOSUPPORT */
 };
 
 #if defined(_WIN32)
@@ -240,7 +240,7 @@ __xmlIOErr(int domain, int code, const char *extra)
     unsigned int idx;
 
     if (code == 0) {
-	if (errno == 0) code = 0;
+        if (errno == 0) code = 0;
 #ifdef EACCES
         else if (errno == EACCES) code = XML_IO_EACCES;
 #endif
@@ -434,30 +434,30 @@ __xmlLoaderErr(void *ctx, const char *msg, const char *filename)
 
     if ((ctxt != NULL) && (ctxt->disableSAX != 0) &&
         (ctxt->instate == XML_PARSER_EOF))
-	return;
+        return;
     if ((ctxt != NULL) && (ctxt->sax != NULL)) {
         if (ctxt->validate) {
-	    channel = ctxt->sax->error;
-	    level = XML_ERR_ERROR;
-	} else {
-	    channel = ctxt->sax->warning;
-	    level = XML_ERR_WARNING;
-	}
-	if (ctxt->sax->initialized == XML_SAX2_MAGIC)
-	    schannel = ctxt->sax->serror;
-	data = ctxt->userData;
+            channel = ctxt->sax->error;
+            level = XML_ERR_ERROR;
+        } else {
+            channel = ctxt->sax->warning;
+            level = XML_ERR_WARNING;
+        }
+        if (ctxt->sax->initialized == XML_SAX2_MAGIC)
+            schannel = ctxt->sax->serror;
+        data = ctxt->userData;
     }
     __xmlRaiseError(schannel, channel, data, ctxt, NULL, XML_FROM_IO,
                     XML_IO_LOAD_ERROR, level, NULL, 0,
-		    filename, NULL, NULL, 0, 0,
-		    msg, filename);
+                    filename, NULL, NULL, 0, 0,
+                    msg, filename);
 
 }
 
 /************************************************************************
- *									*
- *		Tree memory error handler				*
- *									*
+ *                                                                      *
+ *              Tree memory error handler                               *
+ *                                                                      *
  ************************************************************************/
 /**
  * xmlNormalizeWindowsPath:
@@ -580,9 +580,9 @@ xmlPopOutputCallbacks(void)
 #endif /* LIBXML_OUTPUT_ENABLED */
 
 /************************************************************************
- *									*
- *		Standard I/O for file accesses				*
- *									*
+ *                                                                      *
+ *              Standard I/O for file accesses                          *
+ *                                                                      *
  ************************************************************************/
 
 #if defined(_WIN32)
@@ -628,13 +628,13 @@ xmlWrapGzOpenUtf8(const char *path, const char *mode)
     wPath = __xmlIOWin32UTF8ToWChar(path);
     if(wPath)
     {
-	int d, m = (strstr(mode, "r") ? O_RDONLY : O_RDWR);
+        int d, m = (strstr(mode, "r") ? O_RDONLY : O_RDWR);
 #ifdef _O_BINARY
         m |= (strstr(mode, "b") ? _O_BINARY : 0);
 #endif
-	d = _wopen(wPath, m);
-	if (d >= 0)
-	    fd = gzdopen(d, mode);
+        d = _wopen(wPath, m);
+        if (d >= 0)
+            fd = gzdopen(d, mode);
         xmlFree(wPath);
     }
 
@@ -693,7 +693,7 @@ xmlCheckFilename (const char *path)
 #endif
 #endif
     if (path == NULL)
-	return(0);
+        return(0);
 
 #ifdef HAVE_STAT
 #if defined(_WIN32)
@@ -702,8 +702,8 @@ xmlCheckFilename (const char *path)
      * which start with '\\?\'
      */
     if ((path[0] == '\\') && (path[1] == '\\') && (path[2] == '?') &&
-	(path[3] == '\\') )
-	    return 1;
+        (path[3] == '\\') )
+            return 1;
 
     if (xmlWrapStatUtf8(path, &stat_buffer) == -1)
         return 0;
@@ -768,8 +768,8 @@ xmlFdWrite (void * context, const char * buffer, int len) {
     int ret = 0;
 
     if (len > 0) {
-	ret = write((int) (ptrdiff_t) context, &buffer[0], len);
-	if (ret < 0) xmlIOErr(0, "write()");
+        ret = write((int) (ptrdiff_t) context, &buffer[0], len);
+        if (ret < 0) xmlIOErr(0, "write()");
     }
     return(ret);
 }
@@ -822,28 +822,28 @@ xmlFileOpen_real (const char *filename) {
         return(NULL);
 
     if (!strcmp(filename, "-")) {
-	fd = stdin;
-	return((void *) fd);
+        fd = stdin;
+        return((void *) fd);
     }
 
     if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file://localhost/", 17)) {
 #if defined (_WIN32)
-	path = &filename[17];
+        path = &filename[17];
 #else
-	path = &filename[16];
+        path = &filename[16];
 #endif
     } else if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file:///", 8)) {
 #if defined (_WIN32)
-	path = &filename[8];
+        path = &filename[8];
 #else
-	path = &filename[7];
+        path = &filename[7];
 #endif
     } else if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file:/", 6)) {
         /* lots of generators seems to lazy to read RFC 1738 */
 #if defined (_WIN32)
-	path = &filename[6];
+        path = &filename[6];
 #else
-	path = &filename[5];
+        path = &filename[5];
 #endif
     }
 
@@ -878,11 +878,11 @@ xmlFileOpen (const char *filename) {
 
     retval = xmlFileOpen_real(filename);
     if (retval == NULL) {
-	unescaped = xmlURIUnescapeString(filename, 0, NULL);
-	if (unescaped != NULL) {
-	    retval = xmlFileOpen_real(unescaped);
-	    xmlFree(unescaped);
-	}
+        unescaped = xmlURIUnescapeString(filename, 0, NULL);
+        if (unescaped != NULL) {
+            retval = xmlFileOpen_real(unescaped);
+            xmlFree(unescaped);
+        }
     }
 
     return retval;
@@ -904,27 +904,27 @@ xmlFileOpenW (const char *filename) {
     FILE *fd;
 
     if (!strcmp(filename, "-")) {
-	fd = stdout;
-	return((void *) fd);
+        fd = stdout;
+        return((void *) fd);
     }
 
     if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file://localhost/", 17))
 #if defined (_WIN32)
-	path = &filename[17];
+        path = &filename[17];
 #else
-	path = &filename[16];
+        path = &filename[16];
 #endif
     else if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file:///", 8)) {
 #if defined (_WIN32)
-	path = &filename[8];
+        path = &filename[8];
 #else
-	path = &filename[7];
+        path = &filename[7];
 #endif
     } else
-	path = filename;
+        path = filename;
 
     if (path == NULL)
-	return(NULL);
+        return(NULL);
 
 #if defined(_WIN32)
     fd = xmlWrapOpenUtf8(path, 1);
@@ -979,7 +979,7 @@ xmlFileWrite (void * context, const char * buffer, int len) {
     items = fwrite(&buffer[0], len, 1, (FILE *) context);
     if ((items == 0) && (ferror((FILE *) context))) {
         xmlIOErr(0, "fwrite()");
-	return(-1);
+        return(-1);
     }
     return(items * len);
 }
@@ -1003,12 +1003,12 @@ xmlFileClose (void * context) {
     fil = (FILE *) context;
     if ((fil == stdout) || (fil == stderr)) {
         ret = fflush(fil);
-	if (ret < 0)
-	    xmlIOErr(0, "fflush()");
-	return(0);
+        if (ret < 0)
+            xmlIOErr(0, "fflush()");
+        return(0);
     }
     if (fil == stdin)
-	return(0);
+        return(0);
     ret = ( fclose((FILE *) context) == EOF ) ? -1 : 0;
     if (ret < 0)
         xmlIOErr(0, "fclose()");
@@ -1057,9 +1057,9 @@ xmlBufferWrite (void * context, const char * buffer, int len) {
 
 #ifdef LIBXML_ZLIB_ENABLED
 /************************************************************************
- *									*
- *		I/O for compressed file accesses			*
- *									*
+ *                                                                      *
+ *              I/O for compressed file accesses                        *
+ *                                                                      *
  ************************************************************************/
 /**
  * xmlGzfileMatch:
@@ -1095,26 +1095,26 @@ xmlGzfileOpen_real (const char *filename) {
             close(duped_fd);  /* gzdOpen() does not close on failure */
         }
 
-	return((void *) fd);
+        return((void *) fd);
     }
 
     if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file://localhost/", 17))
 #if defined (_WIN32)
-	path = &filename[17];
+        path = &filename[17];
 #else
-	path = &filename[16];
+        path = &filename[16];
 #endif
     else if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file:///", 8)) {
 #if defined (_WIN32)
-	path = &filename[8];
+        path = &filename[8];
 #else
-	path = &filename[7];
+        path = &filename[7];
 #endif
     } else
-	path = filename;
+        path = filename;
 
     if (path == NULL)
-	return(NULL);
+        return(NULL);
     if (!xmlCheckFilename(path))
         return(NULL);
 
@@ -1140,11 +1140,11 @@ xmlGzfileOpen (const char *filename) {
 
     retval = xmlGzfileOpen_real(filename);
     if (retval == NULL) {
-	unescaped = xmlURIUnescapeString(filename, 0, NULL);
-	if (unescaped != NULL) {
-	    retval = xmlGzfileOpen_real(unescaped);
-	}
-	xmlFree(unescaped);
+        unescaped = xmlURIUnescapeString(filename, 0, NULL);
+        if (unescaped != NULL) {
+            retval = xmlGzfileOpen_real(unescaped);
+        }
+        xmlFree(unescaped);
     }
     return retval;
 }
@@ -1174,26 +1174,26 @@ xmlGzfileOpenW (const char *filename, int compression) {
             close(duped_fd);  /* gzdOpen() does not close on failure */
         }
 
-	return((void *) fd);
+        return((void *) fd);
     }
 
     if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file://localhost/", 17))
 #if defined (_WIN32)
-	path = &filename[17];
+        path = &filename[17];
 #else
-	path = &filename[16];
+        path = &filename[16];
 #endif
     else if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file:///", 8)) {
 #if defined (_WIN32)
-	path = &filename[8];
+        path = &filename[8];
 #else
-	path = &filename[7];
+        path = &filename[7];
 #endif
     } else
-	path = filename;
+        path = filename;
 
     if (path == NULL)
-	return(NULL);
+        return(NULL);
 
 #if defined(_WIN32)
     fd = xmlWrapGzOpenUtf8(path, mode);
@@ -1262,9 +1262,9 @@ xmlGzfileClose (void * context) {
 
 #ifdef LIBXML_LZMA_ENABLED
 /************************************************************************
- *									*
- *		I/O for compressed file accesses			*
- *									*
+ *                                                                      *
+ *              I/O for compressed file accesses                        *
+ *                                                                      *
  ************************************************************************/
 #include "xzlib.h"
 /**
@@ -1296,21 +1296,21 @@ xmlXzfileOpen_real (const char *filename) {
 
     if (!strcmp(filename, "-")) {
         fd = __libxml2_xzdopen(dup(fileno(stdin)), "rb");
-	return((void *) fd);
+        return((void *) fd);
     }
 
     if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file://localhost/", 17)) {
-	path = &filename[16];
+        path = &filename[16];
     } else if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file:///", 8)) {
-	path = &filename[7];
+        path = &filename[7];
     } else if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "file:/", 6)) {
         /* lots of generators seems to lazy to read RFC 1738 */
-	path = &filename[5];
+        path = &filename[5];
     } else
-	path = filename;
+        path = filename;
 
     if (path == NULL)
-	return(NULL);
+        return(NULL);
     if (!xmlCheckFilename(path))
         return(NULL);
 
@@ -1334,11 +1334,11 @@ xmlXzfileOpen (const char *filename) {
 
     retval = xmlXzfileOpen_real(filename);
     if (retval == NULL) {
-	unescaped = xmlURIUnescapeString(filename, 0, NULL);
-	if (unescaped != NULL) {
-	    retval = xmlXzfileOpen_real(unescaped);
-	}
-	xmlFree(unescaped);
+        unescaped = xmlURIUnescapeString(filename, 0, NULL);
+        if (unescaped != NULL) {
+            retval = xmlXzfileOpen_real(unescaped);
+        }
+        xmlFree(unescaped);
     }
 
     return retval;
@@ -1381,31 +1381,31 @@ xmlXzfileClose (void * context) {
 
 #ifdef LIBXML_HTTP_ENABLED
 /************************************************************************
- *									*
- *			I/O for HTTP file accesses			*
- *									*
+ *                                                                      *
+ *                      I/O for HTTP file accesses                      *
+ *                                                                      *
  ************************************************************************/
 
 #ifdef LIBXML_OUTPUT_ENABLED
 typedef struct xmlIOHTTPWriteCtxt_
 {
-    int			compression;
+    int                 compression;
 
-    char *		uri;
+    char *              uri;
 
-    void *		doc_buff;
+    void *              doc_buff;
 
 } xmlIOHTTPWriteCtxt, *xmlIOHTTPWriteCtxtPtr;
 
 #ifdef LIBXML_ZLIB_ENABLED
 
-#define DFLT_WBITS		( -15 )
-#define DFLT_MEM_LVL		( 8 )
-#define GZ_MAGIC1		( 0x1f )
-#define GZ_MAGIC2		( 0x8b )
-#define LXML_ZLIB_OS_CODE	( 0x03 )
-#define INIT_HTTP_BUFF_SIZE	( 32768 )
-#define DFLT_ZLIB_RATIO		( 5 )
+#define DFLT_WBITS              ( -15 )
+#define DFLT_MEM_LVL            ( 8 )
+#define GZ_MAGIC1               ( 0x1f )
+#define GZ_MAGIC2               ( 0x8b )
+#define LXML_ZLIB_OS_CODE       ( 0x03 )
+#define INIT_HTTP_BUFF_SIZE     ( 32768 )
+#define DFLT_ZLIB_RATIO         ( 5 )
 
 /*
 **  Data structure and functions to work with sending compressed data
@@ -1414,11 +1414,11 @@ typedef struct xmlIOHTTPWriteCtxt_
 
 typedef struct xmlZMemBuff_
 {
-   unsigned long	size;
-   unsigned long	crc;
+   unsigned long        size;
+   unsigned long        crc;
 
-   unsigned char *	zbuff;
-   z_stream		zctrl;
+   unsigned char *      zbuff;
+   z_stream             zctrl;
 
 } xmlZMemBuff, *xmlZMemBuffPtr;
 
@@ -1433,10 +1433,10 @@ typedef struct xmlZMemBuff_
 static void
 append_reverse_ulong( xmlZMemBuff * buff, unsigned long data ) {
 
-    int		idx;
+    int         idx;
 
     if ( buff == NULL )
-	return;
+        return;
 
     /*
     **  This is plagiarized from putLong in gzio.c (zlib source) where
@@ -1446,9 +1446,9 @@ append_reverse_ulong( xmlZMemBuff * buff, unsigned long data ) {
     */
 
     for ( idx = 0; idx < 4; idx++ ) {
-	*buff->zctrl.next_out = ( data & 0xff );
-	data >>= 8;
-	buff->zctrl.next_out++;
+        *buff->zctrl.next_out = ( data & 0xff );
+        data >>= 8;
+        buff->zctrl.next_out++;
     }
 
     return;
@@ -1469,15 +1469,15 @@ xmlFreeZMemBuff( xmlZMemBuffPtr buff ) {
 #endif
 
     if ( buff == NULL )
-	return;
+        return;
 
     xmlFree( buff->zbuff );
 #ifdef DEBUG_HTTP
     z_err = deflateEnd( &buff->zctrl );
     if ( z_err != Z_OK )
-	xmlGenericError( xmlGenericErrorContext,
-			"xmlFreeZMemBuff:  Error releasing zlib context:  %d\n",
-			z_err );
+        xmlGenericError( xmlGenericErrorContext,
+                        "xmlFreeZMemBuff:  Error releasing zlib context:  %d\n",
+                        z_err );
 #else
     deflateEnd( &buff->zctrl );
 #endif
@@ -1488,7 +1488,7 @@ xmlFreeZMemBuff( xmlZMemBuffPtr buff ) {
 
 /**
  * xmlCreateZMemBuff
- *@compression:	Compression value to use
+ *@compression: Compression value to use
  *
  * Create a memory buffer to hold the compressed XML document.  The
  * compressed document in memory will end up being identical to what
@@ -1499,50 +1499,50 @@ xmlFreeZMemBuff( xmlZMemBuffPtr buff ) {
 static void *
 xmlCreateZMemBuff( int compression ) {
 
-    int			z_err;
-    int			hdr_lgth;
-    xmlZMemBuffPtr	buff = NULL;
+    int                 z_err;
+    int                 hdr_lgth;
+    xmlZMemBuffPtr      buff = NULL;
 
     if ( ( compression < 1 ) || ( compression > 9 ) )
-	return ( NULL );
+        return ( NULL );
 
     /*  Create the control and data areas  */
 
     buff = xmlMalloc( sizeof( xmlZMemBuff ) );
     if ( buff == NULL ) {
-	xmlIOErrMemory("creating buffer context");
-	return ( NULL );
+        xmlIOErrMemory("creating buffer context");
+        return ( NULL );
     }
 
     (void)memset( buff, 0, sizeof( xmlZMemBuff ) );
     buff->size = INIT_HTTP_BUFF_SIZE;
     buff->zbuff = xmlMalloc( buff->size );
     if ( buff->zbuff == NULL ) {
-	xmlFreeZMemBuff( buff );
-	xmlIOErrMemory("creating buffer");
-	return ( NULL );
+        xmlFreeZMemBuff( buff );
+        xmlIOErrMemory("creating buffer");
+        return ( NULL );
     }
 
     z_err = deflateInit2( &buff->zctrl, compression, Z_DEFLATED,
-			    DFLT_WBITS, DFLT_MEM_LVL, Z_DEFAULT_STRATEGY );
+                            DFLT_WBITS, DFLT_MEM_LVL, Z_DEFAULT_STRATEGY );
     if ( z_err != Z_OK ) {
-	xmlChar msg[500];
-	xmlFreeZMemBuff( buff );
-	buff = NULL;
-	xmlStrPrintf(msg, 500,
-		    "xmlCreateZMemBuff:  %s %d\n",
-		    "Error initializing compression context.  ZLIB error:",
-		    z_err );
-	xmlIOErr(XML_IO_WRITE, (const char *) msg);
-	return ( NULL );
+        xmlChar msg[500];
+        xmlFreeZMemBuff( buff );
+        buff = NULL;
+        xmlStrPrintf(msg, 500,
+                    "xmlCreateZMemBuff:  %s %d\n",
+                    "Error initializing compression context.  ZLIB error:",
+                    z_err );
+        xmlIOErr(XML_IO_WRITE, (const char *) msg);
+        return ( NULL );
     }
 
     /*  Set the header data.  The CRC will be needed for the trailer  */
     buff->crc = crc32( 0L, NULL, 0 );
     hdr_lgth = snprintf( (char *)buff->zbuff, buff->size,
-			"%c%c%c%c%c%c%c%c%c%c",
-			GZ_MAGIC1, GZ_MAGIC2, Z_DEFLATED,
-			0, 0, 0, 0, 0, 0, LXML_ZLIB_OS_CODE );
+                        "%c%c%c%c%c%c%c%c%c%c",
+                        GZ_MAGIC1, GZ_MAGIC2, Z_DEFLATED,
+                        0, 0, 0, 0, 0, 0, LXML_ZLIB_OS_CODE );
     buff->zctrl.next_out  = buff->zbuff + hdr_lgth;
     buff->zctrl.avail_out = buff->size - hdr_lgth;
 
@@ -1563,45 +1563,45 @@ xmlCreateZMemBuff( int compression ) {
 static int
 xmlZMemBuffExtend( xmlZMemBuffPtr buff, size_t ext_amt ) {
 
-    int			rc = -1;
-    size_t		new_size;
-    size_t		cur_used;
+    int                 rc = -1;
+    size_t              new_size;
+    size_t              cur_used;
 
-    unsigned char *	tmp_ptr = NULL;
+    unsigned char *     tmp_ptr = NULL;
 
     if ( buff == NULL )
-	return ( -1 );
+        return ( -1 );
 
     else if ( ext_amt == 0 )
-	return ( 0 );
+        return ( 0 );
 
     cur_used = buff->zctrl.next_out - buff->zbuff;
     new_size = buff->size + ext_amt;
 
 #ifdef DEBUG_HTTP
     if ( cur_used > new_size )
-	xmlGenericError( xmlGenericErrorContext,
-			"xmlZMemBuffExtend:  %s\n%s %d bytes.\n",
-			"Buffer overwrite detected during compressed memory",
-			"buffer extension.  Overflowed by",
-			(cur_used - new_size ) );
+        xmlGenericError( xmlGenericErrorContext,
+                        "xmlZMemBuffExtend:  %s\n%s %d bytes.\n",
+                        "Buffer overwrite detected during compressed memory",
+                        "buffer extension.  Overflowed by",
+                        (cur_used - new_size ) );
 #endif
 
     tmp_ptr = xmlRealloc( buff->zbuff, new_size );
     if ( tmp_ptr != NULL ) {
-	rc = 0;
-	buff->size  = new_size;
-	buff->zbuff = tmp_ptr;
-	buff->zctrl.next_out  = tmp_ptr + cur_used;
-	buff->zctrl.avail_out = new_size - cur_used;
+        rc = 0;
+        buff->size  = new_size;
+        buff->zbuff = tmp_ptr;
+        buff->zctrl.next_out  = tmp_ptr + cur_used;
+        buff->zctrl.avail_out = new_size - cur_used;
     }
     else {
-	xmlChar msg[500];
-	xmlStrPrintf(msg, 500,
-		    "xmlZMemBuffExtend:  %s %lu bytes.\n",
-		    "Allocation failure extending output buffer to",
-		    (unsigned long) new_size );
-	xmlIOErr(XML_IO_WRITE, (const char *) msg);
+        xmlChar msg[500];
+        xmlStrPrintf(msg, 500,
+                    "xmlZMemBuffExtend:  %s %lu bytes.\n",
+                    "Allocation failure extending output buffer to",
+                    (unsigned long) new_size );
+        xmlIOErr(XML_IO_WRITE, (const char *) msg);
     }
 
     return ( rc );
@@ -1621,35 +1621,35 @@ xmlZMemBuffExtend( xmlZMemBuffPtr buff, size_t ext_amt ) {
 static int
 xmlZMemBuffAppend( xmlZMemBuffPtr buff, const char * src, int len ) {
 
-    int		z_err;
-    size_t	min_accept;
+    int         z_err;
+    size_t      min_accept;
 
     if ( ( buff == NULL ) || ( src == NULL ) )
-	return ( -1 );
+        return ( -1 );
 
     buff->zctrl.avail_in = len;
     buff->zctrl.next_in  = (unsigned char *)src;
     while ( buff->zctrl.avail_in > 0 ) {
-	/*
-	**  Extend the buffer prior to deflate call if a reasonable amount
-	**  of output buffer space is not available.
-	*/
-	min_accept = buff->zctrl.avail_in / DFLT_ZLIB_RATIO;
-	if ( buff->zctrl.avail_out <= min_accept ) {
-	    if ( xmlZMemBuffExtend( buff, buff->size ) == -1 )
-		return ( -1 );
-	}
+        /*
+        **  Extend the buffer prior to deflate call if a reasonable amount
+        **  of output buffer space is not available.
+        */
+        min_accept = buff->zctrl.avail_in / DFLT_ZLIB_RATIO;
+        if ( buff->zctrl.avail_out <= min_accept ) {
+            if ( xmlZMemBuffExtend( buff, buff->size ) == -1 )
+                return ( -1 );
+        }
 
-	z_err = deflate( &buff->zctrl, Z_NO_FLUSH );
-	if ( z_err != Z_OK ) {
-	    xmlChar msg[500];
-	    xmlStrPrintf(msg, 500,
-			"xmlZMemBuffAppend:  %s %d %s - %d",
-			"Compression error while appending",
-			len, "bytes to buffer.  ZLIB error", z_err );
-	    xmlIOErr(XML_IO_WRITE, (const char *) msg);
-	    return ( -1 );
-	}
+        z_err = deflate( &buff->zctrl, Z_NO_FLUSH );
+        if ( z_err != Z_OK ) {
+            xmlChar msg[500];
+            xmlStrPrintf(msg, 500,
+                        "xmlZMemBuffAppend:  %s %d %s - %d",
+                        "Compression error while appending",
+                        len, "bytes to buffer.  ZLIB error", z_err );
+            xmlIOErr(XML_IO_WRITE, (const char *) msg);
+            return ( -1 );
+        }
     }
 
     buff->crc = crc32( buff->crc, (unsigned char *)src, len );
@@ -1671,23 +1671,23 @@ xmlZMemBuffAppend( xmlZMemBuffPtr buff, const char * src, int len ) {
 static int
 xmlZMemBuffGetContent( xmlZMemBuffPtr buff, char ** data_ref ) {
 
-    int		zlgth = -1;
-    int		z_err;
+    int         zlgth = -1;
+    int         z_err;
 
     if ( ( buff == NULL ) || ( data_ref == NULL ) )
-	return ( -1 );
+        return ( -1 );
 
     /*  Need to loop until compression output buffers are flushed  */
 
     do
     {
-	z_err = deflate( &buff->zctrl, Z_FINISH );
-	if ( z_err == Z_OK ) {
-	    /*  In this case Z_OK means more buffer space needed  */
+        z_err = deflate( &buff->zctrl, Z_FINISH );
+        if ( z_err == Z_OK ) {
+            /*  In this case Z_OK means more buffer space needed  */
 
-	    if ( xmlZMemBuffExtend( buff, buff->size ) == -1 )
-		return ( -1 );
-	}
+            if ( xmlZMemBuffExtend( buff, buff->size ) == -1 )
+                return ( -1 );
+        }
     }
     while ( z_err == Z_OK );
 
@@ -1695,31 +1695,31 @@ xmlZMemBuffGetContent( xmlZMemBuffPtr buff, char ** data_ref ) {
 
     if ( z_err == Z_STREAM_END ) {
 
-	/*  Need to append the gzip data trailer  */
+        /*  Need to append the gzip data trailer  */
 
-	if ( buff->zctrl.avail_out < ( 2 * sizeof( unsigned long ) ) ) {
-	    if ( xmlZMemBuffExtend(buff, (2 * sizeof(unsigned long))) == -1 )
-		return ( -1 );
-	}
+        if ( buff->zctrl.avail_out < ( 2 * sizeof( unsigned long ) ) ) {
+            if ( xmlZMemBuffExtend(buff, (2 * sizeof(unsigned long))) == -1 )
+                return ( -1 );
+        }
 
-	/*
-	**  For whatever reason, the CRC and length data are pushed out
-	**  in reverse byte order.  So a memcpy can't be used here.
-	*/
+        /*
+        **  For whatever reason, the CRC and length data are pushed out
+        **  in reverse byte order.  So a memcpy can't be used here.
+        */
 
-	append_reverse_ulong( buff, buff->crc );
-	append_reverse_ulong( buff, buff->zctrl.total_in );
+        append_reverse_ulong( buff, buff->crc );
+        append_reverse_ulong( buff, buff->zctrl.total_in );
 
-	zlgth = buff->zctrl.next_out - buff->zbuff;
-	*data_ref = (char *)buff->zbuff;
+        zlgth = buff->zctrl.next_out - buff->zbuff;
+        *data_ref = (char *)buff->zbuff;
     }
 
     else {
-	xmlChar msg[500];
-	xmlStrPrintf(msg, 500,
-		    "xmlZMemBuffGetContent:  %s - %d\n",
-		    "Error flushing zlib buffers.  Error code", z_err );
-	xmlIOErr(XML_IO_WRITE, (const char *) msg);
+        xmlChar msg[500];
+        xmlStrPrintf(msg, 500,
+                    "xmlZMemBuffGetContent:  %s - %d\n",
+                    "Error flushing zlib buffers.  Error code", z_err );
+        xmlIOErr(XML_IO_WRITE, (const char *) msg);
     }
 
     return ( zlgth );
@@ -1740,19 +1740,19 @@ static void
 xmlFreeHTTPWriteCtxt( xmlIOHTTPWriteCtxtPtr ctxt )
 {
     if ( ctxt->uri != NULL )
-	xmlFree( ctxt->uri );
+        xmlFree( ctxt->uri );
 
     if ( ctxt->doc_buff != NULL ) {
 
 #ifdef LIBXML_ZLIB_ENABLED
-	if ( ctxt->compression > 0 ) {
-	    xmlFreeZMemBuff( ctxt->doc_buff );
-	}
-	else
+        if ( ctxt->compression > 0 ) {
+            xmlFreeZMemBuff( ctxt->doc_buff );
+        }
+        else
 #endif
-	{
-	    xmlOutputBufferClose( ctxt->doc_buff );
-	}
+        {
+            xmlOutputBufferClose( ctxt->doc_buff );
+        }
     }
 
     xmlFree( ctxt );
@@ -1772,7 +1772,7 @@ xmlFreeHTTPWriteCtxt( xmlIOHTTPWriteCtxtPtr ctxt )
 int
 xmlIOHTTPMatch (const char *filename) {
     if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "http://", 7))
-	return(1);
+        return(1);
     return(0);
 }
 
@@ -1812,7 +1812,7 @@ xmlIOHTTPOpenW(const char *post_uri, int compression ATTRIBUTE_UNUSED)
 
     ctxt = xmlMalloc(sizeof(xmlIOHTTPWriteCtxt));
     if (ctxt == NULL) {
-	xmlIOErrMemory("creating HTTP output context");
+        xmlIOErrMemory("creating HTTP output context");
         return (NULL);
     }
 
@@ -1820,7 +1820,7 @@ xmlIOHTTPOpenW(const char *post_uri, int compression ATTRIBUTE_UNUSED)
 
     ctxt->uri = (char *) xmlStrdup((const xmlChar *)post_uri);
     if (ctxt->uri == NULL) {
-	xmlIOErrMemory("copying URI");
+        xmlIOErrMemory("copying URI");
         xmlFreeHTTPWriteCtxt(ctxt);
         return (NULL);
     }
@@ -1902,32 +1902,32 @@ xmlIOHTTPRead(void * context, char * buffer, int len) {
 static int
 xmlIOHTTPWrite( void * context, const char * buffer, int len ) {
 
-    xmlIOHTTPWriteCtxtPtr	ctxt = context;
+    xmlIOHTTPWriteCtxtPtr       ctxt = context;
 
     if ( ( ctxt == NULL ) || ( ctxt->doc_buff == NULL ) || ( buffer == NULL ) )
-	return ( -1 );
+        return ( -1 );
 
     if ( len > 0 ) {
 
-	/*  Use gzwrite or fwrite as previously setup in the open call  */
+        /*  Use gzwrite or fwrite as previously setup in the open call  */
 
 #ifdef LIBXML_ZLIB_ENABLED
-	if ( ctxt->compression > 0 )
-	    len = xmlZMemBuffAppend( ctxt->doc_buff, buffer, len );
+        if ( ctxt->compression > 0 )
+            len = xmlZMemBuffAppend( ctxt->doc_buff, buffer, len );
 
-	else
+        else
 #endif
-	    len = xmlOutputBufferWrite( ctxt->doc_buff, len, buffer );
+            len = xmlOutputBufferWrite( ctxt->doc_buff, len, buffer );
 
-	if ( len < 0 ) {
-	    xmlChar msg[500];
-	    xmlStrPrintf(msg, 500,
-			"xmlIOHTTPWrite:  %s\n%s '%s'.\n",
-			"Error appending to internal buffer.",
-			"Error sending document to URI",
-			ctxt->uri );
-	    xmlIOErr(XML_IO_WRITE, (const char *) msg);
-	}
+        if ( len < 0 ) {
+            xmlChar msg[500];
+            xmlStrPrintf(msg, 500,
+                        "xmlIOHTTPWrite:  %s\n%s '%s'.\n",
+                        "Error appending to internal buffer.",
+                        "Error sending document to URI",
+                        ctxt->uri );
+            xmlIOErr(XML_IO_WRITE, (const char *) msg);
+        }
     }
 
     return ( len );
@@ -1960,122 +1960,122 @@ xmlIOHTTPClose (void * context) {
 static int
 xmlIOHTTPCloseWrite( void * context, const char * http_mthd ) {
 
-    int				close_rc = -1;
-    int				http_rtn = 0;
-    int				content_lgth = 0;
-    xmlIOHTTPWriteCtxtPtr	ctxt = context;
+    int                         close_rc = -1;
+    int                         http_rtn = 0;
+    int                         content_lgth = 0;
+    xmlIOHTTPWriteCtxtPtr       ctxt = context;
 
-    char *			http_content = NULL;
-    char *			content_encoding = NULL;
-    char *			content_type = (char *) "text/xml";
-    void *			http_ctxt = NULL;
+    char *                      http_content = NULL;
+    char *                      content_encoding = NULL;
+    char *                      content_type = (char *) "text/xml";
+    void *                      http_ctxt = NULL;
 
     if ( ( ctxt == NULL ) || ( http_mthd == NULL ) )
-	return ( -1 );
+        return ( -1 );
 
     /*  Retrieve the content from the appropriate buffer  */
 
 #ifdef LIBXML_ZLIB_ENABLED
 
     if ( ctxt->compression > 0 ) {
-	content_lgth = xmlZMemBuffGetContent( ctxt->doc_buff, &http_content );
-	content_encoding = (char *) "Content-Encoding: gzip";
+        content_lgth = xmlZMemBuffGetContent( ctxt->doc_buff, &http_content );
+        content_encoding = (char *) "Content-Encoding: gzip";
     }
     else
 #endif
     {
-	/*  Pull the data out of the memory output buffer  */
+        /*  Pull the data out of the memory output buffer  */
 
-	xmlOutputBufferPtr	dctxt = ctxt->doc_buff;
-	http_content = (char *) xmlBufContent(dctxt->buffer);
-	content_lgth = xmlBufUse(dctxt->buffer);
+        xmlOutputBufferPtr      dctxt = ctxt->doc_buff;
+        http_content = (char *) xmlBufContent(dctxt->buffer);
+        content_lgth = xmlBufUse(dctxt->buffer);
     }
 
     if ( http_content == NULL ) {
-	xmlChar msg[500];
-	xmlStrPrintf(msg, 500,
-		     "xmlIOHTTPCloseWrite:  %s '%s' %s '%s'.\n",
-		     "Error retrieving content.\nUnable to",
-		     http_mthd, "data to URI", ctxt->uri );
-	xmlIOErr(XML_IO_WRITE, (const char *) msg);
+        xmlChar msg[500];
+        xmlStrPrintf(msg, 500,
+                     "xmlIOHTTPCloseWrite:  %s '%s' %s '%s'.\n",
+                     "Error retrieving content.\nUnable to",
+                     http_mthd, "data to URI", ctxt->uri );
+        xmlIOErr(XML_IO_WRITE, (const char *) msg);
     }
 
     else {
 
-	http_ctxt = xmlNanoHTTPMethod( ctxt->uri, http_mthd, http_content,
-					&content_type, content_encoding,
-					content_lgth );
+        http_ctxt = xmlNanoHTTPMethod( ctxt->uri, http_mthd, http_content,
+                                        &content_type, content_encoding,
+                                        content_lgth );
 
-	if ( http_ctxt != NULL ) {
+        if ( http_ctxt != NULL ) {
 #ifdef DEBUG_HTTP
-	    /*  If testing/debugging - dump reply with request content  */
+            /*  If testing/debugging - dump reply with request content  */
 
-	    FILE *	tst_file = NULL;
-	    char	buffer[ 4096 ];
-	    char *	dump_name = NULL;
-	    int		avail;
+            FILE *      tst_file = NULL;
+            char        buffer[ 4096 ];
+            char *      dump_name = NULL;
+            int         avail;
 
-	    xmlGenericError( xmlGenericErrorContext,
-			"xmlNanoHTTPCloseWrite:  HTTP %s to\n%s returned %d.\n",
-			http_mthd, ctxt->uri,
-			xmlNanoHTTPReturnCode( http_ctxt ) );
+            xmlGenericError( xmlGenericErrorContext,
+                        "xmlNanoHTTPCloseWrite:  HTTP %s to\n%s returned %d.\n",
+                        http_mthd, ctxt->uri,
+                        xmlNanoHTTPReturnCode( http_ctxt ) );
 
-	    /*
-	    **  Since either content or reply may be gzipped,
-	    **  dump them to separate files instead of the
-	    **  standard error context.
-	    */
+            /*
+            **  Since either content or reply may be gzipped,
+            **  dump them to separate files instead of the
+            **  standard error context.
+            */
 
-	    dump_name = tempnam( NULL, "lxml" );
-	    if ( dump_name != NULL ) {
-		(void)snprintf( buffer, sizeof(buffer), "%s.content", dump_name );
+            dump_name = tempnam( NULL, "lxml" );
+            if ( dump_name != NULL ) {
+                (void)snprintf( buffer, sizeof(buffer), "%s.content", dump_name );
 
-		tst_file = fopen( buffer, "wb" );
-		if ( tst_file != NULL ) {
-		    xmlGenericError( xmlGenericErrorContext,
-			"Transmitted content saved in file:  %s\n", buffer );
+                tst_file = fopen( buffer, "wb" );
+                if ( tst_file != NULL ) {
+                    xmlGenericError( xmlGenericErrorContext,
+                        "Transmitted content saved in file:  %s\n", buffer );
 
-		    fwrite( http_content, sizeof( char ),
-					content_lgth, tst_file );
-		    fclose( tst_file );
-		}
+                    fwrite( http_content, sizeof( char ),
+                                        content_lgth, tst_file );
+                    fclose( tst_file );
+                }
 
-		(void)snprintf( buffer, sizeof(buffer), "%s.reply", dump_name );
-		tst_file = fopen( buffer, "wb" );
-		if ( tst_file != NULL ) {
-		    xmlGenericError( xmlGenericErrorContext,
-			"Reply content saved in file:  %s\n", buffer );
+                (void)snprintf( buffer, sizeof(buffer), "%s.reply", dump_name );
+                tst_file = fopen( buffer, "wb" );
+                if ( tst_file != NULL ) {
+                    xmlGenericError( xmlGenericErrorContext,
+                        "Reply content saved in file:  %s\n", buffer );
 
 
-		    while ( (avail = xmlNanoHTTPRead( http_ctxt,
-					buffer, sizeof( buffer ) )) > 0 ) {
+                    while ( (avail = xmlNanoHTTPRead( http_ctxt,
+                                        buffer, sizeof( buffer ) )) > 0 ) {
 
-			fwrite( buffer, sizeof( char ), avail, tst_file );
-		    }
+                        fwrite( buffer, sizeof( char ), avail, tst_file );
+                    }
 
-		    fclose( tst_file );
-		}
+                    fclose( tst_file );
+                }
 
-		free( dump_name );
-	    }
+                free( dump_name );
+            }
 #endif  /*  DEBUG_HTTP  */
 
-	    http_rtn = xmlNanoHTTPReturnCode( http_ctxt );
-	    if ( ( http_rtn >= 200 ) && ( http_rtn < 300 ) )
-		close_rc = 0;
-	    else {
+            http_rtn = xmlNanoHTTPReturnCode( http_ctxt );
+            if ( ( http_rtn >= 200 ) && ( http_rtn < 300 ) )
+                close_rc = 0;
+            else {
                 xmlChar msg[500];
                 xmlStrPrintf(msg, 500,
                       "xmlIOHTTPCloseWrite: HTTP '%s' of %d %s\n'%s' %s %d\n",
-			    http_mthd, content_lgth,
-			    "bytes to URI", ctxt->uri,
-			    "failed.  HTTP return code:", http_rtn );
-		xmlIOErr(XML_IO_WRITE, (const char *) msg);
+                            http_mthd, content_lgth,
+                            "bytes to URI", ctxt->uri,
+                            "failed.  HTTP return code:", http_rtn );
+                xmlIOErr(XML_IO_WRITE, (const char *) msg);
             }
 
-	    xmlNanoHTTPClose( http_ctxt );
-	    xmlFree( content_type );
-	}
+            xmlNanoHTTPClose( http_ctxt );
+            xmlFree( content_type );
+        }
     }
 
     /*  Final cleanups  */
@@ -2117,9 +2117,9 @@ xmlIOHTTPClosePost( void * ctxt ) {
 
 #ifdef LIBXML_FTP_ENABLED
 /************************************************************************
- *									*
- *			I/O for FTP file accesses			*
- *									*
+ *                                                                      *
+ *                      I/O for FTP file accesses                       *
+ *                                                                      *
  ************************************************************************/
 /**
  * xmlIOFTPMatch:
@@ -2132,7 +2132,7 @@ xmlIOHTTPClosePost( void * ctxt ) {
 int
 xmlIOFTPMatch (const char *filename) {
     if (!xmlStrncasecmp(BAD_CAST filename, BAD_CAST "ftp://", 6))
-	return(1);
+        return(1);
     return(0);
 }
 
@@ -2193,10 +2193,10 @@ xmlIOFTPClose (void * context) {
  */
 int
 xmlRegisterInputCallbacks(xmlInputMatchCallback matchFunc,
-	xmlInputOpenCallback openFunc, xmlInputReadCallback readFunc,
-	xmlInputCloseCallback closeFunc) {
+        xmlInputOpenCallback openFunc, xmlInputReadCallback readFunc,
+        xmlInputCloseCallback closeFunc) {
     if (xmlInputCallbackNr >= MAX_INPUT_CALLBACK) {
-	return(-1);
+        return(-1);
     }
     xmlInputCallbackTable[xmlInputCallbackNr].matchcallback = matchFunc;
     xmlInputCallbackTable[xmlInputCallbackNr].opencallback = openFunc;
@@ -2220,10 +2220,10 @@ xmlRegisterInputCallbacks(xmlInputMatchCallback matchFunc,
  */
 int
 xmlRegisterOutputCallbacks(xmlOutputMatchCallback matchFunc,
-	xmlOutputOpenCallback openFunc, xmlOutputWriteCallback writeFunc,
-	xmlOutputCloseCallback closeFunc) {
+        xmlOutputOpenCallback openFunc, xmlOutputWriteCallback writeFunc,
+        xmlOutputCloseCallback closeFunc) {
     if (xmlOutputCallbackNr >= MAX_OUTPUT_CALLBACK) {
-	return(-1);
+        return(-1);
     }
     xmlOutputCallbackTable[xmlOutputCallbackNr].matchcallback = matchFunc;
     xmlOutputCallbackTable[xmlOutputCallbackNr].opencallback = openFunc;
@@ -2242,27 +2242,27 @@ xmlRegisterOutputCallbacks(xmlOutputMatchCallback matchFunc,
 void
 xmlRegisterDefaultInputCallbacks(void) {
     if (xmlInputCallbackInitialized)
-	return;
+        return;
 
     xmlRegisterInputCallbacks(xmlFileMatch, xmlFileOpen,
-	                      xmlFileRead, xmlFileClose);
+                              xmlFileRead, xmlFileClose);
 #ifdef LIBXML_ZLIB_ENABLED
     xmlRegisterInputCallbacks(xmlGzfileMatch, xmlGzfileOpen,
-	                      xmlGzfileRead, xmlGzfileClose);
+                              xmlGzfileRead, xmlGzfileClose);
 #endif /* LIBXML_ZLIB_ENABLED */
 #ifdef LIBXML_LZMA_ENABLED
     xmlRegisterInputCallbacks(xmlXzfileMatch, xmlXzfileOpen,
-	                      xmlXzfileRead, xmlXzfileClose);
+                              xmlXzfileRead, xmlXzfileClose);
 #endif /* LIBXML_LZMA_ENABLED */
 
 #ifdef LIBXML_HTTP_ENABLED
     xmlRegisterInputCallbacks(xmlIOHTTPMatch, xmlIOHTTPOpen,
-	                      xmlIOHTTPRead, xmlIOHTTPClose);
+                              xmlIOHTTPRead, xmlIOHTTPClose);
 #endif /* LIBXML_HTTP_ENABLED */
 
 #ifdef LIBXML_FTP_ENABLED
     xmlRegisterInputCallbacks(xmlIOFTPMatch, xmlIOFTPOpen,
-	                      xmlIOFTPRead, xmlIOFTPClose);
+                              xmlIOFTPRead, xmlIOFTPClose);
 #endif /* LIBXML_FTP_ENABLED */
     xmlInputCallbackInitialized = 1;
 }
@@ -2276,14 +2276,14 @@ xmlRegisterDefaultInputCallbacks(void) {
 void
 xmlRegisterDefaultOutputCallbacks (void) {
     if (xmlOutputCallbackInitialized)
-	return;
+        return;
 
     xmlRegisterOutputCallbacks(xmlFileMatch, xmlFileOpenW,
-	                      xmlFileWrite, xmlFileClose);
+                              xmlFileWrite, xmlFileClose);
 
 #ifdef LIBXML_HTTP_ENABLED
     xmlRegisterOutputCallbacks(xmlIOHTTPMatch, xmlIOHTTPDfltOpenW,
-	                       xmlIOHTTPWrite, xmlIOHTTPClosePut);
+                               xmlIOHTTPWrite, xmlIOHTTPClosePut);
 #endif
 
 /*********************************
@@ -2293,13 +2293,13 @@ xmlRegisterDefaultOutputCallbacks (void) {
 
 #ifdef LIBXML_ZLIB_ENABLED
     xmlRegisterOutputCallbacks(xmlGzfileMatch, xmlGzfileOpen,
-	                       xmlGzfileWrite, xmlGzfileClose);
+                               xmlGzfileWrite, xmlGzfileClose);
 #endif
 
  Nor FTP PUT ....
 #ifdef LIBXML_FTP_ENABLED
     xmlRegisterOutputCallbacks(xmlIOFTPMatch, xmlIOFTPOpen,
-	                       xmlIOFTPWrite, xmlIOFTPClose);
+                               xmlIOFTPWrite, xmlIOFTPClose);
 #endif
  **********************************/
     xmlOutputCallbackInitialized = 1;
@@ -2320,10 +2320,10 @@ xmlRegisterHTTPPostCallbacks( void ) {
     /*  Register defaults if not done previously  */
 
     if ( xmlOutputCallbackInitialized == 0 )
-	xmlRegisterDefaultOutputCallbacks( );
+        xmlRegisterDefaultOutputCallbacks( );
 
     xmlRegisterOutputCallbacks(xmlIOHTTPMatch, xmlIOHTTPDfltOpenW,
-	                       xmlIOHTTPWrite, xmlIOHTTPClosePost);
+                               xmlIOHTTPWrite, xmlIOHTTPClosePost);
     return;
 }
 #endif
@@ -2343,14 +2343,14 @@ xmlAllocParserInputBuffer(xmlCharEncoding enc) {
 
     ret = (xmlParserInputBufferPtr) xmlMalloc(sizeof(xmlParserInputBuffer));
     if (ret == NULL) {
-	xmlIOErrMemory("creating input buffer");
-	return(NULL);
+        xmlIOErrMemory("creating input buffer");
+        return(NULL);
     }
     memset(ret, 0, (size_t) sizeof(xmlParserInputBuffer));
     ret->buffer = xmlBufCreateSize(2 * xmlDefaultBufferSize);
     if (ret->buffer == NULL) {
         xmlFree(ret);
-	return(NULL);
+        return(NULL);
     }
     xmlBufSetAllocationScheme(ret->buffer, XML_BUFFER_ALLOC_DOUBLEIT);
     ret->encoder = xmlGetCharEncodingHandler(enc);
@@ -2382,30 +2382,30 @@ xmlAllocOutputBuffer(xmlCharEncodingHandlerPtr encoder) {
 
     ret = (xmlOutputBufferPtr) xmlMalloc(sizeof(xmlOutputBuffer));
     if (ret == NULL) {
-	xmlIOErrMemory("creating output buffer");
-	return(NULL);
+        xmlIOErrMemory("creating output buffer");
+        return(NULL);
     }
     memset(ret, 0, (size_t) sizeof(xmlOutputBuffer));
     ret->buffer = xmlBufCreate();
     if (ret->buffer == NULL) {
         xmlFree(ret);
-	return(NULL);
+        return(NULL);
     }
     xmlBufSetAllocationScheme(ret->buffer, XML_BUFFER_ALLOC_DOUBLEIT);
 
     ret->encoder = encoder;
     if (encoder != NULL) {
         ret->conv = xmlBufCreateSize(4000);
-	if (ret->conv == NULL) {
+        if (ret->conv == NULL) {
             xmlBufFree(ret->buffer);
-	    xmlFree(ret);
-	    return(NULL);
-	}
+            xmlFree(ret);
+            return(NULL);
+        }
 
-	/*
-	 * This call is designed to initiate the encoder state
-	 */
-	xmlCharEncOutput(ret, 1);
+        /*
+         * This call is designed to initiate the encoder state
+         */
+        xmlCharEncOutput(ret, 1);
     } else
         ret->conv = NULL;
     ret->writecallback = NULL;
@@ -2430,14 +2430,14 @@ xmlAllocOutputBufferInternal(xmlCharEncodingHandlerPtr encoder) {
 
     ret = (xmlOutputBufferPtr) xmlMalloc(sizeof(xmlOutputBuffer));
     if (ret == NULL) {
-	xmlIOErrMemory("creating output buffer");
-	return(NULL);
+        xmlIOErrMemory("creating output buffer");
+        return(NULL);
     }
     memset(ret, 0, (size_t) sizeof(xmlOutputBuffer));
     ret->buffer = xmlBufCreate();
     if (ret->buffer == NULL) {
         xmlFree(ret);
-	return(NULL);
+        return(NULL);
     }
 
 
@@ -2449,15 +2449,15 @@ xmlAllocOutputBufferInternal(xmlCharEncodingHandlerPtr encoder) {
     ret->encoder = encoder;
     if (encoder != NULL) {
         ret->conv = xmlBufCreateSize(4000);
-	if (ret->conv == NULL) {
+        if (ret->conv == NULL) {
             xmlBufFree(ret->buffer);
-	    xmlFree(ret);
-	    return(NULL);
-	}
+            xmlFree(ret);
+            return(NULL);
+        }
 
-	/*
-	 * This call is designed to initiate the encoder state
-	 */
+        /*
+         * This call is designed to initiate the encoder state
+         */
         xmlCharEncOutput(ret, 1);
     } else
         ret->conv = NULL;
@@ -2483,17 +2483,17 @@ xmlFreeParserInputBuffer(xmlParserInputBufferPtr in) {
 
     if (in->raw) {
         xmlBufFree(in->raw);
-	in->raw = NULL;
+        in->raw = NULL;
     }
     if (in->encoder != NULL) {
         xmlCharEncCloseFunc(in->encoder);
     }
     if (in->closecallback != NULL) {
-	in->closecallback(in->context);
+        in->closecallback(in->context);
     }
     if (in->buffer != NULL) {
         xmlBufFree(in->buffer);
-	in->buffer = NULL;
+        in->buffer = NULL;
     }
 
     xmlFree(in);
@@ -2549,7 +2549,7 @@ __xmlParserInputBufferCreateFilename(const char *URI, xmlCharEncoding enc) {
     void *context = NULL;
 
     if (xmlInputCallbackInitialized == 0)
-	xmlRegisterDefaultInputCallbacks();
+        xmlRegisterDefaultInputCallbacks();
 
     if (URI == NULL) return(NULL);
 
@@ -2558,18 +2558,18 @@ __xmlParserInputBufferCreateFilename(const char *URI, xmlCharEncoding enc) {
      * Go in reverse to give precedence to user defined handlers.
      */
     if (context == NULL) {
-	for (i = xmlInputCallbackNr - 1;i >= 0;i--) {
-	    if ((xmlInputCallbackTable[i].matchcallback != NULL) &&
-		(xmlInputCallbackTable[i].matchcallback(URI) != 0)) {
-		context = xmlInputCallbackTable[i].opencallback(URI);
-		if (context != NULL) {
-		    break;
-		}
-	    }
-	}
+        for (i = xmlInputCallbackNr - 1;i >= 0;i--) {
+            if ((xmlInputCallbackTable[i].matchcallback != NULL) &&
+                (xmlInputCallbackTable[i].matchcallback(URI) != 0)) {
+                context = xmlInputCallbackTable[i].opencallback(URI);
+                if (context != NULL) {
+                    break;
+                }
+            }
+        }
     }
     if (context == NULL) {
-	return(NULL);
+        return(NULL);
     }
 
     /*
@@ -2577,34 +2577,34 @@ __xmlParserInputBufferCreateFilename(const char *URI, xmlCharEncoding enc) {
      */
     ret = xmlAllocParserInputBuffer(enc);
     if (ret != NULL) {
-	ret->context = context;
-	ret->readcallback = xmlInputCallbackTable[i].readcallback;
-	ret->closecallback = xmlInputCallbackTable[i].closecallback;
+        ret->context = context;
+        ret->readcallback = xmlInputCallbackTable[i].readcallback;
+        ret->closecallback = xmlInputCallbackTable[i].closecallback;
 #ifdef LIBXML_ZLIB_ENABLED
-	if ((xmlInputCallbackTable[i].opencallback == xmlGzfileOpen) &&
-		(strcmp(URI, "-") != 0)) {
+        if ((xmlInputCallbackTable[i].opencallback == xmlGzfileOpen) &&
+                (strcmp(URI, "-") != 0)) {
 #if defined(ZLIB_VERNUM) && ZLIB_VERNUM >= 0x1230
             ret->compressed = !gzdirect(context);
 #else
-	    if (((z_stream *)context)->avail_in > 4) {
-	        char *cptr, buff4[4];
-		cptr = (char *) ((z_stream *)context)->next_in;
-		if (gzread(context, buff4, 4) == 4) {
-		    if (strncmp(buff4, cptr, 4) == 0)
-		        ret->compressed = 0;
-		    else
-		        ret->compressed = 1;
-		    gzrewind(context);
-		}
-	    }
+            if (((z_stream *)context)->avail_in > 4) {
+                char *cptr, buff4[4];
+                cptr = (char *) ((z_stream *)context)->next_in;
+                if (gzread(context, buff4, 4) == 4) {
+                    if (strncmp(buff4, cptr, 4) == 0)
+                        ret->compressed = 0;
+                    else
+                        ret->compressed = 1;
+                    gzrewind(context);
+                }
+            }
 #endif
-	}
+        }
 #endif
 #ifdef LIBXML_LZMA_ENABLED
-	if ((xmlInputCallbackTable[i].opencallback == xmlXzfileOpen) &&
-		(strcmp(URI, "-") != 0)) {
+        if ((xmlInputCallbackTable[i].opencallback == xmlXzfileOpen) &&
+                (strcmp(URI, "-") != 0)) {
             ret->compressed = __libxml2_xzcompressed(context);
-	}
+        }
 #endif
     }
     else
@@ -2629,9 +2629,9 @@ __xmlParserInputBufferCreateFilename(const char *URI, xmlCharEncoding enc) {
 xmlParserInputBufferPtr
 xmlParserInputBufferCreateFilename(const char *URI, xmlCharEncoding enc) {
     if ((xmlParserInputBufferCreateFilenameValue)) {
-		return xmlParserInputBufferCreateFilenameValue(URI, enc);
-	}
-	return __xmlParserInputBufferCreateFilename(URI, enc);
+                return xmlParserInputBufferCreateFilenameValue(URI, enc);
+        }
+        return __xmlParserInputBufferCreateFilename(URI, enc);
 }
 
 #ifdef LIBXML_OUTPUT_ENABLED
@@ -2649,7 +2649,7 @@ __xmlOutputBufferCreateFilename(const char *URI,
 #endif
 
     if (xmlOutputCallbackInitialized == 0)
-	xmlRegisterDefaultOutputCallbacks();
+        xmlRegisterDefaultOutputCallbacks();
 
     if (URI == NULL) return(NULL);
 
@@ -2657,16 +2657,16 @@ __xmlOutputBufferCreateFilename(const char *URI,
     if (puri != NULL) {
 #ifdef LIBXML_ZLIB_ENABLED
         if ((puri->scheme != NULL) &&
-	    (!xmlStrEqual(BAD_CAST puri->scheme, BAD_CAST "file")))
-	    is_file_uri = 0;
+            (!xmlStrEqual(BAD_CAST puri->scheme, BAD_CAST "file")))
+            is_file_uri = 0;
 #endif
-	/*
-	 * try to limit the damages of the URI unescaping code.
-	 */
-	if ((puri->scheme == NULL) ||
-	    (xmlStrEqual(BAD_CAST puri->scheme, BAD_CAST "file")))
-	    unescaped = xmlURIUnescapeString(URI, 0, NULL);
-	xmlFreeURI(puri);
+        /*
+         * try to limit the damages of the URI unescaping code.
+         */
+        if ((puri->scheme == NULL) ||
+            (xmlStrEqual(BAD_CAST puri->scheme, BAD_CAST "file")))
+            unescaped = xmlURIUnescapeString(URI, 0, NULL);
+        xmlFreeURI(puri);
     }
 
     /*
@@ -2676,35 +2676,35 @@ __xmlOutputBufferCreateFilename(const char *URI,
      */
     if (unescaped != NULL) {
 #ifdef LIBXML_ZLIB_ENABLED
-	if ((compression > 0) && (compression <= 9) && (is_file_uri == 1)) {
-	    context = xmlGzfileOpenW(unescaped, compression);
-	    if (context != NULL) {
-		ret = xmlAllocOutputBufferInternal(encoder);
-		if (ret != NULL) {
-		    ret->context = context;
-		    ret->writecallback = xmlGzfileWrite;
-		    ret->closecallback = xmlGzfileClose;
-		}
-		xmlFree(unescaped);
-		return(ret);
-	    }
-	}
+        if ((compression > 0) && (compression <= 9) && (is_file_uri == 1)) {
+            context = xmlGzfileOpenW(unescaped, compression);
+            if (context != NULL) {
+                ret = xmlAllocOutputBufferInternal(encoder);
+                if (ret != NULL) {
+                    ret->context = context;
+                    ret->writecallback = xmlGzfileWrite;
+                    ret->closecallback = xmlGzfileClose;
+                }
+                xmlFree(unescaped);
+                return(ret);
+            }
+        }
 #endif
-	for (i = xmlOutputCallbackNr - 1;i >= 0;i--) {
-	    if ((xmlOutputCallbackTable[i].matchcallback != NULL) &&
-		(xmlOutputCallbackTable[i].matchcallback(unescaped) != 0)) {
+        for (i = xmlOutputCallbackNr - 1;i >= 0;i--) {
+            if ((xmlOutputCallbackTable[i].matchcallback != NULL) &&
+                (xmlOutputCallbackTable[i].matchcallback(unescaped) != 0)) {
 #if defined(LIBXML_HTTP_ENABLED) && defined(LIBXML_ZLIB_ENABLED)
-		/*  Need to pass compression parameter into HTTP open calls  */
-		if (xmlOutputCallbackTable[i].matchcallback == xmlIOHTTPMatch)
-		    context = xmlIOHTTPOpenW(unescaped, compression);
-		else
+                /*  Need to pass compression parameter into HTTP open calls  */
+                if (xmlOutputCallbackTable[i].matchcallback == xmlIOHTTPMatch)
+                    context = xmlIOHTTPOpenW(unescaped, compression);
+                else
 #endif
-		    context = xmlOutputCallbackTable[i].opencallback(unescaped);
-		if (context != NULL)
-		    break;
-	    }
-	}
-	xmlFree(unescaped);
+                    context = xmlOutputCallbackTable[i].opencallback(unescaped);
+                if (context != NULL)
+                    break;
+            }
+        }
+        xmlFree(unescaped);
     }
 
     /*
@@ -2713,39 +2713,39 @@ __xmlOutputBufferCreateFilename(const char *URI,
      */
     if (context == NULL) {
 #ifdef LIBXML_ZLIB_ENABLED
-	if ((compression > 0) && (compression <= 9) && (is_file_uri == 1)) {
-	    context = xmlGzfileOpenW(URI, compression);
-	    if (context != NULL) {
-		ret = xmlAllocOutputBufferInternal(encoder);
-		if (ret != NULL) {
-		    ret->context = context;
-		    ret->writecallback = xmlGzfileWrite;
-		    ret->closecallback = xmlGzfileClose;
-		}
-		else
-		    xmlGzfileClose(context);
-		return(ret);
-	    }
-	}
+        if ((compression > 0) && (compression <= 9) && (is_file_uri == 1)) {
+            context = xmlGzfileOpenW(URI, compression);
+            if (context != NULL) {
+                ret = xmlAllocOutputBufferInternal(encoder);
+                if (ret != NULL) {
+                    ret->context = context;
+                    ret->writecallback = xmlGzfileWrite;
+                    ret->closecallback = xmlGzfileClose;
+                }
+                else
+                    xmlGzfileClose(context);
+                return(ret);
+            }
+        }
 #endif
-	for (i = xmlOutputCallbackNr - 1;i >= 0;i--) {
-	    if ((xmlOutputCallbackTable[i].matchcallback != NULL) &&
-		(xmlOutputCallbackTable[i].matchcallback(URI) != 0)) {
+        for (i = xmlOutputCallbackNr - 1;i >= 0;i--) {
+            if ((xmlOutputCallbackTable[i].matchcallback != NULL) &&
+                (xmlOutputCallbackTable[i].matchcallback(URI) != 0)) {
 #if defined(LIBXML_HTTP_ENABLED) && defined(LIBXML_ZLIB_ENABLED)
-		/*  Need to pass compression parameter into HTTP open calls  */
-		if (xmlOutputCallbackTable[i].matchcallback == xmlIOHTTPMatch)
-		    context = xmlIOHTTPOpenW(URI, compression);
-		else
+                /*  Need to pass compression parameter into HTTP open calls  */
+                if (xmlOutputCallbackTable[i].matchcallback == xmlIOHTTPMatch)
+                    context = xmlIOHTTPOpenW(URI, compression);
+                else
 #endif
-		    context = xmlOutputCallbackTable[i].opencallback(URI);
-		if (context != NULL)
-		    break;
-	    }
-	}
+                    context = xmlOutputCallbackTable[i].opencallback(URI);
+                if (context != NULL)
+                    break;
+            }
+        }
     }
 
     if (context == NULL) {
-	return(NULL);
+        return(NULL);
     }
 
     /*
@@ -2753,9 +2753,9 @@ __xmlOutputBufferCreateFilename(const char *URI,
      */
     ret = xmlAllocOutputBufferInternal(encoder);
     if (ret != NULL) {
-	ret->context = context;
-	ret->writecallback = xmlOutputCallbackTable[i].writecallback;
-	ret->closecallback = xmlOutputCallbackTable[i].closecallback;
+        ret->context = context;
+        ret->writecallback = xmlOutputCallbackTable[i].writecallback;
+        ret->closecallback = xmlOutputCallbackTable[i].closecallback;
     }
     return(ret);
 }
@@ -2780,9 +2780,9 @@ xmlOutputBufferCreateFilename(const char *URI,
                               xmlCharEncodingHandlerPtr encoder,
                               int compression ATTRIBUTE_UNUSED) {
     if ((xmlOutputBufferCreateFilenameValue)) {
-		return xmlOutputBufferCreateFilenameValue(URI, encoder, compression);
-	}
-	return __xmlOutputBufferCreateFilename(URI, encoder, compression);
+                return xmlOutputBufferCreateFilenameValue(URI, encoder, compression);
+        }
+        return __xmlOutputBufferCreateFilename(URI, encoder, compression);
 }
 #endif /* LIBXML_OUTPUT_ENABLED */
 
@@ -2801,15 +2801,15 @@ xmlParserInputBufferCreateFile(FILE *file, xmlCharEncoding enc) {
     xmlParserInputBufferPtr ret;
 
     if (xmlInputCallbackInitialized == 0)
-	xmlRegisterDefaultInputCallbacks();
+        xmlRegisterDefaultInputCallbacks();
 
     if (file == NULL) return(NULL);
 
     ret = xmlAllocParserInputBuffer(enc);
     if (ret != NULL) {
         ret->context = file;
-	ret->readcallback = xmlFileRead;
-	ret->closecallback = xmlFileFlush;
+        ret->readcallback = xmlFileRead;
+        ret->closecallback = xmlFileFlush;
     }
 
     return(ret);
@@ -2831,15 +2831,15 @@ xmlOutputBufferCreateFile(FILE *file, xmlCharEncodingHandlerPtr encoder) {
     xmlOutputBufferPtr ret;
 
     if (xmlOutputCallbackInitialized == 0)
-	xmlRegisterDefaultOutputCallbacks();
+        xmlRegisterDefaultOutputCallbacks();
 
     if (file == NULL) return(NULL);
 
     ret = xmlAllocOutputBufferInternal(encoder);
     if (ret != NULL) {
         ret->context = file;
-	ret->writecallback = xmlFileWrite;
-	ret->closecallback = xmlFileFlush;
+        ret->writecallback = xmlFileWrite;
+        ret->closecallback = xmlFileFlush;
     }
 
     return(ret);
@@ -2921,8 +2921,8 @@ xmlParserInputBufferCreateFd(int fd, xmlCharEncoding enc) {
     ret = xmlAllocParserInputBuffer(enc);
     if (ret != NULL) {
         ret->context = (void *) (ptrdiff_t) fd;
-	ret->readcallback = xmlFdRead;
-	ret->closecallback = xmlFdClose;
+        ret->readcallback = xmlFdRead;
+        ret->closecallback = xmlFdClose;
     }
 
     return(ret);
@@ -2950,13 +2950,13 @@ xmlParserInputBufferCreateMem(const char *mem, int size, xmlCharEncoding enc) {
     ret = xmlAllocParserInputBuffer(enc);
     if (ret != NULL) {
         ret->context = (void *) mem;
-	ret->readcallback = xmlInputReadCallbackNop;
-	ret->closecallback = NULL;
-	errcode = xmlBufAdd(ret->buffer, (const xmlChar *) mem, size);
-	if (errcode != 0) {
-	    xmlFree(ret);
-	    return(NULL);
-	}
+        ret->readcallback = xmlInputReadCallbackNop;
+        ret->closecallback = NULL;
+        errcode = xmlBufAdd(ret->buffer, (const xmlChar *) mem, size);
+        if (errcode != 0) {
+            xmlFree(ret);
+            return(NULL);
+        }
     }
 
     return(ret);
@@ -2985,14 +2985,14 @@ xmlParserInputBufferCreateStatic(const char *mem, int size,
 
     ret = (xmlParserInputBufferPtr) xmlMalloc(sizeof(xmlParserInputBuffer));
     if (ret == NULL) {
-	xmlIOErrMemory("creating input buffer");
-	return(NULL);
+        xmlIOErrMemory("creating input buffer");
+        return(NULL);
     }
     memset(ret, 0, (size_t) sizeof(xmlParserInputBuffer));
     ret->buffer = xmlBufCreateStatic((void *)mem, (size_t) size);
     if (ret->buffer == NULL) {
         xmlFree(ret);
-	return(NULL);
+        return(NULL);
     }
     ret->encoder = xmlGetCharEncodingHandler(enc);
     if (ret->encoder != NULL)
@@ -3027,8 +3027,8 @@ xmlOutputBufferCreateFd(int fd, xmlCharEncodingHandlerPtr encoder) {
     ret = xmlAllocOutputBufferInternal(encoder);
     if (ret != NULL) {
         ret->context = (void *) (ptrdiff_t) fd;
-	ret->writecallback = xmlFdWrite;
-	ret->closecallback = NULL;
+        ret->writecallback = xmlFdWrite;
+        ret->closecallback = NULL;
     }
 
     return(ret);
@@ -3049,7 +3049,7 @@ xmlOutputBufferCreateFd(int fd, xmlCharEncodingHandlerPtr encoder) {
  */
 xmlParserInputBufferPtr
 xmlParserInputBufferCreateIO(xmlInputReadCallback   ioread,
-	 xmlInputCloseCallback  ioclose, void *ioctx, xmlCharEncoding enc) {
+         xmlInputCloseCallback  ioclose, void *ioctx, xmlCharEncoding enc) {
     xmlParserInputBufferPtr ret;
 
     if (ioread == NULL) return(NULL);
@@ -3057,8 +3057,8 @@ xmlParserInputBufferCreateIO(xmlInputReadCallback   ioread,
     ret = xmlAllocParserInputBuffer(enc);
     if (ret != NULL) {
         ret->context = (void *) ioctx;
-	ret->readcallback = ioread;
-	ret->closecallback = ioclose;
+        ret->readcallback = ioread;
+        ret->closecallback = ioclose;
     }
 
     return(ret);
@@ -3079,8 +3079,8 @@ xmlParserInputBufferCreateIO(xmlInputReadCallback   ioread,
  */
 xmlOutputBufferPtr
 xmlOutputBufferCreateIO(xmlOutputWriteCallback   iowrite,
-	 xmlOutputCloseCallback  ioclose, void *ioctx,
-	 xmlCharEncodingHandlerPtr encoder) {
+         xmlOutputCloseCallback  ioclose, void *ioctx,
+         xmlCharEncodingHandlerPtr encoder) {
     xmlOutputBufferPtr ret;
 
     if (iowrite == NULL) return(NULL);
@@ -3088,8 +3088,8 @@ xmlOutputBufferCreateIO(xmlOutputWriteCallback   iowrite,
     ret = xmlAllocOutputBufferInternal(encoder);
     if (ret != NULL) {
         ret->context = (void *) ioctx;
-	ret->writecallback = iowrite;
-	ret->closecallback = ioclose;
+        ret->writecallback = iowrite;
+        ret->closecallback = ioclose;
     }
 
     return(ret);
@@ -3109,8 +3109,8 @@ xmlParserInputBufferCreateFilenameDefault(xmlParserInputBufferCreateFilenameFunc
 {
     xmlParserInputBufferCreateFilenameFunc old = xmlParserInputBufferCreateFilenameValue;
     if (old == NULL) {
-		old = __xmlParserInputBufferCreateFilename;
-	}
+                old = __xmlParserInputBufferCreateFilename;
+        }
 
     xmlParserInputBufferCreateFilenameValue = func;
     return(old);
@@ -3130,8 +3130,8 @@ xmlOutputBufferCreateFilenameDefault(xmlOutputBufferCreateFilenameFunc func)
     xmlOutputBufferCreateFilenameFunc old = xmlOutputBufferCreateFilenameValue;
 #ifdef LIBXML_OUTPUT_ENABLED
     if (old == NULL) {
-		old = __xmlOutputBufferCreateFilename;
-	}
+                old = __xmlOutputBufferCreateFilename;
+        }
 #endif
     xmlOutputBufferCreateFilenameValue = func;
     return(old);
@@ -3152,7 +3152,7 @@ xmlOutputBufferCreateFilenameDefault(xmlOutputBufferCreateFilenameFunc func)
  */
 int
 xmlParserInputBufferPush(xmlParserInputBufferPtr in,
-	                 int len, const char *buf) {
+                         int len, const char *buf) {
     int nbchars = 0;
     int ret;
 
@@ -3162,35 +3162,35 @@ xmlParserInputBufferPush(xmlParserInputBufferPtr in,
         unsigned int use;
 
         /*
-	 * Store the data in the incoming raw buffer
-	 */
+         * Store the data in the incoming raw buffer
+         */
         if (in->raw == NULL) {
-	    in->raw = xmlBufCreate();
-	}
-	ret = xmlBufAdd(in->raw, (const xmlChar *) buf, len);
-	if (ret != 0)
-	    return(-1);
+            in->raw = xmlBufCreate();
+        }
+        ret = xmlBufAdd(in->raw, (const xmlChar *) buf, len);
+        if (ret != 0)
+            return(-1);
 
-	/*
-	 * convert as much as possible to the parser reading buffer.
-	 */
-	use = xmlBufUse(in->raw);
-	nbchars = xmlCharEncInput(in, 1);
-	if (nbchars < 0) {
-	    xmlIOErr(XML_IO_ENCODER, NULL);
-	    in->error = XML_IO_ENCODER;
-	    return(-1);
-	}
-	in->rawconsumed += (use - xmlBufUse(in->raw));
+        /*
+         * convert as much as possible to the parser reading buffer.
+         */
+        use = xmlBufUse(in->raw);
+        nbchars = xmlCharEncInput(in, 1);
+        if (nbchars < 0) {
+            xmlIOErr(XML_IO_ENCODER, NULL);
+            in->error = XML_IO_ENCODER;
+            return(-1);
+        }
+        in->rawconsumed += (use - xmlBufUse(in->raw));
     } else {
-	nbchars = len;
+        nbchars = len;
         ret = xmlBufAdd(in->buffer, (xmlChar *) buf, nbchars);
-	if (ret != 0)
-	    return(-1);
+        if (ret != 0)
+            return(-1);
     }
 #ifdef DEBUG_INPUT
     xmlGenericError(xmlGenericErrorContext,
-	    "I/O: pushed %d chars, buffer %d/%d\n",
+            "I/O: pushed %d chars, buffer %d/%d\n",
             nbchars, xmlBufUse(in->buffer), xmlBufLength(in->buffer));
 #endif
     return(nbchars);
@@ -3204,8 +3204,8 @@ xmlParserInputBufferPush(xmlParserInputBufferPtr in,
  */
 static int
 endOfInput (void * context ATTRIBUTE_UNUSED,
-	    char * buffer ATTRIBUTE_UNUSED,
-	    int len ATTRIBUTE_UNUSED) {
+            char * buffer ATTRIBUTE_UNUSED,
+            int len ATTRIBUTE_UNUSED) {
     return(0);
 }
 
@@ -3245,16 +3245,16 @@ xmlParserInputBufferGrow(xmlParserInputBufferPtr in, int len) {
      * Call the read method for this I/O type.
      */
     if (in->readcallback != NULL) {
-	res = in->readcallback(in->context, &buffer[0], len);
-	if (res <= 0)
-	    in->readcallback = endOfInput;
+        res = in->readcallback(in->context, &buffer[0], len);
+        if (res <= 0)
+            in->readcallback = endOfInput;
     } else {
-	xmlIOErr(XML_IO_NO_INPUT, NULL);
-	in->error = XML_IO_NO_INPUT;
-	return(-1);
+        xmlIOErr(XML_IO_NO_INPUT, NULL);
+        in->error = XML_IO_NO_INPUT;
+        return(-1);
     }
     if (res < 0) {
-	return(-1);
+        return(-1);
     }
 
     /*
@@ -3262,7 +3262,7 @@ xmlParserInputBufferGrow(xmlParserInputBufferPtr in, int len) {
      */
     if (in->compressed == -1) {
 #ifdef LIBXML_LZMA_ENABLED
-	if (in->readcallback == xmlXzfileRead)
+        if (in->readcallback == xmlXzfileRead)
             in->compressed = __libxml2_xzcompressed(in->context);
 #endif
     }
@@ -3272,33 +3272,33 @@ xmlParserInputBufferGrow(xmlParserInputBufferPtr in, int len) {
         unsigned int use;
 
         /*
-	 * Store the data in the incoming raw buffer
-	 */
+         * Store the data in the incoming raw buffer
+         */
         if (in->raw == NULL) {
-	    in->raw = xmlBufCreate();
-	}
-	res = xmlBufAdd(in->raw, (const xmlChar *) buffer, len);
-	if (res != 0)
-	    return(-1);
+            in->raw = xmlBufCreate();
+        }
+        res = xmlBufAdd(in->raw, (const xmlChar *) buffer, len);
+        if (res != 0)
+            return(-1);
 
-	/*
-	 * convert as much as possible to the parser reading buffer.
-	 */
-	use = xmlBufUse(in->raw);
-	nbchars = xmlCharEncInput(in, 1);
-	if (nbchars < 0) {
-	    xmlIOErr(XML_IO_ENCODER, NULL);
-	    in->error = XML_IO_ENCODER;
-	    return(-1);
-	}
-	in->rawconsumed += (use - xmlBufUse(in->raw));
+        /*
+         * convert as much as possible to the parser reading buffer.
+         */
+        use = xmlBufUse(in->raw);
+        nbchars = xmlCharEncInput(in, 1);
+        if (nbchars < 0) {
+            xmlIOErr(XML_IO_ENCODER, NULL);
+            in->error = XML_IO_ENCODER;
+            return(-1);
+        }
+        in->rawconsumed += (use - xmlBufUse(in->raw));
     } else {
-	nbchars = len;
+        nbchars = len;
         xmlBufAddLen(in->buffer, nbchars);
     }
 #ifdef DEBUG_INPUT
     xmlGenericError(xmlGenericErrorContext,
-	    "I/O: read %d chars, buffer %d\n",
+            "I/O: read %d chars, buffer %d\n",
             nbchars, xmlBufUse(in->buffer));
 #endif
     return(nbchars);
@@ -3320,9 +3320,9 @@ int
 xmlParserInputBufferRead(xmlParserInputBufferPtr in, int len) {
     if ((in == NULL) || (in->error)) return(-1);
     if (in->readcallback != NULL)
-	return(xmlParserInputBufferGrow(in, len));
+        return(xmlParserInputBufferGrow(in, len));
     else if (xmlBufGetAllocationScheme(in->buffer) == XML_BUFFER_ALLOC_IMMUTABLE)
-	return(0);
+        return(0);
     else
         return(-1);
 }
@@ -3354,87 +3354,87 @@ xmlOutputBufferWrite(xmlOutputBufferPtr out, int len, const char *buf) {
     if (out->error) return(-1);
 
     do {
-	chunk = len;
-	if (chunk > 4 * MINLEN)
-	    chunk = 4 * MINLEN;
+        chunk = len;
+        if (chunk > 4 * MINLEN)
+            chunk = 4 * MINLEN;
 
-	/*
-	 * first handle encoding stuff.
-	 */
-	if (out->encoder != NULL) {
-	    /*
-	     * Store the data in the incoming raw buffer
-	     */
-	    if (out->conv == NULL) {
-		out->conv = xmlBufCreate();
-	    }
-	    ret = xmlBufAdd(out->buffer, (const xmlChar *) buf, chunk);
-	    if (ret != 0)
-	        return(-1);
+        /*
+         * first handle encoding stuff.
+         */
+        if (out->encoder != NULL) {
+            /*
+             * Store the data in the incoming raw buffer
+             */
+            if (out->conv == NULL) {
+                out->conv = xmlBufCreate();
+            }
+            ret = xmlBufAdd(out->buffer, (const xmlChar *) buf, chunk);
+            if (ret != 0)
+                return(-1);
 
-	    if ((xmlBufUse(out->buffer) < MINLEN) && (chunk == len))
-		goto done;
+            if ((xmlBufUse(out->buffer) < MINLEN) && (chunk == len))
+                goto done;
 
-	    /*
-	     * convert as much as possible to the parser reading buffer.
-	     */
-	    ret = xmlCharEncOutput(out, 0);
-	    if ((ret < 0) && (ret != -3)) {
-		xmlIOErr(XML_IO_ENCODER, NULL);
-		out->error = XML_IO_ENCODER;
-		return(-1);
-	    }
+            /*
+             * convert as much as possible to the parser reading buffer.
+             */
+            ret = xmlCharEncOutput(out, 0);
+            if ((ret < 0) && (ret != -3)) {
+                xmlIOErr(XML_IO_ENCODER, NULL);
+                out->error = XML_IO_ENCODER;
+                return(-1);
+            }
             if (out->writecallback)
-	        nbchars = xmlBufUse(out->conv);
+                nbchars = xmlBufUse(out->conv);
             else
                 nbchars = ret >= 0 ? ret : 0;
-	} else {
-	    ret = xmlBufAdd(out->buffer, (const xmlChar *) buf, chunk);
-	    if (ret != 0)
-	        return(-1);
+        } else {
+            ret = xmlBufAdd(out->buffer, (const xmlChar *) buf, chunk);
+            if (ret != 0)
+                return(-1);
             if (out->writecallback)
-	        nbchars = xmlBufUse(out->buffer);
+                nbchars = xmlBufUse(out->buffer);
             else
                 nbchars = chunk;
-	}
-	buf += chunk;
-	len -= chunk;
+        }
+        buf += chunk;
+        len -= chunk;
 
-	if (out->writecallback) {
+        if (out->writecallback) {
             if ((nbchars < MINLEN) && (len <= 0))
                 goto done;
 
-	    /*
-	     * second write the stuff to the I/O channel
-	     */
-	    if (out->encoder != NULL) {
-		ret = out->writecallback(out->context,
+            /*
+             * second write the stuff to the I/O channel
+             */
+            if (out->encoder != NULL) {
+                ret = out->writecallback(out->context,
                            (const char *)xmlBufContent(out->conv), nbchars);
-		if (ret >= 0)
-		    xmlBufShrink(out->conv, ret);
-	    } else {
-		ret = out->writecallback(out->context,
+                if (ret >= 0)
+                    xmlBufShrink(out->conv, ret);
+            } else {
+                ret = out->writecallback(out->context,
                            (const char *)xmlBufContent(out->buffer), nbchars);
-		if (ret >= 0)
-		    xmlBufShrink(out->buffer, ret);
-	    }
-	    if (ret < 0) {
-		xmlIOErr(XML_IO_WRITE, NULL);
-		out->error = XML_IO_WRITE;
-		return(ret);
-	    }
+                if (ret >= 0)
+                    xmlBufShrink(out->buffer, ret);
+            }
+            if (ret < 0) {
+                xmlIOErr(XML_IO_WRITE, NULL);
+                out->error = XML_IO_WRITE;
+                return(ret);
+            }
             if (out->written > INT_MAX - ret)
                 out->written = INT_MAX;
             else
                 out->written += ret;
-	}
-	written += nbchars;
+        }
+        written += nbchars;
     } while (len > 0);
 
 done:
 #ifdef DEBUG_INPUT
     xmlGenericError(xmlGenericErrorContext,
-	    "I/O: wrote %d chars\n", written);
+            "I/O: wrote %d chars\n", written);
 #endif
     return(written);
 }
@@ -3463,36 +3463,36 @@ xmlEscapeContent(unsigned char* out, int *outlen,
     inend = in + (*inlen);
 
     while ((in < inend) && (out < outend)) {
-	if (*in == '<') {
-	    if (outend - out < 4) break;
-	    *out++ = '&';
-	    *out++ = 'l';
-	    *out++ = 't';
-	    *out++ = ';';
-	} else if (*in == '>') {
-	    if (outend - out < 4) break;
-	    *out++ = '&';
-	    *out++ = 'g';
-	    *out++ = 't';
-	    *out++ = ';';
-	} else if (*in == '&') {
-	    if (outend - out < 5) break;
-	    *out++ = '&';
-	    *out++ = 'a';
-	    *out++ = 'm';
-	    *out++ = 'p';
-	    *out++ = ';';
-	} else if (*in == '\r') {
-	    if (outend - out < 5) break;
-	    *out++ = '&';
-	    *out++ = '#';
-	    *out++ = '1';
-	    *out++ = '3';
-	    *out++ = ';';
-	} else {
-	    *out++ = (unsigned char) *in;
-	}
-	++in;
+        if (*in == '<') {
+            if (outend - out < 4) break;
+            *out++ = '&';
+            *out++ = 'l';
+            *out++ = 't';
+            *out++ = ';';
+        } else if (*in == '>') {
+            if (outend - out < 4) break;
+            *out++ = '&';
+            *out++ = 'g';
+            *out++ = 't';
+            *out++ = ';';
+        } else if (*in == '&') {
+            if (outend - out < 5) break;
+            *out++ = '&';
+            *out++ = 'a';
+            *out++ = 'm';
+            *out++ = 'p';
+            *out++ = ';';
+        } else if (*in == '\r') {
+            if (outend - out < 5) break;
+            *out++ = '&';
+            *out++ = '#';
+            *out++ = '1';
+            *out++ = '3';
+            *out++ = ';';
+        } else {
+            *out++ = (unsigned char) *in;
+        }
+        ++in;
     }
     *outlen = out - outstart;
     *inlen = in - base;
@@ -3527,7 +3527,7 @@ xmlOutputBufferWriteEscape(xmlOutputBufferPtr out, const xmlChar *str,
 
     if ((out == NULL) || (out->error) || (str == NULL) ||
         (out->buffer == NULL) ||
-	(xmlBufGetAllocationScheme(out->buffer) == XML_BUFFER_ALLOC_IMMUTABLE))
+        (xmlBufGetAllocationScheme(out->buffer) == XML_BUFFER_ALLOC_IMMUTABLE))
         return(-1);
     len = strlen((const char *)str);
     if (len < 0) return(0);
@@ -3538,104 +3538,104 @@ xmlOutputBufferWriteEscape(xmlOutputBufferPtr out, const xmlChar *str,
         oldwritten = written;
 
         /*
-	 * how many bytes to consume and how many bytes to store.
-	 */
-	cons = len;
-	chunk = xmlBufAvail(out->buffer);
+         * how many bytes to consume and how many bytes to store.
+         */
+        cons = len;
+        chunk = xmlBufAvail(out->buffer);
 
         /*
-	 * make sure we have enough room to save first, if this is
-	 * not the case force a flush, but make sure we stay in the loop
-	 */
-	if (chunk < 40) {
-	    if (xmlBufGrow(out->buffer, 100) < 0)
-	        return(-1);
+         * make sure we have enough room to save first, if this is
+         * not the case force a flush, but make sure we stay in the loop
+         */
+        if (chunk < 40) {
+            if (xmlBufGrow(out->buffer, 100) < 0)
+                return(-1);
             oldwritten = -1;
-	    continue;
-	}
+            continue;
+        }
 
-	/*
-	 * first handle encoding stuff.
-	 */
-	if (out->encoder != NULL) {
-	    /*
-	     * Store the data in the incoming raw buffer
-	     */
-	    if (out->conv == NULL) {
-		out->conv = xmlBufCreate();
-	    }
-	    ret = escaping(xmlBufEnd(out->buffer) ,
-	                   &chunk, str, &cons);
-	    if ((ret < 0) || (chunk == 0)) /* chunk==0 => nothing done */
-	        return(-1);
+        /*
+         * first handle encoding stuff.
+         */
+        if (out->encoder != NULL) {
+            /*
+             * Store the data in the incoming raw buffer
+             */
+            if (out->conv == NULL) {
+                out->conv = xmlBufCreate();
+            }
+            ret = escaping(xmlBufEnd(out->buffer) ,
+                           &chunk, str, &cons);
+            if ((ret < 0) || (chunk == 0)) /* chunk==0 => nothing done */
+                return(-1);
             xmlBufAddLen(out->buffer, chunk);
 
-	    if ((xmlBufUse(out->buffer) < MINLEN) && (cons == len))
-		goto done;
+            if ((xmlBufUse(out->buffer) < MINLEN) && (cons == len))
+                goto done;
 
-	    /*
-	     * convert as much as possible to the output buffer.
-	     */
-	    ret = xmlCharEncOutput(out, 0);
-	    if ((ret < 0) && (ret != -3)) {
-		xmlIOErr(XML_IO_ENCODER, NULL);
-		out->error = XML_IO_ENCODER;
-		return(-1);
-	    }
+            /*
+             * convert as much as possible to the output buffer.
+             */
+            ret = xmlCharEncOutput(out, 0);
+            if ((ret < 0) && (ret != -3)) {
+                xmlIOErr(XML_IO_ENCODER, NULL);
+                out->error = XML_IO_ENCODER;
+                return(-1);
+            }
             if (out->writecallback)
-	        nbchars = xmlBufUse(out->conv);
+                nbchars = xmlBufUse(out->conv);
             else
                 nbchars = ret >= 0 ? ret : 0;
-	} else {
-	    ret = escaping(xmlBufEnd(out->buffer), &chunk, str, &cons);
-	    if ((ret < 0) || (chunk == 0)) /* chunk==0 => nothing done */
-	        return(-1);
+        } else {
+            ret = escaping(xmlBufEnd(out->buffer), &chunk, str, &cons);
+            if ((ret < 0) || (chunk == 0)) /* chunk==0 => nothing done */
+                return(-1);
             xmlBufAddLen(out->buffer, chunk);
             if (out->writecallback)
-	        nbchars = xmlBufUse(out->buffer);
+                nbchars = xmlBufUse(out->buffer);
             else
                 nbchars = chunk;
-	}
-	str += cons;
-	len -= cons;
+        }
+        str += cons;
+        len -= cons;
 
-	if (out->writecallback) {
+        if (out->writecallback) {
             if ((nbchars < MINLEN) && (len <= 0))
                 goto done;
 
-	    /*
-	     * second write the stuff to the I/O channel
-	     */
-	    if (out->encoder != NULL) {
-		ret = out->writecallback(out->context,
+            /*
+             * second write the stuff to the I/O channel
+             */
+            if (out->encoder != NULL) {
+                ret = out->writecallback(out->context,
                            (const char *)xmlBufContent(out->conv), nbchars);
-		if (ret >= 0)
-		    xmlBufShrink(out->conv, ret);
-	    } else {
-		ret = out->writecallback(out->context,
+                if (ret >= 0)
+                    xmlBufShrink(out->conv, ret);
+            } else {
+                ret = out->writecallback(out->context,
                            (const char *)xmlBufContent(out->buffer), nbchars);
-		if (ret >= 0)
-		    xmlBufShrink(out->buffer, ret);
-	    }
-	    if (ret < 0) {
-		xmlIOErr(XML_IO_WRITE, NULL);
-		out->error = XML_IO_WRITE;
-		return(ret);
-	    }
+                if (ret >= 0)
+                    xmlBufShrink(out->buffer, ret);
+            }
+            if (ret < 0) {
+                xmlIOErr(XML_IO_WRITE, NULL);
+                out->error = XML_IO_WRITE;
+                return(ret);
+            }
             if (out->written > INT_MAX - ret)
                 out->written = INT_MAX;
             else
                 out->written += ret;
-	} else if (xmlBufAvail(out->buffer) < MINLEN) {
-	    xmlBufGrow(out->buffer, MINLEN);
-	}
-	written += nbchars;
+        } else if (xmlBufAvail(out->buffer) < MINLEN) {
+            xmlBufGrow(out->buffer, MINLEN);
+        }
+        written += nbchars;
     } while ((len > 0) && (oldwritten != written));
 
 done:
 #ifdef DEBUG_INPUT
     xmlGenericError(xmlGenericErrorContext,
-	    "I/O: wrote %d chars\n", written);
+            "I/O: wrote %d chars\n", written);
 #endif
     return(written);
 }
@@ -3663,7 +3663,7 @@ xmlOutputBufferWriteString(xmlOutputBufferPtr out, const char *str) {
     len = strlen(str);
 
     if (len > 0)
-	return(xmlOutputBufferWrite(out, len, str));
+        return(xmlOutputBufferWrite(out, len, str));
     return(len);
 }
 
@@ -3684,40 +3684,40 @@ xmlOutputBufferFlush(xmlOutputBufferPtr out) {
      * first handle encoding stuff.
      */
     if ((out->conv != NULL) && (out->encoder != NULL)) {
-	/*
-	 * convert as much as possible to the parser output buffer.
-	 */
-	do {
-	    nbchars = xmlCharEncOutput(out, 0);
-	    if (nbchars < 0) {
-		xmlIOErr(XML_IO_ENCODER, NULL);
-		out->error = XML_IO_ENCODER;
-		return(-1);
-	    }
-	} while (nbchars);
+        /*
+         * convert as much as possible to the parser output buffer.
+         */
+        do {
+            nbchars = xmlCharEncOutput(out, 0);
+            if (nbchars < 0) {
+                xmlIOErr(XML_IO_ENCODER, NULL);
+                out->error = XML_IO_ENCODER;
+                return(-1);
+            }
+        } while (nbchars);
     }
 
     /*
      * second flush the stuff to the I/O channel
      */
     if ((out->conv != NULL) && (out->encoder != NULL) &&
-	(out->writecallback != NULL)) {
-	ret = out->writecallback(out->context,
+        (out->writecallback != NULL)) {
+        ret = out->writecallback(out->context,
                                  (const char *)xmlBufContent(out->conv),
                                  xmlBufUse(out->conv));
-	if (ret >= 0)
-	    xmlBufShrink(out->conv, ret);
+        if (ret >= 0)
+            xmlBufShrink(out->conv, ret);
     } else if (out->writecallback != NULL) {
-	ret = out->writecallback(out->context,
+        ret = out->writecallback(out->context,
                                  (const char *)xmlBufContent(out->buffer),
                                  xmlBufUse(out->buffer));
-	if (ret >= 0)
-	    xmlBufShrink(out->buffer, ret);
+        if (ret >= 0)
+            xmlBufShrink(out->buffer, ret);
     }
     if (ret < 0) {
-	xmlIOErr(XML_IO_FLUSH, NULL);
-	out->error = XML_IO_FLUSH;
-	return(ret);
+        xmlIOErr(XML_IO_FLUSH, NULL);
+        out->error = XML_IO_FLUSH;
+        return(ret);
     }
     if (out->written > INT_MAX - ret)
         out->written = INT_MAX;
@@ -3726,7 +3726,7 @@ xmlOutputBufferFlush(xmlOutputBufferPtr out) {
 
 #ifdef DEBUG_INPUT
     xmlGenericError(xmlGenericErrorContext,
-	    "I/O: flushed %d chars\n", ret);
+            "I/O: flushed %d chars\n", ret);
 #endif
     return(ret);
 }
@@ -3747,7 +3747,7 @@ xmlParserGetDirectory(const char *filename) {
     char *cur;
 
     if (xmlInputCallbackInitialized == 0)
-	xmlRegisterDefaultInputCallbacks();
+        xmlRegisterDefaultInputCallbacks();
 
     if (filename == NULL) return(NULL);
 
@@ -3762,26 +3762,26 @@ xmlParserGetDirectory(const char *filename) {
     cur = &dir[strlen(dir)];
     while (cur > dir) {
          if (IS_XMLPGD_SEP(*cur)) break;
-	 cur --;
+         cur --;
     }
     if (IS_XMLPGD_SEP(*cur)) {
         if (cur == dir) dir[1] = 0;
-	else *cur = 0;
-	ret = xmlMemStrdup(dir);
+        else *cur = 0;
+        ret = xmlMemStrdup(dir);
     } else {
         if (getcwd(dir, 1024) != NULL) {
-	    dir[1023] = 0;
-	    ret = xmlMemStrdup(dir);
-	}
+            dir[1023] = 0;
+            ret = xmlMemStrdup(dir);
+        }
     }
     return(ret);
 #undef IS_XMLPGD_SEP
 }
 
 /****************************************************************
- *								*
- *		External entities loading			*
- *								*
+ *                                                              *
+ *              External entities loading                       *
+ *                                                              *
  ****************************************************************/
 
 /**
@@ -3813,11 +3813,11 @@ xmlCheckHTTPInput(xmlParserCtxtPtr ctxt, xmlParserInputPtr ret) {
         code = xmlNanoHTTPReturnCode(ret->buf->context);
         if (code >= 400) {
             /* fatal error */
-	    if (ret->filename != NULL)
-		__xmlLoaderErr(ctxt, "failed to load HTTP resource \"%s\"\n",
+            if (ret->filename != NULL)
+                __xmlLoaderErr(ctxt, "failed to load HTTP resource \"%s\"\n",
                          (const char *) ret->filename);
-	    else
-		__xmlLoaderErr(ctxt, "failed to load HTTP resource\n", NULL);
+            else
+                __xmlLoaderErr(ctxt, "failed to load HTTP resource\n", NULL);
             xmlFreeInputStream(ret);
             ret = NULL;
         } else {
@@ -3865,22 +3865,22 @@ static int xmlNoNetExists(const char *URL) {
     const char *path;
 
     if (URL == NULL)
-	return(0);
+        return(0);
 
     if (!xmlStrncasecmp(BAD_CAST URL, BAD_CAST "file://localhost/", 17))
 #if defined (_WIN32)
-	path = &URL[17];
+        path = &URL[17];
 #else
-	path = &URL[16];
+        path = &URL[16];
 #endif
     else if (!xmlStrncasecmp(BAD_CAST URL, BAD_CAST "file:///", 8)) {
 #if defined (_WIN32)
-	path = &URL[8];
+        path = &URL[8];
 #else
-	path = &URL[7];
+        path = &URL[7];
 #endif
     } else
-	path = URL;
+        path = URL;
 
     return xmlCheckFilename(path);
 }
@@ -3912,50 +3912,50 @@ xmlResolveResourceFromCatalog(const char *URL, const char *ID,
     pref = xmlCatalogGetDefaults();
 
     if ((pref != XML_CATA_ALLOW_NONE) && (!xmlNoNetExists(URL))) {
-	/*
-	 * Do a local lookup
-	 */
-	if ((ctxt != NULL) && (ctxt->catalogs != NULL) &&
-	    ((pref == XML_CATA_ALLOW_ALL) ||
-	     (pref == XML_CATA_ALLOW_DOCUMENT))) {
-	    resource = xmlCatalogLocalResolve(ctxt->catalogs,
-					      (const xmlChar *)ID,
-					      (const xmlChar *)URL);
+        /*
+         * Do a local lookup
+         */
+        if ((ctxt != NULL) && (ctxt->catalogs != NULL) &&
+            ((pref == XML_CATA_ALLOW_ALL) ||
+             (pref == XML_CATA_ALLOW_DOCUMENT))) {
+            resource = xmlCatalogLocalResolve(ctxt->catalogs,
+                                              (const xmlChar *)ID,
+                                              (const xmlChar *)URL);
         }
-	/*
-	 * Try a global lookup
-	 */
-	if ((resource == NULL) &&
-	    ((pref == XML_CATA_ALLOW_ALL) ||
-	     (pref == XML_CATA_ALLOW_GLOBAL))) {
-	    resource = xmlCatalogResolve((const xmlChar *)ID,
-					 (const xmlChar *)URL);
-	}
-	if ((resource == NULL) && (URL != NULL))
-	    resource = xmlStrdup((const xmlChar *) URL);
+        /*
+         * Try a global lookup
+         */
+        if ((resource == NULL) &&
+            ((pref == XML_CATA_ALLOW_ALL) ||
+             (pref == XML_CATA_ALLOW_GLOBAL))) {
+            resource = xmlCatalogResolve((const xmlChar *)ID,
+                                         (const xmlChar *)URL);
+        }
+        if ((resource == NULL) && (URL != NULL))
+            resource = xmlStrdup((const xmlChar *) URL);
 
-	/*
-	 * TODO: do an URI lookup on the reference
-	 */
-	if ((resource != NULL) && (!xmlNoNetExists((const char *)resource))) {
-	    xmlChar *tmp = NULL;
+        /*
+         * TODO: do an URI lookup on the reference
+         */
+        if ((resource != NULL) && (!xmlNoNetExists((const char *)resource))) {
+            xmlChar *tmp = NULL;
 
-	    if ((ctxt != NULL) && (ctxt->catalogs != NULL) &&
-		((pref == XML_CATA_ALLOW_ALL) ||
-		 (pref == XML_CATA_ALLOW_DOCUMENT))) {
-		tmp = xmlCatalogLocalResolveURI(ctxt->catalogs, resource);
-	    }
-	    if ((tmp == NULL) &&
-		((pref == XML_CATA_ALLOW_ALL) ||
-	         (pref == XML_CATA_ALLOW_GLOBAL))) {
-		tmp = xmlCatalogResolveURI(resource);
-	    }
+            if ((ctxt != NULL) && (ctxt->catalogs != NULL) &&
+                ((pref == XML_CATA_ALLOW_ALL) ||
+                 (pref == XML_CATA_ALLOW_DOCUMENT))) {
+                tmp = xmlCatalogLocalResolveURI(ctxt->catalogs, resource);
+            }
+            if ((tmp == NULL) &&
+                ((pref == XML_CATA_ALLOW_ALL) ||
+                 (pref == XML_CATA_ALLOW_GLOBAL))) {
+                tmp = xmlCatalogResolveURI(resource);
+            }
 
-	    if (tmp != NULL) {
-		xmlFree(resource);
-		resource = tmp;
-	    }
-	}
+            if (tmp != NULL) {
+                xmlFree(resource);
+                resource = tmp;
+            }
+        }
     }
 
     return resource;
@@ -3987,10 +3987,10 @@ xmlDefaultExternalEntityLoader(const char *URL, const char *ID,
     if ((ctxt != NULL) && (ctxt->options & XML_PARSE_NONET)) {
         int options = ctxt->options;
 
-	ctxt->options -= XML_PARSE_NONET;
+        ctxt->options -= XML_PARSE_NONET;
         ret = xmlNoNetExternalEntityLoader(URL, ID, ctxt);
-	ctxt->options = options;
-	return(ret);
+        ctxt->options = options;
+        return(ret);
     }
 #ifdef LIBXML_CATALOG_ENABLED
     resource = xmlResolveResourceFromCatalog(URL, ID, ctxt);
@@ -4052,26 +4052,26 @@ xmlParserInputPtr
 xmlLoadExternalEntity(const char *URL, const char *ID,
                       xmlParserCtxtPtr ctxt) {
     if ((URL != NULL) && (xmlNoNetExists(URL) == 0)) {
-	char *canonicFilename;
-	xmlParserInputPtr ret;
+        char *canonicFilename;
+        xmlParserInputPtr ret;
 
-	canonicFilename = (char *) xmlCanonicPath((const xmlChar *) URL);
-	if (canonicFilename == NULL) {
+        canonicFilename = (char *) xmlCanonicPath((const xmlChar *) URL);
+        if (canonicFilename == NULL) {
             xmlIOErrMemory("building canonical path\n");
-	    return(NULL);
-	}
+            return(NULL);
+        }
 
-	ret = xmlCurrentExternalEntityLoader(canonicFilename, ID, ctxt);
-	xmlFree(canonicFilename);
-	return(ret);
+        ret = xmlCurrentExternalEntityLoader(canonicFilename, ID, ctxt);
+        xmlFree(canonicFilename);
+        return(ret);
     }
     return(xmlCurrentExternalEntityLoader(URL, ID, ctxt));
 }
 
 /************************************************************************
- *									*
- *		Disabling Network access				*
- *									*
+ *                                                                      *
+ *              Disabling Network access                                *
+ *                                                                      *
  ************************************************************************/
 
 /**
@@ -4096,20 +4096,20 @@ xmlNoNetExternalEntityLoader(const char *URL, const char *ID,
 #endif
 
     if (resource == NULL)
-	resource = (xmlChar *) URL;
+        resource = (xmlChar *) URL;
 
     if (resource != NULL) {
         if ((!xmlStrncasecmp(BAD_CAST resource, BAD_CAST "ftp://", 6)) ||
             (!xmlStrncasecmp(BAD_CAST resource, BAD_CAST "http://", 7))) {
             xmlIOErr(XML_IO_NETWORK_ATTEMPT, (const char *) resource);
-	    if (resource != (xmlChar *) URL)
-		xmlFree(resource);
-	    return(NULL);
-	}
+            if (resource != (xmlChar *) URL)
+                xmlFree(resource);
+            return(NULL);
+        }
     }
     input = xmlDefaultExternalEntityLoader((const char *) resource, ID, ctxt);
     if (resource != (xmlChar *) URL)
-	xmlFree(resource);
+        xmlFree(resource);
     return(input);
 }
 

--- a/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/win32/include/libxml/xmlversion.h
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/libxml/win32/include/libxml/xmlversion.h
@@ -29,21 +29,21 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  *
  * the version string like "1.2.3"
  */
-#define LIBXML_DOTTED_VERSION "2.10.3"
+#define LIBXML_DOTTED_VERSION "2.10.4"
 
 /**
  * LIBXML_VERSION:
  *
  * the version number: 1.2.3 value is 10203
  */
-#define LIBXML_VERSION 21003
+#define LIBXML_VERSION 21004
 
 /**
  * LIBXML_VERSION_STRING:
  *
  * the version number string, 1.2.3 value is "10203"
  */
-#define LIBXML_VERSION_STRING "21003"
+#define LIBXML_VERSION_STRING "21004"
 
 /**
  * LIBXML_VERSION_EXTRA:
@@ -58,7 +58,7 @@ XMLPUBFUN void XMLCALL xmlCheckVersion(int version);
  * Macro to check that the libxml version in use is compatible with
  * the version the software has been compiled against
  */
-#define LIBXML_TEST_VERSION xmlCheckVersion(21003);
+#define LIBXML_TEST_VERSION xmlCheckVersion(21004);
 
 #ifndef VMS
 #if 0


### PR DESCRIPTION
Updated libxml to v2.10.4.Configured and verified on all Windows, Linux and Mac.
Sanity testing looks fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8306115](https://bugs.openjdk.org/browse/JDK-8306115): Update libxml2 to 2.10.4


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Joeri Sykora](https://openjdk.org/census#sykora) (@tiainen - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1108/head:pull/1108` \
`$ git checkout pull/1108`

Update a local copy of the PR: \
`$ git checkout pull/1108` \
`$ git pull https://git.openjdk.org/jfx.git pull/1108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1108`

View PR using the GUI difftool: \
`$ git pr show -t 1108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1108.diff">https://git.openjdk.org/jfx/pull/1108.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1108#issuecomment-1519352270)