### PR TITLE
8310667: Normalize comment blocks in newly-converted package-info.java files

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/beans/binding/package-info.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/binding/package-info.java
@@ -24,58 +24,58 @@
  */
 
 /**
-    <p>Provides classes that create and operate on a {@link Binding Binding}
-        that calculates a value that depends on one or more sources.</p>
-    <h2>Characteristics of Bindings</h2>
-    <p>Bindings are assembled from one or more sources, usually called
-        their dependencies. A binding observes its dependencies for changes
-        and updates its own value according to changes in the dependencies.</p>
-    <p>Almost all bindings defined in this library require
-        implementations of {@link javafx.beans.Observable} for their
-        dependencies. There are two types of implementations already provided,
-        the properties in the package {@link javafx.beans.property} and the
-        observable collections ({@link javafx.collections.ObservableList} and
-        {@link javafx.collections.ObservableMap}). Bindings also implement
-        {@code Observable} and can again serve as sources for other bindings
-        allowing to construct very complex bindings from simple ones.</p>
-    <p>Bindings in our implementation are always calculated lazily.
-        That means, if a dependency changes, the result of a binding is not
-        immediately recalculated, but it is marked as invalid. Next time the
-        value of an invalid binding is requested, it is recalculated.</p>
-    <h2>High Level API and Low Level API</h2>
-    <p>The Binding API is roughly divided in two parts, the High Level
-        Binding API and the Low Level Binding API. The High Level Binding API
-        allows to construct simple bindings in an easy to use fashion.
-        Defining a binding with the High Level API should be straightforward,
-        especially when used in an IDE that provides code completion.
-        Unfortunately it has its limitation and at that point the Low Level
-        API comes into play. Experienced Java developers can use the Low Level
-        API to define bindings, if the functionality of the High Level API is
-        not sufficient or to improve the performance. The main goals of the
-        Low Level API are fast execution and small memory footprint.</p>
-    <p>Following is an example of how both APIs can be used. Assuming
-        we have four instances of {@link
-        javafx.beans.property.DoubleProperty} {@code a}, {@code b}, {@code
-        c} , and {@code d}, we can define a binding that calculates {@code a*b
-        + c*d} with the High Level API for example like this:</p>
-    <p>{@code NumberBinding result = Bindings.add (a.multiply(b),
-        c.multiply(d)); }</p>
-    <p>Defining the same binding using the Low Level API could be done
-        like this:</p>
-    <pre>
-<code>
-DoubleBinding foo = new DoubleBinding() {
-
-    {
-        super.bind(a, b, c, d);
-    }
-
-    &#x40;Override
-    protected double computeValue() {
-        return a.getValue() * b.getValue() + c.getValue() * d.getValue();
-    }
-};
-</code>
-</pre>
-*/
+ * <p>Provides classes that create and operate on a {@link Binding Binding}
+ *     that calculates a value that depends on one or more sources.</p>
+ * <h2>Characteristics of Bindings</h2>
+ * <p>Bindings are assembled from one or more sources, usually called
+ *     their dependencies. A binding observes its dependencies for changes
+ *     and updates its own value according to changes in the dependencies.</p>
+ * <p>Almost all bindings defined in this library require
+ *     implementations of {@link javafx.beans.Observable} for their
+ *     dependencies. There are two types of implementations already provided,
+ *     the properties in the package {@link javafx.beans.property} and the
+ *     observable collections ({@link javafx.collections.ObservableList} and
+ *     {@link javafx.collections.ObservableMap}). Bindings also implement
+ *     {@code Observable} and can again serve as sources for other bindings
+ *     allowing to construct very complex bindings from simple ones.</p>
+ * <p>Bindings in our implementation are always calculated lazily.
+ *     That means, if a dependency changes, the result of a binding is not
+ *     immediately recalculated, but it is marked as invalid. Next time the
+ *     value of an invalid binding is requested, it is recalculated.</p>
+ * <h2>High Level API and Low Level API</h2>
+ * <p>The Binding API is roughly divided in two parts, the High Level
+ *     Binding API and the Low Level Binding API. The High Level Binding API
+ *     allows to construct simple bindings in an easy to use fashion.
+ *     Defining a binding with the High Level API should be straightforward,
+ *     especially when used in an IDE that provides code completion.
+ *     Unfortunately it has its limitation and at that point the Low Level
+ *     API comes into play. Experienced Java developers can use the Low Level
+ *     API to define bindings, if the functionality of the High Level API is
+ *     not sufficient or to improve the performance. The main goals of the
+ *     Low Level API are fast execution and small memory footprint.</p>
+ * <p>Following is an example of how both APIs can be used. Assuming
+ *     we have four instances of {@link
+ *     javafx.beans.property.DoubleProperty} {@code a}, {@code b}, {@code
+ *     c} , and {@code d}, we can define a binding that calculates {@code a*b
+ *     + c*d} with the High Level API for example like this:</p>
+ * <p>{@code NumberBinding result = Bindings.add (a.multiply(b),
+ *     c.multiply(d)); }</p>
+ * <p>Defining the same binding using the Low Level API could be done
+ *     like this:</p>
+ * <pre>
+ * <code>
+ * DoubleBinding foo = new DoubleBinding() {
+ *
+ *     {
+ *         super.bind(a, b, c, d);
+ *     }
+ *
+ *     &#x40;Override
+ *     protected double computeValue() {
+ *         return a.getValue() * b.getValue() + c.getValue() * d.getValue();
+ *     }
+ * };
+ * </code>
+ * </pre>
+ */
 package javafx.beans.binding;

--- a/modules/javafx.base/src/main/java/javafx/beans/package-info.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/package-info.java
@@ -24,22 +24,22 @@
  */
 
 /**
-    <p>The package {@code javafx.beans} contains the interfaces that
-        define the most generic form of observability. All other classes in
-        the JavaFX library, that are observable, extend the {@link javafx.beans.Observable}
-        interface.</p>
-    <p>An implementation of {@code Observable} allows to attach an
-        {@link javafx.beans.InvalidationListener}. The contentBinding gets notified every time
-        the {@code Observable} may have changed. Typical implementations of
-        {@code Observable} are all properties, all bindings, {@link
-        javafx.collections.ObservableList}, and {@link
-        javafx.collections.ObservableMap}.</p>
-    <p>An {@code InvalidationListener} will get no further information,
-        e.g. it will not get the old and the new value of a property. If you
-        need more information consider using a {@link
-        javafx.beans.value.ChangeListener} for properties and bindings, {@link
-        javafx.collections.ListChangeListener} for {@code ObservableLists} or
-        {@link javafx.collections.MapChangeListener} for {@code ObservableMap}
-        instead.</p>
-*/
+ * <p>The package {@code javafx.beans} contains the interfaces that
+ *     define the most generic form of observability. All other classes in
+ *     the JavaFX library, that are observable, extend the {@link javafx.beans.Observable}
+ *     interface.</p>
+ * <p>An implementation of {@code Observable} allows to attach an
+ *     {@link javafx.beans.InvalidationListener}. The contentBinding gets notified every time
+ *     the {@code Observable} may have changed. Typical implementations of
+ *     {@code Observable} are all properties, all bindings, {@link
+ *     javafx.collections.ObservableList}, and {@link
+ *     javafx.collections.ObservableMap}.</p>
+ * <p>An {@code InvalidationListener} will get no further information,
+ *     e.g. it will not get the old and the new value of a property. If you
+ *     need more information consider using a {@link
+ *     javafx.beans.value.ChangeListener} for properties and bindings, {@link
+ *     javafx.collections.ListChangeListener} for {@code ObservableLists} or
+ *     {@link javafx.collections.MapChangeListener} for {@code ObservableMap}
+ *     instead.</p>
+ */
 package javafx.beans;

--- a/modules/javafx.base/src/main/java/javafx/beans/property/adapter/package-info.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/adapter/package-info.java
@@ -24,8 +24,8 @@
  */
 
 /**
-<p>Provides various classes that act as adapters between a regular Java Bean
-property and a corresponding {@link javafx.beans.property.Property JavaFX
-Property}.</p>
-*/
+ * <p>Provides various classes that act as adapters between a regular Java Bean
+ * property and a corresponding {@link javafx.beans.property.Property JavaFX
+ * Property}.</p>
+ */
 package javafx.beans.property.adapter;

--- a/modules/javafx.base/src/main/java/javafx/beans/property/package-info.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/property/package-info.java
@@ -24,33 +24,33 @@
  */
 
 /**
-    <p>The package {@code javafx.beans.property} defines read-only
-        properties and writable properties, plus a number of implementations.
-    </p>
-    <h2>Read-only Properties</h2>
-    <p>Read-only properties have two getters, {@code get()} returns the
-        primitive value, {@code getValue()} returns the boxed value.</p>
-    <p>It is possible to observe read-only properties for changes. They
-        define methods to add and remove {@link
-        javafx.beans.InvalidationListener InvalidationListeners} and {@link
-        javafx.beans.value.ChangeListener ChangeListeners}.</p>
-    <p>To get the context of a read-only property, two methods {@code
-        getBean()} and {@code getName()} are defined. They return the
-        containing bean and the name of a property.</p>
-
-    <h2>Writable Properties</h2>
-    <p>In addition to the functionality defined for read-only
-        properties, writable properties contain the following methods.</p>
-    <p>A writable property defines two setters in addition to the
-        getters defined for read-only properties. The setter {@code set()}
-        takes a primitive value, the second setter {@code setValue()} takes
-        the boxed value.</p>
-    <p>All properties can be bound to {@link
-        javafx.beans.value.ObservableValue ObservableValues} of the same type,
-        which means that the property will always contain the same value as
-        the bound {@code ObservableValue}. It is also possible to define a
-        bidirectional binding between two properties, so that both properties
-        always contain the same value. If one of the properties changes, the
-        other one will be updated.</p>
-*/
+ * <p>The package {@code javafx.beans.property} defines read-only
+ *     properties and writable properties, plus a number of implementations.
+ * </p>
+ * <h2>Read-only Properties</h2>
+ * <p>Read-only properties have two getters, {@code get()} returns the
+ *     primitive value, {@code getValue()} returns the boxed value.</p>
+ * <p>It is possible to observe read-only properties for changes. They
+ *     define methods to add and remove {@link
+ *     javafx.beans.InvalidationListener InvalidationListeners} and {@link
+ *     javafx.beans.value.ChangeListener ChangeListeners}.</p>
+ * <p>To get the context of a read-only property, two methods {@code
+ *     getBean()} and {@code getName()} are defined. They return the
+ *     containing bean and the name of a property.</p>
+ *
+ * <h2>Writable Properties</h2>
+ * <p>In addition to the functionality defined for read-only
+ *     properties, writable properties contain the following methods.</p>
+ * <p>A writable property defines two setters in addition to the
+ *     getters defined for read-only properties. The setter {@code set()}
+ *     takes a primitive value, the second setter {@code setValue()} takes
+ *     the boxed value.</p>
+ * <p>All properties can be bound to {@link
+ *     javafx.beans.value.ObservableValue ObservableValues} of the same type,
+ *     which means that the property will always contain the same value as
+ *     the bound {@code ObservableValue}. It is also possible to define a
+ *     bidirectional binding between two properties, so that both properties
+ *     always contain the same value. If one of the properties changes, the
+ *     other one will be updated.</p>
+ */
 package javafx.beans.property;

--- a/modules/javafx.base/src/main/java/javafx/beans/value/package-info.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/value/package-info.java
@@ -24,99 +24,98 @@
  */
 
 /**
-    <p>The package {@code javafx.beans.value} contains the two
-        fundamental interfaces {@link javafx.beans.value.ObservableValue} and {@link
-        javafx.beans.value.WritableValue} and all of its sub-interfaces.</p>
-
-    <h2>ObservableValue</h2>
-    An ObservableValue wraps a value that can be read and observed for
-    invalidations and changes. Listeners have to implement either {@link
-    javafx.beans.InvalidationListener} or {@link javafx.beans.value.ChangeListener}. To allow
-    working with primitive types directly a number of sub-interfaces are
-    defined.
-    <table>
-        <caption>ObservableValue Table</caption>
-        <tr>
-            <th scope="col">Type</th>
-            <th scope="col">Sub-interface of ObservableValue</th>
-        </tr>
-        <tr>
-            <th scope="row">{@code boolean}</th>
-            <td>{@link javafx.beans.value.ObservableBooleanValue}</td>
-        </tr>
-        <tr>
-            <th scope="row">{@code double}</th>
-            <td>{@link javafx.beans.value.ObservableDoubleValue}</td>
-        </tr>
-        <tr>
-            <th scope="row">{@code float}</th>
-            <td>{@link javafx.beans.value.ObservableFloatValue}</td>
-        </tr>
-        <tr>
-            <th scope="row">{@code int}</th>
-            <td>{@link javafx.beans.value.ObservableIntegerValue}</td>
-        </tr>
-        <tr>
-            <th scope="row">{@code long}</th>
-            <td>{@link javafx.beans.value.ObservableLongValue}</td>
-        </tr>
-        <tr>
-            <th scope="row">{@code double}, {@code float}, {@code int}, {@code long}</th>
-            <td>{@link javafx.beans.value.ObservableNumberValue}</td>
-        </tr>
-        <tr>
-            <th scope="row">{@code Object}</th>
-            <td>{@link javafx.beans.value.ObservableObjectValue}</td>
-        </tr>
-        <tr>
-            <th scope="row">{@code String}</th>
-            <td>{@link javafx.beans.value.ObservableStringValue}</td>
-        </tr>
-    </table>
-
-    <h2>WritableValue</h2>
-    A WritableValue wraps a value that can be read and set. As with {@code
-    ObservableValues}, a number of sub-interfaces are defined to work with
-    primitive types directly.
-    <table>
-        <caption>WritableValue Table</caption>
-        <tr>
-            <th scope="col">Type</th>
-            <th scope="col">Sub-interface of WritableValue</th>
-        </tr>
-        <tr>
-            <th scope="row">{@code boolean}</th>
-            <td>{@link javafx.beans.value.WritableBooleanValue}</td>
-        </tr>
-        <tr>
-            <th scope="row">{@code double}</th>
-            <td>{@link javafx.beans.value.WritableDoubleValue}</td>
-        </tr>
-        <tr>
-            <th scope="row">{@code float}</th>
-            <td>{@link javafx.beans.value.WritableFloatValue}</td>
-        </tr>
-        <tr>
-            <th scope="row">{@code int}</th>
-            <td>{@link javafx.beans.value.WritableIntegerValue}</td>
-        </tr>
-        <tr>
-            <th scope="row">{@code long}</th>
-            <td>{@link javafx.beans.value.WritableLongValue}</td>
-        </tr>
-        <tr>
-            <th scope="row">{@code double}, {@code float}, {@code int}, {@code long}</th>
-            <td>{@link javafx.beans.value.WritableNumberValue}</td>
-        </tr>
-        <tr>
-            <th scope="row">{@code Object}</th>
-            <td>{@link javafx.beans.value.WritableObjectValue}</td>
-        </tr>
-        <tr>
-            <th scope="row">{@code String}</th>
-            <td>{@link javafx.beans.value.WritableStringValue}</td>
-        </tr>
-    </table>
-
-*/
+ * <p>The package {@code javafx.beans.value} contains the two
+ *     fundamental interfaces {@link javafx.beans.value.ObservableValue} and {@link
+ *     javafx.beans.value.WritableValue} and all of its sub-interfaces.</p>
+ *
+ * <h2>ObservableValue</h2>
+ * An ObservableValue wraps a value that can be read and observed for
+ * invalidations and changes. Listeners have to implement either {@link
+ * javafx.beans.InvalidationListener} or {@link javafx.beans.value.ChangeListener}. To allow
+ * working with primitive types directly a number of sub-interfaces are
+ * defined.
+ * <table>
+ *     <caption>ObservableValue Table</caption>
+ *     <tr>
+ *         <th scope="col">Type</th>
+ *         <th scope="col">Sub-interface of ObservableValue</th>
+ *     </tr>
+ *     <tr>
+ *         <th scope="row">{@code boolean}</th>
+ *         <td>{@link javafx.beans.value.ObservableBooleanValue}</td>
+ *     </tr>
+ *     <tr>
+ *         <th scope="row">{@code double}</th>
+ *         <td>{@link javafx.beans.value.ObservableDoubleValue}</td>
+ *     </tr>
+ *     <tr>
+ *         <th scope="row">{@code float}</th>
+ *         <td>{@link javafx.beans.value.ObservableFloatValue}</td>
+ *     </tr>
+ *     <tr>
+ *         <th scope="row">{@code int}</th>
+ *         <td>{@link javafx.beans.value.ObservableIntegerValue}</td>
+ *     </tr>
+ *     <tr>
+ *         <th scope="row">{@code long}</th>
+ *         <td>{@link javafx.beans.value.ObservableLongValue}</td>
+ *     </tr>
+ *     <tr>
+ *         <th scope="row">{@code double}, {@code float}, {@code int}, {@code long}</th>
+ *         <td>{@link javafx.beans.value.ObservableNumberValue}</td>
+ *     </tr>
+ *     <tr>
+ *         <th scope="row">{@code Object}</th>
+ *         <td>{@link javafx.beans.value.ObservableObjectValue}</td>
+ *     </tr>
+ *     <tr>
+ *         <th scope="row">{@code String}</th>
+ *         <td>{@link javafx.beans.value.ObservableStringValue}</td>
+ *     </tr>
+ * </table>
+ *
+ * <h2>WritableValue</h2>
+ * A WritableValue wraps a value that can be read and set. As with {@code
+ * ObservableValues}, a number of sub-interfaces are defined to work with
+ * primitive types directly.
+ * <table>
+ *     <caption>WritableValue Table</caption>
+ *     <tr>
+ *         <th scope="col">Type</th>
+ *         <th scope="col">Sub-interface of WritableValue</th>
+ *     </tr>
+ *     <tr>
+ *         <th scope="row">{@code boolean}</th>
+ *         <td>{@link javafx.beans.value.WritableBooleanValue}</td>
+ *     </tr>
+ *     <tr>
+ *         <th scope="row">{@code double}</th>
+ *         <td>{@link javafx.beans.value.WritableDoubleValue}</td>
+ *     </tr>
+ *     <tr>
+ *         <th scope="row">{@code float}</th>
+ *         <td>{@link javafx.beans.value.WritableFloatValue}</td>
+ *     </tr>
+ *     <tr>
+ *         <th scope="row">{@code int}</th>
+ *         <td>{@link javafx.beans.value.WritableIntegerValue}</td>
+ *     </tr>
+ *     <tr>
+ *         <th scope="row">{@code long}</th>
+ *         <td>{@link javafx.beans.value.WritableLongValue}</td>
+ *     </tr>
+ *     <tr>
+ *         <th scope="row">{@code double}, {@code float}, {@code int}, {@code long}</th>
+ *         <td>{@link javafx.beans.value.WritableNumberValue}</td>
+ *     </tr>
+ *     <tr>
+ *         <th scope="row">{@code Object}</th>
+ *         <td>{@link javafx.beans.value.WritableObjectValue}</td>
+ *     </tr>
+ *     <tr>
+ *         <th scope="row">{@code String}</th>
+ *         <td>{@link javafx.beans.value.WritableStringValue}</td>
+ *     </tr>
+ * </table>
+ */
 package javafx.beans.value;

