### PR TITLE
8306328: Update libFFI to 3.4.4

### DIFF
--- a/modules/javafx.media/src/main/legal/libffi.md
+++ b/modules/javafx.media/src/main/legal/libffi.md
@@ -1,9 +1,9 @@
-## LibFFI v3.4.2
+## LibFFI v3.4.4
 
 ### LibFFI License
 ```
 
-libffi - Copyright (c) 1996-2021  Anthony Green, Red Hat, Inc and others.
+libffi - Copyright (c) 1996-2022  Anthony Green, Red Hat, Inc and others.
 See source files for details.
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/modules/javafx.media/src/main/legal/libffi.md
+++ b/modules/javafx.media/src/main/legal/libffi.md
@@ -25,4 +25,49 @@ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+Copyright (C) 2007-2010  Free Software Foundation, Inc
+Copyright (C) 1996-2014  Red Hat, Inc.
+Copyright (C) 2009-2012 ARM Ltd.
+Copyright (C) 2011 Plausible Labs Cooperative, Inc.
+Copyright (C) 2002  Ranjit Mathew
+Copyright (C) 2002  Bo Thorsen
+Copyright (C) 2002  Roger Sayle
+Copyright (C) 2013  The Written Word, Inc.
+Copyright (C) 2002-2007  Bo Thorsen <bo@suse.de>
+
+```
+
+### AUTHORS File Information
+```
+
+libffi was originally written by Anthony Green <green@moxielogic.com>.
+
+The developers of the GNU Compiler Collection project have made
+innumerable valuable contributions.  See the ChangeLog file for
+details.
+
+Some of the ideas behind libffi were inspired by Gianni Mariani's free
+gencall library for Silicon Graphics machines.
+
+The closure mechanism was designed and implemented by Kresten Krab
+Thorup.
+
+Major processor architecture ports were contributed by the following
+developers:
+
+    aarch64             Marcus Shawcroft, James Greenhalgh
+    x86                 Anthony Green, Jon Beniston
+    x86-64              Bo Thorsen
+
+Jesper Skov and Andrew Haley both did more than their fair share of
+stepping through the code and tracking down bugs.
+
+Thanks also to Tom Tromey for bug fixes, documentation and
+configuration help.
+
+Thanks to Jim Blandy, who provided some useful feedback on the libffi
+interface.
+
+Alex Oliva solved the executable page problem for SElinux.
+
 ```

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/LICENSE
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/LICENSE
@@ -1,4 +1,4 @@
-libffi - Copyright (c) 1996-2021  Anthony Green, Red Hat, Inc and others.
+libffi - Copyright (c) 1996-2022  Anthony Green, Red Hat, Inc and others.
 See source files for details.
 
 Permission is hereby granted, free of charge, to any person obtaining

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/aarch64/ffi.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/aarch64/ffi.h
@@ -1,6 +1,6 @@
 /* -----------------------------------------------------------------*-C-*-
-   libffi 3.4.2
-     - Copyright (c) 2011, 2014, 2019, 2021 Anthony Green
+   libffi 3.4.4
+     - Copyright (c) 2011, 2014, 2019, 2021, 2022 Anthony Green
      - Copyright (c) 1996-2003, 2007, 2008 Red Hat, Inc.
 
    Permission is hereby granted, free of charge, to any person
@@ -320,6 +320,9 @@ typedef struct {
   ffi_cif   *cif;
   void     (*fun)(ffi_cif*,void*,void**,void*);
   void      *user_data;
+#if defined(_MSC_VER) && defined(_M_IX86)
+  void      *padding;
+#endif
 } ffi_closure
 #ifdef __GNUC__
     __attribute__((aligned (8)))
@@ -360,7 +363,7 @@ ffi_prep_closure_loc (ffi_closure*,
               ffi_cif *,
               void (*fun)(ffi_cif*,void*,void**,void*),
               void *user_data,
-              void*codeloc);
+		          void *codeloc);
 
 #ifdef __sgi
 # pragma pack 8
@@ -378,7 +381,7 @@ typedef struct {
 
   /* If this is enabled, then a raw closure has the same layout
      as a regular closure.  We use this to install an intermediate
-     handler to do the transaltion, void** -> ffi_raw*.  */
+     handler to do the translation, void** -> ffi_raw*.  */
 
   void     (*translate_args)(ffi_cif*,void*,void**,void*);
   void      *this_closure;

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/aarch64/ffi.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/aarch64/ffi.h
@@ -363,7 +363,7 @@ ffi_prep_closure_loc (ffi_closure*,
               ffi_cif *,
               void (*fun)(ffi_cif*,void*,void**,void*),
               void *user_data,
-		          void *codeloc);
+              void *codeloc);
 
 #ifdef __sgi
 # pragma pack 8

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/aarch64/fficonfig.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/aarch64/fficonfig.h
@@ -4,16 +4,11 @@
 /* Define if building universal (internal helper macro) */
 /* #undef AC_APPLE_UNIVERSAL_BUILD */
 
-/* Define to one of `_getb67', `GETB67', `getb67' for Cray-2 and Cray-YMP
-   systems. This function is required for `alloca.c' support on those systems.
-   */
-/* #undef CRAY_STACKSEG_END */
-
-/* Define to 1 if using `alloca.c'. */
+/* Define to 1 if using 'alloca.c'. */
 /* #undef C_ALLOCA */
 
 /* Define to the flags needed for the .section .eh_frame directive. */
-#define EH_FRAME_FLAGS "aw"
+#define EH_FRAME_FLAGS "a"
 
 /* Define this if you want extra debugging. */
 /* #undef FFI_DEBUG */
@@ -24,7 +19,8 @@
 /* Cannot use PROT_EXEC on this target, so, we revert to alternative means */
 #define FFI_EXEC_TRAMPOLINE_TABLE 1
 
-/* Define this if you want to enable pax emulated trampolines */
+/* Define this if you want to enable pax emulated trampolines (experimental)
+   */
 /* #undef FFI_MMAP_EXEC_EMUTRAMP_PAX */
 
 /* Cannot use malloc on this target, so, we revert to alternative means */
@@ -36,11 +32,10 @@
 /* Define this if you do not want support for aggregate types. */
 /* #undef FFI_NO_STRUCTS */
 
-/* Define to 1 if you have `alloca', as a function or macro. */
+/* Define to 1 if you have 'alloca', as a function or macro. */
 #define HAVE_ALLOCA 1
 
-/* Define to 1 if you have <alloca.h> and it should be used (not on Ultrix).
-   */
+/* Define to 1 if <alloca.h> works. */
 #define HAVE_ALLOCA_H 1
 
 /* Define if your assembler supports .cfi_* directives. */
@@ -108,10 +103,13 @@
 /* #undef HAVE_PTRAUTH */
 
 /* Define if .eh_frame sections should be read-only. */
-/* #undef HAVE_RO_EH_FRAME */
+#define HAVE_RO_EH_FRAME 1
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
 
 /* Define to 1 if you have the <stdlib.h> header file. */
 #define HAVE_STDLIB_H 1
@@ -153,7 +151,7 @@
 #define PACKAGE_NAME "libffi"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libffi 3.4.2"
+#define PACKAGE_STRING "libffi 3.4.4"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libffi"
@@ -162,7 +160,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "3.4.2"
+#define PACKAGE_VERSION "3.4.4"
 
 /* The size of `double', as computed by sizeof. */
 #define SIZEOF_DOUBLE 8
@@ -181,7 +179,9 @@
     STACK_DIRECTION = 0 => direction of growth unknown */
 /* #undef STACK_DIRECTION */
 
-/* Define to 1 if you have the ANSI C header files. */
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
 #define STDC_HEADERS 1
 
 /* Define if symbols are underscored. */
@@ -192,7 +192,7 @@
 /* #undef USING_PURIFY */
 
 /* Version number of package */
-#define VERSION "3.4.2"
+#define VERSION "3.4.4"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/x64/ffi.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/x64/ffi.h
@@ -1,6 +1,6 @@
 /* -----------------------------------------------------------------*-C-*-
-   libffi 3.4.2
-     - Copyright (c) 2011, 2014, 2019, 2021 Anthony Green
+   libffi 3.4.4
+     - Copyright (c) 2011, 2014, 2019, 2021, 2022 Anthony Green
      - Copyright (c) 1996-2003, 2007, 2008 Red Hat, Inc.
 
    Permission is hereby granted, free of charge, to any person
@@ -320,6 +320,9 @@ typedef struct {
   ffi_cif   *cif;
   void     (*fun)(ffi_cif*,void*,void**,void*);
   void      *user_data;
+#if defined(_MSC_VER) && defined(_M_IX86)
+  void      *padding;
+#endif
 } ffi_closure
 #ifdef __GNUC__
     __attribute__((aligned (8)))
@@ -360,7 +363,7 @@ ffi_prep_closure_loc (ffi_closure*,
               ffi_cif *,
               void (*fun)(ffi_cif*,void*,void**,void*),
               void *user_data,
-              void*codeloc);
+		          void *codeloc);
 
 #ifdef __sgi
 # pragma pack 8
@@ -378,7 +381,7 @@ typedef struct {
 
   /* If this is enabled, then a raw closure has the same layout
      as a regular closure.  We use this to install an intermediate
-     handler to do the transaltion, void** -> ffi_raw*.  */
+     handler to do the translation, void** -> ffi_raw*.  */
 
   void     (*translate_args)(ffi_cif*,void*,void**,void*);
   void      *this_closure;

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/x64/ffi.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/x64/ffi.h
@@ -363,7 +363,7 @@ ffi_prep_closure_loc (ffi_closure*,
               ffi_cif *,
               void (*fun)(ffi_cif*,void*,void**,void*),
               void *user_data,
-		          void *codeloc);
+              void *codeloc);
 
 #ifdef __sgi
 # pragma pack 8

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/x64/fficonfig.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/mac/x64/fficonfig.h
@@ -4,16 +4,11 @@
 /* Define if building universal (internal helper macro) */
 /* #undef AC_APPLE_UNIVERSAL_BUILD */
 
-/* Define to one of `_getb67', `GETB67', `getb67' for Cray-2 and Cray-YMP
-   systems. This function is required for `alloca.c' support on those systems.
-   */
-/* #undef CRAY_STACKSEG_END */
-
-/* Define to 1 if using `alloca.c'. */
+/* Define to 1 if using 'alloca.c'. */
 /* #undef C_ALLOCA */
 
 /* Define to the flags needed for the .section .eh_frame directive. */
-#define EH_FRAME_FLAGS "aw"
+#define EH_FRAME_FLAGS "a"
 
 /* Define this if you want extra debugging. */
 /* #undef FFI_DEBUG */
@@ -24,7 +19,8 @@
 /* Cannot use PROT_EXEC on this target, so, we revert to alternative means */
 /* #undef FFI_EXEC_TRAMPOLINE_TABLE */
 
-/* Define this if you want to enable pax emulated trampolines */
+/* Define this if you want to enable pax emulated trampolines (experimental)
+   */
 /* #undef FFI_MMAP_EXEC_EMUTRAMP_PAX */
 
 /* Cannot use malloc on this target, so, we revert to alternative means */
@@ -36,11 +32,10 @@
 /* Define this if you do not want support for aggregate types. */
 /* #undef FFI_NO_STRUCTS */
 
-/* Define to 1 if you have `alloca', as a function or macro. */
+/* Define to 1 if you have 'alloca', as a function or macro. */
 #define HAVE_ALLOCA 1
 
-/* Define to 1 if you have <alloca.h> and it should be used (not on Ultrix).
-   */
+/* Define to 1 if <alloca.h> works. */
 #define HAVE_ALLOCA_H 1
 
 /* Define if your assembler supports .cfi_* directives. */
@@ -108,10 +103,13 @@
 /* #undef HAVE_PTRAUTH */
 
 /* Define if .eh_frame sections should be read-only. */
-/* #undef HAVE_RO_EH_FRAME */
+#define HAVE_RO_EH_FRAME 1
 
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
 
 /* Define to 1 if you have the <stdlib.h> header file. */
 #define HAVE_STDLIB_H 1
@@ -153,7 +151,7 @@
 #define PACKAGE_NAME "libffi"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libffi 3.4.2"
+#define PACKAGE_STRING "libffi 3.4.4"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libffi"
@@ -162,7 +160,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "3.4.2"
+#define PACKAGE_VERSION "3.4.4"
 
 /* The size of `double', as computed by sizeof. */
 #define SIZEOF_DOUBLE 8
@@ -181,7 +179,9 @@
     STACK_DIRECTION = 0 => direction of growth unknown */
 /* #undef STACK_DIRECTION */
 
-/* Define to 1 if you have the ANSI C header files. */
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
 #define STDC_HEADERS 1
 
 /* Define if symbols are underscored. */
@@ -192,7 +192,7 @@
 /* #undef USING_PURIFY */
 
 /* Version number of package */
-#define VERSION "3.4.2"
+#define VERSION "3.4.4"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x64/ffi.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x64/ffi.h
@@ -1,6 +1,6 @@
 /* -----------------------------------------------------------------*-C-*-
-   libffi 3.4.2
-     - Copyright (c) 2011, 2014, 2019, 2021 Anthony Green
+   libffi 3.4.4
+     - Copyright (c) 2011, 2014, 2019, 2021, 2022 Anthony Green
      - Copyright (c) 1996-2003, 2007, 2008 Red Hat, Inc.
 
    Permission is hereby granted, free of charge, to any person
@@ -320,6 +320,9 @@ typedef struct {
   ffi_cif   *cif;
   void     (*fun)(ffi_cif*,void*,void**,void*);
   void      *user_data;
+#if defined(_MSC_VER) && defined(_M_IX86)
+  void      *padding;
+#endif
 } ffi_closure
 #ifdef __GNUC__
     __attribute__((aligned (8)))
@@ -360,7 +363,7 @@ ffi_prep_closure_loc (ffi_closure*,
               ffi_cif *,
               void (*fun)(ffi_cif*,void*,void**,void*),
               void *user_data,
-              void*codeloc);
+		          void *codeloc);
 
 #ifdef __sgi
 # pragma pack 8
@@ -378,7 +381,7 @@ typedef struct {
 
   /* If this is enabled, then a raw closure has the same layout
      as a regular closure.  We use this to install an intermediate
-     handler to do the transaltion, void** -> ffi_raw*.  */
+     handler to do the translation, void** -> ffi_raw*.  */
 
   void     (*translate_args)(ffi_cif*,void*,void**,void*);
   void      *this_closure;

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x64/ffi.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x64/ffi.h
@@ -363,7 +363,7 @@ ffi_prep_closure_loc (ffi_closure*,
               ffi_cif *,
               void (*fun)(ffi_cif*,void*,void**,void*),
               void *user_data,
-		          void *codeloc);
+              void *codeloc);
 
 #ifdef __sgi
 # pragma pack 8

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x64/fficonfig.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x64/fficonfig.h
@@ -4,12 +4,7 @@
 /* Define if building universal (internal helper macro) */
 /* #undef AC_APPLE_UNIVERSAL_BUILD */
 
-/* Define to one of `_getb67', `GETB67', `getb67' for Cray-2 and Cray-YMP
-   systems. This function is required for `alloca.c' support on those systems.
-   */
-/* #undef CRAY_STACKSEG_END */
-
-/* Define to 1 if using `alloca.c'. */
+/* Define to 1 if using 'alloca.c'. */
 /* #undef C_ALLOCA */
 
 /* Define to the flags needed for the .section .eh_frame directive. */
@@ -24,7 +19,8 @@
 /* Cannot use PROT_EXEC on this target, so, we revert to alternative means */
 /* #undef FFI_EXEC_TRAMPOLINE_TABLE */
 
-/* Define this if you want to enable pax emulated trampolines */
+/* Define this if you want to enable pax emulated trampolines (experimental)
+   */
 /* #undef FFI_MMAP_EXEC_EMUTRAMP_PAX */
 
 /* Cannot use malloc on this target, so, we revert to alternative means */
@@ -36,11 +32,10 @@
 /* Define this if you do not want support for aggregate types. */
 /* #undef FFI_NO_STRUCTS */
 
-/* Define to 1 if you have `alloca', as a function or macro. */
+/* Define to 1 if you have 'alloca', as a function or macro. */
 #define HAVE_ALLOCA 1
 
-/* Define to 1 if you have <alloca.h> and it should be used (not on Ultrix).
-   */
+/* Define to 1 if <alloca.h> works. */
 /* #undef HAVE_ALLOCA_H */
 
 /* Define if your assembler supports .cfi_* directives. */
@@ -113,6 +108,9 @@
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1
 
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
 /* Define to 1 if you have the <stdlib.h> header file. */
 #define HAVE_STDLIB_H 1
 
@@ -153,7 +151,7 @@
 #define PACKAGE_NAME "libffi"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libffi 3.4.2"
+#define PACKAGE_STRING "libffi 3.4.4"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libffi"
@@ -162,7 +160,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "3.4.2"
+#define PACKAGE_VERSION "3.4.4"
 
 /* The size of `double', as computed by sizeof. */
 #define SIZEOF_DOUBLE 8
@@ -181,7 +179,9 @@
     STACK_DIRECTION = 0 => direction of growth unknown */
 /* #undef STACK_DIRECTION */
 
-/* Define to 1 if you have the ANSI C header files. */
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
 /* #undef STDC_HEADERS */
 
 /* Define if symbols are underscored. */
@@ -192,7 +192,7 @@
 /* #undef USING_PURIFY */
 
 /* Version number of package */
-#define VERSION "3.4.2"
+#define VERSION "3.4.4"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x86/ffi.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x86/ffi.h
@@ -1,6 +1,6 @@
 /* -----------------------------------------------------------------*-C-*-
-   libffi 3.4.2
-     - Copyright (c) 2011, 2014, 2019, 2021 Anthony Green
+   libffi 3.4.4
+     - Copyright (c) 2011, 2014, 2019, 2021, 2022 Anthony Green
      - Copyright (c) 1996-2003, 2007, 2008 Red Hat, Inc.
 
    Permission is hereby granted, free of charge, to any person
@@ -320,6 +320,9 @@ typedef struct {
   ffi_cif   *cif;
   void     (*fun)(ffi_cif*,void*,void**,void*);
   void      *user_data;
+#if defined(_MSC_VER) && defined(_M_IX86)
+  void      *padding;
+#endif
 } ffi_closure
 #ifdef __GNUC__
     __attribute__((aligned (8)))
@@ -360,7 +363,7 @@ ffi_prep_closure_loc (ffi_closure*,
               ffi_cif *,
               void (*fun)(ffi_cif*,void*,void**,void*),
               void *user_data,
-              void*codeloc);
+		          void *codeloc);
 
 #ifdef __sgi
 # pragma pack 8
@@ -378,7 +381,7 @@ typedef struct {
 
   /* If this is enabled, then a raw closure has the same layout
      as a regular closure.  We use this to install an intermediate
-     handler to do the transaltion, void** -> ffi_raw*.  */
+     handler to do the translation, void** -> ffi_raw*.  */
 
   void     (*translate_args)(ffi_cif*,void*,void**,void*);
   void      *this_closure;

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x86/ffi.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x86/ffi.h
@@ -363,7 +363,7 @@ ffi_prep_closure_loc (ffi_closure*,
               ffi_cif *,
               void (*fun)(ffi_cif*,void*,void**,void*),
               void *user_data,
-		          void *codeloc);
+              void *codeloc);
 
 #ifdef __sgi
 # pragma pack 8

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x86/fficonfig.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/include/win/x86/fficonfig.h
@@ -4,12 +4,7 @@
 /* Define if building universal (internal helper macro) */
 /* #undef AC_APPLE_UNIVERSAL_BUILD */
 
-/* Define to one of `_getb67', `GETB67', `getb67' for Cray-2 and Cray-YMP
-   systems. This function is required for `alloca.c' support on those systems.
-   */
-/* #undef CRAY_STACKSEG_END */
-
-/* Define to 1 if using `alloca.c'. */
+/* Define to 1 if using 'alloca.c'. */
 /* #undef C_ALLOCA */
 
 /* Define to the flags needed for the .section .eh_frame directive. */
@@ -24,7 +19,8 @@
 /* Cannot use PROT_EXEC on this target, so, we revert to alternative means */
 /* #undef FFI_EXEC_TRAMPOLINE_TABLE */
 
-/* Define this if you want to enable pax emulated trampolines */
+/* Define this if you want to enable pax emulated trampolines (experimental)
+   */
 /* #undef FFI_MMAP_EXEC_EMUTRAMP_PAX */
 
 /* Cannot use malloc on this target, so, we revert to alternative means */
@@ -36,11 +32,10 @@
 /* Define this if you do not want support for aggregate types. */
 /* #undef FFI_NO_STRUCTS */
 
-/* Define to 1 if you have `alloca', as a function or macro. */
+/* Define to 1 if you have 'alloca', as a function or macro. */
 #define HAVE_ALLOCA 1
 
-/* Define to 1 if you have <alloca.h> and it should be used (not on Ultrix).
-   */
+/* Define to 1 if <alloca.h> works. */
 /* #undef HAVE_ALLOCA_H */
 
 /* Define if your assembler supports .cfi_* directives. */
@@ -113,6 +108,9 @@
 /* Define to 1 if you have the <stdint.h> header file. */
 #define HAVE_STDINT_H 1
 
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
 /* Define to 1 if you have the <stdlib.h> header file. */
 #define HAVE_STDLIB_H 1
 
@@ -153,7 +151,7 @@
 #define PACKAGE_NAME "libffi"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "libffi 3.4.2"
+#define PACKAGE_STRING "libffi 3.4.4"
 
 /* Define to the one symbol short name of this package. */
 #define PACKAGE_TARNAME "libffi"
@@ -162,7 +160,7 @@
 #define PACKAGE_URL ""
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "3.4.2"
+#define PACKAGE_VERSION "3.4.4"
 
 /* The size of `double', as computed by sizeof. */
 #define SIZEOF_DOUBLE 8
@@ -181,7 +179,9 @@
     STACK_DIRECTION = 0 => direction of growth unknown */
 /* #undef STACK_DIRECTION */
 
-/* Define to 1 if you have the ANSI C header files. */
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
 /* #undef STDC_HEADERS */
 
 /* Define if symbols are underscored. */
@@ -192,7 +192,7 @@
 /* #undef USING_PURIFY */
 
 /* Version number of package */
-#define VERSION "3.4.2"
+#define VERSION "3.4.4"
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/aarch64/ffi.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/aarch64/ffi.c
@@ -248,13 +248,18 @@ is_vfp_type (const ffi_type *ty)
    state.
 
    The terse state variable names match the names used in the AARCH64
