### PR TITLE
8159048: Animation and AnimationTimer methods must be called on JavaFX Application thread

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,7 +83,8 @@ import java.security.PrivilegedAction;
  * the {@code Animation} from the specified position.
  * <p>
  * Inverting the value of {@link #rateProperty() rate} toggles the play direction.
- *
+ * <p>
+ * The animation runs on the JavaFX Application Thread.
  * @see Timeline
  * @see Transition
  *
@@ -978,12 +979,15 @@ public abstract class Animation {
      * Note: <ul>
      * <li>{@code play()} is an asynchronous call, the {@code Animation} may not
      * start immediately. </ul>
+     * <p>
+     * This method must be called on the JavaFX Application thread.
      *
-     * @throws IllegalStateException
-     *             if embedded in another animation,
+     * @throws IllegalStateException if this method is called on a thread
+     *                other than the JavaFX Application Thread, or if embedded in another animation,
      *                such as {@link SequentialTransition} or {@link ParallelTransition}
      */
     public void play() {
+        Toolkit.getToolkit().checkFxUserThread();
         if (parent != null) {
             throw new IllegalStateException("Cannot start when embedded in another animation");
         }
@@ -1035,11 +1039,15 @@ public abstract class Animation {
      * Note: <ul>
      * <li>{@code stop()} is an asynchronous call, the {@code Animation} may not stop
      * immediately. </ul>
-     * @throws IllegalStateException
-     *             if embedded in another animation,
+     * <p>
+     * This method must be called on the JavaFX Application thread.
+     *
+     * @throws IllegalStateException if this method is called on a thread
+     *                other than the JavaFX Application Thread, or if embedded in another animation,
      *                such as {@link SequentialTransition} or {@link ParallelTransition}
      */
     public void stop() {
+        Toolkit.getToolkit().checkFxUserThread();
         if (parent != null) {
             throw new IllegalStateException("Cannot stop when embedded in another animation");
         }
@@ -1066,11 +1074,15 @@ public abstract class Animation {
      * Note: <ul>
      * <li>{@code pause()} is an asynchronous call, the {@code Animation} may not pause
      * immediately. </ul>
-     * @throws IllegalStateException
-     *             if embedded in another animation,
+     * <p>
+     * This method must be called on the JavaFX Application thread.
+     * 
+     * @throws IllegalStateException if this method is called on a thread
+     *                other than the JavaFX Application Thread, or if embedded in another animation,
      *                such as {@link SequentialTransition} or {@link ParallelTransition}
      */
     public void pause() {
+        Toolkit.getToolkit().checkFxUserThread();
         if (parent != null) {
             throw new IllegalStateException("Cannot pause when embedded in another animation");
         }

--- a/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
@@ -1076,7 +1076,7 @@ public abstract class Animation {
      * immediately. </ul>
      * <p>
      * This method must be called on the JavaFX Application thread.
-     * 
+     *
      * @throws IllegalStateException if this method is called on a thread
      *                other than the JavaFX Application Thread, or if embedded in another animation,
      *                such as {@link SequentialTransition} or {@link ParallelTransition}

--- a/modules/javafx.graphics/src/main/java/javafx/animation/AnimationTimer.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/AnimationTimer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,13 +35,14 @@ import java.security.PrivilegedAction;
 /**
  * The class {@code AnimationTimer} allows to create a timer, that is called in
  * each frame while it is active.
- *
+ * <p>
  * An extending class has to override the method {@link #handle(long)} which
  * will be called in every frame.
- *
+ * <p>
  * The methods {@link AnimationTimer#start()} and {@link #stop()} allow to start
  * and stop the timer.
- *
+ * <p>
+ * The animation timer runs on the JavaFX Application Thread.
  *
  * @since JavaFX 2.0
  */
@@ -96,11 +97,17 @@ public abstract class AnimationTimer {
      * Starts the {@code AnimationTimer}. Once it is started, the
      * {@link #handle(long)} method of this {@code AnimationTimer} will be
      * called in every frame.
-     *
+     * <p>
      * The {@code AnimationTimer} can be stopped by calling {@link #stop()}.
+     * <p>
+     * This method must be called on the JavaFX Application thread.
+     *
+     * @throws IllegalStateException if this method is called on a thread
+     *                  other than the JavaFX Application Thread.
      */
     @SuppressWarnings("removal")
     public void start() {
+        Toolkit.getToolkit().checkFxUserThread();
         if (!active) {
             // Capture the Access Control Context to be used during the animation pulse
             accessCtrlCtx = AccessController.getContext();
@@ -112,8 +119,14 @@ public abstract class AnimationTimer {
     /**
      * Stops the {@code AnimationTimer}. It can be activated again by calling
      * {@link #start()}.
+     * <p>
+     * This method must be called on the JavaFX Application thread.
+     *
+     * @throws IllegalStateException if this method is called on a thread
+     *                  other than the JavaFX Application Thread.
      */
     public void stop() {
+        Toolkit.getToolkit().checkFxUserThread();
         if (active) {
             timer.removeAnimationTimer(timerReceiver);
             active = false;

--- a/tests/system/src/test/java/test/com/sun/javafx/animation/AnimationTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/animation/AnimationTest.java
@@ -113,5 +113,4 @@ public class AnimationTest {
         });
         assertThrows(IllegalStateException.class, pause::stop);
     }
-
 }

--- a/tests/system/src/test/java/test/com/sun/javafx/animation/AnimationTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/animation/AnimationTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.javafx.animation;
+
+import javafx.animation.PauseTransition;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.stage.Stage;
+import javafx.util.Duration;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import test.util.Util;
+
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AnimationTest {
+
+    private static final CountDownLatch startupLatch = new CountDownLatch(1);
+
+    private static Stage primaryStage;
+
+    public static class TestApp extends Application {
+
+        @Override
+        public void init() throws Exception {
+            assertFalse(Platform.isFxApplicationThread());
+        }
+
+        @Override
+        public void start(Stage stage) throws Exception {
+            primaryStage = stage;
+            assertTrue(Platform.isFxApplicationThread());
+
+            startupLatch.countDown();
+        }
+
+    }
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        Util.launch(startupLatch, TestApp.class);
+    }
+
+    @AfterClass
+    public static void shutdown() {
+        Util.shutdown(primaryStage);
+    }
+
+    @Test
+    public void animationOnFXThreadTest() throws InterruptedException {
+        final CountDownLatch l = new CountDownLatch(1);
+        Platform.runLater(() -> {
+            assertTrue(Platform.isFxApplicationThread());
+            PauseTransition pause = new PauseTransition(Duration.seconds(1));
+            pause.play();
+            pause.pause();
+            pause.stop();
+            l.countDown();
+        });
+        l.await();
+    }
+
+    @Test
+    public void startAnimationNotOnFXThreadTest() {
+        assertFalse(Platform.isFxApplicationThread());
+        PauseTransition pause = new PauseTransition(Duration.seconds(1));
+        assertThrows(IllegalStateException.class, pause::play);
+    }
+
+    @Test
+    public void pauseAnimationNotOnFXThreadTest() {
+        assertFalse(Platform.isFxApplicationThread());
+        PauseTransition pause = new PauseTransition(Duration.seconds(1));
+        Platform.runLater(pause::play);
+        assertThrows(IllegalStateException.class, pause::pause);
+    }
+
+    @Test
+    public void stopAnimationNotOnFXThreadTest() {
+        assertFalse(Platform.isFxApplicationThread());
+        PauseTransition pause = new PauseTransition(Duration.seconds(1));
+        Platform.runLater(() -> {
+            pause.play();
+            pause.pause();
+        });
+        assertThrows(IllegalStateException.class, pause::stop);
+    }
+
+}

--- a/tests/system/src/test/java/test/com/sun/javafx/animation/AnimationTimerTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/animation/AnimationTimerTest.java
@@ -109,5 +109,4 @@ public class AnimationTimerTest {
         };
         Platform.runLater(timer::start);
     }
-
 }

--- a/tests/system/src/test/java/test/com/sun/javafx/animation/AnimationTimerTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/animation/AnimationTimerTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.javafx.animation;
+
+import java.util.concurrent.CountDownLatch;
+import javafx.animation.AnimationTimer;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.stage.Stage;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import test.util.Util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AnimationTimerTest {
+
+    private static final CountDownLatch startupLatch = new CountDownLatch(1);
+
+    private static Stage primaryStage;
+
+    public static class TestApp extends Application {
+
+        @Override
+        public void init() throws Exception {
+            assertFalse(Platform.isFxApplicationThread());
+        }
+
+        @Override
+        public void start(Stage stage) throws Exception {
+            primaryStage = stage;
+            assertTrue(Platform.isFxApplicationThread());
+
+            startupLatch.countDown();
+        }
+
+    }
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        Util.launch(startupLatch, TestApp.class);
+    }
+
+    @AfterClass
+    public static void shutdown() {
+        Util.shutdown(primaryStage);
+    }
+
+    @Test
+    public void animationTimerOnFXThreadTest() throws InterruptedException {
+        final CountDownLatch frameCounter = new CountDownLatch(3);
+        Platform.runLater(() -> {
+            AnimationTimer timer = new AnimationTimer() {
+                @Override public void handle(long l) {
+                    frameCounter.countDown();
+                    if (frameCounter.getCount() == 0L) {
+                        stop();
+                    }
+                }
+            };
+            assertTrue(Platform.isFxApplicationThread());
+            timer.start();
+        });
+        frameCounter.await();
+    }
+
+    @Test
+    public void startAnimationTimerNotOnFXThreadTest() {
+        assertFalse(Platform.isFxApplicationThread());
+        AnimationTimer timer = new AnimationTimer() {
+            @Override public void handle(long l) {}
+        };
+        assertThrows(IllegalStateException.class, timer::start);
+    }
+
+    @Test
+    public void stopAnimationTimerNotOnFXThreadTest() {
+        assertFalse(Platform.isFxApplicationThread());
+        AnimationTimer timer = new AnimationTimer() {
+            @Override public void handle(long l) {
+                assertThrows(IllegalStateException.class, () -> stop());
+            }
+        };
+        Platform.runLater(timer::start);
+    }
+
+}


### PR DESCRIPTION
This PR adds a check to the Animation and AnimationTimer public methods to verify that these are called from the JavaFX Application thread. If the call is done from any other thread, an IllegalStateException will be thrown.

This will prevent users from getting unexpected errors (typically NPE, like the one posted in the JBS issue), and will fail fast with a clear exception and reason for it.

The javadoc of the Animation and AnimationTimer classes and public methods has been updated accordingly.

Tests for both classes have been included, failing (as in no exceptions were thrown when calling from a background thread) before this patch, and passing (as in ISE was thrown).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8313378](https://bugs.openjdk.org/browse/JDK-8313378) to be approved
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8159048](https://bugs.openjdk.org/browse/JDK-8159048): Animation and AnimationTimer methods must be called on JavaFX Application thread (**Bug** - P4)
 * [JDK-8313378](https://bugs.openjdk.org/browse/JDK-8313378): Animation and AnimationTimer methods must be called on JavaFX Application thread (**CSR**)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1167/head:pull/1167` \
`$ git checkout pull/1167`

Update a local copy of the PR: \
`$ git checkout pull/1167` \
`$ git pull https://git.openjdk.org/jfx.git pull/1167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1167`

View PR using the GUI difftool: \
`$ git pr show -t 1167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1167.diff">https://git.openjdk.org/jfx/pull/1167.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1167#issuecomment-1657088012)