--- a/modules/javafx.base/src/main/java/javafx/collections/package-info.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/package-info.java
@@ -24,6 +24,6 @@
  */
 
 /**
-<p>Contains the essential JavaFX collections and collection utilities</p>
-*/
+ * <p>Contains the essential JavaFX collections and collection utilities</p>
+ */
 package javafx.collections;

--- a/modules/javafx.base/src/main/java/javafx/collections/transformation/package-info.java
+++ b/modules/javafx.base/src/main/java/javafx/collections/transformation/package-info.java
@@ -24,7 +24,7 @@
  */
 
 /**
-<p>Provides JavaFX collections that wrap and transform (for example, sort
-or filter) other JavaFX collections.</p>
-*/
+ * <p>Provides JavaFX collections that wrap and transform (for example, sort
+ * or filter) other JavaFX collections.</p>
+ */
 package javafx.collections.transformation;

--- a/modules/javafx.base/src/main/java/javafx/event/package-info.java
+++ b/modules/javafx.base/src/main/java/javafx/event/package-info.java
@@ -24,6 +24,6 @@
  */
 
 /**
-<p>Provides basic framework for FX events, their delivery and handling.</p>
-*/
+ * <p>Provides basic framework for FX events, their delivery and handling.</p>
+ */
 package javafx.event;

--- a/modules/javafx.base/src/main/java/javafx/util/converter/package-info.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/package-info.java
@@ -24,13 +24,13 @@
  */
 
 /**
-This package is for standard {@link javafx.util.StringConverter string converters}
-for JavaFX. Example use cases for these implementations include:
-  <ul>
-    <li><a href="../../../javafx/beans/binding/package-summary.html">JavaFX binding API</a>
-        for converting Objects to and from Strings, when the binding requires this.</li>
-    <li>In JavaFX UI controls such as {@link javafx.scene.control.ComboBox ComboBox}
-        and {@link javafx.scene.control.ChoiceBox ChoiceBox}</li>
-  </ul>
-*/
+ * This package is for standard {@link javafx.util.StringConverter string converters}
+ * for JavaFX. Example use cases for these implementations include:
+ *   <ul>
+ *     <li><a href="../../../javafx/beans/binding/package-summary.html">JavaFX binding API</a>
+ *         for converting Objects to and from Strings, when the binding requires this.</li>
+ *     <li>In JavaFX UI controls such as {@link javafx.scene.control.ComboBox ComboBox}
+ *         and {@link javafx.scene.control.ChoiceBox ChoiceBox}</li>
+ *   </ul>
+ */
 package javafx.util.converter;

--- a/modules/javafx.base/src/main/java/javafx/util/package-info.java
+++ b/modules/javafx.base/src/main/java/javafx/util/package-info.java
@@ -24,6 +24,6 @@
  */
 
 /**
-<p>Contains various utilities and helper classes.</p>
-*/
+ * <p>Contains various utilities and helper classes.</p>
+ */
 package javafx.util;

--- a/modules/javafx.controls/src/main/java/javafx/scene/chart/package-info.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/chart/package-info.java
@@ -24,220 +24,220 @@
  */
 
 /**
-<P>The JavaFX User Interface provides a set of chart components that
-are a very convenient way for data visualization. Application
-developers can make use of these off-the-rack graphical charts
-provided by the JavaFX runtime, to visualize a wide variety of data.</P>
-<P>Commom types of charts such as {@link javafx.scene.chart.BarChart
-Bar}, {@link javafx.scene.chart.LineChart Line}, {@link
-javafx.scene.chart.AreaChart Area}, {@link
-javafx.scene.chart.PieChart Pie}, {@link
-javafx.scene.chart.ScatterChart Scatter} and {@link
-javafx.scene.chart.BubbleChart Bubble} charts are provided. These
-charts are easy to create and are customizable. JavaFX Charts API is
-a visual centric API rather than model centric.
-</P>
-<P>JavaFX charts supports animation of chart components as well as
-auto ranging of chart Axis.  In addition, as with other JavaFX UI
-controls, chart visual components can be styled via CSS. Thus, there
-are several public visual properties that can be styled via CSS. An
-example is provided later in the document.
-</P>
-<P>Below is a table listing the existing Chart types and a brief
-summary of their intended use.</P>
-<TABLE>
-<CAPTION>Table of Chart Types</CAPTION>
-    <TR>
-        <TH scope="col">
-            <P>Chart</P>
-        </TH>
-        <TH scope="col">
-            <P>Summary</P>
-        </TH>
-    </TR>
-    <TR>
-        <TH scope="row">
-            <P>{@link javafx.scene.chart.LineChart}</P>
-        </TH>
-        <TD>
-            <P>Plots line between the data points in a series. Used usually to
-            view data trends over time.</P>
-        </TD>
-    </TR>
-    <TR>
-        <TH scope="row">
-            <P>{@link javafx.scene.chart.AreaChart}</P>
-        </TH>
-        <TD>
-            <P>Plots the area between the line that connects the data points
-            and the axis. Good for comparing cumulated totals over time.</P>
-        </TD>
-    </TR>
-    <TR>
-        <TH scope="row">
-            <P>{@link javafx.scene.chart.BarChart}</P>
-        </TH>
-        <TD>
-            <P>Plots rectangular bars with heights indicating data values they
-            represent, and corresponding to the categories they belongs to.
-            Used for displaying discontinuous / discrete data</P>
-        </TD>
-    </TR>
-    <TR>
-        <TH scope="row">
-            <P>{@link javafx.scene.chart.PieChart}</P>
-        </TH>
-        <TD>
-            <P>Plots circular chart divided into segments with each segment
-            representing a value as a proportion of the total. It looks like a
-            Pie and hence the name
-            </P>
-        </TD>
-    </TR>
-    <TR>
-        <TH scope="row">
-            <P>{@link javafx.scene.chart.BubbleChart}</P>
-        </TH>
-        <TD>
-            <P>Plots bubbles for data points in a series. Each plotted entity
-            depicts three parameters in a 2D chart and hence a unique chart
-            type.</P>
-        </TD>
-    </TR>
-    <TR>
-        <TH scope="row">
-            <P>{@link javafx.scene.chart.ScatterChart}</P>
-        </TH>
-        <TD>
-            <P>Plots symbols for the data points in a series. This type of
-            chart is useful in viewing distribution of data and its
-            corelation, if there is any clustering.</P>
-        </TD>
-    </TR>
-</TABLE>
-<P>The {@link javafx.scene.chart.Chart} is the baseclass for all
-charts. It is responsible for drawing the background, frame, title
-and legend. It can be extended to create custom chart types. The
-{@link javafx.scene.chart.XYChart} is the baseclass for all two axis
-charts and it extends from Chart class. It is mostly responsible for
-drawing the two axis and the background of the chart plot. Most
-charts extend from XYChart class except for PieChart which extends
-from Chart class as it is not a two axis chart.
-</P>
-<P>The {@link javafx.scene.chart} package includes axis classes that
-can be used when creating two axis charts. {@link
-javafx.scene.chart.Axis} is the abstract base class of all chart
-axis. {@link javafx.scene.chart.CategoryAxis} plots string categories
-where each value is a unique category along the axis. {@link
-javafx.scene.chart.NumberAxis} plots a range of numbers with major
-tick marks every tickUnit.
-</P>
-<P>For Example BarChart plots data from a sequence of {@link
-javafx.scene.chart.XYChart.Series} objects. Each series contains
-{@link javafx.scene.chart.XYChart.Data} objects.
-</P>
-<pre>{@code
-    // add data
-    XYChart.Series<String,Number> series1 = new XYChart.Series<String,Number>();
-    series1.setName("Data Series 1");
-    series1.getData().add(new XYChart.Data<String,Number>("2007", 567));
-}</pre>
-<P>We can define more series objects similarly. Following code
-snippet shows how to create a BarChart with 3 categories and its X
-and Y axis:
-</P>
-<pre>{@code
-    static String[] years = {"2007", "2008", "2009"};
-    final CategoryAxis xAxis = new CategoryAxis();
-    final NumberAxis yAxis = new NumberAxis();
-    final BarChart<String,Number> bc = new BarChart<String,Number>(xAxis, yAxis);
-    xAxis.setCategories(FXCollections.<String>observableArrayList(Arrays.asList(years)));
-    bc.getData().addAll(series1, series2, series3);
-}</pre>
-<P>JavaFX charts lends itself very well for real time or dynamic
-Charting (like online stocks, web traffic etc) from live data sets.
-Here is an example of a dynamic chart created with simulated data. A
-{@link javafx.animation.Timeline} is used to simulate dynamic data
-for stock price variations over time(hours).
-</P>
-<pre><code>
-    {@literal private XYChart.Series<Number,Number> hourDataSeries;}
-    private NumberAxis xAxis;
-    private Timeline animation;
-    private double hours = 0;
-    private double timeInHours = 0;
-    private double prevY = 10;
-    private double y = 10;
-
-    // timeline to add new data every 60th of a second
-    animation = new Timeline();
-    {@literal animation.getKeyFrames().add(new KeyFrame(Duration.millis(1000 / 60), new EventHandler<ActionEvent>()} {
-        {@literal @Override public void handle(ActionEvent actionEvent)} {
-            // 6 minutes data per frame
-            {@literal for(int count = 0; count < 6; count++)} {
-                nextTime();
-                plotTime();
-            }
-        }
-    }));
-    animation.setCycleCount(Animation.INDEFINITE);
-    xAxis = new NumberAxis(0, 24, 3);
-    final NumberAxis yAxis = new NumberAxis(0, 100, 10);
-    {@literal final LineChart<Number,Number> lc = new LineChart<Number,Number>(xAxis, yAxis)};
-
-    lc.setCreateSymbols(false);
-    lc.setAnimated(false);
-    lc.setLegendVisible(false);
-    lc.setTitle("ACME Company Stock");
-
-    xAxis.setLabel("Time");
-    xAxis.setForceZeroInRange(false);
-    yAxis.setLabel("Share Price");
-    yAxis.setTickLabelFormatter(new NumberAxis.DefaultFormatter(yAxis, "$", null));
-
-    {@literal hourDataSeries = new XYChart.Series<Number,Number>();}
-    hourDataSeries.setName("Hourly Data");
-    {@literal hourDataSeries.getData().add(new XYChart.Data<Number,Number>(timeInHours, prevY));}
-    lc.getData().add(hourDataSeries);
-
-    private void nextTime() {
-        if (minutes == 59) {
-            hours++;
-            minutes = 0;
-        } else {
-            minutes++;
-        }
-        timeInHours = hours + ((1d/60d) * minutes);
-    }
-
-    private void plotTime() {
-        if ((timeInHours % 1) == 0) {
-            // change of hour
-            double oldY = y;
-            y = prevY - 10 + (Math.random() * 20);
-            prevY = oldY;
-            {@literal while (y < 10 || y > 90) y = y - 10 + (Math.random() * 20);}
-            {@literal hourDataSeries.getData().add(new XYChart.Data<Number, Number>(timeInHours, prevY));}
-            // after 25hours delete old data
-            {@literal if (timeInHours > 25) hourDataSeries.getData().remove(0)};
-            // every hour after 24 move range 1 hour
-            {@literal if (timeInHours > 24)} {
-                xAxis.setLowerBound(xAxis.getLowerBound() + 1);
-                xAxis.setUpperBound(xAxis.getUpperBound() + 1);
-            }
-        }
-    }
-</code></pre>
-
-<P>The start method needs to call animation,.play() to start the
-simulated dynamic chart.</P>
-<P>Please refer to javafx.scene.control package documentation on CSS
-styling. An example for styling a Chart via CSS is as follows:- to
-set the chart content background to a certain color:</P>
-<P>.chart-content { -fx-background-color: cyan;}</P>
-<P>Line Chart line color can be styled as follows:-</P>
-<P>.chart-series-line { -fx-stroke: green; -fx-stroke-width: 4px;}</P>
-<P STYLE="margin-bottom: 0in"><BR>
-</P>
-*/
+ * <P>The JavaFX User Interface provides a set of chart components that
+ * are a very convenient way for data visualization. Application
+ * developers can make use of these off-the-rack graphical charts
+ * provided by the JavaFX runtime, to visualize a wide variety of data.</P>
+ * <P>Commom types of charts such as {@link javafx.scene.chart.BarChart
+ * Bar}, {@link javafx.scene.chart.LineChart Line}, {@link
+ * javafx.scene.chart.AreaChart Area}, {@link
+ * javafx.scene.chart.PieChart Pie}, {@link
+ * javafx.scene.chart.ScatterChart Scatter} and {@link
+ * javafx.scene.chart.BubbleChart Bubble} charts are provided. These
+ * charts are easy to create and are customizable. JavaFX Charts API is
+ * a visual centric API rather than model centric.
+ * </P>
+ * <P>JavaFX charts supports animation of chart components as well as
+ * auto ranging of chart Axis.  In addition, as with other JavaFX UI
+ * controls, chart visual components can be styled via CSS. Thus, there
+ * are several public visual properties that can be styled via CSS. An
+ * example is provided later in the document.
+ * </P>
+ * <P>Below is a table listing the existing Chart types and a brief
+ * summary of their intended use.</P>
+ * <TABLE>
+ * <CAPTION>Table of Chart Types</CAPTION>
+ *     <TR>
+ *         <TH scope="col">
+ *             <P>Chart</P>
+ *         </TH>
+ *         <TH scope="col">
+ *             <P>Summary</P>
+ *         </TH>
+ *     </TR>
+ *     <TR>
+ *         <TH scope="row">
+ *             <P>{@link javafx.scene.chart.LineChart}</P>
+ *         </TH>
+ *         <TD>
+ *             <P>Plots line between the data points in a series. Used usually to
+ *             view data trends over time.</P>
+ *         </TD>
+ *     </TR>
+ *     <TR>
+ *         <TH scope="row">
+ *             <P>{@link javafx.scene.chart.AreaChart}</P>
+ *         </TH>
+ *         <TD>
+ *             <P>Plots the area between the line that connects the data points
+ *             and the axis. Good for comparing cumulated totals over time.</P>
+ *         </TD>
+ *     </TR>
+ *     <TR>
+ *         <TH scope="row">
+ *             <P>{@link javafx.scene.chart.BarChart}</P>
+ *         </TH>
+ *         <TD>
+ *             <P>Plots rectangular bars with heights indicating data values they
+ *             represent, and corresponding to the categories they belongs to.
+ *             Used for displaying discontinuous / discrete data</P>
+ *         </TD>
+ *     </TR>
+ *     <TR>
+ *         <TH scope="row">
+ *             <P>{@link javafx.scene.chart.PieChart}</P>
+ *         </TH>
+ *         <TD>
+ *             <P>Plots circular chart divided into segments with each segment
+ *             representing a value as a proportion of the total. It looks like a
+ *             Pie and hence the name
+ *             </P>
+ *         </TD>
+ *     </TR>
+ *     <TR>
+ *         <TH scope="row">
+ *             <P>{@link javafx.scene.chart.BubbleChart}</P>
+ *         </TH>
+ *         <TD>
+ *             <P>Plots bubbles for data points in a series. Each plotted entity
+ *             depicts three parameters in a 2D chart and hence a unique chart
+ *             type.</P>
+ *         </TD>
+ *     </TR>
+ *     <TR>
+ *         <TH scope="row">
+ *             <P>{@link javafx.scene.chart.ScatterChart}</P>
+ *         </TH>
+ *         <TD>
+ *             <P>Plots symbols for the data points in a series. This type of
+ *             chart is useful in viewing distribution of data and its
+ *             corelation, if there is any clustering.</P>
+ *         </TD>
+ *     </TR>
+ * </TABLE>
+ * <P>The {@link javafx.scene.chart.Chart} is the baseclass for all
+ * charts. It is responsible for drawing the background, frame, title
+ * and legend. It can be extended to create custom chart types. The
+ * {@link javafx.scene.chart.XYChart} is the baseclass for all two axis
+ * charts and it extends from Chart class. It is mostly responsible for
+ * drawing the two axis and the background of the chart plot. Most
+ * charts extend from XYChart class except for PieChart which extends
+ * from Chart class as it is not a two axis chart.
+ * </P>
+ * <P>The {@link javafx.scene.chart} package includes axis classes that
+ * can be used when creating two axis charts. {@link
+ * javafx.scene.chart.Axis} is the abstract base class of all chart
+ * axis. {@link javafx.scene.chart.CategoryAxis} plots string categories
+ * where each value is a unique category along the axis. {@link
+ * javafx.scene.chart.NumberAxis} plots a range of numbers with major
+ * tick marks every tickUnit.
+ * </P>
+ * <P>For Example BarChart plots data from a sequence of {@link
+ * javafx.scene.chart.XYChart.Series} objects. Each series contains
+ * {@link javafx.scene.chart.XYChart.Data} objects.
+ * </P>
+ * <pre>{@code
+ *     // add data
+ *     XYChart.Series<String,Number> series1 = new XYChart.Series<String,Number>();
+ *     series1.setName("Data Series 1");
+ *     series1.getData().add(new XYChart.Data<String,Number>("2007", 567));
+ * }</pre>
+ * <P>We can define more series objects similarly. Following code
+ * snippet shows how to create a BarChart with 3 categories and its X
+ * and Y axis:
+ * </P>
+ * <pre>{@code
+ *     static String[] years = {"2007", "2008", "2009"};
+ *     final CategoryAxis xAxis = new CategoryAxis();
+ *     final NumberAxis yAxis = new NumberAxis();
+ *     final BarChart<String,Number> bc = new BarChart<String,Number>(xAxis, yAxis);
+ *     xAxis.setCategories(FXCollections.<String>observableArrayList(Arrays.asList(years)));
+ *     bc.getData().addAll(series1, series2, series3);
+ * }</pre>
+ * <P>JavaFX charts lends itself very well for real time or dynamic
+ * Charting (like online stocks, web traffic etc) from live data sets.
+ * Here is an example of a dynamic chart created with simulated data. A
+ * {@link javafx.animation.Timeline} is used to simulate dynamic data
+ * for stock price variations over time(hours).
+ * </P>
+ * <pre><code>
+ *     {@literal private XYChart.Series<Number,Number> hourDataSeries;}
+ *     private NumberAxis xAxis;
+ *     private Timeline animation;
+ *     private double hours = 0;
+ *     private double timeInHours = 0;
+ *     private double prevY = 10;
+ *     private double y = 10;
+ *
+ *     // timeline to add new data every 60th of a second
+ *     animation = new Timeline();
+ *     {@literal animation.getKeyFrames().add(new KeyFrame(Duration.millis(1000 / 60), new EventHandler<ActionEvent>()} {
+ *         {@literal @Override public void handle(ActionEvent actionEvent)} {
+ *             // 6 minutes data per frame
+ *             {@literal for(int count = 0; count < 6; count++)} {
+ *                 nextTime();
+ *                 plotTime();
+ *             }
+ *         }
+ *     }));
+ *     animation.setCycleCount(Animation.INDEFINITE);
+ *     xAxis = new NumberAxis(0, 24, 3);
+ *     final NumberAxis yAxis = new NumberAxis(0, 100, 10);
+ *     {@literal final LineChart<Number,Number> lc = new LineChart<Number,Number>(xAxis, yAxis)};
+ *
+ *     lc.setCreateSymbols(false);
+ *     lc.setAnimated(false);
+ *     lc.setLegendVisible(false);
+ *     lc.setTitle("ACME Company Stock");
+ *
+ *     xAxis.setLabel("Time");
+ *     xAxis.setForceZeroInRange(false);
+ *     yAxis.setLabel("Share Price");
+ *     yAxis.setTickLabelFormatter(new NumberAxis.DefaultFormatter(yAxis, "$", null));
+ *
+ *     {@literal hourDataSeries = new XYChart.Series<Number,Number>();}
+ *     hourDataSeries.setName("Hourly Data");
+ *     {@literal hourDataSeries.getData().add(new XYChart.Data<Number,Number>(timeInHours, prevY));}
+ *     lc.getData().add(hourDataSeries);
+ *
+ *     private void nextTime() {
+ *         if (minutes == 59) {
+ *             hours++;
+ *             minutes = 0;
+ *         } else {
+ *             minutes++;
+ *         }
+ *         timeInHours = hours + ((1d/60d) * minutes);
+ *     }
+ *
+ *     private void plotTime() {
+ *         if ((timeInHours % 1) == 0) {
+ *             // change of hour
+ *             double oldY = y;
+ *             y = prevY - 10 + (Math.random() * 20);
+ *             prevY = oldY;
+ *             {@literal while (y < 10 || y > 90) y = y - 10 + (Math.random() * 20);}
+ *             {@literal hourDataSeries.getData().add(new XYChart.Data<Number, Number>(timeInHours, prevY));}
+ *             // after 25hours delete old data
+ *             {@literal if (timeInHours > 25) hourDataSeries.getData().remove(0)};
+ *             // every hour after 24 move range 1 hour
+ *             {@literal if (timeInHours > 24)} {
+ *                 xAxis.setLowerBound(xAxis.getLowerBound() + 1);
+ *                 xAxis.setUpperBound(xAxis.getUpperBound() + 1);
+ *             }
+ *         }
+ *     }
+ * </code></pre>
+ *
+ * <P>The start method needs to call animation,.play() to start the
+ * simulated dynamic chart.</P>
+ * <P>Please refer to javafx.scene.control package documentation on CSS
+ * styling. An example for styling a Chart via CSS is as follows:- to
+ * set the chart content background to a certain color:</P>
+ * <P>.chart-content { -fx-background-color: cyan;}</P>
+ * <P>Line Chart line color can be styled as follows:-</P>
+ * <P>.chart-series-line { -fx-stroke: green; -fx-stroke-width: 4px;}</P>
+ * <P STYLE="margin-bottom: 0in"><BR>
+ * </P>
+ */
 package javafx.scene.chart;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/cell/package-info.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/cell/package-info.java
