### PR TITLE
8301763: Adding children to wrong index leaves inconsistent state in Parent#childrenSet 

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/ObservableListWrapper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/ObservableListWrapper.java
@@ -160,6 +160,7 @@ public class ObservableListWrapper<E> extends ModifiableObservableListBase<E> im
 
     @Override
     public void remove(int fromIndex, int toIndex) {
+        Objects.checkFromToIndex(fromIndex, toIndex, size());
         beginChange();
         for (int i = fromIndex; i < toIndex; ++i) {
             remove(fromIndex);

--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/ObservableListWrapper.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/ObservableListWrapper.java
@@ -29,6 +29,7 @@ import java.util.BitSet;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.RandomAccess;
 
 import com.sun.javafx.collections.NonIterableChange.SimplePermutationChange;
@@ -94,6 +95,7 @@ public class ObservableListWrapper<E> extends ModifiableObservableListBase<E> im
 
     @Override
     protected void doAdd(int index, E element) {
+        Objects.checkIndex(index, size() + 1);
         if (elementObserver != null)
             elementObserver.attachListener(element);
         backingList.add(index, element);

--- a/modules/javafx.base/src/main/java/com/sun/javafx/collections/VetoableListDecorator.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/collections/VetoableListDecorator.java
@@ -33,6 +33,8 @@ import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Objects;
+
 import javafx.beans.InvalidationListener;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
@@ -110,6 +112,7 @@ public abstract class VetoableListDecorator<E> implements ObservableList<E> {
 
     @Override
     public boolean setAll(Collection<? extends E> col) {
+        Objects.requireNonNull(col);
         onProposedChange(Collections.unmodifiableList(new ArrayList<>(col)), 0, size());
         try {
             modCount++;
@@ -161,6 +164,7 @@ public abstract class VetoableListDecorator<E> implements ObservableList<E> {
 
     @Override
     public void remove(int from, int to) {
+        Objects.checkFromToIndex(from, to, size());
         onProposedChange(Collections.<E>emptyList(), from, to);
         try {
             modCount++;
@@ -230,6 +234,7 @@ public abstract class VetoableListDecorator<E> implements ObservableList<E> {
 
     @Override
     public boolean addAll(Collection<? extends E> c) {
+        Objects.requireNonNull(c);
         onProposedChange(Collections.unmodifiableList(new ArrayList<>(c)), size(), size());
         try {
             modCount++;
@@ -245,6 +250,8 @@ public abstract class VetoableListDecorator<E> implements ObservableList<E> {
 
     @Override
     public boolean addAll(int index, Collection<? extends E> c) {
+        Objects.requireNonNull(c);
+        Objects.checkIndex(index, size() + 1);
         onProposedChange(Collections.unmodifiableList(new ArrayList<>(c)), index, index);
         try {
             modCount++;
@@ -260,6 +267,7 @@ public abstract class VetoableListDecorator<E> implements ObservableList<E> {
 
     @Override
     public boolean removeAll(Collection<?> c) {
+        Objects.requireNonNull(c);
         removeFromList(this, 0, c, false);
         try {
             modCount++;
@@ -275,6 +283,7 @@ public abstract class VetoableListDecorator<E> implements ObservableList<E> {
 
     @Override
     public boolean retainAll(Collection<?> c) {
+        Objects.requireNonNull(c);
         removeFromList(this, 0, c, true);
         try {
             modCount++;
@@ -313,6 +322,7 @@ public abstract class VetoableListDecorator<E> implements ObservableList<E> {
 
     @Override
     public void add(int index, E element) {
+        Objects.checkIndex(index, size() + 1);
         onProposedChange(Collections.singletonList(element), index, index);
         try {
             modCount++;
@@ -325,6 +335,7 @@ public abstract class VetoableListDecorator<E> implements ObservableList<E> {
 
     @Override
     public E remove(int index) {
+        Objects.checkIndex(index, size());
         onProposedChange(Collections.<E>emptyList(), index, index + 1);
         try {
             modCount++;
@@ -460,6 +471,7 @@ public abstract class VetoableListDecorator<E> implements ObservableList<E> {
 
         @Override
         public boolean addAll(Collection<? extends E> c) {
+            Objects.requireNonNull(c);
             checkForComodification();
             onProposedChange(Collections.unmodifiableList(new ArrayList<>(c)), offset + size(), offset + size());
             try {
@@ -476,6 +488,8 @@ public abstract class VetoableListDecorator<E> implements ObservableList<E> {
 
         @Override
         public boolean addAll(int index, Collection<? extends E> c) {
+            Objects.requireNonNull(c);
+            Objects.checkIndex(index, size() + 1);
             checkForComodification();
             onProposedChange(Collections.unmodifiableList(new ArrayList<>(c)), offset + index, offset + index);
             try {
@@ -492,6 +506,7 @@ public abstract class VetoableListDecorator<E> implements ObservableList<E> {
 
         @Override
         public boolean removeAll(Collection<?> c) {
+            Objects.requireNonNull(c);
             checkForComodification();
             removeFromList(this, offset, c, false);
             try {
@@ -508,6 +523,7 @@ public abstract class VetoableListDecorator<E> implements ObservableList<E> {
 
         @Override
         public boolean retainAll(Collection<?> c) {
+            Objects.requireNonNull(c);
             checkForComodification();
             removeFromList(this, offset, c, true);
             try {
@@ -550,6 +566,7 @@ public abstract class VetoableListDecorator<E> implements ObservableList<E> {
 
         @Override
         public void add(int index, E element) {
+            Objects.checkIndex(index, size() + 1);
             checkForComodification();
             onProposedChange(Collections.singletonList(element), offset + index, offset + index);
             try {
@@ -563,6 +580,7 @@ public abstract class VetoableListDecorator<E> implements ObservableList<E> {
 
         @Override
         public E remove(int index) {
+            Objects.checkIndex(index, size());
             checkForComodification();
             onProposedChange(Collections.<E>emptyList(), offset + index, offset + index + 1);
             try {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
@@ -468,6 +468,16 @@ public abstract class Parent extends Node {
     }) {
         @Override
         protected void onProposedChange(final List<Node> newNodes, int... toBeRemoved) {
+            // We have to veto negative toBeRemoved indexes, otherwise our backing list
+            // might fail and leave childSet in corrupted state.
+            for (int tbr: toBeRemoved) {
+                if (tbr < 0) {
+                    throw new IllegalArgumentException(
+                            constructExceptionMessage(
+                                "negative indexes are not allowed", null));
+                }
+            }
+
             final Scene scene = getScene();
             if (scene != null) {
                 Window w = scene.getWindow();

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Parent.java
@@ -468,16 +468,6 @@ public abstract class Parent extends Node {
     }) {
         @Override
         protected void onProposedChange(final List<Node> newNodes, int... toBeRemoved) {
-            // We have to veto negative toBeRemoved indexes, otherwise our backing list
-            // might fail and leave childSet in corrupted state.
-            for (int tbr: toBeRemoved) {
-                if (tbr < 0) {
-                    throw new IllegalArgumentException(
-                            constructExceptionMessage(
-                                "negative indexes are not allowed", null));
-                }
-            }
-
             final Scene scene = getScene();
             if (scene != null) {
                 Window w = scene.getWindow();

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/ParentTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/ParentTest.java
@@ -839,14 +839,56 @@ public class ParentTest {
     }
 
     @Test
-    public void testNegativeIndexCorruptsChildSet() {
+    public void testNegativeIndex_Add() {
         Group g = new Group();
         g.getChildren().addAll(new Rectangle(), new Rectangle());
 
-        // Adding a negative index should throw IndexOutOfBoundsException and not modify internal state
-        assertThrows(IllegalArgumentException.class, () -> g.getChildren().add(-1, new Rectangle()));
+        int preTestSize = g.getChildren().size();
 
-        // below call should throw no exception
+        // Adding an object at a negative or too big index should throw IndexOutOfBoundsException and not modify internal state
+        assertThrows(IndexOutOfBoundsException.class, () -> g.getChildren().add(-1, new Rectangle()));
+        assertEquals(preTestSize, g.getChildren().size());
+
+        assertThrows(IndexOutOfBoundsException.class, () -> g.getChildren().add(g.getChildren().size() + 1, new Rectangle()));
+        assertEquals(preTestSize, g.getChildren().size());
+
+        // below call should throw no exception - if it does, internal state is corrupted
+        g.getChildren().remove(0);
+    }
+
+    @Test
+    public void testNegativeIndex_Set() {
+        Group g = new Group();
+        g.getChildren().addAll(new Rectangle(), new Rectangle());
+
+        int preTestSize = g.getChildren().size();
+
+        // Setting an object at a negative or too big index should throw IndexOutOfBoundsException and not modify internal state
+        assertThrows(IndexOutOfBoundsException.class, () -> g.getChildren().set(-1, new Rectangle()));
+        assertEquals(preTestSize, g.getChildren().size());
+
+        assertThrows(IndexOutOfBoundsException.class, () -> g.getChildren().set(g.getChildren().size(), new Rectangle()));
+        assertEquals(preTestSize, g.getChildren().size());
+
+        // below call should throw no exception - if it does, internal state is corrupted
+        g.getChildren().remove(0);
+    }
+
+    @Test
+    public void testNegativeIndex_Remove() {
+        Group g = new Group();
+        g.getChildren().addAll(new Rectangle(), new Rectangle());
+
+        int preTestSize = g.getChildren().size();
+
+        // Removing an object at negative or too big index should throw IndexOutOfBoundsException and not modify internal state
+        assertThrows(IndexOutOfBoundsException.class, () -> g.getChildren().remove(-1));
+        assertEquals(preTestSize, g.getChildren().size());
+
+        assertThrows(IndexOutOfBoundsException.class, () -> g.getChildren().remove(g.getChildren().size()));
+        assertEquals(preTestSize, g.getChildren().size());
+
+        // below call should throw no exception - if it does, internal state is corrupted
         g.getChildren().remove(0);
     }
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/ParentTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/ParentTest.java
@@ -838,6 +838,18 @@ public class ParentTest {
         assertNull(res.getIntersectedNode());
     }
 
+    @Test
+    public void testNegativeIndexCorruptsChildSet() {
+        Group g = new Group();
+        g.getChildren().addAll(new Rectangle(), new Rectangle());
+
+        // Adding a negative index should throw IndexOutOfBoundsException and not modify internal state
+        assertThrows(IllegalArgumentException.class, () -> g.getChildren().add(-1, new Rectangle()));
+
+        // below call should throw no exception
+        g.getChildren().remove(0);
+    }
+
     public static class MockParent extends Parent {
         public MockParent(Node... children) {
             ParentShim.getChildren(this).addAll(children);

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/ParentTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/ParentTest.java
@@ -31,6 +31,8 @@ import com.sun.javafx.sg.prism.NGGroup;
 import com.sun.javafx.tk.Toolkit;
 import com.sun.javafx.geom.PickRay;
 import com.sun.javafx.scene.input.PickResultChooser;
+
+import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javafx.scene.Group;
 import javafx.scene.GroupShim;
@@ -886,6 +888,39 @@ public class ParentTest {
         assertEquals(preTestSize, g.getChildren().size());
 
         assertThrows(IndexOutOfBoundsException.class, () -> g.getChildren().remove(g.getChildren().size()));
+        assertEquals(preTestSize, g.getChildren().size());
+
+        // below call should throw no exception - if it does, internal state is corrupted
+        g.getChildren().remove(0);
+    }
+
+    @Test
+    public void testNullObject_AddAll() {
+        Group g = new Group();
+        g.getChildren().addAll(new Rectangle(), new Rectangle());
+
+        int preTestSize = g.getChildren().size();
+
+        // Adding a null object should throw NPE and not modify internal state
+        assertThrows(NullPointerException.class, () -> g.getChildren().addAll((Collection<Node>)null));
+        assertEquals(preTestSize, g.getChildren().size());
+
+        assertThrows(NullPointerException.class, () -> g.getChildren().addAll(0, (Collection<Node>)null));
+        assertEquals(preTestSize, g.getChildren().size());
+
+        // below call should throw no exception - if it does, internal state is corrupted
+        g.getChildren().remove(0);
+    }
+
+    @Test
+    public void testNullObject_SetAll() {
+        Group g = new Group();
+        g.getChildren().addAll(new Rectangle(), new Rectangle());
+
+        int preTestSize = g.getChildren().size();
+
+        // Setting a null object should throw NPE and not modify internal state
+        assertThrows(NullPointerException.class, () -> g.getChildren().setAll((Collection<Node>)null));
         assertEquals(preTestSize, g.getChildren().size());
 
         // below call should throw no exception - if it does, internal state is corrupted


### PR DESCRIPTION
This issue happened because `childSet` member of Parent was modified during `onProposedChange()` call - that call did not recognize negative indexes as invalid, which caused an exception when actually adding the Node to a List.

This seemed like the simplest solution which doesn't rework a lot of code underneath. Exceptions coming from a backing list/collection technically are handled by `VetoableListDecorator`'s try-catch clauses, however `VetoableListDecorator` does not provide an interface to react when such an exception happens - without it we cannot revert `childSet` back to its original state.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8301763](https://bugs.openjdk.org/browse/JDK-8301763): Adding children to wrong index leaves inconsistent state in Parent#childrenSet


### Reviewers
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1136/head:pull/1136` \
`$ git checkout pull/1136`

Update a local copy of the PR: \
`$ git checkout pull/1136` \
`$ git pull https://git.openjdk.org/jfx.git pull/1136/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1136`

View PR using the GUI difftool: \
`$ git pr show -t 1136`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1136.diff">https://git.openjdk.org/jfx/pull/1136.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1136#issuecomment-1547809277)