### PR TITLE
8297316: [TestBug] LocalDateTimeStringConverterTest.testChronologyConsistency fails with JDK 20

### DIFF
--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
@@ -104,15 +104,6 @@ public class LocalDateTimeStringConverterTest {
         this.locale = null;
         this.formatter = null;
         this.parser = null;
-
-        final var version = Runtime.Version.parse(System.getProperty("java.version"));
-        if (version.major() < 20) {
-            // TODO: This can be removed when the minimum version of boot jdk
-            // for JFX build is updated to JDK20 or above.
-            JAPANESE_DATE_STRING = "Saturday, January 12, 60 Shōwa, 12:34:56 PM";
-        } else {
-            JAPANESE_DATE_STRING = "Saturday, January 12, 60 Shōwa, 12:34:56\u202fPM";
-        }
     }
 
     @BeforeClass
@@ -124,6 +115,15 @@ public class LocalDateTimeStringConverterTest {
         // DateTimeFormatter uses default locale, so we can init this after updating locale
         aFormatter = DateTimeFormatter.ofPattern("dd MM yyyy HH mm ss");
         aParser = DateTimeFormatter.ofPattern("yyyy MM dd hh mm ss a");
+
+        final var version = Runtime.Version.parse(System.getProperty("java.version"));
+        if (version.major() < 20) {
+            // TODO: This can be removed when the minimum version of boot jdk
+            // for JFX build is updated to JDK20 or above.
+            JAPANESE_DATE_STRING = "Saturday, January 12, 60 Shōwa, 12:34:56 PM";
+        } else {
+            JAPANESE_DATE_STRING = "Saturday, January 12, 60 Shōwa, 12:34:56\u202fPM";
+        }
     }
 
     @AfterClass

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
@@ -107,6 +107,8 @@ public class LocalDateTimeStringConverterTest {
 
         final var version = Runtime.Version.parse(System.getProperty("java.version"));
         if (version.major() < 20) {
+            // TODO: This can be removed when the minimum version of boot jdk
+            // for JFX build is updated to JDK20 or above.
             JAPANESE_DATE_STRING = "Saturday, January 12, 60 Shōwa, 12:34:56 PM";
         } else {
             JAPANESE_DATE_STRING = "Saturday, January 12, 60 Shōwa, 12:34:56\u202fPM";

--- a/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/util/converter/LocalDateTimeStringConverterTest.java
@@ -52,7 +52,7 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class LocalDateTimeStringConverterTest {
 
-    private static final String JAPANESE_DATE_STRING = "Saturday, January 12, 60 Shōwa, 12:34:56 PM";
+    private static String JAPANESE_DATE_STRING;
     private static final LocalDateTime VALID_LDT_WITH_SECONDS    = LocalDateTime.of(1985, 1, 12, 12, 34, 56);
     private static final LocalDateTime VALID_LDT_WITHOUT_SECONDS = LocalDateTime.of(1985, 1, 12, 12, 34, 0);
 
@@ -104,6 +104,13 @@ public class LocalDateTimeStringConverterTest {
         this.locale = null;
         this.formatter = null;
         this.parser = null;
+
+        final var version = Runtime.Version.parse(System.getProperty("java.version"));
+        if (version.major() < 20) {
+            JAPANESE_DATE_STRING = "Saturday, January 12, 60 Shōwa, 12:34:56 PM";
+        } else {
+            JAPANESE_DATE_STRING = "Saturday, January 12, 60 Shōwa, 12:34:56\u202fPM";
+        }
     }
 
     @BeforeClass


### PR DESCRIPTION
The expected result was changed due to an enhancement in JDK: 
[JDK-8284840](https://bugs.openjdk.org/browse/JDK-8284840): Update CLDR to Version 42.0
Similar tests were corrected in JDK along with the enhancement: [check this for example](https://github.com/openjdk/jdk/blob/4900517479f12b59cd8f1c31ad94ad7487c522f7/test/jdk/java/time/test/java/time/format/TestUnicodeExtension.java#L130)

We need to make similar change. But the expected result is different before JDK20 and with JDK20. The fix checks JDK major version to change expected result accordingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8297316](https://bugs.openjdk.org/browse/JDK-8297316): [TestBug] LocalDateTimeStringConverterTest.testChronologyConsistency fails with JDK 20


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1114/head:pull/1114` \
`$ git checkout pull/1114`

Update a local copy of the PR: \
`$ git checkout pull/1114` \
`$ git pull https://git.openjdk.org/jfx.git pull/1114/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1114`

View PR using the GUI difftool: \
`$ git pr show -t 1114`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1114.diff">https://git.openjdk.org/jfx/pull/1114.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1114#issuecomment-1521262146)