### PR TITLE
8309470: Potential performance improvements in VirtualFlow

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -3062,7 +3062,6 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
                 doRelease = true;
             }
 
-            // if we have a valid cell, we can populate the cache
             answer = getCellLength(cell);
             itemSizeCache.set(idx, answer);
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1117,7 +1117,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
 
         if (needsCellsLayout) {
             for (int i = 0, max = cells.size(); i < max; i++) {
-                Cell<?> cell = cells.get(i);
+                T cell = cells.get(i);
                 if (cell != null) {
                     cell.requestLayout();
                 }
@@ -1161,7 +1161,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
 
         if (!cellNeedsLayout) {
             for (int i = 0; i < cells.size(); i++) {
-                Cell<?> cell = cells.get(i);
+                T cell = cells.get(i);
                 cellNeedsLayout = cell.isNeedsLayout();
                 if (cellNeedsLayout) break;
             }
@@ -1951,7 +1951,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
     /**
      * Gets the breadth of a specific cell
      */
-    double getCellBreadth(Cell cell) {
+    double getCellBreadth(T cell) {
         return isVertical() ?
                 cell.prefWidth(-1)
                 : cell.prefHeight(-1);
@@ -1991,12 +1991,11 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
     protected void resizeCell(T cell) {
         if (cell == null) return;
 
+        double size = Math.max(getMaxPrefBreadth(), getViewportBreadth());
         if (isVertical()) {
-            double width = Math.max(getMaxPrefBreadth(), getViewportBreadth());
-            cell.resize(width, fixedCellSizeEnabled ? getFixedCellSize() : Utils.boundedSize(cell.prefHeight(width), cell.minHeight(width), cell.maxHeight(width)));
+            cell.resize(size, fixedCellSizeEnabled ? getFixedCellSize() : Utils.boundedSize(cell.prefHeight(size), cell.minHeight(size), cell.maxHeight(size)));
         } else {
-            double height = Math.max(getMaxPrefBreadth(), getViewportBreadth());
-            cell.resize(fixedCellSizeEnabled ? getFixedCellSize() : Utils.boundedSize(cell.prefWidth(height), cell.minWidth(height), cell.maxWidth(height)), height);
+            cell.resize(fixedCellSizeEnabled ? getFixedCellSize() : Utils.boundedSize(cell.prefWidth(size), cell.minWidth(size), cell.maxWidth(size)), size);
         }
     }
 
@@ -2693,18 +2692,11 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
      * offset.
      */
     private void fitCells() {
-        double size = Math.max(getMaxPrefBreadth(), getViewportBreadth());
-        boolean isVertical = isVertical();
-
         // Note: Do not optimise this loop by pre-calculating the cells size and
         // storing that into a int value - this can lead to RT-32828
         for (int i = 0; i < cells.size(); i++) {
-            Cell<?> cell = cells.get(i);
-            if (isVertical) {
-                cell.resize(size, cell.prefHeight(size));
-            } else {
-                cell.resize(cell.prefWidth(size), size);
-            }
+            T cell = cells.get(i);
+            resizeCell(cell);
         }
     }
 
@@ -2823,7 +2815,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
         }
     }
 
-    private boolean doesCellContainFocus(Cell<?> c) {
+    private boolean doesCellContainFocus(T c) {
         Scene scene = c.getScene();
         final Node focusOwner = scene == null ? null : scene.getFocusOwner();
 
@@ -3071,11 +3063,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             }
 
             // if we have a valid cell, we can populate the cache
-            if (isVertical()) {
-                answer = cell.getLayoutBounds().getHeight();
-            } else {
-                answer = cell.getLayoutBounds().getWidth();
-            }
+            answer = getCellLength(cell);
             itemSizeCache.set(idx, answer);
 
             if (doRelease) { // we need to release the accumcell
@@ -3103,7 +3091,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
 
         if (itemSizeCache.size() > cellIndex) {
             Double oldSize = itemSizeCache.get(cellIndex);
-            double newSize = isVertical() ? cell.getLayoutBounds().getHeight() : cell.getLayoutBounds().getWidth();
+            double newSize = getCellLength(cell);
             itemSizeCache.set(cellIndex, newSize);
             if ((oldSize != null) && !oldSize.equals(newSize)) {
                 int currentIndex = computeCurrentIndex();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -33,7 +33,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Iterator;
 import java.util.LinkedList;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -1522,6 +1523,105 @@ assertEquals(0, firstCell.getIndex());
         // After resizing, top-cell must still have index 3
         assertEquals(3, firstCell.getIndex());
         assertEquals(-10, firstCell.getLayoutY(),1);
+    }
+
+    @Test
+    public void testComputeHeightShouldNotBeCalledWhenFixedCellSizeIsSet() {
+        int cellSize = 24;
+
+        flow = new VirtualFlowShim();
+        flow.setFixedCellSize(cellSize);
+        flow.setCellFactory(p -> new CellStub(flow) {
+
+            @Override
+            protected double computeMinHeight(double width) {
+                fail();
+                return 1337;
+            }
+
+            @Override
+            protected double computeMaxHeight(double width) {
+                fail();
+                return 1337;
+            }
+
+            @Override
+            protected double computePrefHeight(double width) {
+                fail();
+                return 1337;
+            }
+        });
+        flow.setCellCount(100);
+        flow.resize(300, 300);
+
+        pulse();
+        pulse();
+
+        for (int i = 0; i < 10; i++) {
+            IndexedCell<?> cell = flow.getCell(i);
+            double cellPosition = flow.getCellPosition(cell);
+            int expectedPosition = i * cellSize;
+            assertEquals(expectedPosition, cellPosition, 0d);
+        }
+
+        flow.scrollPixels(cellSize * 10);
+
+        for (int i = 10; i < 20; i++) {
+            IndexedCell<?> cell = flow.getCell(i);
+            double cellPosition = flow.getCellPosition(cell);
+            int expectedPosition = (i - 10) * cellSize;
+            assertEquals(expectedPosition, cellPosition, 0d);
+        }
+    }
+
+    @Test
+    public void testComputeWidthShouldNotBeCalledWhenFixedCellSizeIsSet() {
+        int cellSize = 24;
+
+        flow = new VirtualFlowShim();
+        flow.setVertical(false);
+        flow.setFixedCellSize(cellSize);
+        flow.setCellFactory(p -> new CellStub(flow) {
+
+            @Override
+            protected double computeMinWidth(double height) {
+                fail();
+                return 1337;
+            }
+
+            @Override
+            protected double computeMaxWidth(double height) {
+                fail();
+                return 1337;
+            }
+
+            @Override
+            protected double computePrefWidth(double height) {
+                fail();
+                return 1337;
+            }
+        });
+        flow.setCellCount(100);
+        flow.resize(300, 300);
+
+        pulse();
+        pulse();
+
+        for (int i = 0; i < 10; i++) {
+            IndexedCell<?> cell = flow.getCell(i);
+            double cellPosition = flow.getCellPosition(cell);
+            int expectedPosition = i * cellSize;
+            assertEquals(expectedPosition, cellPosition, 0d);
+        }
+
+        flow.scrollPixels(cellSize * 10);
+
+        for (int i = 10; i < 20; i++) {
+            IndexedCell<?> cell = flow.getCell(i);
+            double cellPosition = flow.getCellPosition(cell);
+            int expectedPosition = (i - 10) * cellSize;
+            assertEquals(expectedPosition, cellPosition, 0d);
+        }
     }
 }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -28,6 +28,7 @@ package test.javafx.scene.control.skin;
 import java.util.AbstractList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -1525,79 +1526,29 @@ assertEquals(0, firstCell.getIndex());
         assertEquals(-10, firstCell.getLayoutY(),1);
     }
 
+    /**
+     * The VirtualFlow should never call the compute height methods when a fixed cell size is set.
+     */
     @Test
     public void testComputeHeightShouldNotBeCalledWhenFixedCellSizeIsSet() {
         int cellSize = 24;
 
-        flow = new VirtualFlowShim();
+        flow = new VirtualFlowShim<>();
         flow.setFixedCellSize(cellSize);
         flow.setCellFactory(p -> new CellStub(flow) {
 
             @Override
             protected double computeMinHeight(double width) {
-                fail();
                 return 1337;
             }
 
             @Override
             protected double computeMaxHeight(double width) {
-                fail();
                 return 1337;
             }
 
             @Override
             protected double computePrefHeight(double width) {
-                fail();
-                return 1337;
-            }
-        });
-        flow.setCellCount(100);
-        flow.resize(300, 300);
-
-        pulse();
-        pulse();
-
-        for (int i = 0; i < 10; i++) {
-            IndexedCell<?> cell = flow.getCell(i);
-            double cellPosition = flow.getCellPosition(cell);
-            int expectedPosition = i * cellSize;
-            assertEquals(expectedPosition, cellPosition, 0d);
-        }
-
-        flow.scrollPixels(cellSize * 10);
-
-        for (int i = 10; i < 20; i++) {
-            IndexedCell<?> cell = flow.getCell(i);
-            double cellPosition = flow.getCellPosition(cell);
-            int expectedPosition = (i - 10) * cellSize;
-            assertEquals(expectedPosition, cellPosition, 0d);
-        }
-    }
-
-    @Test
-    public void testComputeWidthShouldNotBeCalledWhenFixedCellSizeIsSet() {
-        int cellSize = 24;
-
-        flow = new VirtualFlowShim();
-        flow.setVertical(false);
-        flow.setFixedCellSize(cellSize);
-        flow.setCellFactory(p -> new CellStub(flow) {
-
-            @Override
-            protected double computeMinWidth(double height) {
-                fail();
-                return 1337;
-            }
-
-            @Override
-            protected double computeMaxWidth(double height) {
-                fail();
-                return 1337;
-            }
-
-            @Override
-            protected double computePrefWidth(double height) {
-                fail();
                 return 1337;
             }
         });
@@ -1612,6 +1563,9 @@ assertEquals(0, firstCell.getIndex());
             double cellPosition = flow.getCellPosition(cell);
             int expectedPosition = i * cellSize;
             assertEquals(expectedPosition, cellPosition, 0d);
+            assertEquals(cellSize, cell.getHeight(), 0d);
+
+            assertNotEquals(cellSize, cell.getWidth(), 0d);
         }
 
         flow.scrollPixels(cellSize * 10);
@@ -1621,6 +1575,65 @@ assertEquals(0, firstCell.getIndex());
             double cellPosition = flow.getCellPosition(cell);
             int expectedPosition = (i - 10) * cellSize;
             assertEquals(expectedPosition, cellPosition, 0d);
+            assertEquals(cellSize, cell.getHeight(), 0d);
+
+            assertNotEquals(cellSize, cell.getWidth(), 0d);
+        }
+    }
+
+    /**
+     * The VirtualFlow should never call the compute width methods when a fixed cell size is set.
+     */
+    @Test
+    public void testComputeWidthShouldNotBeCalledWhenFixedCellSizeIsSet() {
+        int cellSize = 24;
+
+        flow = new VirtualFlowShim<>();
+        flow.setVertical(false);
+        flow.setFixedCellSize(cellSize);
+        flow.setCellFactory(p -> new CellStub(flow) {
+
+            @Override
+            protected double computeMinWidth(double height) {
+                return 1337;
+            }
+
+            @Override
+            protected double computeMaxWidth(double height) {
+                return 1337;
+            }
+
+            @Override
+            protected double computePrefWidth(double height) {
+                return 1337;
+            }
+        });
+        flow.setCellCount(100);
+        flow.resize(cellSize * 10, cellSize * 10);
+
+        pulse();
+        pulse();
+
+        for (int i = 0; i < 10; i++) {
+            IndexedCell<?> cell = flow.getCell(i);
+            double cellPosition = flow.getCellPosition(cell);
+            int expectedPosition = i * cellSize;
+            assertEquals(expectedPosition, cellPosition, 0d);
+            assertEquals(cellSize, cell.getWidth(), 0d);
+
+            assertNotEquals(cellSize, cell.getHeight(), 0d);
+        }
+
+        flow.scrollPixels(cellSize * 10);
+
+        for (int i = 10; i < 20; i++) {
+            IndexedCell<?> cell = flow.getCell(i);
+            double cellPosition = flow.getCellPosition(cell);
+            int expectedPosition = (i - 10) * cellSize;
+            assertEquals(expectedPosition, cellPosition, 0d);
+            assertEquals(cellSize, cell.getWidth(), 0d);
+
+            assertNotEquals(cellSize, cell.getHeight(), 0d);
         }
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -1602,7 +1602,7 @@ assertEquals(0, firstCell.getIndex());
             }
         });
         flow.setCellCount(100);
