### PR TITLE
8299756: Minor updates in CSS Reference

### DIFF
--- a/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
+++ b/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
@@ -1595,8 +1595,8 @@
     <p class="grammar">[ logical | visual | logical-vertical-center ]</p>
     <ul>
       <li><strong>logical</strong>: The logical bounds are based on font metrics information.
-          The width is based on the glyph advances and the height on the ascent, descent, and
-          line gap. Except for the last line which does not include the line gap.
+          The width is based on the glyph advances and the height of the ascent, descent, and
+          line gap, except for the last line which does not include the line gap.
           This is usually the fastest option.</li>
       <li><strong>visual</strong>: Use visual bounds as the basis for calculating the bounds.
           This is likely to be slower than using logical bounds.</li>
@@ -3242,6 +3242,7 @@
       </tbody>
     </table>
     <!-- Controls -->
+    <h2><a id="controls">Controls</a></h2>
     <table class="package" width="100%">
       <tbody>
         <tr>

--- a/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
+++ b/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
@@ -3152,7 +3152,7 @@
         </tr>
         <tr>
         <th colspan="4" class="parents" scope="row">Also has <a href="#fontprops">font
-            properties</a> and all properties of <a href="#parent">Parent</a></th>
+            properties</a> and all properties of <a href="#pane">Pane</a></th>
         </tr>
       </tbody>
     </table>

--- a/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
+++ b/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
@@ -2,7 +2,7 @@
 
 <!--
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -277,6 +277,7 @@
           <li><a href="#typefont">&lt;font&gt;</a></li>
           <li><a href="#typepaint">&lt;paint&gt;</a></li>
           <li><a href="#typecolor">&lt;color&gt;</a></li>
+          <li><a href="#typetextbounds">&lt;text-bounds&gt;</a></li>
         </ul>
       </li>
         <li><a href="#stage">Stage</a>
@@ -351,6 +352,7 @@
           <li>javafx.scene.text
             <ul>
               <li><a href="#text">Text</a></li>
+              <li><a href="#textflow">TextFlow</a></li>
             </ul>
           </li>
         </ul>
@@ -362,7 +364,7 @@
           </li>
         </ul>
       </li>
-      <li><a href="#controls">Controls</a>
+      <li><a id="controls">Controls</a>
         <ul>
           <li>javafx.scene.control
             <ul>
@@ -1071,6 +1073,7 @@
       font family. An actual font family name available on the system can be
       used, or one of the following generic family names can be used:</p>
     <ul>
+      <li>'system'</li>
       <li>'serif' (e.g., Times)</li>
       <li>'sans-serif' (e.g., Helvetica)</li>
       <li>'cursive' (e.g., Zapf-Chancery)</li>
@@ -1576,6 +1579,32 @@
           href="#typecolor"
           class="typelink">&lt;color&gt;</a>
         ) ]+ </span></p>
+    <h3><a id="typetextbounds">&lt;text-bounds&gt;</a></h3>
+    <p>The geometry of text can be measured either in terms of the bounds of
+       the particular text to be rendered - visual bounds, or as properties
+       of the font and the characters to be rendered - logical bounds.
+       Visual bounds are more useful for positioning text as graphics, and
+       for obtaining tight enclosing bounds around the text.</p>
+    <p>Logical bounds are important for laying out text relative to other
+       text and other components, particularly those which also contain text.
+       The bounds isn't specific to the text being rendered, and so will
+       report heights which account for the potential ascent and descent of
+       text using the font at its specified size. Also leading and trailing
+       spaces are part of the logical advance width of the text.</p>
+    <p>&nbsp;</p>
+    <p class="grammar">[ logical | visual | logical-vertical-center ]</p>
+    <ul>
+      <li><strong>logical</strong>: The logical bounds are based on font metrics information.
+          The width is based on the glyph advances and the height on the ascent, descent, and
+          line gap. Except for the last line which does not include the line gap.
+          This is usually the fastest option.</li>
+      <li><strong>visual</strong>: Use visual bounds as the basis for calculating the bounds.
+          This is likely to be slower than using logical bounds.</li>
+      <li><strong>logical-vertical-center</strong>: Use logical vertical centered bounds
+          as the basis for calculating the bounds.
+          This bounds type is typically used to center Text nodes vertically
+          within the bounds of its parent.</li>
+    </ul>
     <h2><a id="stage">Stage</a></h2>
     <table class="package" width="100%">
         <tbody>
@@ -1668,7 +1697,7 @@
           <td class="default">false</td>
           <td class="range">&nbsp;</td>
           <td>The default value for controls is true, although there are some exceptions.
-          See <a href="#controls">Controls</a> for details.</td>
+          See <a href="#control">Control</a> for details.</td>
         </tr>
         <tr>
         <th class="propertyname" scope="row">-fx-view-order</th>
@@ -3025,6 +3054,24 @@
       </thead>
       <tbody>
         <tr>
