### PR TITLE
8307363: TextFlow.underlineShape()

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/text/TextFlow.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/text/TextFlow.java
@@ -232,7 +232,7 @@ public class TextFlow extends Pane {
     }
 
     /**
-     * Returns underline shape for the range of the text in local coordinates.
+     * Returns the shape for the underline in local coordinates.
      *
      * @param start the beginning character index for the range
      * @param end the end character index (non-inclusive) for the range

--- a/modules/javafx.graphics/src/main/java/javafx/scene/text/TextFlow.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/text/TextFlow.java
@@ -231,6 +231,18 @@ public class TextFlow extends Pane {
         return getRange(start, end, TextLayout.TYPE_TEXT);
     }
 
+    /**
+     * Returns underline shape for the range of the text in local coordinates.
+     *
+     * @param start the beginning character index for the range
+     * @param end the end character index (non-inclusive) for the range
+     * @return an array of {@code PathElement} which can be used to create a {@code Shape}
+     * @since 21
+     */
+    public final PathElement[] underlineShape(int start, int end) {
+        return getRange(start, end, TextLayout.TYPE_UNDERLINE);
+    }
+
     @Override
     public boolean usesMirroring() {
         return false;

--- a/tests/manual/monkey/src/com/oracle/tools/fx/monkey/pages/TextFlowPage.java
+++ b/tests/manual/monkey/src/com/oracle/tools/fx/monkey/pages/TextFlowPage.java
@@ -58,11 +58,13 @@ public class TextFlowPage extends TestPaneBase {
     protected final FontSelector fontSelector;
     protected final CheckBox showChars;
     protected final CheckBox showCaretPath;
+    protected final CheckBox underline;
     protected final TextFlow control;
     protected final Label pickResult;
     protected final Label hitInfo;
     protected final Label hitInfo2;
     protected final Path caretPath;
+    protected final Path underlinePath;
     private static final String INLINE = "$INLINE";
     private static final String RICH_TEXT = "$RICH";
 
@@ -82,6 +84,12 @@ public class TextFlowPage extends TestPaneBase {
         caretPath.setStrokeWidth(1);
         caretPath.setStroke(Color.RED);
         caretPath.setManaged(false);
+
+        underlinePath = new Path();
+        underlinePath.setStrokeWidth(1);
+        underlinePath.setStroke(Color.GREEN);
+        underlinePath.setFill(Color.YELLOW);
+        underlinePath.setManaged(false);
 
         textSelector = TextSelector.fromPairs(
             "textSelector",
@@ -104,7 +112,13 @@ public class TextFlowPage extends TestPaneBase {
         showCaretPath = new CheckBox("show caret path");
         showCaretPath.setId("showCaretPath");
         showCaretPath.selectedProperty().addListener((p) -> {
-            updateControl();
+            updateCaret();
+        });
+        
+        underline = new CheckBox("underline shape");
+        underline.setId("underline");
+        underline.selectedProperty().addListener((p) -> {
+            updateUnderline();
         });
 
         OptionPane p = new OptionPane();
@@ -116,6 +130,7 @@ public class TextFlowPage extends TestPaneBase {
         p.option(fontSelector.sizeNode());
         p.option(showChars);
         p.option(showCaretPath);
+        p.option(underline);
         p.option(new Separator(Orientation.HORIZONTAL));
         p.label("Pick Result:");
         p.option(pickResult);
@@ -142,16 +157,12 @@ public class TextFlowPage extends TestPaneBase {
             control.getChildren().add(g);
         }
 
-        if (showCaretPath.isSelected()) {
-            caretPath.getElements().clear();
-            control.getChildren().add(caretPath);
+        caretPath.getElements().clear();
+        underlinePath.getElements().clear();
+        control.getChildren().addAll(underlinePath, caretPath);
 
-            int len = computeTextLength(control);
-            for (int i = 0; i < len; i++) {
-                PathElement[] es = control.caretShape(i, true);
-                caretPath.getElements().addAll(es);
-            }
-        }
+        updateCaret();
+        updateUnderline();
     }
 
     /** TextFlow.getTextLength() */
@@ -220,5 +231,27 @@ public class TextFlowPage extends TestPaneBase {
         Point2D p = new Point2D(ev.getX(), ev.getY());
         HitInfo h = control.hitTest(p);
         hitInfo.setText(String.valueOf(h));
+    }
+
+    protected void updateUnderline() {
+        if (underline.isSelected()) {
+            int len = computeTextLength(control);
+            PathElement[] es = control.underlineShape(0, len);
+            underlinePath.getElements().addAll(es);
+        } else {
+            underlinePath.getElements().clear();
+        }
+    }
+
+    protected void updateCaret() {
+        if (showCaretPath.isSelected()) {
+            int len = computeTextLength(control);
+            for (int i = 0; i < len; i++) {
+                PathElement[] es = control.caretShape(i, true);
+                caretPath.getElements().addAll(es);
+            }
+        } else {
+            caretPath.getElements().clear();
+        }
     }
 }

--- a/tests/manual/monkey/src/com/oracle/tools/fx/monkey/pages/TextFlowPage.java
+++ b/tests/manual/monkey/src/com/oracle/tools/fx/monkey/pages/TextFlowPage.java
@@ -114,7 +114,7 @@ public class TextFlowPage extends TestPaneBase {
         showCaretPath.selectedProperty().addListener((p) -> {
             updateCaret();
         });
-        
+
         underline = new CheckBox("underline shape");
         underline.setId("underline");
         underline.selectedProperty().addListener((p) -> {
@@ -171,8 +171,10 @@ public class TextFlowPage extends TestPaneBase {
         for (Node n: f.getChildrenUnmodifiable()) {
             if (n instanceof Text t) {
                 len += t.getText().length();
+            } else {
+                // treat any other nodes as having length 1
+                len++;
             }
-            // embedded nodes do not have an associated text
         }
         return len;
     }

--- a/tests/system/src/test/java/test/javafx/scene/text/TextFlowNodeTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/text/TextFlowNodeTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.text;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import javafx.geometry.Bounds;
+import javafx.scene.shape.Path;
+import javafx.scene.shape.PathElement;
+import javafx.scene.text.Font;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import com.sun.javafx.application.PlatformImpl;
+
+/**
+ * Tests TextFlow Node
+ */
+public class TextFlowNodeTest {
+    @BeforeClass
+    public static void initFX() {
+        final CountDownLatch startupLatch = new CountDownLatch(1);
+        PlatformImpl.startup(() -> {
+            startupLatch.countDown();
+        });
+        try {
+            if (!startupLatch.await(5, TimeUnit.SECONDS)) {
+                Assert.fail("Timeout waiting for FX runtime to start");
+            }
+        } catch (InterruptedException ex) {
+            Assert.fail("Unexpected exception: " + ex);
+        }
+    }
+
+    @Test
+    public void testUnderlineShape() {
+        Text t1 = new Text("one ");
+        t1.setFont(new Font("Monospaced Regular", 16));
+        Text t2 = new Text("two.");
+        TextFlow f = new TextFlow(t1, t2);
+
+        // underline 0,0 must be empty
+        PathElement[] p = f.underlineShape(0, 0);
+        Assert.assertNotNull(p);
+        Assert.assertEquals(p.length, 0);
+
+        // underline 1,0 .. 1,len must increase monotonically
+        int len = t1.getText().length() + t2.getText().length();
+        double w = 0.0;
+        for (int i = 1; i < len; i++) {
+            p = f.underlineShape(0, i);
+            Assert.assertNotNull(p);
+
+            // width must increase
+            Bounds b = new Path(p).getBoundsInLocal();
+            Assert.assertTrue(b.getWidth() > w);
+            w = b.getWidth();
+
+            // test height greater than zero
+            Assert.assertTrue(b.getHeight() > 0.0);
+        }
+
+        // 0,1000 same as 0,len
+        Bounds b1 = new Path(f.underlineShape(0, len)).getBoundsInLocal();
+        Bounds b2 = new Path(f.underlineShape(0, 1000)).getBoundsInLocal();
+        Assert.assertEquals(b1, b2);
+        Assert.assertTrue(b1.getHeight() > 0.0);
+    }
+}

--- a/tests/system/src/test/java/test/javafx/scene/text/TextFlowNodeTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/text/TextFlowNodeTest.java
@@ -26,7 +26,6 @@
 package test.javafx.scene.text;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import javafx.geometry.Bounds;
 import javafx.scene.shape.Path;
 import javafx.scene.shape.PathElement;
@@ -36,7 +35,7 @@ import javafx.scene.text.TextFlow;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import com.sun.javafx.application.PlatformImpl;
+import test.util.Util;
 
 /**
  * Tests TextFlow Node
@@ -44,17 +43,8 @@ import com.sun.javafx.application.PlatformImpl;
 public class TextFlowNodeTest {
     @BeforeClass
     public static void initFX() {
-        final CountDownLatch startupLatch = new CountDownLatch(1);
-        PlatformImpl.startup(() -> {
-            startupLatch.countDown();
-        });
-        try {
-            if (!startupLatch.await(5, TimeUnit.SECONDS)) {
-                Assert.fail("Timeout waiting for FX runtime to start");
-            }
-        } catch (InterruptedException ex) {
-            Assert.fail("Unexpected exception: " + ex);
-        }
+        CountDownLatch startupLatch = new CountDownLatch(1);
+        Util.startup(startupLatch, startupLatch::countDown);
     }
 
     @Test
@@ -67,7 +57,7 @@ public class TextFlowNodeTest {
         // underline 0,0 must be empty
         PathElement[] p = f.underlineShape(0, 0);
         Assert.assertNotNull(p);
-        Assert.assertEquals(p.length, 0);
+        Assert.assertEquals(0, p.length);
 
         // underline 1,0 .. 1,len must increase monotonically
         int len = t1.getText().length() + t2.getText().length();


### PR DESCRIPTION
Adding TextFlow.underlineShape() to add support for a spellchecker-like decoration, using 
```
getRange(start, end, TextLayout.TYPE_UNDERLINE);
```

which mirrors an existing method in Text with exactly the same signature.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8307861](https://bugs.openjdk.org/browse/JDK-8307861) to be approved
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8307363](https://bugs.openjdk.org/browse/JDK-8307363): TextFlow.underlineShape()
 * [JDK-8307861](https://bugs.openjdk.org/browse/JDK-8307861): TextFlow.underlineShape() (**CSR**)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1127/head:pull/1127` \
`$ git checkout pull/1127`

Update a local copy of the PR: \
`$ git checkout pull/1127` \
`$ git pull https://git.openjdk.org/jfx.git pull/1127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1127`

View PR using the GUI difftool: \
`$ git pr show -t 1127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1127.diff">https://git.openjdk.org/jfx/pull/1127.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1127#issuecomment-1535489091)