### PR TITLE
8091153: Customize the Table Button Menu

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableHeaderRow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableHeaderRow.java
@@ -465,11 +465,11 @@ public class TableHeaderRow extends StackPane {
     }
 
     /**
-     * Shows a menu containing all leaf columns as item.
+     * Shows a menu containing all leaf columns as items.
      * An item can be selected/deselected to make the corresponding column visible/invisible.
      *
-     * @implNote This method can be overridden to create and show a custom menu.
-     * @param mouseEvent the {@link MouseEvent} which was generated when the table menu button was pressed.
+     * @implNote This method can be overridden to create and show a custom menu
+     * @param mouseEvent the {@link MouseEvent} which was generated when the table menu button was pressed
      * @since 21
      */
     protected void showColumnMenu(MouseEvent mouseEvent) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableHeaderRow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableHeaderRow.java
@@ -469,7 +469,7 @@ public class TableHeaderRow extends StackPane {
      * An item can be selected/deselected to make the corresponding column visible/invisible.
      *
      * @implNote This method can be overridden to create and show a custom menu.
-     * @param mouseEvent the {@link MouseEvent} which was generated when the table menu button was pressed
+     * @param mouseEvent the {@code MouseEvent} which was generated when the table menu button was pressed
      * @since 21
      */
     protected void showColumnMenu(MouseEvent mouseEvent) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableHeaderRow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableHeaderRow.java
@@ -465,11 +465,12 @@ public class TableHeaderRow extends StackPane {
     }
 
     /**
-     * Shows a menu with all leaf columns.
-     * These can selected/deselected to make the corresponding column visible/invisible.
-     * This method can be overridden if there is a desire to create and show a custom menu.
+     * Shows a menu containing all leaf columns as item.
+     * An item can be selected/deselected to make the corresponding column visible/invisible.
      *
-     * @param mouseEvent the {@link MouseEvent} which was generated when the corner region was pressed.
+     * @implNote This method can be overridden to create and show a custom menu.
+     * @param mouseEvent the {@link MouseEvent} which was generated when the table menu button was pressed.
+     * @since 21
      */
     protected void showColumnMenu(MouseEvent mouseEvent) {
         if (columnPopupMenu == null) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableHeaderRow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableHeaderRow.java
@@ -50,6 +50,7 @@ import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Control;
 import javafx.scene.control.Label;
 import javafx.scene.control.TableColumnBase;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
@@ -257,19 +258,7 @@ public class TableHeaderRow extends StackPane {
             cornerRegion.visibleProperty().bind(tableMenuButtonVisibleProperty);
         }
 
-        cornerRegion.setOnMousePressed(me -> {
-            if (columnPopupMenu == null) {
-                columnPopupMenu = new ContextMenu();
-                columnMenuItems = new HashMap<>();
-
-                TableSkinUtils.getVisibleLeafColumns(skin).addListener(weakTableColumnsListener);
-                TableSkinUtils.getColumns(tableSkin).addListener(weakTableColumnsListener);
-                updateTableColumnListeners(TableSkinUtils.getColumns(tableSkin), List.of());
-            }
-            // show a popupMenu which lists all columns
-            columnPopupMenu.show(cornerRegion, Side.BOTTOM, 0, 0);
-            me.consume();
-        });
+        cornerRegion.setOnMousePressed(this::showColumnMenu);
         cornerRegion.visibleProperty().addListener(weakCornerPaddingListener);
         flow.getVbar().visibleProperty().addListener(weakCornerPaddingListener);
 
@@ -475,7 +464,25 @@ public class TableHeaderRow extends StackPane {
         return new NestedTableColumnHeader(null);
     }
 
+    /**
+     * Shows a menu with all leaf columns.
+     * These can selected/deselected to make the corresponding column visible/invisible.
+     * This method can be overridden if there is a desire to create and show a custom menu.
+     *
+     * @param mouseEvent the {@link MouseEvent} which was generated when the corner region was pressed.
+     */
+    protected void showColumnMenu(MouseEvent mouseEvent) {
+        if (columnPopupMenu == null) {
+            columnPopupMenu = new ContextMenu();
+            columnMenuItems = new HashMap<>();
 
+            TableSkinUtils.getVisibleLeafColumns(tableSkin).addListener(weakTableColumnsListener);
+            TableSkinUtils.getColumns(tableSkin).addListener(weakTableColumnsListener);
+            updateTableColumnListeners(TableSkinUtils.getColumns(tableSkin), List.of());
+        }
+        columnPopupMenu.show(cornerRegion, Side.BOTTOM, 0, 0);
+        mouseEvent.consume();
+    }
 
     /* *************************************************************************
      *                                                                         *

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableHeaderRow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableHeaderRow.java
@@ -468,7 +468,7 @@ public class TableHeaderRow extends StackPane {
      * Shows a menu containing all leaf columns as items.
      * An item can be selected/deselected to make the corresponding column visible/invisible.
      *
-     * @implNote This method can be overridden to create and show a custom menu
+     * @implNote This method can be overridden to create and show a custom menu.
      * @param mouseEvent the {@link MouseEvent} which was generated when the table menu button was pressed
      * @since 21
      */

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableViewTableHeaderRowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableViewTableHeaderRowTest.java
@@ -33,6 +33,9 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.skin.TableHeaderRow;
 import javafx.scene.control.skin.TableHeaderRowShim;
+import javafx.scene.control.skin.TableViewSkin;
+import javafx.scene.control.skin.TableViewSkinBase;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Pane;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -202,6 +205,48 @@ public class TableViewTableHeaderRowTest {
 
         assertEquals(tableView.getColumns().size(), columnPopupMenu.getItems().size());
         assertTrue(columnPopupMenu.getItems().size() < itemSize);
+    }
+
+    @Test
+    void testOverriddenColumnPopupMenu() {
+        tableView.setSkin(new CustomTableViewSkin<>(tableView));
+
+        tableHeaderRow = VirtualFlowTestUtils.getTableHeaderRow(tableView);
+        cornerRegion = TableHeaderRowShim.getCornerRegion(tableHeaderRow);
+
+        ContextMenu columnPopupMenu = TableHeaderRowShim.getColumnPopupMenu(tableHeaderRow);
+        assertNull(columnPopupMenu);
+
+        MouseEventFirer mouseEventFirer = new MouseEventFirer(cornerRegion);
+        mouseEventFirer.fireMousePressed();
+
+        // Since the showColumnMenu() is overridden, the column popup menu should not be created.
+        columnPopupMenu = TableHeaderRowShim.getColumnPopupMenu(tableHeaderRow);
+        assertNull(columnPopupMenu);
+    }
+
+    private static class CustomTableViewSkin<S> extends TableViewSkin<S> {
+
+        public CustomTableViewSkin(TableView<S> control) {
+            super(control);
+        }
+
+        @Override
+        protected TableHeaderRow createTableHeaderRow() {
+            return new CustomTableHeaderRow(this);
+        }
+
+        private static class CustomTableHeaderRow extends TableHeaderRow {
+
+            public CustomTableHeaderRow(TableViewSkinBase skin) {
+                super(skin);
+            }
+
+            @Override
+            protected void showColumnMenu(MouseEvent mouseEvent) {
+                // noop - overridden for testing
+            }
+        }
     }
 
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableViewTableHeaderRowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableViewTableHeaderRowTest.java
@@ -33,6 +33,9 @@ import javafx.scene.control.TreeTableColumn;
 import javafx.scene.control.TreeTableView;
 import javafx.scene.control.skin.TableHeaderRow;
 import javafx.scene.control.skin.TableHeaderRowShim;
+import javafx.scene.control.skin.TableViewSkinBase;
+import javafx.scene.control.skin.TreeTableViewSkin;
+import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Pane;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -203,6 +206,48 @@ public class TreeTableViewTableHeaderRowTest {
 
         assertEquals(treeTableView.getColumns().size(), columnPopupMenu.getItems().size());
         assertTrue(columnPopupMenu.getItems().size() < itemSize);
+    }
+
+    @Test
+    void testOverriddenColumnPopupMenu() {
+        treeTableView.setSkin(new CustomTreeTableViewSkin<>(treeTableView));
+
+        tableHeaderRow = VirtualFlowTestUtils.getTableHeaderRow(treeTableView);
+        cornerRegion = TableHeaderRowShim.getCornerRegion(tableHeaderRow);
+
+        ContextMenu columnPopupMenu = TableHeaderRowShim.getColumnPopupMenu(tableHeaderRow);
+        assertNull(columnPopupMenu);
+
+        MouseEventFirer mouseEventFirer = new MouseEventFirer(cornerRegion);
+        mouseEventFirer.fireMousePressed();
+
+        // Since the showColumnMenu() is overridden, the column popup menu should not be created.
+        columnPopupMenu = TableHeaderRowShim.getColumnPopupMenu(tableHeaderRow);
+        assertNull(columnPopupMenu);
+    }
+
+    private static class CustomTreeTableViewSkin<S> extends TreeTableViewSkin<S> {
+
+        public CustomTreeTableViewSkin(TreeTableView<S> control) {
+            super(control);
+        }
+
+        @Override
+        protected TableHeaderRow createTableHeaderRow() {
+            return new CustomTableHeaderRow(this);
+        }
+
+        private static class CustomTableHeaderRow extends TableHeaderRow {
+
+            public CustomTableHeaderRow(TableViewSkinBase skin) {
+                super(skin);
+            }
+
+            @Override
+            protected void showColumnMenu(MouseEvent mouseEvent) {
+                // noop - overridden for testing
+            }
+        }
     }
 
 }


### PR DESCRIPTION
This PR implements a way to override the table column menu. 
When the `cornerRegion` is pressed, it will now call the `showColumnMenu` method. This new method is protected and therefore can be overidden by developers. If not overridden, the known default column 'ContextMenu' is created and shown.

This PR also resolves [JDK-8091419 ](https://bugs.openjdk.org/browse/JDK-8091419) (The method `showColumnMenu` can be overridden and made public now)

This PR also helps with [JDK-8092148](https://bugs.openjdk.org/browse/JDK-8092148), but does not address all the points mentioned in the ticket. 
Now that everyone can provide their own implementation, we can think of treating the current implementation of the table column menu as an [MVP](https://en.wikipedia.org/wiki/Minimum_viable_product) and any other requested feature/idea should be fulfilled by providing your own implementaion of the menu.

/issue add JDK-8091419

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))
- [x] Change requires CSR request [JDK-8308121](https://bugs.openjdk.org/browse/JDK-8308121) to be approved

### Issues
 * [JDK-8091153](https://bugs.openjdk.org/browse/JDK-8091153): Customize the Table Button Menu
 * [JDK-8091419](https://bugs.openjdk.org/browse/JDK-8091419): TableView: invoke table menu button programmatically
 * [JDK-8308121](https://bugs.openjdk.org/browse/JDK-8308121): Customize the Table Button Menu (**CSR**)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1135/head:pull/1135` \
`$ git checkout pull/1135`

Update a local copy of the PR: \
`$ git checkout pull/1135` \
`$ git pull https://git.openjdk.org/jfx.git pull/1135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1135`

View PR using the GUI difftool: \
`$ git pr show -t 1135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1135.diff">https://git.openjdk.org/jfx/pull/1135.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1135#issuecomment-1546734028)