### PR TITLE
8310846: Skip failing test InitialWindowSizeTest on Linux

### DIFF
--- a/tests/system/src/test/java/test/com/sun/glass/ui/InitialWindowSizeTest.java
+++ b/tests/system/src/test/java/test/com/sun/glass/ui/InitialWindowSizeTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import test.util.Util;
+import com.sun.javafx.PlatformUtil;
 import javafx.application.Application;
 import javafx.geometry.Dimension2D;
 import javafx.scene.Scene;
@@ -38,6 +39,7 @@ import javafx.stage.Stage;
 import java.util.concurrent.CountDownLatch;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
 
 public class InitialWindowSizeTest {
 
@@ -71,6 +73,9 @@ public class InitialWindowSizeTest {
 
     @Test
     public void testInitialWindowSize() {
+        // JDK-8310845
+        assumeFalse(PlatformUtil.isLinux());
+
         Util.waitForLatch(startupLatch, 10, "startupLatch");
 
         assertTrue(Double.isNaN(showingSize.getWidth()), "width = " + showingSize.getWidth() + ", expected = NaN");


### PR DESCRIPTION
Skips `InitialWindowSizeTest` on Linux until [JDK-8310845](https://bugs.openjdk.org/browse/JDK-8310845) is fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310846](https://bugs.openjdk.org/browse/JDK-8310846): Skip failing test InitialWindowSizeTest on Linux (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1162/head:pull/1162` \
`$ git checkout pull/1162`

Update a local copy of the PR: \
`$ git checkout pull/1162` \
`$ git pull https://git.openjdk.org/jfx.git pull/1162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1162`

View PR using the GUI difftool: \
`$ git pr show -t 1162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1162.diff">https://git.openjdk.org/jfx/pull/1162.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1162#issuecomment-1605826888)