### PR TITLE
8306648: Update the JavaDocs to show the NEW section and DEPRECATED versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4145,6 +4145,9 @@ task javadoc(type: Javadoc, dependsOn: createMSPfile) {
     options.tags("factory")
     options.tags("see")
 
+    options.addStringOption("-since").setValue("9,10,11,12,13,14,15,16,17,18,19,20")
+    options.addStringOption("-since-label").setValue("New API since JavaFX 9")
+
     options.windowTitle("${javadocTitle}")
     options.header("${javadocHeader}")
     options.bottom("${javadocBottom}")


### PR DESCRIPTION
Adds the javadoc commands to generate the NEW page and to be able to select versions in the DEPRECATED page.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8306648](https://bugs.openjdk.org/browse/JDK-8306648): Update the JavaDocs to show the NEW section and DEPRECATED versions (**Enhancement** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1109/head:pull/1109` \
`$ git checkout pull/1109`

Update a local copy of the PR: \
`$ git checkout pull/1109` \
`$ git pull https://git.openjdk.org/jfx.git pull/1109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1109`

View PR using the GUI difftool: \
`$ git pr show -t 1109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1109.diff">https://git.openjdk.org/jfx/pull/1109.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1109#issuecomment-1517847902)