### PR TITLE
8089373: Translation from character to key code is not sufficient

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
@@ -755,7 +755,7 @@ public abstract class Application {
      * The default implementation bridges to the existing getKeyCodeForChar call. Platform
      * instances are expected to override this call.
      */
-    protected boolean _getKeyCanGenerateCharacter(int hardwareCode, int vkCode, char c) {
+    protected boolean _canKeyGenerateCharacter(int hardwareCode, int vkCode, char c) {
         if (vkCode != com.sun.glass.events.KeyEvent.VK_UNDEFINED) {
             return getKeyCodeForChar(c) == vkCode;
         }
@@ -771,10 +771,10 @@ public abstract class Application {
      * @param hardwareCode the platform-specific key identifier
      * @param vkCode the JavaFX key code
      * @param c the character
-     * @return true if the key can generate the character
+     * @return {@code true} if the key can generate the character
      */
-    public final boolean getKeyCanGenerateCharacter(int hardwareCode, int vkCode, char c) {
-        return _getKeyCanGenerateCharacter(hardwareCode, vkCode, c);
+    public final boolean canKeyGenerateCharacter(int hardwareCode, int vkCode, char c) {
+        return _canKeyGenerateCharacter(hardwareCode, vkCode, c);
     }
 
     protected int _isKeyLocked(int keyCode) {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -749,6 +749,32 @@ public abstract class Application {
      */
     public static int getKeyCodeForChar(char c) {
         return application._getKeyCodeForChar(c);
+    }
+
+    /**
+     * The default implementation bridges to the existing getKeyCodeForChar call. Platform
+     * instances are expected to override this call.
+     */
+    protected boolean _getKeyCanGenerateCharacter(int hardwareCode, int vkCode, char c) {
+        if (vkCode != com.sun.glass.events.KeyEvent.VK_UNDEFINED) {
+            return getKeyCodeForChar(c) == vkCode;
+        }
+        return false;
+    }
+
+    /**
+     * Returns true if the key is capable of producing the given Unicode
+     * character. The call will be provided enough information to identify the
+     * key, either a vkCode that is not VK_UNDEFINED or a hardwareCode that is
+     * non-negative or both.
+     *
+     * @param hardwareCode the platform-specific key identifier
+     * @param vkCode the JavaFX key code
+     * @param c the character
+     * @return true if the key can generate the character
+     */
+    public final boolean getKeyCanGenerateCharacter(int hardwareCode, int vkCode, char c) {
+        return _getKeyCanGenerateCharacter(hardwareCode, vkCode, c);
     }
 
     protected int _isKeyLocked(int keyCode) {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/View.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/View.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,8 +65,11 @@ public abstract class View {
     public static class EventHandler {
         public void handleViewEvent(View view, long time, int type) {
         }
-        public void handleKeyEvent(View view, long time, int action,
-                int keyCode, char[] keyChars, int modifiers) {
+        public boolean handleKeyEvent(View view, long time, int action,
+                int keyCode, char[] keyChars, int modifiers, int hardwareCode)
+        {
+            /* Event was not consumed */
+            return false;
         }
         public void handleMenuEvent(View view, int x, int y, int xAbs,
                 int yAbs, boolean isKeyboardTrigger) {
@@ -536,11 +539,13 @@ public abstract class View {
         }
     }
 
-    private void handleKeyEvent(long time, int action,
-            int keyCode, char[] keyChars, int modifiers) {
+    private boolean handleKeyEvent(long time, int action,
+            int keyCode, char[] keyChars, int modifiers, int hardwareCode) {
         if (this.eventHandler != null) {
-            this.eventHandler.handleKeyEvent(this, time, action, keyCode, keyChars, modifiers);
+            return this.eventHandler.handleKeyEvent(this, time, action, keyCode,
+                                                    keyChars, modifiers, hardwareCode);
         }
+        return false;
     }
 
     private void handleMouseEvent(long time, int type, int button, int x, int y,
@@ -963,7 +968,12 @@ public abstract class View {
     }
 
     protected void notifyKey(int type, int keyCode, char[] keyChars, int modifiers) {
-        handleKeyEvent(System.nanoTime(), type, keyCode, keyChars, modifiers);
+        handleKeyEvent(System.nanoTime(), type, keyCode, keyChars, modifiers, -1);
+    }
+
+    // Returns true iff event was consumed
+    protected boolean notifyKeyEx(int type, int keyCode, char[] keyChars, int modifiers, int hardwareCode) {
+        return handleKeyEvent(System.nanoTime(), type, keyCode, keyChars, modifiers, hardwareCode);
     }
 
     protected void notifyInputMethod(String text, int[] clauseBoundary,

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/View.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/View.java
@@ -972,7 +972,7 @@ public abstract class View {
     }
 
     // Returns true iff event was consumed
-    protected boolean notifyKeyEx(int type, int keyCode, char[] keyChars, int modifiers, int hardwareCode) {
+    protected boolean notifyKey(int type, int keyCode, char[] keyChars, int modifiers, int hardwareCode) {
         return handleKeyEvent(System.nanoTime(), type, keyCode, keyChars, modifiers, hardwareCode);
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
@@ -377,13 +377,13 @@ final class WinApplication extends Application implements InvokeLaterDispatcher.
 
     @Override
     protected int _getKeyCodeForChar(char c) {
-        // This platform has migrated to getKeyCanGenerateCharacter
+        // This platform has migrated to canKeyGenerateCharacter
         // so getKeyCodeForChar will no longer be called.
-        return 0;
+        throw new UnsupportedOperationException("Windows uses canKeyGenerateCharacter");
     }
 
     @Override
-    protected native boolean _getKeyCanGenerateCharacter(int hardwareCode, int vkCode, char c);
+    protected native boolean _canKeyGenerateCharacter(int hardwareCode, int vkCode, char c);
 
     @Override
     protected native int _isKeyLocked(int keyCode);

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -376,7 +376,14 @@ final class WinApplication extends Application implements InvokeLaterDispatcher.
     }
 
     @Override
-    protected native int _getKeyCodeForChar(char c);
+    protected int _getKeyCodeForChar(char c) {
+        // This platform has migrated to getKeyCanGenerateCharacter
+        // so getKeyCodeForChar will no longer be called.
+        return 0;
+    }
+
+    @Override
+    protected native boolean _getKeyCanGenerateCharacter(int hardwareCode, int vkCode, char c);
 
     @Override
     protected native int _isKeyLocked(int keyCode);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/SceneHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/SceneHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,8 +53,8 @@ public final class SceneHelper {
         sceneAccessor.enableInputMethodEvents(scene, enable);
     }
 
-    public static void processKeyEvent(Scene scene, KeyEvent e) {
-        sceneAccessor.processKeyEvent(scene, e);
+    public static boolean processKeyEvent(Scene scene, KeyEvent e) {
+        return sceneAccessor.processKeyEvent(scene, e);
     }
 
     public static void processMouseEvent(Scene scene, MouseEvent e) {
@@ -118,7 +118,7 @@ public final class SceneHelper {
     public interface SceneAccessor {
         void enableInputMethodEvents(Scene scene, boolean enable);
 
-        void processKeyEvent(Scene scene, KeyEvent e);
+        boolean processKeyEvent(Scene scene, KeyEvent e);
 
         void processMouseEvent(Scene scene, MouseEvent e);
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/input/KeyEventHelper.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/input/KeyEventHelper.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.javafx.scene.input;
+
+import com.sun.javafx.util.Utils;
+import javafx.scene.input.KeyEvent;
+
+/**
+ * Used to access internal methods of KeyEvent.
+ */
+public class KeyEventHelper {
+
+    private static KeyEventAccessor keyEventAccessor;
+
+    static {
+        Utils.forceInit(KeyEvent.class);
+    }
+
+    private KeyEventHelper() {
+    }
+
+    public static void setHardwareCode(KeyEvent keyEvent, int hardwareCode) {
+        keyEventAccessor.setHardwareCode(keyEvent, hardwareCode);
+    }
+
+    public static int getHardwareCode(KeyEvent keyEvent) {
+        return keyEventAccessor.getHardwareCode(keyEvent);
+    }
+
+    public static void setKeyEventAccessor(final KeyEventAccessor newAccessor) {
+        if (keyEventAccessor != null) {
+            throw new IllegalStateException();
+        }
+
+        keyEventAccessor = newAccessor;
+    }
+
+    public interface KeyEventAccessor {
+        void setHardwareCode(KeyEvent keyEvent, int hardwareCode);
+        int getHardwareCode(KeyEvent keyEvent);
+    }
+}

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKSceneListener.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKSceneListener.java
@@ -65,7 +65,7 @@ public interface TKSceneListener {
      * Pass a key event to the scene to handle
      *
      * @param keyEvent The key event
-     * @return true iff the event was consumed
+     * @return {@code true} if the event was consumed
      */
     public boolean keyEvent(KeyEvent keyEvent);
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKSceneListener.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKSceneListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,8 +63,11 @@ public interface TKSceneListener {
 
     /**
      * Pass a key event to the scene to handle
+     *
+     * @param keyEvent The key event
+     * @return true iff the event was consumed
      */
-    public void keyEvent(KeyEvent keyEvent);
+    public boolean keyEvent(KeyEvent keyEvent);
 
     /**
      * Pass an input method event to the scene to handle

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -703,6 +703,15 @@ public abstract class Toolkit {
                            float dashOffset);
 
     public abstract int getKeyCodeForChar(String character);
+    /**
+     * The default implementation bridges into the existing getKeyCodeForChar call.
+     */
+    public boolean getKeyCanGenerateCharacter(KeyEvent event, String character) {
+        if (event.getCode() != KeyCode.UNDEFINED) {
+            return getKeyCodeForChar(character) == event.getCode().getCode();
+        }
+        return false;
+    }
     public abstract Dimension2D getBestCursorSize(int preferredWidth, int preferredHeight);
     public abstract int getMaximumCursorColors();
     public abstract PathElement[] convertShapeToFXPath(Object shape);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/Toolkit.java
@@ -706,7 +706,7 @@ public abstract class Toolkit {
     /**
      * The default implementation bridges into the existing getKeyCodeForChar call.
      */
-    public boolean getKeyCanGenerateCharacter(KeyEvent event, String character) {
+    public boolean canKeyGenerateCharacter(KeyEvent event, String character) {
         if (event.getCode() != KeyCode.UNDEFINED) {
             return getKeyCodeForChar(character) == event.getCode().getCode();
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ import com.sun.javafx.PlatformUtil;
 import com.sun.javafx.collections.TrackableObservableList;
 import com.sun.javafx.logging.PulseLogger;
 import static com.sun.javafx.logging.PulseLogger.PULSE_LOGGING_ENABLED;
+import com.sun.javafx.scene.input.KeyEventHelper;
 import com.sun.javafx.scene.input.KeyCodeMap;
 
 import javafx.collections.ListChangeListener;
@@ -147,22 +148,25 @@ class GlassViewEventHandler extends View.EventHandler {
     }
 
     private final KeyEventNotification keyNotification = new KeyEventNotification();
-    private class KeyEventNotification implements PrivilegedAction<Void> {
+    private class KeyEventNotification implements PrivilegedAction<Boolean> {
         View view;
         long time;
         int type;
         int key;
         char[] chars;
         int modifiers;
+        int hardwareCode;
 
         private KeyCode lastKeyCode;
 
         @Override
-        public Void run() {
+        public Boolean run() {
             if (PULSE_LOGGING_ENABLED) {
                 PulseLogger.newInput(keyEventType(type).toString());
             }
             WindowStage stage = scene.getWindowStage();
+            Boolean consumed = Boolean.FALSE;
+
             try {
                 boolean shiftDown = (modifiers & KeyEvent.MODIFIER_SHIFT) != 0;
                 boolean controlDown = (modifiers & KeyEvent.MODIFIER_CONTROL) != 0;
@@ -177,6 +181,7 @@ class GlassViewEventHandler extends View.EventHandler {
                         str, text,
                         KeyCodeMap.valueOf(key) ,
                         shiftDown, controlDown, altDown, metaDown);
+                KeyEventHelper.setHardwareCode(keyEvent, hardwareCode);
 
                 KeyCode keyCode = KeyCodeMap.valueOf(key);
                 switch (type) {
@@ -215,7 +220,8 @@ class GlassViewEventHandler extends View.EventHandler {
                             }
                         }
                         if (scene.sceneListener != null) {
-                            scene.sceneListener.keyEvent(keyEvent);
+                            if (scene.sceneListener.keyEvent(keyEvent))
+                                consumed = Boolean.TRUE;
                         }
                         break;
                     default:
@@ -231,13 +237,13 @@ class GlassViewEventHandler extends View.EventHandler {
                     PulseLogger.newInput(null);
                 }
             }
-            return null;
+            return consumed;
         }
     }
 
     @SuppressWarnings("removal")
-    @Override public void handleKeyEvent(View view, long time, int type, int key,
-                                         char[] chars, int modifiers)
+    @Override public boolean handleKeyEvent(View view, long time, int type, int key,
+                                            char[] chars, int modifiers, int hardwareCode)
     {
         keyNotification.view = view;
         keyNotification.time = time;
@@ -245,8 +251,9 @@ class GlassViewEventHandler extends View.EventHandler {
         keyNotification.key = key;
         keyNotification.chars = chars;
         keyNotification.modifiers = modifiers;
+        keyNotification.hardwareCode = hardwareCode;
 
-        QuantumToolkit.runWithoutRenderLock(() -> {
+        return QuantumToolkit.runWithoutRenderLock(() -> {
             return AccessController.doPrivileged(keyNotification, scene.getAccessControlContext());
         });
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
@@ -165,7 +165,6 @@ class GlassViewEventHandler extends View.EventHandler {
                 PulseLogger.newInput(keyEventType(type).toString());
             }
             WindowStage stage = scene.getWindowStage();
-            Boolean consumed = Boolean.FALSE;
 
             try {
                 boolean shiftDown = (modifiers & KeyEvent.MODIFIER_SHIFT) != 0;
@@ -221,7 +220,7 @@ class GlassViewEventHandler extends View.EventHandler {
                         }
                         if (scene.sceneListener != null) {
                             if (scene.sceneListener.keyEvent(keyEvent))
-                                consumed = Boolean.TRUE;
+                                return Boolean.TRUE;
                         }
                         break;
                     default:
@@ -237,7 +236,7 @@ class GlassViewEventHandler extends View.EventHandler {
                     PulseLogger.newInput(null);
                 }
             }
-            return consumed;
+            return Boolean.FALSE;
         }
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
@@ -95,6 +95,7 @@ import com.sun.javafx.geom.transform.BaseTransform;
 import com.sun.javafx.perf.PerformanceTracker;
 import com.sun.javafx.runtime.async.AbstractRemoteResource;
 import com.sun.javafx.runtime.async.AsyncOperationListener;
+import com.sun.javafx.scene.input.KeyEventHelper;
 import com.sun.javafx.scene.text.TextLayoutFactory;
 import com.sun.javafx.sg.prism.NGNode;
 import com.sun.javafx.tk.CompletionListener;
@@ -1084,6 +1085,20 @@ public final class QuantumToolkit extends Toolkit {
                 ? com.sun.glass.events.KeyEvent.getKeyCodeForChar(
                           character.charAt(0))
                 : com.sun.glass.events.KeyEvent.VK_UNDEFINED;
+    }
+
+    // The Quantum version of this call knows that we may have the hardware key code
+    // available.
+    @Override public boolean getKeyCanGenerateCharacter(KeyEvent keyEvent, String character) {
+        int hardwareCode = KeyEventHelper.getHardwareCode(keyEvent);
+        if (keyEvent.getCode() != KeyCode.UNDEFINED || hardwareCode != -1) {
+            if (character.length() == 1)
+                return Application.GetApplication().getKeyCanGenerateCharacter(
+                    hardwareCode,
+                    keyEvent.getCode().getCode(),
+                    character.charAt(0));
+        }
+        return false;
     }
 
     @Override public PathElement[] convertShapeToFXPath(Object shape) {

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
@@ -1089,11 +1089,11 @@ public final class QuantumToolkit extends Toolkit {
 
     // The Quantum version of this call knows that we may have the hardware key code
     // available.
-    @Override public boolean getKeyCanGenerateCharacter(KeyEvent keyEvent, String character) {
+    @Override public boolean canKeyGenerateCharacter(KeyEvent keyEvent, String character) {
         int hardwareCode = KeyEventHelper.getHardwareCode(keyEvent);
         if (keyEvent.getCode() != KeyCode.UNDEFINED || hardwareCode != -1) {
             if (character.length() == 1)
-                return Application.GetApplication().getKeyCanGenerateCharacter(
+                return Application.GetApplication().canKeyGenerateCharacter(
                     hardwareCode,
                     keyEvent.getCode().getCode(),
                     character.charAt(0));

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,6 +35,7 @@ import com.sun.javafx.collections.TrackableObservableList;
 import com.sun.javafx.css.StyleManager;
 import com.sun.javafx.cursor.CursorFrame;
 import com.sun.javafx.event.EventQueue;
+import com.sun.javafx.event.EventUtil;
 import com.sun.javafx.geom.PickRay;
 import com.sun.javafx.geom.Vec3d;
 import com.sun.javafx.geom.transform.BaseTransform;
@@ -397,8 +398,8 @@ public class Scene implements EventTarget {
                         }
 
                         @Override
-                        public void processKeyEvent(Scene scene, KeyEvent e) {
-                            scene.processKeyEvent(e);
+                        public boolean processKeyEvent(Scene scene, KeyEvent e) {
+                            return scene.processKeyEvent(e);
                         }
 
                         @Override
@@ -2178,7 +2179,10 @@ public class Scene implements EventTarget {
         traverse(node, Direction.NEXT, TraversalMethod.DEFAULT);
     }
 
-    void processKeyEvent(KeyEvent e) {
+    /**
+     * @return true iff the event was consumed
+     */
+    boolean processKeyEvent(KeyEvent e) {
         if (dndGesture != null) {
             if (!dndGesture.processKey(e)) {
                 dndGesture = null;
@@ -2191,7 +2195,7 @@ public class Scene implements EventTarget {
 
         // send the key event to the current focus owner or to scene if
         // the focus owner is not set
-        Event.fireEvent(eventTarget, e);
+        return EventUtil.fireEvent(eventTarget, e) == null;
     }
 
     void requestFocus(Node node, boolean focusVisible) {
@@ -2710,9 +2714,9 @@ public class Scene implements EventTarget {
 
 
         @Override
-        public void keyEvent(KeyEvent keyEvent)
+        public boolean keyEvent(KeyEvent keyEvent)
         {
-            processKeyEvent(keyEvent);
+            return processKeyEvent(keyEvent);
         }
 
         @Override

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -2180,7 +2180,7 @@ public class Scene implements EventTarget {
     }
 
     /**
-     * @return true iff the event was consumed
+     * @return {@code true} if the event was consumed
      */
     boolean processKeyEvent(KeyEvent e) {
         if (dndGesture != null) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/KeyCharacterCombination.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/KeyCharacterCombination.java
@@ -110,7 +110,7 @@ public final class KeyCharacterCombination extends KeyCombination {
     @Override
     public boolean match(final KeyEvent event) {
         return (super.match(event) &&
-                Toolkit.getToolkit().getKeyCanGenerateCharacter(event, getCharacter()));
+                Toolkit.getToolkit().canKeyGenerateCharacter(event, getCharacter()));
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/KeyCharacterCombination.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/KeyCharacterCombination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,12 +109,8 @@ public final class KeyCharacterCombination extends KeyCombination {
      */
     @Override
     public boolean match(final KeyEvent event) {
-        if (event.getCode() == KeyCode.UNDEFINED) {
-            return false;
-        }
-        return (event.getCode().getCode()
-                       == Toolkit.getToolkit().getKeyCodeForChar(getCharacter()))
-                   && super.match(event);
+        return (super.match(event) &&
+                Toolkit.getToolkit().getKeyCanGenerateCharacter(event, getCharacter()));
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/KeyEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/KeyEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@
 package javafx.scene.input;
 
 import com.sun.javafx.tk.Toolkit;
+import com.sun.javafx.scene.input.KeyEventHelper;
+
 import javafx.beans.NamedArg;
 import javafx.event.EventTarget;
 import javafx.event.EventType;
@@ -134,6 +136,7 @@ public final class KeyEvent extends InputEvent {
         this.controlDown = controlDown;
         this.altDown = altDown;
         this.metaDown = metaDown;
+        this.hardwareCode = -1;
     }
 
     /**
@@ -162,6 +165,7 @@ public final class KeyEvent extends InputEvent {
         this.controlDown = controlDown;
         this.altDown = altDown;
         this.metaDown = metaDown;
+        this.hardwareCode = -1;
     }
 
     /**
@@ -378,6 +382,32 @@ public final class KeyEvent extends InputEvent {
         return (EventType<KeyEvent>) super.getEventType();
     }
 
+    /**
+     * The hardware key code which is private to the implementation.
+     */
+    private int hardwareCode;
 
+    int getHardwareCode() {
+        return hardwareCode;
+    }
 
+    void setHardwareCode(int newCode) {
+        hardwareCode = newCode;
+    }
+
+    static {
+        KeyEventHelper.setKeyEventAccessor(
+            new KeyEventHelper.KeyEventAccessor() {
+                @Override
+                public void setHardwareCode(KeyEvent keyEvent, int hardwareCode) {
+                    keyEvent.setHardwareCode(hardwareCode);
+                }
+
+                @Override
+                public int getHardwareCode(KeyEvent keyEvent) {
+                    return keyEvent.getHardwareCode();
+                }
+            }
+        );
+    }
 }

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassView.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassView.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -171,8 +171,8 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_win_WinView__1initIDs
     ASSERT(javaIDs.View.notifyRepaint);
     if (env->ExceptionCheck()) return;
 
-     javaIDs.View.notifyKey = env->GetMethodID(cls, "notifyKey", "(II[CI)V");
-     ASSERT(javaIDs.View.notifyKey);
+     javaIDs.View.notifyKeyEx = env->GetMethodID(cls, "notifyKeyEx", "(II[CII)Z");
+     ASSERT(javaIDs.View.notifyKeyEx);
      if (env->ExceptionCheck()) return;
 
      javaIDs.View.notifyMouse = env->GetMethodID(cls, "notifyMouse", "(IIIIIIIZZ)V");

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassView.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassView.cpp
@@ -171,8 +171,8 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_win_WinView__1initIDs
     ASSERT(javaIDs.View.notifyRepaint);
     if (env->ExceptionCheck()) return;
 
-     javaIDs.View.notifyKeyEx = env->GetMethodID(cls, "notifyKeyEx", "(II[CII)Z");
-     ASSERT(javaIDs.View.notifyKeyEx);
+     javaIDs.View.notifyKey = env->GetMethodID(cls, "notifyKey", "(II[CII)Z");
+     ASSERT(javaIDs.View.notifyKey);
      if (env->ExceptionCheck()) return;
 
      javaIDs.View.notifyMouse = env->GetMethodID(cls, "notifyMouse", "(IIIIIIIZZ)V");

--- a/modules/javafx.graphics/src/main/native-glass/win/KeyTable.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/KeyTable.cpp
@@ -344,10 +344,10 @@ BOOL IsExtendedKey(UINT vkey) {
 
 /*
  * Class:     com_sun_glass_ui_win_WinApplication
- * Method:    _getKeyCanGenerateCharacter
+ * Method:    _canKeyGenerateCharacter
  * Signature: (IIC)Z
  */
-JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_win_WinApplication__1getKeyCanGenerateCharacter
+JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_win_WinApplication__1canKeyGenerateCharacter
   (JNIEnv *env, jobject jApplication, jint hardwareCode, jint vkCode, jchar character)
 {
     HKL layout = ::GetKeyboardLayout(GlassApplication::GetMainThreadId());

--- a/modules/javafx.graphics/src/main/native-glass/win/Utils.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/Utils.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -447,7 +447,7 @@ typedef struct _tagJavaIDs {
     struct {
         jmethodID notifyResize;
         jmethodID notifyRepaint;
-        jmethodID notifyKey;
+        jmethodID notifyKeyEx;
         jmethodID notifyMouse;
         jmethodID notifyMenu;
         jmethodID notifyScroll;

--- a/modules/javafx.graphics/src/main/native-glass/win/Utils.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/Utils.h
@@ -447,7 +447,7 @@ typedef struct _tagJavaIDs {
     struct {
         jmethodID notifyResize;
         jmethodID notifyRepaint;
-        jmethodID notifyKeyEx;
+        jmethodID notifyKey;
         jmethodID notifyMouse;
         jmethodID notifyMenu;
         jmethodID notifyScroll;

--- a/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
@@ -469,14 +469,14 @@ void ViewContainer::HandleViewKeyEvent(HWND hwnd, UINT msg, WPARAM wParam, LPARA
         {
             // MS Windows doesn't send WM_KEYDOWN for the PrintScreen key,
             // so we synthesize one
-            env->CallBooleanMethod(GetView(), javaIDs.View.notifyKeyEx,
+            env->CallBooleanMethod(GetView(), javaIDs.View.notifyKey,
                     com_sun_glass_events_KeyEvent_PRESS,
                     jKeyCode, jKeyChars, jModifiers, jint(wKey));
             CheckAndClearException(env);
         }
 
         if (GetGlassView()) {
-            env->CallBooleanMethod(GetView(), javaIDs.View.notifyKeyEx,
+            env->CallBooleanMethod(GetView(), javaIDs.View.notifyKey,
                     (msg == WM_KEYDOWN || msg == WM_SYSKEYDOWN) ?
                     com_sun_glass_events_KeyEvent_PRESS : com_sun_glass_events_KeyEvent_RELEASE,
                     jKeyCode, jKeyChars, jModifiers, jint(wKey));
@@ -513,7 +513,7 @@ void ViewContainer::SendViewTypedEvent(int repCount, jchar wChar)
             }
             env->ReleaseCharArrayElements(jKeyChars, nKeyChars, 0);
 
-            env->CallBooleanMethod(GetView(), javaIDs.View.notifyKeyEx,
+            env->CallBooleanMethod(GetView(), javaIDs.View.notifyKey,
                                 com_sun_glass_events_KeyEvent_TYPED,
                                 com_sun_glass_events_KeyEvent_VK_UNDEFINED, jKeyChars,
                                 GetModifiers(), -1);

--- a/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
@@ -469,17 +469,17 @@ void ViewContainer::HandleViewKeyEvent(HWND hwnd, UINT msg, WPARAM wParam, LPARA
         {
             // MS Windows doesn't send WM_KEYDOWN for the PrintScreen key,
             // so we synthesize one
-            env->CallVoidMethod(GetView(), javaIDs.View.notifyKey,
+            env->CallBooleanMethod(GetView(), javaIDs.View.notifyKeyEx,
                     com_sun_glass_events_KeyEvent_PRESS,
-                    jKeyCode, jKeyChars, jModifiers);
+                    jKeyCode, jKeyChars, jModifiers, jint(wKey));
             CheckAndClearException(env);
         }
 
         if (GetGlassView()) {
-            env->CallVoidMethod(GetView(), javaIDs.View.notifyKey,
+            env->CallBooleanMethod(GetView(), javaIDs.View.notifyKeyEx,
                     (msg == WM_KEYDOWN || msg == WM_SYSKEYDOWN) ?
                     com_sun_glass_events_KeyEvent_PRESS : com_sun_glass_events_KeyEvent_RELEASE,
-                    jKeyCode, jKeyChars, jModifiers);
+                    jKeyCode, jKeyChars, jModifiers, jint(wKey));
             CheckAndClearException(env);
         }
 
@@ -513,10 +513,10 @@ void ViewContainer::SendViewTypedEvent(int repCount, jchar wChar)
             }
             env->ReleaseCharArrayElements(jKeyChars, nKeyChars, 0);
 
-            env->CallVoidMethod(GetView(), javaIDs.View.notifyKey,
+            env->CallBooleanMethod(GetView(), javaIDs.View.notifyKeyEx,
                                 com_sun_glass_events_KeyEvent_TYPED,
                                 com_sun_glass_events_KeyEvent_VK_UNDEFINED, jKeyChars,
-                                GetModifiers());
+                                GetModifiers(), -1);
             CheckAndClearException(env);
         }
         env->DeleteLocalRef(jKeyChars);

--- a/tests/manual/events/.classpath
+++ b/tests/manual/events/.classpath
@@ -5,6 +5,11 @@
 			<attribute name="module" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry combineaccessrules="false" kind="src" path="/controls">
+		<attributes>
+			<attribute name="module" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry combineaccessrules="false" kind="src" path="/graphics">
 		<attributes>
 			<attribute name="module" value="true"/>

--- a/tests/manual/events/KeyboardTest.java
+++ b/tests/manual/events/KeyboardTest.java
@@ -1,0 +1,855 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.ArrayList;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Timer;
+import java.util.TimerTask;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.event.EventHandler;
+import javafx.geometry.Insets;
+import javafx.scene.Node;
+import javafx.scene.control.Button;
+import javafx.scene.control.ChoiceBox;
+import javafx.scene.control.TextArea;
+import javafx.scene.input.KeyCharacterCombination;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.VBox;
+import javafx.scene.robot.Robot;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+
+/*
+ * This application tests key event handling in JavaFX. Each test uses a Robot
+ * to send platform key events and then verifies that the correct JavaFX
+ * KeyEvents are generated.
+ *
+ * To provide thorough coverage a test has to be targeted at a specific layout.
+ * Currently there are tests for U.S. (QWERTY), French (AZERTY), German (QWERTZ)
+ * and Spanish (QWERTY) on Mac, Windows, and Linux. Since there's no way for
+ * JavaFX to force the layout or verify which layout is currently active it is
+ * up to the tester to configure the correct layout before running the test.
+ *
+ * Each language-specific test must be run against the default layout for that
+ * language. For example, the German test is designed to work with the layout
+ * labeled "German" on a Mac, not "German - Standard" or any other variant.
+ *
+ * There is also a generic test for Latin layouts which verifies that KeyCodes A
+ * through Z are reachable and generate the letters 'a' through 'z'. An even
+ * more generic test is available for non-Latin, non-IME layouts which verifies
+ * that KeyCodes A through Z generate characters.
+ *
+ * None of these tests cover the top-row function keys or the Caps Lock key.
+ * They also do not cover dead keys or keys which generate accented characters
+ * (the latter don't have KeyCodes so the Robot cannot access them).
+ *
+ * These tests always check that the given KeyCode generates the expected
+ * character (if any). They can optionally check that KeyCharacterCombinations
+ * match for characters on that key. This option is disabled by default since
+ * KeyCharacterCombinations don't work reliably on most platforms (for now).
+ *
+ * Mac users will need to grant permission for the Terminal application to use
+ * accessibility features. Add Terminal to the list of applications in
+ * System Settings > Privacy & Security > Accessibility.
+ */
+
+public class KeyboardTest extends Application {
+
+    public static void main(String[] args) {
+        Application.launch(args);
+    }
+
+    private static final String os = System.getProperty("os.name");
+    private static final boolean onMac = os.startsWith("Mac");
+    private static final boolean onLinux = os.startsWith("Linux");
+    private static final boolean onWindows = os.startsWith("Windows");
+
+    /**
+     * Data for testing one key including the code and expected character.
+     */
+    static private class KeyData {
+        /*
+         * If character is null it means we don't expect a TYPED event. If
+         * character is "wild" it means we'll accept anything (used for testing
+         * non-Latin layouts).
+         */
+        public final KeyCode   code;
+        public final String    character;
+
+        /*
+         * Optional characters on this key accessed using modifiers like Shift,
+         * Option, or AltGr.
+         */
+        public String          comboChar;
+        public String          comboChar2;
+
+        /*
+         * We also test a handful of KeyCodes which should not generate any
+         * events, like UNDEFINED. For these we set the absent flag.
+         */
+        public boolean         absent;
+
+        public KeyData(KeyCode cd, String ch, String combo1, String combo2) {
+            code = cd;
+            character = ch;
+            comboChar = combo1;
+            comboChar2 = combo2;
+            absent = false;
+        }
+    }
+
+    /**
+     * List of keys to test for one layout
+     */
+    @SuppressWarnings("serial")
+    static private class KeyList extends ArrayList<KeyData> {}
+
+    static private class KeyListBuilder {
+
+        private final KeyList list = new KeyList();
+        public final KeyList getList() {
+            return list;
+        }
+
+        private static final String DOUBLE_QUOTE = "\"";
+        private static final String QUOTE        = "\'";
+        private static final String BACK_SLASH   = "\\";
+        private static final String A_GRAVE      = "\u00E0";
+        private static final String E_GRAVE      = "\u00E8";
+        private static final String E_ACUTE      = "\u00E9";
+        private static final String SECTION      = "\u00A7";
+        private static final String C_CEDILLA    = "\u00E7";
+        private static final String DEGREE_SIGN  = "\u00B0";
+        private static final String POUND_SIGN   = "\u00A3";
+        private static final String MIDDLE_DOT   = "\u00B7";
+        private static final String INV_EXCLAMATION_MARK = "\u00A1";
+        private static final String INV_QUESTION_MARK    = "\u00BF";
+
+        /* Add a key with unshifted and shifted characters */
+        private void add(KeyCode cd, String base, String shifted) {
+            list.add(new KeyData(cd, base, shifted, null));
+        }
+
+        /* Add a key with an unshifted character */
+        private void add(KeyCode cd, String base) {
+            list.add(new KeyData(cd, base, null, null));
+        }
+
+        /* Add a key that does not generate a TYPED event */
+        private void add(KeyCode cd) {
+            list.add(new KeyData(cd, null, null, null));
+        }
+
+        /* Add a key with unshifted, shifted, and AltGr/Option characters */
+        private void add(KeyCode cd, String base, String shifted, String altGr) {
+            list.add(new KeyData(cd, base, shifted, altGr));
+        }
+
+        /* Add a key that should not generate any events */
+        public void addAbsent(KeyCode cd) {
+            KeyData missing = new KeyData(cd, null, null, null);
+            missing.absent = true;
+            list.add(missing);
+        }
+
+        /*
+         * Add keys A through Z assuming they generate 'a' through 'z' unshifted
+         * and 'A' to 'Z' shifted
+         */
+        private void addLetters() {
+            for (Character c = 'A'; c <= 'Z'; ++c) {
+                String s = String.valueOf(c);
+                KeyCode code = KeyCode.valueOf(s);
+                add(code, s.toLowerCase(Locale.ENGLISH), s);
+            }
+        }
+
+        private void addDigits() {
+            add(KeyCode.DIGIT0, "0");
+            add(KeyCode.DIGIT1, "1");
+            add(KeyCode.DIGIT2, "2");
+            add(KeyCode.DIGIT3, "3");
+            add(KeyCode.DIGIT4, "4");
+            add(KeyCode.DIGIT5, "5");
+            add(KeyCode.DIGIT6, "6");
+            add(KeyCode.DIGIT7, "7");
+            add(KeyCode.DIGIT8, "8");
+            add(KeyCode.DIGIT9, "9");
+        }
+
+        private void addKeypad() {
+            add(KeyCode.NUMPAD0,  "0");
+            add(KeyCode.NUMPAD1,  "1");
+            add(KeyCode.NUMPAD2,  "2");
+            add(KeyCode.NUMPAD3,  "3");
+            add(KeyCode.NUMPAD4,  "4");
+            add(KeyCode.NUMPAD5,  "5");
+            add(KeyCode.NUMPAD6,  "6");
+            add(KeyCode.NUMPAD7,  "7");
+            add(KeyCode.NUMPAD8,  "8");
+            add(KeyCode.NUMPAD9,  "9");
+            add(KeyCode.ADD,      "+");
+            add(KeyCode.SUBTRACT, "-");
+            add(KeyCode.MULTIPLY, "*");
+            add(KeyCode.DIVIDE,   "/");
+            if (onMac) {
+                add(KeyCode.CLEAR, "");
+            }
+            /*
+             * We do not add DECIMAL since the character it generates varies by
+             * platform and language. It will be added later.
+             */
+        }
+
+        private void addNavigation() {
+            add(KeyCode.HOME);
+            add(KeyCode.END);
+            add(KeyCode.PAGE_UP);
+            add(KeyCode.PAGE_DOWN);
+            add(KeyCode.UP);
+            add(KeyCode.DOWN);
+            add(KeyCode.LEFT);
+            add(KeyCode.RIGHT);
+        }
+
+        private void addMiscellaneous() {
+            add(KeyCode.SHIFT);
+            add(KeyCode.ALT);
+            add(KeyCode.CONTROL);
+
+            add(KeyCode.SPACE, " ");
+            add(KeyCode.TAB,   "\t");
+
+            /*
+             * ENTER is assigned to both Return and Enter which generate
+             * different characters.
+             */
+            add(KeyCode.ENTER, "wild");
+
+            if (onMac) {
+                add(KeyCode.COMMAND);
+                add(KeyCode.BACK_SPACE, "");
+                add(KeyCode.DELETE,     "");
+                add(KeyCode.ESCAPE,     "");
+            } else {
+                add(KeyCode.BACK_SPACE, "\u0008");
+                add(KeyCode.DELETE,     "\u007F");
+                add(KeyCode.ESCAPE,     "\u001B");
+                add(KeyCode.INSERT);
+
+                // Sent twice to toggle off and back on
+                add(KeyCode.NUM_LOCK);
+                add(KeyCode.NUM_LOCK);
+            }
+
+            /*
+             * We do not test CAPS. Every platform has special case code for
+             * CAPS that generates multiple PRESSED and RELEASED events in
+             * succession.
+             */
+
+            /*
+             * Clearly this KeyCode should not generate any events.
+             */
+            addAbsent(KeyCode.UNDEFINED);
+        }
+
+        /*
+         * Add all of the keys common to all layouts
+         */
+        private void addCommon() {
+            addKeypad();
+            addNavigation();
+            addMiscellaneous();
+        }
+
+        /*
+         * The U.S. English QWERTY layout. Same on all platforms.
+         */
+        public static KeyList usEnglishKeys() {
+            KeyListBuilder builder = new KeyListBuilder();
+            builder.addCommon();
+            builder.addLetters();
+
+            builder.add(KeyCode.DIGIT0, "0", ")");
+            builder.add(KeyCode.DIGIT1, "1", "!");
+            builder.add(KeyCode.DIGIT2, "2", "@");
+            builder.add(KeyCode.DIGIT3, "3", "#");
+            builder.add(KeyCode.DIGIT4, "4", "$");
+            builder.add(KeyCode.DIGIT5, "5", "%");
+            builder.add(KeyCode.DIGIT6, "6", "^");
+            builder.add(KeyCode.DIGIT7, "7", "&");
+            builder.add(KeyCode.DIGIT8, "8", "*");
+            builder.add(KeyCode.DIGIT9, "9", "(");
+
+            builder.add(KeyCode.BACK_QUOTE,    "`",  "~");
+            builder.add(KeyCode.MINUS,         "-",  "_");
+            builder.add(KeyCode.EQUALS,        "=",  "+");
+            builder.add(KeyCode.OPEN_BRACKET,  "[",  "{");
+            builder.add(KeyCode.CLOSE_BRACKET, "]",  "}");
+            builder.add(KeyCode.BACK_SLASH,    BACK_SLASH, "|");
+            builder.add(KeyCode.SEMICOLON,     ";",  ":");
+            builder.add(KeyCode.QUOTE,         QUOTE, DOUBLE_QUOTE);
+            builder.add(KeyCode.COMMA,         ",",  "<");
+            builder.add(KeyCode.PERIOD,        ".",  ">");
+            builder.add(KeyCode.SLASH,         "/",  "?");
+
+            builder.add(KeyCode.DECIMAL,       ".");
+
+            builder.addAbsent(KeyCode.PLUS);
+
+            return builder.getList();
+        }
+
+        /* The French AZERTY layout */
+        public static KeyList frenchKeys() {
+            KeyListBuilder builder = new KeyListBuilder();
+            builder.addCommon();
+            builder.addLetters();
+
+            /* Include one combination that involves AltGr/Option. */
+            final String altGrFive = (onMac ? "{" : "[");
+
+            /*
+             * On a French layout the unshifted top-row keys (which generate
+             * digits in most other languages) generate punctuation or accented
+             * characters. Linux uses these characters to generate KeyCodes; Mac
+             * and Windows still encode these keys as digits.
+             */
+            if (onLinux) {
+                builder.add(KeyCode.AMPERSAND,        "&",          "1");
+                builder.add(KeyCode.QUOTEDBL,         DOUBLE_QUOTE, "3");
+                builder.add(KeyCode.QUOTE,            QUOTE,        "4");
+                builder.add(KeyCode.LEFT_PARENTHESIS, "(",          "5", altGrFive);
+                builder.add(KeyCode.MINUS,            "-",          "6");
+                builder.add(KeyCode.UNDERSCORE,       "_",          "8");
+            } else {
+                builder.add(KeyCode.DIGIT0, A_GRAVE,      "0");
+                builder.add(KeyCode.DIGIT1, "&",          "1");
+                builder.add(KeyCode.DIGIT2, E_ACUTE,      "2");
+                builder.add(KeyCode.DIGIT3, DOUBLE_QUOTE, "3");
+                builder.add(KeyCode.DIGIT4, QUOTE,        "4");
+                builder.add(KeyCode.DIGIT5, "(",          "5", altGrFive);
+                /* Six and eight require some tweaking, below */
+                builder.add(KeyCode.DIGIT7, E_GRAVE,      "7");
+                builder.add(KeyCode.DIGIT9, C_CEDILLA,    "9");
+
+                if (onMac) {
+                    builder.add(KeyCode.DIGIT6, SECTION,  "6");
+                    builder.add(KeyCode.DIGIT8, "!",      "8");
+                } else {
+                    builder.add(KeyCode.DIGIT6, "-",      "6");
+                    builder.add(KeyCode.DIGIT8, "_",      "8");
+                }
+            }
+
+            builder.add(KeyCode.LESS,              "<", ">");
+            builder.add(KeyCode.RIGHT_PARENTHESIS, ")", DEGREE_SIGN);
+            builder.add(KeyCode.COMMA,             ",", "?");
+            builder.add(KeyCode.SEMICOLON,         ";", ".");
+            builder.add(KeyCode.COLON,             ":", "/");
+            builder.add(KeyCode.EQUALS,            "=", "+");
+
+            if (onMac) {
+                builder.add(KeyCode.DOLLAR,        "$", "*");
+                builder.add(KeyCode.MINUS,         "-", "_");
+                builder.add(KeyCode.DECIMAL,       ",");
+            } else {
+                builder.add(KeyCode.DOLLAR,           "$", POUND_SIGN);
+                builder.add(KeyCode.EXCLAMATION_MARK, "!", SECTION);
+                builder.add(KeyCode.DECIMAL,          ".");
+            }
+
+            builder.addAbsent(KeyCode.PLUS);
+
+            return builder.getList();
+        }
+
+        /* The German QWERTZ layout */
+        public static KeyList germanKeys() {
+            KeyListBuilder builder = new KeyListBuilder();
+            builder.addCommon();
+            builder.addLetters();
+
+            /* Include one combination that involves Option/AltGr */
+            final String altGrSeven = (onMac ? "|" : "{");
+            final String decimalCharacter = (onLinux ? "." : ",");
+
+            builder.add(KeyCode.DIGIT0, "0", "=");
+            builder.add(KeyCode.DIGIT1, "1", "!");
+            builder.add(KeyCode.DIGIT2, "2", DOUBLE_QUOTE);
+            builder.add(KeyCode.DIGIT3, "3", SECTION);
+            builder.add(KeyCode.DIGIT4, "4", "$");
+            builder.add(KeyCode.DIGIT5, "5", "%");
+            builder.add(KeyCode.DIGIT6, "6", "&");
+            builder.add(KeyCode.DIGIT7, "7", "/", altGrSeven);
+            builder.add(KeyCode.DIGIT8, "8", "(");
+            builder.add(KeyCode.DIGIT9, "9", ")");
+
+            builder.add(KeyCode.LESS,        "<", ">");
+            builder.add(KeyCode.PLUS,        "+", "*");
+            builder.add(KeyCode.NUMBER_SIGN, "#", QUOTE);
+            builder.add(KeyCode.COMMA,       ",", ";");
+            builder.add(KeyCode.PERIOD,      ".", ":");
+            builder.add(KeyCode.MINUS,       "-", "_");
+
+            builder.add(KeyCode.DECIMAL,     decimalCharacter);
+
+            builder.addAbsent(KeyCode.COLON);
+
+            return builder.getList();
+        }
+
+        /* Spanish QWERTY */
+        public static KeyList spanishKeys() {
+            KeyListBuilder builder = new KeyListBuilder();
+            builder.addCommon();
+            builder.addLetters();
+
+            final String decimalCharacter = (onMac ? "," : ".");
+
+            builder.add(KeyCode.DIGIT0, "0", "=");
+            builder.add(KeyCode.DIGIT1, "1", "!");
+            builder.add(KeyCode.DIGIT2, "2", DOUBLE_QUOTE);
+            builder.add(KeyCode.DIGIT3, "3", MIDDLE_DOT);
+            builder.add(KeyCode.DIGIT4, "4", "$");
+            builder.add(KeyCode.DIGIT5, "5", "%");
+            builder.add(KeyCode.DIGIT6, "6", "&");
+            builder.add(KeyCode.DIGIT7, "7", "/");
+            builder.add(KeyCode.DIGIT8, "8", "(");
+            builder.add(KeyCode.DIGIT9, "9", ")");
+
+            builder.add(KeyCode.QUOTE,        QUOTE, "?");
+            builder.add(KeyCode.INVERTED_EXCLAMATION_MARK, INV_EXCLAMATION_MARK, INV_QUESTION_MARK);
+            builder.add(KeyCode.PLUS,         "+", "*", "]");
+            builder.add(KeyCode.LESS,         "<", ">");
+            builder.add(KeyCode.COMMA,        ",", ";");
+            builder.add(KeyCode.PERIOD,       ".", ":");
+            builder.add(KeyCode.MINUS,        "-", "_");
+
+            builder.add(KeyCode.DECIMAL,      decimalCharacter);
+
+            builder.addAbsent(KeyCode.EQUALS);
+
+            return builder.getList();
+        }
+
+        /*
+         * A generic Latin layout. No digits since layouts derived from French
+         * won't generate digit characters and may not even be encoded as digits
+         * on Linux.
+         */
+        public static KeyList latinKeys() {
+            KeyListBuilder builder = new KeyListBuilder();
+            builder.addCommon();
+            builder.addLetters();
+            return builder.getList();
+        }
+
+        /*
+         * For non-Latin layouts that do not use an IME (Greek, Cyrillic) we
+         * should be able to access the letter KeyCodes though we have no idea
+         * what characters they generate.
+         */
+        public static KeyList nonLatinKeys() {
+            KeyListBuilder builder = new KeyListBuilder();
+            builder.addCommon();
+            builder.addDigits();
+            for (Character c = 'A'; c <= 'Z'; ++c) {
+                String s = String.valueOf(c);
+                KeyCode code = KeyCode.valueOf(s);
+                builder.add(code, "wild");
+            }
+            return builder.getList();
+        }
+    }
+
+    private enum Layout {
+        US_ENGLISH("U.S. English", KeyListBuilder.usEnglishKeys()),
+        FRENCH("French", KeyListBuilder.frenchKeys()),
+        GERMAN("German", KeyListBuilder.germanKeys()),
+        SPANISH("Spanish", KeyListBuilder.spanishKeys()),
+        LATIN("Latin", KeyListBuilder.latinKeys()),
+        NON_LATIN("non-Latin", KeyListBuilder.nonLatinKeys());
+
+        private final String label;
+        private final KeyList keys;
+
+        private Layout(String l, KeyList k) {
+            this.label = l;
+            this.keys = k;
+        }
+
+        public String toString() {
+            return label;
+        }
+
+        public KeyList getKeys() {
+            return keys;
+        }
+    }
+
+    /*
+     * KeyCharacterCombinations should really work on the numeric keypad but
+     * currently don't on Windows and Linux. The tests can exclude combinations
+     * entirely, exclude just the numeric keypad, or cover both the main
+     * keyboard and the keypad.
+     */
+    private enum CombinationScope {
+        NONE("without combinations"),
+        NO_KEYPAD("without keypad combinations"),
+        ALL("with all combinations");
+
+        private final String label;
+
+        private CombinationScope(String l) {
+            this.label = l;
+        }
+
+        public String toString() {
+            return label;
+        }
+    }
+
+    private interface Logging {
+        public void clear();
+        public void addLine(String s);
+    }
+
+    /*
+     * The class that walks through the key list sending Robot events and
+     * verifies the expected KeyEvents come back.
+     */
+    private class TestRunner {
+
+        /*
+         * Configured during initialization
+         */
+        private final Layout layout;
+        private final CombinationScope combinationScope;
+        private final Node focusNode;
+        private final Logging log;
+        private final KeyList keys;
+
+        /*
+         * Our progress
+         */
+        private int currentIndex = -1;
+        private int numSent = 0;
+        private int numFailed = 0;
+
+        /* The character in the last TYPED event */
+        private String characterReceived = null;
+
+        private final Robot robot = new Robot();
+        private Timer timer = null;
+
+        private final EventHandler<KeyEvent> pressedHandler = this::pressedEvent;
+        private final EventHandler<KeyEvent> releasedHandler = this::releasedEvent;
+        private final EventHandler<KeyEvent> typedHandler = this::typedEvent;
+
+        private Runnable runAtEnd = null;
+
+        public TestRunner(Layout layout, CombinationScope scope,
+                          Node focusNode, Logging log) {
+            this.layout = layout;
+            this.combinationScope = scope;
+            this.focusNode = focusNode;
+            this.log = log;
+            this.keys = layout.getKeys();
+        }
+
+        private String toPrintable(String s) {
+            if (s == null) {
+                return "null";
+            } else if (!s.isEmpty()) {
+                char c = s.charAt(0);
+                int codePoint = s.codePointAt(0);
+                if (Character.isISOControl(c) || Character.isWhitespace(c)) {
+                    return String.format("U+%04X", codePoint);
+                } else {
+                    return s;
+                }
+            }
+            return "empty";
+        }
+
+        private void fail(String s) {
+            numFailed += 1;
+            log.addLine("Failed: " + s);
+        }
+
+        private void start(Runnable atEnd) {
+            runAtEnd = atEnd;
+
+            log.clear();
+
+            Optional<Boolean> capsLockOn = Platform.isKeyLocked(KeyCode.CAPS);
+            Optional<Boolean> numLockOn = Platform.isKeyLocked(KeyCode.NUM_LOCK);
+            boolean proceed = true;
+            if (capsLockOn.isPresent() && capsLockOn.get() == Boolean.TRUE) {
+                log.addLine("Disable Caps Lock before running test.");
+                proceed = false;
+            }
+            if (numLockOn.isPresent() && numLockOn.get() == Boolean.FALSE) {
+                log.addLine("Enable Num Lock before running test.");
+                proceed = false;
+            }
+            if (!proceed) {
+                if (runAtEnd != null) {
+                    runAtEnd.run();
+                }
+                return;
+            }
+
+            String osName = "unknown";
+            if (onWindows) {
+                osName = "Win";
+            } else if (onMac) {
+                osName = "Mac";
+            } else if (onLinux) {
+                osName = "Linux";
+            }
+
+            log.addLine("[" + osName + "] Testing " + keys.size() + " keys on "
+                    + layout + " " + combinationScope);
+
+            focusNode.addEventFilter(KeyEvent.KEY_PRESSED, pressedHandler);
+            focusNode.addEventFilter(KeyEvent.KEY_RELEASED, releasedHandler);
+            focusNode.addEventFilter(KeyEvent.KEY_TYPED, typedHandler);
+            focusNode.requestFocus();
+
+            currentIndex = -1;
+            advance();
+        }
+
+        private void advance() {
+            if (timer != null) {
+                timer.cancel();
+                timer = null;
+            }
+            currentIndex += 1;
+            if (currentIndex >= keys.size()) {
+                cleanup();
+            } else {
+                characterReceived = null;
+                numSent += 1;
+                KeyData data = keys.get(currentIndex);
+                Platform.runLater(() -> sendCode(data.code));
+            }
+        }
+
+        private void sendCode(KeyCode code) {
+            /*
+            * This timer is cleared when the RELEASED event calls advance().
+            */
+            TimerTask task = new TimerTask() {
+                public void run() {
+                    Platform.runLater(() -> keyTimedOut());
+                }
+            };
+            timer = new Timer();
+            timer.schedule(task, 100);
+            robot.keyPress(code);
+            robot.keyRelease(code);
+        }
+
+        /*
+        * No RELEASED event arrived. Acceptable if the key was supposed to be
+        * absent.
+        */
+        private void keyTimedOut() {
+            KeyData key = keys.get(currentIndex);
+            if (!key.absent) {
+                fail("code " + key.code.getName() + " did not produce any events");
+            }
+            advance();
+        }
+
+        private static boolean isOnKeypad(KeyCode code) {
+            switch (code) {
+                case DIVIDE, MULTIPLY, SUBTRACT, ADD, DECIMAL:
+                case NUMPAD0, NUMPAD1, NUMPAD2, NUMPAD3, NUMPAD4:
+                case NUMPAD5, NUMPAD6, NUMPAD7, NUMPAD8, NUMPAD9:
+                    return true;
+            }
+            return false;
+        }
+
+        private void checkCombination(KeyEvent event, String comboString) {
+            if (combinationScope == CombinationScope.NONE) {
+                return;
+            }
+            if (comboString == null || comboString.isEmpty() || comboString.equals("wild")) {
+                return;
+            }
+            if (isOnKeypad(event.getCode()) && (combinationScope != CombinationScope.ALL)) {
+                return;
+            }
+
+            KeyCharacterCombination combo = new KeyCharacterCombination(comboString);
+            if (!combo.match(event)) {
+                fail("code " + event.getCode().getName() + " did not match combination "
+                    + toPrintable(combo.getCharacter()));
+            }
+        }
+
+        private void pressedEvent(KeyEvent e) {
+            KeyData key = keys.get(currentIndex);
+            KeyCode got = e.getCode();
+            KeyCode expected = key.code;
+            String preamble = "code " + key.code.getName() + " ";
+
+            if (key.absent) {
+                fail(preamble + "produced an unexpected PRESSED event");
+            } else if (expected != got) {
+                fail(preamble + "was sent but code " + got.getName() + " was received");
+            } else {
+                checkCombination(e, key.character);
+                checkCombination(e, key.comboChar);
+                checkCombination(e, key.comboChar2);
+            }
+            e.consume();
+        }
+
+        private void typedEvent(KeyEvent e) {
+            KeyData key = keys.get(currentIndex);
+            String preamble = "code " + key.code.getName() + " ";
+            characterReceived = e.getCharacter();
+
+            if (key.character == null) {
+                String printable = toPrintable(characterReceived);
+                fail(preamble + "produced an unexpected TYPED event (" + printable + ")");
+            } else if (key.character.equals("wild")) {
+                if (characterReceived == null || characterReceived.isEmpty()) {
+                    fail(preamble + "produced a TYPED event with no character");
+                }
+            } else if (!key.character.equals(characterReceived)) {
+                fail(preamble + "generated " + toPrintable(characterReceived)
+                    + " instead of " + toPrintable(key.character));
+            }
+            e.consume();
+        }
+
+        private void releasedEvent(KeyEvent e) {
+            KeyData key = keys.get(currentIndex);
+            String preamble = "code " + key.code.getName() + " ";
+
+            if (key.absent) {
+                fail(preamble + "produced an unexpected RELEASED event");
+            } else if ((key.character != null) && (characterReceived == null)) {
+                fail(preamble + "did not produce a TYPED event");
+            }
+            e.consume();
+            advance();
+        }
+
+        /*
+         * Called after the list of keys is exhausted.
+         */
+        private void cleanup() {
+            if (timer != null) {
+                timer.cancel();
+                timer = null;
+            }
+
+            focusNode.removeEventFilter(KeyEvent.KEY_PRESSED, pressedHandler);
+            focusNode.removeEventFilter(KeyEvent.KEY_RELEASED, releasedHandler);
+            focusNode.removeEventFilter(KeyEvent.KEY_TYPED, typedHandler);
+
+            log.addLine("Tested " + numSent + " keys with "
+                    + (numFailed == 1 ? "1 failure" : numFailed + " failures"));
+
+            if (runAtEnd != null) {
+                runAtEnd.run();
+            }
+        }
+    }
+
+    private class TextLogging implements Logging {
+        private final TextArea textArea;
+        public TextLogging(TextArea ta) {
+            textArea = ta;
+        }
+
+        public void clear() {
+            textArea.setText("");
+        }
+
+        public void addLine(String s) {
+            textArea.appendText(s + "\n");
+        }
+    }
+
+    @Override
+    public void start(Stage stage) {
+
+        final TextArea logArea = new TextArea();
+        logArea.setEditable(false);
+        Logging logger = new TextLogging(logArea);
+
+        ChoiceBox<Layout> layoutChoice = new ChoiceBox<>();
+        layoutChoice.getItems().setAll(Layout.values());
+        layoutChoice.setValue(Layout.US_ENGLISH);
+
+        ChoiceBox<CombinationScope> combinationChoice = new ChoiceBox<>();
+        combinationChoice.getItems().setAll(CombinationScope.values());
+        combinationChoice.setValue(CombinationScope.NONE);
+
+        Button testButton = new Button("Run test");
+        testButton.setOnAction(b -> {
+            testButton.setDisable(true);
+            Layout layout = layoutChoice.getValue();
+            CombinationScope comboScope = combinationChoice.getValue();
+            TestRunner testRunner = new TestRunner(layout, comboScope, logArea, logger);
+            testRunner.start(() -> {
+                testButton.setDisable(false);
+                testButton.requestFocus();
+            });
+        });
+
+        HBox testControls = new HBox();
+        testControls.setSpacing(5);
+        testControls.getChildren().addAll(testButton, layoutChoice, combinationChoice);
+
+        VBox root = new VBox();
+        root.setPadding(new Insets(5));
+        root.setSpacing(5);
+        VBox.setVgrow(logArea, Priority.ALWAYS);
+        root.getChildren().addAll(testControls, logArea);
+
+        Scene scene = new Scene(root, 640, 640);
+        stage.setScene(scene);
+        stage.setTitle("Keyboard Test");
+        stage.show();
+
+        Platform.runLater(testButton::requestFocus);
+    }
+}


### PR DESCRIPTION
Note: the Java-side changes in this PR are also in #694 which fixes the same issue (and more) on Linux. Unfortunately the Linux Robot code is not working making it difficult to test on that platform (see #718).

KeyCharacterCombinations allow the specification of accelerators based on characters whose KeyCodes vary across keyboard layouts. For example, the + character is on KeyCode.EQUALS on a U.S. English layout, KeyCode.PLUS on a German layout, and KeyCode.DIGIT1 on a Mac Swiss German layout. KeyCharacterCombinations finds the correct KeyCode by calling `Toolkit.getKeyCodeForChar`.

`getKeyCodeForChar` can only return one KeyCode for a given character so it can't easily handle characters which appear in more than one location, like + which is on the main keyboard and the numeric keypad. It's also reliant on KeyCodes which prevents KeyCharacterCombinations from working on keys with no codes (e.g. the base character contains a diacritic). It also relies on the platform to map from a character to a key which is the reverse of how key mapping normally works making it slow and/or imprecise to implement on Mac and Linux (Windows is the only platform with a system call to do this).

This PR introduces a new way for a platform to pass key information to the Java core. `View.notifyKeyEx` takes an additional platform-specific `hardwareCode` which identifies the key and is tracked in a private field in the KeyEvent. This is opt-in; a platform can continue to call the old `View.notifyKey` method and allow the `hardwareCode` to default to -1.

On the back-end `KeyCharacterCombination.match` calls the new routine `Toolkit.getKeyCanGenerateCharacter` which unpacks the KeyEvent information and sends it on to the Application. This is also opt-in; the default implementation falls back to the Application's `getKeyCodeForChar` call. Platforms which call `View.notifyKeyEx` will be handed the `hardwareCode` for the key in addition to the Java KeyCode.

The new `View.notifyKeyEx` returns a boolean indicating whether the event was consumed or not. This plays no role here but will be used later to fix [JDK-8087863](https://bugs.openjdk.org/browse/JDK-8087863).

For testing I've included the manual KeyboardTest app that also appears in PR #425. Tests with keypad combinations should now work.

Note: this PR only fixes Windows. Fixes for Mac and Linux but can't be submitted until #425 and #718 are integrated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8089373](https://bugs.openjdk.org/browse/JDK-8089373): Translation from character to key code is not sufficient (**Bug** - P4)
 * [JDK-8274967](https://bugs.openjdk.org/browse/JDK-8274967): KeyCharacterCombinations for punctuation and symbols fail on non-US keyboards (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1126/head:pull/1126` \
`$ git checkout pull/1126`

Update a local copy of the PR: \
`$ git checkout pull/1126` \
`$ git pull https://git.openjdk.org/jfx.git pull/1126/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1126`

View PR using the GUI difftool: \
`$ git pr show -t 1126`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1126.diff">https://git.openjdk.org/jfx/pull/1126.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1126#issuecomment-1535142007)