### PR TITLE
8231865: JFXPanel sends resize event with size 0x0 on HiDPI devices

### DIFF
--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
@@ -608,15 +608,15 @@ public class JFXPanel extends JComponent {
     private void updateComponentSize() {
         int oldWidth = pWidth;
         int oldHeight = pHeight;
-        // It's quite possible to get negative values here, this is not
-        // what JavaFX embedded scenes/stages are ready to
-        pWidth = Math.max(0, getWidth());
-        pHeight = Math.max(0, getHeight());
         if (getBorder() != null) {
             Insets i = getBorder().getBorderInsets(this);
             pWidth -= (i.left + i.right);
             pHeight -= (i.top + i.bottom);
         }
+        // It's quite possible to get negative values here, this is not
+        // what JavaFX embedded scenes/stages are ready to
+        pWidth = Math.max(0, getWidth());
+        pHeight = Math.max(0, getHeight());
         double newScaleFactorX = scaleFactorX;
         double newScaleFactorY = scaleFactorY;
         Graphics g = getGraphics();

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
@@ -626,6 +626,9 @@ public class JFXPanel extends JComponent {
         newScaleFactorY = GraphicsEnvironment.getLocalGraphicsEnvironment().
                           getDefaultScreenDevice().getDefaultConfiguration().
                           getDefaultTransform().getScaleY();
+        if (oldWidth == 0 && oldHeight == 0 && pWidth == 0 && pHeight == 0) {
+            return;
+        }
         if (oldWidth != pWidth || oldHeight != pHeight ||
             newScaleFactorX != scaleFactorX || newScaleFactorY != scaleFactorY)
         {


### PR DESCRIPTION
If the scaleFactors used for the current device are not 1.0, a JXFPanel will send a resize event with 0x0 dimensions to the JavaFX scene which can have undesirable effects, which is because the resize pixel buffer is created even for initial size of 9x0 width,height.
Fix is to make sure to prevent resizing the pixel buffer for initial width/height of 0.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8231865](https://bugs.openjdk.org/browse/JDK-8231865): JFXPanel sends resize event with size 0x0 on HiDPI devices (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1168/head:pull/1168` \
`$ git checkout pull/1168`

Update a local copy of the PR: \
`$ git checkout pull/1168` \
`$ git pull https://git.openjdk.org/jfx.git pull/1168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1168`

View PR using the GUI difftool: \
`$ git pr show -t 1168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1168.diff">https://git.openjdk.org/jfx/pull/1168.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1168#issuecomment-1618816951)