### PR TITLE
8308017: [Mac] Update deprecated constants in GlassWindow code

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
@@ -116,7 +116,7 @@ extern NSSize maxScreenDimensions;
         return nil;
     }
 
-    if (windowStyle & (NSUtilityWindowMask | NSNonactivatingPanelMask)) {
+    if (windowStyle & (NSWindowStyleMaskUtilityWindow | NSWindowStyleMaskNonactivatingPanel)) {
         self->nsWindow = [[GlassWindow_Panel alloc] initWithDelegate:self
                                                            frameRect:contentRect
                                                            styleMask:windowStyle
@@ -220,11 +220,11 @@ extern NSSize maxScreenDimensions;
 - (void)_setResizable
 {
     NSUInteger mask = [self->nsWindow styleMask];
-    if ((mask & NSResizableWindowMask) != 0)
+    if ((mask & NSWindowStyleMaskResizable) != 0)
     {
         if (self->isDecorated == YES)
         {
-            mask &= ~(NSUInteger)NSResizableWindowMask;
+            mask &= ~(NSUInteger)NSWindowStyleMaskResizable;
             [self->nsWindow setStyleMask: mask];
             [self->nsWindow setShowsResizeIndicator:NO];
 
@@ -237,7 +237,7 @@ extern NSSize maxScreenDimensions;
     {
         if (self->isDecorated == YES)
         {
-            mask |= NSResizableWindowMask;
+            mask |= NSWindowStyleMaskResizable;
             [self->nsWindow setStyleMask: mask];
             [self->nsWindow setShowsResizeIndicator:YES];
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Overrides.m
@@ -200,7 +200,7 @@
     //NSLog(@"windowWillEnterFullScreen");
 
     NSUInteger mask = [self->nsWindow styleMask];
-    self->isWindowResizable = ((mask & NSResizableWindowMask) != 0);
+    self->isWindowResizable = ((mask & NSWindowStyleMaskResizable) != 0);
     [[self->view delegate] setResizableForFullscreen:YES];
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
@@ -307,7 +307,7 @@ GLASS_NS_WINDOW_IMPLEMENTATION
 
 - (void)sendEvent:(NSEvent *)event
 {
-    if ([event type] == NSLeftMouseDown || [event type] == NSRightMouseDown || [event type] == NSOtherMouseDown)
+    if ([event type] == NSEventTypeLeftMouseDown || [event type] == NSEventTypeRightMouseDown || [event type] == NSEventTypeOtherMouseDown)
     {
         NSPoint p = [NSEvent mouseLocation];
         NSRect frame = [self->nsWindow frame];
@@ -383,11 +383,11 @@ static jlong _createWindowCommonDo(JNIEnv *env, jobject jWindow, jlong jOwnerPtr
 
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     {
-        NSUInteger styleMask = NSBorderlessWindowMask;
+        NSUInteger styleMask = NSWindowStyleMaskBorderless;
         // only titled windows get title
         if ((jStyleMask&com_sun_glass_ui_Window_TITLED) != 0)
         {
-            styleMask = styleMask|NSTitledWindowMask;
+            styleMask = styleMask|NSWindowStyleMaskTitled;
         }
 
         bool isUtility = (jStyleMask & com_sun_glass_ui_Window_UTILITY) != 0;
@@ -398,7 +398,7 @@ static jlong _createWindowCommonDo(JNIEnv *env, jobject jWindow, jlong jOwnerPtr
         {
             if ((jStyleMask&com_sun_glass_ui_Window_CLOSABLE) != 0)
             {
-                styleMask = styleMask|NSClosableWindowMask;
+                styleMask = styleMask|NSWindowStyleMaskClosable;
             }
 
             if (((jStyleMask&com_sun_glass_ui_Window_MINIMIZABLE) != 0) ||
@@ -406,23 +406,23 @@ static jlong _createWindowCommonDo(JNIEnv *env, jobject jWindow, jlong jOwnerPtr
             {
                 // on Mac OS X there is one set for min/max buttons,
                 // so if clients requests either one, we turn them both on
-                styleMask = styleMask|NSMiniaturizableWindowMask;
+                styleMask = styleMask|NSWindowStyleMaskMiniaturizable;
             }
 
             if ((jStyleMask&com_sun_glass_ui_Window_UNIFIED) != 0) {
-                styleMask = styleMask|NSTexturedBackgroundWindowMask;
+                styleMask = styleMask|NSWindowStyleMaskTexturedBackground;
             }
 
             if (isUtility)
             {
-                styleMask = styleMask | NSUtilityWindowMask | NSNonactivatingPanelMask;
+                styleMask = styleMask | NSWindowStyleMaskUtilityWindow | NSWindowStyleMaskNonactivatingPanel;
             }
         }
 
         if (isPopup)
         {
             // can receive keyboard input without activating the owning application
-            styleMask = styleMask|NSNonactivatingPanelMask;
+            styleMask = styleMask|NSWindowStyleMaskNonactivatingPanel;
         }
 
         // initial size must be 0x0 otherwise we don't get resize update if the initial size happens to be the exact same size as the later programatical one!
@@ -704,19 +704,19 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacWindow__1setEnabled
         NSButton *zoomButton = [window->nsWindow standardWindowButton:NSWindowZoomButton];
         if ((window->isEnabled) && (window->isResizable)){
             [window->nsWindow setStyleMask: window->enabledStyleMask];
-            if (window->enabledStyleMask & NSResizableWindowMask) {
+            if (window->enabledStyleMask & NSWindowStyleMaskResizable) {
                 [zoomButton setEnabled:YES];
             }
         }
         else if((window->isEnabled) && (!window->isResizable)){
             [window->nsWindow setStyleMask:
-                (window->enabledStyleMask & ~(NSUInteger) NSResizableWindowMask)];
+                (window->enabledStyleMask & ~(NSUInteger) NSWindowStyleMaskResizable)];
             [zoomButton setEnabled:NO];
         }
         else{
             window->enabledStyleMask = [window->nsWindow styleMask];
             [window->nsWindow setStyleMask:
-                (window->enabledStyleMask & ~(NSUInteger)(NSMiniaturizableWindowMask | NSResizableWindowMask))];
+                (window->enabledStyleMask & ~(NSUInteger)(NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable))];
             [zoomButton setEnabled:NO];
         }
     }
@@ -819,7 +819,7 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_mac_MacWindow__1setView
         {
             CALayer *layer = [window->view layer];
             if (([layer isKindOfClass:[CAOpenGLLayer class]] == YES) &&
-                (([window->nsWindow styleMask] & NSTexturedBackgroundWindowMask) == NO))
+                (([window->nsWindow styleMask] & NSWindowStyleMaskTexturedBackground) == NO))
             {
                 [((CAOpenGLLayer*)layer) setOpaque:[window->nsWindow isOpaque]];
             }
@@ -1024,7 +1024,7 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_mac_MacWindow__1maximize
         {
             window->preZoomedRect = [window->nsWindow frame];
 
-            if ([window->nsWindow styleMask] != NSBorderlessWindowMask)
+            if ([window->nsWindow styleMask] != NSWindowStyleMaskBorderless)
             {
                 [window->nsWindow zoom:nil];
                 // windowShouldZoom will be called automatically in this case
@@ -1268,13 +1268,13 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_mac_MacWindow__1minimize
         GlassWindow *window = getGlassWindow(env, jPtr);
 
         NSUInteger styleMask = [window->nsWindow styleMask];
-        BOOL isMiniaturizable = (styleMask & NSMiniaturizableWindowMask) != 0;
+        BOOL isMiniaturizable = (styleMask & NSWindowStyleMaskMiniaturizable) != 0;
 
         // if the window does not have NSMiniaturizableWindowMask set
         // we need to temporarily set it to allow the window to
         // be programmatically minimized or restored.
         if (!isMiniaturizable) {
-            [window->nsWindow setStyleMask: styleMask | NSMiniaturizableWindowMask];
+            [window->nsWindow setStyleMask: styleMask | NSWindowStyleMaskMiniaturizable];
         }
 
         if (jMiniaturize == JNI_TRUE)


### PR DESCRIPTION
In macOS 10.12 Apple renamed a bunch of constants to match the Swift enumeration style. JavaFX is still using the old deprecated constants which generates over 50 warnings during the build. JavaFX 18 upped the minimum macOS version to 10.12 so it's time to migrate to the new names.

This is strictly a rename to mollify the compiler. At a binary level the values are the same so JavaFX should work fine on a pre-10.12 system.

Fun fact: Xcode 14 (released late 2022) officially dropped support for macOS 10.12.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308017](https://bugs.openjdk.org/browse/JDK-8308017): [Mac] Update deprecated constants in GlassWindow code


### Reviewers
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - Author)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1137/head:pull/1137` \
`$ git checkout pull/1137`

Update a local copy of the PR: \
`$ git checkout pull/1137` \
`$ git pull https://git.openjdk.org/jfx.git pull/1137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1137`

View PR using the GUI difftool: \
`$ git pr show -t 1137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1137.diff">https://git.openjdk.org/jfx/pull/1137.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1137#issuecomment-1548059795)