### PR TITLE
8308114: Bump minimum version of macOS for x64 to 11.0 (matching aarch64)

### DIFF
--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -55,8 +55,7 @@ def defaultSdkPath = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOS
 
 // Set the minimum API version that we require (developers do not need to override this)
 // Note that this is not necessarily the same as the preferred SDK version
-def isAarch64 = TARGET_ARCH == "aarch64" || TARGET_ARCH == "arm64";
-def macOSMinVersion = isAarch64 ? "11.0" : "10.12";
+def macOSMinVersion = "11.0";
 defineProperty("MACOSX_MIN_VERSION", macOSMinVersion);
 
 def macOSMinVersionArr = macOSMinVersion.split("\\.")


### PR DESCRIPTION
This PR bumps the minimum deployment target for JavaFX to macOS 11.0 (Big Sur) on x64 platforms, matching the current minimum on aarch64.

As a follow-on to this, I will file a (low-priority) cleanup issue to remove any `@available` checks for 10.x, since those will then be no-ops.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8308114](https://bugs.openjdk.org/browse/JDK-8308114): Bump minimum version of macOS for x64 to 11.0 (matching aarch64)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1139/head:pull/1139` \
`$ git checkout pull/1139`

Update a local copy of the PR: \
`$ git checkout pull/1139` \
`$ git pull https://git.openjdk.org/jfx.git pull/1139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1139`

View PR using the GUI difftool: \
`$ git pr show -t 1139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1139.diff">https://git.openjdk.org/jfx/pull/1139.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1139#issuecomment-1548341035)