### PR TITLE
8297071: Provide gradle "TEST_ONLY" flag to completely suppress building the sdk and shims

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           set -x
           export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
-          bash gradlew --info --continue -PBUILD_SDK_FOR_TEST=false test -x :web:test
+          bash gradlew --info --continue -PTEST_ONLY=true test -x :web:test
 
 
   macos_x64_build:
@@ -225,7 +225,7 @@ jobs:
           set -x
           #export PATH="$JAVA_HOME/bin:$ANT_HOME/bin:$PATH"
           export PATH="$JAVA_HOME/bin:$PATH"
-          bash gradlew --info --continue -PBUILD_SDK_FOR_TEST=false test -x :web:test
+          bash gradlew --info --continue -PTEST_ONLY=true test -x :web:test
 
 
   windows_x64_build:
@@ -337,4 +337,4 @@ jobs:
           echo "ANT_HOME=$env:ANT_HOME"
           $env:Path = "$env:THE_PATH" ;
           echo "Path=$env:Path"
-          .\gradlew.bat --info --continue -PBUILD_SDK_FOR_TEST=false test -x :web:test
+          .\gradlew.bat --info --continue -PTEST_ONLY=true test -x :web:test

--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,9 @@
  *  - FXML Project tests are not running
  *
  * Adding a new project or task:
- *  - Fix for JDK-XXXXXXX, introduces a restriction on assigning name for project or task.
+ *  - Fix for JDK-8297071, introduces a restriction on assigning name for a project or task.
  *    - If the name of project or task contains word test/Test then it is considered as test task.
- *    - If the name of project or task contains word shim/Shim then it is considered as shims task.
+ *    - If the name of a task contains word shim/Shim then it is considered as shims task.
  *    - See TEST_ONLY flag, isTestTask() method, the tasks: shims and sdk for more clarity.
  */
 defaultTasks = ["sdk"]
