### PR TITLE
8311185: VirtualFlow jump when cellcount changes

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -862,6 +862,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
                 oldIndex = cellCount;
             }
             resetSizeEstimates();
+            getOrCreateCellSize(oldIndex);
             recalculateAndImproveEstimatedSize(DEFAULT_IMPROVEMENT, oldIndex, oldOffset);
 
             boolean countChanged = oldCount != cellCount;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -1749,6 +1749,24 @@ assertEquals(0, firstCell.getIndex());
         assertTrue(newCounter < 100);
 
     }
+
+    @Test
+    public void testAddCellWithBigCurrentOne() {
+        int idx = flow.shim_computeCurrentIndex();
+        assertEquals(0, idx);
+        for (int i = 0; i < 20; i++) {
+            flow.scrollPixels(40);
+            pulse();
+        }
+        pulse();
+        idx = flow.shim_computeCurrentIndex();
+        assertEquals(29, idx);
+        flow.setCellCount(101);
+        pulse();
+        idx = flow.shim_computeCurrentIndex();
+        assertEquals(29, idx);
+    }
+
 }
 
 class GraphicalCellStub extends IndexedCellShim<Node> {


### PR DESCRIPTION
When the cellcount changes, we need to make sure that the size of the current first visible cell is known.

This avoids index errors due to the current offset (between the top of the viewport and the current first visible cell) being potentially larger than the new estimated cellsize.

Added a test that fails before and succeeds after the patch. The test uses the same logic as the reproducer in the JBS issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8311185](https://bugs.openjdk.org/browse/JDK-8311185): VirtualFlow jump when cellcount changes (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1164/head:pull/1164` \
`$ git checkout pull/1164`

Update a local copy of the PR: \
`$ git checkout pull/1164` \
`$ git pull https://git.openjdk.org/jfx.git pull/1164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1164`

View PR using the GUI difftool: \
`$ git pr show -t 1164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1164.diff">https://git.openjdk.org/jfx/pull/1164.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1164#issuecomment-1614982179)