-   PCS. */
+   PCS.
+
+   The struct area is allocated downwards from the top of the argument
+   area.  It is used to hold copies of structures passed by value that are
+   bigger than 16 bytes.  */
 
 struct arg_state
 {
   unsigned ngrn;                /* Next general-purpose register number. */
   unsigned nsrn;                /* Next vector register number. */
   size_t nsaa;                  /* Next stack offset. */
+  size_t next_struct_area;	/* Place to allocate big structs. */
 
 #if defined (__APPLE__)
   unsigned allocating_variadic;
@@ -263,11 +268,12 @@ struct arg_state
 
 /* Initialize a procedure call argument marshalling state.  */
 static void
-arg_init (struct arg_state *state)
+arg_init (struct arg_state *state, size_t size)
 {
   state->ngrn = 0;
   state->nsrn = 0;
   state->nsaa = 0;
+  state->next_struct_area = size;
 #if defined (__APPLE__)
   state->allocating_variadic = 0;
 #endif
@@ -296,30 +302,76 @@ allocate_to_stack (struct arg_state *state, void *stack,
   return (char *)stack + nsaa;
 }
 
+/* Allocate and copy a structure that is passed by value on the stack and
+   return a pointer to it.  */
+static void *
+allocate_and_copy_struct_to_stack (struct arg_state *state, void *stack,
+				   size_t alignment, size_t size, void *value)
+{
+  size_t dest = state->next_struct_area - size;
+
+  /* Round down to the natural alignment of the value.  */
+  dest = FFI_ALIGN_DOWN (dest, alignment);
+  state->next_struct_area = dest;
+
+  return memcpy ((char *) stack + dest, value, size);
+}
+
 static ffi_arg
 extend_integer_type (void *source, int type)
 {
   switch (type)
     {
     case FFI_TYPE_UINT8:
-      return *(UINT8 *) source;
+      {
+        UINT8 u8;
+        memcpy (&u8, source, sizeof (u8));
+        return u8;
+      }
     case FFI_TYPE_SINT8:
-      return *(SINT8 *) source;
+      {
+        SINT8 s8;
+        memcpy (&s8, source, sizeof (s8));
+        return s8;
+      }
     case FFI_TYPE_UINT16:
-      return *(UINT16 *) source;
+      {
+        UINT16 u16;
+        memcpy (&u16, source, sizeof (u16));
+        return u16;
+      }
     case FFI_TYPE_SINT16:
-      return *(SINT16 *) source;
+      {
+        SINT16 s16;
+        memcpy (&s16, source, sizeof (s16));
+        return s16;
+      }
     case FFI_TYPE_UINT32:
-      return *(UINT32 *) source;
+      {
+        UINT32 u32;
+        memcpy (&u32, source, sizeof (u32));
+        return u32;
+      }
     case FFI_TYPE_INT:
     case FFI_TYPE_SINT32:
-      return *(SINT32 *) source;
+      {
+        SINT32 s32;
+        memcpy (&s32, source, sizeof (s32));
+        return s32;
+      }
     case FFI_TYPE_UINT64:
     case FFI_TYPE_SINT64:
-      return *(UINT64 *) source;
-      break;
+      {
+        UINT64 u64;
+        memcpy (&u64, source, sizeof (u64));
+        return u64;
+      }
     case FFI_TYPE_POINTER:
-      return *(uintptr_t *) source;
+      {
+        uintptr_t uptr;
+        memcpy (&uptr, source, sizeof (uptr));
+        return uptr;
+      }
     default:
       abort();
     }
@@ -335,48 +387,48 @@ extend_hfa_type (void *dest, void *src, int h)
   void *x0;
 
   asm volatile (
-"adr    %0, 0f\n"
-"       add     %0, %0, %1\n"
-"       br      %0\n"
-"0:     ldp     s16, s17, [%3]\n"       /* S4 */
-"       ldp     s18, s19, [%3, #8]\n"
-"       b       4f\n"
-"       ldp     s16, s17, [%3]\n"       /* S3 */
-"       ldr     s18, [%3, #8]\n"
-"       b       3f\n"
-"       ldp     s16, s17, [%3]\n"       /* S2 */
-"       b       2f\n"
-"       nop\n"
-"       ldr     s16, [%3]\n"            /* S1 */
-"       b       1f\n"
-"       nop\n"
-"       ldp     d16, d17, [%3]\n"       /* D4 */
-"       ldp     d18, d19, [%3, #16]\n"
-"       b       4f\n"
-"       ldp     d16, d17, [%3]\n"       /* D3 */
-"       ldr     d18, [%3, #16]\n"
-"       b       3f\n"
-"       ldp     d16, d17, [%3]\n"       /* D2 */
-"       b       2f\n"
-"       nop\n"
-"       ldr     d16, [%3]\n"            /* D1 */
-"       b       1f\n"
-"       nop\n"
-"       ldp     q16, q17, [%3]\n"       /* Q4 */
-"       ldp     q18, q19, [%3, #32]\n"
-"       b       4f\n"
-"       ldp     q16, q17, [%3]\n"       /* Q3 */
-"       ldr     q18, [%3, #32]\n"
-"       b       3f\n"
-"       ldp     q16, q17, [%3]\n"       /* Q2 */
-"       b       2f\n"
-"       nop\n"
-"       ldr     q16, [%3]\n"            /* Q1 */
-"       b       1f\n"
-"4:     str     q19, [%2, #48]\n"
-"3:     str     q18, [%2, #32]\n"
-"2:     str     q17, [%2, #16]\n"
-"1:     str     q16, [%2]"
+	"adr	%0, 0f\n"
+"	add	%0, %0, %1\n"
+"	br	%0\n"
+"0:	ldp	s16, s17, [%3]\n"	/* S4 */
+"	ldp	s18, s19, [%3, #8]\n"
+"	b	4f\n"
+"	ldp	s16, s17, [%3]\n"	/* S3 */
+"	ldr	s18, [%3, #8]\n"
+"	b	3f\n"
+"	ldp	s16, s17, [%3]\n"	/* S2 */
+"	b	2f\n"
+"	nop\n"
+"	ldr	s16, [%3]\n"		/* S1 */
+"	b	1f\n"
+"	nop\n"
+"	ldp	d16, d17, [%3]\n"	/* D4 */
+"	ldp	d18, d19, [%3, #16]\n"
+"	b	4f\n"
+"	ldp	d16, d17, [%3]\n"	/* D3 */
+"	ldr	d18, [%3, #16]\n"
+"	b	3f\n"
+"	ldp	d16, d17, [%3]\n"	/* D2 */
+"	b	2f\n"
+"	nop\n"
+"	ldr	d16, [%3]\n"		/* D1 */
+"	b	1f\n"
+"	nop\n"
+"	ldp	q16, q17, [%3]\n"	/* Q4 */
+"	ldp	q18, q19, [%3, #32]\n"
+"	b	4f\n"
+"	ldp	q16, q17, [%3]\n"	/* Q3 */
+"	ldr	q18, [%3, #32]\n"
+"	b	3f\n"
+"	ldp	q16, q17, [%3]\n"	/* Q2 */
+"	b	2f\n"
+"	nop\n"
+"	ldr	q16, [%3]\n"		/* Q1 */
+"	b	1f\n"
+"4:	str	q19, [%2, #48]\n"
+"3:	str	q18, [%2, #32]\n"
+"2:	str	q17, [%2, #16]\n"
+"1:	str	q16, [%2]"
     : "=&r"(x0)
     : "r"(f * 12), "r"(dest), "r"(src)
     : "memory", "v16", "v17", "v18", "v19");
@@ -624,13 +676,14 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *orig_rvalue,
   frame = (void*)((uintptr_t)stack + (uintptr_t)stack_bytes);
   rvalue = (rsize ? (void*)((uintptr_t)frame + 40) : orig_rvalue);
 
-  arg_init (&state);
+  arg_init (&state, stack_bytes);
   for (i = 0, nargs = cif->nargs; i < nargs; i++)
     {
       ffi_type *ty = cif->arg_types[i];
       size_t s = ty->size;
       void *a = avalue[i];
       int h, t;
+      void *dest;
 
       t = ty->type;
       switch (t)
@@ -678,8 +731,6 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *orig_rvalue,
     case FFI_TYPE_STRUCT:
     case FFI_TYPE_COMPLEX:
       {
-        void *dest;
-
         h = is_vfp_type (ty);
         if (h)
           {
@@ -712,9 +763,12 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *orig_rvalue,
         else if (s > 16)
           {
         /* If the argument is a composite type that is larger than 16
-           bytes, then the argument has been copied to memory, and
+		   bytes, then the argument is copied to memory, and
            the argument is replaced by a pointer to the copy.  */
-        a = &avalue[i];
+		dest = allocate_and_copy_struct_to_stack (&state, stack,
+							  ty->alignment, s,
+							  avalue[i]);
+		a = &dest;
         t = FFI_TYPE_POINTER;
         s = sizeof (void *);
         goto do_pointer;
@@ -809,23 +863,23 @@ ffi_prep_closure_loc (ffi_closure *closure,
     start = ffi_closure_SYSV;
 
 #if FFI_EXEC_TRAMPOLINE_TABLE
-#ifdef __MACH__
-#ifdef HAVE_PTRAUTH
+# ifdef __MACH__
+#  ifdef HAVE_PTRAUTH
   codeloc = ptrauth_auth_data(codeloc, ptrauth_key_function_pointer, 0);
-#endif
+#  endif
   void **config = (void **)((uint8_t *)codeloc - PAGE_MAX_SIZE);
   config[0] = closure;
   config[1] = start;
-#endif
+# endif
 #else
   static const unsigned char trampoline[16] = {
-    0x90, 0x00, 0x00, 0x58,     /* ldr  x16, tramp+16   */
-    0xf1, 0xff, 0xff, 0x10,     /* adr  x17, tramp+0    */
-    0x00, 0x02, 0x1f, 0xd6      /* br   x16             */
+    0x90, 0x00, 0x00, 0x58,	/* ldr	x16, tramp+16	*/
+    0xf1, 0xff, 0xff, 0x10,	/* adr	x17, tramp+0	*/
+    0x00, 0x02, 0x1f, 0xd6	/* br	x16		*/
   };
   char *tramp = closure->tramp;
 
-#if defined(FFI_EXEC_STATIC_TRAMP)
+# if defined(FFI_EXEC_STATIC_TRAMP)
   if (ffi_tramp_is_present(closure))
     {
       /* Initialize the static trampoline's parameters. */
@@ -836,7 +890,7 @@ ffi_prep_closure_loc (ffi_closure *closure,
       ffi_tramp_set_parms (closure->ftramp, start, closure);
       goto out;
     }
-#endif
+# endif
 
   /* Initialize the dynamic trampoline. */
   memcpy (tramp, trampoline, sizeof(trampoline));
@@ -846,15 +900,17 @@ ffi_prep_closure_loc (ffi_closure *closure,
   ffi_clear_cache(tramp, tramp + FFI_TRAMPOLINE_SIZE);
 
   /* Also flush the cache for code mapping.  */
-#ifdef _WIN32
+# ifdef _WIN32
   // Not using dlmalloc.c for Windows ARM64 builds
   // so calling ffi_data_to_code_pointer() isn't necessary
   unsigned char *tramp_code = tramp;
-  #else
+# else
   unsigned char *tramp_code = ffi_data_to_code_pointer (tramp);
-  #endif
+# endif
   ffi_clear_cache (tramp_code, tramp_code + FFI_TRAMPOLINE_SIZE);
+# if defined(FFI_EXEC_STATIC_TRAMP)
 out:
+# endif
 #endif
 
   closure->cif = cif;
@@ -917,7 +973,7 @@ ffi_closure_SYSV_inner (ffi_cif *cif,
   int i, h, nargs, flags, isvariadic = 0;
   struct arg_state state;
 
-  arg_init (&state);
+  arg_init (&state, cif->bytes);
 
   flags = cif->flags;
   if (flags & AARCH64_FLAG_VARARG)
@@ -1004,9 +1060,18 @@ ffi_closure_SYSV_inner (ffi_cif *cif,
             {
               /* Replace Composite type of size greater than 16 with a
                   pointer.  */
+#ifdef __ILP32__
+             UINT64 avalue_tmp;
+             memcpy (&avalue_tmp,
+                  allocate_int_to_reg_or_stack (context, &state,
+                                               stack, sizeof (void *)),
+                  sizeof (UINT64));
+             avalue[i] = (void *)(UINT32)avalue_tmp;
+#else
               avalue[i] = *(void **)
               allocate_int_to_reg_or_stack (context, &state, stack,
                                          sizeof (void *));
+#endif
             }
           else
             {

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/aarch64/ffi.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/aarch64/ffi.c
@@ -259,7 +259,7 @@ struct arg_state
   unsigned ngrn;                /* Next general-purpose register number. */
   unsigned nsrn;                /* Next vector register number. */
   size_t nsaa;                  /* Next stack offset. */
-  size_t next_struct_area;	/* Place to allocate big structs. */
+  size_t next_struct_area;      /* Place to allocate big structs. */
 
 #if defined (__APPLE__)
   unsigned allocating_variadic;
@@ -306,7 +306,7 @@ allocate_to_stack (struct arg_state *state, void *stack,
    return a pointer to it.  */
 static void *
 allocate_and_copy_struct_to_stack (struct arg_state *state, void *stack,
-				   size_t alignment, size_t size, void *value)
+                                   size_t alignment, size_t size, void *value)
 {
   size_t dest = state->next_struct_area - size;
 
@@ -387,48 +387,48 @@ extend_hfa_type (void *dest, void *src, int h)
   void *x0;
 
   asm volatile (
-	"adr	%0, 0f\n"
-"	add	%0, %0, %1\n"
-"	br	%0\n"
-"0:	ldp	s16, s17, [%3]\n"	/* S4 */
-"	ldp	s18, s19, [%3, #8]\n"
-"	b	4f\n"
-"	ldp	s16, s17, [%3]\n"	/* S3 */
-"	ldr	s18, [%3, #8]\n"
-"	b	3f\n"
-"	ldp	s16, s17, [%3]\n"	/* S2 */
-"	b	2f\n"
-"	nop\n"
-"	ldr	s16, [%3]\n"		/* S1 */
-"	b	1f\n"
-"	nop\n"
-"	ldp	d16, d17, [%3]\n"	/* D4 */
-"	ldp	d18, d19, [%3, #16]\n"
-"	b	4f\n"
-"	ldp	d16, d17, [%3]\n"	/* D3 */
-"	ldr	d18, [%3, #16]\n"
-"	b	3f\n"
-"	ldp	d16, d17, [%3]\n"	/* D2 */
-"	b	2f\n"
-"	nop\n"
-"	ldr	d16, [%3]\n"		/* D1 */
-"	b	1f\n"
-"	nop\n"
-"	ldp	q16, q17, [%3]\n"	/* Q4 */
-"	ldp	q18, q19, [%3, #32]\n"
-"	b	4f\n"
-"	ldp	q16, q17, [%3]\n"	/* Q3 */
-"	ldr	q18, [%3, #32]\n"
-"	b	3f\n"
-"	ldp	q16, q17, [%3]\n"	/* Q2 */
-"	b	2f\n"
-"	nop\n"
-"	ldr	q16, [%3]\n"		/* Q1 */
-"	b	1f\n"
-"4:	str	q19, [%2, #48]\n"
-"3:	str	q18, [%2, #32]\n"
-"2:	str	q17, [%2, #16]\n"
-"1:	str	q16, [%2]"
+"adr    %0, 0f\n"
+"       add     %0, %0, %1\n"
+"       br      %0\n"
+"0:     ldp     s16, s17, [%3]\n"       /* S4 */
+"       ldp     s18, s19, [%3, #8]\n"
+"       b       4f\n"
+"       ldp     s16, s17, [%3]\n"       /* S3 */
+"       ldr     s18, [%3, #8]\n"
+"       b       3f\n"
+"       ldp     s16, s17, [%3]\n"       /* S2 */
+"       b       2f\n"
+"       nop\n"
+"       ldr     s16, [%3]\n"            /* S1 */
+"       b       1f\n"
+"       nop\n"
+"       ldp     d16, d17, [%3]\n"       /* D4 */
+"       ldp     d18, d19, [%3, #16]\n"
+"       b       4f\n"
+"       ldp     d16, d17, [%3]\n"       /* D3 */
+"       ldr     d18, [%3, #16]\n"
+"       b       3f\n"
+"       ldp     d16, d17, [%3]\n"       /* D2 */
+"       b       2f\n"
+"       nop\n"
+"       ldr     d16, [%3]\n"            /* D1 */
+"       b       1f\n"
+"       nop\n"
+"       ldp     q16, q17, [%3]\n"       /* Q4 */
+"       ldp     q18, q19, [%3, #32]\n"
+"       b       4f\n"
+"       ldp     q16, q17, [%3]\n"       /* Q3 */
+"       ldr     q18, [%3, #32]\n"
+"       b       3f\n"
+"       ldp     q16, q17, [%3]\n"       /* Q2 */
+"       b       2f\n"
+"       nop\n"
+"       ldr     q16, [%3]\n"            /* Q1 */
+"       b       1f\n"
+"4:     str     q19, [%2, #48]\n"
+"3:     str     q18, [%2, #32]\n"
+"2:     str     q17, [%2, #16]\n"
+"1:     str     q16, [%2]"
     : "=&r"(x0)
     : "r"(f * 12), "r"(dest), "r"(src)
     : "memory", "v16", "v17", "v18", "v19");
@@ -763,12 +763,12 @@ ffi_call_int (ffi_cif *cif, void (*fn)(void), void *orig_rvalue,
         else if (s > 16)
           {
         /* If the argument is a composite type that is larger than 16
-		   bytes, then the argument is copied to memory, and
+           bytes, then the argument is copied to memory, and
            the argument is replaced by a pointer to the copy.  */
-		dest = allocate_and_copy_struct_to_stack (&state, stack,
-							  ty->alignment, s,
-							  avalue[i]);
-		a = &dest;
+        dest = allocate_and_copy_struct_to_stack (&state, stack,
+                                                  ty->alignment, s,
+                                                  avalue[i]);
+        a = &dest;
         t = FFI_TYPE_POINTER;
         s = sizeof (void *);
         goto do_pointer;
@@ -872,10 +872,10 @@ ffi_prep_closure_loc (ffi_closure *closure,
   config[1] = start;
 # endif
 #else
-  static const unsigned char trampoline[16] = {
-    0x90, 0x00, 0x00, 0x58,	/* ldr	x16, tramp+16	*/
-    0xf1, 0xff, 0xff, 0x10,	/* adr	x17, tramp+0	*/
-    0x00, 0x02, 0x1f, 0xd6	/* br	x16		*/
+static const unsigned char trampoline[16] = {
+    0x90, 0x00, 0x00, 0x58,     /* ldr  x16, tramp+16   */
+    0xf1, 0xff, 0xff, 0x10,     /* adr  x17, tramp+0    */
+    0x00, 0x02, 0x1f, 0xd6      /* br   x16             */
   };
   char *tramp = closure->tramp;
 

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/closures.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/closures.c
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------
-   closures.c - Copyright (c) 2019 Anthony Green
+   closures.c - Copyright (c) 2019, 2022 Anthony Green
                 Copyright (c) 2007, 2009, 2010 Red Hat, Inc.
                 Copyright (C) 2007, 2009, 2010 Free Software Foundation, Inc
                 Copyright (c) 2011 Plausible Labs Cooperative, Inc.
@@ -27,7 +27,7 @@
    DEALINGS IN THE SOFTWARE.
    ----------------------------------------------------------------------- */
 
-#if defined __linux__ && !defined _GNU_SOURCE
+#if (defined __linux__ || defined __CYGWIN__) && !defined _GNU_SOURCE
 #define _GNU_SOURCE 1
 #endif
 
@@ -133,7 +133,7 @@ ffi_tramp_is_present (__attribute__((unused)) void *ptr)
 #  define FFI_MMAP_EXEC_WRIT 1
 #  define HAVE_MNTENT 1
 # endif
-# if defined(_WIN32) || defined(__OS2__)
+# if defined(__CYGWIN__) || defined(_WIN32) || defined(__OS2__)
 /* Windows systems may have Data Execution Protection (DEP) enabled,
    which requires the use of VirtualMalloc/VirtualFree to alloc/free
    executable memory. */
@@ -141,14 +141,18 @@ ffi_tramp_is_present (__attribute__((unused)) void *ptr)
 # endif
 #endif
 
-#if FFI_MMAP_EXEC_WRIT && !defined FFI_MMAP_EXEC_SELINUX
-# if defined(__linux__) && !defined(__ANDROID__)
+#if FFI_MMAP_EXEC_WRIT && defined(__linux__) && !defined(__ANDROID__)
+# if !defined FFI_MMAP_EXEC_SELINUX
 /* When defined to 1 check for SELinux and if SELinux is active,
    don't attempt PROT_EXEC|PROT_WRITE mapping at all, as that
    might cause audit messages.  */
 #  define FFI_MMAP_EXEC_SELINUX 1
-# endif
-#endif
+# endif /* !defined FFI_MMAP_EXEC_SELINUX */
+# if !defined FFI_MMAP_PAX
+/* Also check for PaX MPROTECT */
+#  define FFI_MMAP_PAX 1
+# endif /* !defined FFI_MMAP_PAX */
+#endif /* FFI_MMAP_EXEC_WRIT && defined(__linux__) && !defined(__ANDROID__) */
 
 #if FFI_CLOSURES
 
@@ -230,10 +234,22 @@ ffi_trampoline_table_alloc (void)
   kt = vm_remap (mach_task_self (), &trampoline_page, PAGE_MAX_SIZE, 0x0,
          VM_FLAGS_OVERWRITE, mach_task_self (), trampoline_page_template,
          FALSE, &cur_prot, &max_prot, VM_INHERIT_SHARE);
-  if (kt != KERN_SUCCESS || !(cur_prot & VM_PROT_EXECUTE))
+  if (kt != KERN_SUCCESS)
     {
       vm_deallocate (mach_task_self (), config_page, PAGE_MAX_SIZE * 2);
       return NULL;
+    }
+
+  if (!(cur_prot & VM_PROT_EXECUTE))
+    {
+      /* If VM_PROT_EXECUTE isn't set on the remapped trampoline page, set it */
+      kt = vm_protect (mach_task_self (), trampoline_page, PAGE_MAX_SIZE,
+         FALSE, cur_prot | VM_PROT_EXECUTE);
+      if (kt != KERN_SUCCESS)
+        {
+          vm_deallocate (mach_task_self (), config_page, PAGE_MAX_SIZE * 2);
+          return NULL;
+        }
     }
 
   /* We have valid trampoline and config pages */
@@ -467,14 +483,18 @@ selinux_enabled_check (void)
 
 #endif /* !FFI_MMAP_EXEC_SELINUX */
 
-/* On PaX enable kernels that have MPROTECT enable we can't use PROT_EXEC. */
-#ifdef FFI_MMAP_EXEC_EMUTRAMP_PAX
+/* On PaX enable kernels that have MPROTECT enabled we can't use PROT_EXEC. */
+#if defined FFI_MMAP_PAX
 #include <stdlib.h>
 
-static int emutramp_enabled = -1;
+enum {
+  PAX_MPROTECT = (1 << 0),
+  PAX_EMUTRAMP = (1 << 1),
+};
+static int cached_pax_flags = -1;
 
 static int
-emutramp_enabled_check (void)
+pax_flags_check (void)
 {
   char *buf = NULL;
   size_t len = 0;
@@ -488,9 +508,10 @@ emutramp_enabled_check (void)
   while (getline (&buf, &len, f) != -1)
     if (!strncmp (buf, "PaX:", 4))
       {
-        char emutramp;
-        if (sscanf (buf, "%*s %*c%c", &emutramp) == 1)
-          ret = (emutramp == 'E');
+        if (NULL != strchr (buf + 4, 'M'))
+          ret |= PAX_MPROTECT;
+        if (NULL != strchr (buf + 4, 'E'))
+          ret |= PAX_EMUTRAMP;
         break;
       }
   free (buf);
@@ -498,9 +519,13 @@ emutramp_enabled_check (void)
   return ret;
 }
 
-#define is_emutramp_enabled() (emutramp_enabled >= 0 ? emutramp_enabled \
-                               : (emutramp_enabled = emutramp_enabled_check ()))
-#endif /* FFI_MMAP_EXEC_EMUTRAMP_PAX */
+#define get_pax_flags() (cached_pax_flags >= 0 ? cached_pax_flags \
+                               : (cached_pax_flags = pax_flags_check ()))
+#define has_pax_flags(flags) ((flags) == ((flags) & get_pax_flags ()))
+#define is_mprotect_enabled() (has_pax_flags (PAX_MPROTECT))
+#define is_emutramp_enabled() (has_pax_flags (PAX_EMUTRAMP))
+
+#endif /* defined FFI_MMAP_PAX */
 
 #elif defined (__CYGWIN__) || defined(__INTERIX)
 
@@ -511,9 +536,10 @@ emutramp_enabled_check (void)
 
 #endif /* !defined(X86_WIN32) && !defined(X86_WIN64) */
 
-#ifndef FFI_MMAP_EXEC_EMUTRAMP_PAX
-#define is_emutramp_enabled() 0
-#endif /* FFI_MMAP_EXEC_EMUTRAMP_PAX */
+#if !defined FFI_MMAP_PAX
+# define is_mprotect_enabled() 0
+# define is_emutramp_enabled() 0
+#endif /* !defined FFI_MMAP_PAX */
 
 /* Declare all functions defined in dlmalloc.c as static.  */
 static void *dlmalloc(size_t);
@@ -737,7 +763,7 @@ open_temp_exec_file_opts_next (void)
 
 /* Return a file descriptor of a temporary zero-sized file in a
    writable and executable filesystem.  */
-static int
+int
 open_temp_exec_file (void)
 {
   int fd;
@@ -878,13 +904,23 @@ dlmmap (void *start, size_t length, int prot,
       return ptr;
     }
 
-  if (execfd == -1 && is_emutramp_enabled ())
+  /* -1 != execfd hints that we already decided to use dlmmap_locked
+     last time.  */
+  if (execfd == -1 && is_mprotect_enabled ())
     {
-      ptr = mmap (start, length, prot & ~PROT_EXEC, flags, fd, offset);
-      return ptr;
+#ifdef FFI_MMAP_EXEC_EMUTRAMP_PAX
+      if (is_emutramp_enabled ())
+        {
+          /* emutramp requires the kernel recognizing the trampoline pattern
+             generated by ffi_prep_closure_loc; there is no way to test
+             in advance whether this will work, so this is experimental.  */
+          ptr = mmap (start, length, prot & ~PROT_EXEC, flags, fd, offset);
+          return ptr;
+        }
+#endif
+      /* fallback to dlmmap_locked.  */
     }
-
-  if (execfd == -1 && !is_selinux_enabled ())
+  else if (execfd == -1 && !is_selinux_enabled ())
     {
       ptr = mmap (start, length, prot | PROT_EXEC, flags, fd, offset);
 
@@ -897,16 +933,11 @@ dlmmap (void *start, size_t length, int prot,
      MREMAP_DUP and prot at this point.  */
     }
 
-  if (execsize == 0 || execfd == -1)
-    {
-      pthread_mutex_lock (&open_temp_exec_file_mutex);
-      ptr = dlmmap_locked (start, length, prot, flags, offset);
-      pthread_mutex_unlock (&open_temp_exec_file_mutex);
+  pthread_mutex_lock (&open_temp_exec_file_mutex);
+  ptr = dlmmap_locked (start, length, prot, flags, offset);
+  pthread_mutex_unlock (&open_temp_exec_file_mutex);
 
-      return ptr;
-    }
-
-  return dlmmap_locked (start, length, prot, flags, offset);
+  return ptr;
 }
 
 /* Release memory at the given address, as well as the corresponding

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/dlmalloc.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/dlmalloc.c
@@ -592,6 +592,11 @@ DEFAULT_MMAP_THRESHOLD       default: 256K
   malloc does support the following options.
 */
 
+/* The system's malloc.h may have conflicting defines. */
+#undef M_TRIM_THRESHOLD
+#undef M_GRANULARITY
+#undef M_MMAP_THRESHOLD
+
 #define M_TRIM_THRESHOLD     (-1)
 #define M_GRANULARITY        (-2)
 #define M_MMAP_THRESHOLD     (-3)

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/prep_cif.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/prep_cif.c
@@ -1,6 +1,7 @@
 /* -----------------------------------------------------------------------
    prep_cif.c - Copyright (c) 2011, 2012, 2021  Anthony Green
                 Copyright (c) 1996, 1998, 2007  Red Hat, Inc.
+                Copyright (c) 2022 Oracle and/or its affiliates.
 
    Permission is hereby granted, free of charge, to any person obtaining
    a copy of this software and associated documentation files (the
@@ -240,7 +241,7 @@ ffi_status ffi_prep_cif_var(ffi_cif *cif,
   if (rc != FFI_OK)
     return rc;
 
-  for (i = 1; i < ntotalargs; i++)
+  for (i = nfixedargs; i < ntotalargs; i++)
     {
       ffi_type *arg_type = atypes[i];
       if (arg_type == &ffi_type_float

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/ffi.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/ffi.c
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------
-   ffi.c - Copyright (c) 2017  Anthony Green
+   ffi.c - Copyright (c) 2017, 2022  Anthony Green
            Copyright (c) 1996, 1998, 1999, 2001, 2007, 2008  Red Hat, Inc.
            Copyright (c) 2002  Ranjit Mathew
            Copyright (c) 2002  Bo Thorsen
@@ -117,15 +117,16 @@ ffi_prep_cif_machdep(ffi_cif *cif)
       flags = X86_RET_INT64;
       break;
             case FFI_TYPE_STRUCT:
-#ifndef X86
-      /* ??? This should be a different ABI rather than an ifdef.  */
-      if (cif->rtype->size == 1)
+      {
+#ifdef X86_WIN32
+        size_t size = cif->rtype->size;
+        if (size == 1)
     flags = X86_RET_STRUCT_1B;
-      else if (cif->rtype->size == 2)
+        else if (size == 2)
     flags = X86_RET_STRUCT_2B;
-      else if (cif->rtype->size == 4)
+        else if (size == 4)
     flags = X86_RET_INT32;
-      else if (cif->rtype->size == 8)
+        else if (size == 8)
     flags = X86_RET_INT64;
       else
 #endif
@@ -146,6 +147,7 @@ ffi_prep_cif_machdep(ffi_cif *cif)
       /* Allocate space for return value pointer.  */
       bytes += FFI_ALIGN (sizeof(void*), FFI_SIZEOF_ARG);
         }
+      }
       break;
     case FFI_TYPE_COMPLEX:
       switch (cif->rtype->elements[0]->type)
@@ -182,7 +184,12 @@ ffi_prep_cif_machdep(ffi_cif *cif)
       {
       ffi_type *t = cif->arg_types[i];
 
-      bytes = FFI_ALIGN (bytes, t->alignment);
+#if defined(X86_WIN32)
+      if (cabi == FFI_STDCALL)
+        bytes = FFI_ALIGN (bytes, FFI_SIZEOF_ARG);
+      else
+#endif
+        bytes = FFI_ALIGN (bytes, t->alignment);
       bytes += FFI_ALIGN (t->size, FFI_SIZEOF_ARG);
       }
   cif->bytes = bytes;
@@ -217,19 +224,19 @@ extend_basic_type(void *arg, int type)
 
 struct call_frame
 {
-  void *ebp;            /* 0 */
-  void *retaddr;        /* 4 */
-  void (*fn)(void);     /* 8 */
-  int flags;            /* 12 */
-  void *rvalue;         /* 16 */
-  unsigned regs[3];     /* 20-28 */
+  void *ebp;		/* 0 */
+  void *retaddr;	/* 4 */
+  void (*fn)(void);	/* 8 */
+  int flags;		/* 12 */
+  void *rvalue;		/* 16 */
+  unsigned regs[3];	/* 20-28 */
 };
 
 struct abi_params
 {
-  int dir;              /* parameter growth direction */
-  int static_chain;     /* the static chain register used by gcc */
-  int nregs;            /* number of register parameters */
+  int dir;		/* parameter growth direction */
+  int static_chain;	/* the static chain register used by gcc */
+  int nregs;		/* number of register parameters */
   int regs[3];
 };
 
@@ -430,11 +437,11 @@ void FFI_HIDDEN ffi_closure_REGISTER_alt(void);
 
 struct closure_frame
 {
-  unsigned rettemp[4];                          /* 0 */
-  unsigned regs[3];                             /* 16-24 */
-  ffi_cif *cif;                                 /* 28 */
-  void (*fun)(ffi_cif*,void*,void**,void*);     /* 32 */
-  void *user_data;                              /* 36 */
+  unsigned rettemp[4];				/* 0 */
+  unsigned regs[3];				/* 16-24 */
+  ffi_cif *cif;					/* 28 */
+  void (*fun)(ffi_cif*,void*,void**,void*);	/* 32 */
+  void *user_data;				/* 36 */
 };
 
 int FFI_HIDDEN FFI_DECLARE_FASTCALL
@@ -609,7 +616,9 @@ ffi_prep_closure_loc (ffi_closure* closure,
   tramp[9] = 0xe9;
   *(unsigned *)(tramp + 10) = (unsigned)dest - ((unsigned)codeloc + 14);
 
+#if defined(FFI_EXEC_STATIC_TRAMP)
 out:
+#endif
   closure->cif = cif;
   closure->fun = fun;
   closure->user_data = user_data;

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/ffi.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/ffi.c
@@ -224,19 +224,19 @@ extend_basic_type(void *arg, int type)
 
 struct call_frame
 {
-  void *ebp;		/* 0 */
-  void *retaddr;	/* 4 */
-  void (*fn)(void);	/* 8 */
-  int flags;		/* 12 */
-  void *rvalue;		/* 16 */
-  unsigned regs[3];	/* 20-28 */
+  void *ebp;            /* 0 */
+  void *retaddr;        /* 4 */
+  void (*fn)(void);     /* 8 */
+  int flags;            /* 12 */
+  void *rvalue;         /* 16 */
+  unsigned regs[3];     /* 20-28 */
 };
 
 struct abi_params
 {
-  int dir;		/* parameter growth direction */
-  int static_chain;	/* the static chain register used by gcc */
-  int nregs;		/* number of register parameters */
+  int dir;              /* parameter growth direction */
+  int static_chain;     /* the static chain register used by gcc */
+  int nregs;            /* number of register parameters */
   int regs[3];
 };
 
@@ -437,11 +437,11 @@ void FFI_HIDDEN ffi_closure_REGISTER_alt(void);
 
 struct closure_frame
 {
-  unsigned rettemp[4];				/* 0 */
-  unsigned regs[3];				/* 16-24 */
-  ffi_cif *cif;					/* 28 */
-  void (*fun)(ffi_cif*,void*,void**,void*);	/* 32 */
-  void *user_data;				/* 36 */
+  unsigned rettemp[4];                          /* 0 */
+  unsigned regs[3];                             /* 16-24 */
+  ffi_cif *cif;                                 /* 28 */
+  void (*fun)(ffi_cif*,void*,void**,void*);     /* 32 */
+  void *user_data;                              /* 36 */
 };
 
 int FFI_HIDDEN FFI_DECLARE_FASTCALL

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/ffi64.c
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/ffi64.c
@@ -65,8 +65,8 @@ struct register_args
   /* Registers for argument passing.  */
   UINT64 gpr[MAX_GPR_REGS];
   union big_int_union sse[MAX_SSE_REGS];
-  UINT64 rax;	/* ssecount */
-  UINT64 r10;	/* static chain */
+  UINT64 rax;   /* ssecount */
+  UINT64 r10;   /* static chain */
 };
 
 extern void ffi_call_unix64 (void *args, unsigned long bytes, unsigned flags,
@@ -100,7 +100,7 @@ enum x86_64_reg_class
 
 #define MAX_CLASSES 4
 
-#define SSE_CLASS_P(X)	((X) >= X86_64_SSE_CLASS && X <= X86_64_SSEUP_CLASS)
+#define SSE_CLASS_P(X) ((X) >= X86_64_SSE_CLASS && X <= X86_64_SSEUP_CLASS)
 
 /* x86-64 register passing implementation.  See x86-64 ABI for details.  Goal
    of this code is to classify each 8bytes of incoming argument by the register

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/ffitarget.h
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/ffitarget.h
@@ -41,6 +41,9 @@
 
 #if defined (X86_64) && defined (__i386__)
 #undef X86_64
+#warning ******************************************************
+#warning ********** X86 IS DEFINED ****************************
+#warning ******************************************************
 #define X86
 #endif
 
@@ -159,4 +162,3 @@ typedef enum ffi_abi {
 #endif
 
 #endif
-

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/sysv_intel.S
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/sysv_intel.S
@@ -1,5 +1,5 @@
 /* -----------------------------------------------------------------------
-   sysv.S - Copyright (c) 2017  Anthony Green
+   sysv.S - Copyright (c) 2017, 2022  Anthony Green
           - Copyright (c) 2013  The Written Word, Inc.
           - Copyright (c) 1996,1998,2001-2003,2005,2008,2010  Red Hat, Inc.
 
@@ -45,15 +45,15 @@
    The use of ORG asserts that we're at the correct location.  */
 /* ??? The clang assembler doesn't handle .org with symbolic expressions.  */
 #if defined(__clang__) || defined(__APPLE__) || (defined (__sun__) && defined(__svr4__))
-# define E(BASE, X)     ALIGN 8
+# define E(BASE, X)	ALIGN 8
 #else
-# define E(BASE, X)     ALIGN 8; ORG BASE + X * 8
+# define E(BASE, X)	ALIGN 8; ORG BASE + X * 8
 #endif
 
     .686P
     .MODEL FLAT
 
-EXTRN   @ffi_closure_inner@8:PROC
+EXTRN	@ffi_closure_inner@8:PROC
 _TEXT SEGMENT
 
 /* This is declared as
@@ -73,12 +73,12 @@ PUBLIC @ffi_call_i386@8
 L(UW0):
         cfi_startproc
  #if !HAVE_FASTCALL
-        mov         ecx, [esp+4]
-        mov     edx, [esp+8]
+	mov	    ecx, [esp+4]
+	mov 	edx, [esp+8]
  #endif
-        mov         eax, [esp]          /* move the return address */
-        mov         [ecx], ebp          /* store ebp into local frame */
-        mov     [ecx+4], eax    /* store retaddr into local frame */
+	mov	    eax, [esp]		/* move the return address */
+	mov	    [ecx], ebp		/* store ebp into local frame */
+	mov 	[ecx+4], eax	/* store retaddr into local frame */
 
         /* New stack frame based off ebp.  This is a itty bit of unwind
            trickery in that the CFA *has* changed.  There is no easy way
@@ -87,85 +87,85 @@ L(UW0):
            unwind back to ffi_call.  Note that the location to which we
            moved the return address is (the new) CFA-4, so from the
            perspective of the unwind info, it hasn't moved.  */
-        mov     ebp, ecx
+	mov 	ebp, ecx
 L(UW1):
-        // cfi_def_cfa(%ebp, 8)
-        // cfi_rel_offset(%ebp, 0)
+	/* cfi_def_cfa(%ebp, 8) */
+	/* cfi_rel_offset(%ebp, 0) */
 
-        mov     esp, edx                /* set outgoing argument stack */
-        mov     eax, [20+R_EAX*4+ebp]   /* set register arguments */
-        mov     edx, [20+R_EDX*4+ebp]
-        mov         ecx, [20+R_ECX*4+ebp]
+	mov 	esp, edx		/* set outgoing argument stack */
+	mov 	eax, [20+R_EAX*4+ebp]	/* set register arguments */
+	mov 	edx, [20+R_EDX*4+ebp]
+	mov	    ecx, [20+R_ECX*4+ebp]
 
-        call    dword ptr [ebp+8]
+	call	dword ptr [ebp+8]
 
-        mov         ecx, [12+ebp]               /* load return type code */
-        mov     [ebp+8], ebx            /* preserve %ebx */
+	mov	    ecx, [12+ebp]		/* load return type code */
+	mov 	[ebp+8], ebx		/* preserve %ebx */
 L(UW2):
-        // cfi_rel_offset(%ebx, 8)
+	/* cfi_rel_offset(%ebx, 8) */
 
-        and     ecx, X86_RET_TYPE_MASK
-        lea     ebx, [L(store_table) + ecx * 8]
-        mov     ecx, [ebp+16]           /* load result address */
-        jmp         ebx
+	and 	ecx, X86_RET_TYPE_MASK
+	lea 	ebx, [L(store_table) + ecx * 8]
+	mov 	ecx, [ebp+16]		/* load result address */
+	jmp	    ebx
 
-        ALIGN   8
+	ALIGN	8
 L(store_table):
 E(L(store_table), X86_RET_FLOAT)
-        fstp    DWORD PTR [ecx]
-        jmp     L(e1)
+	fstp	DWORD PTR [ecx]
+	jmp	L(e1)
 E(L(store_table), X86_RET_DOUBLE)
-        fstp    QWORD PTR [ecx]
-        jmp     L(e1)
+	fstp	QWORD PTR [ecx]
+	jmp	L(e1)
 E(L(store_table), X86_RET_LDOUBLE)
-        fstp    QWORD PTR [ecx]
-        jmp     L(e1)
+	fstp	QWORD PTR [ecx]
+	jmp	L(e1)
 E(L(store_table), X86_RET_SINT8)
-        movsx   eax, al
-        mov     [ecx], eax
-        jmp     L(e1)
+	movsx	eax, al
+	mov	[ecx], eax
+	jmp	L(e1)
 E(L(store_table), X86_RET_SINT16)
-        movsx   eax, ax
-        mov     [ecx], eax
-        jmp     L(e1)
+	movsx	eax, ax
+	mov	[ecx], eax
+	jmp	L(e1)
 E(L(store_table), X86_RET_UINT8)
-        movzx   eax, al
-        mov     [ecx], eax
-        jmp     L(e1)
+	movzx	eax, al
+	mov	[ecx], eax
+	jmp	L(e1)
 E(L(store_table), X86_RET_UINT16)
-        movzx   eax, ax
-        mov     [ecx], eax
-        jmp     L(e1)
+	movzx	eax, ax
+	mov	[ecx], eax
+	jmp	L(e1)
 E(L(store_table), X86_RET_INT64)
-        mov     [ecx+4], edx
+	mov	[ecx+4], edx
         /* fallthru */
 E(L(store_table), X86_RET_int 32)
-        mov     [ecx], eax
+	mov	[ecx], eax
         /* fallthru */
 E(L(store_table), X86_RET_VOID)
 L(e1):
-        mov         ebx, [ebp+8]
-        mov         esp, ebp
-        pop     ebp
+	mov	    ebx, [ebp+8]
+	mov	    esp, ebp
+	pop 	ebp
 L(UW3):
-        // cfi_remember_state
-        // cfi_def_cfa(%esp, 4)
-        // cfi_restore(%ebx)
-        // cfi_restore(%ebp)
+	/* cfi_remember_state */
+	/* cfi_def_cfa(%esp, 4) */
+	/* cfi_restore(%ebx) */
+	/* cfi_restore(%ebp) */
         ret
 L(UW4):
-        // cfi_restore_state
+	/* cfi_restore_state */
 
 E(L(store_table), X86_RET_STRUCTPOP)
-        jmp         L(e1)
+	jmp	    L(e1)
 E(L(store_table), X86_RET_STRUCTARG)
-        jmp         L(e1)
+	jmp	    L(e1)
 E(L(store_table), X86_RET_STRUCT_1B)
-        mov     [ecx], al
-        jmp         L(e1)
+	mov 	[ecx], al
+	jmp	    L(e1)
 E(L(store_table), X86_RET_STRUCT_2B)
-        mov     [ecx], ax
-        jmp         L(e1)
+	mov 	[ecx], ax
+	jmp	    L(e1)
 
         /* Fill out the table so that bad values are predictable.  */
 E(L(store_table), X86_RET_UNUSED14)
@@ -174,7 +174,7 @@ E(L(store_table), X86_RET_UNUSED15)
         int 3
 
 L(UW5):
-        // cfi_endproc
+	/* cfi_endproc */
 ENDF(@ffi_call_i386@8)
 
 /* The inner helper is declared as
@@ -184,96 +184,96 @@ ENDF(@ffi_call_i386@8)
 
    Thus the arguments are placed in
 
-        ecx:    frame
-        edx:    argp
+	ecx:	frame
+	edx:	argp
 */
 
 /* Macros to help setting up the closure_data structure.  */
 
 #if HAVE_FASTCALL
-# define closure_FS     (40 + 4)
-# define closure_CF     0
+# define closure_FS	(40 + 4)
+# define closure_CF	0
 #else
-# define closure_FS     (8 + 40 + 12)
-# define closure_CF     8
+# define closure_FS	(8 + 40 + 12)
+# define closure_CF	8
 #endif
 
 FFI_CLOSURE_SAVE_REGS MACRO
-        mov     [esp + closure_CF+16+R_EAX*4], eax
-        mov     [esp + closure_CF+16+R_EDX*4], edx
-        mov     [esp + closure_CF+16+R_ECX*4], ecx
+	mov 	[esp + closure_CF+16+R_EAX*4], eax
+	mov 	[esp + closure_CF+16+R_EDX*4], edx
+	mov 	[esp + closure_CF+16+R_ECX*4], ecx
 ENDM
 
 FFI_CLOSURE_COPY_TRAMP_DATA MACRO
-        mov     edx, [eax+FFI_TRAMPOLINE_SIZE]      /* copy cif */
-        mov     ecx, [eax+FFI_TRAMPOLINE_SIZE+4]    /* copy fun */
-        mov     eax, [eax+FFI_TRAMPOLINE_SIZE+8];   /* copy user_data */
-        mov     [esp+closure_CF+28], edx
-        mov     [esp+closure_CF+32], ecx
-        mov     [esp+closure_CF+36], eax
+	mov 	edx, [eax+FFI_TRAMPOLINE_SIZE]      /* copy cif */
+	mov 	ecx, [eax+FFI_TRAMPOLINE_SIZE+4]    /* copy fun */
+	mov 	eax, [eax+FFI_TRAMPOLINE_SIZE+8];   /* copy user_data */
+	mov 	[esp+closure_CF+28], edx
+	mov 	[esp+closure_CF+32], ecx
+	mov 	[esp+closure_CF+36], eax
 ENDM
 
 #if HAVE_FASTCALL
 FFI_CLOSURE_PREP_CALL MACRO
-        mov         ecx, esp                    /* load closure_data */
-        lea     edx, [esp+closure_FS+4]     /* load incoming stack */
+	mov	    ecx, esp                    /* load closure_data */
+	lea 	edx, [esp+closure_FS+4]     /* load incoming stack */
 ENDM
 #else
 FFI_CLOSURE_PREP_CALL MACRO
-        lea     ecx, [esp+closure_CF]       /* load closure_data */
-        lea     edx, [esp+closure_FS+4]     /* load incoming stack */
-        mov     [esp], ecx
-        mov     [esp+4], edx
+	lea 	ecx, [esp+closure_CF]       /* load closure_data */
+	lea 	edx, [esp+closure_FS+4]     /* load incoming stack */
+	mov 	[esp], ecx
+	mov 	[esp+4], edx
 ENDM
 #endif
 
 FFI_CLOSURE_CALL_INNER MACRO UWN
-        call    @ffi_closure_inner@8
+	call	@ffi_closure_inner@8
 ENDM
 
 FFI_CLOSURE_MASK_AND_JUMP MACRO LABEL
-        and         eax, X86_RET_TYPE_MASK
-        lea     edx, [LABEL+eax*8]
-        mov     eax, [esp+closure_CF]       /* optimiztic load */
-        jmp         edx
+	and	    eax, X86_RET_TYPE_MASK
+	lea 	edx, [LABEL+eax*8]
+	mov 	eax, [esp+closure_CF]       /* optimiztic load */
+	jmp	    edx
 ENDM
 
 ALIGN 16
 PUBLIC ffi_go_closure_EAX
 ffi_go_closure_EAX PROC C
 L(UW6):
-        // cfi_startproc
-        sub     esp, closure_FS
+	/* cfi_startproc */
+	sub	esp, closure_FS
 L(UW7):
-        // cfi_def_cfa_offset(closure_FS + 4)
+	/* cfi_def_cfa_offset(closure_FS + 4) */
         FFI_CLOSURE_SAVE_REGS
-        mov     edx, [eax+4]                    /* copy cif */
-        mov     ecx, [eax +8]                   /* copy fun */
-        mov     [esp+closure_CF+28], edx
-        mov     [esp+closure_CF+32], ecx
-        mov     [esp+closure_CF+36], eax        /* closure is user_data */
-        jmp     L(do_closure_i386)
+	mov     edx, [eax+4]			/* copy cif */
+	mov 	ecx, [eax +8]			/* copy fun */
+	mov 	[esp+closure_CF+28], edx
+	mov 	[esp+closure_CF+32], ecx
+	mov 	[esp+closure_CF+36], eax	/* closure is user_data */
+	jmp	L(do_closure_i386)
 L(UW8):
-        // cfi_endproc
+	/* cfi_endproc */
 ENDF(ffi_go_closure_EAX)
 
 ALIGN 16
 PUBLIC ffi_go_closure_ECX
 ffi_go_closure_ECX PROC C
 L(UW9):
-        // cfi_startproc
-        sub     esp, closure_FS
+	/* cfi_startproc */
+	sub 	esp, closure_FS
 L(UW10):
-        // cfi_def_cfa_offset(closure_FS + 4)
+	/* cfi_def_cfa_offset(closure_FS + 4) */
         FFI_CLOSURE_SAVE_REGS
-        mov     edx, [ecx+4]                    /* copy cif */
-        mov     eax, [ecx+8]                    /* copy fun */
-        mov     [esp+closure_CF+28], edx
-        mov     [esp+closure_CF+32], eax
-        mov     [esp+closure_CF+36], ecx        /* closure is user_data */
-        jmp     L(do_closure_i386)
+	mov 	edx, [ecx+4]			/* copy cif */
+	mov 	eax, [ecx+8]			/* copy fun */
+	mov 	[esp+closure_CF+28], edx
+	mov 	[esp+closure_CF+32], eax
+	mov 	[esp+closure_CF+36], ecx	/* closure is user_data */
+	jmp	L(do_closure_i386)
 L(UW11):
-        // cfi_endproc
+	/* cfi_endproc */
 ENDF(ffi_go_closure_ECX)
 
 /* The closure entry points are reached from the ffi_closure trampoline.
@@ -283,10 +283,10 @@ ALIGN 16
 PUBLIC ffi_closure_i386
 ffi_closure_i386 PROC C
 L(UW12):
-        // cfi_startproc
-        sub         esp, closure_FS
+	/* cfi_startproc */
+	sub	    esp, closure_FS
 L(UW13):
-        // cfi_def_cfa_offset(closure_FS + 4)
+	/* cfi_def_cfa_offset(closure_FS + 4) */
 
         FFI_CLOSURE_SAVE_REGS
         FFI_CLOSURE_COPY_TRAMP_DATA
@@ -301,55 +301,55 @@ L(do_closure_i386)::
     ALIGN 8
 L(load_table2):
 E(L(load_table2), X86_RET_FLOAT)
-        fld     dword ptr [esp+closure_CF]
-        jmp     L(e2)
+	fld 	dword ptr [esp+closure_CF]
+	jmp	L(e2)
 E(L(load_table2), X86_RET_DOUBLE)
-        fld     qword ptr [esp+closure_CF]
-        jmp     L(e2)
+	fld 	qword ptr [esp+closure_CF]
+	jmp	L(e2)
 E(L(load_table2), X86_RET_LDOUBLE)
-        fld     qword ptr [esp+closure_CF]
-        jmp     L(e2)
+	fld 	qword ptr [esp+closure_CF]
+	jmp	L(e2)
 E(L(load_table2), X86_RET_SINT8)
-        movsx   eax, al
-        jmp     L(e2)
+	movsx	eax, al
+	jmp	L(e2)
 E(L(load_table2), X86_RET_SINT16)
-        movsx   eax, ax
-        jmp     L(e2)
+	movsx	eax, ax
+	jmp	L(e2)
 E(L(load_table2), X86_RET_UINT8)
-        movzx   eax, al
-        jmp     L(e2)
+	movzx	eax, al
+	jmp	L(e2)
 E(L(load_table2), X86_RET_UINT16)
-        movzx   eax, ax
-        jmp     L(e2)
+	movzx	eax, ax
+	jmp	L(e2)
 E(L(load_table2), X86_RET_INT64)
-        mov     edx, [esp+closure_CF+4]
-        jmp     L(e2)
+	mov 	edx, [esp+closure_CF+4]
+	jmp	L(e2)
 E(L(load_table2), X86_RET_INT32)
         nop
         /* fallthru */
 E(L(load_table2), X86_RET_VOID)
 L(e2):
-        add     esp, closure_FS
+	add 	esp, closure_FS
 L(UW16):
-        // cfi_adjust_cfa_offset(-closure_FS)
+	/* cfi_adjust_cfa_offset(-closure_FS) */
         ret
 L(UW17):
-        // cfi_adjust_cfa_offset(closure_FS)
+	/* cfi_adjust_cfa_offset(closure_FS) */
 E(L(load_table2), X86_RET_STRUCTPOP)
-        add     esp, closure_FS
+	add 	esp, closure_FS
 L(UW18):
-        // cfi_adjust_cfa_offset(-closure_FS)
-        ret     4
+	/* cfi_adjust_cfa_offset(-closure_FS) */
+	ret	4
 L(UW19):
-        // cfi_adjust_cfa_offset(closure_FS)
+	/* cfi_adjust_cfa_offset(closure_FS) */
 E(L(load_table2), X86_RET_STRUCTARG)
-        jmp     L(e2)
+	jmp	L(e2)
 E(L(load_table2), X86_RET_STRUCT_1B)
-        movzx   eax, al
-        jmp     L(e2)
+	movzx	eax, al
+	jmp	L(e2)
 E(L(load_table2), X86_RET_STRUCT_2B)
-        movzx   eax, ax
-        jmp     L(e2)
+	movzx	eax, ax
+	jmp	L(e2)
 
         /* Fill out the table so that bad values are predictable.  */
 E(L(load_table2), X86_RET_UNUSED14)
@@ -358,26 +358,26 @@ E(L(load_table2), X86_RET_UNUSED15)
         int 3
 
 L(UW20):
-        // cfi_endproc
+	/* cfi_endproc */
 ENDF(ffi_closure_i386)
 
 ALIGN 16
-PUBLIC  ffi_go_closure_STDCALL
+PUBLIC	ffi_go_closure_STDCALL
 ffi_go_closure_STDCALL PROC C
 L(UW21):
-        // cfi_startproc
-        sub     esp, closure_FS
+	/* cfi_startproc */
+	sub 	esp, closure_FS
 L(UW22):
-        // cfi_def_cfa_offset(closure_FS + 4)
+	/* cfi_def_cfa_offset(closure_FS + 4) */
         FFI_CLOSURE_SAVE_REGS
-        mov     edx, [ecx+4]                    /* copy cif */
-        mov     eax, [ecx+8]                    /* copy fun */
-        mov     [esp+closure_CF+28], edx
-        mov     [esp+closure_CF+32], eax
-        mov     [esp+closure_CF+36], ecx        /* closure is user_data */
-        jmp     L(do_closure_STDCALL)
+	mov 	edx, [ecx+4]			/* copy cif */
+	mov 	eax, [ecx+8]			/* copy fun */
+	mov 	[esp+closure_CF+28], edx
+	mov 	[esp+closure_CF+32], eax
+	mov 	[esp+closure_CF+36], ecx	/* closure is user_data */
+	jmp	L(do_closure_STDCALL)
 L(UW23):
-        // cfi_endproc
+	/* cfi_endproc */
 ENDF(ffi_go_closure_STDCALL)
 
 /* For REGISTER, we have no available parameter registers, and so we
@@ -387,19 +387,19 @@ ALIGN 16
 PUBLIC ffi_closure_REGISTER
 ffi_closure_REGISTER PROC C
 L(UW24):
-        // cfi_startproc
-        // cfi_def_cfa(%esp, 8)
-        // cfi_offset(%eip, -8)
-        sub     esp, closure_FS-4
+	/* cfi_startproc */
+	/* cfi_def_cfa(%esp, 8) */
+	/* cfi_offset(%eip, -8) */
+	sub 	esp, closure_FS-4
 L(UW25):
-        // cfi_def_cfa_offset(closure_FS + 4)
+	/* cfi_def_cfa_offset(closure_FS + 4) */
         FFI_CLOSURE_SAVE_REGS
-        mov     ecx, [esp+closure_FS-4]         /* load retaddr */
-        mov     eax, [esp+closure_FS]           /* load closure */
-        mov     [esp+closure_FS], ecx           /* move retaddr */
-        jmp     L(do_closure_REGISTER)
+	mov	ecx, [esp+closure_FS-4] 	/* load retaddr */
+	mov	eax, [esp+closure_FS]		/* load closure */
+	mov	[esp+closure_FS], ecx		/* move retaddr */
+	jmp	L(do_closure_REGISTER)
 L(UW26):
-        // cfi_endproc
+	/* cfi_endproc */
 ENDF(ffi_closure_REGISTER)
 
 /* For STDCALL (and others), we need to pop N bytes of arguments off
@@ -410,10 +410,10 @@ ALIGN 16
 PUBLIC ffi_closure_STDCALL
 ffi_closure_STDCALL PROC C
 L(UW27):
-        // cfi_startproc
-        sub     esp, closure_FS
+	/* cfi_startproc */
+	sub 	esp, closure_FS
 L(UW28):
-        // cfi_def_cfa_offset(closure_FS + 4)
+	/* cfi_def_cfa_offset(closure_FS + 4) */
 
         FFI_CLOSURE_SAVE_REGS
 
@@ -428,11 +428,11 @@ L(do_closure_STDCALL)::
         FFI_CLOSURE_PREP_CALL
         FFI_CLOSURE_CALL_INNER(29)
 
-        mov     ecx, eax
-        shr     ecx, X86_RET_POP_SHIFT      /* isolate pop count */
-        lea     ecx, [esp+closure_FS+ecx]       /* compute popped esp */
-        mov     edx, [esp+closure_FS]           /* move return address */
-        mov     [ecx], edx
+	mov 	ecx, eax
+	shr 	ecx, X86_RET_POP_SHIFT	    /* isolate pop count */
+	lea 	ecx, [esp+closure_FS+ecx]	/* compute popped esp */
+	mov 	edx, [esp+closure_FS]		/* move return address */
+	mov 	[ecx], edx
 
         /* From this point on, the value of %esp upon return is %ecx+4,
            and we've copied the return address to %ecx to make return easy.
@@ -473,7 +473,7 @@ E(L(load_table3), X86_RET_UINT16)
         mov     esp, ecx
         ret
 E(L(load_table3), X86_RET_INT64)
-        mov     edx, [esp+closure_CF+4]
+	mov 	edx, [esp+closure_CF+4]
         mov     esp, ecx
         ret
 E(L(load_table3), X86_RET_int 32)
@@ -486,15 +486,15 @@ E(L(load_table3), X86_RET_STRUCTPOP)
         mov     esp, ecx
         ret
 E(L(load_table3), X86_RET_STRUCTARG)
-        mov     esp, ecx
+	mov 	esp, ecx
         ret
 E(L(load_table3), X86_RET_STRUCT_1B)
-        movzx   eax, al
-        mov     esp, ecx
+	movzx	eax, al
+	mov 	esp, ecx
         ret
 E(L(load_table3), X86_RET_STRUCT_2B)
-        movzx   eax, ax
-        mov     esp, ecx
+	movzx	eax, ax
+	mov 	esp, ecx
         ret
 
         /* Fill out the table so that bad values are predictable.  */
@@ -504,102 +504,102 @@ E(L(load_table3), X86_RET_UNUSED15)
         int 3
 
 L(UW31):
-        // cfi_endproc
+	/* cfi_endproc */
 ENDF(ffi_closure_STDCALL)
 
 #if !FFI_NO_RAW_API
 
-#define raw_closure_S_FS        (16+16+12)
+#define raw_closure_S_FS	(16+16+12)
 
 ALIGN 16
 PUBLIC ffi_closure_raw_SYSV
 ffi_closure_raw_SYSV PROC C
 L(UW32):
-        // cfi_startproc
-        sub     esp, raw_closure_S_FS
+	/* cfi_startproc */
+	sub 	esp, raw_closure_S_FS
 L(UW33):
-        // cfi_def_cfa_offset(raw_closure_S_FS + 4)
-        mov     [esp+raw_closure_S_FS-4], ebx
+	/* cfi_def_cfa_offset(raw_closure_S_FS + 4) */
+	mov 	[esp+raw_closure_S_FS-4], ebx
 L(UW34):
-        // cfi_rel_offset(%ebx, raw_closure_S_FS-4)
+	/* cfi_rel_offset(%ebx, raw_closure_S_FS-4) */
 
-        mov     edx, [eax+FFI_TRAMPOLINE_SIZE+8]        /* load cl->user_data */
-        mov     [esp+12], edx
-        lea     edx, [esp+raw_closure_S_FS+4]           /* load raw_args */
-        mov     [esp+8], edx
-        lea     edx, [esp+16]                           /* load &res */
-        mov     [esp+4], edx
-        mov     ebx, [eax+FFI_TRAMPOLINE_SIZE]          /* load cl->cif */
-        mov     [esp], ebx
-        call    DWORD PTR [eax+FFI_TRAMPOLINE_SIZE+4]           /* call cl->fun */
+	mov 	edx, [eax+FFI_TRAMPOLINE_SIZE+8]	/* load cl->user_data */
+	mov 	[esp+12], edx
+	lea 	edx, [esp+raw_closure_S_FS+4]		/* load raw_args */
+	mov 	[esp+8], edx
+	lea 	edx, [esp+16]				/* load &res */
+	mov 	[esp+4], edx
+	mov 	ebx, [eax+FFI_TRAMPOLINE_SIZE]		/* load cl->cif */
+	mov 	[esp], ebx
+	call	DWORD PTR [eax+FFI_TRAMPOLINE_SIZE+4]		/* call cl->fun */
 
-        mov     eax, [ebx+20]                   /* load cif->flags */
-        and     eax, X86_RET_TYPE_MASK
-// #ifdef __PIC__
-//      call    __x86.get_pc_thunk.bx
-// L(pc4):
-//      lea     ecx, L(load_table4)-L(pc4)(%ebx, %eax, 8), %ecx
-// #else
-        lea     ecx, [L(load_table4)+eax+8]
-// #endif
-        mov     ebx, [esp+raw_closure_S_FS-4]
+	mov 	eax, [ebx+20]			/* load cif->flags */
+	and 	eax, X86_RET_TYPE_MASK
+/* #ifdef __PIC__ */
+/* 	call	__x86.get_pc_thunk.bx */
+/* L(pc4): */
+/* 	lea 	ecx, L(load_table4)-L(pc4)(%ebx, %eax, 8), %ecx */
+/* #else */
+	lea 	ecx, [L(load_table4)+eax+8]
+/* #endif */
+	mov 	ebx, [esp+raw_closure_S_FS-4]
 L(UW35):
-        // cfi_restore(%ebx)
-        mov     eax, [esp+16]                           /* Optimistic load */
-        jmp         dword ptr [ecx]
+	/* cfi_restore(%ebx) */
+	mov 	eax, [esp+16]				/* Optimistic load */
+	jmp	    dword ptr [ecx]
 
         ALIGN 8
 L(load_table4):
 E(L(load_table4), X86_RET_FLOAT)
-        fld     DWORD PTR [esp +16]
-        jmp     L(e4)
+	fld 	DWORD PTR [esp +16]
+	jmp	L(e4)
 E(L(load_table4), X86_RET_DOUBLE)
-        fld     QWORD PTR [esp +16]
-        jmp     L(e4)
+	fld 	QWORD PTR [esp +16]
+	jmp	L(e4)
 E(L(load_table4), X86_RET_LDOUBLE)
-        fld     QWORD PTR [esp +16]
-        jmp     L(e4)
+	fld 	QWORD PTR [esp +16]
+	jmp	L(e4)
 E(L(load_table4), X86_RET_SINT8)
-        movsx   eax, al
-        jmp     L(e4)
+	movsx	eax, al
+	jmp	L(e4)
 E(L(load_table4), X86_RET_SINT16)
-        movsx   eax, ax
-        jmp     L(e4)
+	movsx	eax, ax
+	jmp	L(e4)
 E(L(load_table4), X86_RET_UINT8)
-        movzx   eax, al
-        jmp     L(e4)
+	movzx	eax, al
+	jmp	L(e4)
 E(L(load_table4), X86_RET_UINT16)
-        movzx   eax, ax
-        jmp     L(e4)
+	movzx	eax, ax
+	jmp	L(e4)
 E(L(load_table4), X86_RET_INT64)
-        mov     edx, [esp+16+4]
-        jmp     L(e4)
+	mov 	edx, [esp+16+4]
+	jmp	L(e4)
 E(L(load_table4), X86_RET_int 32)
         nop
         /* fallthru */
 E(L(load_table4), X86_RET_VOID)
 L(e4):
-        add     esp, raw_closure_S_FS
+	add 	esp, raw_closure_S_FS
 L(UW36):
-        // cfi_adjust_cfa_offset(-raw_closure_S_FS)
+	/* cfi_adjust_cfa_offset(-raw_closure_S_FS) */
         ret
 L(UW37):
-        // cfi_adjust_cfa_offset(raw_closure_S_FS)
+	/* cfi_adjust_cfa_offset(raw_closure_S_FS) */
 E(L(load_table4), X86_RET_STRUCTPOP)
-        add     esp, raw_closure_S_FS
+	add 	esp, raw_closure_S_FS
 L(UW38):
-        // cfi_adjust_cfa_offset(-raw_closure_S_FS)
-        ret     4
+	/* cfi_adjust_cfa_offset(-raw_closure_S_FS) */
+	ret	4
 L(UW39):
-        // cfi_adjust_cfa_offset(raw_closure_S_FS)
+	/* cfi_adjust_cfa_offset(raw_closure_S_FS) */
 E(L(load_table4), X86_RET_STRUCTARG)
-        jmp     L(e4)
+	jmp	L(e4)
 E(L(load_table4), X86_RET_STRUCT_1B)
-        movzx   eax, al
-        jmp     L(e4)
+	movzx	eax, al
+	jmp	L(e4)
 E(L(load_table4), X86_RET_STRUCT_2B)
-        movzx   eax, ax
-        jmp     L(e4)
+	movzx	eax, ax
+	jmp	L(e4)
 
         /* Fill out the table so that bad values are predictable.  */
 E(L(load_table4), X86_RET_UNUSED14)
@@ -608,114 +608,114 @@ E(L(load_table4), X86_RET_UNUSED15)
         int 3
 
 L(UW40):
-        // cfi_endproc
+	/* cfi_endproc */
 ENDF(ffi_closure_raw_SYSV)
 
-#define raw_closure_T_FS        (16+16+8)
+#define raw_closure_T_FS	(16+16+8)
 
 ALIGN 16
 PUBLIC ffi_closure_raw_THISCALL
 ffi_closure_raw_THISCALL PROC C
 L(UW41):
-        // cfi_startproc
+	/* cfi_startproc */
         /* Rearrange the stack such that %ecx is the first argument.
            This means moving the return address.  */
-        pop     edx
+	pop 	edx
 L(UW42):
-        // cfi_def_cfa_offset(0)
-        // cfi_register(%eip, %edx)
-        push    ecx
+	/* cfi_def_cfa_offset(0) */
+	/* cfi_register(%eip, %edx) */
+	push	ecx
 L(UW43):
-        // cfi_adjust_cfa_offset(4)
-        push    edx
+	/* cfi_adjust_cfa_offset(4) */
+	push 	edx
 L(UW44):
-        // cfi_adjust_cfa_offset(4)
-        // cfi_rel_offset(%eip, 0)
-        sub     esp, raw_closure_T_FS
+	/* cfi_adjust_cfa_offset(4) */
+	/* cfi_rel_offset(%eip, 0) */
+	sub 	esp, raw_closure_T_FS
 L(UW45):
-        // cfi_adjust_cfa_offset(raw_closure_T_FS)
-        mov     [esp+raw_closure_T_FS-4], ebx
+	/* cfi_adjust_cfa_offset(raw_closure_T_FS) */
+	mov 	[esp+raw_closure_T_FS-4], ebx
 L(UW46):
-        // cfi_rel_offset(%ebx, raw_closure_T_FS-4)
+	/* cfi_rel_offset(%ebx, raw_closure_T_FS-4) */
 
-        mov     edx, [eax+FFI_TRAMPOLINE_SIZE+8]        /* load cl->user_data */
-        mov     [esp+12], edx
-        lea     edx, [esp+raw_closure_T_FS+4]           /* load raw_args */
-        mov     [esp+8], edx
-        lea     edx, [esp+16]                           /* load &res */
-        mov     [esp+4], edx
-        mov     ebx, [eax+FFI_TRAMPOLINE_SIZE]          /* load cl->cif */
-        mov     [esp], ebx
-        call    DWORD PTR [eax+FFI_TRAMPOLINE_SIZE+4]           /* call cl->fun */
+	mov 	edx, [eax+FFI_TRAMPOLINE_SIZE+8]	/* load cl->user_data */
+	mov 	[esp+12], edx
+	lea 	edx, [esp+raw_closure_T_FS+4]		/* load raw_args */
+	mov 	[esp+8], edx
+	lea 	edx, [esp+16]				/* load &res */
+	mov 	[esp+4], edx
+	mov 	ebx, [eax+FFI_TRAMPOLINE_SIZE]		/* load cl->cif */
+	mov 	[esp], ebx
+	call	DWORD PTR [eax+FFI_TRAMPOLINE_SIZE+4]		/* call cl->fun */
 
-        mov     eax, [ebx+20]                           /* load cif->flags */
-        and     eax, X86_RET_TYPE_MASK
-// #ifdef __PIC__
-//      call    __x86.get_pc_thunk.bx
-// L(pc5):
-//      leal    L(load_table5)-L(pc5)(%ebx, %eax, 8), %ecx
-// #else
-        lea     ecx, [L(load_table5)+eax*8]
-//#endif
-        mov     ebx, [esp+raw_closure_T_FS-4]
+	mov 	eax, [ebx+20]				/* load cif->flags */
+	and 	eax, X86_RET_TYPE_MASK
+/* #ifdef __PIC__ */
+/* 	call	__x86.get_pc_thunk.bx */
+/* L(pc5): */
+/* 	leal	L(load_table5)-L(pc5)(%ebx, %eax, 8), %ecx */
+/* #else */
+	lea 	ecx, [L(load_table5)+eax*8]
+/*#endif */
+	mov 	ebx, [esp+raw_closure_T_FS-4]
 L(UW47):
-        // cfi_restore(%ebx)
-        mov     eax, [esp+16]                           /* Optimistic load */
-        jmp         DWORD PTR [ecx]
+	/* cfi_restore(%ebx) */
+	mov 	eax, [esp+16]				/* Optimistic load */
+	jmp	    DWORD PTR [ecx]
 
         AlIGN 4
 L(load_table5):
 E(L(load_table5), X86_RET_FLOAT)
-        fld     DWORD PTR [esp +16]
-        jmp     L(e5)
+	fld	DWORD PTR [esp +16]
+	jmp	L(e5)
 E(L(load_table5), X86_RET_DOUBLE)
-        fld     QWORD PTR [esp +16]
-        jmp     L(e5)
+	fld	QWORD PTR [esp +16]
+	jmp	L(e5)
 E(L(load_table5), X86_RET_LDOUBLE)
-        fld     QWORD PTR [esp+16]
-        jmp     L(e5)
+	fld	QWORD PTR [esp+16]
+	jmp	L(e5)
 E(L(load_table5), X86_RET_SINT8)
-        movsx   eax, al
-        jmp     L(e5)
+	movsx	eax, al
+	jmp	L(e5)
 E(L(load_table5), X86_RET_SINT16)
-        movsx   eax, ax
-        jmp     L(e5)
+	movsx	eax, ax
+	jmp	L(e5)
 E(L(load_table5), X86_RET_UINT8)
-        movzx   eax, al
-        jmp     L(e5)
+	movzx	eax, al
+	jmp	L(e5)
 E(L(load_table5), X86_RET_UINT16)
-        movzx   eax, ax
-        jmp     L(e5)
+	movzx	eax, ax
+	jmp	L(e5)
 E(L(load_table5), X86_RET_INT64)
-        mov     edx, [esp+16+4]
-        jmp     L(e5)
+	mov 	edx, [esp+16+4]
+	jmp	L(e5)
 E(L(load_table5), X86_RET_int 32)
         nop
         /* fallthru */
 E(L(load_table5), X86_RET_VOID)
 L(e5):
-        add     esp, raw_closure_T_FS
+	add 	esp, raw_closure_T_FS
 L(UW48):
-        // cfi_adjust_cfa_offset(-raw_closure_T_FS)
+	/* cfi_adjust_cfa_offset(-raw_closure_T_FS) */
         /* Remove the extra %ecx argument we pushed.  */
-        ret     4
+	ret	4
 L(UW49):
-        // cfi_adjust_cfa_offset(raw_closure_T_FS)
+	/* cfi_adjust_cfa_offset(raw_closure_T_FS) */
 E(L(load_table5), X86_RET_STRUCTPOP)
-        add     esp, raw_closure_T_FS
+	add 	esp, raw_closure_T_FS
 L(UW50):
-        // cfi_adjust_cfa_offset(-raw_closure_T_FS)
-        ret     8
+	/* cfi_adjust_cfa_offset(-raw_closure_T_FS) */
+	ret	8
 L(UW51):
-        // cfi_adjust_cfa_offset(raw_closure_T_FS)
+	/* cfi_adjust_cfa_offset(raw_closure_T_FS) */
 E(L(load_table5), X86_RET_STRUCTARG)
-        jmp     L(e5)
+	jmp	L(e5)
 E(L(load_table5), X86_RET_STRUCT_1B)
-        movzx   eax, al
-        jmp     L(e5)
+	movzx	eax, al
+	jmp	L(e5)
 E(L(load_table5), X86_RET_STRUCT_2B)
-        movzx   eax, ax
-        jmp     L(e5)
+	movzx	eax, ax
+	jmp	L(e5)
 
         /* Fill out the table so that bad values are predictable.  */
 E(L(load_table5), X86_RET_UNUSED14)
@@ -724,39 +724,42 @@ E(L(load_table5), X86_RET_UNUSED15)
         int 3
 
 L(UW52):
-        // cfi_endproc
+	/* cfi_endproc */
 ENDF(ffi_closure_raw_THISCALL)
 
 #endif /* !FFI_NO_RAW_API */
 
 #ifdef X86_DARWIN
-# define COMDAT(X)                                                      \
-        .section __TEXT,__text,coalesced,pure_instructions;             \
-        .weak_definition X;                                             \
+# define COMDAT(X)							\
+        .section __TEXT,__text,coalesced,pure_instructions;		\
+        .weak_definition X;						\
         FFI_HIDDEN(X)
 #elif defined __ELF__ && !(defined(__sun__) && defined(__svr4__))
-# define COMDAT(X)                                                      \
-        .section .text.X,"axG",@progbits,X,comdat;                      \
-        PUBLIC  X;                                                      \
+# define COMDAT(X)							\
+	.section .text.X,"axG",@progbits,X,comdat;			\
+	PUBLIC	X;							\
         FFI_HIDDEN(X)
 #else
 # define COMDAT(X)
 #endif
 
-// #if defined(__PIC__)
-//      COMDAT(C(__x86.get_pc_thunk.bx))
-// C(__x86.get_pc_thunk.bx):
-//      movl    (%esp), %ebx
-//      ret
-// ENDF(C(__x86.get_pc_thunk.bx))
-// # if defined X86_DARWIN || defined HAVE_HIDDEN_VISIBILITY_ATTRIBUTE
-//      COMDAT(C(__x86.get_pc_thunk.dx))
-// C(__x86.get_pc_thunk.dx):
-//      movl    (%esp), %edx
-//      ret
-// ENDF(C(__x86.get_pc_thunk.dx))
-// #endif /* DARWIN || HIDDEN */
-// #endif /* __PIC__ */
+#if 0
+#if defined(__PIC__)
+	COMDAT(C(__x86.get_pc_thunk.bx))
+C(__x86.get_pc_thunk.bx):
+	movl	(%esp), %ebx
+	ret
+ENDF(C(__x86.get_pc_thunk.bx))
+# if defined X86_DARWIN || defined HAVE_HIDDEN_VISIBILITY_ATTRIBUTE
+	COMDAT(C(__x86.get_pc_thunk.dx))
+C(__x86.get_pc_thunk.dx):
+	movl	(%esp), %edx
+	ret
+ENDF(C(__x86.get_pc_thunk.dx))
+#endif /* DARWIN || HIDDEN */
+#endif /* __PIC__ */
+#endif
+
 
 #if 0
 /* Sadly, OSX cctools-as doesn't understand .cfi directives at all.  */
@@ -773,214 +776,214 @@ EHFrame0:
 #endif
 
 #ifdef HAVE_AS_X86_PCREL
-# define PCREL(X)       X - .
+# define PCREL(X)	X - .
 #else
-# define PCREL(X)       X@rel
+# define PCREL(X)	X@rel
 #endif
 
 /* Simplify advancing between labels.  Assume DW_CFA_advance_loc1 fits.  */
-#define ADV(N, P)       .byte 2, L(N)-L(P)
+#define ADV(N, P)	.byte 2, L(N)-L(P)
 
         .balign 4
 L(CIE):
-        .set    L(set0),L(ECIE)-L(SCIE)
-        .long   L(set0)                 /* CIE Length */
+	.set	L(set0),L(ECIE)-L(SCIE)
+	.long	L(set0)			/* CIE Length */
 L(SCIE):
-        .long   0                       /* CIE Identifier Tag */
-        .byte   1                       /* CIE Version */
-        .ascii  "zR\0"                  /* CIE Augmentation */
-        .byte   1                       /* CIE Code Alignment Factor */
-        .byte   0x7c                    /* CIE Data Alignment Factor */
-        .byte   0x8                     /* CIE RA Column */
-        .byte   1                       /* Augmentation size */
-        .byte   0x1b                    /* FDE Encoding (pcrel sdata4) */
-        .byte   0xc, 4, 4               /* DW_CFA_def_cfa, %esp offset 4 */
-        .byte   0x80+8, 1               /* DW_CFA_offset, %eip offset 1*-4 */
+	.long	0			/* CIE Identifier Tag */
+	.byte	1			/* CIE Version */
+	.ascii	"zR\0"			/* CIE Augmentation */
+	.byte	1			/* CIE Code Alignment Factor */
+	.byte	0x7c			/* CIE Data Alignment Factor */
+	.byte	0x8			/* CIE RA Column */
+	.byte	1			/* Augmentation size */
+	.byte	0x1b			/* FDE Encoding (pcrel sdata4) */
+	.byte	0xc, 4, 4		/* DW_CFA_def_cfa, %esp offset 4 */
+	.byte	0x80+8, 1		/* DW_CFA_offset, %eip offset 1*-4 */
         .balign 4
 L(ECIE):
 
-        .set    L(set1),L(EFDE1)-L(SFDE1)
-        .long   L(set1)                 /* FDE Length */
+	.set	L(set1),L(EFDE1)-L(SFDE1)
+	.long	L(set1)			/* FDE Length */
 L(SFDE1):
-        .long   L(SFDE1)-L(CIE)         /* FDE CIE offset */
-        .long   PCREL(L(UW0))           /* Initial location */
-        .long   L(UW5)-L(UW0)           /* Address range */
-        .byte   0                       /* Augmentation size */
+	.long	L(SFDE1)-L(CIE)		/* FDE CIE offset */
+	.long	PCREL(L(UW0))		/* Initial location */
+	.long	L(UW5)-L(UW0)		/* Address range */
+	.byte	0			/* Augmentation size */
         ADV(UW1, UW0)
-        .byte   0xc, 5, 8               /* DW_CFA_def_cfa, %ebp 8 */
-        .byte   0x80+5, 2               /* DW_CFA_offset, %ebp 2*-4 */
+	.byte	0xc, 5, 8		/* DW_CFA_def_cfa, %ebp 8 */
+	.byte	0x80+5, 2		/* DW_CFA_offset, %ebp 2*-4 */
         ADV(UW2, UW1)
-        .byte   0x80+3, 0               /* DW_CFA_offset, %ebx 0*-4 */
+	.byte	0x80+3, 0		/* DW_CFA_offset, %ebx 0*-4 */
         ADV(UW3, UW2)
-        .byte   0xa                     /* DW_CFA_remember_state */
-        .byte   0xc, 4, 4               /* DW_CFA_def_cfa, %esp 4 */
-        .byte   0xc0+3                  /* DW_CFA_restore, %ebx */
-        .byte   0xc0+5                  /* DW_CFA_restore, %ebp */
+	.byte	0xa			/* DW_CFA_remember_state */
+	.byte	0xc, 4, 4		/* DW_CFA_def_cfa, %esp 4 */
+	.byte	0xc0+3			/* DW_CFA_restore, %ebx */
+	.byte	0xc0+5			/* DW_CFA_restore, %ebp */
         ADV(UW4, UW3)
-        .byte   0xb                     /* DW_CFA_restore_state */
-        .balign 4
+	.byte	0xb			/* DW_CFA_restore_state */
+	.balign	4
 L(EFDE1):
 
-        .set    L(set2),L(EFDE2)-L(SFDE2)
-        .long   L(set2)                 /* FDE Length */
+	.set	L(set2),L(EFDE2)-L(SFDE2)
+	.long	L(set2)			/* FDE Length */
 L(SFDE2):
-        .long   L(SFDE2)-L(CIE)         /* FDE CIE offset */
-        .long   PCREL(L(UW6))           /* Initial location */
-        .long   L(UW8)-L(UW6)           /* Address range */
-        .byte   0                       /* Augmentation size */
+	.long	L(SFDE2)-L(CIE)		/* FDE CIE offset */
+	.long	PCREL(L(UW6))		/* Initial location */
+	.long	L(UW8)-L(UW6)		/* Address range */
+	.byte	0			/* Augmentation size */
         ADV(UW7, UW6)
-        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
-        .balign 4
+	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
+	.balign	4
 L(EFDE2):
 
-        .set    L(set3),L(EFDE3)-L(SFDE3)
-        .long   L(set3)                 /* FDE Length */
+	.set	L(set3),L(EFDE3)-L(SFDE3)
+	.long	L(set3)			/* FDE Length */
 L(SFDE3):
-        .long   L(SFDE3)-L(CIE)         /* FDE CIE offset */
-        .long   PCREL(L(UW9))           /* Initial location */
-        .long   L(UW11)-L(UW9)          /* Address range */
-        .byte   0                       /* Augmentation size */
+	.long	L(SFDE3)-L(CIE)		/* FDE CIE offset */
+	.long	PCREL(L(UW9))		/* Initial location */
+	.long	L(UW11)-L(UW9)		/* Address range */
+	.byte	0			/* Augmentation size */
         ADV(UW10, UW9)
-        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
-        .balign 4
+	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
+	.balign	4
 L(EFDE3):
 
-        .set    L(set4),L(EFDE4)-L(SFDE4)
-        .long   L(set4)                 /* FDE Length */
+	.set	L(set4),L(EFDE4)-L(SFDE4)
+	.long	L(set4)			/* FDE Length */
 L(SFDE4):
-        .long   L(SFDE4)-L(CIE)         /* FDE CIE offset */
-        .long   PCREL(L(UW12))          /* Initial location */
-        .long   L(UW20)-L(UW12)         /* Address range */
-        .byte   0                       /* Augmentation size */
+	.long	L(SFDE4)-L(CIE)		/* FDE CIE offset */
+	.long	PCREL(L(UW12))		/* Initial location */
+	.long	L(UW20)-L(UW12)		/* Address range */
+	.byte	0			/* Augmentation size */
         ADV(UW13, UW12)
-        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
 #ifdef FFI_CLOSURE_CALL_INNER_SAVE_EBX
         ADV(UW14, UW13)
-        .byte   0x80+3, (40-(closure_FS+4))/-4  /* DW_CFA_offset %ebx */
+	.byte	0x80+3, (40-(closure_FS+4))/-4  /* DW_CFA_offset %ebx */
         ADV(UW15, UW14)
-        .byte   0xc0+3                  /* DW_CFA_restore %ebx */
+	.byte	0xc0+3			/* DW_CFA_restore %ebx */
         ADV(UW16, UW15)
 #else
         ADV(UW16, UW13)
 #endif
-        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
+	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
         ADV(UW17, UW16)
-        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
         ADV(UW18, UW17)
-        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
+	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
         ADV(UW19, UW18)
-        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
-        .balign 4
+	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
+	.balign	4
 L(EFDE4):
 
-        .set    L(set5),L(EFDE5)-L(SFDE5)
-        .long   L(set5)                 /* FDE Length */
+	.set	L(set5),L(EFDE5)-L(SFDE5)
+	.long	L(set5)			/* FDE Length */
 L(SFDE5):
-        .long   L(SFDE5)-L(CIE)         /* FDE CIE offset */
-        .long   PCREL(L(UW21))          /* Initial location */
-        .long   L(UW23)-L(UW21)         /* Address range */
-        .byte   0                       /* Augmentation size */
+	.long	L(SFDE5)-L(CIE)		/* FDE CIE offset */
+	.long	PCREL(L(UW21))		/* Initial location */
+	.long	L(UW23)-L(UW21)		/* Address range */
+	.byte	0			/* Augmentation size */
         ADV(UW22, UW21)
-        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
-        .balign 4
+	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
+	.balign	4
 L(EFDE5):
 
-        .set    L(set6),L(EFDE6)-L(SFDE6)
-        .long   L(set6)                 /* FDE Length */
+	.set	L(set6),L(EFDE6)-L(SFDE6)
+	.long	L(set6)			/* FDE Length */
 L(SFDE6):
-        .long   L(SFDE6)-L(CIE)         /* FDE CIE offset */
-        .long   PCREL(L(UW24))          /* Initial location */
-        .long   L(UW26)-L(UW24)         /* Address range */
-        .byte   0                       /* Augmentation size */
-        .byte   0xe, 8                  /* DW_CFA_def_cfa_offset */
-        .byte   0x80+8, 2               /* DW_CFA_offset %eip, 2*-4 */
+	.long	L(SFDE6)-L(CIE)		/* FDE CIE offset */
+	.long	PCREL(L(UW24))		/* Initial location */
+	.long	L(UW26)-L(UW24)		/* Address range */
+	.byte	0			/* Augmentation size */
+	.byte	0xe, 8			/* DW_CFA_def_cfa_offset */
+	.byte	0x80+8, 2		/* DW_CFA_offset %eip, 2*-4 */
         ADV(UW25, UW24)
-        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
-        .balign 4
+	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
+	.balign	4
 L(EFDE6):
 
-        .set    L(set7),L(EFDE7)-L(SFDE7)
-        .long   L(set7)                 /* FDE Length */
+	.set	L(set7),L(EFDE7)-L(SFDE7)
+	.long	L(set7)			/* FDE Length */
 L(SFDE7):
-        .long   L(SFDE7)-L(CIE)         /* FDE CIE offset */
-        .long   PCREL(L(UW27))          /* Initial location */
-        .long   L(UW31)-L(UW27)         /* Address range */
-        .byte   0                       /* Augmentation size */
+	.long	L(SFDE7)-L(CIE)		/* FDE CIE offset */
+	.long	PCREL(L(UW27))		/* Initial location */
+	.long	L(UW31)-L(UW27)		/* Address range */
+	.byte	0			/* Augmentation size */
         ADV(UW28, UW27)
-        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
 #ifdef FFI_CLOSURE_CALL_INNER_SAVE_EBX
         ADV(UW29, UW28)
-        .byte   0x80+3, (40-(closure_FS+4))/-4  /* DW_CFA_offset %ebx */
+	.byte	0x80+3, (40-(closure_FS+4))/-4  /* DW_CFA_offset %ebx */
         ADV(UW30, UW29)
-        .byte   0xc0+3                  /* DW_CFA_restore %ebx */
+	.byte	0xc0+3			/* DW_CFA_restore %ebx */
 #endif
-        .balign 4
+	.balign	4
 L(EFDE7):
 
 #if !FFI_NO_RAW_API
-        .set    L(set8),L(EFDE8)-L(SFDE8)
-        .long   L(set8)                 /* FDE Length */
+	.set	L(set8),L(EFDE8)-L(SFDE8)
+	.long	L(set8)			/* FDE Length */
 L(SFDE8):
-        .long   L(SFDE8)-L(CIE)         /* FDE CIE offset */
-        .long   PCREL(L(UW32))          /* Initial location */
-        .long   L(UW40)-L(UW32)         /* Address range */
-        .byte   0                       /* Augmentation size */
+	.long	L(SFDE8)-L(CIE)		/* FDE CIE offset */
+	.long	PCREL(L(UW32))		/* Initial location */
+	.long	L(UW40)-L(UW32)		/* Address range */
+	.byte	0			/* Augmentation size */
         ADV(UW33, UW32)
-        .byte   0xe, raw_closure_S_FS+4 /* DW_CFA_def_cfa_offset */
+	.byte	0xe, raw_closure_S_FS+4	/* DW_CFA_def_cfa_offset */
         ADV(UW34, UW33)
-        .byte   0x80+3, 2               /* DW_CFA_offset %ebx 2*-4 */
+	.byte	0x80+3, 2		/* DW_CFA_offset %ebx 2*-4 */
         ADV(UW35, UW34)
-        .byte   0xc0+3                  /* DW_CFA_restore %ebx */
+	.byte	0xc0+3			/* DW_CFA_restore %ebx */
         ADV(UW36, UW35)
-        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
+	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
         ADV(UW37, UW36)
-        .byte   0xe, raw_closure_S_FS+4 /* DW_CFA_def_cfa_offset */
+	.byte	0xe, raw_closure_S_FS+4	/* DW_CFA_def_cfa_offset */
         ADV(UW38, UW37)
-        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
+	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
         ADV(UW39, UW38)
-        .byte   0xe, raw_closure_S_FS+4 /* DW_CFA_def_cfa_offset */
-        .balign 4
+	.byte	0xe, raw_closure_S_FS+4	/* DW_CFA_def_cfa_offset */
+	.balign	4
 L(EFDE8):
 
-        .set    L(set9),L(EFDE9)-L(SFDE9)
-        .long   L(set9)                 /* FDE Length */
+	.set	L(set9),L(EFDE9)-L(SFDE9)
+	.long	L(set9)			/* FDE Length */
 L(SFDE9):
-        .long   L(SFDE9)-L(CIE)         /* FDE CIE offset */
-        .long   PCREL(L(UW41))          /* Initial location */
-        .long   L(UW52)-L(UW41)         /* Address range */
-        .byte   0                       /* Augmentation size */
+	.long	L(SFDE9)-L(CIE)		/* FDE CIE offset */
+	.long	PCREL(L(UW41))		/* Initial location */
+	.long	L(UW52)-L(UW41)		/* Address range */
+	.byte	0			/* Augmentation size */
         ADV(UW42, UW41)
-        .byte   0xe, 0                  /* DW_CFA_def_cfa_offset */
-        .byte   0x9, 8, 2               /* DW_CFA_register %eip, %edx */
+	.byte	0xe, 0			/* DW_CFA_def_cfa_offset */
+	.byte	0x9, 8, 2		/* DW_CFA_register %eip, %edx */
         ADV(UW43, UW42)
-        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
+	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
         ADV(UW44, UW43)
-        .byte   0xe, 8                  /* DW_CFA_def_cfa_offset */
-        .byte   0x80+8, 2               /* DW_CFA_offset %eip 2*-4 */
+	.byte	0xe, 8			/* DW_CFA_def_cfa_offset */
+	.byte	0x80+8, 2		/* DW_CFA_offset %eip 2*-4 */
         ADV(UW45, UW44)
-        .byte   0xe, raw_closure_T_FS+8 /* DW_CFA_def_cfa_offset */
+	.byte	0xe, raw_closure_T_FS+8	/* DW_CFA_def_cfa_offset */
         ADV(UW46, UW45)
-        .byte   0x80+3, 3               /* DW_CFA_offset %ebx 3*-4 */
+	.byte	0x80+3, 3		/* DW_CFA_offset %ebx 3*-4 */
         ADV(UW47, UW46)
-        .byte   0xc0+3                  /* DW_CFA_restore %ebx */
+	.byte	0xc0+3			/* DW_CFA_restore %ebx */
         ADV(UW48, UW47)
-        .byte   0xe, 8                  /* DW_CFA_def_cfa_offset */
+	.byte	0xe, 8			/* DW_CFA_def_cfa_offset */
         ADV(UW49, UW48)
-        .byte   0xe, raw_closure_T_FS+8 /* DW_CFA_def_cfa_offset */
+	.byte	0xe, raw_closure_T_FS+8	/* DW_CFA_def_cfa_offset */
         ADV(UW50, UW49)
-        .byte   0xe, 8                  /* DW_CFA_def_cfa_offset */
+	.byte	0xe, 8			/* DW_CFA_def_cfa_offset */
         ADV(UW51, UW50)
-        .byte   0xe, raw_closure_T_FS+8 /* DW_CFA_def_cfa_offset */
-        .balign 4
+	.byte	0xe, raw_closure_T_FS+8	/* DW_CFA_def_cfa_offset */
+	.balign	4
 L(EFDE9):
 #endif /* !FFI_NO_RAW_API */
 
 #ifdef _WIN32
-        .def     @feat.00;
-        .scl    3;
-        .type   0;
+	.def	 @feat.00;
+	.scl	3;
+	.type	0;
         .endef
-        PUBLIC  @feat.00
+	PUBLIC	@feat.00
 @feat.00 = 1
 #endif
 
@@ -988,7 +991,7 @@ L(EFDE9):
 #endif /* ifndef __x86_64__ */
 
 #if defined __ELF__ && defined __linux__
-        .section        .note.GNU-stack,"",@progbits
+	.section	.note.GNU-stack,"",@progbits
 #endif
 #endif
 

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/sysv_intel.S
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/sysv_intel.S
@@ -45,15 +45,15 @@
    The use of ORG asserts that we're at the correct location.  */
 /* ??? The clang assembler doesn't handle .org with symbolic expressions.  */
 #if defined(__clang__) || defined(__APPLE__) || (defined (__sun__) && defined(__svr4__))
-# define E(BASE, X)	ALIGN 8
+# define E(BASE, X)     ALIGN 8
 #else
-# define E(BASE, X)	ALIGN 8; ORG BASE + X * 8
+# define E(BASE, X)     ALIGN 8; ORG BASE + X * 8
 #endif
 
     .686P
     .MODEL FLAT
 
-EXTRN	@ffi_closure_inner@8:PROC
+EXTRN   @ffi_closure_inner@8:PROC
 _TEXT SEGMENT
 
 /* This is declared as
@@ -73,12 +73,12 @@ PUBLIC @ffi_call_i386@8
 L(UW0):
         cfi_startproc
  #if !HAVE_FASTCALL
-	mov	    ecx, [esp+4]
-	mov 	edx, [esp+8]
+        mov         ecx, [esp+4]
+        mov     edx, [esp+8]
  #endif
-	mov	    eax, [esp]		/* move the return address */
-	mov	    [ecx], ebp		/* store ebp into local frame */
-	mov 	[ecx+4], eax	/* store retaddr into local frame */
+        mov         eax, [esp]          /* move the return address */
+        mov         [ecx], ebp          /* store ebp into local frame */
+        mov     [ecx+4], eax    /* store retaddr into local frame */
 
         /* New stack frame based off ebp.  This is a itty bit of unwind
            trickery in that the CFA *has* changed.  There is no easy way
@@ -87,85 +87,85 @@ L(UW0):
            unwind back to ffi_call.  Note that the location to which we
            moved the return address is (the new) CFA-4, so from the
            perspective of the unwind info, it hasn't moved.  */
-	mov 	ebp, ecx
+        mov     ebp, ecx
 L(UW1):
-	/* cfi_def_cfa(%ebp, 8) */
-	/* cfi_rel_offset(%ebp, 0) */
+        /* cfi_def_cfa(%ebp, 8) */
+        /* cfi_rel_offset(%ebp, 0) */
 
-	mov 	esp, edx		/* set outgoing argument stack */
-	mov 	eax, [20+R_EAX*4+ebp]	/* set register arguments */
-	mov 	edx, [20+R_EDX*4+ebp]
-	mov	    ecx, [20+R_ECX*4+ebp]
+        mov     esp, edx                /* set outgoing argument stack */
+        mov     eax, [20+R_EAX*4+ebp]   /* set register arguments */
+        mov     edx, [20+R_EDX*4+ebp]
+        mov         ecx, [20+R_ECX*4+ebp]
 
-	call	dword ptr [ebp+8]
+        call    dword ptr [ebp+8]
 
-	mov	    ecx, [12+ebp]		/* load return type code */
-	mov 	[ebp+8], ebx		/* preserve %ebx */
+        mov         ecx, [12+ebp]               /* load return type code */
+        mov     [ebp+8], ebx            /* preserve %ebx */
 L(UW2):
-	/* cfi_rel_offset(%ebx, 8) */
+        // cfi_rel_offset(%ebx, 8)
 
-	and 	ecx, X86_RET_TYPE_MASK
-	lea 	ebx, [L(store_table) + ecx * 8]
-	mov 	ecx, [ebp+16]		/* load result address */
-	jmp	    ebx
+        and     ecx, X86_RET_TYPE_MASK
+        lea     ebx, [L(store_table) + ecx * 8]
+        mov     ecx, [ebp+16]           /* load result address */
+        jmp         ebx
 
-	ALIGN	8
+        ALIGN   8
 L(store_table):
 E(L(store_table), X86_RET_FLOAT)
-	fstp	DWORD PTR [ecx]
-	jmp	L(e1)
+        fstp    DWORD PTR [ecx]
+        jmp     L(e1)
 E(L(store_table), X86_RET_DOUBLE)
-	fstp	QWORD PTR [ecx]
-	jmp	L(e1)
+        fstp    QWORD PTR [ecx]
+        jmp     L(e1)
 E(L(store_table), X86_RET_LDOUBLE)
-	fstp	QWORD PTR [ecx]
-	jmp	L(e1)
+        fstp    QWORD PTR [ecx]
+        jmp     L(e1)
 E(L(store_table), X86_RET_SINT8)
-	movsx	eax, al
-	mov	[ecx], eax
-	jmp	L(e1)
+        movsx   eax, al
+        mov     [ecx], eax
+        jmp     L(e1)
 E(L(store_table), X86_RET_SINT16)
-	movsx	eax, ax
-	mov	[ecx], eax
-	jmp	L(e1)
+        movsx   eax, ax
+        mov     [ecx], eax
+        jmp     L(e1)
 E(L(store_table), X86_RET_UINT8)
-	movzx	eax, al
-	mov	[ecx], eax
-	jmp	L(e1)
+        movzx   eax, al
+        mov     [ecx], eax
+        jmp     L(e1)
 E(L(store_table), X86_RET_UINT16)
-	movzx	eax, ax
-	mov	[ecx], eax
-	jmp	L(e1)
+        movzx   eax, ax
+        mov     [ecx], eax
+        jmp     L(e1)
 E(L(store_table), X86_RET_INT64)
-	mov	[ecx+4], edx
+        mov     [ecx+4], edx
         /* fallthru */
 E(L(store_table), X86_RET_int 32)
-	mov	[ecx], eax
+        mov     [ecx], eax
         /* fallthru */
 E(L(store_table), X86_RET_VOID)
 L(e1):
-	mov	    ebx, [ebp+8]
-	mov	    esp, ebp
-	pop 	ebp
+        mov         ebx, [ebp+8]
+        mov         esp, ebp
+        pop     ebp
 L(UW3):
-	/* cfi_remember_state */
-	/* cfi_def_cfa(%esp, 4) */
-	/* cfi_restore(%ebx) */
-	/* cfi_restore(%ebp) */
+        /* cfi_remember_state */
+        /* cfi_def_cfa(%esp, 4) */
+        /* cfi_restore(%ebx) */
+        /* cfi_restore(%ebp) */
         ret
 L(UW4):
-	/* cfi_restore_state */
+        /* cfi_restore_state */
 
 E(L(store_table), X86_RET_STRUCTPOP)
-	jmp	    L(e1)
+        jmp         L(e1)
 E(L(store_table), X86_RET_STRUCTARG)
-	jmp	    L(e1)
+        jmp         L(e1)
 E(L(store_table), X86_RET_STRUCT_1B)
-	mov 	[ecx], al
-	jmp	    L(e1)
+        mov     [ecx], al
+        jmp         L(e1)
 E(L(store_table), X86_RET_STRUCT_2B)
-	mov 	[ecx], ax
-	jmp	    L(e1)
+        mov     [ecx], ax
+        jmp         L(e1)
 
         /* Fill out the table so that bad values are predictable.  */
 E(L(store_table), X86_RET_UNUSED14)
@@ -174,7 +174,7 @@ E(L(store_table), X86_RET_UNUSED15)
         int 3
 
 L(UW5):
-	/* cfi_endproc */
+        /* cfi_endproc */
 ENDF(@ffi_call_i386@8)
 
 /* The inner helper is declared as
@@ -184,96 +184,96 @@ ENDF(@ffi_call_i386@8)
 
    Thus the arguments are placed in
 
-	ecx:	frame
-	edx:	argp
+        ecx:    frame
+        edx:    argp
 */
 
 /* Macros to help setting up the closure_data structure.  */
 
 #if HAVE_FASTCALL
-# define closure_FS	(40 + 4)
-# define closure_CF	0
+# define closure_FS     (40 + 4)
+# define closure_CF     0
 #else
-# define closure_FS	(8 + 40 + 12)
-# define closure_CF	8
+# define closure_FS     (8 + 40 + 12)
+# define closure_CF     8
 #endif
 
 FFI_CLOSURE_SAVE_REGS MACRO
-	mov 	[esp + closure_CF+16+R_EAX*4], eax
-	mov 	[esp + closure_CF+16+R_EDX*4], edx
-	mov 	[esp + closure_CF+16+R_ECX*4], ecx
+        mov     [esp + closure_CF+16+R_EAX*4], eax
+        mov     [esp + closure_CF+16+R_EDX*4], edx
+        mov     [esp + closure_CF+16+R_ECX*4], ecx
 ENDM
 
 FFI_CLOSURE_COPY_TRAMP_DATA MACRO
-	mov 	edx, [eax+FFI_TRAMPOLINE_SIZE]      /* copy cif */
-	mov 	ecx, [eax+FFI_TRAMPOLINE_SIZE+4]    /* copy fun */
-	mov 	eax, [eax+FFI_TRAMPOLINE_SIZE+8];   /* copy user_data */
-	mov 	[esp+closure_CF+28], edx
-	mov 	[esp+closure_CF+32], ecx
-	mov 	[esp+closure_CF+36], eax
+        mov     edx, [eax+FFI_TRAMPOLINE_SIZE]      /* copy cif */
+        mov     ecx, [eax+FFI_TRAMPOLINE_SIZE+4]    /* copy fun */
+        mov     eax, [eax+FFI_TRAMPOLINE_SIZE+8];   /* copy user_data */
+        mov     [esp+closure_CF+28], edx
+        mov     [esp+closure_CF+32], ecx
+        mov     [esp+closure_CF+36], eax
 ENDM
 
 #if HAVE_FASTCALL
 FFI_CLOSURE_PREP_CALL MACRO
-	mov	    ecx, esp                    /* load closure_data */
-	lea 	edx, [esp+closure_FS+4]     /* load incoming stack */
+        mov         ecx, esp                    /* load closure_data */
+        lea     edx, [esp+closure_FS+4]     /* load incoming stack */
 ENDM
 #else
 FFI_CLOSURE_PREP_CALL MACRO
-	lea 	ecx, [esp+closure_CF]       /* load closure_data */
-	lea 	edx, [esp+closure_FS+4]     /* load incoming stack */
-	mov 	[esp], ecx
-	mov 	[esp+4], edx
+        lea     ecx, [esp+closure_CF]       /* load closure_data */
+        lea     edx, [esp+closure_FS+4]     /* load incoming stack */
+        mov     [esp], ecx
+        mov     [esp+4], edx
 ENDM
 #endif
 
 FFI_CLOSURE_CALL_INNER MACRO UWN
-	call	@ffi_closure_inner@8
+        call    @ffi_closure_inner@8
 ENDM
 
 FFI_CLOSURE_MASK_AND_JUMP MACRO LABEL
-	and	    eax, X86_RET_TYPE_MASK
-	lea 	edx, [LABEL+eax*8]
-	mov 	eax, [esp+closure_CF]       /* optimiztic load */
-	jmp	    edx
+        and         eax, X86_RET_TYPE_MASK
+        lea     edx, [LABEL+eax*8]
+        mov     eax, [esp+closure_CF]       /* optimiztic load */
+        jmp         edx
 ENDM
 
 ALIGN 16
 PUBLIC ffi_go_closure_EAX
 ffi_go_closure_EAX PROC C
 L(UW6):
-	/* cfi_startproc */
-	sub	esp, closure_FS
+        /* cfi_startproc */
+        sub     esp, closure_FS
 L(UW7):
-	/* cfi_def_cfa_offset(closure_FS + 4) */
+        /* cfi_def_cfa_offset(closure_FS + 4) */
         FFI_CLOSURE_SAVE_REGS
-	mov     edx, [eax+4]			/* copy cif */
-	mov 	ecx, [eax +8]			/* copy fun */
-	mov 	[esp+closure_CF+28], edx
-	mov 	[esp+closure_CF+32], ecx
-	mov 	[esp+closure_CF+36], eax	/* closure is user_data */
-	jmp	L(do_closure_i386)
+        mov     edx, [eax+4]                    /* copy cif */
+        mov     ecx, [eax +8]                   /* copy fun */
+        mov     [esp+closure_CF+28], edx
+        mov     [esp+closure_CF+32], ecx
+        mov     [esp+closure_CF+36], eax        /* closure is user_data */
+        jmp     L(do_closure_i386)
 L(UW8):
-	/* cfi_endproc */
+        // cfi_endproc
 ENDF(ffi_go_closure_EAX)
 
 ALIGN 16
 PUBLIC ffi_go_closure_ECX
 ffi_go_closure_ECX PROC C
 L(UW9):
-	/* cfi_startproc */
-	sub 	esp, closure_FS
+        /* cfi_startproc */
+        sub     esp, closure_FS
 L(UW10):
-	/* cfi_def_cfa_offset(closure_FS + 4) */
+        /* cfi_def_cfa_offset(closure_FS + 4) */
         FFI_CLOSURE_SAVE_REGS
-	mov 	edx, [ecx+4]			/* copy cif */
-	mov 	eax, [ecx+8]			/* copy fun */
-	mov 	[esp+closure_CF+28], edx
-	mov 	[esp+closure_CF+32], eax
-	mov 	[esp+closure_CF+36], ecx	/* closure is user_data */
-	jmp	L(do_closure_i386)
+        mov     edx, [ecx+4]                    /* copy cif */
+        mov     eax, [ecx+8]                    /* copy fun */
+        mov     [esp+closure_CF+28], edx
+        mov     [esp+closure_CF+32], eax
+        mov     [esp+closure_CF+36], ecx        /* closure is user_data */
+        jmp     L(do_closure_i386)
 L(UW11):
-	/* cfi_endproc */
+        /* cfi_endproc */
 ENDF(ffi_go_closure_ECX)
 
 /* The closure entry points are reached from the ffi_closure trampoline.
@@ -283,10 +283,10 @@ ALIGN 16
 PUBLIC ffi_closure_i386
 ffi_closure_i386 PROC C
 L(UW12):
-	/* cfi_startproc */
-	sub	    esp, closure_FS
+        /* cfi_startproc */
+        sub         esp, closure_FS
 L(UW13):
-	/* cfi_def_cfa_offset(closure_FS + 4) */
+        /* cfi_def_cfa_offset(closure_FS + 4) */
 
         FFI_CLOSURE_SAVE_REGS
         FFI_CLOSURE_COPY_TRAMP_DATA
@@ -301,55 +301,55 @@ L(do_closure_i386)::
     ALIGN 8
 L(load_table2):
 E(L(load_table2), X86_RET_FLOAT)
-	fld 	dword ptr [esp+closure_CF]
-	jmp	L(e2)
+        fld     dword ptr [esp+closure_CF]
+        jmp     L(e2)
 E(L(load_table2), X86_RET_DOUBLE)
-	fld 	qword ptr [esp+closure_CF]
-	jmp	L(e2)
+        fld     qword ptr [esp+closure_CF]
+        jmp     L(e2)
 E(L(load_table2), X86_RET_LDOUBLE)
-	fld 	qword ptr [esp+closure_CF]
-	jmp	L(e2)
+        fld     qword ptr [esp+closure_CF]
+        jmp     L(e2)
 E(L(load_table2), X86_RET_SINT8)
-	movsx	eax, al
-	jmp	L(e2)
+        movsx   eax, al
+        jmp     L(e2)
 E(L(load_table2), X86_RET_SINT16)
-	movsx	eax, ax
-	jmp	L(e2)
+        movsx   eax, ax
+        jmp     L(e2)
 E(L(load_table2), X86_RET_UINT8)
-	movzx	eax, al
-	jmp	L(e2)
+        movzx   eax, al
+        jmp     L(e2)
 E(L(load_table2), X86_RET_UINT16)
-	movzx	eax, ax
-	jmp	L(e2)
+        movzx   eax, ax
+        jmp     L(e2)
 E(L(load_table2), X86_RET_INT64)
-	mov 	edx, [esp+closure_CF+4]
-	jmp	L(e2)
+        mov     edx, [esp+closure_CF+4]
+        jmp     L(e2)
 E(L(load_table2), X86_RET_INT32)
         nop
         /* fallthru */
 E(L(load_table2), X86_RET_VOID)
 L(e2):
-	add 	esp, closure_FS
+        add     esp, closure_FS
 L(UW16):
-	/* cfi_adjust_cfa_offset(-closure_FS) */
+        /* cfi_adjust_cfa_offset(-closure_FS) */
         ret
 L(UW17):
-	/* cfi_adjust_cfa_offset(closure_FS) */
+        /* cfi_adjust_cfa_offset(closure_FS) */
 E(L(load_table2), X86_RET_STRUCTPOP)
-	add 	esp, closure_FS
+        add     esp, closure_FS
 L(UW18):
-	/* cfi_adjust_cfa_offset(-closure_FS) */
-	ret	4
+        /* cfi_adjust_cfa_offset(-closure_FS) */
+        ret     4
 L(UW19):
-	/* cfi_adjust_cfa_offset(closure_FS) */
+        /* cfi_adjust_cfa_offset(closure_FS) */
 E(L(load_table2), X86_RET_STRUCTARG)
-	jmp	L(e2)
+        jmp     L(e2)
 E(L(load_table2), X86_RET_STRUCT_1B)
-	movzx	eax, al
-	jmp	L(e2)
+        movzx   eax, al
+        jmp     L(e2)
 E(L(load_table2), X86_RET_STRUCT_2B)
-	movzx	eax, ax
-	jmp	L(e2)
+        movzx   eax, ax
+        jmp     L(e2)
 
         /* Fill out the table so that bad values are predictable.  */
 E(L(load_table2), X86_RET_UNUSED14)
@@ -358,26 +358,26 @@ E(L(load_table2), X86_RET_UNUSED15)
         int 3
 
 L(UW20):
-	/* cfi_endproc */
+        /* cfi_endproc */
 ENDF(ffi_closure_i386)
 
 ALIGN 16
-PUBLIC	ffi_go_closure_STDCALL
+PUBLIC  ffi_go_closure_STDCALL
 ffi_go_closure_STDCALL PROC C
 L(UW21):
-	/* cfi_startproc */
-	sub 	esp, closure_FS
+        /* cfi_startproc */
+        sub     esp, closure_FS
 L(UW22):
-	/* cfi_def_cfa_offset(closure_FS + 4) */
+        /* cfi_def_cfa_offset(closure_FS + 4) */
         FFI_CLOSURE_SAVE_REGS
-	mov 	edx, [ecx+4]			/* copy cif */
-	mov 	eax, [ecx+8]			/* copy fun */
-	mov 	[esp+closure_CF+28], edx
-	mov 	[esp+closure_CF+32], eax
-	mov 	[esp+closure_CF+36], ecx	/* closure is user_data */
-	jmp	L(do_closure_STDCALL)
+        mov     edx, [ecx+4]                    /* copy cif */
+        mov     eax, [ecx+8]                    /* copy fun */
+        mov     [esp+closure_CF+28], edx
+        mov     [esp+closure_CF+32], eax
+        mov     [esp+closure_CF+36], ecx        /* closure is user_data */
+        jmp     L(do_closure_STDCALL)
 L(UW23):
-	/* cfi_endproc */
+        /* cfi_endproc */
 ENDF(ffi_go_closure_STDCALL)
 
 /* For REGISTER, we have no available parameter registers, and so we
@@ -387,19 +387,19 @@ ALIGN 16
 PUBLIC ffi_closure_REGISTER
 ffi_closure_REGISTER PROC C
 L(UW24):
-	/* cfi_startproc */
-	/* cfi_def_cfa(%esp, 8) */
-	/* cfi_offset(%eip, -8) */
-	sub 	esp, closure_FS-4
+        /* cfi_startproc */
+        /* cfi_def_cfa(%esp, 8) */
+        /* cfi_offset(%eip, -8) */
+        sub     esp, closure_FS-4
 L(UW25):
-	/* cfi_def_cfa_offset(closure_FS + 4) */
+        /* cfi_def_cfa_offset(closure_FS + 4) */
         FFI_CLOSURE_SAVE_REGS
-	mov	ecx, [esp+closure_FS-4] 	/* load retaddr */
-	mov	eax, [esp+closure_FS]		/* load closure */
-	mov	[esp+closure_FS], ecx		/* move retaddr */
-	jmp	L(do_closure_REGISTER)
+        mov     ecx, [esp+closure_FS-4]         /* load retaddr */
+        mov     eax, [esp+closure_FS]           /* load closure */
+        mov     [esp+closure_FS], ecx           /* move retaddr */
+        jmp     L(do_closure_REGISTER)
 L(UW26):
-	/* cfi_endproc */
+        /* cfi_endproc */
 ENDF(ffi_closure_REGISTER)
 
 /* For STDCALL (and others), we need to pop N bytes of arguments off
@@ -410,10 +410,10 @@ ALIGN 16
 PUBLIC ffi_closure_STDCALL
 ffi_closure_STDCALL PROC C
 L(UW27):
-	/* cfi_startproc */
-	sub 	esp, closure_FS
+        /* cfi_startproc */
+        sub     esp, closure_FS
 L(UW28):
-	/* cfi_def_cfa_offset(closure_FS + 4) */
+        /* cfi_def_cfa_offset(closure_FS + 4) */
 
         FFI_CLOSURE_SAVE_REGS
 
@@ -428,11 +428,11 @@ L(do_closure_STDCALL)::
         FFI_CLOSURE_PREP_CALL
         FFI_CLOSURE_CALL_INNER(29)
 
-	mov 	ecx, eax
-	shr 	ecx, X86_RET_POP_SHIFT	    /* isolate pop count */
-	lea 	ecx, [esp+closure_FS+ecx]	/* compute popped esp */
-	mov 	edx, [esp+closure_FS]		/* move return address */
-	mov 	[ecx], edx
+        mov     ecx, eax
+        shr     ecx, X86_RET_POP_SHIFT      /* isolate pop count */
+        lea     ecx, [esp+closure_FS+ecx]       /* compute popped esp */
+        mov     edx, [esp+closure_FS]           /* move return address */
+        mov     [ecx], edx
 
         /* From this point on, the value of %esp upon return is %ecx+4,
            and we've copied the return address to %ecx to make return easy.
@@ -473,7 +473,7 @@ E(L(load_table3), X86_RET_UINT16)
         mov     esp, ecx
         ret
 E(L(load_table3), X86_RET_INT64)
-	mov 	edx, [esp+closure_CF+4]
+        mov     edx, [esp+closure_CF+4]
         mov     esp, ecx
         ret
 E(L(load_table3), X86_RET_int 32)
@@ -486,15 +486,15 @@ E(L(load_table3), X86_RET_STRUCTPOP)
         mov     esp, ecx
         ret
 E(L(load_table3), X86_RET_STRUCTARG)
-	mov 	esp, ecx
+        mov     esp, ecx
         ret
 E(L(load_table3), X86_RET_STRUCT_1B)
-	movzx	eax, al
-	mov 	esp, ecx
+        movzx   eax, al
+        mov     esp, ecx
         ret
 E(L(load_table3), X86_RET_STRUCT_2B)
-	movzx	eax, ax
-	mov 	esp, ecx
+        movzx   eax, ax
+        mov     esp, ecx
         ret
 
         /* Fill out the table so that bad values are predictable.  */
@@ -504,102 +504,102 @@ E(L(load_table3), X86_RET_UNUSED15)
         int 3
 
 L(UW31):
-	/* cfi_endproc */
+        /* cfi_endproc */
 ENDF(ffi_closure_STDCALL)
 
 #if !FFI_NO_RAW_API
 
-#define raw_closure_S_FS	(16+16+12)
+#define raw_closure_S_FS        (16+16+12)
 
 ALIGN 16
 PUBLIC ffi_closure_raw_SYSV
 ffi_closure_raw_SYSV PROC C
 L(UW32):
-	/* cfi_startproc */
-	sub 	esp, raw_closure_S_FS
+        /* cfi_startproc */
+        sub     esp, raw_closure_S_FS
 L(UW33):
-	/* cfi_def_cfa_offset(raw_closure_S_FS + 4) */
-	mov 	[esp+raw_closure_S_FS-4], ebx
+        /* cfi_def_cfa_offset(raw_closure_S_FS + 4) */
+        mov     [esp+raw_closure_S_FS-4], ebx
 L(UW34):
-	/* cfi_rel_offset(%ebx, raw_closure_S_FS-4) */
+        /* cfi_rel_offset(%ebx, raw_closure_S_FS-4) */
 
-	mov 	edx, [eax+FFI_TRAMPOLINE_SIZE+8]	/* load cl->user_data */
-	mov 	[esp+12], edx
-	lea 	edx, [esp+raw_closure_S_FS+4]		/* load raw_args */
-	mov 	[esp+8], edx
-	lea 	edx, [esp+16]				/* load &res */
-	mov 	[esp+4], edx
-	mov 	ebx, [eax+FFI_TRAMPOLINE_SIZE]		/* load cl->cif */
-	mov 	[esp], ebx
-	call	DWORD PTR [eax+FFI_TRAMPOLINE_SIZE+4]		/* call cl->fun */
+        mov     edx, [eax+FFI_TRAMPOLINE_SIZE+8]        /* load cl->user_data */
+        mov     [esp+12], edx
+        lea     edx, [esp+raw_closure_S_FS+4]           /* load raw_args */
+        mov     [esp+8], edx
+        lea     edx, [esp+16]                           /* load &res */
+        mov     [esp+4], edx
+        mov     ebx, [eax+FFI_TRAMPOLINE_SIZE]          /* load cl->cif */
+        mov     [esp], ebx
+        call    DWORD PTR [eax+FFI_TRAMPOLINE_SIZE+4]           /* call cl->fun */
 
-	mov 	eax, [ebx+20]			/* load cif->flags */
-	and 	eax, X86_RET_TYPE_MASK
+        mov     eax, [ebx+20]                   /* load cif->flags */
+        and     eax, X86_RET_TYPE_MASK
 /* #ifdef __PIC__ */
-/* 	call	__x86.get_pc_thunk.bx */
+/*      call    __x86.get_pc_thunk.bx */
 /* L(pc4): */
-/* 	lea 	ecx, L(load_table4)-L(pc4)(%ebx, %eax, 8), %ecx */
+/*      lea     ecx, L(load_table4)-L(pc4)(%ebx, %eax, 8), %ecx */
 /* #else */
-	lea 	ecx, [L(load_table4)+eax+8]
+        lea     ecx, [L(load_table4)+eax+8]
 /* #endif */
-	mov 	ebx, [esp+raw_closure_S_FS-4]
+        mov     ebx, [esp+raw_closure_S_FS-4]
 L(UW35):
-	/* cfi_restore(%ebx) */
-	mov 	eax, [esp+16]				/* Optimistic load */
-	jmp	    dword ptr [ecx]
+        /* cfi_restore(%ebx) */
+        mov     eax, [esp+16]                           /* Optimistic load */
+        jmp         dword ptr [ecx]
 
         ALIGN 8
 L(load_table4):
 E(L(load_table4), X86_RET_FLOAT)
-	fld 	DWORD PTR [esp +16]
-	jmp	L(e4)
+        fld     DWORD PTR [esp +16]
+        jmp     L(e4)
 E(L(load_table4), X86_RET_DOUBLE)
-	fld 	QWORD PTR [esp +16]
-	jmp	L(e4)
+        fld     QWORD PTR [esp +16]
+        jmp     L(e4)
 E(L(load_table4), X86_RET_LDOUBLE)
-	fld 	QWORD PTR [esp +16]
-	jmp	L(e4)
+        fld     QWORD PTR [esp +16]
+        jmp     L(e4)
 E(L(load_table4), X86_RET_SINT8)
-	movsx	eax, al
-	jmp	L(e4)
+        movsx   eax, al
+        jmp     L(e4)
 E(L(load_table4), X86_RET_SINT16)
-	movsx	eax, ax
-	jmp	L(e4)
+        movsx   eax, ax
+        jmp     L(e4)
 E(L(load_table4), X86_RET_UINT8)
-	movzx	eax, al
-	jmp	L(e4)
+        movzx   eax, al
+        jmp     L(e4)
 E(L(load_table4), X86_RET_UINT16)
-	movzx	eax, ax
-	jmp	L(e4)
+        movzx   eax, ax
+        jmp     L(e4)
 E(L(load_table4), X86_RET_INT64)
-	mov 	edx, [esp+16+4]
-	jmp	L(e4)
+        mov     edx, [esp+16+4]
+        jmp     L(e4)
 E(L(load_table4), X86_RET_int 32)
         nop
         /* fallthru */
 E(L(load_table4), X86_RET_VOID)
 L(e4):
-	add 	esp, raw_closure_S_FS
+        add     esp, raw_closure_S_FS
 L(UW36):
-	/* cfi_adjust_cfa_offset(-raw_closure_S_FS) */
+        /* cfi_adjust_cfa_offset(-raw_closure_S_FS) */
         ret
 L(UW37):
-	/* cfi_adjust_cfa_offset(raw_closure_S_FS) */
+        /* cfi_adjust_cfa_offset(raw_closure_S_FS) */
 E(L(load_table4), X86_RET_STRUCTPOP)
-	add 	esp, raw_closure_S_FS
+        add     esp, raw_closure_S_FS
 L(UW38):
-	/* cfi_adjust_cfa_offset(-raw_closure_S_FS) */
-	ret	4
+        /* cfi_adjust_cfa_offset(-raw_closure_S_FS) */
+        ret     4
 L(UW39):
-	/* cfi_adjust_cfa_offset(raw_closure_S_FS) */
+        /* cfi_adjust_cfa_offset(raw_closure_S_FS) */
 E(L(load_table4), X86_RET_STRUCTARG)
-	jmp	L(e4)
+        jmp     L(e4)
 E(L(load_table4), X86_RET_STRUCT_1B)
-	movzx	eax, al
-	jmp	L(e4)
+        movzx   eax, al
+        jmp     L(e4)
 E(L(load_table4), X86_RET_STRUCT_2B)
-	movzx	eax, ax
-	jmp	L(e4)
+        movzx   eax, ax
+        jmp     L(e4)
 
         /* Fill out the table so that bad values are predictable.  */
 E(L(load_table4), X86_RET_UNUSED14)
@@ -608,114 +608,114 @@ E(L(load_table4), X86_RET_UNUSED15)
         int 3
 
 L(UW40):
-	/* cfi_endproc */
+        /* cfi_endproc */
 ENDF(ffi_closure_raw_SYSV)
 
-#define raw_closure_T_FS	(16+16+8)
+#define raw_closure_T_FS        (16+16+8)
 
 ALIGN 16
 PUBLIC ffi_closure_raw_THISCALL
 ffi_closure_raw_THISCALL PROC C
 L(UW41):
-	/* cfi_startproc */
+        /* cfi_startproc */
         /* Rearrange the stack such that %ecx is the first argument.
            This means moving the return address.  */
-	pop 	edx
+        pop     edx
 L(UW42):
-	/* cfi_def_cfa_offset(0) */
-	/* cfi_register(%eip, %edx) */
-	push	ecx
+        /* cfi_def_cfa_offset(0) */
+        /* cfi_register(%eip, %edx) */
+        push    ecx
 L(UW43):
-	/* cfi_adjust_cfa_offset(4) */
-	push 	edx
+        /* cfi_adjust_cfa_offset(4) */
+        push    edx
 L(UW44):
-	/* cfi_adjust_cfa_offset(4) */
-	/* cfi_rel_offset(%eip, 0) */
-	sub 	esp, raw_closure_T_FS
+        /* cfi_adjust_cfa_offset(4) */
+        /* cfi_rel_offset(%eip, 0) */
+        sub     esp, raw_closure_T_FS
 L(UW45):
-	/* cfi_adjust_cfa_offset(raw_closure_T_FS) */
-	mov 	[esp+raw_closure_T_FS-4], ebx
+        /* cfi_adjust_cfa_offset(raw_closure_T_FS) */
+        mov     [esp+raw_closure_T_FS-4], ebx
 L(UW46):
-	/* cfi_rel_offset(%ebx, raw_closure_T_FS-4) */
+        /* cfi_rel_offset(%ebx, raw_closure_T_FS-4) */
 
-	mov 	edx, [eax+FFI_TRAMPOLINE_SIZE+8]	/* load cl->user_data */
-	mov 	[esp+12], edx
-	lea 	edx, [esp+raw_closure_T_FS+4]		/* load raw_args */
-	mov 	[esp+8], edx
-	lea 	edx, [esp+16]				/* load &res */
-	mov 	[esp+4], edx
-	mov 	ebx, [eax+FFI_TRAMPOLINE_SIZE]		/* load cl->cif */
-	mov 	[esp], ebx
-	call	DWORD PTR [eax+FFI_TRAMPOLINE_SIZE+4]		/* call cl->fun */
+        mov     edx, [eax+FFI_TRAMPOLINE_SIZE+8]        /* load cl->user_data */
+        mov     [esp+12], edx
+        lea     edx, [esp+raw_closure_T_FS+4]           /* load raw_args */
+        mov     [esp+8], edx
+        lea     edx, [esp+16]                           /* load &res */
+        mov     [esp+4], edx
+        mov     ebx, [eax+FFI_TRAMPOLINE_SIZE]          /* load cl->cif */
+        mov     [esp], ebx
+        call    DWORD PTR [eax+FFI_TRAMPOLINE_SIZE+4]           /* call cl->fun */
 
-	mov 	eax, [ebx+20]				/* load cif->flags */
-	and 	eax, X86_RET_TYPE_MASK
+        mov     eax, [ebx+20]                           /* load cif->flags */
+        and     eax, X86_RET_TYPE_MASK
 /* #ifdef __PIC__ */
-/* 	call	__x86.get_pc_thunk.bx */
+/*      call    __x86.get_pc_thunk.bx */
 /* L(pc5): */
-/* 	leal	L(load_table5)-L(pc5)(%ebx, %eax, 8), %ecx */
+/*      leal    L(load_table5)-L(pc5)(%ebx, %eax, 8), %ecx */
 /* #else */
-	lea 	ecx, [L(load_table5)+eax*8]
+        lea     ecx, [L(load_table5)+eax*8]
 /*#endif */
-	mov 	ebx, [esp+raw_closure_T_FS-4]
+        mov     ebx, [esp+raw_closure_T_FS-4]
 L(UW47):
-	/* cfi_restore(%ebx) */
-	mov 	eax, [esp+16]				/* Optimistic load */
-	jmp	    DWORD PTR [ecx]
+        /* cfi_restore(%ebx) */
+        mov     eax, [esp+16]                           /* Optimistic load */
+        jmp         DWORD PTR [ecx]
 
         AlIGN 4
 L(load_table5):
 E(L(load_table5), X86_RET_FLOAT)
-	fld	DWORD PTR [esp +16]
-	jmp	L(e5)
+        fld     DWORD PTR [esp +16]
+        jmp     L(e5)
 E(L(load_table5), X86_RET_DOUBLE)
-	fld	QWORD PTR [esp +16]
-	jmp	L(e5)
+        fld     QWORD PTR [esp +16]
+        jmp     L(e5)
 E(L(load_table5), X86_RET_LDOUBLE)
-	fld	QWORD PTR [esp+16]
-	jmp	L(e5)
+        fld     QWORD PTR [esp+16]
+        jmp     L(e5)
 E(L(load_table5), X86_RET_SINT8)
-	movsx	eax, al
-	jmp	L(e5)
+        movsx   eax, al
+        jmp     L(e5)
 E(L(load_table5), X86_RET_SINT16)
-	movsx	eax, ax
-	jmp	L(e5)
+        movsx   eax, ax
+        jmp     L(e5)
 E(L(load_table5), X86_RET_UINT8)
-	movzx	eax, al
-	jmp	L(e5)
+        movzx   eax, al
+        jmp     L(e5)
 E(L(load_table5), X86_RET_UINT16)
-	movzx	eax, ax
-	jmp	L(e5)
+        movzx   eax, ax
+        jmp     L(e5)
 E(L(load_table5), X86_RET_INT64)
-	mov 	edx, [esp+16+4]
-	jmp	L(e5)
+        mov     edx, [esp+16+4]
+        jmp     L(e5)
 E(L(load_table5), X86_RET_int 32)
         nop
         /* fallthru */
 E(L(load_table5), X86_RET_VOID)
 L(e5):
-	add 	esp, raw_closure_T_FS
+        add     esp, raw_closure_T_FS
 L(UW48):
-	/* cfi_adjust_cfa_offset(-raw_closure_T_FS) */
+        /* cfi_adjust_cfa_offset(-raw_closure_T_FS) */
         /* Remove the extra %ecx argument we pushed.  */
-	ret	4
+        ret     4
 L(UW49):
-	/* cfi_adjust_cfa_offset(raw_closure_T_FS) */
+        /* cfi_adjust_cfa_offset(raw_closure_T_FS) */
 E(L(load_table5), X86_RET_STRUCTPOP)
-	add 	esp, raw_closure_T_FS
+        add     esp, raw_closure_T_FS
 L(UW50):
-	/* cfi_adjust_cfa_offset(-raw_closure_T_FS) */
-	ret	8
+        /* cfi_adjust_cfa_offset(-raw_closure_T_FS) */
+        ret     8
 L(UW51):
-	/* cfi_adjust_cfa_offset(raw_closure_T_FS) */
+        /* cfi_adjust_cfa_offset(raw_closure_T_FS) */
 E(L(load_table5), X86_RET_STRUCTARG)
-	jmp	L(e5)
+        jmp     L(e5)
 E(L(load_table5), X86_RET_STRUCT_1B)
-	movzx	eax, al
-	jmp	L(e5)
+        movzx   eax, al
+        jmp     L(e5)
 E(L(load_table5), X86_RET_STRUCT_2B)
-	movzx	eax, ax
-	jmp	L(e5)
+        movzx   eax, ax
+        jmp     L(e5)
 
         /* Fill out the table so that bad values are predictable.  */
 E(L(load_table5), X86_RET_UNUSED14)
@@ -724,20 +724,20 @@ E(L(load_table5), X86_RET_UNUSED15)
         int 3
 
 L(UW52):
-	/* cfi_endproc */
+        /* cfi_endproc */
 ENDF(ffi_closure_raw_THISCALL)
 
 #endif /* !FFI_NO_RAW_API */
 
 #ifdef X86_DARWIN
-# define COMDAT(X)							\
-        .section __TEXT,__text,coalesced,pure_instructions;		\
-        .weak_definition X;						\
+# define COMDAT(X)                                                      \
+        .section __TEXT,__text,coalesced,pure_instructions;             \
+        .weak_definition X;                                             \
         FFI_HIDDEN(X)
 #elif defined __ELF__ && !(defined(__sun__) && defined(__svr4__))
-# define COMDAT(X)							\
-	.section .text.X,"axG",@progbits,X,comdat;			\
-	PUBLIC	X;							\
+# define COMDAT(X)                                                      \
+        .section .text.X,"axG",@progbits,X,comdat;                      \
+        PUBLIC  X;                                                      \
         FFI_HIDDEN(X)
 #else
 # define COMDAT(X)
@@ -745,16 +745,16 @@ ENDF(ffi_closure_raw_THISCALL)
 
 #if 0
 #if defined(__PIC__)
-	COMDAT(C(__x86.get_pc_thunk.bx))
+     COMDAT(C(__x86.get_pc_thunk.bx))
 C(__x86.get_pc_thunk.bx):
-	movl	(%esp), %ebx
-	ret
+     movl    (%esp), %ebx
+     ret
 ENDF(C(__x86.get_pc_thunk.bx))
 # if defined X86_DARWIN || defined HAVE_HIDDEN_VISIBILITY_ATTRIBUTE
-	COMDAT(C(__x86.get_pc_thunk.dx))
+     COMDAT(C(__x86.get_pc_thunk.dx))
 C(__x86.get_pc_thunk.dx):
-	movl	(%esp), %edx
-	ret
+     movl    (%esp), %edx
+     ret
 ENDF(C(__x86.get_pc_thunk.dx))
 #endif /* DARWIN || HIDDEN */
 #endif /* __PIC__ */
@@ -776,214 +776,214 @@ EHFrame0:
 #endif
 
 #ifdef HAVE_AS_X86_PCREL
-# define PCREL(X)	X - .
+# define PCREL(X)       X - .
 #else
-# define PCREL(X)	X@rel
+# define PCREL(X)       X@rel
 #endif
 
 /* Simplify advancing between labels.  Assume DW_CFA_advance_loc1 fits.  */
-#define ADV(N, P)	.byte 2, L(N)-L(P)
+#define ADV(N, P)       .byte 2, L(N)-L(P)
 
         .balign 4
 L(CIE):
-	.set	L(set0),L(ECIE)-L(SCIE)
-	.long	L(set0)			/* CIE Length */
+        .set    L(set0),L(ECIE)-L(SCIE)
+        .long   L(set0)                 /* CIE Length */
 L(SCIE):
-	.long	0			/* CIE Identifier Tag */
-	.byte	1			/* CIE Version */
-	.ascii	"zR\0"			/* CIE Augmentation */
-	.byte	1			/* CIE Code Alignment Factor */
-	.byte	0x7c			/* CIE Data Alignment Factor */
-	.byte	0x8			/* CIE RA Column */
-	.byte	1			/* Augmentation size */
-	.byte	0x1b			/* FDE Encoding (pcrel sdata4) */
-	.byte	0xc, 4, 4		/* DW_CFA_def_cfa, %esp offset 4 */
-	.byte	0x80+8, 1		/* DW_CFA_offset, %eip offset 1*-4 */
+        .long   0                       /* CIE Identifier Tag */
+        .byte   1                       /* CIE Version */
+        .ascii  "zR\0"                  /* CIE Augmentation */
+        .byte   1                       /* CIE Code Alignment Factor */
+        .byte   0x7c                    /* CIE Data Alignment Factor */
+        .byte   0x8                     /* CIE RA Column */
+        .byte   1                       /* Augmentation size */
+        .byte   0x1b                    /* FDE Encoding (pcrel sdata4) */
+        .byte   0xc, 4, 4               /* DW_CFA_def_cfa, %esp offset 4 */
+        .byte   0x80+8, 1               /* DW_CFA_offset, %eip offset 1*-4 */
         .balign 4
 L(ECIE):
 
-	.set	L(set1),L(EFDE1)-L(SFDE1)
-	.long	L(set1)			/* FDE Length */
+        .set    L(set1),L(EFDE1)-L(SFDE1)
+        .long   L(set1)                 /* FDE Length */
 L(SFDE1):
-	.long	L(SFDE1)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW0))		/* Initial location */
-	.long	L(UW5)-L(UW0)		/* Address range */
-	.byte	0			/* Augmentation size */
+        .long   L(SFDE1)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW0))           /* Initial location */
+        .long   L(UW5)-L(UW0)           /* Address range */
+        .byte   0                       /* Augmentation size */
         ADV(UW1, UW0)
-	.byte	0xc, 5, 8		/* DW_CFA_def_cfa, %ebp 8 */
-	.byte	0x80+5, 2		/* DW_CFA_offset, %ebp 2*-4 */
+        .byte   0xc, 5, 8               /* DW_CFA_def_cfa, %ebp 8 */
+        .byte   0x80+5, 2               /* DW_CFA_offset, %ebp 2*-4 */
         ADV(UW2, UW1)
-	.byte	0x80+3, 0		/* DW_CFA_offset, %ebx 0*-4 */
+        .byte   0x80+3, 0               /* DW_CFA_offset, %ebx 0*-4 */
         ADV(UW3, UW2)
-	.byte	0xa			/* DW_CFA_remember_state */
-	.byte	0xc, 4, 4		/* DW_CFA_def_cfa, %esp 4 */
-	.byte	0xc0+3			/* DW_CFA_restore, %ebx */
-	.byte	0xc0+5			/* DW_CFA_restore, %ebp */
+        .byte   0xa                     /* DW_CFA_remember_state */
+        .byte   0xc, 4, 4               /* DW_CFA_def_cfa, %esp 4 */
+        .byte   0xc0+3                  /* DW_CFA_restore, %ebx */
+        .byte   0xc0+5                  /* DW_CFA_restore, %ebp */
         ADV(UW4, UW3)
-	.byte	0xb			/* DW_CFA_restore_state */
-	.balign	4
+        .byte   0xb                     /* DW_CFA_restore_state */
+        .balign 4
 L(EFDE1):
 
-	.set	L(set2),L(EFDE2)-L(SFDE2)
-	.long	L(set2)			/* FDE Length */
+        .set    L(set2),L(EFDE2)-L(SFDE2)
+        .long   L(set2)                 /* FDE Length */
 L(SFDE2):
-	.long	L(SFDE2)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW6))		/* Initial location */
-	.long	L(UW8)-L(UW6)		/* Address range */
-	.byte	0			/* Augmentation size */
+        .long   L(SFDE2)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW6))           /* Initial location */
+        .long   L(UW8)-L(UW6)           /* Address range */
+        .byte   0                       /* Augmentation size */
         ADV(UW7, UW6)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE2):
 
-	.set	L(set3),L(EFDE3)-L(SFDE3)
-	.long	L(set3)			/* FDE Length */
+        .set    L(set3),L(EFDE3)-L(SFDE3)
+        .long   L(set3)                 /* FDE Length */
 L(SFDE3):
-	.long	L(SFDE3)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW9))		/* Initial location */
-	.long	L(UW11)-L(UW9)		/* Address range */
-	.byte	0			/* Augmentation size */
+        .long   L(SFDE3)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW9))           /* Initial location */
+        .long   L(UW11)-L(UW9)          /* Address range */
+        .byte   0                       /* Augmentation size */
         ADV(UW10, UW9)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE3):
 
-	.set	L(set4),L(EFDE4)-L(SFDE4)
-	.long	L(set4)			/* FDE Length */
+        .set    L(set4),L(EFDE4)-L(SFDE4)
+        .long   L(set4)                 /* FDE Length */
 L(SFDE4):
-	.long	L(SFDE4)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW12))		/* Initial location */
-	.long	L(UW20)-L(UW12)		/* Address range */
-	.byte	0			/* Augmentation size */
+        .long   L(SFDE4)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW12))          /* Initial location */
+        .long   L(UW20)-L(UW12)         /* Address range */
+        .byte   0                       /* Augmentation size */
         ADV(UW13, UW12)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
 #ifdef FFI_CLOSURE_CALL_INNER_SAVE_EBX
         ADV(UW14, UW13)