@@ -24,16 +24,16 @@
  */
 
 /**
-    <p>The <code>javafx.scene.control.cell</code> package is where all cell-related
-    classes are located, other than the core classes such as
-    {@link javafx.scene.control.Cell Cell}, {@link javafx.scene.control.IndexedCell IndexedCell},
-    {@link javafx.scene.control.ListCell ListCell}, {@link javafx.scene.control.TreeCell TreeCell},
-    and {@link javafx.scene.control.TableCell TableCell}. At present this package
-    is relatively bare, but it is where future cell-related classes will be located.</p>
-
-    <p>It is important to note that whilst most cells in this package are editable,
-        for a cells editing functionality to be enabled it is required that all
-        related classes have editing enabled. For example, in a TableView, both
-        the TableView and the relevant TableColumn must have setEditing(true) called.
-*/
+ * <p>The <code>javafx.scene.control.cell</code> package is where all cell-related
+ * classes are located, other than the core classes such as
+ * {@link javafx.scene.control.Cell Cell}, {@link javafx.scene.control.IndexedCell IndexedCell},
+ * {@link javafx.scene.control.ListCell ListCell}, {@link javafx.scene.control.TreeCell TreeCell},
+ * and {@link javafx.scene.control.TableCell TableCell}. At present this package
+ * is relatively bare, but it is where future cell-related classes will be located.</p>
+ *
+ * <p>It is important to note that whilst most cells in this package are editable,
+ *     for a cells editing functionality to be enabled it is required that all
+ *     related classes have editing enabled. For example, in a TableView, both
+ *     the TableView and the relevant TableColumn must have setEditing(true) called.
+ */
 package javafx.scene.control.cell;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/package-info.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/package-info.java
