### PR TITLE
8307076: gradle test should always run tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2006,6 +2006,9 @@ allprojects {
     test {
         useJUnitPlatform();
 
+        // Always run tests
+        outputs.upToDateWhen { false }
+
         executable = JAVA;
         enableAssertions = true;
         testLogging.exceptionFormat = "full";


### PR DESCRIPTION
"gradle test" won't rerun a test that has already passed. This is surprising behavior, especially for UI toolkit tests where there might be many reasons to want to run the tests again, even if none of that tests "inputs" have changed. This is especially bothersome when debugging an intermittent test failure. Unlike rebuilding the JavaFX runtime or the docs, where there is no need to rerun a task that was successful if none of the inputs to that task have changed, I expect gradle to run my test when I tell it to.

This PR will make test tasks always run when specified.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307076](https://bugs.openjdk.org/browse/JDK-8307076): gradle test should always run tests


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1120/head:pull/1120` \
`$ git checkout pull/1120`

Update a local copy of the PR: \
`$ git checkout pull/1120` \
`$ git pull https://git.openjdk.org/jfx.git pull/1120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1120`

View PR using the GUI difftool: \
`$ git pr show -t 1120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1120.diff">https://git.openjdk.org/jfx/pull/1120.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1120#issuecomment-1528795620)