### PR TITLE
JDK-8298104: NPE on synchronizeSceneNodes()

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -2480,7 +2480,7 @@ public class Scene implements EventTarget {
                 for (int i = 0 ; i < dirtyNodesSize; ++i) {
                     Node node = dirtyNodes[i];
                     dirtyNodes[i] = null;
-                    if (node.getScene() == Scene.this) {
+                    if (node != null && node.getScene() == Scene.this) {
                             node.syncPeer();
                         }
                     }


### PR DESCRIPTION
A null pointer exception occurs on the ScenePulseListener when iterating through the dirty node list.
A null check is needed on the node before calling node.getScene().

The error occurs occasionally and causes the application to crash.
/signed

Issue: [JDK-8298104: NPE on synchronizeSceneNodes()](https://bugs.openjdk.org/browse/JDK-8298104)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298104](https://bugs.openjdk.org/browse/JDK-8298104): NPE on synchronizeSceneNodes() (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1123/head:pull/1123` \
`$ git checkout pull/1123`

Update a local copy of the PR: \
`$ git checkout pull/1123` \
`$ git pull https://git.openjdk.org/jfx.git pull/1123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1123`

View PR using the GUI difftool: \
`$ git pr show -t 1123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1123.diff">https://git.openjdk.org/jfx/pull/1123.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1123#issuecomment-1533712897)