### PR TITLE
8296590: StraightLineTest fails always on Linux and sometimes on other platforms

### DIFF
--- a/tests/system/src/test/java/test/javafx/scene/web/StraightLineTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/StraightLineTest.java
@@ -154,6 +154,8 @@ public class StraightLineTest {
         });
 
         assertTrue("Timeout when waiting for focus change ", Util.await(webViewStateLatch));
+        //introduce sleep , so that web contents would be loaded , then take snapshot for testing
+        Util.sleep(1000);
 
         Util.runAndWait(() -> {
             WritableImage snapshot = straightLineTestApp.primaryStage.getScene().snapshot(null);


### PR DESCRIPTION
Issue: The test fails, in case snapshot is taken before web view finish web content load
Solution: Introduce a sleep , before taking snapshot of web view , to test straight line