### PR TITLE
8307542: Call to FcConfigAppFontAddFile uses wrong prototype, arguments

### DIFF
--- a/modules/javafx.graphics/src/main/native-font/pango.c
+++ b/modules/javafx.graphics/src/main/native-font/pango.c
@@ -243,7 +243,7 @@ JNIEXPORT jboolean JNICALL OS_NATIVE(FcConfigAppFontAddFile)
         if (text) {
 //            rc = (jboolean)FcConfigAppFontAddFile(arg0, text);
             if (fp) {
-                rc = (jboolean)((jboolean (*)(void *, const char *))fp)(arg0, text);
+                rc = (jboolean)((int (*)(void *, const char *))fp)((void *)arg0, text);
             }
             (*env)->ReleaseStringUTFChars(env, arg1, text);
         }


### PR DESCRIPTION
Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307542](https://bugs.openjdk.org/browse/JDK-8307542): Call to FcConfigAppFontAddFile uses wrong prototype, arguments (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1128/head:pull/1128` \
`$ git checkout pull/1128`

Update a local copy of the PR: \
`$ git checkout pull/1128` \
`$ git pull https://git.openjdk.org/jfx.git pull/1128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1128`

View PR using the GUI difftool: \
`$ git pr show -t 1128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1128.diff">https://git.openjdk.org/jfx/pull/1128.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1128#issuecomment-1536466793)