### PR TITLE
8306708: Region.layoutInArea uses incorrect snap scale value

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/Region.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2606,12 +2606,11 @@ public class Region extends Parent {
             }
         }
 
-
         if (child.isResizable()) {
             Vec2d size = boundedNodeSizeWithBias(child, areaWidth - left - right, areaHeight - top - bottom,
                     fillWidth, fillHeight, TEMP_VEC2D);
             child.resize(snapSize(size.x, isSnapToPixel, snapScaleX),
-                         snapSize(size.y, isSnapToPixel, snapScaleX));
+                         snapSize(size.y, isSnapToPixel, snapScaleY));
         }
         position(child, areaX, areaY, areaWidth, areaHeight, areaBaselineOffset,
                 top, right, bottom, left, halignment, valignment, isSnapToPixel);


### PR DESCRIPTION
In the following line, snapScaleX is used twice:

```java
    child.resize(snapSize(size.x, isSnapToPixel, snapScaleX),
                 snapSize(size.y, isSnapToPixel, snapScaleX));
```

Looks like a copy-and-paste bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306708](https://bugs.openjdk.org/browse/JDK-8306708): Region.layoutInArea uses incorrect snap scale value


### Reviewers
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1112/head:pull/1112` \
`$ git checkout pull/1112`

Update a local copy of the PR: \
`$ git checkout pull/1112` \
`$ git pull https://git.openjdk.org/jfx.git pull/1112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1112`

View PR using the GUI difftool: \
`$ git pr show -t 1112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1112.diff">https://git.openjdk.org/jfx/pull/1112.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1112#issuecomment-1519149842)