-	.byte	0x80+3, (40-(closure_FS+4))/-4  /* DW_CFA_offset %ebx */
+        .byte   0x80+3, (40-(closure_FS+4))/-4  /* DW_CFA_offset %ebx */
         ADV(UW15, UW14)
-	.byte	0xc0+3			/* DW_CFA_restore %ebx */
+        .byte   0xc0+3                  /* DW_CFA_restore %ebx */
         ADV(UW16, UW15)
 #else
         ADV(UW16, UW13)
 #endif
-	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
+        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
         ADV(UW17, UW16)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
         ADV(UW18, UW17)
-	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
+        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
         ADV(UW19, UW18)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE4):
 
-	.set	L(set5),L(EFDE5)-L(SFDE5)
-	.long	L(set5)			/* FDE Length */
+        .set    L(set5),L(EFDE5)-L(SFDE5)
+        .long   L(set5)                 /* FDE Length */
 L(SFDE5):
-	.long	L(SFDE5)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW21))		/* Initial location */
-	.long	L(UW23)-L(UW21)		/* Address range */
-	.byte	0			/* Augmentation size */
+        .long   L(SFDE5)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW21))          /* Initial location */
+        .long   L(UW23)-L(UW21)         /* Address range */
+        .byte   0                       /* Augmentation size */
         ADV(UW22, UW21)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE5):
 
