### PR TITLE
8307538: Memory leak in TreeTableView when calling refresh

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableRowSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableRowSkinTest.java
@@ -25,7 +25,11 @@
 
 package test.javafx.scene.control.skin;
 
-import com.sun.javafx.tk.Toolkit;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.lang.ref.WeakReference;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
@@ -44,14 +48,11 @@ import javafx.scene.control.skin.TreeTableRowSkin;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import com.sun.javafx.tk.Toolkit;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
 import test.com.sun.javafx.scene.control.test.Person;
-
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import test.util.memory.JMemoryBuddy;
 
 public class TreeTableRowSkinTest {
 
@@ -318,6 +319,20 @@ public class TreeTableRowSkinTest {
     @Test
     public void invisibleColumnsShouldRemoveCorrespondingCellsInRow() {
         invisibleColumnsShouldRemoveCorrespondingCellsInRowImpl();
+    }
+
+    /** TreeTableView.refresh() must release all discarded cells JDK-8307538 */
+    @Test
+    public void cellsMustBeCollectableAfterRefresh() {
+        IndexedCell<?> row = VirtualFlowTestUtils.getCell(treeTableView, 0);
+        assertNotNull(row);
+        WeakReference<Object> ref = new WeakReference<>(row);
+        row = null;
+
+        treeTableView.refresh();
+        Toolkit.getToolkit().firePulse();
+
+        JMemoryBuddy.assertCollectable(ref);
     }
 
     @AfterEach

--- a/tests/manual/monkey/src/com/oracle/tools/fx/monkey/MonkeyTesterApp.java
+++ b/tests/manual/monkey/src/com/oracle/tools/fx/monkey/MonkeyTesterApp.java
@@ -26,17 +26,13 @@ package com.oracle.tools.fx.monkey;
 
 import java.util.Arrays;
 import java.util.Comparator;
-import com.oracle.tools.fx.monkey.pages.DemoPage;
-import com.oracle.tools.fx.monkey.settings.FxSettings;
-import com.oracle.tools.fx.monkey.util.FX;
-import com.oracle.tools.fx.monkey.util.Native2AsciiPane;
-import com.oracle.tools.fx.monkey.util.TestPaneBase;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
 import javafx.geometry.NodeOrientation;
+import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.CheckMenuItem;
@@ -52,6 +48,11 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
+import com.oracle.tools.fx.monkey.pages.DemoPage;
+import com.oracle.tools.fx.monkey.settings.FxSettings;
+import com.oracle.tools.fx.monkey.util.FX;
+import com.oracle.tools.fx.monkey.util.HasSkinnable;
+import com.oracle.tools.fx.monkey.util.Native2AsciiPane;
 
 /**
  * Monkey Tester Application.
@@ -150,6 +151,10 @@ public class MonkeyTesterApp extends Application {
         // Page
         FX.menu(b, "_Page");
         FX.item(b, "Reload Current Page", this::reloadCurrentPage);
+        // Skin
+        FX.menu(b, "_Skin");
+        FX.item(b, "Set New Skin", this::newSkin);
+        FX.item(b, "<null> Skin", this::nullSkin);
         // Menu
         FX.menu(b, "_Menu");
         ToggleGroup g = new ToggleGroup();
@@ -243,5 +248,19 @@ public class MonkeyTesterApp extends Application {
         s.setTitle("Native to ASCII");
         s.setScene(new Scene(new Native2AsciiPane()));
         s.show();
+    }
+
+    protected void nullSkin() {
+        Node n = contentPane.getCenter();
+        if (n instanceof HasSkinnable s) {
+            s.nullSkin();
+        }
+    }
+
+    protected void newSkin() {
+        Node n = contentPane.getCenter();
+        if (n instanceof HasSkinnable s) {
+            s.newSkin();
+        }
     }
 }

--- a/tests/manual/monkey/src/com/oracle/tools/fx/monkey/pages/ListViewPage.java
+++ b/tests/manual/monkey/src/com/oracle/tools/fx/monkey/pages/ListViewPage.java
@@ -32,9 +32,11 @@ import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.ListView;
 import javafx.scene.control.SelectionMode;
+import javafx.scene.control.skin.ListViewSkin;
 import javafx.scene.control.skin.VirtualFlow;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.Pane;
+import com.oracle.tools.fx.monkey.util.HasSkinnable;
 import com.oracle.tools.fx.monkey.util.OptionPane;
 import com.oracle.tools.fx.monkey.util.SequenceNumber;
 import com.oracle.tools.fx.monkey.util.TestPaneBase;
@@ -42,7 +44,7 @@ import com.oracle.tools.fx.monkey.util.TestPaneBase;
 /**
  * ListView page
  */
-public class ListViewPage extends TestPaneBase {
+public class ListViewPage extends TestPaneBase implements HasSkinnable {
     enum Demo {
         EMPTY("Empty"),
         LARGE("Large"),
@@ -116,6 +118,11 @@ public class ListViewPage extends TestPaneBase {
             jump();
         });
 
+        Button refresh = new Button("Refresh");
+        refresh.setOnAction((ev) -> {
+            control.refresh();
+        });
+
         // layout
 
         OptionPane p = new OptionPane();
@@ -127,6 +134,7 @@ public class ListViewPage extends TestPaneBase {
         p.option(selectionSelector);
         p.option(nullFocusModel);
         p.option(jumpButton);
+        p.option(refresh);
         setOptions(p);
 
         demoSelector.getSelectionModel().selectFirst();
@@ -266,5 +274,15 @@ public class ListViewPage extends TestPaneBase {
             }
         }
         return null;
+    }
+
+    @Override
+    public void nullSkin() {
+        control.setSkin(null);
+    }
+
+    @Override
+    public void newSkin() {
+        control.setSkin(new ListViewSkin(control));
     }
 }

--- a/tests/manual/monkey/src/com/oracle/tools/fx/monkey/pages/TableViewPage.java
+++ b/tests/manual/monkey/src/com/oracle/tools/fx/monkey/pages/TableViewPage.java
@@ -38,10 +38,12 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableColumnBase;
 import javafx.scene.control.TableView;
 import javafx.scene.control.TableView.ResizeFeatures;
+import javafx.scene.control.skin.TableViewSkin;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.Pane;
 import javafx.scene.text.Text;
 import javafx.util.Callback;
+import com.oracle.tools.fx.monkey.util.HasSkinnable;
 import com.oracle.tools.fx.monkey.util.OptionPane;
 import com.oracle.tools.fx.monkey.util.SequenceNumber;
 import com.oracle.tools.fx.monkey.util.TestPaneBase;
@@ -49,7 +51,7 @@ import com.oracle.tools.fx.monkey.util.TestPaneBase;
 /**
  * TableView page
  */
-public class TableViewPage extends TestPaneBase {
+public class TableViewPage extends TestPaneBase implements HasSkinnable {
     enum Demo {
         PREF("pref only"),
         VARIABLE("variable cell height"),
@@ -719,5 +721,15 @@ public class TableViewPage extends TestPaneBase {
             }
             return false;
         }
+    }
+
+    @Override
+    public void nullSkin() {
+        table.setSkin(null);
+    }
+
+    @Override
+    public void newSkin() {
+        table.setSkin(new TableViewSkin<>(table));
     }
 }

--- a/tests/manual/monkey/src/com/oracle/tools/fx/monkey/pages/TableViewPage.java
+++ b/tests/manual/monkey/src/com/oracle/tools/fx/monkey/pages/TableViewPage.java
@@ -187,6 +187,11 @@ public class TableViewPage extends TestPaneBase {
             updatePane();
         });
 
+        Button refresh = new Button("Refresh");
+        refresh.setOnAction((ev) -> {
+            table.refresh();
+        });
+
         // layout
 
         OptionPane p = new OptionPane();
@@ -203,6 +208,7 @@ public class TableViewPage extends TestPaneBase {
         p.option(nullFocusModel);
         p.option(hideColumn);
         p.option(fixedHeight);
+        p.option(refresh);
         setOptions(p);
 
         demoSelector.getSelectionModel().selectFirst();

--- a/tests/manual/monkey/src/com/oracle/tools/fx/monkey/pages/TreeTableViewPage.java
+++ b/tests/manual/monkey/src/com/oracle/tools/fx/monkey/pages/TreeTableViewPage.java
@@ -37,10 +37,12 @@ import javafx.scene.control.TreeTableCell;
 import javafx.scene.control.TreeTableColumn;
 import javafx.scene.control.TreeTableView;
 import javafx.scene.control.TreeTableView.ResizeFeatures;
+import javafx.scene.control.skin.TreeTableViewSkin;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.Pane;
 import javafx.scene.text.Text;
 import javafx.util.Callback;
+import com.oracle.tools.fx.monkey.util.HasSkinnable;
 import com.oracle.tools.fx.monkey.util.OptionPane;
 import com.oracle.tools.fx.monkey.util.SequenceNumber;
 import com.oracle.tools.fx.monkey.util.TestPaneBase;
@@ -48,7 +50,7 @@ import com.oracle.tools.fx.monkey.util.TestPaneBase;
 /**
  * TreeTableView page
  */
-public class TreeTableViewPage extends TestPaneBase {
+public class TreeTableViewPage extends TestPaneBase implements HasSkinnable {
     enum Demo {
         PREF("pref only"),
         VARIABLE("variable cell height"),
@@ -594,6 +596,16 @@ public class TreeTableViewPage extends TestPaneBase {
 
     protected String newItem() {
         return SequenceNumber.next();
+    }
+
+    @Override
+    public void nullSkin() {
+        tree.setSkin(null);
+    }
+
+    @Override
+    public void newSkin() {
+        tree.setSkin(new TreeTableViewSkin<>(tree));
     }
 
     /**

--- a/tests/manual/monkey/src/com/oracle/tools/fx/monkey/pages/TreeTableViewPage.java
+++ b/tests/manual/monkey/src/com/oracle/tools/fx/monkey/pages/TreeTableViewPage.java
@@ -156,6 +156,11 @@ public class TreeTableViewPage extends TestPaneBase {
             tree.setShowRoot(false);
         });
 
+        Button refresh = new Button("Refresh");
+        refresh.setOnAction((ev) -> {
+            tree.refresh();
+        });
+
         // layout
 
         OptionPane p = new OptionPane();
@@ -167,6 +172,7 @@ public class TreeTableViewPage extends TestPaneBase {
         p.label("Selection Model:");
         p.option(selectionSelector);
         p.option(nullFocusModel);
+        p.option(refresh);
         setOptions(p);
 
         demoSelector.getSelectionModel().selectFirst();

--- a/tests/manual/monkey/src/com/oracle/tools/fx/monkey/util/HasSkinnable.java
+++ b/tests/manual/monkey/src/com/oracle/tools/fx/monkey/util/HasSkinnable.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.oracle.tools.fx.monkey.util;
+
+/**
+ * This interface enables manipulations with the {@link Control}'s {@link Skin}.
+ */
+public interface HasSkinnable {
+    /** Sets null {@link Skin} in the underlying {@link Control} */
+    public void nullSkin();
+
+    /** Sets a new default {@link Skin} in the underlying {@link Control} */
+    public void newSkin();
+}


### PR DESCRIPTION
Fixed a memory leak in TreeTableView by using WeakInvalidationListener (which is the right approach in this particular situation) - the leak is specific to TreeTableRowSkin.

Added a unit test.

Added Refresh buttons and Skin menu to the Monkey Tester (will expand these to other controls as a part next MT update).