### PR TITLE
8307208: Add GridPane constructor that accepts hGap and vGap values

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/GridPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/GridPane.java
@@ -735,6 +735,20 @@ public class GridPane extends Pane {
     }
 
     /**
+     * Creates a GridPane layout with the given {@link #hgapProperty() hgap} and {@link #vgapProperty() vgap}.
+     *
+     * @param hgap the width of the horizontal gaps between columns
+     * @param vgap the height of the vertical gaps between rows
+     *
+     * @since 21
+     */
+    public GridPane(double hgap, double vgap) {
+        this();
+        setHgap(hgap);
+        setVgap(vgap);
+    }
+
+    /**
      * The width of the horizontal gaps between columns.
      * @return the width of the horizontal gaps between columns
      */

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/GridPaneTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/layout/GridPaneTest.java
@@ -3158,4 +3158,15 @@ public class GridPaneTest {
 
         assertEquals(160, gridpane.prefHeight(-1), 1e-100);
     }
+
+    @Test
+    public void testGridPaneHgapVgapConstructor() {
+        assertEquals(0, gridpane.getHgap(), 0);
+        assertEquals(0, gridpane.getVgap(), 0);
+
+        gridpane = new GridPane(3, 8);
+
+        assertEquals(3, gridpane.getHgap(), 0);
+        assertEquals(8, gridpane.getVgap(), 0);
+    }
 }


### PR DESCRIPTION
This PR adds a new constructor to `GridPane` that accepts a `hgap` and a `vgap`.
As also written in the ticket, this is a small enhancement to improve the creation of a layout involving a `GridPane` without FXML.
In my experience, the `hgap` and the `vgap` are almost always set when creating a layout with the `GridPane`, as a space between the content just looks much better.

This also fits well with other classes like `HBox` and `VBox`, which also provide a constructor that accepts the spacing.