### PR TITLE
8306590: Add Windows/macOS system files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,17 @@ testbin/
 *.rej
 *.swp
 *~
+
+# Ignore macOS system files
+.DS_Store
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Ignore Windows system files
+Desktop.ini
+Thumbs.db


### PR DESCRIPTION
Adding the following windows/macos system files to the root .gitignore:

# Ignore macOS files
.DS_Store
.DocumentRevisions-V100 // file backups
.fseventsd/ // contains log of file events 
.Spotlight-V100 // usb root
.Trashes/ // usb root 
.TemporaryItems/ 
.VolumeIcon.icns // attached disk icon
.com.apple.timemachine.donotpresent // time machine

# windows
Desktop.ini // folder view options
Thumbs.db // thumbnail cache