+        <th class="propertyname" scope="row">-fx-bounds-type</th>
+          <td class="value"><a href="#typetextbounds" class="typelink">&lt;text-bounds&gt;</a></td>
+          <td>logical</td>
+          <td></td>
+        </tr>
+        <tr>
+        <th class="propertyname" scope="row">-fx-line-spacing</th>
+          <td class="value"><a href="#typenumber" class="typelink">&lt;number&gt;</a></td>
+          <td>0</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+        <th class="propertyname" scope="row">-fx-fill</th>
+          <td class="value"><a href="#typepaint" class="typelink">&lt;paint&gt;</a></td>
+          <td>BLACK</td>
+          <td>text color</td>
+        </tr>
+        <tr>
         <th class="propertyname" scope="row">-fx-font</th>
           <td class="value"><a href="#typefont" class="typelink">&lt;font&gt;</a></td>
           <td>Font.DEFAULT</td>
@@ -3069,6 +3116,43 @@
         <tr>
         <th colspan="4" class="parents" scope="row">Also has <a href="#fontprops">font
             properties</a> and all properties of <a href="#shape">Shape</a></th>
+        </tr>
+      </tbody>
+    </table>
+    <h4><a id="textflow">TextFlow</a></h4>
+<p class="styleclass">Style class: empty by default</p>
+    <table class="csspropertytable">
+    <caption>Available CSS Properties</caption>
+      <thead>
+        <tr>
+        <th class="propertyname" scope="col">CSS Property</th>
+        <th class="value" scope="col">Values</th>
+        <th scope="col">Default</th>
+        <th scope="col">Comments</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+        <th class="propertyname" scope="row">-fx-line-spacing</th>
+          <td class="value"><a href="#typenumber" class="typelink">&lt;number&gt;</a></td>
+          <td>0</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+        <th class="propertyname" scope="row">-fx-tab-size</th>
+          <td class="value"><a href="#typenumber" class="typelink">&lt;integer&gt;</a></td>
+          <td>8</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+        <th class="propertyname" scope="row">-fx-text-alignment</th>
+          <td class="value">[ left | center | right | justify ] </td>
+          <td>left</td>
+          <td>inherits</td>
+        </tr>
+        <tr>
+        <th colspan="4" class="parents" scope="row">Also has <a href="#fontprops">font
+            properties</a> and all properties of <a href="#parent">Parent</a></th>
         </tr>
       </tbody>
     </table>

--- a/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
+++ b/modules/javafx.graphics/src/main/docs/javafx/scene/doc-files/cssref.html
@@ -364,7 +364,7 @@
           </li>
         </ul>
       </li>
-      <li><a id="controls">Controls</a>
+      <li><a href="#controls">Controls</a>
         <ul>
           <li>javafx.scene.control
             <ul>
@@ -1587,7 +1587,7 @@
        for obtaining tight enclosing bounds around the text.</p>
     <p>Logical bounds are important for laying out text relative to other
        text and other components, particularly those which also contain text.
-       The bounds isn't specific to the text being rendered, and so will
+       The bounds aren't specific to the text being rendered, and so will
        report heights which account for the potential ascent and descent of
        text using the font at its specified size. Also leading and trailing
        spaces are part of the logical advance width of the text.</p>

--- a/modules/javafx.graphics/src/main/java/javafx/scene/text/TextBoundsType.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/text/TextBoundsType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ package javafx.scene.text;
  * <p>
  * Logical bounds are important for laying out text relative to other
  * text and other components, particularly those which also contain text.
- * The bounds isn't specific to the text being rendered, and so will
+ * The bounds aren't specific to the text being rendered, and so will
  * report heights which account for the potential ascent and descent of
  * text using the font at its specified size. Also leading and trailing
  * spaces are part of the logical advance width of the text.

--- a/modules/javafx.graphics/src/main/java/javafx/scene/text/TextBoundsType.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/text/TextBoundsType.java
@@ -51,8 +51,8 @@ public enum TextBoundsType {
      * Use logical bounds as the basis for calculating the bounds.
      * <p>
      * The logical bounds are based on font metrics information. The width is
-     * based on the glyph advances and the height on the ascent, descent, and
-     * line gap. Except for the last line which does not include the line gap.
+     * based on the glyph advances and the height of the ascent, descent, and
+     * line gap, except for the last line which does not include the line gap.
      * <p>
      * Note: This is usually the fastest option.
      */


### PR DESCRIPTION
Minor fixes and addition of missing sections:

- The 'system' font is missing from the list of generic font family names in the <font> section. ✓
- Explicitly add text color property -fx-fill to Text section, so as not to confuse with Labeled -fx-text-fill ✓
- TextFlow section is missing, properties: -fx-text-alignment, -fx-line-spacing, -fx-tab-size ✓
- Text: missing -fx-line-spacing, -fx-bounds-type ✓
- -fx-focus-traversable is in Node and not in Control (though there is some relevant comment) - keep as is. ✓
- Node: broken link to 'Control' (sic, not Controls) in "... see Controls for details" ✓
- Missing &lt;text-bounds-type> type ✓

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8299756](https://bugs.openjdk.org/browse/JDK-8299756): Minor updates in CSS Reference


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**) 🔄 Re-review required (review applies to [8a9aa465](https://git.openjdk.org/jfx/pull/1144/files/8a9aa465a784b0fa1607358e23b9a02a69c93173))
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1144/head:pull/1144` \
`$ git checkout pull/1144`

Update a local copy of the PR: \
`$ git checkout pull/1144` \
`$ git pull https://git.openjdk.org/jfx.git pull/1144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1144`

View PR using the GUI difftool: \
`$ git pr show -t 1144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1144.diff">https://git.openjdk.org/jfx/pull/1144.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1144#issuecomment-1565030614)