### PR TITLE
8311806: Class ButtonAccessibility is implemented twice

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/AccessibleBase.m
@@ -40,10 +40,10 @@ static NSMutableDictionary * rolesMap;
      */
     rolesMap = [[NSMutableDictionary alloc] initWithCapacity:4];
 
-    [rolesMap setObject:@"ButtonAccessibility" forKey:@"BUTTON"];
-    [rolesMap setObject:@"ButtonAccessibility" forKey:@"DECREMENT_BUTTON"];
-    [rolesMap setObject:@"ButtonAccessibility" forKey:@"INCREMENT_BUTTON"];
-    [rolesMap setObject:@"ButtonAccessibility" forKey:@"SPLIT_MENU_BUTTON"];
+    [rolesMap setObject:@"JFXButtonAccessibility" forKey:@"BUTTON"];
+    [rolesMap setObject:@"JFXButtonAccessibility" forKey:@"DECREMENT_BUTTON"];
+    [rolesMap setObject:@"JFXButtonAccessibility" forKey:@"INCREMENT_BUTTON"];
+    [rolesMap setObject:@"JFXButtonAccessibility" forKey:@"SPLIT_MENU_BUTTON"];
 
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXButtonAccessibility.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXButtonAccessibility.h
@@ -26,7 +26,7 @@
 #import "AccessibleBase.h"
 #import <AppKit/AppKit.h>
 
-@interface ButtonAccessibility : AccessibleBase <NSAccessibilityButton> {
+@interface JFXButtonAccessibility : AccessibleBase <NSAccessibilityButton> {
 
 };
 - (NSAccessibilityRole)accessibilityRole;

--- a/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXButtonAccessibility.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/a11y/JFXButtonAccessibility.m
@@ -23,12 +23,12 @@
  * questions.
  */
 
-#import "ButtonAccessibility.h"
+#import "JFXButtonAccessibility.h"
 
 /*
  * Implementation of the accessibility peer for the pushbutton role
  */
-@implementation ButtonAccessibility
+@implementation JFXButtonAccessibility
 - (NSAccessibilityRole)accessibilityRole
 {
     return NSAccessibilityButtonRole;


### PR DESCRIPTION
To avoid confusion on the os x dynamic linker side i renamed native classes from ButtonAccessibility to JFXButtonAccessibility. I will use JFX prefix down the line to avoid any confusion when running with the latest JDK that also migrated to the new a11y API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8311806](https://bugs.openjdk.org/browse/JDK-8311806): Class ButtonAccessibility is implemented twice (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1174/head:pull/1174` \
`$ git checkout pull/1174`

Update a local copy of the PR: \
`$ git checkout pull/1174` \
`$ git pull https://git.openjdk.org/jfx.git pull/1174/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1174`

View PR using the GUI difftool: \
`$ git pr show -t 1174`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1174.diff">https://git.openjdk.org/jfx/pull/1174.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1174#issuecomment-1629706252)