### PR TITLE
8304922: [testbug] SliderTooltipNPETest fails on Linux

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/SliderTooltipNPETest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/SliderTooltipNPETest.java
@@ -28,6 +28,8 @@ package test.robot.javafx.scene;
 import java.util.concurrent.CountDownLatch;
 
 import com.sun.javafx.PlatformUtil;
+import com.sun.javafx.tk.Toolkit;
+
 import javafx.application.Application;
 import javafx.scene.input.MouseButton;
 import javafx.application.Platform;
@@ -75,8 +77,6 @@ public class SliderTooltipNPETest {
 
     @Test
     public void testSliderTooltipNPE() throws Throwable {
-        assumeTrue(!PlatformUtil.isLinux()); // JDK-8304922
-
         Assert.assertTrue(slider.getTooltip().getConsumeAutoHidingEvents());
         dragSliderAfterTooltipDisplayed(DRAG_DISTANCE);
         if (exception != null) {
@@ -94,6 +94,7 @@ public class SliderTooltipNPETest {
                                 slider.getLayoutX() + slider.getLayoutBounds().getWidth()/2),
                             (int)(scene.getWindow().getY() + scene.getY() +
                                 slider.getLayoutY() + slider.getLayoutBounds().getHeight()/2));
+            Toolkit.getToolkit().firePulse();
         });
 
         Util.waitForLatch(tooltipLatch, 5, "Timeout waiting for tooltip to display");

--- a/tests/system/src/test/java/test/robot/javafx/scene/SliderTooltipNPETest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/SliderTooltipNPETest.java
@@ -88,6 +88,13 @@ public class SliderTooltipNPETest {
     }
 
     private void dragSliderAfterTooltipDisplayed(int dragDistance) throws Exception {
+        Util.runAndWait(() -> {
+            // Click somewhere in the Stage to ensure that it is active
+            robot.mouseMove((int)(scene.getWindow().getX() + scene.getX()),
+                            (int)(scene.getWindow().getY() + scene.getY()));
+            robot.mouseClick(MouseButton.PRIMARY);
+        });
+
         Thread.sleep(1000); // Wait for slider to layout
 
         Util.runAndWait(() -> {


### PR DESCRIPTION
The test was failing on the first run and then it was not failing. Cause for the failure looked to be the UI state not getting updated. Hence added call to `Toolkit` `firePulse` method.

Able to run the test consistently without failure in Linux after the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304922](https://bugs.openjdk.org/browse/JDK-8304922): [testbug] SliderTooltipNPETest fails on Linux (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1119/head:pull/1119` \
`$ git checkout pull/1119`

Update a local copy of the PR: \
`$ git checkout pull/1119` \
`$ git pull https://git.openjdk.org/jfx.git pull/1119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1119`

View PR using the GUI difftool: \
`$ git pr show -t 1119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1119.diff">https://git.openjdk.org/jfx/pull/1119.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1119#issuecomment-1527477502)