### PR TITLE
8310638: Filtering a TableView with a large number of items freezes the UI

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -2989,7 +2989,11 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
         return baseOffset;
     }
 
-    protected int computeCurrentIndex() {
+    /**
+     * Compute the index of the first visible cell
+     * This has package access ONLY FOR TESTING.
+     */
+    int computeCurrentIndex() {
         return computeCurrentIndex(getCellCount());
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -858,6 +858,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             int oldIndex = computeCurrentIndex(oldCount);
             double oldOffset = computeViewportOffset(getPosition(), oldCount);
             int cellCount = get();
+            if (oldIndex > cellCount) oldIndex = cellCount;
             resetSizeEstimates();
             recalculateAndImproveEstimatedSize(DEFAULT_IMPROVEMENT, oldIndex, oldOffset);
 
@@ -2988,7 +2989,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
         return baseOffset;
     }
 
-    private int computeCurrentIndex() {
+    protected int computeCurrentIndex() {
         return computeCurrentIndex(getCellCount());
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -858,7 +858,9 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             int oldIndex = computeCurrentIndex(oldCount);
             double oldOffset = computeViewportOffset(getPosition(), oldCount);
             int cellCount = get();
-            if (oldIndex > cellCount) oldIndex = cellCount;
+            if (oldIndex > cellCount) {
+                oldIndex = cellCount;
+            }
             resetSizeEstimates();
             recalculateAndImproveEstimatedSize(DEFAULT_IMPROVEMENT, oldIndex, oldOffset);
 

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/VirtualFlowShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/VirtualFlowShim.java
@@ -80,6 +80,10 @@ public class VirtualFlowShim<T extends IndexedCell> extends VirtualFlow<T> {
         return super.getVbar();
     }
 
+    public int shim_computeCurrentIndex() {
+        return super.computeCurrentIndex();
+    }
+
     public ClippedContainer get_clipView() {
         return super.clipView;
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -70,6 +70,7 @@ public class VirtualFlowTest {
     private CellStub a;
     private CellStub b;
     private CellStub c;
+    private int prefSizeCounter;
 
     // The VirtualFlow we are going to test. By default, there are 100 cells
     // and each cell is 100 wide and 25 tall, except for the 30th cell, which
@@ -78,6 +79,7 @@ public class VirtualFlowTest {
 
 
     @Before public void setUp() {
+        prefSizeCounter = 0;
         list = new ArrayLinkedListShim<>();
         a = new CellStub(flow, "A");
         b = new CellStub(flow, "B");
@@ -99,6 +101,7 @@ public class VirtualFlowTest {
 
             @Override
             protected double computePrefWidth(double height) {
+                prefSizeCounter++;
                 return flow.isVertical() ? (getIndex() == 29 ? 200 : 100) : (getIndex() == 29 ? 100 : 25);
             }
 
@@ -114,6 +117,7 @@ public class VirtualFlowTest {
 
             @Override
             protected double computePrefHeight(double width) {
+                prefSizeCounter++;
                 return flow.isVertical() ? (getIndex() == 29 ? 100 : 25) : (getIndex() == 29 ? 200 : 100);
             }
         });
@@ -1712,6 +1716,38 @@ assertEquals(0, firstCell.getIndex());
         // Trigger layout and see if the computeXXX method are called above.
         pulse();
         pulse();
+    }
+
+    @Test
+    public void testLowerCellCount() {
+        flow.setCellCount(10000);
+        int idx = flow.shim_computeCurrentIndex();
+        assertEquals(0, idx);
+
+        assertTrue(prefSizeCounter < 500);
+        int cntr = prefSizeCounter;
+        flow.scrollTo(9999);
+        pulse();
+        idx = flow.shim_computeCurrentIndex();
+        assertTrue(idx < 10000);
+        int newCounter = prefSizeCounter - cntr;
+        assertTrue(newCounter < 100);
+        cntr = prefSizeCounter;
+
+        flow.setCellCount(5000);
+        idx = flow.shim_computeCurrentIndex();
+        assertTrue(idx < 5000);
+        newCounter = prefSizeCounter - cntr;
+        assertTrue(newCounter < 100);
+        cntr = prefSizeCounter;
+
+        pulse();
+        idx = flow.shim_computeCurrentIndex();
+        assertTrue(idx < 5000);
+        newCounter = prefSizeCounter - cntr;
+
+        assertTrue(newCounter < 100);
+
     }
 }
 


### PR DESCRIPTION
This PR fix a performance issue introduced by the fix for JDK-8306447. In that PR, we changed the behavior in case the cellcount changes. In case the cellcount changes to a lower value than the original one, we have to make sure the current index is not higher than the new amount of cells as that would lead to unnecessary computations.

Fix for JDK-8310638

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8310638](https://bugs.openjdk.org/browse/JDK-8310638): Filtering a TableView with a large number of items freezes the UI (**Bug** - P2)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer) 🔄 Re-review required (review applies to [6b4ed092](https://git.openjdk.org/jfx/pull/1163/files/6b4ed092509539f463ef267898855fc816dace62))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1163/head:pull/1163` \
`$ git checkout pull/1163`

Update a local copy of the PR: \
`$ git checkout pull/1163` \
`$ git pull https://git.openjdk.org/jfx.git pull/1163/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1163`

View PR using the GUI difftool: \
`$ git pr show -t 1163`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1163.diff">https://git.openjdk.org/jfx/pull/1163.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1163#issuecomment-1607510369)