### PR TITLE
8296919: Make system tests that detect memory leaks more robust by using JMemoryBuddy utility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3465,6 +3465,7 @@ project(":web") {
         implementation project(":graphics")
         implementation project(":controls")
         implementation project(":media")
+        testImplementation project(":base").sourceSets.test.output
     }
 
     compileJava.dependsOn updateCacheIfNeeded

--- a/tests/system/src/test/java/test/javafx/embed/swing/SwingNodeDnDMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/SwingNodeDnDMemoryLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 
 import javax.swing.JLabel;
+import java.lang.reflect.InvocationTargetException;
 
 import javafx.application.Application;
 import javafx.embed.swing.SwingNode;
@@ -45,12 +46,12 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import test.util.Util;
+import test.util.memory.JMemoryBuddy;
 
 public class SwingNodeDnDMemoryLeakTest {
 
     final static int TOTAL_SWINGNODE = 10;
     static CountDownLatch launchLatch = new CountDownLatch(1);
-    final static int GC_ATTEMPTS = 10;
     ArrayList<WeakReference<SwingNode>> weakRefArrSN =
                                       new ArrayList(TOTAL_SWINGNODE);
 
@@ -65,12 +66,14 @@ public class SwingNodeDnDMemoryLeakTest {
     }
 
     @Test
-    public void testSwingNodeMemoryLeak() {
+    public void testSwingNodeMemoryLeak() throws InvocationTargetException, InterruptedException {
         Util.runAndWait(() -> {
             testSwingNodeObjectsInStage();
         });
-        attemptGCSwingNode();
-        assertEquals(TOTAL_SWINGNODE, getCleanedUpSwingNodeCount());
+
+        for (WeakReference<SwingNode> ref : weakRefArrSN) {
+            JMemoryBuddy.assertCollectable(ref);
+        }
     }
 
     private void testSwingNodeObjectsInStage() {
@@ -108,21 +111,6 @@ public class SwingNodeDnDMemoryLeakTest {
             if (tempStage[i] != null) {
                 tempStage[i].close();
                 tempStage[i] = null;
-            }
-        }
-    }
-
-    private void attemptGCSwingNode() {
-        // Attempt gc GC_ATTEMPTS times
-        for (int i = 0; i < GC_ATTEMPTS; i++) {
-            System.gc();
-            if (getCleanedUpSwingNodeCount() == TOTAL_SWINGNODE) {
-                break;
-            }
-            try {
-                Thread.sleep(500);
-            } catch (InterruptedException e) {
-                System.err.println("InterruptedException occurred during Thread.sleep()");
             }
         }
     }

--- a/tests/system/src/test/java/test/javafx/embed/swing/SwingNodeMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/embed/swing/SwingNodeMemoryLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,10 +29,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assume.assumeTrue;
 
 import java.lang.ref.WeakReference;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 
 import javax.swing.JLabel;
+import javax.swing.SwingUtilities;
 
 import javafx.application.Application;
 import javafx.embed.swing.SwingNode;
@@ -47,6 +49,7 @@ import org.junit.Test;
 import com.sun.javafx.PlatformUtil;
 
 import test.util.Util;
+import test.util.memory.JMemoryBuddy;
 
 public class SwingNodeMemoryLeakTest {
 
@@ -69,18 +72,20 @@ public class SwingNodeMemoryLeakTest {
     }
 
     @Test
-    public void testSwingNodeMemoryLeak() {
-        if (PlatformUtil.isMac()) {
-            assumeTrue(Boolean.getBoolean("unstable.test")); // JDK-8196614
-        }
+    public void testSwingNodeMemoryLeak() throws InterruptedException, InvocationTargetException {
         Util.runAndWait(() -> {
             testSwingNodeObjectsInStage();
         });
-        attemptGCSwingNode();
-        assertEquals(TOTAL_SWINGNODE, getCleanedUpSwingNodeCount());
 
-        attemptGCJLabel();
-        assertEquals(TOTAL_SWINGNODE, getCleanedUpJLabelCount());
+        SwingUtilities.invokeAndWait(() -> Util.sleep(500));
+
+        for (WeakReference<SwingNode> ref : weakRefArrSN) {
+            JMemoryBuddy.assertCollectable(ref);
+        }
+
+        for (WeakReference<JLabel> ref : weakRefArrJL) {
+            JMemoryBuddy.assertCollectable(ref);
+        }
     }
 
     private void testSwingNodeObjectsInStage() {
@@ -120,35 +125,6 @@ public class SwingNodeMemoryLeakTest {
         }
     }
 
-    private void attemptGCSwingNode() {
-        // Attempt gc GC_ATTEMPTS times
-        for (int i = 0; i < GC_ATTEMPTS; i++) {
-            System.gc();
-            if (getCleanedUpSwingNodeCount() == TOTAL_SWINGNODE) {
-                break;
-            }
-            try {
-                Thread.sleep(250);
-            } catch (InterruptedException e) {
-                System.err.println("InterruptedException occurred during Thread.sleep()");
-            }
-        }
-    }
-
-    private void attemptGCJLabel() {
-        // Attempt gc GC_ATTEMPTS times
-        for (int i = 0; i < GC_ATTEMPTS; i++) {
-            System.gc();
-            if (getCleanedUpJLabelCount() == TOTAL_SWINGNODE) {
-                break;
-            }
-            try {
-                Thread.sleep(250);
-            } catch (InterruptedException e) {
-                System.err.println("InterruptedException occurred during Thread.sleep()");
-            }
-        }
-    }
     private int getCleanedUpSwingNodeCount() {
         int count = 0;
         for (WeakReference<SwingNode> ref : weakRefArrSN) {

--- a/tests/system/src/test/java/test/javafx/scene/control/TabPaneHeaderLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/TabPaneHeaderLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,8 +41,9 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import junit.framework.Assert;
 import test.util.Util;
+import test.util.memory.JMemoryBuddy;
+
 
 public class TabPaneHeaderLeakTest {
 
@@ -92,16 +93,8 @@ public class TabPaneHeaderLeakTest {
             tabPane.getTabs().clear();
             root.getChildren().clear();
         });
-        for (int i = 0; i < 10; i++) {
-            System.gc();
-            if (tabWeakRef.get() == null &&
-                textFieldWeakRef.get() == null) {
-                break;
-            }
-            Util.sleep(500);
-        }
-        // Ensure that Tab and TextField are GCed.
-        Assert.assertNull("Couldn't collect Tab", tabWeakRef.get());
-        Assert.assertNull("Couldn't collect TextField", textFieldWeakRef.get());
+
+        JMemoryBuddy.assertCollectable(tabWeakRef);
+        JMemoryBuddy.assertCollectable(textFieldWeakRef);
     }
 }

--- a/tests/system/src/test/java/test/javafx/scene/shape/ShapeViewOrderLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/shape/ShapeViewOrderLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,8 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import junit.framework.Assert;
 import test.util.Util;
+import test.util.memory.JMemoryBuddy;
 
 public class ShapeViewOrderLeakTest {
 
@@ -94,14 +94,7 @@ public class ShapeViewOrderLeakTest {
             group.getChildren().clear();
             root.getChildren().clear();
         });
-        for (int i = 0; i < 10; i++) {
-            System.gc();
-            if (shapeWeakRef.get() == null) {
-                break;
-            }
-            Util.sleep(500);
-        }
-        // Ensure that Shape is GCed.
-        Assert.assertNull("Couldn't collect Shape", shapeWeakRef.get());
+
+        JMemoryBuddy.assertCollectable(shapeWeakRef);
     }
 }

--- a/tests/system/src/test/java/test/javafx/stage/FocusedWindowTestBase.java
+++ b/tests/system/src/test/java/test/javafx/stage/FocusedWindowTestBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import javafx.stage.Stage;
 import org.junit.Assert;
 
 import test.util.Util;
+import test.util.memory.JMemoryBuddy;
 
 public abstract class FocusedWindowTestBase {
 
@@ -80,16 +81,6 @@ public abstract class FocusedWindowTestBase {
     }
 
     public static void assertCollectable(WeakReference weakReference) throws Exception {
-        int counter = 0;
-
-        System.gc();
-
-        while (counter < 10 && weakReference.get() != null) {
-            Thread.sleep(100);
-            counter = counter + 1;
-            System.gc();
-        }
-
-        Assert.assertNull(weakReference.get());
+        JMemoryBuddy.assertCollectable(weakReference);
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/web/TooltipFXTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/web/TooltipFXTest.java
@@ -49,6 +49,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import test.util.Util;
+import test.util.memory.JMemoryBuddy;
 
 public class TooltipFXTest {
 
@@ -164,13 +165,6 @@ public class TooltipFXTest {
             scene = null;
         });
 
-        for (int j = 0; j < 5; ++j) {
-            System.gc();
-            if (webViewRef.get() == null) {
-                break;
-            }
-            Util.sleep(SLEEP_TIME);
-        }
-        assertNull("webViewRef is not null", webViewRef.get());
+        JMemoryBuddy.assertCollectable(webViewRef);
     }
 }


### PR DESCRIPTION
Verified these changes on all platforms and saw no abnormalities in test execution.

This change is based on a preliminary patch done by @aghaisas , with some minor changes and the addition of one Leak-related web test. EventListenerLeak test was not touched, as it is a separate manual test app instead of a JUnit test.