-	.set	L(set6),L(EFDE6)-L(SFDE6)
-	.long	L(set6)			/* FDE Length */
+        .set    L(set6),L(EFDE6)-L(SFDE6)
+        .long   L(set6)                 /* FDE Length */
 L(SFDE6):
-	.long	L(SFDE6)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW24))		/* Initial location */
-	.long	L(UW26)-L(UW24)		/* Address range */
-	.byte	0			/* Augmentation size */
-	.byte	0xe, 8			/* DW_CFA_def_cfa_offset */
-	.byte	0x80+8, 2		/* DW_CFA_offset %eip, 2*-4 */
+        .long   L(SFDE6)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW24))          /* Initial location */
+        .long   L(UW26)-L(UW24)         /* Address range */
+        .byte   0                       /* Augmentation size */
+        .byte   0xe, 8                  /* DW_CFA_def_cfa_offset */
+        .byte   0x80+8, 2               /* DW_CFA_offset %eip, 2*-4 */
         ADV(UW25, UW24)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE6):
 
-	.set	L(set7),L(EFDE7)-L(SFDE7)
-	.long	L(set7)			/* FDE Length */
+        .set    L(set7),L(EFDE7)-L(SFDE7)
+        .long   L(set7)                 /* FDE Length */
 L(SFDE7):
