### PR TITLE
8278422: Replace use of deprecated single string variant of Runtime.exec method

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/HostServicesDelegate.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/HostServicesDelegate.java
@@ -135,11 +135,16 @@ public abstract class HostServicesDelegate {
             String osName = System.getProperty("os.name");
             try {
                 if (osName.startsWith("Mac OS")) {
-                    Runtime.getRuntime().exec(
-                            "open " + uri);
+                    Runtime.getRuntime().exec(new String[] {
+                        "open",
+                        uri
+                    });
                 } else if (osName.startsWith("Windows")) {
-                    Runtime.getRuntime().exec(
-                            "rundll32 url.dll,FileProtocolHandler " + uri);
+                    Runtime.getRuntime().exec(new String[] {
+                        "rundll32",
+                        "url.dll,FileProtocolHandler",
+                        uri
+                    });
                 } else { //assume Unix or Linux
                     String browser = null;
                     for (String b : browsers) {


### PR DESCRIPTION
Calls of `Runtime.getRuntime().exec()` were changed to `String[]` variant.

Only Windows and macOS parts were affected, tests work good on both platforms.

I looked through the code and didn't find any other cases of `Runtime.getRuntime().exec(String)` being used, so that should cover all possible deprecation warnings for this issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * ⚠️ Temporary failure when trying to retrieve information on issue `8278422`.<!-- temporary issue failure -->


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1130/head:pull/1130` \
`$ git checkout pull/1130`

Update a local copy of the PR: \
`$ git checkout pull/1130` \
`$ git pull https://git.openjdk.org/jfx.git pull/1130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1130`

View PR using the GUI difftool: \
`$ git pr show -t 1130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1130.diff">https://git.openjdk.org/jfx/pull/1130.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1130#issuecomment-1540218385)