### PR TITLE
8242419: JFXPanel: MouseEvent always reports that Primary button changed state if held

### DIFF
--- a/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/SwingEvents.java
+++ b/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/SwingEvents.java
@@ -93,7 +93,7 @@ public class SwingEvents {
             } else if ((extModifiers & MouseEvent.getMaskForButton(5)) != 0) {
                 abstractButton = AbstractEvents.MOUSEEVENT_FORWARD_BUTTON;
             }
-	}
+        }
         return abstractButton;
     }
 

--- a/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/SwingEvents.java
+++ b/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/SwingEvents.java
@@ -81,17 +81,19 @@ public class SwingEvents {
                 break;
         }
         // Fix for RT-15457: we should report mouse buttons for mouse drags
-        if ((extModifiers & MouseEvent.BUTTON1_DOWN_MASK) != 0) {
-            abstractButton = AbstractEvents.MOUSEEVENT_PRIMARY_BUTTON;
-        } else if ((extModifiers & MouseEvent.BUTTON2_DOWN_MASK) != 0) {
-            abstractButton = AbstractEvents.MOUSEEVENT_MIDDLE_BUTTON;
-        } else if ((extModifiers & MouseEvent.BUTTON3_DOWN_MASK) != 0) {
-            abstractButton = AbstractEvents.MOUSEEVENT_SECONDARY_BUTTON;
-        } else if ((extModifiers & MouseEvent.getMaskForButton(4)) != 0) {
-            abstractButton = AbstractEvents.MOUSEEVENT_BACK_BUTTON;
-        } else if ((extModifiers & MouseEvent.getMaskForButton(5)) != 0) {
-            abstractButton = AbstractEvents.MOUSEEVENT_FORWARD_BUTTON;
-        }
+        if (abstractButton == AbstractEvents.MOUSEEVENT_NONE_BUTTON) {
+            if ((extModifiers & MouseEvent.BUTTON1_DOWN_MASK) != 0) {
+                abstractButton = AbstractEvents.MOUSEEVENT_PRIMARY_BUTTON;
+            } else if ((extModifiers & MouseEvent.BUTTON2_DOWN_MASK) != 0) {
+                abstractButton = AbstractEvents.MOUSEEVENT_MIDDLE_BUTTON;
+            } else if ((extModifiers & MouseEvent.BUTTON3_DOWN_MASK) != 0) {
+                abstractButton = AbstractEvents.MOUSEEVENT_SECONDARY_BUTTON;
+            } else if ((extModifiers & MouseEvent.getMaskForButton(4)) != 0) {
+                abstractButton = AbstractEvents.MOUSEEVENT_BACK_BUTTON;
+            } else if ((extModifiers & MouseEvent.getMaskForButton(5)) != 0) {
+                abstractButton = AbstractEvents.MOUSEEVENT_FORWARD_BUTTON;
+            }
+	}
         return abstractButton;
     }
 

--- a/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/SwingEvents.java
+++ b/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/SwingEvents.java
@@ -80,8 +80,8 @@ public class SwingEvents {
             default:
                 break;
         }
-        // Fix for RT-15457: we should report mouse buttons for mouse drags
         if (abstractButton == AbstractEvents.MOUSEEVENT_NONE_BUTTON) {
+            // Fix for RT-15457: we should report mouse buttons for mouse drags
             if ((extModifiers & MouseEvent.BUTTON1_DOWN_MASK) != 0) {
                 abstractButton = AbstractEvents.MOUSEEVENT_PRIMARY_BUTTON;
             } else if ((extModifiers & MouseEvent.BUTTON2_DOWN_MASK) != 0) {


### PR DESCRIPTION
If an EventHandler or EventFilter for a mouse button is attached to a scene within a JFXPanel and the **primary mouse button** is held, any mouse button click will create an event such that event.getButton().name() wrongly returns PRIMARY, even if the secondary or middle button was clicked. 
This is because `SwingEvents.mouseButtonToEmbedMouseButton()` overwrites the button name after checking the modifier value. 
For mouse click with primary button  `mouseButtonToEmbedMouseButton` is first called with `BUTTON1 `and modifier `BUTTON1_DOWN_MASK `(ie 1024) and then when secondary button(ie right button is clicked) `mouseButtonToEmbedMouseButton` is called with `BUTTON3 `and modifier `BUTTON3_DOWN_MASK | BUTTON1_DOWN_MASK` (ie 5120) 
and when secondary button is released, `mouseButtonToEmbedMouseButton` is again called with `BUTTON3 `but with modifier `BUTTON1_DOWN_MASK `(1024) resulting in button being declared PRIMARY.

Fix is to make sure not to overwrite button name if a button name is already assigned.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8242419](https://bugs.openjdk.org/browse/JDK-8242419): JFXPanel: MouseEvent always reports that Primary button changed state if held (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1170/head:pull/1170` \
`$ git checkout pull/1170`

Update a local copy of the PR: \
`$ git checkout pull/1170` \
`$ git pull https://git.openjdk.org/jfx.git pull/1170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1170`

View PR using the GUI difftool: \
`$ git pr show -t 1170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1170.diff">https://git.openjdk.org/jfx/pull/1170.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1170#issuecomment-1620957564)