### PR TITLE
8090267: JFXPanel Input Problem

### DIFF
--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
@@ -947,7 +947,7 @@ public class JFXPanel extends JComponent {
     public InputMethodRequests getInputMethodRequests() {
         EmbeddedSceneInterface scene = scenePeer;
         if (scene == null) {
-            return null;
+            return new InputMethodSupport.InputMethodRequestsAdapter(null);
         }
         return new InputMethodSupport.InputMethodRequestsAdapter(scene.getInputMethodRequests());
     }
@@ -1025,6 +1025,7 @@ public class JFXPanel extends JComponent {
                 });
                 return;
             }
+            getInputMethodRequests();
             if (pWidth > 0 && pHeight > 0) {
                 scenePeer.setSize(pWidth, pHeight);
             }


### PR DESCRIPTION
When Japanse (IME on) is inputted to the TextFIeld, which is on JFXPanel, 
small window for inputting appears on top-left side of screen

![image](https://github.com/openjdk/jfx/assets/43534309/65833d59-528e-4087-9992-9f86b8b8c47f)

For swing-interop case, WmImeStartComposition starts composition in native ImmSetCompositionWindow window as "m_useNativeCompWindow" below is true for FX
https://github.com/openjdk/jdk/blob/514816ed7d7dea1fb13d32b80aef89774bee13d3/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp#L3957

m_useNativeCompWindow is true because during sun.awt.im.InputContext#focusGained() calls activateInputMethod which calls WInputMethod.activate() which calls haveActiveClient() which checks for
clientComponent.getInputMethodRequests().
Now, in JFXPanel, getInputMethodRequests() returns null as setEmbeddedScene() is not called yet.
Since getInputMethodRequests() returns null, haveActiveClient() is false which calls enableNativeIME() with 1 [thereby native composition window is enabled]
https://github.com/openjdk/jdk/blob/514816ed7d7dea1fb13d32b80aef89774bee13d3/src/java.desktop/windows/classes/sun/awt/windows/WInputMethod.java#L316

Proposed fix is to ensure there is an active client "initially" so that enableNativeIME() is called with 0 and no native compostion window is shown.
getInputMethodRequests() is called in setEmbeddedScene() so as to make sure getInputMethodRequest() is initialised to correct "InputMethodSupport.InputMethodRequestsAdapter.fxRequests" object and not NULL.

AFter fix
![image](https://github.com/openjdk/jfx/assets/43534309/ec3d8343-9295-4950-885b-f9983b9b017a)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8090267](https://bugs.openjdk.org/browse/JDK-8090267): JFXPanel Input Problem (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1169/head:pull/1169` \
`$ git checkout pull/1169`

Update a local copy of the PR: \
`$ git checkout pull/1169` \
`$ git pull https://git.openjdk.org/jfx.git pull/1169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1169`

View PR using the GUI difftool: \
`$ git pr show -t 1169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1169.diff">https://git.openjdk.org/jfx/pull/1169.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1169#issuecomment-1619549346)