### PR TITLE
8311216: DataURI can lose information in some charset environments

### DIFF
--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/util/DataURITest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/util/DataURITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,11 @@
 package test.com.sun.javafx.util;
 
 import com.sun.javafx.util.DataURI;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class DataURITest {
 
@@ -40,11 +42,11 @@ public class DataURITest {
         assertNull(uri);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testParametersListWithoutKeyValuePairsIsInvalid() {
         String data = "data:foo;bar;baz,";
         assertTrue(DataURI.matchScheme(data));
-        DataURI uri = DataURI.tryParse(data);
+        assertThrows(IllegalArgumentException.class, () -> DataURI.tryParse(data));
     }
 
     @Test
@@ -172,6 +174,33 @@ public class DataURITest {
         DataURI uri = DataURI.tryParse(data);
         assertNotNull(uri);
         assertEquals("data:text/plain;charset=utf-8;base64,SGVsbG9Xb3JsZE...RIZWxsb1dvcmxk", uri.toString());
+    }
+
+    @Test
+    public void testPercentEncodedTextIsDecodedAccordingToRFC3986() {
+        // We use URLEncoder here to escape the emoji character using percent-encoding.
+        // When DataURI parses its payload, it automatically converts percent-encoded characters back to octets.
+        String input = URLEncoder.encode("🙂", StandardCharsets.UTF_8);
+        String output = new String(DataURI.tryParse("data:," + input).getData(), StandardCharsets.UTF_8);
+        assertEquals("🙂", output);
+
+        // In the next case, URLEncoder replaces the space character with '+'.
+        // Since DataURI does not know about this special encoding, the '+' character is retained.
+        input = URLEncoder.encode("Hello 🙂!", StandardCharsets.UTF_8);
+        output = new String(DataURI.tryParse("data:," + input).getData(), StandardCharsets.UTF_8);
+        assertEquals("Hello+🙂!", output);
+    }
+
+    @Test
+    public void testPercentEncodedTextContainsInvalidEscapeSequence() {
+        var ex = assertThrows(IllegalArgumentException.class, () -> DataURI.tryParse("data:,%XY"));
+        assertTrue(ex.getMessage().startsWith("Invalid"));
+
+        ex = assertThrows(IllegalArgumentException.class, () -> DataURI.tryParse("data:,%5G"));
+        assertTrue(ex.getMessage().startsWith("Invalid"));
+
+        ex = assertThrows(IllegalArgumentException.class, () -> DataURI.tryParse("data:,%0"));
+        assertTrue(ex.getMessage().startsWith("Incomplete"));
     }
 
 }

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/util/DataURITest.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/util/DataURITest.java
@@ -35,6 +35,16 @@ import static org.junit.jupiter.api.Assertions.*;
 public class DataURITest {
 
     @Test
+    public void testNullIsInvalid() {
+        assertNull(DataURI.tryParse(null));
+    }
+
+    @Test
+    public void testEmptyStringIsInvalid() {
+        assertNull(DataURI.tryParse(""));
+    }
+
+    @Test
     public void testMissingDataSeparatorIsInvalid() {
         String data = "data:";
         DataURI uri = DataURI.tryParse(data);
@@ -200,6 +210,9 @@ public class DataURITest {
         assertTrue(ex.getMessage().startsWith("Invalid"));
 
         ex = assertThrows(IllegalArgumentException.class, () -> DataURI.tryParse("data:,%0"));
+        assertTrue(ex.getMessage().startsWith("Incomplete"));
+
+        ex = assertThrows(IllegalArgumentException.class, () -> DataURI.tryParse("data:,%"));
         assertTrue(ex.getMessage().startsWith("Incomplete"));
     }
 


### PR DESCRIPTION
DataURI uses the following implementation to decode the percent-encoded payload of a "data" URI:

```
...
String data = uri.substring(dataSeparator + 1);
Charset charset = Charset.defaultCharset();
...
URLDecoder.decode(data.replace("+", "%2B"), charset).getBytes(charset)
```

This approach only works if the charset that is passed into `URLDecoder.decode` and `String.getBytes` doesn't lose information when converting between `String` and `byte[]` representations, as might happen in a US-ASCII environment.

This PR solves the problem by not using `URLDecoder`, but instead simply decoding percent-encoded escape sequences as specified by RFC 3986, page 11.

**Note to reviewers**: the failing test can only be observed when the JVM uses a default charset that can't represent the payload, which can be enforced by specifying the `-Dfile.encoding=US-ASCII` VM option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8311216](https://bugs.openjdk.org/browse/JDK-8311216): DataURI can lose information in some charset environments (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1165/head:pull/1165` \
`$ git checkout pull/1165`

Update a local copy of the PR: \
`$ git checkout pull/1165` \
`$ git pull https://git.openjdk.org/jfx.git pull/1165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1165`

View PR using the GUI difftool: \
`$ git pr show -t 1165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1165.diff">https://git.openjdk.org/jfx/pull/1165.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1165#issuecomment-1616164021)