@@ -3489,7 +3489,7 @@ project(":web") {
 
     compileJava.dependsOn updateCacheIfNeeded
 
-    task webArchiveJar(type: Jar) {
+    task testWebArchiveJar(type: Jar) {
         from (project.file("$projectDir/src/test/resources/test/html")) {
             include "**/archive-*.*"
         }
@@ -3543,7 +3543,7 @@ project(":web") {
         systemProperty 'glass.platform', 'Monocle'
         systemProperty 'monocle.platform', 'Headless'
         systemProperty 'prism.order', 'sw'
-        dependsOn webArchiveJar
+        dependsOn testWebArchiveJar
         def testResourceDir = file("$buildDir/testing/resources")
         jvmArgs "-DWEB_ARCHIVE_JAR_TEST_DIR=$testResourceDir"
         systemProperty 'java.security.manager', 'allow'

--- a/build.gradle
+++ b/build.gradle
@@ -4209,7 +4209,7 @@ task shims() {
 task sdk() {
     if (!IS_TEST_ONLY) {
         rootProject.getTasksByName("test", true).each { t ->
-            if (t.enabled) t.dependsOn(sdk)
+            if (t.enabled) t.dependsOn(shims)
         }
     } else {
         gradle.taskGraph.whenReady { theTaskGraph ->

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,12 @@
  *  - ServiceWithSecurityManagerTest fails to complete when run from gradle.
  *  - Integrate Parfait reports for C code
  *  - FXML Project tests are not running
+ *
+ * Adding a new project or task:
+ *  - Fix for JDK-XXXXXXX, introduces a restriction on assigning name for project or task.
+ *    - If the name of project or task contains word test/Test then it is considered as test task.
+ *    - If the name of project or task contains word shim/Shim then it is considered as shims task.
+ *    - See TEST_ONLY flag, isTestTask() method, the tasks: shims and sdk for more clarity.
  */
 defaultTasks = ["sdk"]
 
@@ -609,7 +615,9 @@ ext.CROSS_TOOLS_DIR = file(crossToolsDir)
 defineProperty("BUILD_SDK_FOR_TEST", "true")
 def buildSdkForTest = Boolean.parseBoolean(BUILD_SDK_FOR_TEST)
 
-// Specifies whether to run tests with the existing javafx.* modules instead of compiling a new one
+// Specifies whether to run only test tasks using the already built javafx.* modules
+// and shim classes, instead of rebuilding them.
+// If true, then all non test tasks, except verifyJava are disabled. see task sdk and isTestTask method.
 defineProperty("TEST_ONLY", "false")
 ext.IS_TEST_ONLY = Boolean.parseBoolean(TEST_ONLY) || !buildSdkForTest
 
@@ -1808,6 +1816,14 @@ int compareJdkVersion(String a, String b) {
         if (aIntArr[i] > bIntArr[i]) return  1;
     }
     return 0;
+}
+
+/**
+ * Returns true if the name of task or name of task's project contains word test/Test.
+ */
+boolean isTestTask(Task task) {
+    return (task.project.name.contains("test") || task.project.name.contains("Test")
+                 || task.name.contains("test") || task.name.contains("Test"))
 }
 
 // Task to verify the minimum level of Java needed to build JavaFX
@@ -4195,11 +4211,11 @@ task javadoc(type: Javadoc, dependsOn: createMSPfile) {
 }
 
 task shims() {
-    gradle.allprojects { aProject ->
-        if (aProject.hasProperty("sourceSets") && aProject.sourceSets.hasProperty('shims')) {
-            aProject.tasks.each { aTask ->
-                if (aTask.name.contains("shim") || aTask.name.contains("Shim")) {
-                    dependsOn(aTask)
+    gradle.allprojects { project ->
+        if (project.hasProperty("sourceSets") && project.sourceSets.hasProperty('shims')) {
+            project.tasks.each { task ->
+                if (task.name.contains("shim") || task.name.contains("Shim")) {
+                    dependsOn(task)
                 }
             }
         }
@@ -4212,10 +4228,9 @@ task sdk() {
             if (t.enabled) t.dependsOn(shims)
         }
     } else {
-        gradle.taskGraph.whenReady { theTaskGraph ->
-            theTaskGraph.allTasks.each { task ->
-                if (!task.name.contains("test") && !task.name.contains("Test") &&
-                    !task.name.equals("verifyJava")) {
+        gradle.taskGraph.whenReady { taskGraph ->
+            taskGraph.allTasks.each { task ->
+                if (!isTestTask(task) && !task.name.equals("verifyJava")) {
                     task.enabled = false
                 }
             }

--- a/build.gradle
+++ b/build.gradle
@@ -605,9 +605,13 @@ if (hasProperty("CROSS_TOOLS_DIR")) {
 }
 ext.CROSS_TOOLS_DIR = file(crossToolsDir)
 
-// Specifies whether to run tests with the existing javafx.* modules instead of compiling a new one
+// For backward compatibility, -PBUILD_SDK_FOR_TEST=false will set TEST_ONLY to true
 defineProperty("BUILD_SDK_FOR_TEST", "true")
-ext.DO_BUILD_SDK_FOR_TEST = Boolean.parseBoolean(BUILD_SDK_FOR_TEST)
+def buildSdkForTest = Boolean.parseBoolean(BUILD_SDK_FOR_TEST)
+
+// Specifies whether to run tests with the existing javafx.* modules instead of compiling a new one
+defineProperty("TEST_ONLY", "false")
+ext.IS_TEST_ONLY = Boolean.parseBoolean(TEST_ONLY) || !buildSdkForTest
 
 // Make sure JDK_HOME/bin/java exists
 if (!file(JAVA).exists()) throw new Exception("Missing or incorrect path to 'java': '$JAVA'. Perhaps bad JDK_HOME? $JDK_HOME")
@@ -4190,13 +4194,36 @@ task javadoc(type: Javadoc, dependsOn: createMSPfile) {
     dependsOn(projectsToDocument.collect { project -> project.getTasksByName("classes", true)});
 }
 
-task sdk() {
-    if (DO_BUILD_SDK_FOR_TEST) {
-        rootProject.getTasksByName("test", true).each { t ->
-            if (t.enabled) t.dependsOn(sdk)
+task shims() {
+    gradle.allprojects { aProject ->
+        if (aProject.hasProperty("sourceSets") && aProject.sourceSets.hasProperty('shims')) {
+            aProject.tasks.each { aTask ->
+                if (aTask.name.contains("shim") || aTask.name.contains("Shim")) {
+                    dependsOn(aTask)
+                }
+            }
         }
     }
 }
+
+task sdk() {
+    if (!IS_TEST_ONLY) {
+        rootProject.getTasksByName("test", true).each { t ->
+            if (t.enabled) t.dependsOn(sdk)
+        }
+    } else {
+        gradle.taskGraph.whenReady { theTaskGraph ->
+            theTaskGraph.allTasks.each { task ->
+                if (!task.name.contains("test") && !task.name.contains("Test") &&
+                    !task.name.equals("verifyJava")) {
+                    task.enabled = false
+                }
+            }
+        }
+    }
+}
+
+shims.dependsOn(sdk)
 
 task jmods() {
     dependsOn(sdk)

--- a/build.gradle
+++ b/build.gradle
@@ -4288,7 +4288,7 @@ task zips() {
 }
 
 task all() {
-    dependsOn(sdk,publicExports,apps,perf,zips)
+    dependsOn(sdk, shims, publicExports, apps, perf, zips)
 }
 
 

--- a/gradle.properties.template
+++ b/gradle.properties.template
@@ -69,11 +69,15 @@
 
 #INCLUDE_ES2 = true
 
-# Specifies whether to build SDK for running unit tests
-# By default, it is set to true and the tests are running of the
-# fresh-built SDK. If set to false, this flag removes main sources
-# compilation tasks and building the whole SDK. The existing SDK is used
-# instead, and must have been previously built
+# Specifies whether to build SDK for running the provided test task.
+# By default, it is set to false and the tests are running of the
+# fresh-built SDK. If set to true, this flag disables all non test tasks,
+# and it is expected that sdk and shims tasks have been previously built.
+
+#TEST_ONLY = true
+
+# Same as TEST_ONLY, excpet that the name and values have opposite meaning.
+# Recommended to use TEST_ONLY instead of this property.
 
 #BUILD_SDK_FOR_TEST = false
 

--- a/gradle.properties.template
+++ b/gradle.properties.template
@@ -76,11 +76,6 @@
 
 #TEST_ONLY = true
 
-# Same as TEST_ONLY, excpet that the name and values have opposite meaning.
-# Recommended to use TEST_ONLY instead of this property.
-
-#BUILD_SDK_FOR_TEST = false
-
 # Specifies whether to do a full test run or a "smoke test" run. By default we
 # do a smoke test run which excludes all tests that show a window or play media.
 # Certain long running tests might also be excluded when this is not set.


### PR DESCRIPTION
Add `TEST_ONLY` flag to gradle with default value as false.
Add new task named `shims`, This task depends on all shim tasks from all projects. Hence it will build all shim classes.

If TEST_ONLY is set to true, the all non test tasks get disabled. When running a test task, this flag would reduce time in checking if all non test tasks are up to date.
How to use:
1. Following command would fail in a clean repo, 
  > gradle -PTEST_ONLY=true :base:test
2. The sdk and shims task must have been executed before running any test
  > gradle sdk shims
  > gradle -PTEST_ONLY=true :base:test
3. Setting this flag to true with non test task would result in no task being run.
  > gradle -PTEST_ONLY=true sdk  -> It will not build sdk task

TIP: use `--dry-run` option of gradle for speeding up testing the effect of this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8297071](https://bugs.openjdk.org/browse/JDK-8297071): Provide gradle "TEST_ONLY" flag to completely suppress building the sdk and shims


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1117/head:pull/1117` \
`$ git checkout pull/1117`

Update a local copy of the PR: \
`$ git checkout pull/1117` \
`$ git pull https://git.openjdk.org/jfx.git pull/1117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1117`

View PR using the GUI difftool: \
`$ git pr show -t 1117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1117.diff">https://git.openjdk.org/jfx/pull/1117.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1117#issuecomment-1525312510)