### PR TITLE
8260342: FXMLLoader fails to load a sub layout using fx:include with the resources attribute

### DIFF
--- a/modules/javafx.fxml/src/main/java/javafx/fxml/FXMLLoader.java
+++ b/modules/javafx.fxml/src/main/java/javafx/fxml/FXMLLoader.java
@@ -1098,12 +1098,11 @@ public class FXMLLoader {
                     if (loadListener != null) {
                         loadListener.readInternalAttribute(localName, value);
                     }
-                    final ResourceBundle loaderResources = FXMLLoader.this.resources;
-                    if (loaderResources == null) {
+                    if (FXMLLoader.this.resources == null) {
                         resources = ResourceBundle.getBundle(value, Locale.getDefault());
                     } else {
-                        final ClassLoader cl = loaderResources.getClass().getClassLoader();
-                        resources = cl == null ?
+                        final ClassLoader cl = FXMLLoader.this.resources.getClass().getClassLoader();
+                        resources = (cl == null) ?
                                 ResourceBundle.getBundle(value, Locale.getDefault()) :
                                 ResourceBundle.getBundle(value, Locale.getDefault(), cl);
                     }

--- a/modules/javafx.fxml/src/main/java/javafx/fxml/FXMLLoader.java
+++ b/modules/javafx.fxml/src/main/java/javafx/fxml/FXMLLoader.java
@@ -1098,9 +1098,15 @@ public class FXMLLoader {
                     if (loadListener != null) {
                         loadListener.readInternalAttribute(localName, value);
                     }
-
-                    resources = ResourceBundle.getBundle(value, Locale.getDefault(),
-                            FXMLLoader.this.resources.getClass().getClassLoader());
+                    final ResourceBundle loaderResources = FXMLLoader.this.resources;
+                    if (loaderResources == null) {
+                        resources = ResourceBundle.getBundle(value, Locale.getDefault());
+                    } else {
+                        final ClassLoader cl = loaderResources.getClass().getClassLoader();
+                        resources = cl == null ?
+                                ResourceBundle.getBundle(value, Locale.getDefault()) :
+                                ResourceBundle.getBundle(value, Locale.getDefault(), cl);
+                    }
                 } else if (localName.equals(INCLUDE_CHARSET_ATTRIBUTE)) {
                     if (loadListener != null) {
                         loadListener.readInternalAttribute(localName, value);

--- a/modules/javafx.fxml/src/test/java/test/javafx/fxml/FXMLLoaderIncludeResourcesTest.java
+++ b/modules/javafx.fxml/src/test/java/test/javafx/fxml/FXMLLoaderIncludeResourcesTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.fxml;
+
+import javafx.fxml.FXMLLoader;
+import javafx.fxml.LoadException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.MissingResourceException;
+import java.util.ResourceBundle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class FXMLLoaderIncludeResourcesTest {
+
+    @Test
+    void testIncludeNotFound() {
+        final var loader = new FXMLLoader(getClass().getResource("fxmlloader_include_resource_test_not_found.fxml"));
+        try {
+            loader.load();
+            fail("Expected MissingResourceException");
+        } catch (final LoadException e) {
+            assertTrue(e.getCause() instanceof MissingResourceException);
+        } catch (final IOException e) {
+            fail("Expected MissingResourceException");
+        }
+    }
+
+    @Test
+    void testIncludeRootNonNullResources() throws IOException {
+        final var loader = new FXMLLoader(getClass().getResource("fxmlloader_include_resource_test.fxml"));
+        final var innerBundle = ResourceBundle.getBundle("test.javafx.fxml.fxmlloader_include_resource_test_inner");
+        loader.setResources(innerBundle);
+        final Widget root = loader.load();
+        final var inner = root.getChildren().get(0);
+        assertEquals(innerBundle.getString("inner"), inner.getName());
+        final var child = inner.getChildren().get(0);
+        final var nestedBundle = ResourceBundle.getBundle("test.javafx.fxml.fxmlloader_include_resource_test_nested");
+        assertEquals(nestedBundle.getString("nested"), child.getName());
+    }
+
+    @Test
+    void testIncludeRootNullResources() throws IOException {
+        final var loader = new FXMLLoader(getClass().getResource("fxmlloader_include_resource_test.fxml"));
+        final Widget root = loader.load();
+        final var inner = root.getChildren().get(0);
+        final var innerBundle = ResourceBundle.getBundle("test.javafx.fxml.fxmlloader_include_resource_test_inner");
+        assertEquals(innerBundle.getString("inner"), inner.getName());
+        final var child = inner.getChildren().get(0);
+        final var nestedBundle = ResourceBundle.getBundle("test.javafx.fxml.fxmlloader_include_resource_test_nested");
+        assertEquals(nestedBundle.getString("nested"), child.getName());
+    }
+}

--- a/modules/javafx.fxml/src/test/resources/test/javafx/fxml/fxmlloader_include_resource_test.fxml
+++ b/modules/javafx.fxml/src/test/resources/test/javafx/fxml/fxmlloader_include_resource_test.fxml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+This code is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License version 2 only, as
+published by the Free Software Foundation.  Oracle designates this
+particular file as subject to the "Classpath" exception as provided
+by Oracle in the LICENSE file that accompanied this code.
+
+This code is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+version 2 for more details (a copy is included in the LICENSE file that
+accompanied this code).
+
+You should have received a copy of the GNU General Public License version
+2 along with this work; if not, write to the Free Software Foundation,
+Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+or visit www.oracle.com if you need additional information or have any
+questions.
+-->
+
+<?import test.javafx.fxml.Widget?>
+<Widget xmlns:fx="http://javafx.com/fxml">
+    <fx:include source="fxmlloader_include_resource_test_inner.fxml" resources="test/javafx/fxml/fxmlloader_include_resource_test_inner"/>
+</Widget>

--- a/modules/javafx.fxml/src/test/resources/test/javafx/fxml/fxmlloader_include_resource_test_inner.fxml
+++ b/modules/javafx.fxml/src/test/resources/test/javafx/fxml/fxmlloader_include_resource_test_inner.fxml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+This code is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License version 2 only, as
+published by the Free Software Foundation.  Oracle designates this
+particular file as subject to the "Classpath" exception as provided
+by Oracle in the LICENSE file that accompanied this code.
+
+This code is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+version 2 for more details (a copy is included in the LICENSE file that
+accompanied this code).
+
+You should have received a copy of the GNU General Public License version
+2 along with this work; if not, write to the Free Software Foundation,
+Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+or visit www.oracle.com if you need additional information or have any
+questions.
+-->
+
+<?import test.javafx.fxml.Widget?>
+<Widget name="%inner" xmlns:fx="http://javafx.com/fxml/1" >
+    <fx:include source="/test/javafx/fxml/fxmlloader_include_resource_test_nested.fxml" resources="test/javafx/fxml/fxmlloader_include_resource_test_nested"/>
+</Widget>

--- a/modules/javafx.fxml/src/test/resources/test/javafx/fxml/fxmlloader_include_resource_test_inner.properties
+++ b/modules/javafx.fxml/src/test/resources/test/javafx/fxml/fxmlloader_include_resource_test_inner.properties
@@ -1,0 +1,1 @@
+inner=inner

--- a/modules/javafx.fxml/src/test/resources/test/javafx/fxml/fxmlloader_include_resource_test_nested.fxml
+++ b/modules/javafx.fxml/src/test/resources/test/javafx/fxml/fxmlloader_include_resource_test_nested.fxml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+This code is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License version 2 only, as
+published by the Free Software Foundation.  Oracle designates this
+particular file as subject to the "Classpath" exception as provided
+by Oracle in the LICENSE file that accompanied this code.
+
+This code is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+version 2 for more details (a copy is included in the LICENSE file that
+accompanied this code).
+
+You should have received a copy of the GNU General Public License version
+2 along with this work; if not, write to the Free Software Foundation,
+Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+or visit www.oracle.com if you need additional information or have any
+questions.
+-->
+
+<?import test.javafx.fxml.Widget?>
+<Widget name="%nested" xmlns:fx="http://javafx.com/fxml" />

--- a/modules/javafx.fxml/src/test/resources/test/javafx/fxml/fxmlloader_include_resource_test_nested.properties
+++ b/modules/javafx.fxml/src/test/resources/test/javafx/fxml/fxmlloader_include_resource_test_nested.properties
@@ -1,0 +1,1 @@
+nested=nested

--- a/modules/javafx.fxml/src/test/resources/test/javafx/fxml/fxmlloader_include_resource_test_not_found.fxml
+++ b/modules/javafx.fxml/src/test/resources/test/javafx/fxml/fxmlloader_include_resource_test_not_found.fxml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+
+This code is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License version 2 only, as
+published by the Free Software Foundation.  Oracle designates this
+particular file as subject to the "Classpath" exception as provided
+by Oracle in the LICENSE file that accompanied this code.
+
+This code is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+version 2 for more details (a copy is included in the LICENSE file that
+accompanied this code).
+
+You should have received a copy of the GNU General Public License version
+2 along with this work; if not, write to the Free Software Foundation,
+Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+or visit www.oracle.com if you need additional information or have any
+questions.
+-->
+
+<?import test.javafx.fxml.Widget?>
+<Widget xmlns:fx="http://javafx.com/fxml">
+    <fx:include source="fxmlloader_include_resource_test_inner.fxml" resources="fxmlloader_include_resource_test_not_found"/>
+</Widget>


### PR DESCRIPTION
This fixes ResourceBundle loading by calling `ResourceBundle.getBundle(value, Locale.getDefault())` when the loader resources are null or their classloader is null.    
Apparently the original author of the bug report said they would submit a pull request, but it seems like it never happened.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8260342](https://bugs.openjdk.org/browse/JDK-8260342): FXMLLoader fails to load a sub layout using fx:include with the resources attribute (**Bug** - P4)


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1158/head:pull/1158` \
`$ git checkout pull/1158`

Update a local copy of the PR: \
`$ git checkout pull/1158` \
`$ git pull https://git.openjdk.org/jfx.git pull/1158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1158`

View PR using the GUI difftool: \
`$ git pr show -t 1158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1158.diff">https://git.openjdk.org/jfx/pull/1158.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1158#issuecomment-1600617078)