-	.long	L(SFDE7)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW27))		/* Initial location */
-	.long	L(UW31)-L(UW27)		/* Address range */
-	.byte	0			/* Augmentation size */
+        .long   L(SFDE7)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW27))          /* Initial location */
+        .long   L(UW31)-L(UW27)         /* Address range */
+        .byte   0                       /* Augmentation size */
         ADV(UW28, UW27)
-	.byte	0xe, closure_FS+4	/* DW_CFA_def_cfa_offset */
+        .byte   0xe, closure_FS+4       /* DW_CFA_def_cfa_offset */
 #ifdef FFI_CLOSURE_CALL_INNER_SAVE_EBX
         ADV(UW29, UW28)
-	.byte	0x80+3, (40-(closure_FS+4))/-4  /* DW_CFA_offset %ebx */
+        .byte   0x80+3, (40-(closure_FS+4))/-4  /* DW_CFA_offset %ebx */
         ADV(UW30, UW29)
-	.byte	0xc0+3			/* DW_CFA_restore %ebx */
+        .byte   0xc0+3                  /* DW_CFA_restore %ebx */
 #endif
-	.balign	4
+        .balign 4
 L(EFDE7):
 
 #if !FFI_NO_RAW_API
-	.set	L(set8),L(EFDE8)-L(SFDE8)
-	.long	L(set8)			/* FDE Length */
+        .set    L(set8),L(EFDE8)-L(SFDE8)
+        .long   L(set8)                 /* FDE Length */
 L(SFDE8):
-	.long	L(SFDE8)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW32))		/* Initial location */
-	.long	L(UW40)-L(UW32)		/* Address range */
-	.byte	0			/* Augmentation size */
+        .long   L(SFDE8)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW32))          /* Initial location */
+        .long   L(UW40)-L(UW32)         /* Address range */
+        .byte   0                       /* Augmentation size */
         ADV(UW33, UW32)
-	.byte	0xe, raw_closure_S_FS+4	/* DW_CFA_def_cfa_offset */
+        .byte   0xe, raw_closure_S_FS+4 /* DW_CFA_def_cfa_offset */
         ADV(UW34, UW33)
-	.byte	0x80+3, 2		/* DW_CFA_offset %ebx 2*-4 */
+        .byte   0x80+3, 2               /* DW_CFA_offset %ebx 2*-4 */
         ADV(UW35, UW34)
-	.byte	0xc0+3			/* DW_CFA_restore %ebx */
+        .byte   0xc0+3                  /* DW_CFA_restore %ebx */
         ADV(UW36, UW35)
-	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
+        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
         ADV(UW37, UW36)
-	.byte	0xe, raw_closure_S_FS+4	/* DW_CFA_def_cfa_offset */
+        .byte   0xe, raw_closure_S_FS+4 /* DW_CFA_def_cfa_offset */
         ADV(UW38, UW37)
-	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
+        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
         ADV(UW39, UW38)
-	.byte	0xe, raw_closure_S_FS+4	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .byte   0xe, raw_closure_S_FS+4 /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE8):
 
-	.set	L(set9),L(EFDE9)-L(SFDE9)
-	.long	L(set9)			/* FDE Length */
+        .set    L(set9),L(EFDE9)-L(SFDE9)
+        .long   L(set9)                 /* FDE Length */
 L(SFDE9):
-	.long	L(SFDE9)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW41))		/* Initial location */
-	.long	L(UW52)-L(UW41)		/* Address range */
-	.byte	0			/* Augmentation size */
+        .long   L(SFDE9)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW41))          /* Initial location */
+        .long   L(UW52)-L(UW41)         /* Address range */
+        .byte   0                       /* Augmentation size */
         ADV(UW42, UW41)
-	.byte	0xe, 0			/* DW_CFA_def_cfa_offset */
-	.byte	0x9, 8, 2		/* DW_CFA_register %eip, %edx */
+        .byte   0xe, 0                  /* DW_CFA_def_cfa_offset */
+        .byte   0x9, 8, 2               /* DW_CFA_register %eip, %edx */
         ADV(UW43, UW42)
-	.byte	0xe, 4			/* DW_CFA_def_cfa_offset */
+        .byte   0xe, 4                  /* DW_CFA_def_cfa_offset */
         ADV(UW44, UW43)
-	.byte	0xe, 8			/* DW_CFA_def_cfa_offset */
-	.byte	0x80+8, 2		/* DW_CFA_offset %eip 2*-4 */
+        .byte   0xe, 8                  /* DW_CFA_def_cfa_offset */
+        .byte   0x80+8, 2               /* DW_CFA_offset %eip 2*-4 */
         ADV(UW45, UW44)
-	.byte	0xe, raw_closure_T_FS+8	/* DW_CFA_def_cfa_offset */
+        .byte   0xe, raw_closure_T_FS+8 /* DW_CFA_def_cfa_offset */
         ADV(UW46, UW45)
-	.byte	0x80+3, 3		/* DW_CFA_offset %ebx 3*-4 */
+        .byte   0x80+3, 3               /* DW_CFA_offset %ebx 3*-4 */
         ADV(UW47, UW46)
-	.byte	0xc0+3			/* DW_CFA_restore %ebx */
+        .byte   0xc0+3                  /* DW_CFA_restore %ebx */
         ADV(UW48, UW47)
-	.byte	0xe, 8			/* DW_CFA_def_cfa_offset */
+        .byte   0xe, 8                  /* DW_CFA_def_cfa_offset */
         ADV(UW49, UW48)
-	.byte	0xe, raw_closure_T_FS+8	/* DW_CFA_def_cfa_offset */
+        .byte   0xe, raw_closure_T_FS+8 /* DW_CFA_def_cfa_offset */
         ADV(UW50, UW49)
-	.byte	0xe, 8			/* DW_CFA_def_cfa_offset */
+        .byte   0xe, 8                  /* DW_CFA_def_cfa_offset */
         ADV(UW51, UW50)
-	.byte	0xe, raw_closure_T_FS+8	/* DW_CFA_def_cfa_offset */
-	.balign	4
+        .byte   0xe, raw_closure_T_FS+8 /* DW_CFA_def_cfa_offset */
+        .balign 4
 L(EFDE9):
 #endif /* !FFI_NO_RAW_API */
 
 #ifdef _WIN32
-	.def	 @feat.00;
-	.scl	3;
-	.type	0;
+        .def     @feat.00;
+        .scl    3;
+        .type   0;
         .endef
-	PUBLIC	@feat.00
+        PUBLIC  @feat.00
 @feat.00 = 1
 #endif
 
@@ -991,7 +991,7 @@ L(EFDE9):
 #endif /* ifndef __x86_64__ */
 
 #if defined __ELF__ && defined __linux__
-	.section	.note.GNU-stack,"",@progbits
+        .section        .note.GNU-stack,"",@progbits
 #endif
 #endif
 

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/unix64.S
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/unix64.S
@@ -39,14 +39,13 @@
    actual table.  The entry points into the table are all 8 bytes.
    The use of ORG asserts that we're at the correct location.  */
 /* ??? The clang assembler doesn't handle .org with symbolic expressions.  */
-#if defined(__clang__) || defined(__APPLE__) || (defined (__sun__) && defined(__svr4__))
-# define E(BASE, X)     .balign 8
+#ifdef __CET__
+/* Double slot size to 16 byte to add 4 bytes of ENDBR64.  */
+# define E(BASE, X)	.balign 8; .org BASE + X * 16
+#elif defined(__clang__) || defined(__APPLE__) || (defined (__sun__) && defined(__svr4__))
+# define E(BASE, X)	.balign 8
 #else
-# ifdef __CET__
-#  define E(BASE, X)    .balign 8; .org BASE + X * 16
-# else
-#  define E(BASE, X)    .balign 8; .org BASE + X * 8
-# endif
+# define E(BASE, X)	.balign 8; .org BASE + X * 8
 #endif
 
 /* ffi_call_unix64 (void *args, unsigned long bytes, unsigned flags,
@@ -56,20 +55,20 @@
    for this function.  This has been allocated by ffi_call.  We also
    deallocate some of the stack that has been alloca'd.  */
 
-        .balign 8
-        .globl  C(ffi_call_unix64)
+	.balign	8
+	.globl	C(ffi_call_unix64)
         FFI_HIDDEN(C(ffi_call_unix64))
 
 C(ffi_call_unix64):
 L(UW0):
         _CET_ENDBR
-        movq    (%rsp), %r10            /* Load return address.  */
-        leaq    (%rdi, %rsi), %rax      /* Find local stack base.  */
-        movq    %rdx, (%rax)            /* Save flags.  */
-        movq    %rcx, 8(%rax)           /* Save raddr.  */
-        movq    %rbp, 16(%rax)          /* Save old frame pointer.  */
-        movq    %r10, 24(%rax)          /* Relocate return address.  */
-        movq    %rax, %rbp              /* Finalize local stack frame.  */
+	movq	(%rsp), %r10		/* Load return address.  */
+	leaq	(%rdi, %rsi), %rax	/* Find local stack base.  */
+	movq	%rdx, (%rax)		/* Save flags.  */
+	movq	%rcx, 8(%rax)		/* Save raddr.  */
+	movq	%rbp, 16(%rax)		/* Save old frame pointer.  */
+	movq	%r10, 24(%rax)		/* Relocate return address.  */
+	movq	%rax, %rbp		/* Finalize local stack frame.  */
 
         /* New stack frame based off rbp.  This is a itty bit of unwind
            trickery in that the CFA *has* changed.  There is no easy way
@@ -82,139 +81,139 @@ L(UW1):
         /* cfi_def_cfa(%rbp, 32) */
         /* cfi_rel_offset(%rbp, 16) */
 
