### PR TITLE
8310024: Skip failing scene change tests on macOS

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/SceneChangeEventsTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/SceneChangeEventsTest.java
@@ -26,6 +26,9 @@
 package test.robot.javafx.scene;
 
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+
+import com.sun.javafx.PlatformUtil;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -129,11 +132,14 @@ public class SceneChangeEventsTest {
 
     @BeforeClass
     public static void initFX() {
+        assumeTrue(!PlatformUtil.isMac()); // See JDK-8300094
         Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        if (stage != null) {
+            Util.shutdown(stage);
+        }
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/SceneChangeShouldNotFocusStageTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/SceneChangeShouldNotFocusStageTest.java
@@ -25,6 +25,7 @@
 
 package test.robot.javafx.scene;
 
+import com.sun.javafx.PlatformUtil;
 import javafx.animation.Animation;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
@@ -44,6 +45,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 public class SceneChangeShouldNotFocusStageTest {
     static Stage stage;
@@ -57,12 +59,15 @@ public class SceneChangeShouldNotFocusStageTest {
 
     @BeforeAll
     public static void initFX() throws Exception {
+        assumeTrue(!PlatformUtil.isMac()); // See JDK-8305675
         Util.launch(startupLatch, TestApp.class);
     }
 
     @AfterAll
     public static void exit() {
-        Util.shutdown(stage);
+        if (stage != null) {
+            Util.shutdown(stage);
+        }
     }
 
     public static class TestApp extends Application {


### PR DESCRIPTION
Simple fix to skip two failing tests on macOS until the underlying bugs are fixed:

SceneChangeEventsTest::testSceneChange -- [JDK-8300094](https://bugs.openjdk.org/browse/JDK-8300094)
SceneChangeShouldNotFocusStageTest::windowShouldRemainIconified -- [JDK-8305675](https://bugs.openjdk.org/browse/JDK-8305675)

With this patch, we now get a clean test run on macOS 12 and 13.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310024](https://bugs.openjdk.org/browse/JDK-8310024): Skip failing scene change tests on macOS (**Bug** - P4)


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1153/head:pull/1153` \
`$ git checkout pull/1153`

Update a local copy of the PR: \
`$ git checkout pull/1153` \
`$ git pull https://git.openjdk.org/jfx.git pull/1153/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1153`

View PR using the GUI difftool: \
`$ git pr show -t 1153`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1153.diff">https://git.openjdk.org/jfx/pull/1153.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1153#issuecomment-1591240246)