### PR TITLE
8308191: [macOS] VoiceOver decorations are shifted on second monitor

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacAccessible.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacAccessible.java
@@ -964,9 +964,7 @@ final class MacAccessible extends Accessible {
     }
 
     private Bounds flipBounds(Bounds bounds) {
-        View view = getRootView((Scene)getAttribute(SCENE));
-        if (view == null || view.getWindow() == null) return null;
-        Screen screen = view.getWindow().getScreen();
+        Screen screen = Screen.getMainScreen();
         float height = screen.getHeight();
         return new BoundingBox(bounds.getMinX(),
                                height - bounds.getMinY() - bounds.getHeight(),


### PR DESCRIPTION
The coordinate system of the Mac OS X is reversed to the JavaFX coordinate system meaning that zero point [0,0] is the bottom left corner of the main screen and positive Y coordinate means elevation of the point above the zero line. Taking that into account we should use the main screen's height in order to calculate the correct vertical offset of the window - even if coordinates are physically on the secondary screen, otherwise on screens with different height that are not aligned along the bottom border we will have a wrong vertical position.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8308191](https://bugs.openjdk.org/browse/JDK-8308191): [macOS] VoiceOver decorations are shifted on second monitor


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1147/head:pull/1147` \
`$ git checkout pull/1147`

Update a local copy of the PR: \
`$ git checkout pull/1147` \
`$ git pull https://git.openjdk.org/jfx.git pull/1147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1147`

View PR using the GUI difftool: \
`$ git pr show -t 1147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1147.diff">https://git.openjdk.org/jfx/pull/1147.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1147#issuecomment-1569120160)