-        movq    %rdi, %r10              /* Save a copy of the register area. */
-        movq    %r8, %r11               /* Save a copy of the target fn.  */
+	movq	%rdi, %r10		/* Save a copy of the register area. */
+	movq	%r8, %r11		/* Save a copy of the target fn.  */
 
         /* Load up all argument registers.  */
-        movq    (%r10), %rdi
-        movq    0x08(%r10), %rsi
-        movq    0x10(%r10), %rdx
-        movq    0x18(%r10), %rcx
-        movq    0x20(%r10), %r8
-        movq    0x28(%r10), %r9
-        movl    0xb0(%r10), %eax        /* Set number of SSE registers.  */
-        testl   %eax, %eax
-        jnz     L(load_sse)
+	movq	(%r10), %rdi
+	movq	0x08(%r10), %rsi
+	movq	0x10(%r10), %rdx
+	movq	0x18(%r10), %rcx
+	movq	0x20(%r10), %r8
+	movq	0x28(%r10), %r9
+	movl	0xb0(%r10), %eax	/* Set number of SSE registers.  */
+	testl	%eax, %eax
+	jnz	L(load_sse)
 L(ret_from_load_sse):
 
         /* Deallocate the reg arg area, except for r10, then load via pop.  */
-        leaq    0xb8(%r10), %rsp
-        popq    %r10
+	leaq	0xb8(%r10), %rsp
+	popq	%r10
 
         /* Call the user function.  */
-        call    *%r11
+	call	*%r11
 
         /* Deallocate stack arg area; local stack frame in redzone.  */
-        leaq    24(%rbp), %rsp
+	leaq	24(%rbp), %rsp
 
-        movq    0(%rbp), %rcx           /* Reload flags.  */
-        movq    8(%rbp), %rdi           /* Reload raddr.  */
-        movq    16(%rbp), %rbp          /* Reload old frame pointer.  */
+	movq	0(%rbp), %rcx		/* Reload flags.  */
+	movq	8(%rbp), %rdi		/* Reload raddr.  */
+	movq	16(%rbp), %rbp		/* Reload old frame pointer.  */
 L(UW2):
         /* cfi_remember_state */
         /* cfi_def_cfa(%rsp, 8) */
         /* cfi_restore(%rbp) */
 
         /* The first byte of the flags contains the FFI_TYPE.  */
-        cmpb    $UNIX64_RET_LAST, %cl
-        movzbl  %cl, %r10d
-        leaq    L(store_table)(%rip), %r11
-        ja      L(sa)
+	cmpb	$UNIX64_RET_LAST, %cl
+	movzbl	%cl, %r10d
+	leaq	L(store_table)(%rip), %r11
+	ja	L(sa)
 #ifdef __CET__
         /* NB: Originally, each slot is 8 byte.  4 bytes of ENDBR64 +
            4 bytes NOP padding double slot size to 16 bytes.  */
-        addl    %r10d, %r10d
+	addl	%r10d, %r10d
 #endif
-        leaq    (%r11, %r10, 8), %r10
+	leaq	(%r11, %r10, 8), %r10
 
         /* Prep for the structure cases: scratch area in redzone.  */
-        leaq    -20(%rsp), %rsi
-        jmp     *%r10
+	leaq	-20(%rsp), %rsi
+	jmp	*%r10
 
-        .balign 8
+	.balign	8
 L(store_table):
 E(L(store_table), UNIX64_RET_VOID)
         _CET_ENDBR
         ret
 E(L(store_table), UNIX64_RET_UINT8)
         _CET_ENDBR
-        movzbl  %al, %eax
-        movq    %rax, (%rdi)
+	movzbl	%al, %eax
+	movq	%rax, (%rdi)
         ret
 E(L(store_table), UNIX64_RET_UINT16)
         _CET_ENDBR
-        movzwl  %ax, %eax
-        movq    %rax, (%rdi)
+	movzwl	%ax, %eax
+	movq	%rax, (%rdi)
         ret
 E(L(store_table), UNIX64_RET_UINT32)
         _CET_ENDBR
-        movl    %eax, %eax
-        movq    %rax, (%rdi)
+	movl	%eax, %eax
+	movq	%rax, (%rdi)
         ret
 E(L(store_table), UNIX64_RET_SINT8)
         _CET_ENDBR
-        movsbq  %al, %rax
-        movq    %rax, (%rdi)
+	movsbq	%al, %rax
+	movq	%rax, (%rdi)
         ret
 E(L(store_table), UNIX64_RET_SINT16)
         _CET_ENDBR
-        movswq  %ax, %rax
-        movq    %rax, (%rdi)
+	movswq	%ax, %rax
+	movq	%rax, (%rdi)
         ret
 E(L(store_table), UNIX64_RET_SINT32)
         _CET_ENDBR
         cltq
-        movq    %rax, (%rdi)
+	movq	%rax, (%rdi)
         ret
 E(L(store_table), UNIX64_RET_INT64)
         _CET_ENDBR
-        movq    %rax, (%rdi)
+	movq	%rax, (%rdi)
         ret
 E(L(store_table), UNIX64_RET_XMM32)
         _CET_ENDBR
-        movd    %xmm0, (%rdi)
+	movd	%xmm0, (%rdi)
         ret
 E(L(store_table), UNIX64_RET_XMM64)
         _CET_ENDBR
-        movq    %xmm0, (%rdi)
+	movq	%xmm0, (%rdi)
         ret
 E(L(store_table), UNIX64_RET_X87)
         _CET_ENDBR
-        fstpt   (%rdi)
+	fstpt	(%rdi)
         ret
 E(L(store_table), UNIX64_RET_X87_2)
         _CET_ENDBR
-        fstpt   (%rdi)
-        fstpt   16(%rdi)
+	fstpt	(%rdi)
+	fstpt	16(%rdi)
         ret
 E(L(store_table), UNIX64_RET_ST_XMM0_RAX)
         _CET_ENDBR
-        movq    %rax, 8(%rsi)
-        jmp     L(s3)
+	movq	%rax, 8(%rsi)
+	jmp	L(s3)
 E(L(store_table), UNIX64_RET_ST_RAX_XMM0)
         _CET_ENDBR
-        movq    %xmm0, 8(%rsi)
-        jmp     L(s2)
+	movq	%xmm0, 8(%rsi)
+	jmp	L(s2)
 E(L(store_table), UNIX64_RET_ST_XMM0_XMM1)
         _CET_ENDBR
-        movq    %xmm1, 8(%rsi)
-        jmp     L(s3)
+	movq	%xmm1, 8(%rsi)
+	jmp	L(s3)
 E(L(store_table), UNIX64_RET_ST_RAX_RDX)
         _CET_ENDBR
-        movq    %rdx, 8(%rsi)
+	movq	%rdx, 8(%rsi)
 L(s2):
-        movq    %rax, (%rsi)
-        shrl    $UNIX64_SIZE_SHIFT, %ecx
+	movq	%rax, (%rsi)
+	shrl	$UNIX64_SIZE_SHIFT, %ecx
         rep movsb
         ret
         .balign 8
 L(s3):
-        movq    %xmm0, (%rsi)
-        shrl    $UNIX64_SIZE_SHIFT, %ecx
+	movq	%xmm0, (%rsi)
+	shrl	$UNIX64_SIZE_SHIFT, %ecx
         rep movsb
         ret
 
-L(sa):  call    PLT(C(abort))
+L(sa):	call	PLT(C(abort))
 
         /* Many times we can avoid loading any SSE registers at all.
            It's not worth an indirect jump to load the exact set of
@@ -223,65 +222,65 @@ L(sa):  call    PLT(C(abort))
 L(UW3):
         /* cfi_restore_state */
 L(load_sse):
-        movdqa  0x30(%r10), %xmm0
-        movdqa  0x40(%r10), %xmm1
-        movdqa  0x50(%r10), %xmm2
-        movdqa  0x60(%r10), %xmm3
-        movdqa  0x70(%r10), %xmm4
-        movdqa  0x80(%r10), %xmm5
-        movdqa  0x90(%r10), %xmm6
-        movdqa  0xa0(%r10), %xmm7
-        jmp     L(ret_from_load_sse)
+	movdqa	0x30(%r10), %xmm0
+	movdqa	0x40(%r10), %xmm1
+	movdqa	0x50(%r10), %xmm2
+	movdqa	0x60(%r10), %xmm3
+	movdqa	0x70(%r10), %xmm4
+	movdqa	0x80(%r10), %xmm5
+	movdqa	0x90(%r10), %xmm6
+	movdqa	0xa0(%r10), %xmm7
+	jmp	L(ret_from_load_sse)
 
 L(UW4):
 ENDF(C(ffi_call_unix64))
 
 /* 6 general registers, 8 vector registers,
    32 bytes of rvalue, 8 bytes of alignment.  */
-#define ffi_closure_OFS_G       0
-#define ffi_closure_OFS_V       (6*8)
-#define ffi_closure_OFS_RVALUE  (ffi_closure_OFS_V + 8*16)
-#define ffi_closure_FS          (ffi_closure_OFS_RVALUE + 32 + 8)
+#define ffi_closure_OFS_G	0
+#define ffi_closure_OFS_V	(6*8)
+#define ffi_closure_OFS_RVALUE	(ffi_closure_OFS_V + 8*16)
+#define ffi_closure_FS		(ffi_closure_OFS_RVALUE + 32 + 8)
 
 /* The location of rvalue within the red zone after deallocating the frame.  */
-#define ffi_closure_RED_RVALUE  (ffi_closure_OFS_RVALUE - ffi_closure_FS)
+#define ffi_closure_RED_RVALUE	(ffi_closure_OFS_RVALUE - ffi_closure_FS)
 
-        .balign 2
-        .globl  C(ffi_closure_unix64_sse)
+	.balign	2
+	.globl	C(ffi_closure_unix64_sse)
         FFI_HIDDEN(C(ffi_closure_unix64_sse))
 
 C(ffi_closure_unix64_sse):
 L(UW5):
         _CET_ENDBR
-        subq    $ffi_closure_FS, %rsp
+	subq	$ffi_closure_FS, %rsp
 L(UW6):
         /* cfi_adjust_cfa_offset(ffi_closure_FS) */
 
-        movdqa  %xmm0, ffi_closure_OFS_V+0x00(%rsp)
-        movdqa  %xmm1, ffi_closure_OFS_V+0x10(%rsp)
-        movdqa  %xmm2, ffi_closure_OFS_V+0x20(%rsp)
-        movdqa  %xmm3, ffi_closure_OFS_V+0x30(%rsp)
-        movdqa  %xmm4, ffi_closure_OFS_V+0x40(%rsp)
-        movdqa  %xmm5, ffi_closure_OFS_V+0x50(%rsp)
-        movdqa  %xmm6, ffi_closure_OFS_V+0x60(%rsp)
-        movdqa  %xmm7, ffi_closure_OFS_V+0x70(%rsp)
-        jmp     L(sse_entry1)
+	movdqa	%xmm0, ffi_closure_OFS_V+0x00(%rsp)
+	movdqa	%xmm1, ffi_closure_OFS_V+0x10(%rsp)
+	movdqa	%xmm2, ffi_closure_OFS_V+0x20(%rsp)
+	movdqa	%xmm3, ffi_closure_OFS_V+0x30(%rsp)
+	movdqa	%xmm4, ffi_closure_OFS_V+0x40(%rsp)
+	movdqa	%xmm5, ffi_closure_OFS_V+0x50(%rsp)
+	movdqa	%xmm6, ffi_closure_OFS_V+0x60(%rsp)
+	movdqa	%xmm7, ffi_closure_OFS_V+0x70(%rsp)
+	jmp	L(sse_entry1)
 
 L(UW7):
 ENDF(C(ffi_closure_unix64_sse))
 
-        .balign 2
-        .globl  C(ffi_closure_unix64)
+	.balign	2
+	.globl	C(ffi_closure_unix64)
         FFI_HIDDEN(C(ffi_closure_unix64))
 
 C(ffi_closure_unix64):
 L(UW8):
         _CET_ENDBR
-        subq    $ffi_closure_FS, %rsp
+	subq	$ffi_closure_FS, %rsp
 L(UW9):
         /* cfi_adjust_cfa_offset(ffi_closure_FS) */
 L(sse_entry1):
-        movq    %rdi, ffi_closure_OFS_G+0x00(%rsp)
+	movq	%rdi, ffi_closure_OFS_G+0x00(%rsp)
         movq    %rsi, ffi_closure_OFS_G+0x08(%rsp)
         movq    %rdx, ffi_closure_OFS_G+0x10(%rsp)
         movq    %rcx, ffi_closure_OFS_G+0x18(%rsp)
@@ -289,153 +288,153 @@ L(sse_entry1):
         movq    %r9,  ffi_closure_OFS_G+0x28(%rsp)
 
 #ifdef __ILP32__
-        movl    FFI_TRAMPOLINE_SIZE(%r10), %edi         /* Load cif */
-        movl    FFI_TRAMPOLINE_SIZE+4(%r10), %esi       /* Load fun */
-        movl    FFI_TRAMPOLINE_SIZE+8(%r10), %edx       /* Load user_data */
+	movl	FFI_TRAMPOLINE_SIZE(%r10), %edi		/* Load cif */
+	movl	FFI_TRAMPOLINE_SIZE+4(%r10), %esi	/* Load fun */
+	movl	FFI_TRAMPOLINE_SIZE+8(%r10), %edx	/* Load user_data */
 #else
-        movq    FFI_TRAMPOLINE_SIZE(%r10), %rdi         /* Load cif */
-        movq    FFI_TRAMPOLINE_SIZE+8(%r10), %rsi       /* Load fun */
-        movq    FFI_TRAMPOLINE_SIZE+16(%r10), %rdx      /* Load user_data */
+	movq	FFI_TRAMPOLINE_SIZE(%r10), %rdi		/* Load cif */
+	movq	FFI_TRAMPOLINE_SIZE+8(%r10), %rsi	/* Load fun */
+	movq	FFI_TRAMPOLINE_SIZE+16(%r10), %rdx	/* Load user_data */
 #endif
 L(do_closure):
-        leaq    ffi_closure_OFS_RVALUE(%rsp), %rcx      /* Load rvalue */
-        movq    %rsp, %r8                               /* Load reg_args */
-        leaq    ffi_closure_FS+8(%rsp), %r9             /* Load argp */
-        call    PLT(C(ffi_closure_unix64_inner))
+	leaq	ffi_closure_OFS_RVALUE(%rsp), %rcx	/* Load rvalue */
+	movq	%rsp, %r8				/* Load reg_args */
+	leaq	ffi_closure_FS+8(%rsp), %r9		/* Load argp */
+	call	PLT(C(ffi_closure_unix64_inner))
 
         /* Deallocate stack frame early; return value is now in redzone.  */
-        addq    $ffi_closure_FS, %rsp
+	addq	$ffi_closure_FS, %rsp
 L(UW10):
         /* cfi_adjust_cfa_offset(-ffi_closure_FS) */
 
         /* The first byte of the return value contains the FFI_TYPE.  */
-        cmpb    $UNIX64_RET_LAST, %al
-        movzbl  %al, %r10d
-        leaq    L(load_table)(%rip), %r11
-        ja      L(la)
+	cmpb	$UNIX64_RET_LAST, %al
+	movzbl	%al, %r10d
+	leaq	L(load_table)(%rip), %r11
+	ja	L(la)
 #ifdef __CET__
         /* NB: Originally, each slot is 8 byte.  4 bytes of ENDBR64 +
            4 bytes NOP padding double slot size to 16 bytes.  */
-        addl    %r10d, %r10d
+	addl	%r10d, %r10d
 #endif
-        leaq    (%r11, %r10, 8), %r10
-        leaq    ffi_closure_RED_RVALUE(%rsp), %rsi
-        jmp     *%r10
+	leaq	(%r11, %r10, 8), %r10
+	leaq	ffi_closure_RED_RVALUE(%rsp), %rsi
+	jmp	*%r10
 
-        .balign 8
+	.balign	8
 L(load_table):
 E(L(load_table), UNIX64_RET_VOID)
         _CET_ENDBR
         ret
 E(L(load_table), UNIX64_RET_UINT8)
         _CET_ENDBR
-        movzbl  (%rsi), %eax
+	movzbl	(%rsi), %eax
         ret
 E(L(load_table), UNIX64_RET_UINT16)
         _CET_ENDBR
-        movzwl  (%rsi), %eax
+	movzwl	(%rsi), %eax
         ret
 E(L(load_table), UNIX64_RET_UINT32)
         _CET_ENDBR
-        movl    (%rsi), %eax
+	movl	(%rsi), %eax
         ret
 E(L(load_table), UNIX64_RET_SINT8)
         _CET_ENDBR
-        movsbl  (%rsi), %eax
+	movsbl	(%rsi), %eax
         ret
 E(L(load_table), UNIX64_RET_SINT16)
         _CET_ENDBR
-        movswl  (%rsi), %eax
+	movswl	(%rsi), %eax
         ret
 E(L(load_table), UNIX64_RET_SINT32)
         _CET_ENDBR
-        movl    (%rsi), %eax
+	movl	(%rsi), %eax
         ret
 E(L(load_table), UNIX64_RET_INT64)
         _CET_ENDBR
-        movq    (%rsi), %rax
+	movq	(%rsi), %rax
         ret
 E(L(load_table), UNIX64_RET_XMM32)
         _CET_ENDBR
-        movd    (%rsi), %xmm0
+	movd	(%rsi), %xmm0
         ret
 E(L(load_table), UNIX64_RET_XMM64)
         _CET_ENDBR
-        movq    (%rsi), %xmm0
+	movq	(%rsi), %xmm0
         ret
 E(L(load_table), UNIX64_RET_X87)
         _CET_ENDBR
-        fldt    (%rsi)
+	fldt	(%rsi)
         ret
 E(L(load_table), UNIX64_RET_X87_2)
         _CET_ENDBR
-        fldt    16(%rsi)
-        fldt    (%rsi)
+	fldt	16(%rsi)
+	fldt	(%rsi)
         ret
 E(L(load_table), UNIX64_RET_ST_XMM0_RAX)
         _CET_ENDBR
-        movq    8(%rsi), %rax
-        jmp     L(l3)
+	movq	8(%rsi), %rax
+	jmp	L(l3)
 E(L(load_table), UNIX64_RET_ST_RAX_XMM0)
         _CET_ENDBR
-        movq    8(%rsi), %xmm0
-        jmp     L(l2)
+	movq	8(%rsi), %xmm0
+	jmp	L(l2)
 E(L(load_table), UNIX64_RET_ST_XMM0_XMM1)
         _CET_ENDBR
-        movq    8(%rsi), %xmm1
-        jmp     L(l3)
+	movq	8(%rsi), %xmm1
+	jmp	L(l3)
 E(L(load_table), UNIX64_RET_ST_RAX_RDX)
         _CET_ENDBR
-        movq    8(%rsi), %rdx
+	movq	8(%rsi), %rdx
 L(l2):
-        movq    (%rsi), %rax
+	movq	(%rsi), %rax
         ret
-        .balign 8
+	.balign	8
 L(l3):
-        movq    (%rsi), %xmm0
+	movq	(%rsi), %xmm0
         ret
 
-L(la):  call    PLT(C(abort))
+L(la):	call	PLT(C(abort))
 
 L(UW11):
 ENDF(C(ffi_closure_unix64))
 
-        .balign 2
-        .globl  C(ffi_go_closure_unix64_sse)
+	.balign	2
+	.globl	C(ffi_go_closure_unix64_sse)
         FFI_HIDDEN(C(ffi_go_closure_unix64_sse))
 
 C(ffi_go_closure_unix64_sse):
 L(UW12):
         _CET_ENDBR
-        subq    $ffi_closure_FS, %rsp
+	subq	$ffi_closure_FS, %rsp
 L(UW13):
         /* cfi_adjust_cfa_offset(ffi_closure_FS) */
 
-        movdqa  %xmm0, ffi_closure_OFS_V+0x00(%rsp)
-        movdqa  %xmm1, ffi_closure_OFS_V+0x10(%rsp)
-        movdqa  %xmm2, ffi_closure_OFS_V+0x20(%rsp)
-        movdqa  %xmm3, ffi_closure_OFS_V+0x30(%rsp)
-        movdqa  %xmm4, ffi_closure_OFS_V+0x40(%rsp)
-        movdqa  %xmm5, ffi_closure_OFS_V+0x50(%rsp)
-        movdqa  %xmm6, ffi_closure_OFS_V+0x60(%rsp)
-        movdqa  %xmm7, ffi_closure_OFS_V+0x70(%rsp)
-        jmp     L(sse_entry2)
+	movdqa	%xmm0, ffi_closure_OFS_V+0x00(%rsp)
+	movdqa	%xmm1, ffi_closure_OFS_V+0x10(%rsp)
+	movdqa	%xmm2, ffi_closure_OFS_V+0x20(%rsp)
+	movdqa	%xmm3, ffi_closure_OFS_V+0x30(%rsp)
+	movdqa	%xmm4, ffi_closure_OFS_V+0x40(%rsp)
+	movdqa	%xmm5, ffi_closure_OFS_V+0x50(%rsp)
+	movdqa	%xmm6, ffi_closure_OFS_V+0x60(%rsp)
+	movdqa	%xmm7, ffi_closure_OFS_V+0x70(%rsp)
+	jmp	L(sse_entry2)
 
 L(UW14):
 ENDF(C(ffi_go_closure_unix64_sse))
 
-        .balign 2
-        .globl  C(ffi_go_closure_unix64)
+	.balign	2
+	.globl	C(ffi_go_closure_unix64)
         FFI_HIDDEN(C(ffi_go_closure_unix64))
 
 C(ffi_go_closure_unix64):
 L(UW15):
         _CET_ENDBR
-        subq    $ffi_closure_FS, %rsp
+	subq	$ffi_closure_FS, %rsp
 L(UW16):
         /* cfi_adjust_cfa_offset(ffi_closure_FS) */
 L(sse_entry2):
-        movq    %rdi, ffi_closure_OFS_G+0x00(%rsp)
+	movq	%rdi, ffi_closure_OFS_G+0x00(%rsp)
         movq    %rsi, ffi_closure_OFS_G+0x08(%rsp)
         movq    %rdx, ffi_closure_OFS_G+0x10(%rsp)
         movq    %rcx, ffi_closure_OFS_G+0x18(%rsp)
@@ -443,42 +442,42 @@ L(sse_entry2):
         movq    %r9,  ffi_closure_OFS_G+0x28(%rsp)
 
 #ifdef __ILP32__
-        movl    4(%r10), %edi           /* Load cif */
-        movl    8(%r10), %esi           /* Load fun */
-        movl    %r10d, %edx             /* Load closure (user_data) */
+	movl	4(%r10), %edi		/* Load cif */
+	movl	8(%r10), %esi		/* Load fun */
+	movl	%r10d, %edx		/* Load closure (user_data) */
 #else
-        movq    8(%r10), %rdi           /* Load cif */
-        movq    16(%r10), %rsi          /* Load fun */
-        movq    %r10, %rdx              /* Load closure (user_data) */
+	movq	8(%r10), %rdi		/* Load cif */
+	movq	16(%r10), %rsi		/* Load fun */
+	movq	%r10, %rdx		/* Load closure (user_data) */
 #endif
-        jmp     L(do_closure)
+	jmp	L(do_closure)
 
 L(UW17):
 ENDF(C(ffi_go_closure_unix64))
 
 #if defined(FFI_EXEC_STATIC_TRAMP)
-        .balign 8
-        .globl  C(ffi_closure_unix64_sse_alt)
+	.balign	8
+	.globl	C(ffi_closure_unix64_sse_alt)
         FFI_HIDDEN(C(ffi_closure_unix64_sse_alt))
 
 C(ffi_closure_unix64_sse_alt):
         /* See the comments above trampoline_code_table. */
         _CET_ENDBR
-        movq    8(%rsp), %r10                   /* Load closure in r10 */
-        addq    $16, %rsp                       /* Restore the stack */
-        jmp     C(ffi_closure_unix64_sse)
+	movq	8(%rsp), %r10			/* Load closure in r10 */
+	addq	$16, %rsp			/* Restore the stack */
+	jmp	C(ffi_closure_unix64_sse)
 ENDF(C(ffi_closure_unix64_sse_alt))
 
-        .balign 8
-        .globl  C(ffi_closure_unix64_alt)
+	.balign	8
+	.globl	C(ffi_closure_unix64_alt)
         FFI_HIDDEN(C(ffi_closure_unix64_alt))
 
 C(ffi_closure_unix64_alt):
         /* See the comments above trampoline_code_table. */
         _CET_ENDBR
-        movq    8(%rsp), %r10                   /* Load closure in r10 */
-        addq    $16, %rsp                       /* Restore the stack */
-        jmp     C(ffi_closure_unix64)
+	movq	8(%rsp), %r10			/* Load closure in r10 */
+	addq	$16, %rsp			/* Restore the stack */
+	jmp	C(ffi_closure_unix64)
         ENDF(C(ffi_closure_unix64_alt))
 
 /*
@@ -505,30 +504,46 @@ C(ffi_closure_unix64_alt):
  * - restore the stack pointer to what it was when the trampoline was invoked.
  */
 #ifdef ENDBR_PRESENT
-#define X86_DATA_OFFSET         4077
-#define X86_CODE_OFFSET         4073
+# define X86_DATA_OFFSET	4077
+# ifdef __ILP32__
+#  define X86_CODE_OFFSET	4069
+# else
+#  define X86_CODE_OFFSET	4073
+# endif
 #else
-#define X86_DATA_OFFSET         4081
-#define X86_CODE_OFFSET         4077
+# define X86_DATA_OFFSET	4081
+# ifdef __ILP32__
+#  define X86_CODE_OFFSET	4073
+# else
+#  define X86_CODE_OFFSET	4077
+# endif
 #endif
 
-        .align  UNIX64_TRAMP_MAP_SIZE
-        .globl  trampoline_code_table
+	.align	UNIX64_TRAMP_MAP_SIZE
+	.globl	trampoline_code_table
         FFI_HIDDEN(C(trampoline_code_table))
 
 C(trampoline_code_table):
-        .rept   UNIX64_TRAMP_MAP_SIZE / UNIX64_TRAMP_SIZE
+	.rept	UNIX64_TRAMP_MAP_SIZE / UNIX64_TRAMP_SIZE
         _CET_ENDBR
-        subq    $16, %rsp                       /* Make space on the stack */
-        movq    %r10, (%rsp)                    /* Save %r10 on stack */
-        movq    X86_DATA_OFFSET(%rip), %r10     /* Copy data into %r10 */
-        movq    %r10, 8(%rsp)                   /* Save data on stack */
-        movq    X86_CODE_OFFSET(%rip), %r10     /* Copy code into %r10 */
-        jmp     *%r10                           /* Jump to code */
-        .align  8
+	subq	$16, %rsp			/* Make space on the stack */
+	movq	%r10, (%rsp)			/* Save %r10 on stack */
+#ifdef __ILP32__
+	movl	X86_DATA_OFFSET(%rip), %r10d	/* Copy data into %r10 */
+#else
+	movq	X86_DATA_OFFSET(%rip), %r10	/* Copy data into %r10 */
+#endif
+	movq	%r10, 8(%rsp)			/* Save data on stack */
+#ifdef __ILP32__
+	movl	X86_CODE_OFFSET(%rip), %r10d	/* Copy code into %r10 */
+#else
+	movq	X86_CODE_OFFSET(%rip), %r10	/* Copy code into %r10 */
+#endif
+	jmp	*%r10				/* Jump to code */
+	.align	8
         .endr
 ENDF(C(trampoline_code_table))
-        .align  UNIX64_TRAMP_MAP_SIZE
+	.align	UNIX64_TRAMP_MAP_SIZE
 #endif /* FFI_EXEC_STATIC_TRAMP */
 
 /* Sadly, OSX cctools-as doesn't understand .cfi directives at all.  */
@@ -543,107 +558,107 @@ EHFrame0:
 #endif
 
 #ifdef HAVE_AS_X86_PCREL
-# define PCREL(X)       X - .
+# define PCREL(X)	X - .
 #else
-# define PCREL(X)       X@rel
+# define PCREL(X)	X@rel
 #endif
 
 /* Simplify advancing between labels.  Assume DW_CFA_advance_loc1 fits.  */
 #ifdef __CET__
 /* Use DW_CFA_advance_loc2 when IBT is enabled.  */
-# define ADV(N, P)      .byte 3; .2byte L(N)-L(P)
+# define ADV(N, P)	.byte 3; .2byte L(N)-L(P)
 #else
-# define ADV(N, P)      .byte 2, L(N)-L(P)
+# define ADV(N, P)	.byte 2, L(N)-L(P)
 #endif
 
         .balign 8
 L(CIE):
-        .set    L(set0),L(ECIE)-L(SCIE)
-        .long   L(set0)                 /* CIE Length */
+	.set	L(set0),L(ECIE)-L(SCIE)
+	.long	L(set0)			/* CIE Length */
 L(SCIE):
-        .long   0                       /* CIE Identifier Tag */
-        .byte   1                       /* CIE Version */
-        .ascii  "zR\0"                  /* CIE Augmentation */
-        .byte   1                       /* CIE Code Alignment Factor */
-        .byte   0x78                    /* CIE Data Alignment Factor */
-        .byte   0x10                    /* CIE RA Column */
-        .byte   1                       /* Augmentation size */
-        .byte   0x1b                    /* FDE Encoding (pcrel sdata4) */
-        .byte   0xc, 7, 8               /* DW_CFA_def_cfa, %rsp offset 8 */
-        .byte   0x80+16, 1              /* DW_CFA_offset, %rip offset 1*-8 */
+	.long	0			/* CIE Identifier Tag */
+	.byte	1			/* CIE Version */
+	.ascii	"zR\0"			/* CIE Augmentation */
+	.byte	1			/* CIE Code Alignment Factor */
+	.byte	0x78			/* CIE Data Alignment Factor */
+	.byte	0x10			/* CIE RA Column */
+	.byte	1			/* Augmentation size */
+	.byte	0x1b			/* FDE Encoding (pcrel sdata4) */
+	.byte	0xc, 7, 8		/* DW_CFA_def_cfa, %rsp offset 8 */
+	.byte	0x80+16, 1		/* DW_CFA_offset, %rip offset 1*-8 */
         .balign 8
 L(ECIE):
 
-        .set    L(set1),L(EFDE1)-L(SFDE1)
-        .long   L(set1)                 /* FDE Length */
+	.set	L(set1),L(EFDE1)-L(SFDE1)
+	.long	L(set1)			/* FDE Length */
 L(SFDE1):
-        .long   L(SFDE1)-L(CIE)         /* FDE CIE offset */
-        .long   PCREL(L(UW0))           /* Initial location */
-        .long   L(UW4)-L(UW0)           /* Address range */
-        .byte   0                       /* Augmentation size */
+	.long	L(SFDE1)-L(CIE)		/* FDE CIE offset */
+	.long	PCREL(L(UW0))		/* Initial location */
+	.long	L(UW4)-L(UW0)		/* Address range */
+	.byte	0			/* Augmentation size */
         ADV(UW1, UW0)
-        .byte   0xc, 6, 32              /* DW_CFA_def_cfa, %rbp 32 */
-        .byte   0x80+6, 2               /* DW_CFA_offset, %rbp 2*-8 */
+	.byte	0xc, 6, 32		/* DW_CFA_def_cfa, %rbp 32 */
+	.byte	0x80+6, 2		/* DW_CFA_offset, %rbp 2*-8 */
         ADV(UW2, UW1)
-        .byte   0xa                     /* DW_CFA_remember_state */
-        .byte   0xc, 7, 8               /* DW_CFA_def_cfa, %rsp 8 */
-        .byte   0xc0+6                  /* DW_CFA_restore, %rbp */
+	.byte	0xa			/* DW_CFA_remember_state */
+	.byte	0xc, 7, 8		/* DW_CFA_def_cfa, %rsp 8 */
+	.byte	0xc0+6			/* DW_CFA_restore, %rbp */
         ADV(UW3, UW2)
-        .byte   0xb                     /* DW_CFA_restore_state */
-        .balign 8
+	.byte	0xb			/* DW_CFA_restore_state */
+	.balign	8
 L(EFDE1):
 
-        .set    L(set2),L(EFDE2)-L(SFDE2)
-        .long   L(set2)                 /* FDE Length */
+	.set	L(set2),L(EFDE2)-L(SFDE2)
+	.long	L(set2)			/* FDE Length */
 L(SFDE2):
-        .long   L(SFDE2)-L(CIE)         /* FDE CIE offset */
-        .long   PCREL(L(UW5))           /* Initial location */
-        .long   L(UW7)-L(UW5)           /* Address range */
-        .byte   0                       /* Augmentation size */
+	.long	L(SFDE2)-L(CIE)		/* FDE CIE offset */
+	.long	PCREL(L(UW5))		/* Initial location */
+	.long	L(UW7)-L(UW5)		/* Address range */
+	.byte	0			/* Augmentation size */
         ADV(UW6, UW5)
-        .byte   0xe                     /* DW_CFA_def_cfa_offset */
-        .byte   ffi_closure_FS + 8, 1   /* uleb128, assuming 128 <= FS < 255 */
-        .balign 8
+	.byte	0xe			/* DW_CFA_def_cfa_offset */
+	.byte	ffi_closure_FS + 8, 1	/* uleb128, assuming 128 <= FS < 255 */
+	.balign	8
 L(EFDE2):
 
-        .set    L(set3),L(EFDE3)-L(SFDE3)
-        .long   L(set3)                 /* FDE Length */
+	.set	L(set3),L(EFDE3)-L(SFDE3)
+	.long	L(set3)			/* FDE Length */
 L(SFDE3):
-        .long   L(SFDE3)-L(CIE)         /* FDE CIE offset */
-        .long   PCREL(L(UW8))           /* Initial location */
-        .long   L(UW11)-L(UW8)          /* Address range */
-        .byte   0                       /* Augmentation size */
+	.long	L(SFDE3)-L(CIE)		/* FDE CIE offset */
+	.long	PCREL(L(UW8))		/* Initial location */
+	.long	L(UW11)-L(UW8)		/* Address range */
+	.byte	0			/* Augmentation size */
         ADV(UW9, UW8)
-        .byte   0xe                     /* DW_CFA_def_cfa_offset */
-        .byte   ffi_closure_FS + 8, 1   /* uleb128, assuming 128 <= FS < 255 */
+	.byte	0xe			/* DW_CFA_def_cfa_offset */
+	.byte	ffi_closure_FS + 8, 1	/* uleb128, assuming 128 <= FS < 255 */
         ADV(UW10, UW9)
-        .byte   0xe, 8                  /* DW_CFA_def_cfa_offset 8 */
+	.byte	0xe, 8			/* DW_CFA_def_cfa_offset 8 */
 L(EFDE3):
 
-        .set    L(set4),L(EFDE4)-L(SFDE4)
-        .long   L(set4)                 /* FDE Length */
+	.set	L(set4),L(EFDE4)-L(SFDE4)
+	.long	L(set4)			/* FDE Length */
 L(SFDE4):