@@ -24,129 +24,129 @@
  */
 
 /**
-    <p>The JavaFX User Interface Controls (UI Controls or just Controls) are
-    specialized Nodes in the JavaFX Scenegraph especially suited for reuse in
-    many different application contexts. They are designed to be highly
-    customizable visually by designers and developers. They are designed to work
-    well with layout systems. Examples of prominent controls include {@link javafx.scene.control.Button Button},
-    {@link javafx.scene.control.Label Label}, {@link javafx.scene.control.ListView ListView}, and {@link javafx.scene.control.TextField TextField}.</p>
-
-    <p>Since Controls are {@link javafx.scene.Node Nodes} in the scenegraph,
-    they can be freely mixed with {@link javafx.scene.Group Groups},
-    {@link javafx.scene.image.ImageView Images},
-    {@link javafx.scene.media.MediaView Media},
-    {@link javafx.scene.text.Text Text}, and
-    {@link javafx.scene.shape.Shape basic geometric shapes}. While
-    writing new UI Controls is not trivial, using and styling them
-    is very easy, especially to existing web developers.</p>
-
-    <p>The remainder of this document will describe the basic architecture of
-    the JavaFX UI Control library, how to style existing controls, write custom
-    skins, and how to use controls to build up more complicated user interfaces.
-    </p>
-
-    <h2>Architecture</h2>
-
-    <p>Controls follow the classic MVC design pattern. The {@link javafx.scene.control.Control Control} is
-    the "model". It contains both the state and the functions which manipulate
-    that state. The Control class itself does not know how it is rendered or
-    what the user interaction is. These tasks are delegated to the
-    {@link javafx.scene.control.Skin Skin} ("view"), which may internally separate
-    out the view and controller functionality into separate classes, although
-    at present there is no public API for the "controller" aspect.</p>
-
-    <p>All Controls extend from the Control class, which is in turn a
-    {@link javafx.scene.Parent Parent} node, and which is a
-    {@link javafx.scene.Node Node}. Every Control has a reference to a single Skin, which
-    is the view implementation for the Control. The Control delegates to the
-    Skin the responsibility of computing the min, max, and pref sizes of the
-    Control, the baseline offset, and hit testing (containment and
-    intersection). It is also the responsibility of the Skin, or a delegate of
-    the Skin, to implement and repond to all relevant key
-    events which occur on the Control when it contains the focus.</p>
-
-    <h2>Control</h2>
-
-    <p>Control extends from {@link javafx.scene.Parent Parent}, and as such, is
-    not a leaf node. From the perspective of a developer or designer the Control
-    can be thought of as if it were a leaf node in many cases. For example, the
-    developer or designer can consider a Button as if it were a Rectangle or
-    other simple leaf node.</p>
-
-    <p>Since a Control is resizable, a Control
-    will be <strong>auto-sized to its preferred size</strong> on each scenegraph
-    pulse. Setting the width and height of the Control does not affect its
-    preferred size. When used in a layout container, the layout constraints
-    imposed upon the Control (or manually specified on the Control) will
-    determine how it is positioned and sized.</p>
-
-    <p>The Skin of a Control can be changed at any time. Doing so will mark the
-    Control as needing to be laid out since changing the Skin likely has changed
-    the preferred size of the Control. If no Skin is specified at the time that
-    the Control is created, then a default CSS-based skin will be provided for
-    all of the built-in Controls.</p>
-
-    <p>Each Control may have an optional tooltip specified. The Tooltip is a
-    Control which displays some (usually textual) information about the control
-    to the user when the mouse hovers over the Control from some period of time.
-    It can be styled from CSS the same as with other Controls.</p>
-
-    <p>{@code focusTraversable} is overridden in Control to be true by default,
-    whereas with Node it is false by default. Controls which should not be
-    focusable by default (such as Label) override this to be false.</p>
-
-    <p>The getMinWidth, getMinHeight, getPrefWidth, getPrefHeight, getMaxWidth,
-    and getMaxHeight functions are delegated directly to the Skin. The
-    baselineOffset method is delegated to the node of the skin. It is not
-    recommended that subclasses alter these delegations.</p>
-
-    <h2>Styling Controls</h2>
-
-    <p>There are two methods for customizing the look of a Control. The most
-    difficult and yet most flexible approach is to write a new Skin for the
-    Control which precisely implements the visuals which you
-    desire for the Control. Consult the Skin documentation for more details.</p>
-
-    <p>The easiest and yet very powerful method for styling the built in
-    Controls is by using CSS. Please note that in this release the following
-    CSS description applies only to the default Skins provided for the built
-    in Controls. Subsequent releases will make this generally available for
-    any custom third party Controls which desire to take advantage of these
-    CSS capabilities.</p>
-
-    <p>Each of the default Skins for the built in Controls is comprised of
-    multiple individually styleable areas or regions. This is much like an
-    HTML page which is made up of {@literal <div>'s} and then styled from
-    CSS. Each individual region may be drawn with backgrounds, borders, images,
-    padding, margins, and so on. The JavaFX CSS support includes the ability
-    to have multiple backgrounds and borders, and to derive colors. These
-    capabilities make it extremely easy to alter the look of Controls in
-    JavaFX from CSS.</p>
-
-    <p>The colors used for drawing the default Skins of the built in Controls
-    are all derived from a base color, an accent color and a background
-    color. Simply by modifying the base color for a Control you can alter the
-    derived gradients and create Buttons or other Controls which visually fit
-    in with the default Skins but visually stand out.</p>
-
-    <p>As with all other Nodes in the scenegraph, Controls can be styled by
-    using an external stylesheet, or by specifying the style directly on the
-    Control. Although for examples it is easier to express and understand by
-    specifying the style directly on the Node, it is recommended to use an
-    external stylesheet and use either the styleClass or id of the Control,
-    just as you would use the "class" or id of an HTML element with HTML
-    CSS.</p>
-
-    <p>Each UI Control specifies a styleClass which may be used to
-    style controls from an external stylesheet. For example, the Button
-    control is given the "button" CSS style class. The CSS style class names
-    are hyphen-separated lower case as opposed to camel case, otherwise, they
-    are exactly the same. For example, Button is "button", RadioButton is
-    "radio-button", Tooltip is "tooltip" and so on.</p>
-
-    <p>The class documentation for each Control defines the default Skin
-    regions which can be styled. For further information regarding the CSS
-    capabilities provided with JavaFX, see the
-    <a href="../../../../javafx.graphics/javafx/scene/doc-files/cssref.html">CSS Reference Guide</a>.</p>
-*/
+ * <p>The JavaFX User Interface Controls (UI Controls or just Controls) are
+ * specialized Nodes in the JavaFX Scenegraph especially suited for reuse in
+ * many different application contexts. They are designed to be highly
+ * customizable visually by designers and developers. They are designed to work
+ * well with layout systems. Examples of prominent controls include {@link javafx.scene.control.Button Button},
+ * {@link javafx.scene.control.Label Label}, {@link javafx.scene.control.ListView ListView}, and {@link javafx.scene.control.TextField TextField}.</p>
+ *
+ * <p>Since Controls are {@link javafx.scene.Node Nodes} in the scenegraph,
+ * they can be freely mixed with {@link javafx.scene.Group Groups},
+ * {@link javafx.scene.image.ImageView Images},
+ * {@link javafx.scene.media.MediaView Media},
+ * {@link javafx.scene.text.Text Text}, and
+ * {@link javafx.scene.shape.Shape basic geometric shapes}. While
+ * writing new UI Controls is not trivial, using and styling them
+ * is very easy, especially to existing web developers.</p>
+ *
+ * <p>The remainder of this document will describe the basic architecture of
+ * the JavaFX UI Control library, how to style existing controls, write custom
+ * skins, and how to use controls to build up more complicated user interfaces.
+ * </p>
+ *
+ * <h2>Architecture</h2>
+ *
+ * <p>Controls follow the classic MVC design pattern. The {@link javafx.scene.control.Control Control} is
+ * the "model". It contains both the state and the functions which manipulate
+ * that state. The Control class itself does not know how it is rendered or
+ * what the user interaction is. These tasks are delegated to the
+ * {@link javafx.scene.control.Skin Skin} ("view"), which may internally separate
+ * out the view and controller functionality into separate classes, although
+ * at present there is no public API for the "controller" aspect.</p>
+ *
+ * <p>All Controls extend from the Control class, which is in turn a
+ * {@link javafx.scene.Parent Parent} node, and which is a
+ * {@link javafx.scene.Node Node}. Every Control has a reference to a single Skin, which
+ * is the view implementation for the Control. The Control delegates to the
+ * Skin the responsibility of computing the min, max, and pref sizes of the
+ * Control, the baseline offset, and hit testing (containment and
+ * intersection). It is also the responsibility of the Skin, or a delegate of
+ * the Skin, to implement and repond to all relevant key
+ * events which occur on the Control when it contains the focus.</p>
+ *
+ * <h2>Control</h2>
+ *
+ * <p>Control extends from {@link javafx.scene.Parent Parent}, and as such, is
+ * not a leaf node. From the perspective of a developer or designer the Control
+ * can be thought of as if it were a leaf node in many cases. For example, the
+ * developer or designer can consider a Button as if it were a Rectangle or
+ * other simple leaf node.</p>
+ *
+ * <p>Since a Control is resizable, a Control
+ * will be <strong>auto-sized to its preferred size</strong> on each scenegraph
+ * pulse. Setting the width and height of the Control does not affect its
+ * preferred size. When used in a layout container, the layout constraints
+ * imposed upon the Control (or manually specified on the Control) will
+ * determine how it is positioned and sized.</p>
+ *
+ * <p>The Skin of a Control can be changed at any time. Doing so will mark the
+ * Control as needing to be laid out since changing the Skin likely has changed
+ * the preferred size of the Control. If no Skin is specified at the time that
+ * the Control is created, then a default CSS-based skin will be provided for
+ * all of the built-in Controls.</p>
+ *
+ * <p>Each Control may have an optional tooltip specified. The Tooltip is a
+ * Control which displays some (usually textual) information about the control
+ * to the user when the mouse hovers over the Control from some period of time.
+ * It can be styled from CSS the same as with other Controls.</p>
+ *
+ * <p>{@code focusTraversable} is overridden in Control to be true by default,
+ * whereas with Node it is false by default. Controls which should not be
+ * focusable by default (such as Label) override this to be false.</p>
+ *
+ * <p>The getMinWidth, getMinHeight, getPrefWidth, getPrefHeight, getMaxWidth,
+ * and getMaxHeight functions are delegated directly to the Skin. The
+ * baselineOffset method is delegated to the node of the skin. It is not
+ * recommended that subclasses alter these delegations.</p>
+ *
+ * <h2>Styling Controls</h2>
+ *
+ * <p>There are two methods for customizing the look of a Control. The most
+ * difficult and yet most flexible approach is to write a new Skin for the
+ * Control which precisely implements the visuals which you
+ * desire for the Control. Consult the Skin documentation for more details.</p>
+ *
+ * <p>The easiest and yet very powerful method for styling the built in
+ * Controls is by using CSS. Please note that in this release the following
+ * CSS description applies only to the default Skins provided for the built
+ * in Controls. Subsequent releases will make this generally available for
+ * any custom third party Controls which desire to take advantage of these
+ * CSS capabilities.</p>
+ *
+ * <p>Each of the default Skins for the built in Controls is comprised of
+ * multiple individually styleable areas or regions. This is much like an
+ * HTML page which is made up of {@literal <div>'s} and then styled from
+ * CSS. Each individual region may be drawn with backgrounds, borders, images,
+ * padding, margins, and so on. The JavaFX CSS support includes the ability
+ * to have multiple backgrounds and borders, and to derive colors. These
+ * capabilities make it extremely easy to alter the look of Controls in
+ * JavaFX from CSS.</p>
+ *
+ * <p>The colors used for drawing the default Skins of the built in Controls
+ * are all derived from a base color, an accent color and a background
+ * color. Simply by modifying the base color for a Control you can alter the
+ * derived gradients and create Buttons or other Controls which visually fit
+ * in with the default Skins but visually stand out.</p>
+ *
+ * <p>As with all other Nodes in the scenegraph, Controls can be styled by
+ * using an external stylesheet, or by specifying the style directly on the
+ * Control. Although for examples it is easier to express and understand by
+ * specifying the style directly on the Node, it is recommended to use an
+ * external stylesheet and use either the styleClass or id of the Control,
+ * just as you would use the "class" or id of an HTML element with HTML
+ * CSS.</p>
+ *
+ * <p>Each UI Control specifies a styleClass which may be used to
+ * style controls from an external stylesheet. For example, the Button
+ * control is given the "button" CSS style class. The CSS style class names
+ * are hyphen-separated lower case as opposed to camel case, otherwise, they
+ * are exactly the same. For example, Button is "button", RadioButton is
+ * "radio-button", Tooltip is "tooltip" and so on.</p>
+ *
+ * <p>The class documentation for each Control defines the default Skin
+ * regions which can be styled. For further information regarding the CSS
+ * capabilities provided with JavaFX, see the
+ * <a href="../../../../javafx.graphics/javafx/scene/doc-files/cssref.html">CSS Reference Guide</a>.</p>
+ */
 package javafx.scene.control;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/package-info.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/package-info.java
@@ -24,7 +24,7 @@
  */
 
 /**
-  <p>The javafx.scene.control.skin package is where the skin classes, typically
-    one for each UI control, are located</p>
-*/
+ * <p>The javafx.scene.control.skin package is where the skin classes, typically
+ *   one for each UI control, are located</p>
+ */
 package javafx.scene.control.skin;

--- a/modules/javafx.fxml/src/main/java/javafx/fxml/package-info.java
+++ b/modules/javafx.fxml/src/main/java/javafx/fxml/package-info.java
@@ -24,8 +24,8 @@
  */
 
 /**
-<p>Contains classes for loading an object hierarchy from markup. For more
-information, see the <a href="doc-files/introduction_to_fxml.html">Introduction
-to FXML</a> document.</p>
-*/
+ * <p>Contains classes for loading an object hierarchy from markup. For more
+ * information, see the <a href="doc-files/introduction_to_fxml.html">Introduction
+ * to FXML</a> document.</p>
+ */
 package javafx.fxml;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/package-info.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/iio/package-info.java
@@ -24,16 +24,16 @@
  */
 
 /**
-Provides image loading capability for Java FX.
-
-<p>A plugin for loading a given format is added by creating an
-<code>ImageFormatDescription</code> to provide the principal attributes for
-recognizing images stored in the format, an <code>ImageLoader</code> which
-performs the actual loading of the image data and metadata, and an
-<code>ImageLoaderFactory</code> which is able to create an
-<code>ImageLoader</code> for a stream of image data stored in the format.
-The <code>ImageLoaderFactory</code> is registered with the
-<code>ImageStorage</code> object which manages all <code>ImageLoader</code>s
-and which also supplies convenience loading methods for application use.
-*/
+ * Provides image loading capability for Java FX.
+ *
+ * <p>A plugin for loading a given format is added by creating an
+ * <code>ImageFormatDescription</code> to provide the principal attributes for
+ * recognizing images stored in the format, an <code>ImageLoader</code> which
+ * performs the actual loading of the image data and metadata, and an
+ * <code>ImageLoaderFactory</code> which is able to create an
+ * <code>ImageLoader</code> for a stream of image data stored in the format.
+ * The <code>ImageLoaderFactory</code> is registered with the
+ * <code>ImageStorage</code> object which manages all <code>ImageLoader</code>s
+ * and which also supplies convenience loading methods for application use.
+ */
 package com.sun.javafx.iio;

--- a/modules/javafx.graphics/src/main/java/javafx/animation/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/package-info.java
@@ -24,9 +24,9 @@
  */
 
 /**
-<p>Provides the set of classes for ease of use transition based animations.</p>
-<p>It offers a simple framework for incorporating animations onto an internal
-{@link javafx.animation.Timeline Timeline}. It also provides high level constructs to compose the effects
-of multiple animations.</p>
-*/
+ * <p>Provides the set of classes for ease of use transition based animations.</p>
+ * <p>It offers a simple framework for incorporating animations onto an internal
+ * {@link javafx.animation.Timeline Timeline}. It also provides high level constructs to compose the effects
+ * of multiple animations.</p>
+ */
 package javafx.animation;

--- a/modules/javafx.graphics/src/main/java/javafx/application/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/package-info.java
@@ -24,9 +24,9 @@
  */
 
 /**
-<p>Provides the application life-cycle classes.</p>
-<p>The
-<a href="Application.html">Application</a> class is the primary class from
-which JavaFX applications extend.</p>
-*/
+ * <p>Provides the application life-cycle classes.</p>
+ * <p>The
+ * <a href="Application.html">Application</a> class is the primary class from
+ * which JavaFX applications extend.</p>
+ */
 package javafx.application;

--- a/modules/javafx.graphics/src/main/java/javafx/concurrent/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/concurrent/package-info.java
@@ -24,11 +24,11 @@
  */
 
 /**
-<p>Provides the set of classes for javafx.concurrent.</p>
-<p>This package provides the ability to run application code on threads other
-than the JavaFX event dispatch thread. The ability to control the execution
-and track the progress of the application code is also provided.</p>
-
-<!--Things to document: use of non-daemon threads, auto-restarting a Service.-->
-*/
+ * <p>Provides the set of classes for javafx.concurrent.</p>
+ * <p>This package provides the ability to run application code on threads other
+ * than the JavaFX event dispatch thread. The ability to control the execution
+ * and track the progress of the application code is also provided.</p>
+ *
+ * <!--Things to document: use of non-daemon threads, auto-restarting a Service.-->
+ */
 package javafx.concurrent;

--- a/modules/javafx.graphics/src/main/java/javafx/css/converter/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/converter/package-info.java
@@ -24,7 +24,7 @@
  */
 
 /**
-<p>Provides various {@link javafx.css.StyleConverter StyleConverter} classes
-that convert CSS parsed values.</p>
-*/
+ * <p>Provides various {@link javafx.css.StyleConverter StyleConverter} classes
+ * that convert CSS parsed values.</p>
+ */
 package javafx.css.converter;

--- a/modules/javafx.graphics/src/main/java/javafx/css/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/package-info.java
@@ -24,50 +24,48 @@
  */
 
 /**
-
-<p>Provides API for making properties styleable via CSS and for supporting
-pseudo-class state.</p>
-
-<p>The JavaFX Scene Graph provides the facility to style nodes using
-CSS (Cascading Style Sheets).
-The {@link javafx.scene.Node Node} class contains {@code id}, {@code styleClass}, and
-{@code style} variables which are used by CSS selectors to find nodes
-to which styles should be applied. The {@link javafx.scene.Scene Scene} class and
-{@link javafx.scene.Parent Parent} class contain a
-the {@code stylesheets} variable which is a list of URLs that
-reference CSS style sheets that are to be applied to the nodes within
-that scene or parent.
-<p>The primary classes in this package are:</p>
-
-<dl>
-
-<dt>{@link javafx.css.CssMetaData CssMetaData}</dt>
-<dd>Defines the CSS property and provides a link back to the
-    {@link javafx.css.StyleableProperty StyleableProperty}.
-    By convention, classes that have CssMetaData implement a
-    {@code public static List<CssMetaData<? extends Styleable>> getClassCssMetaData()} method that
-    allows other classes to include CssMetaData from an inherited class. The
-    method {@link javafx.scene.Node#getCssMetaData() getCssMetaData()} should
-    be overridden to return {@code getClassCssMetaData()}. The CSS implementation
-    frequently calls {@code getCssMetaData()}. It is strongly recommended that
-    the returned list be a {@code final static}.</dd>
-
-<dt>{@link javafx.css.StyleableProperty StyleableProperty}</dt>
-<dd>Defines the interface that the CSS implementation uses to set values on a
-    property and provides a link back to the {@code CssMetaData} that
-    corresponds to the property. The {@link javafx.css.StyleablePropertyFactory StyleablePropertyFactory}
-    greatly simplifies creating a StyleableProperty and its corresponding CssMetaData.</dd>
-
-<dt>{@link javafx.css.PseudoClass PseudoClass}</dt>
-<dd>Defines a pseudo-class which can be set or cleared via the method
-    {@link javafx.scene.Node#pseudoClassStateChanged(javafx.css.PseudoClass, boolean)
-    pseudoClassStateChanged}. </dd>
-
-</dl>
-
-<p>For further information about CSS, how to apply CSS styles
-to nodes, and what properties are available for styling, see the
-<a href="../scene/doc-files/cssref.html">CSS Reference Guide</a>.</p>
-
-*/
+ * <p>Provides API for making properties styleable via CSS and for supporting
+ * pseudo-class state.</p>
+ *
+ * <p>The JavaFX Scene Graph provides the facility to style nodes using
+ * CSS (Cascading Style Sheets).
+ * The {@link javafx.scene.Node Node} class contains {@code id}, {@code styleClass}, and
+ * {@code style} variables which are used by CSS selectors to find nodes
+ * to which styles should be applied. The {@link javafx.scene.Scene Scene} class and
+ * {@link javafx.scene.Parent Parent} class contain a
+ * the {@code stylesheets} variable which is a list of URLs that
+ * reference CSS style sheets that are to be applied to the nodes within
+ * that scene or parent.
+ * <p>The primary classes in this package are:</p>
+ *
+ * <dl>
+ *
+ * <dt>{@link javafx.css.CssMetaData CssMetaData}</dt>
+ * <dd>Defines the CSS property and provides a link back to the
+ *     {@link javafx.css.StyleableProperty StyleableProperty}.
+ *     By convention, classes that have CssMetaData implement a
+ *     {@code public static List<CssMetaData<? extends Styleable>> getClassCssMetaData()} method that
+ *     allows other classes to include CssMetaData from an inherited class. The
+ *     method {@link javafx.scene.Node#getCssMetaData() getCssMetaData()} should
+ *     be overridden to return {@code getClassCssMetaData()}. The CSS implementation
+ *     frequently calls {@code getCssMetaData()}. It is strongly recommended that
+ *     the returned list be a {@code final static}.</dd>
+ *
+ * <dt>{@link javafx.css.StyleableProperty StyleableProperty}</dt>
+ * <dd>Defines the interface that the CSS implementation uses to set values on a
+ *     property and provides a link back to the {@code CssMetaData} that
+ *     corresponds to the property. The {@link javafx.css.StyleablePropertyFactory StyleablePropertyFactory}
+ *     greatly simplifies creating a StyleableProperty and its corresponding CssMetaData.</dd>
+ *
+ * <dt>{@link javafx.css.PseudoClass PseudoClass}</dt>
+ * <dd>Defines a pseudo-class which can be set or cleared via the method
+ *     {@link javafx.scene.Node#pseudoClassStateChanged(javafx.css.PseudoClass, boolean)
+ *     pseudoClassStateChanged}. </dd>
+ *
+ * </dl>
+ *
+ * <p>For further information about CSS, how to apply CSS styles
+ * to nodes, and what properties are available for styling, see the
+ * <a href="../scene/doc-files/cssref.html">CSS Reference Guide</a>.</p>
+ */
 package javafx.css;

--- a/modules/javafx.graphics/src/main/java/javafx/geometry/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/geometry/package-info.java
@@ -24,7 +24,7 @@
  */
 
 /**
-<p>Provides the set of 2D classes for defining and performing operations on
-objects related to two-dimensional geometry. </p>
-*/
+ * <p>Provides the set of 2D classes for defining and performing operations on
+ * objects related to two-dimensional geometry. </p>
+ */
 package javafx.geometry;

--- a/modules/javafx.graphics/src/main/java/javafx/print/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/package-info.java
@@ -24,7 +24,6 @@
  */
 
 /**
-
-<p>Provides the public classes for the JavaFX Printing API.
-*/
+ * <p>Provides the public classes for the JavaFX Printing API.
+ */
 package javafx.print;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/canvas/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/canvas/package-info.java
@@ -24,6 +24,6 @@
  */
 
 /**
-<p>Provides the set of classes for canvas, an immediate mode style of rendering API.</p>
-*/
+ * <p>Provides the set of classes for canvas, an immediate mode style of rendering API.</p>
+ */
 package javafx.scene.canvas;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/effect/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/effect/package-info.java
@@ -24,21 +24,21 @@
  */
 
 /**
-<p>Provides the set of classes for attaching graphical filter effects to JavaFX Scene Graph Nodes.</p>
-<p>An effect is a graphical algorithm that produces an image, typically
-   as a modification of a source image.
-   An effect can be associated with a scene graph {@code Node} by setting the
-   {@link javafx.scene.Node#effectProperty effect}
-   attribute.
-   Some effects change the color properties of the source pixels
-   (such as {@link javafx.scene.effect.ColorAdjust}),
-   others combine multiple images together (such as
-   {@link javafx.scene.effect.Blend Blend}),
-   while still others warp or move the pixels of the source image around (such as
-   {@link javafx.scene.effect.DisplacementMap DisplacementMap} or {@link javafx.scene.effect.PerspectiveTransform PerspectiveTransform}).
-   All effects have at least one input defined and the input can be set
-   to another effect to chain the effects together and combine their
-   results, or it can be left unspecified in which case the effect will
-   operate on a graphical rendering of the node it is attached to.</p>
-*/
+ * <p>Provides the set of classes for attaching graphical filter effects to JavaFX Scene Graph Nodes.</p>
+ * <p>An effect is a graphical algorithm that produces an image, typically
+ *    as a modification of a source image.
+ *    An effect can be associated with a scene graph {@code Node} by setting the
+ *    {@link javafx.scene.Node#effectProperty effect}
+ *    attribute.
+ *    Some effects change the color properties of the source pixels
+ *    (such as {@link javafx.scene.effect.ColorAdjust}),
+ *    others combine multiple images together (such as
+ *    {@link javafx.scene.effect.Blend Blend}),
+ *    while still others warp or move the pixels of the source image around (such as
+ *    {@link javafx.scene.effect.DisplacementMap DisplacementMap} or {@link javafx.scene.effect.PerspectiveTransform PerspectiveTransform}).
+ *    All effects have at least one input defined and the input can be set
+ *    to another effect to chain the effects together and combine their
+ *    results, or it can be left unspecified in which case the effect will
+ *    operate on a graphical rendering of the node it is attached to.</p>
+ */
 package javafx.scene.effect;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/image/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/image/package-info.java
@@ -24,19 +24,18 @@
  */
 
 /**
-<p>Provides the set of classes for loading and displaying images.</p>
-<ul>
-    <li> The {@link javafx.scene.image.Image} class is used to load images
-    (synchronously or asynchronously). Image can be resized as it is loaded and
-    the resizing can be performed with specified filtering quality and
-    with an option of preserving image's original aspect ratio.
-
-    <li> The {@link javafx.scene.image.ImageView} is a {@code Node} used
-    for displaying images loaded with {@code Image} class.
-    It allows displaying a dynamically scaled and/or cropped view of the source
-    image. The scaling can be performed with specified filtering quality and
-    with an option of preserving image's original aspect ratio.
-</ul>
-
-*/
+ * <p>Provides the set of classes for loading and displaying images.</p>
+ * <ul>
+ *     <li> The {@link javafx.scene.image.Image} class is used to load images
+ *     (synchronously or asynchronously). Image can be resized as it is loaded and
+ *     the resizing can be performed with specified filtering quality and
+ *     with an option of preserving image's original aspect ratio.
+ *
+ *     <li> The {@link javafx.scene.image.ImageView} is a {@code Node} used
+ *     for displaying images loaded with {@code Image} class.
+ *     It allows displaying a dynamically scaled and/or cropped view of the source
+ *     image. The scaling can be performed with specified filtering quality and
+ *     with an option of preserving image's original aspect ratio.
+ * </ul>
+ */
 package javafx.scene.image;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/package-info.java
@@ -24,6 +24,6 @@
  */
 
 /**
-<p>Provides the set of classes for mouse and keyboard input event handling.</p>
-*/
+ * <p>Provides the set of classes for mouse and keyboard input event handling.</p>
+ */
 package javafx.scene.input;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/package-info.java
@@ -24,177 +24,176 @@
  */
 
 /**
-<p>
-Provides classes to support user interface layout.
-Each layout pane class supports a different layout strategy for its children
-and applications may nest these layout panes to achieve the needed layout structure
-in the user interface.  Once a node is added to one of the layout panes,
-the pane will automatically manage the layout for the node, so the application
-should not position or resize the node directly; see &quot;Node Resizability&quot;
-for more details.
-</p>
-
-<h2>Scene Graph Layout Mechanism</h2>
-<p>
-The scene graph layout mechanism is driven automatically by the system once
-the application creates and displays a {@link javafx.scene.Scene Scene}.
-The scene graph detects dynamic node changes which affect layout (such as a
-change in size or content) and calls {@code requestLayout()}, which marks that
-branch as needing layout so that on the next pulse, a top-down layout pass is
-executed on that branch by invoking {@code layout()} on that branch's root.
-During that layout pass, the {@code layoutChildren()} callback method will
-be called on each parent to layout its children.  This mechanism is designed
-to maximize layout efficiency by ensuring multiple layout requests are coalesced
-and processed in a single pass rather than executing re-layout on on each minute
-change. Therefore, applications should not invoke layout directly on nodes.
-</p>
-
-
-<h2>Node Resizability</h2>
-<p>
-The scene graph supports both resizable and non-resizable node classes.  The
-{@code isResizable()} method on {@link javafx.scene.Node Node} returns whether a
-given node is resizable or not.  {@literal A resizable node class is one which supports a range
-of acceptable sizes (minimum <= preferred <= maximum), allowing its parent to resize
-it within that range during layout, given the parent's own layout policy and the
-layout needs of sibling nodes.}  Node supports the following methods for layout code
-to determine a node's resizable range:
-<pre><code>
-    public Orientation getContentBias()
-    public double minWidth(double height)
-    public double minHeight(double width)
-    public double prefWidth(double height)
-    public double prefHeight(double width)
-    public double maxWidth(double height)
-    public double maxHeight(double width)
-</code></pre>
-<p>
-Non-resizable node classes, on the other hand, do <em>not</em> have a consistent
-resizing API and so are <em>not</em> resized by their parents during layout.
-Applications must establish the size of non-resizable nodes by setting
-appropriate properties on each instance. These classes return their current layout bounds for
-min, pref, and max, and the {@code resize()} method becomes a no-op.</p>
-<p>
-<br>Resizable classes: {@link javafx.scene.layout.Region Region}, {@link javafx.scene.control.Control Control}, {@link javafx.scene.web.WebView WebView}
-<br>Non-Resizable classes: {@link javafx.scene.Group Group}, {@link javafx.scene.shape.Shape Shape}, {@link javafx.scene.text.Text Text}
-</p>
-<p>
-For example, a Button control (resizable) computes its min, pref, and max sizes
-which its parent will use to resize it during layout, so the application only needs
-to configure its content and properties:
-
-<pre><code>    Button button = new Button("Apply");
-</code></pre>
-However, a Circle (non-resizable) cannot be resized by its parent, so the application
-needs to set appropriate geometric properties which determine its size:
-
-<pre><code>    Circle circle = new Circle();
-    circle.setRadius(50);
-</code></pre>
-
-<h2>Resizable Range</h2>
-
-Each resizable node class computes an appropriate min, pref, and max size based
-on its own content and property settings (it's 'intrinsic' size range).
-Some resizable classes have an unbounded max size (all layout panes) while
-others have a max size that is clamped by default to their preferred size (buttons)
-(See individual class documentation for the default range of each class).
-While these defaults are geared towards common usage, applications often need
-to explicitly alter or set a node's resizable range to achieve certain layouts.
-The resizable classes provide properties for overriding the min, pref and max
-sizes for this purpose.
-<p>For example, to override the preferred size of a ListView:</p>
-<pre><code>    listview.setPrefSize(200,300);
-</code></pre>
-<p>Or, to change the max width of a button so it will resize wider to fill a space:
-<pre><code>    button.setMaxWidth(Double.MAX_VALUE);
-</code></pre>
-<p>For the inverse case, where the application needs to clamp the node's min
-or max size to its preferred:
-<pre><code>    listview.setMaxSize(Region.USE_PREF_SIZE, Region.USE_PREF_SIZE);
-</code></pre>
-And finally, if the application needs to restore the intrinsically computed values:
-<pre><code>    listview.setPrefSize(Region.USE_COMPUTED_SIZE, Region.USE_COMPUTED_SIZE);
-</code></pre>
-
-<h2>CSS Styling and Node Sizing</h2>
-
-Applications cannot reliably query the bounds of a resizable node until it has been
-added to a scene because the size of that node may be dependent on CSS.  This is
-because CSS is used to style many aspects of a node which affect it's preferred size
-(font, padding, borders, etc) and so the node cannot be laid out (resized) until
-CSS has been applied and the parent can access valid size range metrics.
-This is always true for Controls (and any panes that contain them), because they
-rely on CSS for their default style, even if no user-level style sheets have been set.
-Stylesheets are set at the Scene level, which means that styles cannot even
-be determined until a node's enclosing scene has been initialized. Once a Scene
-is initialized, CSS is applied to nodes on each pulse (when needed) just before
-the layout pass.
-
-
-
-<h2>Visual Bounds vs. Layout Bounds</h2>
-
-A graphically rich user interface often has the need to make a distinction between
-a node's visual bounds and the bounds used for layout.  For example, the tight visual
-bounds of a Text node's character glyphs would not work for layout, as the text
-would not be aligned and leading/trailing whitespace would be discounted.  Also,
-sometimes applications wish to apply affects and transforms to nodes without
-disturbing the surrounding layout (bouncing, jiggling, drop shadows, glows, etc).
-To support this distinction in the scene graph, {@link javafx.scene.Node Node}
-provides the {@code layoutBounds} property to define the 'logical' bounds
-of the node for layout and {@code boundsInParent} to define the visual bounds
-once all effects, clipping, and transforms have been applied.
-
-<p>These two bounds properties will often differ for a given node and
-{@code layoutBounds} is computed differently depending on the node class:
-
-<table border="1">
- <caption>Bounds Computation Table</caption>
- <thead>
-     <tr>
-         <th scope="col">Node Type</th>
-         <th scope="col">Layout Bounds</th>
-     </tr>
- </thead>
- <tbody>
-     <tr>
-         <th scope="row">{@link javafx.scene.shape.Shape Shape},{@link javafx.scene.image.ImageView ImageView}</th>
-         <td>Includes geometric bounds (geometry plus stroke).
-             Does NOT include effect, clip, or any transforms.
-         </td>
-     </tr>
-     <tr>
-         <th scope="row">{@link javafx.scene.text.Text Text}</th>
-         <td>logical bounds based on the font height and content width, including white space.
-             can be configured to be tight bounds around chars glyphs by setting {@code boundsType}.
-             Does NOT include effect, clip, or any transforms.
-         </td>
-     </tr>
-     <tr>
-         <th scope="row">{@link javafx.scene.layout.Region Region}, {@link javafx.scene.control.Control Control}, {@link javafx.scene.web.WebView WebView}</th>
-         <td>always {@code [0,0 width x height]} regardless of visual bounds,
-             which might be larger or smaller than layout bounds.
-         </td>
-     </tr>
-     <tr>
-         <th scope="row">{@link javafx.scene.Group Group}</th>
-         <td>Union of all visible children's visual bounds ({@code boundsInParent})
-             Does NOT include effect, clip, or transforms set directly on group,
-             however DOES include effect, clip, transforms set on individual children since
-             those are included in the child's {@code boundsInParent}.
-         </td>
-     </tr>
- </tbody>
-</table>
-<p>
-So for example, if a {@link javafx.scene.effect.DropShadow DropShadow} is added to a shape,
-that shadow will <em>not</em>  be factored into layout by default.  Or, if a
-{@link javafx.animation.ScaleTransition ScaleTransition} is used to
-pulse the size of a button, that pulse animation will not disturb layout around
-that button.  If an application wishes to have the effect, clip, or transform
-factored into the layout of a node, it should wrap that node in a Group.
-</p>
-
-*/
+ * <p>
+ * Provides classes to support user interface layout.
+ * Each layout pane class supports a different layout strategy for its children
+ * and applications may nest these layout panes to achieve the needed layout structure
+ * in the user interface.  Once a node is added to one of the layout panes,
+ * the pane will automatically manage the layout for the node, so the application
+ * should not position or resize the node directly; see &quot;Node Resizability&quot;
+ * for more details.
+ * </p>
+ *
+ * <h2>Scene Graph Layout Mechanism</h2>
+ * <p>
+ * The scene graph layout mechanism is driven automatically by the system once
+ * the application creates and displays a {@link javafx.scene.Scene Scene}.
+ * The scene graph detects dynamic node changes which affect layout (such as a
+ * change in size or content) and calls {@code requestLayout()}, which marks that
+ * branch as needing layout so that on the next pulse, a top-down layout pass is
+ * executed on that branch by invoking {@code layout()} on that branch's root.
+ * During that layout pass, the {@code layoutChildren()} callback method will
+ * be called on each parent to layout its children.  This mechanism is designed
+ * to maximize layout efficiency by ensuring multiple layout requests are coalesced
+ * and processed in a single pass rather than executing re-layout on on each minute
+ * change. Therefore, applications should not invoke layout directly on nodes.
+ * </p>
+ *
+ *
+ * <h2>Node Resizability</h2>
+ * <p>
+ * The scene graph supports both resizable and non-resizable node classes.  The
+ * {@code isResizable()} method on {@link javafx.scene.Node Node} returns whether a
+ * given node is resizable or not.  {@literal A resizable node class is one which supports a range
+ * of acceptable sizes (minimum <= preferred <= maximum), allowing its parent to resize
+ * it within that range during layout, given the parent's own layout policy and the
+ * layout needs of sibling nodes.}  Node supports the following methods for layout code
+ * to determine a node's resizable range:
+ * <pre><code>
+ *     public Orientation getContentBias()
+ *     public double minWidth(double height)
+ *     public double minHeight(double width)
+ *     public double prefWidth(double height)
+ *     public double prefHeight(double width)
+ *     public double maxWidth(double height)
+ *     public double maxHeight(double width)
+ * </code></pre>
+ * <p>
+ * Non-resizable node classes, on the other hand, do <em>not</em> have a consistent
+ * resizing API and so are <em>not</em> resized by their parents during layout.
+ * Applications must establish the size of non-resizable nodes by setting
+ * appropriate properties on each instance. These classes return their current layout bounds for
+ * min, pref, and max, and the {@code resize()} method becomes a no-op.</p>
+ * <p>
+ * <br>Resizable classes: {@link javafx.scene.layout.Region Region}, {@link javafx.scene.control.Control Control}, {@link javafx.scene.web.WebView WebView}
+ * <br>Non-Resizable classes: {@link javafx.scene.Group Group}, {@link javafx.scene.shape.Shape Shape}, {@link javafx.scene.text.Text Text}
+ * </p>
+ * <p>
+ * For example, a Button control (resizable) computes its min, pref, and max sizes
+ * which its parent will use to resize it during layout, so the application only needs
+ * to configure its content and properties:
+ *
+ * <pre><code>    Button button = new Button("Apply");
+ * </code></pre>
+ * However, a Circle (non-resizable) cannot be resized by its parent, so the application
+ * needs to set appropriate geometric properties which determine its size:
+ *
+ * <pre><code>    Circle circle = new Circle();
+ *     circle.setRadius(50);
+ * </code></pre>
+ *
+ * <h2>Resizable Range</h2>
+ *
+ * Each resizable node class computes an appropriate min, pref, and max size based
+ * on its own content and property settings (it's 'intrinsic' size range).
+ * Some resizable classes have an unbounded max size (all layout panes) while
+ * others have a max size that is clamped by default to their preferred size (buttons)
+ * (See individual class documentation for the default range of each class).
+ * While these defaults are geared towards common usage, applications often need
+ * to explicitly alter or set a node's resizable range to achieve certain layouts.
+ * The resizable classes provide properties for overriding the min, pref and max
+ * sizes for this purpose.
+ * <p>For example, to override the preferred size of a ListView:</p>
+ * <pre><code>    listview.setPrefSize(200,300);
+ * </code></pre>
+ * <p>Or, to change the max width of a button so it will resize wider to fill a space:
+ * <pre><code>    button.setMaxWidth(Double.MAX_VALUE);
+ * </code></pre>
+ * <p>For the inverse case, where the application needs to clamp the node's min
+ * or max size to its preferred:
+ * <pre><code>    listview.setMaxSize(Region.USE_PREF_SIZE, Region.USE_PREF_SIZE);
+ * </code></pre>
+ * And finally, if the application needs to restore the intrinsically computed values:
+ * <pre><code>    listview.setPrefSize(Region.USE_COMPUTED_SIZE, Region.USE_COMPUTED_SIZE);
+ * </code></pre>
+ *
+ * <h2>CSS Styling and Node Sizing</h2>
+ *
+ * Applications cannot reliably query the bounds of a resizable node until it has been
+ * added to a scene because the size of that node may be dependent on CSS.  This is
+ * because CSS is used to style many aspects of a node which affect it's preferred size
+ * (font, padding, borders, etc) and so the node cannot be laid out (resized) until
+ * CSS has been applied and the parent can access valid size range metrics.
+ * This is always true for Controls (and any panes that contain them), because they
+ * rely on CSS for their default style, even if no user-level style sheets have been set.
+ * Stylesheets are set at the Scene level, which means that styles cannot even
+ * be determined until a node's enclosing scene has been initialized. Once a Scene
+ * is initialized, CSS is applied to nodes on each pulse (when needed) just before
+ * the layout pass.
+ *
+ *
+ *
+ * <h2>Visual Bounds vs. Layout Bounds</h2>
+ *
+ * A graphically rich user interface often has the need to make a distinction between
+ * a node's visual bounds and the bounds used for layout.  For example, the tight visual
+ * bounds of a Text node's character glyphs would not work for layout, as the text
+ * would not be aligned and leading/trailing whitespace would be discounted.  Also,
+ * sometimes applications wish to apply affects and transforms to nodes without
+ * disturbing the surrounding layout (bouncing, jiggling, drop shadows, glows, etc).
+ * To support this distinction in the scene graph, {@link javafx.scene.Node Node}
+ * provides the {@code layoutBounds} property to define the 'logical' bounds
+ * of the node for layout and {@code boundsInParent} to define the visual bounds
+ * once all effects, clipping, and transforms have been applied.
+ *
+ * <p>These two bounds properties will often differ for a given node and
+ * {@code layoutBounds} is computed differently depending on the node class:
+ *
+ * <table border="1">
+ *  <caption>Bounds Computation Table</caption>
+ *  <thead>
+ *      <tr>
+ *          <th scope="col">Node Type</th>
+ *          <th scope="col">Layout Bounds</th>
+ *      </tr>
+ *  </thead>
+ *  <tbody>
+ *      <tr>
+ *          <th scope="row">{@link javafx.scene.shape.Shape Shape},{@link javafx.scene.image.ImageView ImageView}</th>
+ *          <td>Includes geometric bounds (geometry plus stroke).
+ *              Does NOT include effect, clip, or any transforms.
+ *          </td>
+ *      </tr>
+ *      <tr>
+ *          <th scope="row">{@link javafx.scene.text.Text Text}</th>
+ *          <td>logical bounds based on the font height and content width, including white space.
+ *              can be configured to be tight bounds around chars glyphs by setting {@code boundsType}.
+ *              Does NOT include effect, clip, or any transforms.
+ *          </td>
+ *      </tr>
+ *      <tr>
+ *          <th scope="row">{@link javafx.scene.layout.Region Region}, {@link javafx.scene.control.Control Control}, {@link javafx.scene.web.WebView WebView}</th>
+ *          <td>always {@code [0,0 width x height]} regardless of visual bounds,
+ *              which might be larger or smaller than layout bounds.
+ *          </td>
+ *      </tr>
+ *      <tr>
+ *          <th scope="row">{@link javafx.scene.Group Group}</th>
+ *          <td>Union of all visible children's visual bounds ({@code boundsInParent})
+ *              Does NOT include effect, clip, or transforms set directly on group,
+ *              however DOES include effect, clip, transforms set on individual children since
+ *              those are included in the child's {@code boundsInParent}.
+ *          </td>
+ *      </tr>
+ *  </tbody>
+ * </table>
+ * <p>
+ * So for example, if a {@link javafx.scene.effect.DropShadow DropShadow} is added to a shape,
+ * that shadow will <em>not</em>  be factored into layout by default.  Or, if a
+ * {@link javafx.animation.ScaleTransition ScaleTransition} is used to
+ * pulse the size of a button, that pulse animation will not disturb layout around
+ * that button.  If an application wishes to have the effect, clip, or transform
+ * factored into the layout of a node, it should wrap that node in a Group.
+ * </p>
+ */
 package javafx.scene.layout;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/package-info.java
@@ -24,161 +24,160 @@
  */
 
 /**
-
-<p>Provides the core set of base
-classes for the JavaFX Scene Graph API. A scene graph is a tree-like
-data structure, where each item in the tree has zero or one parent and
-zero or more children.</p>
-
-<p>The two primary classes in this package are:</p>
-
-<ul>
-
-<li>{@link javafx.scene.Scene Scene} &ndash; Defines the scene to be rendered. It
-contains a {@code fill} variable that specifies the background of
-the scene, {@code width} and {@code height} variables that
-specify the size of the scene, and a {@code content} sequence
-that contains a list of "root" {@code Nodes} to be rendered onto
-the scene. This sequence of {@code Nodes} is the scene graph for
-this {@code Scene}.
-A {@code Scene} is rendered onto a {@link javafx.stage.Stage}, which is the
-top-level container for JavaFX content.</li>
-
-<li>{@link javafx.scene.Node Node} &ndash; Abstract base class for all nodes in the
-scene graph. Each node is either a "leaf" node with no child nodes or
-a "branch" node with zero or more child nodes. Each node in the tree
-has zero or one parent. Only a single node within each tree in the
-scene graph will have no parent, which is often referred to as the
-"root" node.
-There may be several trees in the scene graph. Some trees may be part of
-a {@link javafx.scene.Scene Scene}, in which case they are eligible to be displayed.
-Other trees might not be part of any {@link javafx.scene.Scene Scene}.</li>
-
-</ul>
-
-<p>Branch nodes are of type {@link javafx.scene.Parent Parent} or
-subclasses thereof.</p>
-
-<p>Leaf nodes are classes such as
-{@link javafx.scene.shape.Rectangle}, {@link javafx.scene.text.Text},
-{@link javafx.scene.image.ImageView}, {@link javafx.scene.media.MediaView},
-or other such leaf classes which cannot have children.
-
-<p>A node may occur at most once anywhere in the scene
-graph. Specifically, a node must appear no more than once in the children
-list of a {@link javafx.scene.Parent Parent} or as the clip of a
-{@link javafx.scene.Node Node}.
-See the {@link javafx.scene.Node Node} class for more details on these restrictions.</p>
-
-<h2>Example</h2>
-
-<p>An example JavaFX scene graph is as follows:</p>
-
-<pre>
-package example;
-
-import javafx.application.Application;
-import javafx.stage.Stage;
-import javafx.scene.Scene;
-import javafx.scene.Group;
-import javafx.scene.paint.Color;
-import javafx.scene.shape.Circle;
-import javafx.scene.text.Text;
-import javafx.scene.text.Font;
-
-public class Example extends Application {
-
-    &#64;Override public void start(Stage stage) {
-
-        Group root = new Group();
-        Scene scene = new Scene(root, 200, 150);
-        scene.setFill(Color.LIGHTGRAY);
-
-        Circle circle = new Circle(60, 40, 30, Color.GREEN);
-
-        Text text = new Text(10, 90, "JavaFX Scene");
-        text.setFill(Color.DARKRED);
-
-        Font font = new Font(20);
-        text.setFont(font);
-
-        root.getChildren().add(circle);
-        root.getChildren().add(text);
-        stage.setScene(scene);
-        stage.show();
-    }
-
-    public static void main(String[] args) {
-        Application.launch(args);
-    }
-}
-</pre>
-
-<p>The above example will generate the following image:</p>
-
-<p><img src="doc-files/Scene1.png" alt="A visual rendering of the JavaFX Scene example"></p>
-
-<h2>Coordinate System and Transformations</h2>
-
-<p>The {@code Node} class defines a traditional computer graphics "local"
-coordinate system in which the {@code x} axis increases to the right and the
-{@code y} axis increases downwards. The concrete node classes for shapes
-provide variables for defining the geometry and location of the shape
-within this local coordinate space. For example,
-{@link javafx.scene.shape.Rectangle} provides {@code x}, {@code y},
-{@code width}, {@code height} variables while
-{@link javafx.scene.shape.Circle} provides {@code centerX}, {@code centerY},
-and {@code radius}.</p>
-
-<p>Any {@code Node} can have transformations applied to it. These include
-translation, rotation, scaling, or shearing transformations. A transformation
-will change the position, orientation, or size of the coordinate system as
-viewed from the parent of the node that has been transformed.</p>
-
-<p>See the {@link javafx.scene.Node Node} class for more information on transformations.</p>
-
-<h2>Bounding Rectangle</h2>
-
-<p>Since every {@code Node} has transformations, every Node's geometric
-bounding rectangle can be described differently depending on whether
-transformations are accounted for or not.</p>
-
-<p>Each {@code Node} has the following properties which
-specifies these bounding rectangles:</p>
-
-<ul>
-
-<li>{@code boundsInLocal} &ndash; specifies the bounds of the
-{@code Node} in untransformed local coordinates.</li>
-
-<li>{@code boundsInParent} &ndash; specifies the bounds of the
-{@code Node} after all transformations have been applied.
-It is called "boundsInParent" because the
-rectangle will be relative to the parent's coordinate system.</li>
-
-<li>{@code layoutBounds} &ndash; specifies the rectangular bounds of
-the {@code Node} that should be used as the basis for layout
-calculations, and may differ from the visual bounds of the node. For
-shapes, Text, and ImageView, the default {@code layoutBounds} includes
-only the shape geometry.</li>
-
-</ul>
-
-<p>See the {@link javafx.scene.Node Node} class for more information on bounding rectangles.</p>
-
-<h2>CSS</h2>
-<p>
-The JavaFX Scene Graph provides the facility to style nodes using
-CSS (Cascading Style Sheets).
-The {@link javafx.scene.Node Node} class contains {@code id}, {@code styleClass}, and
-{@code style} variables are used by CSS selectors to find nodes
-to which styles should be applied. The {@link javafx.scene.Scene Scene} class contains
-the {@code stylesheets} variable which is a sequence of URLs that
-reference CSS style sheets that are to be applied to the nodes within
-that scene.
-<p>
-For further information about CSS, how to apply CSS styles
-to nodes, and what properties are available for styling, see the
-<a href="doc-files/cssref.html">CSS Reference Guide</a>.
-*/
+ * <p>Provides the core set of base
+ * classes for the JavaFX Scene Graph API. A scene graph is a tree-like
+ * data structure, where each item in the tree has zero or one parent and
+ * zero or more children.</p>
+ *
+ * <p>The two primary classes in this package are:</p>
+ *
+ * <ul>
+ *
+ * <li>{@link javafx.scene.Scene Scene} &ndash; Defines the scene to be rendered. It
+ * contains a {@code fill} variable that specifies the background of
+ * the scene, {@code width} and {@code height} variables that
+ * specify the size of the scene, and a {@code content} sequence
+ * that contains a list of "root" {@code Nodes} to be rendered onto
+ * the scene. This sequence of {@code Nodes} is the scene graph for
+ * this {@code Scene}.
+ * A {@code Scene} is rendered onto a {@link javafx.stage.Stage}, which is the
+ * top-level container for JavaFX content.</li>
+ *
+ * <li>{@link javafx.scene.Node Node} &ndash; Abstract base class for all nodes in the
+ * scene graph. Each node is either a "leaf" node with no child nodes or
+ * a "branch" node with zero or more child nodes. Each node in the tree
+ * has zero or one parent. Only a single node within each tree in the
+ * scene graph will have no parent, which is often referred to as the
+ * "root" node.
+ * There may be several trees in the scene graph. Some trees may be part of
+ * a {@link javafx.scene.Scene Scene}, in which case they are eligible to be displayed.
+ * Other trees might not be part of any {@link javafx.scene.Scene Scene}.</li>
+ *
+ * </ul>
+ *
+ * <p>Branch nodes are of type {@link javafx.scene.Parent Parent} or
+ * subclasses thereof.</p>
+ *
+ * <p>Leaf nodes are classes such as
+ * {@link javafx.scene.shape.Rectangle}, {@link javafx.scene.text.Text},
+ * {@link javafx.scene.image.ImageView}, {@link javafx.scene.media.MediaView},
+ * or other such leaf classes which cannot have children.
+ *
+ * <p>A node may occur at most once anywhere in the scene
+ * graph. Specifically, a node must appear no more than once in the children
+ * list of a {@link javafx.scene.Parent Parent} or as the clip of a
+ * {@link javafx.scene.Node Node}.
+ * See the {@link javafx.scene.Node Node} class for more details on these restrictions.</p>
+ *
+ * <h2>Example</h2>
+ *
+ * <p>An example JavaFX scene graph is as follows:</p>
+ *
+ * <pre>
+ * package example;
+ *
+ * import javafx.application.Application;
+ * import javafx.stage.Stage;
+ * import javafx.scene.Scene;
+ * import javafx.scene.Group;
+ * import javafx.scene.paint.Color;
+ * import javafx.scene.shape.Circle;
+ * import javafx.scene.text.Text;
+ * import javafx.scene.text.Font;
+ *
+ * public class Example extends Application {
+ *
+ *     &#64;Override public void start(Stage stage) {
+ *
+ *         Group root = new Group();
+ *         Scene scene = new Scene(root, 200, 150);
+ *         scene.setFill(Color.LIGHTGRAY);
+ *
+ *         Circle circle = new Circle(60, 40, 30, Color.GREEN);
+ *
+ *         Text text = new Text(10, 90, "JavaFX Scene");
+ *         text.setFill(Color.DARKRED);
+ *
+ *         Font font = new Font(20);
+ *         text.setFont(font);
+ *
+ *         root.getChildren().add(circle);
+ *         root.getChildren().add(text);
+ *         stage.setScene(scene);
+ *         stage.show();
+ *     }
+ *
+ *     public static void main(String[] args) {
+ *         Application.launch(args);
+ *     }
+ * }
+ * </pre>
+ *
+ * <p>The above example will generate the following image:</p>
+ *
+ * <p><img src="doc-files/Scene1.png" alt="A visual rendering of the JavaFX Scene example"></p>
+ *
+ * <h2>Coordinate System and Transformations</h2>
+ *
+ * <p>The {@code Node} class defines a traditional computer graphics "local"
+ * coordinate system in which the {@code x} axis increases to the right and the
+ * {@code y} axis increases downwards. The concrete node classes for shapes
+ * provide variables for defining the geometry and location of the shape
+ * within this local coordinate space. For example,
+ * {@link javafx.scene.shape.Rectangle} provides {@code x}, {@code y},
+ * {@code width}, {@code height} variables while
+ * {@link javafx.scene.shape.Circle} provides {@code centerX}, {@code centerY},
+ * and {@code radius}.</p>
+ *
+ * <p>Any {@code Node} can have transformations applied to it. These include
+ * translation, rotation, scaling, or shearing transformations. A transformation
+ * will change the position, orientation, or size of the coordinate system as
+ * viewed from the parent of the node that has been transformed.</p>
+ *
+ * <p>See the {@link javafx.scene.Node Node} class for more information on transformations.</p>
+ *
+ * <h2>Bounding Rectangle</h2>
+ *
+ * <p>Since every {@code Node} has transformations, every Node's geometric
+ * bounding rectangle can be described differently depending on whether
+ * transformations are accounted for or not.</p>
+ *
+ * <p>Each {@code Node} has the following properties which
+ * specifies these bounding rectangles:</p>
+ *
+ * <ul>
+ *
+ * <li>{@code boundsInLocal} &ndash; specifies the bounds of the
+ * {@code Node} in untransformed local coordinates.</li>
+ *
+ * <li>{@code boundsInParent} &ndash; specifies the bounds of the
+ * {@code Node} after all transformations have been applied.
+ * It is called "boundsInParent" because the
+ * rectangle will be relative to the parent's coordinate system.</li>
+ *
+ * <li>{@code layoutBounds} &ndash; specifies the rectangular bounds of
+ * the {@code Node} that should be used as the basis for layout
+ * calculations, and may differ from the visual bounds of the node. For
+ * shapes, Text, and ImageView, the default {@code layoutBounds} includes
+ * only the shape geometry.</li>
+ *
+ * </ul>
+ *
+ * <p>See the {@link javafx.scene.Node Node} class for more information on bounding rectangles.</p>
+ *
+ * <h2>CSS</h2>
+ * <p>
+ * The JavaFX Scene Graph provides the facility to style nodes using
+ * CSS (Cascading Style Sheets).
+ * The {@link javafx.scene.Node Node} class contains {@code id}, {@code styleClass}, and
+ * {@code style} variables are used by CSS selectors to find nodes
+ * to which styles should be applied. The {@link javafx.scene.Scene Scene} class contains
+ * the {@code stylesheets} variable which is a sequence of URLs that
+ * reference CSS style sheets that are to be applied to the nodes within
+ * that scene.
+ * <p>
+ * For further information about CSS, how to apply CSS styles
+ * to nodes, and what properties are available for styling, see the
+ * <a href="doc-files/cssref.html">CSS Reference Guide</a>.
+ */
 package javafx.scene;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/paint/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/paint/package-info.java
@@ -24,7 +24,7 @@
  */
 
 /**
-<p>Provides the set of classes for colors and gradients used to fill shapes and
-backgrounds when rendering the scene graph. </p>
-*/
+ * <p>Provides the set of classes for colors and gradients used to fill shapes and
+ * backgrounds when rendering the scene graph. </p>
+ */
 package javafx.scene.paint;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/robot/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/robot/package-info.java
@@ -24,6 +24,6 @@
  */
 
 /**
-<p>Provides API for simulating user interaction such as typing keys on the keyboard and using the mouse. </p>
-*/
+ * <p>Provides API for simulating user interaction such as typing keys on the keyboard and using the mouse. </p>
+ */
 package javafx.scene.robot;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/shape/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/shape/package-info.java
@@ -24,7 +24,7 @@
  */
 
 /**
-<p>Provides the set of 2D classes for defining and performing operations on
-objects related to two-dimensional geometry.</p>
-*/
+ * <p>Provides the set of 2D classes for defining and performing operations on
+ * objects related to two-dimensional geometry.</p>
+ */
 package javafx.scene.shape;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/text/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/text/package-info.java
@@ -24,6 +24,6 @@
  */
 
 /**
-<p>Provides the set of classes for fonts and renderable Text Node.</p>
-*/
+ * <p>Provides the set of classes for fonts and renderable Text Node.</p>
+ */
 package javafx.scene.text;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/transform/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/transform/package-info.java
@@ -24,7 +24,7 @@
  */
 
 /**
-<p>Provides the set of convenient classes to perform rotating, scaling,
-shearing, and translation transformations for {@code Affine} objects.</p>
-*/
+ * <p>Provides the set of convenient classes to perform rotating, scaling,
+ * shearing, and translation transformations for {@code Affine} objects.</p>
+ */
 package javafx.scene.transform;

--- a/modules/javafx.graphics/src/main/java/javafx/stage/package-info.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/package-info.java
@@ -24,6 +24,6 @@
  */
 
 /**
-<p>Provides the top-level container classes for JavaFX content.</p>
-*/
+ * <p>Provides the top-level container classes for JavaFX content.</p>
+ */
 package javafx.stage;

--- a/modules/javafx.media/src/main/java/javafx/scene/media/package-info.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/package-info.java
@@ -24,277 +24,276 @@
  */
 
 /**
-<p>Provides the set of classes for integrating audio and video into Java FX
-Applications. The primary use for this package is media playback. There are
-three principal classes in the media package:
-{@link javafx.scene.media.Media Media},
-{@link javafx.scene.media.MediaPlayer MediaPlayer}, and
-{@link javafx.scene.media.MediaView MediaView}.
-</p>
-<h2>Contents</h2>
-<ol>
-<li><a href="#SupportedMediaTypes">Supported Media Types</a></li>
-<li><a href="#SupportedProtocols">Supported Protocols</a></li>
-<li><a href="#SupportedMetadataTags">Supported Metadata Tags</a></li>
-<li><a href="#PlayingMediaInJavaFX">Playing Media in Java FX</a></li>
-</ol>
-
-<a id="SupportedMediaTypes"></a>
-<h3>Supported Media Types</h3>
-
-Java FX supports a number of different media types. A media type is considered to
-be the combination of a container format and one or more encodings. In some
-cases the container format might simply be an elementary stream containing the
-encoded data.
-
-<h4>Supported Encoding Types</h4>
-
-<p>
-An encoding type specifies how sampled audio or video data are stored. Usually
-the encoding type implies a particular compression algorithm. The following
-table indicates the encoding types supported by Java FX Media.
-</p>
-
-<table border="1">
-<caption>Media Encoding Table</caption>
-<tr><th scope="col">Encoding</th><th scope="col">Type</th><th scope="col">Description</th></tr>
-<tr><th scope="row">AAC</th><td>Audio</td><td>Advanced Audio Coding audio compression</td></tr>
-<tr><th scope="row">MP3</th><td>Audio</td>
-<td>Raw MPEG-1, 2, and 2.5 audio; layers I, II, and III; all supported
-combinations of sampling frequencies and bit rates. Note: File must contain at least 3 MP3 frames.</td>
-</tr>
-<tr><th scope="row">PCM</th><td>Audio</td><td>Uncompressed, raw audio samples</td></tr>
-<tr><th scope="row">H.264/AVC</th><td>Video</td><td>H.264/MPEG-4 Part 10 / AVC (Advanced Video Coding)
-video compression</td></tr>
-<tr><th scope="row">H.265/HEVC</th><td>Video</td><td>H.265/MPEG-H Part 2 / HEVC (High Efficiency Video Coding)
-video compression</td></tr>
-</table>
-
-<h4>Supported Container Types</h4>
-
-<p>
-A container type specifies the file format used to store the encoded audio,
-video, and other media data. Each container type is associated with one or more
-MIME types, file extensions, and file signatures (the initial bytes in the file).
-The following table indicates the combination of container and encoding types
-supported by Java FX Media.
-</p>
-
-<table border="1">
-<caption>Media Container / Encoding Types Table</caption>
-<tr><th scope="col">Container</th><th scope="col">Description</th><th scope="col">Video Encoding</th>
-<th scope="col">Audio Encoding</th><th scope="col">MIME Type</th><th scope="col">File Extension</th></tr>
-<tr><th scope="row">AIFF</th><td>Audio Interchange File Format</td><td>N/A</td>
-    <td>PCM</td><td>audio/x-aiff</td><td>.aif, .aiff</td></tr>
-<tr><th scope="row">HLS (*)</th><td>MP2T HTTP Live Streaming (audiovisual)</td><td>H.264/AVC</td>
-    <td>AAC</td><td>application/vnd.apple.mpegurl, audio/mpegurl</td><td>.m3u8</td></tr>
-<tr><th scope="row">HLS (*)</th><td>MP3 HTTP Live Streaming (audio-only)</td><td>N/A</td>
-    <td>MP3</td><td>application/vnd.apple.mpegurl, audio/mpegurl</td><td>.m3u8</td></tr>
-<tr><th scope="row">HLS (*)</th><td>fMP4 HTTP Live Streaming (audiovisual)</td><td>H.264/AVC</td>
-    <td>AAC</td><td>application/vnd.apple.mpegurl, audio/mpegurl</td><td>.m3u8</td></tr>
-<tr><th scope="row">HLS (*)</th><td>fMP4 HTTP Live Streaming (audiovisual)</td><td>H.265/HEVC</td>
-    <td>AAC</td><td>application/vnd.apple.mpegurl, audio/mpegurl</td><td>.m3u8</td></tr>
-<tr><th scope="row">HLS (*)</th><td>fMP4 HTTP Live Streaming (audio-only)</td><td>N/A</td>
-    <td>AAC</td><td>application/vnd.apple.mpegurl, audio/mpegurl</td><td>.m3u8</td></tr>
-<tr><th scope="row">HLS (*)</th><td>AAC HTTP Live Streaming (audio-only)</td><td>N/A</td>
-    <td>AAC</td><td>application/vnd.apple.mpegurl, audio/mpegurl</td><td>.m3u8</td></tr>
-<tr><th scope="row">MP3</th><td>MPEG-1, 2, 2.5 raw audio stream possibly with ID3 metadata v2.3 or v2.4</td>
-    <td>N/A</td><td>MP3</td><td>audio/mpeg</td><td>.mp3</td></tr>
-<tr><th scope="row">MP4</th><td>MPEG-4 Part 14</td><td>H.264/AVC</td>
-    <td>AAC</td><td>video/mp4, audio/x-m4a, video/x-m4v</td><td>.mp4, .m4a, .m4v</td></tr>
-<tr><th scope="row">MP4</th><td>MPEG-4 Part 14</td><td>H.265/HEVC</td>
-    <td>AAC</td><td>video/mp4, audio/x-m4a, video/x-m4v</td><td>.mp4, .m4a, .m4v</td></tr>
-<tr><th scope="row">WAV</th><td>Waveform Audio Format</td><td>N/A</td>
-    <td>PCM</td><td>audio/x-wav</td><td>.wav</td></tr>
-</table>
-
-<br>(*) HLS is a protocol rather than a container type but is included here to
-aggregate similar attributes.
-
-<a id="SupportedProtocols"></a>
-<h3>Supported Protocols</h3>
-
-<table border="1">
-<caption>Supported Protocols Table</caption>
-<tr><th scope="col">Protocol</th><th scope="col">Description</th><th scope="col">Reference</th></tr>
-<tr>
-    <th scope="row">FILE</th>
-    <td>Protocol for URI representation of local files</td>
-    <td><a href="https://docs.oracle.com/javase/8/docs/api/java/net/URI.html">java.net.URI</a></td>
-</tr>
-<tr>
-    <th scope="row">HTTP</th>
-    <td>Hypertext transfer protocol for representation of remote files</td>
-    <td><a href="https://docs.oracle.com/javase/8/docs/api/java/net/URI.html">java.net.URI</a></td>
-</tr>
-<tr>
-    <th scope="row">HTTPS</th>
-    <td>Hypertext transfer protocol secure for representation of remote files</td>
-    <td><a href="https://docs.oracle.com/javase/8/docs/api/java/net/URI.html">java.net.URI</a></td>
-</tr>
-<tr>
-    <th scope="row">JAR</th>
-    <td>Representation of media entries in files accessible via the FILE, HTTP or HTTPS protocols</td>
-    <td><a href="https://docs.oracle.com/javase/8/docs/api/java/net/JarURLConnection.html">java.net.JarURLConnection</a></td>
-</tr>
-<tr>
-    <th scope="row">HTTP Live Streaming (HLS)</th>
-    <td>Playlist-based media streaming via HTTP or HTTPS</td>
-    <td><a href="http://tools.ietf.org/html/draft-pantos-http-live-streaming">Internet-Draft: HTTP Live Streaming</a></td>
-</tr>
-</table>
-<br>
-<h4>MPEG-4 Playback via HTTP</h4>
-<p>
-It is recommended that MPEG-4 media to be played over HTTP or HTTPS be formatted such that the
-headers required to decode the stream appear at the beginning of the file. Otherwise,
-playback might stall until the entire file is downloaded.
-</p>
-<h4>HTTP Live Streaming (HLS)</h4>
-<p>
-HLS playback handles sources with these characteristics:
-</p>
-<ul>
-    <li>On-demand and live playlists.</li>
-    <li>Elementary MP3 audio streams (audio/mpegurl) and multiplexed MP2T streams
-        (application/vnd.apple.mpegurl) with one AAC audio and one H.264/AVC video track.</li>
-    <li>Playlists with integer or float duration.</li>
-</ul>
-<p>
-Sources which do not conform to this basic profile are not guaranteed to be handled.
-The playlist contains information about the streams comprising the source and is
-downloaded at the start of playback. Switching between alternate streams, bit rates,
-and video resolutions is handled automatically as a function of network conditions.
-</p>
-
-<a id="SupportedMetadataTags"></a>
-<h3>Supported Metadata Tags</h3>
-
-A media container may also include certain metadata which describe the media in
-the file. The Java FX Media API makes the metadata available via the
-{@link javafx.scene.media.Media#getMetadata()} method. The keys in this mapping
-are referred to as <i>tags</i> with the tags supported by Java FX Media listed in
-the following table. Note that which tags are available for a given media source
-depend on the metadata actually stored in that source, i.e., not all tags are
-guaranteed to be available.
-
-<table border="1">
-<caption>"Metadata Keys and Tags Table</caption>
-<tr><th scope="col"> Container </th><th scope="col"> Tag (type String) </th><th scope="col"> Type </th><th scope="col"> Description </th></tr>
-<tr><td> MP3 </td><th scope="row"> raw&nbsp;metadata </th><td> Map&lt;String,ByteBuffer&gt; </td><td>The raw metadata according to the appropriate media specification. The key "ID3" maps to MP3 ID3v2 metadata.</td></tr>
-<tr><td> MP3 </td><th scope="row"> album&nbsp;artist </th><td> java.lang.String </td><td>The artist for the overall album, possibly "Various Artists" for compilations.</td></tr>
-<tr><td> MP3 </td><th scope="row"> album </th><td> java.lang.String </td><td>The name of the album.</td></tr>
-<tr><td> MP3 </td><th scope="row"> artist </th><td> java.lang.String </td><td>The artist of the track.</td></tr>
-<tr><td> MP3 </td><th scope="row"> comment-N </th><td> java.lang.String </td><td>A comment where N is a 0-relative index. Comment format: ContentDescription[lng]=Comment </td></tr>
-<tr><td> MP3 </td><th scope="row"> composer </th><td> java.lang.String </td><td>The composer of the track.</td></tr>
-<tr><td> MP3 </td><th scope="row"> year </th><td> java.lang.Integer </td><td>The year the track was recorded.</td></tr>
-<tr><td> MP3 </td><th scope="row"> disc&nbsp;count </th><td> java.lang.Integer </td><td>The number of discs in the album.</td></tr>
-<tr><td> MP3 </td><th scope="row"> disc&nbsp;number </th><td> java.lang.Integer </td><td>The 1-relative index of the disc on which this track appears.</td></tr>
-<tr><td> MP3 </td><th scope="row"> duration </th><td> javafx.util.Duration </td><td>The duration of the track.</td></tr>
-<tr><td> MP3 </td><th scope="row"> genre </th><td> java.lang.String </td><td>The genre of the track, for example, "Classical," "Darkwave," or "Jazz."</td></tr>
-<tr><td> MP3 </td><th scope="row"> image </th><td> javafx.scene.image.Image </td><td>The album cover.</td></tr>
-<tr><td> MP3 </td><th scope="row"> title </th><td> java.lang.String </td><td>The name of the track.</td></tr>
-<tr><td> MP3 </td><th scope="row"> track&nbsp;count </th><td> java.lang.Integer </td><td>The number of tracks on the album.</td></tr>
-<tr><td> MP3 </td><th scope="row"> track&nbsp;number </th><td> java.lang.Integer </td><td>The 1-relative index of this track on the disc.</td></tr>
-</table>
-
-<a id="PlayingMediaInJavaFX"></a>
-<h3>Playing Media in Java FX</h3>
-<h4>Basic Playback</h4>
-<p>
-The basic steps required to play media in Java FX are:
-</p>
-<ol>
-    <li>Create a {@link javafx.scene.media.Media} object for the desired media source.</li>
-    <li>Create a {@link javafx.scene.media.MediaPlayer} object from the <code>Media</code> object.</li>
-    <li>Create a {@link javafx.scene.media.MediaView} object.</li>
-    <li>Add the <code>MediaPlayer</code> to the <code>MediaView</code>.</li>
-    <li>Add the <code>MediaView</code> to the scene graph.</li>
-    <li>Invoke {@link javafx.scene.media.MediaPlayer#play()}.</li>
-</ol>
-The foregoing steps are illustrated by the sample code in the <code>MediaView</code>
-class documentation. Some things which should be noted are:
-<ul>
-    <li>One <code>Media</code> object may be shared among multiple <code>MediaPlayer</code>s.
-    <li>One <code>MediaPlayer</code> may be shared amoung multiple <code>MediaView</code>s.
-    <li>Media may be played directly by a <code>MediaPlayer</code>
-        without creating a <code>MediaView</code> although a view is required for display.</li>
-    <li>Instead of <code>MediaPlayer.play()</code>,
-        {@link javafx.scene.media.MediaPlayer#setAutoPlay MediaPlayer.setAutoPlay(true)}
-        may be used to request that playing start as soon as possible.</li>
-    <li><code>MediaPlayer</code> has several operational states defined by
-        {@link javafx.scene.media.MediaPlayer.Status}.
-    <li>Audio-only media may instead be played using {@link javafx.scene.media.AudioClip}
-        (recommended for low latency playback of short clips).</li>
-</ul>
-<h4>Error Handling</h4>
-<p>
-Errors using Java FX Media may be either synchronous or asynchronous. In general
-synchronous errors will manifest themselves as a Java <code>Exception</code> and
-asynchronous errors will cause a Java FX property to be set. In the latter case
-either the <code>error</code> property may be observed directly, an
-<code>onError</code> callback registered, or possibly both.</p>
-
-<p>The main sources of synchronous errors are
-{@link javafx.scene.media.Media#Media Media()} and
-{@link javafx.scene.media.MediaPlayer#MediaPlayer MediaPlayer()}.
-The asynchronous error properties are
-{@link javafx.scene.media.Media#errorProperty Media.error} and
-{@link javafx.scene.media.MediaPlayer#errorProperty MediaPlayer.error}, and the
-asynchronous error callbacks
-{@link javafx.scene.media.Media#onErrorProperty Media.onError},
-{@link javafx.scene.media.MediaPlayer#onErrorProperty MediaPlayer.onError}, and
-{@link javafx.scene.media.MediaView#onErrorProperty MediaView.onError}.</p>
-
-<p>
-Some errors might be duplicated. For example, a <code>MediaPlayer</code> will
-propagate an error that it encounters to its associated <code>Media</code>, and
-a <code>MediaPlayer</code> to all its associated <code>MediaView</code>s. As a
-consequence, it is possible to receive multiple notifications of the occurrence
-of a given error, depending on which properties are monitored.
-</p>
-
-<p>The following code snippet illustrates error handling with media:</p>
-<pre>{@code
-    String source;
-    Media media;
-    MediaPlayer mediaPlayer;
-    MediaView mediaView;
-    try {
-        media = new Media(source);
-        if (media.getError() == null) {
-            media.setOnError(new Runnable() {
-                public void run() {
-                    // Handle asynchronous error in Media object.
-                }
-            });
-            try {
-                mediaPlayer = new MediaPlayer(media);
-                if (mediaPlayer.getError() == null) {
-                    mediaPlayer.setOnError(new Runnable() {
-                        public void run() {
-                            // Handle asynchronous error in MediaPlayer object.
-                        }
-                    });
-                    mediaView = new MediaView(mediaPlayer);
-                    mediaView.setOnError(new EventHandler<MediaErrorEvent>() {
-                        public void handle(MediaErrorEvent t) {
-                            // Handle asynchronous error in MediaView.
-                        }
-                    });
-                } else {
-                    // Handle synchronous error creating MediaPlayer.
-                }
-            } catch (Exception mediaPlayerException) {
-                // Handle exception in MediaPlayer constructor.
-            }
-        } else {
-            // Handle synchronous error creating Media.
-        }
-    } catch (Exception mediaException) {
-        // Handle exception in Media constructor.
-    }
-}</pre>
-
-*/
+ * <p>Provides the set of classes for integrating audio and video into Java FX
+ * Applications. The primary use for this package is media playback. There are
+ * three principal classes in the media package:
+ * {@link javafx.scene.media.Media Media},
+ * {@link javafx.scene.media.MediaPlayer MediaPlayer}, and
+ * {@link javafx.scene.media.MediaView MediaView}.
+ * </p>
+ * <h2>Contents</h2>
+ * <ol>
+ * <li><a href="#SupportedMediaTypes">Supported Media Types</a></li>
+ * <li><a href="#SupportedProtocols">Supported Protocols</a></li>
+ * <li><a href="#SupportedMetadataTags">Supported Metadata Tags</a></li>
+ * <li><a href="#PlayingMediaInJavaFX">Playing Media in Java FX</a></li>
+ * </ol>
+ *
+ * <a id="SupportedMediaTypes"></a>
+ * <h3>Supported Media Types</h3>
+ *
+ * Java FX supports a number of different media types. A media type is considered to
+ * be the combination of a container format and one or more encodings. In some
+ * cases the container format might simply be an elementary stream containing the
+ * encoded data.
+ *
+ * <h4>Supported Encoding Types</h4>
+ *
+ * <p>
+ * An encoding type specifies how sampled audio or video data are stored. Usually
+ * the encoding type implies a particular compression algorithm. The following
+ * table indicates the encoding types supported by Java FX Media.
+ * </p>
+ *
+ * <table border="1">
+ * <caption>Media Encoding Table</caption>
+ * <tr><th scope="col">Encoding</th><th scope="col">Type</th><th scope="col">Description</th></tr>
+ * <tr><th scope="row">AAC</th><td>Audio</td><td>Advanced Audio Coding audio compression</td></tr>
+ * <tr><th scope="row">MP3</th><td>Audio</td>
+ * <td>Raw MPEG-1, 2, and 2.5 audio; layers I, II, and III; all supported
+ * combinations of sampling frequencies and bit rates. Note: File must contain at least 3 MP3 frames.</td>
+ * </tr>
+ * <tr><th scope="row">PCM</th><td>Audio</td><td>Uncompressed, raw audio samples</td></tr>
+ * <tr><th scope="row">H.264/AVC</th><td>Video</td><td>H.264/MPEG-4 Part 10 / AVC (Advanced Video Coding)
+ * video compression</td></tr>
+ * <tr><th scope="row">H.265/HEVC</th><td>Video</td><td>H.265/MPEG-H Part 2 / HEVC (High Efficiency Video Coding)
+ * video compression</td></tr>
+ * </table>
+ *
+ * <h4>Supported Container Types</h4>
+ *
+ * <p>
+ * A container type specifies the file format used to store the encoded audio,
+ * video, and other media data. Each container type is associated with one or more
+ * MIME types, file extensions, and file signatures (the initial bytes in the file).
+ * The following table indicates the combination of container and encoding types
+ * supported by Java FX Media.
+ * </p>
+ *
+ * <table border="1">
+ * <caption>Media Container / Encoding Types Table</caption>
+ * <tr><th scope="col">Container</th><th scope="col">Description</th><th scope="col">Video Encoding</th>
+ * <th scope="col">Audio Encoding</th><th scope="col">MIME Type</th><th scope="col">File Extension</th></tr>
+ * <tr><th scope="row">AIFF</th><td>Audio Interchange File Format</td><td>N/A</td>
+ *     <td>PCM</td><td>audio/x-aiff</td><td>.aif, .aiff</td></tr>
+ * <tr><th scope="row">HLS (*)</th><td>MP2T HTTP Live Streaming (audiovisual)</td><td>H.264/AVC</td>
+ *     <td>AAC</td><td>application/vnd.apple.mpegurl, audio/mpegurl</td><td>.m3u8</td></tr>
+ * <tr><th scope="row">HLS (*)</th><td>MP3 HTTP Live Streaming (audio-only)</td><td>N/A</td>
+ *     <td>MP3</td><td>application/vnd.apple.mpegurl, audio/mpegurl</td><td>.m3u8</td></tr>
+ * <tr><th scope="row">HLS (*)</th><td>fMP4 HTTP Live Streaming (audiovisual)</td><td>H.264/AVC</td>
+ *     <td>AAC</td><td>application/vnd.apple.mpegurl, audio/mpegurl</td><td>.m3u8</td></tr>
+ * <tr><th scope="row">HLS (*)</th><td>fMP4 HTTP Live Streaming (audiovisual)</td><td>H.265/HEVC</td>
+ *     <td>AAC</td><td>application/vnd.apple.mpegurl, audio/mpegurl</td><td>.m3u8</td></tr>
+ * <tr><th scope="row">HLS (*)</th><td>fMP4 HTTP Live Streaming (audio-only)</td><td>N/A</td>
+ *     <td>AAC</td><td>application/vnd.apple.mpegurl, audio/mpegurl</td><td>.m3u8</td></tr>
+ * <tr><th scope="row">HLS (*)</th><td>AAC HTTP Live Streaming (audio-only)</td><td>N/A</td>
+ *     <td>AAC</td><td>application/vnd.apple.mpegurl, audio/mpegurl</td><td>.m3u8</td></tr>
+ * <tr><th scope="row">MP3</th><td>MPEG-1, 2, 2.5 raw audio stream possibly with ID3 metadata v2.3 or v2.4</td>
+ *     <td>N/A</td><td>MP3</td><td>audio/mpeg</td><td>.mp3</td></tr>
+ * <tr><th scope="row">MP4</th><td>MPEG-4 Part 14</td><td>H.264/AVC</td>
+ *     <td>AAC</td><td>video/mp4, audio/x-m4a, video/x-m4v</td><td>.mp4, .m4a, .m4v</td></tr>
+ * <tr><th scope="row">MP4</th><td>MPEG-4 Part 14</td><td>H.265/HEVC</td>
+ *     <td>AAC</td><td>video/mp4, audio/x-m4a, video/x-m4v</td><td>.mp4, .m4a, .m4v</td></tr>
+ * <tr><th scope="row">WAV</th><td>Waveform Audio Format</td><td>N/A</td>
+ *     <td>PCM</td><td>audio/x-wav</td><td>.wav</td></tr>
+ * </table>
+ *
+ * <br>(*) HLS is a protocol rather than a container type but is included here to
+ * aggregate similar attributes.
+ *
+ * <a id="SupportedProtocols"></a>
+ * <h3>Supported Protocols</h3>
+ *
+ * <table border="1">
+ * <caption>Supported Protocols Table</caption>
+ * <tr><th scope="col">Protocol</th><th scope="col">Description</th><th scope="col">Reference</th></tr>
+ * <tr>
+ *     <th scope="row">FILE</th>
+ *     <td>Protocol for URI representation of local files</td>
+ *     <td><a href="https://docs.oracle.com/javase/8/docs/api/java/net/URI.html">java.net.URI</a></td>
+ * </tr>
+ * <tr>
+ *     <th scope="row">HTTP</th>
+ *     <td>Hypertext transfer protocol for representation of remote files</td>
+ *     <td><a href="https://docs.oracle.com/javase/8/docs/api/java/net/URI.html">java.net.URI</a></td>
+ * </tr>
+ * <tr>
+ *     <th scope="row">HTTPS</th>
+ *     <td>Hypertext transfer protocol secure for representation of remote files</td>
+ *     <td><a href="https://docs.oracle.com/javase/8/docs/api/java/net/URI.html">java.net.URI</a></td>
+ * </tr>
+ * <tr>
+ *     <th scope="row">JAR</th>
+ *     <td>Representation of media entries in files accessible via the FILE, HTTP or HTTPS protocols</td>
+ *     <td><a href="https://docs.oracle.com/javase/8/docs/api/java/net/JarURLConnection.html">java.net.JarURLConnection</a></td>
+ * </tr>
+ * <tr>
+ *     <th scope="row">HTTP Live Streaming (HLS)</th>
+ *     <td>Playlist-based media streaming via HTTP or HTTPS</td>
+ *     <td><a href="http://tools.ietf.org/html/draft-pantos-http-live-streaming">Internet-Draft: HTTP Live Streaming</a></td>
+ * </tr>
+ * </table>
+ * <br>
+ * <h4>MPEG-4 Playback via HTTP</h4>
+ * <p>
+ * It is recommended that MPEG-4 media to be played over HTTP or HTTPS be formatted such that the
+ * headers required to decode the stream appear at the beginning of the file. Otherwise,
+ * playback might stall until the entire file is downloaded.
+ * </p>
+ * <h4>HTTP Live Streaming (HLS)</h4>
+ * <p>
+ * HLS playback handles sources with these characteristics:
+ * </p>
+ * <ul>
+ *     <li>On-demand and live playlists.</li>
+ *     <li>Elementary MP3 audio streams (audio/mpegurl) and multiplexed MP2T streams
+ *         (application/vnd.apple.mpegurl) with one AAC audio and one H.264/AVC video track.</li>
+ *     <li>Playlists with integer or float duration.</li>
+ * </ul>
+ * <p>
+ * Sources which do not conform to this basic profile are not guaranteed to be handled.
+ * The playlist contains information about the streams comprising the source and is
+ * downloaded at the start of playback. Switching between alternate streams, bit rates,
+ * and video resolutions is handled automatically as a function of network conditions.
+ * </p>
+ *
+ * <a id="SupportedMetadataTags"></a>
+ * <h3>Supported Metadata Tags</h3>
+ *
+ * A media container may also include certain metadata which describe the media in
+ * the file. The Java FX Media API makes the metadata available via the
+ * {@link javafx.scene.media.Media#getMetadata()} method. The keys in this mapping
+ * are referred to as <i>tags</i> with the tags supported by Java FX Media listed in
+ * the following table. Note that which tags are available for a given media source
+ * depend on the metadata actually stored in that source, i.e., not all tags are
+ * guaranteed to be available.
+ *
+ * <table border="1">
+ * <caption>"Metadata Keys and Tags Table</caption>
+ * <tr><th scope="col"> Container </th><th scope="col"> Tag (type String) </th><th scope="col"> Type </th><th scope="col"> Description </th></tr>
+ * <tr><td> MP3 </td><th scope="row"> raw&nbsp;metadata </th><td> Map&lt;String,ByteBuffer&gt; </td><td>The raw metadata according to the appropriate media specification. The key "ID3" maps to MP3 ID3v2 metadata.</td></tr>
+ * <tr><td> MP3 </td><th scope="row"> album&nbsp;artist </th><td> java.lang.String </td><td>The artist for the overall album, possibly "Various Artists" for compilations.</td></tr>
+ * <tr><td> MP3 </td><th scope="row"> album </th><td> java.lang.String </td><td>The name of the album.</td></tr>
+ * <tr><td> MP3 </td><th scope="row"> artist </th><td> java.lang.String </td><td>The artist of the track.</td></tr>
+ * <tr><td> MP3 </td><th scope="row"> comment-N </th><td> java.lang.String </td><td>A comment where N is a 0-relative index. Comment format: ContentDescription[lng]=Comment </td></tr>
+ * <tr><td> MP3 </td><th scope="row"> composer </th><td> java.lang.String </td><td>The composer of the track.</td></tr>
+ * <tr><td> MP3 </td><th scope="row"> year </th><td> java.lang.Integer </td><td>The year the track was recorded.</td></tr>
+ * <tr><td> MP3 </td><th scope="row"> disc&nbsp;count </th><td> java.lang.Integer </td><td>The number of discs in the album.</td></tr>
+ * <tr><td> MP3 </td><th scope="row"> disc&nbsp;number </th><td> java.lang.Integer </td><td>The 1-relative index of the disc on which this track appears.</td></tr>
+ * <tr><td> MP3 </td><th scope="row"> duration </th><td> javafx.util.Duration </td><td>The duration of the track.</td></tr>
+ * <tr><td> MP3 </td><th scope="row"> genre </th><td> java.lang.String </td><td>The genre of the track, for example, "Classical," "Darkwave," or "Jazz."</td></tr>
+ * <tr><td> MP3 </td><th scope="row"> image </th><td> javafx.scene.image.Image </td><td>The album cover.</td></tr>
+ * <tr><td> MP3 </td><th scope="row"> title </th><td> java.lang.String </td><td>The name of the track.</td></tr>
+ * <tr><td> MP3 </td><th scope="row"> track&nbsp;count </th><td> java.lang.Integer </td><td>The number of tracks on the album.</td></tr>
+ * <tr><td> MP3 </td><th scope="row"> track&nbsp;number </th><td> java.lang.Integer </td><td>The 1-relative index of this track on the disc.</td></tr>
+ * </table>
+ *
+ * <a id="PlayingMediaInJavaFX"></a>
+ * <h3>Playing Media in Java FX</h3>
+ * <h4>Basic Playback</h4>
+ * <p>
+ * The basic steps required to play media in Java FX are:
+ * </p>
+ * <ol>
+ *     <li>Create a {@link javafx.scene.media.Media} object for the desired media source.</li>
+ *     <li>Create a {@link javafx.scene.media.MediaPlayer} object from the <code>Media</code> object.</li>
+ *     <li>Create a {@link javafx.scene.media.MediaView} object.</li>
+ *     <li>Add the <code>MediaPlayer</code> to the <code>MediaView</code>.</li>
+ *     <li>Add the <code>MediaView</code> to the scene graph.</li>
+ *     <li>Invoke {@link javafx.scene.media.MediaPlayer#play()}.</li>
+ * </ol>
+ * The foregoing steps are illustrated by the sample code in the <code>MediaView</code>
+ * class documentation. Some things which should be noted are:
+ * <ul>
+ *     <li>One <code>Media</code> object may be shared among multiple <code>MediaPlayer</code>s.
+ *     <li>One <code>MediaPlayer</code> may be shared amoung multiple <code>MediaView</code>s.
+ *     <li>Media may be played directly by a <code>MediaPlayer</code>
+ *         without creating a <code>MediaView</code> although a view is required for display.</li>
+ *     <li>Instead of <code>MediaPlayer.play()</code>,
+ *         {@link javafx.scene.media.MediaPlayer#setAutoPlay MediaPlayer.setAutoPlay(true)}
+ *         may be used to request that playing start as soon as possible.</li>
+ *     <li><code>MediaPlayer</code> has several operational states defined by
+ *         {@link javafx.scene.media.MediaPlayer.Status}.
+ *     <li>Audio-only media may instead be played using {@link javafx.scene.media.AudioClip}
+ *         (recommended for low latency playback of short clips).</li>
+ * </ul>
+ * <h4>Error Handling</h4>
+ * <p>
+ * Errors using Java FX Media may be either synchronous or asynchronous. In general
+ * synchronous errors will manifest themselves as a Java <code>Exception</code> and
+ * asynchronous errors will cause a Java FX property to be set. In the latter case
+ * either the <code>error</code> property may be observed directly, an
+ * <code>onError</code> callback registered, or possibly both.</p>
+ *
+ * <p>The main sources of synchronous errors are
+ * {@link javafx.scene.media.Media#Media Media()} and
+ * {@link javafx.scene.media.MediaPlayer#MediaPlayer MediaPlayer()}.
+ * The asynchronous error properties are
+ * {@link javafx.scene.media.Media#errorProperty Media.error} and
+ * {@link javafx.scene.media.MediaPlayer#errorProperty MediaPlayer.error}, and the
+ * asynchronous error callbacks
+ * {@link javafx.scene.media.Media#onErrorProperty Media.onError},
+ * {@link javafx.scene.media.MediaPlayer#onErrorProperty MediaPlayer.onError}, and
+ * {@link javafx.scene.media.MediaView#onErrorProperty MediaView.onError}.</p>
+ *
+ * <p>
+ * Some errors might be duplicated. For example, a <code>MediaPlayer</code> will
+ * propagate an error that it encounters to its associated <code>Media</code>, and
+ * a <code>MediaPlayer</code> to all its associated <code>MediaView</code>s. As a
+ * consequence, it is possible to receive multiple notifications of the occurrence
+ * of a given error, depending on which properties are monitored.
+ * </p>
+ *
+ * <p>The following code snippet illustrates error handling with media:</p>
+ * <pre>{@code
+ *     String source;
+ *     Media media;
+ *     MediaPlayer mediaPlayer;
+ *     MediaView mediaView;
+ *     try {
+ *         media = new Media(source);
+ *         if (media.getError() == null) {
+ *             media.setOnError(new Runnable() {
+ *                 public void run() {
+ *                     // Handle asynchronous error in Media object.
+ *                 }
+ *             });
+ *             try {
+ *                 mediaPlayer = new MediaPlayer(media);
+ *                 if (mediaPlayer.getError() == null) {
+ *                     mediaPlayer.setOnError(new Runnable() {
+ *                         public void run() {
+ *                             // Handle asynchronous error in MediaPlayer object.
+ *                         }
+ *                     });
+ *                     mediaView = new MediaView(mediaPlayer);
+ *                     mediaView.setOnError(new EventHandler<MediaErrorEvent>() {
+ *                         public void handle(MediaErrorEvent t) {
+ *                             // Handle asynchronous error in MediaView.
+ *                         }
+ *                     });
+ *                 } else {
+ *                     // Handle synchronous error creating MediaPlayer.
+ *                 }
+ *             } catch (Exception mediaPlayerException) {
+ *                 // Handle exception in MediaPlayer constructor.
+ *             }
+ *         } else {
+ *             // Handle synchronous error creating Media.
+ *         }
+ *     } catch (Exception mediaException) {
+ *         // Handle exception in Media constructor.
+ *     }
+ * }</pre>
+ */
 package javafx.scene.media;

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/package-info.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/package-info.java
@@ -24,23 +24,22 @@
  */
 
 /**
-<p>Defines APIs for the JavaFX / Swing interop support included with the
-   JavaFX UI toolkit, including {@link javafx.embed.swing.SwingNode} (for
-   embedding Swing inside a JavaFX application) and
-   {@link javafx.embed.swing.JFXPanel} (for embedding JavaFX inside a Swing
-   application). </p>
-<p>The {@link javafx.embed.swing.JFXPanel JFXPanel} class defines a
-   lightweight Swing component, which accepts and renders an instance of
-   {@link javafx.scene.Scene Scene} and forwards all input events from Swing
-   to the attached JavaFX scene.
-   The {@link javafx.embed.swing.SwingNode} class is used to embed
-   a Swing content into a JavaFX application.
-   The content to be displayed is specified with the {@code SwingNode.setContent} method
-   that accepts an instance of a Swing {@code JComponent}. The hierarchy of components
-   contained in the {@code JComponent} instance should not contain any heavyweight
-   components, otherwise {@code SwingNode} may fail to paint it. The content gets
-   repainted automatically. All the input and focus events are forwarded to the
-   {@code JComponent} instance.</p>
-
-*/
+ * <p>Defines APIs for the JavaFX / Swing interop support included with the
+ *    JavaFX UI toolkit, including {@link javafx.embed.swing.SwingNode} (for
+ *    embedding Swing inside a JavaFX application) and
+ *    {@link javafx.embed.swing.JFXPanel} (for embedding JavaFX inside a Swing
+ *    application). </p>
+ * <p>The {@link javafx.embed.swing.JFXPanel JFXPanel} class defines a
+ *    lightweight Swing component, which accepts and renders an instance of
+ *    {@link javafx.scene.Scene Scene} and forwards all input events from Swing
+ *    to the attached JavaFX scene.
+ *    The {@link javafx.embed.swing.SwingNode} class is used to embed
+ *    a Swing content into a JavaFX application.
+ *    The content to be displayed is specified with the {@code SwingNode.setContent} method
+ *    that accepts an instance of a Swing {@code JComponent}. The hierarchy of components
+ *    contained in the {@code JComponent} instance should not contain any heavyweight
+ *    components, otherwise {@code SwingNode} may fail to paint it. The content gets
+ *    repainted automatically. All the input and focus events are forwarded to the
+ *    {@code JComponent} instance.</p>
+ */
 package javafx.embed.swing;

--- a/modules/javafx.swt/src/main/java/javafx/embed/swt/package-info.java
+++ b/modules/javafx.swt/src/main/java/javafx/embed/swt/package-info.java
@@ -24,11 +24,11 @@
  */
 
 /**
-<p>Provides the set of classes to use JavaFX inside SWT applications.</p>
-<p>The {@link javafx.embed.swt.FXCanvas FXCanvas} class is the base class
-that provides JavaFX and SWT interoperability. This class defines an
-SWT component, which accepts and renders an instance of
-{@link javafx.scene.Scene Scene} and forwards all input events from SWT
-to the attached JavaFX scene.</p>
-*/
+ * <p>Provides the set of classes to use JavaFX inside SWT applications.</p>
+ * <p>The {@link javafx.embed.swt.FXCanvas FXCanvas} class is the base class
+ * that provides JavaFX and SWT interoperability. This class defines an
+ * SWT component, which accepts and renders an instance of
+ * {@link javafx.scene.Scene Scene} and forwards all input events from SWT
+ * to the attached JavaFX scene.</p>
+ */
 package javafx.embed.swt;

--- a/modules/javafx.web/src/main/java/javafx/scene/web/package-info.java
+++ b/modules/javafx.web/src/main/java/javafx/scene/web/package-info.java
@@ -24,30 +24,29 @@
  */
 
 /**
-<p>This package provides means for loading and displaying Web content. Its
-    functionality is implemented by two core classes:
-
-<p>{@link javafx.scene.web.WebEngine} is a non-visual component capable of
-    loading Web pages, creating DOM objects for them, and running scripts
-    inside pages.
-
-<p>{@link javafx.scene.web.WebView} is a {@link javafx.scene.Node} that
-    presents a Web page managed by a {@code WebEngine}. Each {@code WebView}
-    has a {@code WebEngine} associated with it. This association is
-    established at the time {@code WebView} is instantiated, and cannot be
-    changed later.
-
-<p>Both {@code WebEngine} and {@code WebView} should be created and
-    manipulated on FX User thread.
-
-<p>The code snippet below shows a typical usage scenario:
-
-<pre>{@code
-    WebView webView = new WebView();
-    WebEngine webEngine = webView.getEngine();
-    webEngine.load("http://javafx.com");
-    // add webView to the scene
-}</pre>
-
-*/
+ * <p>This package provides means for loading and displaying Web content. Its
+ *     functionality is implemented by two core classes:
+ *
+ * <p>{@link javafx.scene.web.WebEngine} is a non-visual component capable of
+ *     loading Web pages, creating DOM objects for them, and running scripts
+ *     inside pages.
+ *
+ * <p>{@link javafx.scene.web.WebView} is a {@link javafx.scene.Node} that
+ *     presents a Web page managed by a {@code WebEngine}. Each {@code WebView}
+ *     has a {@code WebEngine} associated with it. This association is
+ *     established at the time {@code WebView} is instantiated, and cannot be
+ *     changed later.
+ *
+ * <p>Both {@code WebEngine} and {@code WebView} should be created and
+ *     manipulated on FX User thread.
+ *
+ * <p>The code snippet below shows a typical usage scenario:
+ *
+ * <pre>{@code
+ *     WebView webView = new WebView();
+ *     WebEngine webEngine = webView.getEngine();
+ *     webEngine.load("http://javafx.com");
+ *     // add webView to the scene
+ * }</pre>
+ */
 package javafx.scene.web;


### PR DESCRIPTION
This is a follow-up fix for [JDK-8180066](https://bugs.openjdk.org/browse/JDK-8180066). As mentioned in the description of PR #1159, we should normalize the javadoc comment blocks in the `package-info.java` files, which were converted from `package.html`.

In addition to being good cleanup, it also resolves a CI test failure that was introduced by [JDK-8180066](https://bugs.openjdk.org/browse/JDK-8180066), and is being tracked by [JDK-8310654](https://bugs.openjdk.org/browse/JDK-8310654).

The generated API docs are identical before and after this fix, excluding white-space changes. So the following show zero differences:

```
$ diff -w -r before/build/javadoc after/build/javadoc
```

Additionally, the following now passes, whereas it fails without this fix:

```
$ gradle :graphics:test
```

/issue add 8310654

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8310667](https://bugs.openjdk.org/browse/JDK-8310667): Normalize comment blocks in newly-converted package-info.java files (**Bug** - P3)
 * [JDK-8310654](https://bugs.openjdk.org/browse/JDK-8310654): validateSourceSets task fails on javafx/scene/package-info.java after JDK-8180066 (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1160/head:pull/1160` \
`$ git checkout pull/1160`

Update a local copy of the PR: \
`$ git checkout pull/1160` \
`$ git pull https://git.openjdk.org/jfx.git pull/1160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1160`

View PR using the GUI difftool: \
`$ git pr show -t 1160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1160.diff">https://git.openjdk.org/jfx/pull/1160.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1160#issuecomment-1603147284)