### PR TITLE
8194704: Text/TextFlow hitTest() javadoc

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/text/Text.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/text/Text.java
@@ -1011,7 +1011,7 @@ public class Text extends Shape {
     }
 
     /**
-     * Maps local point to {@code HitInfo} in the content.
+     * Maps local point to {@link HitInfo} in the content.
      *
      * @param point the specified point to be tested
      * @return a {@code HitInfo} representing the character index found

--- a/modules/javafx.graphics/src/main/java/javafx/scene/text/Text.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/text/Text.java
@@ -1011,7 +1011,7 @@ public class Text extends Shape {
     }
 
     /**
-     * Maps local point to index in the content.
+     * Maps local point to {@code HitInfo} in the content.
      *
      * @param point the specified point to be tested
      * @return a {@code HitInfo} representing the character index found

--- a/modules/javafx.graphics/src/main/java/javafx/scene/text/TextFlow.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/text/TextFlow.java
@@ -188,7 +188,7 @@ public class TextFlow extends Pane {
     }
 
     /**
-     * Maps local point to index in the content.
+     * Maps local point to {@link HitInfo} in the content.
      *
      * @param point the specified point to be tested
      * @return a {@code HitInfo} representing the character index found


### PR DESCRIPTION
correcting javadoc (index) -> (hit info)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8194704](https://bugs.openjdk.org/browse/JDK-8194704): Text/TextFlow hitTest() javadoc (**Bug** - `"4"`)


### Reviewers
 * [Karthik P K](https://openjdk.org/census#kpk) (@karthikpandelu - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1149/head:pull/1149` \
`$ git checkout pull/1149`

Update a local copy of the PR: \
`$ git checkout pull/1149` \
`$ git pull https://git.openjdk.org/jfx.git pull/1149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1149`

View PR using the GUI difftool: \
`$ git pr show -t 1149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1149.diff">https://git.openjdk.org/jfx/pull/1149.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1149#issuecomment-1579559566)