-        .long   L(SFDE4)-L(CIE)         /* FDE CIE offset */
-        .long   PCREL(L(UW12))          /* Initial location */
-        .long   L(UW14)-L(UW12)         /* Address range */
-        .byte   0                       /* Augmentation size */
+	.long	L(SFDE4)-L(CIE)		/* FDE CIE offset */
+	.long	PCREL(L(UW12))		/* Initial location */
+	.long	L(UW14)-L(UW12)		/* Address range */
+	.byte	0			/* Augmentation size */
         ADV(UW13, UW12)
-        .byte   0xe                     /* DW_CFA_def_cfa_offset */
-        .byte   ffi_closure_FS + 8, 1   /* uleb128, assuming 128 <= FS < 255 */
-        .balign 8
+	.byte	0xe			/* DW_CFA_def_cfa_offset */
+	.byte	ffi_closure_FS + 8, 1	/* uleb128, assuming 128 <= FS < 255 */
+	.balign	8
 L(EFDE4):
 
-        .set    L(set5),L(EFDE5)-L(SFDE5)
-        .long   L(set5)                 /* FDE Length */
+	.set	L(set5),L(EFDE5)-L(SFDE5)
+	.long	L(set5)			/* FDE Length */
 L(SFDE5):
-        .long   L(SFDE5)-L(CIE)         /* FDE CIE offset */
-        .long   PCREL(L(UW15))          /* Initial location */
-        .long   L(UW17)-L(UW15)         /* Address range */
-        .byte   0                       /* Augmentation size */
+	.long	L(SFDE5)-L(CIE)		/* FDE CIE offset */
+	.long	PCREL(L(UW15))		/* Initial location */
+	.long	L(UW17)-L(UW15)		/* Address range */
+	.byte	0			/* Augmentation size */
         ADV(UW16, UW15)
-        .byte   0xe                     /* DW_CFA_def_cfa_offset */
-        .byte   ffi_closure_FS + 8, 1   /* uleb128, assuming 128 <= FS < 255 */
-        .balign 8
+	.byte	0xe			/* DW_CFA_def_cfa_offset */
+	.byte	ffi_closure_FS + 8, 1	/* uleb128, assuming 128 <= FS < 255 */
+	.balign	8
 L(EFDE5):
 #ifdef __APPLE__
         .subsections_via_symbols
@@ -692,5 +707,5 @@ L(EFDE5):
 
 #endif /* __x86_64__ */
 #if defined __ELF__ && defined __linux__
-        .section        .note.GNU-stack,"",@progbits
+	.section	.note.GNU-stack,"",@progbits
 #endif

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/unix64.S
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/unix64.S
@@ -41,11 +41,11 @@
 /* ??? The clang assembler doesn't handle .org with symbolic expressions.  */
 #ifdef __CET__
 /* Double slot size to 16 byte to add 4 bytes of ENDBR64.  */
-# define E(BASE, X)	.balign 8; .org BASE + X * 16
+# define E(BASE, X)     .balign 8; .org BASE + X * 16
 #elif defined(__clang__) || defined(__APPLE__) || (defined (__sun__) && defined(__svr4__))
-# define E(BASE, X)	.balign 8
+# define E(BASE, X)     .balign 8
 #else
-# define E(BASE, X)	.balign 8; .org BASE + X * 8
+# define E(BASE, X)     .balign 8; .org BASE + X * 8
 #endif
 
 /* ffi_call_unix64 (void *args, unsigned long bytes, unsigned flags,
@@ -55,20 +55,20 @@
    for this function.  This has been allocated by ffi_call.  We also
    deallocate some of the stack that has been alloca'd.  */
 
-	.balign	8
-	.globl	C(ffi_call_unix64)
+        .balign 8
+        .globl  C(ffi_call_unix64)
         FFI_HIDDEN(C(ffi_call_unix64))
 
 C(ffi_call_unix64):
 L(UW0):
         _CET_ENDBR
-	movq	(%rsp), %r10		/* Load return address.  */
-	leaq	(%rdi, %rsi), %rax	/* Find local stack base.  */
-	movq	%rdx, (%rax)		/* Save flags.  */
-	movq	%rcx, 8(%rax)		/* Save raddr.  */
-	movq	%rbp, 16(%rax)		/* Save old frame pointer.  */
-	movq	%r10, 24(%rax)		/* Relocate return address.  */
-	movq	%rax, %rbp		/* Finalize local stack frame.  */
+        movq    (%rsp), %r10            /* Load return address.  */
+        leaq    (%rdi, %rsi), %rax      /* Find local stack base.  */
+        movq    %rdx, (%rax)            /* Save flags.  */
+        movq    %rcx, 8(%rax)           /* Save raddr.  */
+        movq    %rbp, 16(%rax)          /* Save old frame pointer.  */
+        movq    %r10, 24(%rax)          /* Relocate return address.  */
+        movq    %rax, %rbp              /* Finalize local stack frame.  */
 
         /* New stack frame based off rbp.  This is a itty bit of unwind
            trickery in that the CFA *has* changed.  There is no easy way
@@ -81,139 +81,139 @@ L(UW1):
         /* cfi_def_cfa(%rbp, 32) */
         /* cfi_rel_offset(%rbp, 16) */
 
-	movq	%rdi, %r10		/* Save a copy of the register area. */
-	movq	%r8, %r11		/* Save a copy of the target fn.  */
+        movq    %rdi, %r10              /* Save a copy of the register area. */
+        movq    %r8, %r11               /* Save a copy of the target fn.  */
 
         /* Load up all argument registers.  */
-	movq	(%r10), %rdi
-	movq	0x08(%r10), %rsi
-	movq	0x10(%r10), %rdx
-	movq	0x18(%r10), %rcx
-	movq	0x20(%r10), %r8
-	movq	0x28(%r10), %r9
-	movl	0xb0(%r10), %eax	/* Set number of SSE registers.  */
-	testl	%eax, %eax
-	jnz	L(load_sse)
+        movq    (%r10), %rdi
+        movq    0x08(%r10), %rsi
+        movq    0x10(%r10), %rdx
+        movq    0x18(%r10), %rcx
+        movq    0x20(%r10), %r8
+        movq    0x28(%r10), %r9
+        movl    0xb0(%r10), %eax        /* Set number of SSE registers.  */
+        testl   %eax, %eax
+        jnz     L(load_sse)
 L(ret_from_load_sse):
 
         /* Deallocate the reg arg area, except for r10, then load via pop.  */
-	leaq	0xb8(%r10), %rsp
-	popq	%r10
+        leaq    0xb8(%r10), %rsp
+        popq    %r10
 
         /* Call the user function.  */
-	call	*%r11
+        call    *%r11
 
         /* Deallocate stack arg area; local stack frame in redzone.  */
-	leaq	24(%rbp), %rsp
+        leaq    24(%rbp), %rsp
 
-	movq	0(%rbp), %rcx		/* Reload flags.  */
-	movq	8(%rbp), %rdi		/* Reload raddr.  */
-	movq	16(%rbp), %rbp		/* Reload old frame pointer.  */
+        movq    0(%rbp), %rcx           /* Reload flags.  */
+        movq    8(%rbp), %rdi           /* Reload raddr.  */
+        movq    16(%rbp), %rbp          /* Reload old frame pointer.  */
 L(UW2):
         /* cfi_remember_state */
         /* cfi_def_cfa(%rsp, 8) */
         /* cfi_restore(%rbp) */
 
         /* The first byte of the flags contains the FFI_TYPE.  */
-	cmpb	$UNIX64_RET_LAST, %cl
-	movzbl	%cl, %r10d
-	leaq	L(store_table)(%rip), %r11
-	ja	L(sa)
+        cmpb    $UNIX64_RET_LAST, %cl
+        movzbl  %cl, %r10d
+        leaq    L(store_table)(%rip), %r11
+        ja      L(sa)
 #ifdef __CET__
         /* NB: Originally, each slot is 8 byte.  4 bytes of ENDBR64 +
            4 bytes NOP padding double slot size to 16 bytes.  */
-	addl	%r10d, %r10d
+        addl    %r10d, %r10d
 #endif
-	leaq	(%r11, %r10, 8), %r10
+        leaq    (%r11, %r10, 8), %r10
 
         /* Prep for the structure cases: scratch area in redzone.  */
-	leaq	-20(%rsp), %rsi
-	jmp	*%r10
+        leaq    -20(%rsp), %rsi
+        jmp     *%r10
 
-	.balign	8
+        .balign 8
 L(store_table):
 E(L(store_table), UNIX64_RET_VOID)
         _CET_ENDBR
         ret
 E(L(store_table), UNIX64_RET_UINT8)
         _CET_ENDBR
-	movzbl	%al, %eax
-	movq	%rax, (%rdi)
+        movzbl  %al, %eax
+        movq    %rax, (%rdi)
         ret
 E(L(store_table), UNIX64_RET_UINT16)
         _CET_ENDBR
-	movzwl	%ax, %eax
-	movq	%rax, (%rdi)
+        movzwl  %ax, %eax
+        movq    %rax, (%rdi)
         ret
 E(L(store_table), UNIX64_RET_UINT32)
         _CET_ENDBR
-	movl	%eax, %eax
-	movq	%rax, (%rdi)
+        movl    %eax, %eax
+        movq    %rax, (%rdi)
         ret
 E(L(store_table), UNIX64_RET_SINT8)
         _CET_ENDBR
-	movsbq	%al, %rax
-	movq	%rax, (%rdi)
+        movsbq  %al, %rax
+        movq    %rax, (%rdi)
         ret
 E(L(store_table), UNIX64_RET_SINT16)
         _CET_ENDBR
-	movswq	%ax, %rax
-	movq	%rax, (%rdi)
+        movswq  %ax, %rax
+        movq    %rax, (%rdi)
         ret
 E(L(store_table), UNIX64_RET_SINT32)
         _CET_ENDBR
         cltq
-	movq	%rax, (%rdi)
+        movq    %rax, (%rdi)
         ret
 E(L(store_table), UNIX64_RET_INT64)
         _CET_ENDBR
-	movq	%rax, (%rdi)
+        movq    %rax, (%rdi)
         ret
 E(L(store_table), UNIX64_RET_XMM32)
         _CET_ENDBR
-	movd	%xmm0, (%rdi)
+        movd    %xmm0, (%rdi)
         ret
 E(L(store_table), UNIX64_RET_XMM64)
         _CET_ENDBR
-	movq	%xmm0, (%rdi)
+        movq    %xmm0, (%rdi)
         ret
 E(L(store_table), UNIX64_RET_X87)
         _CET_ENDBR
-	fstpt	(%rdi)
+        fstpt   (%rdi)
         ret
 E(L(store_table), UNIX64_RET_X87_2)
         _CET_ENDBR
-	fstpt	(%rdi)
-	fstpt	16(%rdi)
+        fstpt   (%rdi)
+        fstpt   16(%rdi)
         ret
 E(L(store_table), UNIX64_RET_ST_XMM0_RAX)
         _CET_ENDBR
-	movq	%rax, 8(%rsi)
-	jmp	L(s3)
+        movq    %rax, 8(%rsi)
+        jmp     L(s3)
 E(L(store_table), UNIX64_RET_ST_RAX_XMM0)
         _CET_ENDBR
-	movq	%xmm0, 8(%rsi)
-	jmp	L(s2)
+        movq    %xmm0, 8(%rsi)
+        jmp     L(s2)
 E(L(store_table), UNIX64_RET_ST_XMM0_XMM1)
         _CET_ENDBR
-	movq	%xmm1, 8(%rsi)
-	jmp	L(s3)
+        movq    %xmm1, 8(%rsi)
+        jmp     L(s3)
 E(L(store_table), UNIX64_RET_ST_RAX_RDX)
         _CET_ENDBR
-	movq	%rdx, 8(%rsi)
+        movq    %rdx, 8(%rsi)
 L(s2):
-	movq	%rax, (%rsi)
-	shrl	$UNIX64_SIZE_SHIFT, %ecx
+        movq    %rax, (%rsi)
+        shrl    $UNIX64_SIZE_SHIFT, %ecx
         rep movsb
         ret
         .balign 8
 L(s3):
-	movq	%xmm0, (%rsi)
-	shrl	$UNIX64_SIZE_SHIFT, %ecx
+        movq    %xmm0, (%rsi)
+        shrl    $UNIX64_SIZE_SHIFT, %ecx
         rep movsb
         ret
 
-L(sa):	call	PLT(C(abort))
+L(sa):  call    PLT(C(abort))
 
         /* Many times we can avoid loading any SSE registers at all.
            It's not worth an indirect jump to load the exact set of
@@ -222,65 +222,65 @@ L(sa):	call	PLT(C(abort))
 L(UW3):
         /* cfi_restore_state */
 L(load_sse):
-	movdqa	0x30(%r10), %xmm0
-	movdqa	0x40(%r10), %xmm1
-	movdqa	0x50(%r10), %xmm2
-	movdqa	0x60(%r10), %xmm3
-	movdqa	0x70(%r10), %xmm4
-	movdqa	0x80(%r10), %xmm5
-	movdqa	0x90(%r10), %xmm6
-	movdqa	0xa0(%r10), %xmm7
-	jmp	L(ret_from_load_sse)
+        movdqa  0x30(%r10), %xmm0
+        movdqa  0x40(%r10), %xmm1
+        movdqa  0x50(%r10), %xmm2
+        movdqa  0x60(%r10), %xmm3
+        movdqa  0x70(%r10), %xmm4
+        movdqa  0x80(%r10), %xmm5
+        movdqa  0x90(%r10), %xmm6
+        movdqa  0xa0(%r10), %xmm7
+        jmp     L(ret_from_load_sse)
 
 L(UW4):
 ENDF(C(ffi_call_unix64))
 
 /* 6 general registers, 8 vector registers,
    32 bytes of rvalue, 8 bytes of alignment.  */
-#define ffi_closure_OFS_G	0
-#define ffi_closure_OFS_V	(6*8)
-#define ffi_closure_OFS_RVALUE	(ffi_closure_OFS_V + 8*16)
-#define ffi_closure_FS		(ffi_closure_OFS_RVALUE + 32 + 8)
+#define ffi_closure_OFS_G       0
+#define ffi_closure_OFS_V       (6*8)
+#define ffi_closure_OFS_RVALUE  (ffi_closure_OFS_V + 8*16)
+#define ffi_closure_FS          (ffi_closure_OFS_RVALUE + 32 + 8)
 
 /* The location of rvalue within the red zone after deallocating the frame.  */
-#define ffi_closure_RED_RVALUE	(ffi_closure_OFS_RVALUE - ffi_closure_FS)
+#define ffi_closure_RED_RVALUE  (ffi_closure_OFS_RVALUE - ffi_closure_FS)
 
-	.balign	2
-	.globl	C(ffi_closure_unix64_sse)
+        .balign 2
+        .globl  C(ffi_closure_unix64_sse)
         FFI_HIDDEN(C(ffi_closure_unix64_sse))
 
 C(ffi_closure_unix64_sse):
 L(UW5):
         _CET_ENDBR
-	subq	$ffi_closure_FS, %rsp
+        subq    $ffi_closure_FS, %rsp
 L(UW6):
         /* cfi_adjust_cfa_offset(ffi_closure_FS) */
 
-	movdqa	%xmm0, ffi_closure_OFS_V+0x00(%rsp)
-	movdqa	%xmm1, ffi_closure_OFS_V+0x10(%rsp)
-	movdqa	%xmm2, ffi_closure_OFS_V+0x20(%rsp)
-	movdqa	%xmm3, ffi_closure_OFS_V+0x30(%rsp)
-	movdqa	%xmm4, ffi_closure_OFS_V+0x40(%rsp)
-	movdqa	%xmm5, ffi_closure_OFS_V+0x50(%rsp)
-	movdqa	%xmm6, ffi_closure_OFS_V+0x60(%rsp)
-	movdqa	%xmm7, ffi_closure_OFS_V+0x70(%rsp)
-	jmp	L(sse_entry1)
+        movdqa  %xmm0, ffi_closure_OFS_V+0x00(%rsp)
+        movdqa  %xmm1, ffi_closure_OFS_V+0x10(%rsp)
+        movdqa  %xmm2, ffi_closure_OFS_V+0x20(%rsp)
+        movdqa  %xmm3, ffi_closure_OFS_V+0x30(%rsp)
+        movdqa  %xmm4, ffi_closure_OFS_V+0x40(%rsp)
+        movdqa  %xmm5, ffi_closure_OFS_V+0x50(%rsp)
+        movdqa  %xmm6, ffi_closure_OFS_V+0x60(%rsp)
+        movdqa  %xmm7, ffi_closure_OFS_V+0x70(%rsp)
+        jmp     L(sse_entry1)
 
 L(UW7):
 ENDF(C(ffi_closure_unix64_sse))
 
-	.balign	2
-	.globl	C(ffi_closure_unix64)
+        .balign 2
+        .globl  C(ffi_closure_unix64)
         FFI_HIDDEN(C(ffi_closure_unix64))
 
 C(ffi_closure_unix64):
 L(UW8):
         _CET_ENDBR
-	subq	$ffi_closure_FS, %rsp
+        subq    $ffi_closure_FS, %rsp
 L(UW9):
         /* cfi_adjust_cfa_offset(ffi_closure_FS) */
 L(sse_entry1):
-	movq	%rdi, ffi_closure_OFS_G+0x00(%rsp)
+        movq    %rdi, ffi_closure_OFS_G+0x00(%rsp)
         movq    %rsi, ffi_closure_OFS_G+0x08(%rsp)
         movq    %rdx, ffi_closure_OFS_G+0x10(%rsp)
         movq    %rcx, ffi_closure_OFS_G+0x18(%rsp)
@@ -288,153 +288,153 @@ L(sse_entry1):
         movq    %r9,  ffi_closure_OFS_G+0x28(%rsp)
 
 #ifdef __ILP32__
-	movl	FFI_TRAMPOLINE_SIZE(%r10), %edi		/* Load cif */
-	movl	FFI_TRAMPOLINE_SIZE+4(%r10), %esi	/* Load fun */
-	movl	FFI_TRAMPOLINE_SIZE+8(%r10), %edx	/* Load user_data */
+        movl    FFI_TRAMPOLINE_SIZE(%r10), %edi         /* Load cif */
+        movl    FFI_TRAMPOLINE_SIZE+4(%r10), %esi       /* Load fun */
+        movl    FFI_TRAMPOLINE_SIZE+8(%r10), %edx       /* Load user_data */
 #else
-	movq	FFI_TRAMPOLINE_SIZE(%r10), %rdi		/* Load cif */
-	movq	FFI_TRAMPOLINE_SIZE+8(%r10), %rsi	/* Load fun */
-	movq	FFI_TRAMPOLINE_SIZE+16(%r10), %rdx	/* Load user_data */
+        movq    FFI_TRAMPOLINE_SIZE(%r10), %rdi         /* Load cif */
+        movq    FFI_TRAMPOLINE_SIZE+8(%r10), %rsi       /* Load fun */
+        movq    FFI_TRAMPOLINE_SIZE+16(%r10), %rdx      /* Load user_data */
 #endif
 L(do_closure):
-	leaq	ffi_closure_OFS_RVALUE(%rsp), %rcx	/* Load rvalue */
-	movq	%rsp, %r8				/* Load reg_args */
-	leaq	ffi_closure_FS+8(%rsp), %r9		/* Load argp */
-	call	PLT(C(ffi_closure_unix64_inner))
+        leaq    ffi_closure_OFS_RVALUE(%rsp), %rcx      /* Load rvalue */
+        movq    %rsp, %r8                               /* Load reg_args */
+        leaq    ffi_closure_FS+8(%rsp), %r9             /* Load argp */
+        call    PLT(C(ffi_closure_unix64_inner))
 
         /* Deallocate stack frame early; return value is now in redzone.  */
-	addq	$ffi_closure_FS, %rsp
+        addq    $ffi_closure_FS, %rsp
 L(UW10):
         /* cfi_adjust_cfa_offset(-ffi_closure_FS) */
 
         /* The first byte of the return value contains the FFI_TYPE.  */
-	cmpb	$UNIX64_RET_LAST, %al
-	movzbl	%al, %r10d
-	leaq	L(load_table)(%rip), %r11
-	ja	L(la)
+        cmpb    $UNIX64_RET_LAST, %al
+        movzbl  %al, %r10d
+        leaq    L(load_table)(%rip), %r11
+        ja      L(la)
 #ifdef __CET__
         /* NB: Originally, each slot is 8 byte.  4 bytes of ENDBR64 +
            4 bytes NOP padding double slot size to 16 bytes.  */
-	addl	%r10d, %r10d
+        addl    %r10d, %r10d
 #endif
-	leaq	(%r11, %r10, 8), %r10
-	leaq	ffi_closure_RED_RVALUE(%rsp), %rsi
-	jmp	*%r10
+        leaq    (%r11, %r10, 8), %r10
+        leaq    ffi_closure_RED_RVALUE(%rsp), %rsi
+        jmp     *%r10
 
-	.balign	8
+        .balign 8
 L(load_table):
 E(L(load_table), UNIX64_RET_VOID)
         _CET_ENDBR
         ret
 E(L(load_table), UNIX64_RET_UINT8)
         _CET_ENDBR
-	movzbl	(%rsi), %eax
+        movzbl  (%rsi), %eax
         ret
 E(L(load_table), UNIX64_RET_UINT16)
         _CET_ENDBR
-	movzwl	(%rsi), %eax
+        movzwl  (%rsi), %eax
         ret
 E(L(load_table), UNIX64_RET_UINT32)
         _CET_ENDBR
-	movl	(%rsi), %eax
+        movl    (%rsi), %eax
         ret
 E(L(load_table), UNIX64_RET_SINT8)
         _CET_ENDBR
-	movsbl	(%rsi), %eax
+        movsbl  (%rsi), %eax
         ret
 E(L(load_table), UNIX64_RET_SINT16)
         _CET_ENDBR
-	movswl	(%rsi), %eax
+        movswl  (%rsi), %eax
         ret
 E(L(load_table), UNIX64_RET_SINT32)
         _CET_ENDBR
-	movl	(%rsi), %eax
+        movl    (%rsi), %eax
         ret
 E(L(load_table), UNIX64_RET_INT64)
         _CET_ENDBR
-	movq	(%rsi), %rax
+        movq    (%rsi), %rax
         ret
 E(L(load_table), UNIX64_RET_XMM32)
         _CET_ENDBR
-	movd	(%rsi), %xmm0
+        movd    (%rsi), %xmm0
         ret
 E(L(load_table), UNIX64_RET_XMM64)
         _CET_ENDBR
-	movq	(%rsi), %xmm0
+        movq    (%rsi), %xmm0
         ret
 E(L(load_table), UNIX64_RET_X87)
         _CET_ENDBR
-	fldt	(%rsi)
+        fldt    (%rsi)
         ret
 E(L(load_table), UNIX64_RET_X87_2)
         _CET_ENDBR
-	fldt	16(%rsi)
-	fldt	(%rsi)
+        fldt    16(%rsi)
+        fldt    (%rsi)
         ret
 E(L(load_table), UNIX64_RET_ST_XMM0_RAX)
         _CET_ENDBR
-	movq	8(%rsi), %rax
-	jmp	L(l3)
+        movq    8(%rsi), %rax
+        jmp     L(l3)
 E(L(load_table), UNIX64_RET_ST_RAX_XMM0)
         _CET_ENDBR
-	movq	8(%rsi), %xmm0
-	jmp	L(l2)
+        movq    8(%rsi), %xmm0
+        jmp     L(l2)
 E(L(load_table), UNIX64_RET_ST_XMM0_XMM1)
         _CET_ENDBR
-	movq	8(%rsi), %xmm1
-	jmp	L(l3)
+        movq    8(%rsi), %xmm1
+        jmp     L(l3)
 E(L(load_table), UNIX64_RET_ST_RAX_RDX)
         _CET_ENDBR
-	movq	8(%rsi), %rdx
+        movq    8(%rsi), %rdx
 L(l2):
-	movq	(%rsi), %rax
+        movq    (%rsi), %rax
         ret
-	.balign	8
+        .balign 8
 L(l3):
-	movq	(%rsi), %xmm0
+        movq    (%rsi), %xmm0
         ret
 
-L(la):	call	PLT(C(abort))
+L(la):  call    PLT(C(abort))
 
 L(UW11):
 ENDF(C(ffi_closure_unix64))
 
-	.balign	2
-	.globl	C(ffi_go_closure_unix64_sse)
+        .balign 2
+        .globl  C(ffi_go_closure_unix64_sse)
         FFI_HIDDEN(C(ffi_go_closure_unix64_sse))
 
 C(ffi_go_closure_unix64_sse):
 L(UW12):
         _CET_ENDBR
-	subq	$ffi_closure_FS, %rsp
+        subq    $ffi_closure_FS, %rsp
 L(UW13):
         /* cfi_adjust_cfa_offset(ffi_closure_FS) */
 
-	movdqa	%xmm0, ffi_closure_OFS_V+0x00(%rsp)
-	movdqa	%xmm1, ffi_closure_OFS_V+0x10(%rsp)
-	movdqa	%xmm2, ffi_closure_OFS_V+0x20(%rsp)
-	movdqa	%xmm3, ffi_closure_OFS_V+0x30(%rsp)
-	movdqa	%xmm4, ffi_closure_OFS_V+0x40(%rsp)
-	movdqa	%xmm5, ffi_closure_OFS_V+0x50(%rsp)
-	movdqa	%xmm6, ffi_closure_OFS_V+0x60(%rsp)
-	movdqa	%xmm7, ffi_closure_OFS_V+0x70(%rsp)
-	jmp	L(sse_entry2)
+        movdqa  %xmm0, ffi_closure_OFS_V+0x00(%rsp)
+        movdqa  %xmm1, ffi_closure_OFS_V+0x10(%rsp)
+        movdqa  %xmm2, ffi_closure_OFS_V+0x20(%rsp)
+        movdqa  %xmm3, ffi_closure_OFS_V+0x30(%rsp)
+        movdqa  %xmm4, ffi_closure_OFS_V+0x40(%rsp)
+        movdqa  %xmm5, ffi_closure_OFS_V+0x50(%rsp)
+        movdqa  %xmm6, ffi_closure_OFS_V+0x60(%rsp)
+        movdqa  %xmm7, ffi_closure_OFS_V+0x70(%rsp)
+        jmp     L(sse_entry2)
 
 L(UW14):
 ENDF(C(ffi_go_closure_unix64_sse))
 
-	.balign	2
-	.globl	C(ffi_go_closure_unix64)
+        .balign 2
+        .globl  C(ffi_go_closure_unix64)
         FFI_HIDDEN(C(ffi_go_closure_unix64))
 
 C(ffi_go_closure_unix64):
 L(UW15):
         _CET_ENDBR
-	subq	$ffi_closure_FS, %rsp
+        subq    $ffi_closure_FS, %rsp
 L(UW16):
         /* cfi_adjust_cfa_offset(ffi_closure_FS) */
 L(sse_entry2):
-	movq	%rdi, ffi_closure_OFS_G+0x00(%rsp)
+        movq    %rdi, ffi_closure_OFS_G+0x00(%rsp)
         movq    %rsi, ffi_closure_OFS_G+0x08(%rsp)
         movq    %rdx, ffi_closure_OFS_G+0x10(%rsp)
         movq    %rcx, ffi_closure_OFS_G+0x18(%rsp)
@@ -442,42 +442,42 @@ L(sse_entry2):
         movq    %r9,  ffi_closure_OFS_G+0x28(%rsp)
 
 #ifdef __ILP32__
-	movl	4(%r10), %edi		/* Load cif */
-	movl	8(%r10), %esi		/* Load fun */
-	movl	%r10d, %edx		/* Load closure (user_data) */
+        movl    4(%r10), %edi           /* Load cif */
+        movl    8(%r10), %esi           /* Load fun */
+        movl    %r10d, %edx             /* Load closure (user_data) */
 #else
-	movq	8(%r10), %rdi		/* Load cif */
-	movq	16(%r10), %rsi		/* Load fun */
-	movq	%r10, %rdx		/* Load closure (user_data) */
+        movq    8(%r10), %rdi           /* Load cif */
+        movq    16(%r10), %rsi          /* Load fun */
+        movq    %r10, %rdx              /* Load closure (user_data) */
 #endif
-	jmp	L(do_closure)
+        jmp     L(do_closure)
 
 L(UW17):
 ENDF(C(ffi_go_closure_unix64))
 
 #if defined(FFI_EXEC_STATIC_TRAMP)
-	.balign	8
-	.globl	C(ffi_closure_unix64_sse_alt)
+        .balign 8
+        .globl  C(ffi_closure_unix64_sse_alt)
         FFI_HIDDEN(C(ffi_closure_unix64_sse_alt))
 
 C(ffi_closure_unix64_sse_alt):
         /* See the comments above trampoline_code_table. */
         _CET_ENDBR
-	movq	8(%rsp), %r10			/* Load closure in r10 */
-	addq	$16, %rsp			/* Restore the stack */
-	jmp	C(ffi_closure_unix64_sse)
+        movq    8(%rsp), %r10                   /* Load closure in r10 */
+        addq    $16, %rsp                       /* Restore the stack */
+        jmp     C(ffi_closure_unix64_sse)
 ENDF(C(ffi_closure_unix64_sse_alt))
 
-	.balign	8
-	.globl	C(ffi_closure_unix64_alt)
+        .balign 8
+        .globl  C(ffi_closure_unix64_alt)
         FFI_HIDDEN(C(ffi_closure_unix64_alt))
 
 C(ffi_closure_unix64_alt):
         /* See the comments above trampoline_code_table. */
         _CET_ENDBR
-	movq	8(%rsp), %r10			/* Load closure in r10 */
-	addq	$16, %rsp			/* Restore the stack */
-	jmp	C(ffi_closure_unix64)
+        movq    8(%rsp), %r10                   /* Load closure in r10 */
+        addq    $16, %rsp                       /* Restore the stack */
+        jmp     C(ffi_closure_unix64)
         ENDF(C(ffi_closure_unix64_alt))
 
 /*
@@ -504,46 +504,46 @@ C(ffi_closure_unix64_alt):
  * - restore the stack pointer to what it was when the trampoline was invoked.
  */
 #ifdef ENDBR_PRESENT
-# define X86_DATA_OFFSET	4077
+#define X86_DATA_OFFSET         4077
 # ifdef __ILP32__
-#  define X86_CODE_OFFSET	4069
+#  define X86_CODE_OFFSET       4069
 # else
-#  define X86_CODE_OFFSET	4073
+#define X86_CODE_OFFSET         4073
 # endif
 #else
-# define X86_DATA_OFFSET	4081
+# define X86_DATA_OFFSET        4081
 # ifdef __ILP32__
-#  define X86_CODE_OFFSET	4073
+#  define X86_CODE_OFFSET       4073
 # else
-#  define X86_CODE_OFFSET	4077
+#  define X86_CODE_OFFSET       4077
 # endif
 #endif
 
-	.align	UNIX64_TRAMP_MAP_SIZE
-	.globl	trampoline_code_table
+        .align  UNIX64_TRAMP_MAP_SIZE
+        .globl  trampoline_code_table
         FFI_HIDDEN(C(trampoline_code_table))
 
 C(trampoline_code_table):
-	.rept	UNIX64_TRAMP_MAP_SIZE / UNIX64_TRAMP_SIZE
+        .rept   UNIX64_TRAMP_MAP_SIZE / UNIX64_TRAMP_SIZE
         _CET_ENDBR
-	subq	$16, %rsp			/* Make space on the stack */
-	movq	%r10, (%rsp)			/* Save %r10 on stack */
-#ifdef __ILP32__
-	movl	X86_DATA_OFFSET(%rip), %r10d	/* Copy data into %r10 */
+        subq    $16, %rsp                       /* Make space on the stack */
+        movq    %r10, (%rsp)                    /* Save %r10 on stack */
+ #ifdef __ILP32__
+        movl    X86_DATA_OFFSET(%rip), %r10d    /* Copy data into %r10 */
 #else
-	movq	X86_DATA_OFFSET(%rip), %r10	/* Copy data into %r10 */
+        movq    X86_DATA_OFFSET(%rip), %r10     /* Copy data into %r10 */
 #endif
-	movq	%r10, 8(%rsp)			/* Save data on stack */
+        movq    %r10, 8(%rsp)                   /* Save data on stack */
 #ifdef __ILP32__
-	movl	X86_CODE_OFFSET(%rip), %r10d	/* Copy code into %r10 */
+        movl    X86_CODE_OFFSET(%rip), %r10d    /* Copy code into %r10 */
 #else
-	movq	X86_CODE_OFFSET(%rip), %r10	/* Copy code into %r10 */
+        movq    X86_CODE_OFFSET(%rip), %r10     /* Copy code into %r10 */
 #endif
-	jmp	*%r10				/* Jump to code */
-	.align	8
+        jmp     *%r10                           /* Jump to code */
+        .align  8
         .endr
 ENDF(C(trampoline_code_table))
-	.align	UNIX64_TRAMP_MAP_SIZE
+        .align  UNIX64_TRAMP_MAP_SIZE
 #endif /* FFI_EXEC_STATIC_TRAMP */
 
 /* Sadly, OSX cctools-as doesn't understand .cfi directives at all.  */
@@ -558,107 +558,107 @@ EHFrame0:
 #endif
 
 #ifdef HAVE_AS_X86_PCREL
-# define PCREL(X)	X - .
+# define PCREL(X)       X - .
 #else
-# define PCREL(X)	X@rel
+# define PCREL(X)       X@rel
 #endif
 
 /* Simplify advancing between labels.  Assume DW_CFA_advance_loc1 fits.  */
 #ifdef __CET__
 /* Use DW_CFA_advance_loc2 when IBT is enabled.  */
-# define ADV(N, P)	.byte 3; .2byte L(N)-L(P)
+# define ADV(N, P)      .byte 3; .2byte L(N)-L(P)
 #else
-# define ADV(N, P)	.byte 2, L(N)-L(P)
+# define ADV(N, P)      .byte 2, L(N)-L(P)
 #endif
 
         .balign 8
 L(CIE):
-	.set	L(set0),L(ECIE)-L(SCIE)
-	.long	L(set0)			/* CIE Length */
+        .set    L(set0),L(ECIE)-L(SCIE)
+        .long   L(set0)                 /* CIE Length */
 L(SCIE):
-	.long	0			/* CIE Identifier Tag */
-	.byte	1			/* CIE Version */
-	.ascii	"zR\0"			/* CIE Augmentation */
-	.byte	1			/* CIE Code Alignment Factor */
-	.byte	0x78			/* CIE Data Alignment Factor */
-	.byte	0x10			/* CIE RA Column */
-	.byte	1			/* Augmentation size */
-	.byte	0x1b			/* FDE Encoding (pcrel sdata4) */
-	.byte	0xc, 7, 8		/* DW_CFA_def_cfa, %rsp offset 8 */
-	.byte	0x80+16, 1		/* DW_CFA_offset, %rip offset 1*-8 */
+        .long   0                       /* CIE Identifier Tag */
+        .byte   1                       /* CIE Version */
+        .ascii  "zR\0"                  /* CIE Augmentation */
+        .byte   1                       /* CIE Code Alignment Factor */
+        .byte   0x78                    /* CIE Data Alignment Factor */
+        .byte   0x10                    /* CIE RA Column */
+        .byte   1                       /* Augmentation size */
+        .byte   0x1b                    /* FDE Encoding (pcrel sdata4) */
+        .byte   0xc, 7, 8               /* DW_CFA_def_cfa, %rsp offset 8 */
+        .byte   0x80+16, 1              /* DW_CFA_offset, %rip offset 1*-8 */
         .balign 8
 L(ECIE):
 
