### PR TITLE
8310847: [Mac] Silence OpenGL deprecation warnings

### DIFF
--- a/buildSrc/mac.gradle
+++ b/buildSrc/mac.gradle
@@ -188,6 +188,7 @@ MAC.glass.nativeSource = [file("${project("graphics").projectDir}/src/main/nativ
         file("${project("graphics").projectDir}/src/main/native-glass/mac/a11y")]
 MAC.glass.compiler = compiler
 MAC.glass.ccFlags = [ccFlags,
+    "-DGL_SILENCE_DEPRECATION",
     "-DMACOS_MIN_VERSION_MAJOR=$macOSMinVersionMajor",
     "-DMACOS_MIN_VERSION_MINOR=$macOSMinVersionMinor"].flatten()
 MAC.glass.linker = linker
@@ -238,7 +239,7 @@ MAC.prismES2.nativeSource = [
     file("${project("graphics").projectDir}/src/main/native-prism-es2/macosx")
 ]
 MAC.prismES2.compiler = compiler
-MAC.prismES2.ccFlags = ["-DMACOSX", ccFlags].flatten()
+MAC.prismES2.ccFlags = ["-DGL_SILENCE_DEPRECATION", "-DMACOSX", ccFlags].flatten()
 MAC.prismES2.linker = linker
 MAC.prismES2.linkFlags = [linkFlags].flatten()
 MAC.prismES2.lib = "prism_es2"

--- a/modules/javafx.graphics/src/main/native-prism-es2/macosx/MacOSXWindowSystemInterface.m
+++ b/modules/javafx.graphics/src/main/native-prism-es2/macosx/MacOSXWindowSystemInterface.m
@@ -178,5 +178,5 @@ jboolean flushBuffer(void *nsJContext) {
 
 void setSwapInterval(void *nsJContext, int swapInterval) {
     NSOpenGLContext *nsContext = (NSOpenGLContext *) nsJContext;
-    [nsContext setValues : &swapInterval forParameter : NSOpenGLCPSwapInterval];
+    [nsContext setValues : &swapInterval forParameter : NSOpenGLContextParameterSwapInterval];
 }


### PR DESCRIPTION
The Mac build issues a lot of warnings including several related to the deprecation of OpenGL in macOS 10.14. Now that the deployment target for JavaFX is 11.0 across the board these warnings are showing up on both M1 and Intel builds. Luckily Apple provides a simply way to silence these warnings by setting a single C preprocessor define.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310847](https://bugs.openjdk.org/browse/JDK-8310847): [Mac] Silence OpenGL deprecation warnings (**Bug** - P4)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1161/head:pull/1161` \
`$ git checkout pull/1161`

Update a local copy of the PR: \
`$ git checkout pull/1161` \
`$ git pull https://git.openjdk.org/jfx.git pull/1161/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1161`

View PR using the GUI difftool: \
`$ git pr show -t 1161`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1161.diff">https://git.openjdk.org/jfx/pull/1161.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1161#issuecomment-1605670595)