-        flow.resize(300, 300);
+        flow.resize(cellSize * 10, cellSize * 10);
 
         pulse();
         pulse();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -1527,9 +1528,10 @@ assertEquals(0, firstCell.getIndex());
 
     /**
      * The VirtualFlow should never call the compute height methods when a fixed cell size is set.
+     * If it is called the height will be wrong for some cells.
      */
     @Test
-    public void testComputeHeightShouldNotBeCalledWhenFixedCellSizeIsSet() {
+    public void testComputeHeightShouldNotBeUsedWhenFixedCellSizeIsSet() {
         int cellSize = 24;
 
         flow = new VirtualFlowShim<>();
@@ -1582,9 +1584,10 @@ assertEquals(0, firstCell.getIndex());
 
     /**
      * The VirtualFlow should never call the compute width methods when a fixed cell size is set.
+     * If it is called the width will be wrong for some cells.
      */
     @Test
-    public void testComputeWidthShouldNotBeCalledWhenFixedCellSizeIsSet() {
+    public void testComputeWidthShouldNotBeUsedWhenFixedCellSizeIsSet() {
         int cellSize = 24;
 
         flow = new VirtualFlowShim<>();
@@ -1634,6 +1637,81 @@ assertEquals(0, firstCell.getIndex());
 
             assertNotEquals(cellSize, cell.getHeight(), 0d);
         }
+    }
+
+    /**
+     * The VirtualFlow should never call the compute height methods when a fixed cell size is set.
+     */
+    @Test
+    public void testComputeHeightShouldNotBeCalledWhenFixedCellSizeIsSet() {
+        int cellSize = 24;
+
+        flow = new VirtualFlowShim<>();
+        flow.setFixedCellSize(cellSize);
+        flow.setCellFactory(p -> new CellStub(flow) {
+
+            @Override
+            protected double computeMinHeight(double width) {
+                fail();
+                return 1337;
+            }
+
+            @Override
+            protected double computeMaxHeight(double width) {
+                fail();
+                return 1337;
+            }
+
+            @Override
+            protected double computePrefHeight(double width) {
+                fail();
+                return 1337;
+            }
+        });
+        flow.setCellCount(100);
+        flow.resize(cellSize * 10, cellSize * 10);
+
+        // Trigger layout and see if the computeXXX method are called above.
+        pulse();
+        pulse();
+    }
+
+    /**
+     * The VirtualFlow should never call the compute width methods when a fixed cell size is set.
+     */
+    @Test
+    public void testComputeWidthShouldNotBeCalledWhenFixedCellSizeIsSet() {
+        int cellSize = 24;
+
+        flow = new VirtualFlowShim<>();
+        flow.setVertical(false);
+        flow.setFixedCellSize(cellSize);
+        flow.setCellFactory(p -> new CellStub(flow) {
+
+            @Override
+            protected double computeMinWidth(double height) {
+                fail();
+                return 1337;
+            }
+
+            @Override
+            protected double computeMaxWidth(double height) {
+                fail();
+                return 1337;
+            }
+
+            @Override
+            protected double computePrefWidth(double height) {
+                fail();
+                return 1337;
+            }
+        });
+        flow.setCellCount(100);
+        flow.resize(cellSize * 10, cellSize * 10);
+
+        // Trigger layout and see if the computeXXX method are called above.
+        pulse();
+        pulse();
     }
 }
 


### PR DESCRIPTION
This PR does two small improvements to `VirtualFlow`.
Until now, the `VirtualFlow` sometimes called the `computeHeight` or `computeWidth` methods, although a fixed cell size is set and we therefore don't need to call those method (and never should do, as we may don't get the expected result and mix computed sizes with the fixed cell size).

Added tests that fail before and pass now. They check that the `computeHeight` or `computeWidth` (non vertical flow) are never called when a fixed cell size is set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8309470](https://bugs.openjdk.org/browse/JDK-8309470): Potential performance improvements in VirtualFlow (**Enhancement** - P4)


### Reviewers
 * [Karthik P K](https://openjdk.org/census#kpk) (@karthikpandelu - Committer)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1150/head:pull/1150` \
`$ git checkout pull/1150`

Update a local copy of the PR: \
`$ git checkout pull/1150` \
`$ git pull https://git.openjdk.org/jfx.git pull/1150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1150`

View PR using the GUI difftool: \
`$ git pr show -t 1150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1150.diff">https://git.openjdk.org/jfx/pull/1150.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1150#issuecomment-1581509677)