-	.set	L(set1),L(EFDE1)-L(SFDE1)
-	.long	L(set1)			/* FDE Length */
+        .set    L(set1),L(EFDE1)-L(SFDE1)
+        .long   L(set1)                 /* FDE Length */
 L(SFDE1):
-	.long	L(SFDE1)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW0))		/* Initial location */
-	.long	L(UW4)-L(UW0)		/* Address range */
-	.byte	0			/* Augmentation size */
+        .long   L(SFDE1)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW0))           /* Initial location */
+        .long   L(UW4)-L(UW0)           /* Address range */
+        .byte   0                       /* Augmentation size */
         ADV(UW1, UW0)
-	.byte	0xc, 6, 32		/* DW_CFA_def_cfa, %rbp 32 */
-	.byte	0x80+6, 2		/* DW_CFA_offset, %rbp 2*-8 */
+        .byte   0xc, 6, 32              /* DW_CFA_def_cfa, %rbp 32 */
+        .byte   0x80+6, 2               /* DW_CFA_offset, %rbp 2*-8 */
         ADV(UW2, UW1)
-	.byte	0xa			/* DW_CFA_remember_state */
-	.byte	0xc, 7, 8		/* DW_CFA_def_cfa, %rsp 8 */
-	.byte	0xc0+6			/* DW_CFA_restore, %rbp */
+        .byte   0xa                     /* DW_CFA_remember_state */
+        .byte   0xc, 7, 8               /* DW_CFA_def_cfa, %rsp 8 */
+        .byte   0xc0+6                  /* DW_CFA_restore, %rbp */
         ADV(UW3, UW2)
-	.byte	0xb			/* DW_CFA_restore_state */
-	.balign	8
+        .byte   0xb                     /* DW_CFA_restore_state */
+        .balign 8
 L(EFDE1):
 
-	.set	L(set2),L(EFDE2)-L(SFDE2)
-	.long	L(set2)			/* FDE Length */
+        .set    L(set2),L(EFDE2)-L(SFDE2)
+        .long   L(set2)                 /* FDE Length */
 L(SFDE2):
-	.long	L(SFDE2)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW5))		/* Initial location */
-	.long	L(UW7)-L(UW5)		/* Address range */
-	.byte	0			/* Augmentation size */
+        .long   L(SFDE2)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW5))           /* Initial location */
+        .long   L(UW7)-L(UW5)           /* Address range */
+        .byte   0                       /* Augmentation size */
         ADV(UW6, UW5)
-	.byte	0xe			/* DW_CFA_def_cfa_offset */
-	.byte	ffi_closure_FS + 8, 1	/* uleb128, assuming 128 <= FS < 255 */
-	.balign	8
+        .byte   0xe                     /* DW_CFA_def_cfa_offset */
+        .byte   ffi_closure_FS + 8, 1   /* uleb128, assuming 128 <= FS < 255 */
+        .balign 8
 L(EFDE2):
 
-	.set	L(set3),L(EFDE3)-L(SFDE3)
-	.long	L(set3)			/* FDE Length */
+        .set    L(set3),L(EFDE3)-L(SFDE3)
+        .long   L(set3)                 /* FDE Length */
 L(SFDE3):
-	.long	L(SFDE3)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW8))		/* Initial location */
-	.long	L(UW11)-L(UW8)		/* Address range */
-	.byte	0			/* Augmentation size */
+        .long   L(SFDE3)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW8))           /* Initial location */
+        .long   L(UW11)-L(UW8)          /* Address range */
+        .byte   0                       /* Augmentation size */
         ADV(UW9, UW8)
-	.byte	0xe			/* DW_CFA_def_cfa_offset */
-	.byte	ffi_closure_FS + 8, 1	/* uleb128, assuming 128 <= FS < 255 */
+        .byte   0xe                     /* DW_CFA_def_cfa_offset */
+        .byte   ffi_closure_FS + 8, 1   /* uleb128, assuming 128 <= FS < 255 */
         ADV(UW10, UW9)
-	.byte	0xe, 8			/* DW_CFA_def_cfa_offset 8 */
+        .byte   0xe, 8                  /* DW_CFA_def_cfa_offset 8 */
 L(EFDE3):
 
-	.set	L(set4),L(EFDE4)-L(SFDE4)
-	.long	L(set4)			/* FDE Length */
+        .set    L(set4),L(EFDE4)-L(SFDE4)
+        .long   L(set4)                 /* FDE Length */
 L(SFDE4):
-	.long	L(SFDE4)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW12))		/* Initial location */
-	.long	L(UW14)-L(UW12)		/* Address range */
-	.byte	0			/* Augmentation size */
+        .long   L(SFDE4)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW12))          /* Initial location */
+        .long   L(UW14)-L(UW12)         /* Address range */
+        .byte   0                       /* Augmentation size */
         ADV(UW13, UW12)
-	.byte	0xe			/* DW_CFA_def_cfa_offset */
-	.byte	ffi_closure_FS + 8, 1	/* uleb128, assuming 128 <= FS < 255 */
-	.balign	8
+        .byte   0xe                     /* DW_CFA_def_cfa_offset */
+        .byte   ffi_closure_FS + 8, 1   /* uleb128, assuming 128 <= FS < 255 */
+        .balign 8
 L(EFDE4):
 
-	.set	L(set5),L(EFDE5)-L(SFDE5)
-	.long	L(set5)			/* FDE Length */
+        .set    L(set5),L(EFDE5)-L(SFDE5)
+        .long   L(set5)                 /* FDE Length */
 L(SFDE5):
-	.long	L(SFDE5)-L(CIE)		/* FDE CIE offset */
-	.long	PCREL(L(UW15))		/* Initial location */
-	.long	L(UW17)-L(UW15)		/* Address range */
-	.byte	0			/* Augmentation size */
+        .long   L(SFDE5)-L(CIE)         /* FDE CIE offset */
+        .long   PCREL(L(UW15))          /* Initial location */
+        .long   L(UW17)-L(UW15)         /* Address range */
+        .byte   0                       /* Augmentation size */
         ADV(UW16, UW15)
-	.byte	0xe			/* DW_CFA_def_cfa_offset */
-	.byte	ffi_closure_FS + 8, 1	/* uleb128, assuming 128 <= FS < 255 */
-	.balign	8
+        .byte   0xe                     /* DW_CFA_def_cfa_offset */
+        .byte   ffi_closure_FS + 8, 1   /* uleb128, assuming 128 <= FS < 255 */
+        .balign 8
 L(EFDE5):
 #ifdef __APPLE__
         .subsections_via_symbols
@@ -707,5 +707,5 @@ L(EFDE5):
 
 #endif /* __x86_64__ */
 #if defined __ELF__ && defined __linux__
-	.section	.note.GNU-stack,"",@progbits
+        .section        .note.GNU-stack,"",@progbits
 #endif

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/win64.S
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/win64.S
@@ -11,16 +11,16 @@
 
 #ifdef X86_WIN64
 #define SEH(...) __VA_ARGS__
-#define arg0	%rcx
-#define arg1	%rdx
-#define arg2	%r8
-#define arg3	%r9
+#define arg0    %rcx
+#define arg1    %rdx
+#define arg2    %r8
+#define arg3    %r9
 #else
 #define SEH(...)
-#define arg0	%rdi
-#define arg1	%rsi
-#define arg2	%rdx
-#define arg3	%rcx
+#define arg0    %rdi
+#define arg1    %rsi
+#define arg2    %rdx
+#define arg3    %rcx
 #endif
 
 /* This macro allows the safe creation of jump tables without an
@@ -28,9 +28,9 @@
    The use of ORG asserts that we're at the correct location.  */
 /* ??? The clang assembler doesn't handle .org with symbolic expressions.  */
 #if defined(__clang__) || defined(__APPLE__) || (defined (__sun__) && defined(__svr4__))
-# define E(BASE, X)	.balign 8
+# define E(BASE, X)     .balign 8
 #else
-# define E(BASE, X)	.balign 8; .org BASE + (X) * 8
+# define E(BASE, X)     .balign 8; .org BASE + (X) * 8
 #endif
 
         .text
@@ -41,8 +41,8 @@
    for this function.  This has been allocated by ffi_call.  We also
    deallocate some of the stack that has been alloca'd.  */
 
-	.align	8
-	.globl	C(ffi_call_win64)
+        .align  8
+        .globl  C(ffi_call_win64)
         FFI_HIDDEN(C(ffi_call_win64))
 
         SEH(.seh_proc ffi_call_win64)
@@ -50,113 +50,113 @@ C(ffi_call_win64):
         cfi_startproc
         _CET_ENDBR
         /* Set up the local stack frame and install it in rbp/rsp.  */
-	movq	(%rsp), %rax
-	movq	%rbp, (arg1)
-	movq	%rax, 8(arg1)
-	movq	arg1, %rbp
+        movq    (%rsp), %rax
+        movq    %rbp, (arg1)
+        movq    %rax, 8(arg1)
+        movq    arg1, %rbp
         cfi_def_cfa(%rbp, 16)
         cfi_rel_offset(%rbp, 0)
         SEH(.seh_pushreg %rbp)
         SEH(.seh_setframe %rbp, 0)
         SEH(.seh_endprologue)
-	movq	arg0, %rsp
+        movq    arg0, %rsp
 
-	movq	arg2, %r10
+        movq    arg2, %r10
 
         /* Load all slots into both general and xmm registers.  */
-	movq	(%rsp), %rcx
-	movsd	(%rsp), %xmm0
-	movq	8(%rsp), %rdx
-	movsd	8(%rsp), %xmm1
-	movq	16(%rsp), %r8
-	movsd	16(%rsp), %xmm2
-	movq	24(%rsp), %r9
-	movsd	24(%rsp), %xmm3
+        movq    (%rsp), %rcx
+        movsd   (%rsp), %xmm0
+        movq    8(%rsp), %rdx
+        movsd   8(%rsp), %xmm1
+        movq    16(%rsp), %r8
+        movsd   16(%rsp), %xmm2
+        movq    24(%rsp), %r9
+        movsd   24(%rsp), %xmm3
 
-	call	*16(%rbp)
+        call    *16(%rbp)
 
-	movl	24(%rbp), %ecx
-	movq	32(%rbp), %r8
-	leaq	0f(%rip), %r10
-	cmpl	$FFI_TYPE_SMALL_STRUCT_4B, %ecx
-	leaq	(%r10, %rcx, 8), %r10
-	ja	99f
+        movl    24(%rbp), %ecx
+        movq    32(%rbp), %r8
+        leaq    0f(%rip), %r10
+        cmpl    $FFI_TYPE_SMALL_STRUCT_4B, %ecx
+        leaq    (%r10, %rcx, 8), %r10
+        ja      99f
         _CET_NOTRACK jmp *%r10
 
 /* Below, we're space constrained most of the time.  Thus we eschew the
    modern "mov, pop, ret" sequence (5 bytes) for "leave, ret" (2 bytes).  */
-#define epilogue		\
-	leaveq;			\
-	cfi_remember_state;	\
-	cfi_def_cfa(%rsp, 8);	\
-	cfi_restore(%rbp);	\
-	ret;			\
+#define epilogue                \
+        leaveq;                 \
+        cfi_remember_state;     \
+        cfi_def_cfa(%rsp, 8);   \
+        cfi_restore(%rbp);      \
+        ret;                    \
         cfi_restore_state
 
-	.align	8
+        .align  8
 0:
 E(0b, FFI_TYPE_VOID)
         epilogue
 E(0b, FFI_TYPE_INT)
-	movslq	%eax, %rax
-	movq	%rax, (%r8)
+        movslq  %eax, %rax
+        movq    %rax, (%r8)
         epilogue
 E(0b, FFI_TYPE_FLOAT)
-	movss	%xmm0, (%r8)
+        movss   %xmm0, (%r8)
         epilogue
 E(0b, FFI_TYPE_DOUBLE)
-	movsd	%xmm0, (%r8)
+        movsd   %xmm0, (%r8)
         epilogue
 // FFI_TYPE_LONGDOUBLE may be FFI_TYPE_DOUBLE but we need a different value here.
 E(0b, FFI_TYPE_DOUBLE + 1)
-	call	PLT(C(abort))
+        call    PLT(C(abort))
 E(0b, FFI_TYPE_UINT8)
-	movzbl	%al, %eax
-	movq	%rax, (%r8)
+        movzbl  %al, %eax
+        movq    %rax, (%r8)
         epilogue
 E(0b, FFI_TYPE_SINT8)
-	movsbq	%al, %rax
-	jmp	98f
+        movsbq  %al, %rax
+        jmp     98f
 E(0b, FFI_TYPE_UINT16)
-	movzwl	%ax, %eax
-	movq	%rax, (%r8)
+        movzwl  %ax, %eax
+        movq    %rax, (%r8)
         epilogue
 E(0b, FFI_TYPE_SINT16)
-	movswq	%ax, %rax
-	jmp	98f
+        movswq  %ax, %rax
+        jmp     98f
 E(0b, FFI_TYPE_UINT32)
-	movl	%eax, %eax
-	movq	%rax, (%r8)
+        movl    %eax, %eax
+        movq    %rax, (%r8)
         epilogue
 E(0b, FFI_TYPE_SINT32)
-	movslq	%eax, %rax
-	movq	%rax, (%r8)
+        movslq  %eax, %rax
+        movq    %rax, (%r8)
         epilogue
 E(0b, FFI_TYPE_UINT64)
-98:	movq	%rax, (%r8)
+98:     movq    %rax, (%r8)
         epilogue
 E(0b, FFI_TYPE_SINT64)
-	movq	%rax, (%r8)
+        movq    %rax, (%r8)
         epilogue
 E(0b, FFI_TYPE_STRUCT)
         epilogue
 E(0b, FFI_TYPE_POINTER)
-	movq	%rax, (%r8)
+        movq    %rax, (%r8)
         epilogue
 E(0b, FFI_TYPE_COMPLEX)
-	call	PLT(C(abort))
+        call    PLT(C(abort))
 E(0b, FFI_TYPE_SMALL_STRUCT_1B)
-	movb	%al, (%r8)
+        movb    %al, (%r8)
         epilogue
 E(0b, FFI_TYPE_SMALL_STRUCT_2B)
-	movw	%ax, (%r8)
+        movw    %ax, (%r8)
         epilogue
 E(0b, FFI_TYPE_SMALL_STRUCT_4B)
-	movl	%eax, (%r8)
+        movl    %eax, (%r8)
         epilogue
 
-	.align	8
-99:	call	PLT(C(abort))
+        .align  8
+99:     call    PLT(C(abort))
 
         epilogue
 
@@ -166,12 +166,12 @@ E(0b, FFI_TYPE_SMALL_STRUCT_4B)
 
 /* 32 bytes of outgoing register stack space, 8 bytes of alignment,
    16 bytes of result, 32 bytes of xmm registers.  */
-#define ffi_clo_FS	(32+8+16+32)
-#define ffi_clo_OFF_R	(32+8)
-#define ffi_clo_OFF_X	(32+8+16)
+#define ffi_clo_FS      (32+8+16+32)
+#define ffi_clo_OFF_R   (32+8)
+#define ffi_clo_OFF_X   (32+8+16)
 
-	.align	8
-	.globl	C(ffi_go_closure_win64)
+        .align  8
+        .globl  C(ffi_go_closure_win64)
         FFI_HIDDEN(C(ffi_go_closure_win64))
 
         SEH(.seh_proc ffi_go_closure_win64)
@@ -179,20 +179,20 @@ C(ffi_go_closure_win64):
         cfi_startproc
         _CET_ENDBR
         /* Save all integer arguments into the incoming reg stack space.  */
-	movq	%rcx, 8(%rsp)
-	movq	%rdx, 16(%rsp)
-	movq	%r8, 24(%rsp)
-	movq	%r9, 32(%rsp)
+        movq    %rcx, 8(%rsp)
+        movq    %rdx, 16(%rsp)
+        movq    %r8, 24(%rsp)
+        movq    %r9, 32(%rsp)
 
-	movq	8(%r10), %rcx			/* load cif */
-	movq	16(%r10), %rdx			/* load fun */
-	movq	%r10, %r8			/* closure is user_data */
-	jmp	0f
+        movq    8(%r10), %rcx                   /* load cif */
+        movq    16(%r10), %rdx                  /* load fun */
+        movq    %r10, %r8                       /* closure is user_data */
+        jmp     0f
         cfi_endproc
         SEH(.seh_endproc)
 
-	.align	8
-	.globl	C(ffi_closure_win64)
+        .align  8
+        .globl  C(ffi_closure_win64)
         FFI_HIDDEN(C(ffi_closure_win64))
 
         SEH(.seh_proc ffi_closure_win64)
@@ -200,34 +200,34 @@ C(ffi_closure_win64):
         cfi_startproc
         _CET_ENDBR
         /* Save all integer arguments into the incoming reg stack space.  */
-	movq	%rcx, 8(%rsp)
-	movq	%rdx, 16(%rsp)
-	movq	%r8, 24(%rsp)
-	movq	%r9, 32(%rsp)
+        movq    %rcx, 8(%rsp)
+        movq    %rdx, 16(%rsp)
+        movq    %r8, 24(%rsp)
+        movq    %r9, 32(%rsp)
 
-	movq	FFI_TRAMPOLINE_SIZE(%r10), %rcx		/* load cif */
-	movq	FFI_TRAMPOLINE_SIZE+8(%r10), %rdx	/* load fun */
-	movq	FFI_TRAMPOLINE_SIZE+16(%r10), %r8	/* load user_data */
+        movq    FFI_TRAMPOLINE_SIZE(%r10), %rcx         /* load cif */
+        movq    FFI_TRAMPOLINE_SIZE+8(%r10), %rdx       /* load fun */
+        movq    FFI_TRAMPOLINE_SIZE+16(%r10), %r8       /* load user_data */
 0:
-	subq	$ffi_clo_FS, %rsp
+        subq    $ffi_clo_FS, %rsp
         cfi_adjust_cfa_offset(ffi_clo_FS)
         SEH(.seh_stackalloc ffi_clo_FS)
         SEH(.seh_endprologue)
 
         /* Save all sse arguments into the stack frame.  */
-	movsd	%xmm0, ffi_clo_OFF_X(%rsp)
-	movsd	%xmm1, ffi_clo_OFF_X+8(%rsp)
-	movsd	%xmm2, ffi_clo_OFF_X+16(%rsp)
-	movsd	%xmm3, ffi_clo_OFF_X+24(%rsp)
+        movsd   %xmm0, ffi_clo_OFF_X(%rsp)
+        movsd   %xmm1, ffi_clo_OFF_X+8(%rsp)
+        movsd   %xmm2, ffi_clo_OFF_X+16(%rsp)
+        movsd   %xmm3, ffi_clo_OFF_X+24(%rsp)
 
-	leaq	ffi_clo_OFF_R(%rsp), %r9
-	call	PLT(C(ffi_closure_win64_inner))
+        leaq    ffi_clo_OFF_R(%rsp), %r9
+        call    PLT(C(ffi_closure_win64_inner))
 
         /* Load the result into both possible result registers.  */
         movq    ffi_clo_OFF_R(%rsp), %rax
         movsd   ffi_clo_OFF_R(%rsp), %xmm0
 
-	addq	$ffi_clo_FS, %rsp
+        addq    $ffi_clo_FS, %rsp
         cfi_adjust_cfa_offset(-ffi_clo_FS)
         ret
 
@@ -235,20 +235,20 @@ C(ffi_closure_win64):
         SEH(.seh_endproc)
 
 #if defined(FFI_EXEC_STATIC_TRAMP)
-	.align	8
-	.globl	C(ffi_closure_win64_alt)
+        .align  8
+        .globl  C(ffi_closure_win64_alt)
         FFI_HIDDEN(C(ffi_closure_win64_alt))
 
         SEH(.seh_proc ffi_closure_win64_alt)
 C(ffi_closure_win64_alt):
         _CET_ENDBR
-	movq	8(%rsp), %r10
-	addq	$16, %rsp
-	jmp	C(ffi_closure_win64)
+        movq    8(%rsp), %r10
+        addq    $16, %rsp
+        jmp     C(ffi_closure_win64)
         SEH(.seh_endproc)
 #endif
 #endif /* __x86_64__ */
 
 #if defined __ELF__ && defined __linux__
-	.section	.note.GNU-stack,"",@progbits
+        .section        .note.GNU-stack,"",@progbits
 #endif

--- a/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/win64.S
+++ b/modules/javafx.media/src/main/native/gstreamer/3rd_party/libffi/src/x86/win64.S
@@ -11,16 +11,16 @@
 
 #ifdef X86_WIN64
 #define SEH(...) __VA_ARGS__
-#define arg0    %rcx
-#define arg1    %rdx
-#define arg2    %r8
-#define arg3    %r9
+#define arg0	%rcx
+#define arg1	%rdx
+#define arg2	%r8
+#define arg3	%r9
 #else
 #define SEH(...)
-#define arg0    %rdi
-#define arg1    %rsi
-#define arg2    %rdx
-#define arg3    %rcx
+#define arg0	%rdi
+#define arg1	%rsi
+#define arg2	%rdx
+#define arg3	%rcx
 #endif
 
 /* This macro allows the safe creation of jump tables without an
@@ -28,9 +28,9 @@
    The use of ORG asserts that we're at the correct location.  */
 /* ??? The clang assembler doesn't handle .org with symbolic expressions.  */
 #if defined(__clang__) || defined(__APPLE__) || (defined (__sun__) && defined(__svr4__))
-# define E(BASE, X)     .balign 8
+# define E(BASE, X)	.balign 8
 #else
-# define E(BASE, X)     .balign 8; .org BASE + (X) * 8
+# define E(BASE, X)	.balign 8; .org BASE + (X) * 8
 #endif
 
         .text
@@ -41,8 +41,8 @@
    for this function.  This has been allocated by ffi_call.  We also
    deallocate some of the stack that has been alloca'd.  */
 
-        .align  8
-        .globl  C(ffi_call_win64)
+	.align	8
+	.globl	C(ffi_call_win64)
         FFI_HIDDEN(C(ffi_call_win64))
 
         SEH(.seh_proc ffi_call_win64)
@@ -50,114 +50,113 @@ C(ffi_call_win64):
         cfi_startproc
         _CET_ENDBR
         /* Set up the local stack frame and install it in rbp/rsp.  */
-        movq    (%rsp), %rax
-        movq    %rbp, (arg1)
-        movq    %rax, 8(arg1)
-        movq    arg1, %rbp
+	movq	(%rsp), %rax
+	movq	%rbp, (arg1)
+	movq	%rax, 8(arg1)
+	movq	arg1, %rbp
         cfi_def_cfa(%rbp, 16)
         cfi_rel_offset(%rbp, 0)
         SEH(.seh_pushreg %rbp)
         SEH(.seh_setframe %rbp, 0)
         SEH(.seh_endprologue)
-        movq    arg0, %rsp
+	movq	arg0, %rsp
 
-        movq    arg2, %r10
+	movq	arg2, %r10
 
         /* Load all slots into both general and xmm registers.  */
-        movq    (%rsp), %rcx
-        movsd   (%rsp), %xmm0
-        movq    8(%rsp), %rdx
-        movsd   8(%rsp), %xmm1
-        movq    16(%rsp), %r8
-        movsd   16(%rsp), %xmm2
-        movq    24(%rsp), %r9
-        movsd   24(%rsp), %xmm3
+	movq	(%rsp), %rcx
+	movsd	(%rsp), %xmm0
+	movq	8(%rsp), %rdx
+	movsd	8(%rsp), %xmm1
+	movq	16(%rsp), %r8
+	movsd	16(%rsp), %xmm2
+	movq	24(%rsp), %r9
+	movsd	24(%rsp), %xmm3
 
-        call    *16(%rbp)
+	call	*16(%rbp)
 
-        movl    24(%rbp), %ecx
-        movq    32(%rbp), %r8
-        leaq    0f(%rip), %r10
-        cmpl    $FFI_TYPE_SMALL_STRUCT_4B, %ecx
-        leaq    (%r10, %rcx, 8), %r10
-        ja      99f
+	movl	24(%rbp), %ecx
+	movq	32(%rbp), %r8
+	leaq	0f(%rip), %r10
+	cmpl	$FFI_TYPE_SMALL_STRUCT_4B, %ecx
+	leaq	(%r10, %rcx, 8), %r10
+	ja	99f
         _CET_NOTRACK jmp *%r10
 
 /* Below, we're space constrained most of the time.  Thus we eschew the
    modern "mov, pop, ret" sequence (5 bytes) for "leave, ret" (2 bytes).  */
-.macro epilogue
-        leaveq
-        cfi_remember_state
-        cfi_def_cfa(%rsp, 8)
-        cfi_restore(%rbp)
-        ret
+#define epilogue		\
+	leaveq;			\
+	cfi_remember_state;	\
+	cfi_def_cfa(%rsp, 8);	\
+	cfi_restore(%rbp);	\
+	ret;			\
         cfi_restore_state
-.endm
 
-        .align  8
+	.align	8
 0:
 E(0b, FFI_TYPE_VOID)
         epilogue
 E(0b, FFI_TYPE_INT)
-        movslq  %eax, %rax
-        movq    %rax, (%r8)
+	movslq	%eax, %rax
+	movq	%rax, (%r8)
         epilogue
 E(0b, FFI_TYPE_FLOAT)
-        movss   %xmm0, (%r8)
+	movss	%xmm0, (%r8)
         epilogue
 E(0b, FFI_TYPE_DOUBLE)
-        movsd   %xmm0, (%r8)
+	movsd	%xmm0, (%r8)
         epilogue
 // FFI_TYPE_LONGDOUBLE may be FFI_TYPE_DOUBLE but we need a different value here.
 E(0b, FFI_TYPE_DOUBLE + 1)
-        call    PLT(C(abort))
+	call	PLT(C(abort))
 E(0b, FFI_TYPE_UINT8)
-        movzbl  %al, %eax
-        movq    %rax, (%r8)
+	movzbl	%al, %eax
+	movq	%rax, (%r8)
         epilogue
 E(0b, FFI_TYPE_SINT8)
-        movsbq  %al, %rax
-        jmp     98f
+	movsbq	%al, %rax
+	jmp	98f
 E(0b, FFI_TYPE_UINT16)
-        movzwl  %ax, %eax
-        movq    %rax, (%r8)
+	movzwl	%ax, %eax
+	movq	%rax, (%r8)
         epilogue
 E(0b, FFI_TYPE_SINT16)
-        movswq  %ax, %rax
-        jmp     98f
+	movswq	%ax, %rax
+	jmp	98f
 E(0b, FFI_TYPE_UINT32)
-        movl    %eax, %eax
-        movq    %rax, (%r8)
+	movl	%eax, %eax
+	movq	%rax, (%r8)
         epilogue
 E(0b, FFI_TYPE_SINT32)
-        movslq  %eax, %rax
-        movq    %rax, (%r8)
+	movslq	%eax, %rax
+	movq	%rax, (%r8)
         epilogue
 E(0b, FFI_TYPE_UINT64)
-98:     movq    %rax, (%r8)
+98:	movq	%rax, (%r8)
         epilogue
 E(0b, FFI_TYPE_SINT64)
-        movq    %rax, (%r8)
+	movq	%rax, (%r8)
         epilogue
 E(0b, FFI_TYPE_STRUCT)
         epilogue
 E(0b, FFI_TYPE_POINTER)
-        movq    %rax, (%r8)
+	movq	%rax, (%r8)
         epilogue
 E(0b, FFI_TYPE_COMPLEX)
-        call    PLT(C(abort))
+	call	PLT(C(abort))
 E(0b, FFI_TYPE_SMALL_STRUCT_1B)
-        movb    %al, (%r8)
+	movb	%al, (%r8)
         epilogue
 E(0b, FFI_TYPE_SMALL_STRUCT_2B)
-        movw    %ax, (%r8)
+	movw	%ax, (%r8)
         epilogue
 E(0b, FFI_TYPE_SMALL_STRUCT_4B)
-        movl    %eax, (%r8)
+	movl	%eax, (%r8)
         epilogue
 
-        .align  8
-99:     call    PLT(C(abort))
+	.align	8
+99:	call	PLT(C(abort))
 
         epilogue
 
@@ -167,12 +166,12 @@ E(0b, FFI_TYPE_SMALL_STRUCT_4B)
 
 /* 32 bytes of outgoing register stack space, 8 bytes of alignment,
    16 bytes of result, 32 bytes of xmm registers.  */
-#define ffi_clo_FS      (32+8+16+32)
-#define ffi_clo_OFF_R   (32+8)
-#define ffi_clo_OFF_X   (32+8+16)
+#define ffi_clo_FS	(32+8+16+32)
+#define ffi_clo_OFF_R	(32+8)
+#define ffi_clo_OFF_X	(32+8+16)
 
-        .align  8
-        .globl  C(ffi_go_closure_win64)
+	.align	8
+	.globl	C(ffi_go_closure_win64)
         FFI_HIDDEN(C(ffi_go_closure_win64))
 
         SEH(.seh_proc ffi_go_closure_win64)
@@ -180,20 +179,20 @@ C(ffi_go_closure_win64):
         cfi_startproc
         _CET_ENDBR
         /* Save all integer arguments into the incoming reg stack space.  */
-        movq    %rcx, 8(%rsp)
-        movq    %rdx, 16(%rsp)
-        movq    %r8, 24(%rsp)
-        movq    %r9, 32(%rsp)
+	movq	%rcx, 8(%rsp)
+	movq	%rdx, 16(%rsp)
+	movq	%r8, 24(%rsp)
+	movq	%r9, 32(%rsp)
 
-        movq    8(%r10), %rcx                   /* load cif */
-        movq    16(%r10), %rdx                  /* load fun */
-        movq    %r10, %r8                       /* closure is user_data */
-        jmp     0f
+	movq	8(%r10), %rcx			/* load cif */
+	movq	16(%r10), %rdx			/* load fun */
+	movq	%r10, %r8			/* closure is user_data */
+	jmp	0f
         cfi_endproc
         SEH(.seh_endproc)
 
-        .align  8
-        .globl  C(ffi_closure_win64)
+	.align	8
+	.globl	C(ffi_closure_win64)
         FFI_HIDDEN(C(ffi_closure_win64))
 
         SEH(.seh_proc ffi_closure_win64)
@@ -201,34 +200,34 @@ C(ffi_closure_win64):
         cfi_startproc
         _CET_ENDBR
         /* Save all integer arguments into the incoming reg stack space.  */
-        movq    %rcx, 8(%rsp)
-        movq    %rdx, 16(%rsp)
-        movq    %r8, 24(%rsp)
-        movq    %r9, 32(%rsp)
+	movq	%rcx, 8(%rsp)
+	movq	%rdx, 16(%rsp)
+	movq	%r8, 24(%rsp)
+	movq	%r9, 32(%rsp)
 
-        movq    FFI_TRAMPOLINE_SIZE(%r10), %rcx         /* load cif */
-        movq    FFI_TRAMPOLINE_SIZE+8(%r10), %rdx       /* load fun */
-        movq    FFI_TRAMPOLINE_SIZE+16(%r10), %r8       /* load user_data */
+	movq	FFI_TRAMPOLINE_SIZE(%r10), %rcx		/* load cif */
+	movq	FFI_TRAMPOLINE_SIZE+8(%r10), %rdx	/* load fun */
+	movq	FFI_TRAMPOLINE_SIZE+16(%r10), %r8	/* load user_data */
 0:
-        subq    $ffi_clo_FS, %rsp
+	subq	$ffi_clo_FS, %rsp
         cfi_adjust_cfa_offset(ffi_clo_FS)
         SEH(.seh_stackalloc ffi_clo_FS)
         SEH(.seh_endprologue)
 
         /* Save all sse arguments into the stack frame.  */
-        movsd   %xmm0, ffi_clo_OFF_X(%rsp)
-        movsd   %xmm1, ffi_clo_OFF_X+8(%rsp)
-        movsd   %xmm2, ffi_clo_OFF_X+16(%rsp)
-        movsd   %xmm3, ffi_clo_OFF_X+24(%rsp)
+	movsd	%xmm0, ffi_clo_OFF_X(%rsp)
+	movsd	%xmm1, ffi_clo_OFF_X+8(%rsp)
+	movsd	%xmm2, ffi_clo_OFF_X+16(%rsp)
+	movsd	%xmm3, ffi_clo_OFF_X+24(%rsp)
 
-        leaq    ffi_clo_OFF_R(%rsp), %r9
-        call    PLT(C(ffi_closure_win64_inner))
+	leaq	ffi_clo_OFF_R(%rsp), %r9
+	call	PLT(C(ffi_closure_win64_inner))
 
         /* Load the result into both possible result registers.  */
         movq    ffi_clo_OFF_R(%rsp), %rax
         movsd   ffi_clo_OFF_R(%rsp), %xmm0
 
-        addq    $ffi_clo_FS, %rsp
+	addq	$ffi_clo_FS, %rsp
         cfi_adjust_cfa_offset(-ffi_clo_FS)
         ret
 
@@ -236,20 +235,20 @@ C(ffi_closure_win64):
         SEH(.seh_endproc)
 
 #if defined(FFI_EXEC_STATIC_TRAMP)
-        .align  8
-        .globl  C(ffi_closure_win64_alt)
+	.align	8
+	.globl	C(ffi_closure_win64_alt)
         FFI_HIDDEN(C(ffi_closure_win64_alt))
 
         SEH(.seh_proc ffi_closure_win64_alt)
 C(ffi_closure_win64_alt):
         _CET_ENDBR
-        movq    8(%rsp), %r10
-        addq    $16, %rsp
-        jmp     C(ffi_closure_win64)
+	movq	8(%rsp), %r10
+	addq	$16, %rsp
+	jmp	C(ffi_closure_win64)
         SEH(.seh_endproc)
 #endif
 #endif /* __x86_64__ */
 
 #if defined __ELF__ && defined __linux__
-        .section        .note.GNU-stack,"",@progbits
+	.section	.note.GNU-stack,"",@progbits
 #endif


### PR DESCRIPTION
- libFFI updated to 3.4.4.
- No additional changes are done to the code.
- Tested on Linux, Windows x64 and macOS x64/aarch64.
- Windows x86 config files are updated, but no build/testing was done for 32-bit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8306328](https://bugs.openjdk.org/browse/JDK-8306328): Update libFFI to 3.4.4


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1131/head:pull/1131` \
`$ git checkout pull/1131`

Update a local copy of the PR: \
`$ git checkout pull/1131` \
`$ git pull https://git.openjdk.org/jfx.git pull/1131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1131`

View PR using the GUI difftool: \
`$ git pr show -t 1131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1131.diff">https://git.openjdk.org/jfx/pull/1131.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1131#issuecomment-1542887705)