### PR TITLE
JDK-8312528: Move Subscription interface from javafx.beans to javafx.util

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/ConditionalBinding.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/ConditionalBinding.java
@@ -27,8 +27,8 @@ package com.sun.javafx.binding;
 
 import java.util.Objects;
 
-import javafx.beans.Subscription;
 import javafx.beans.value.ObservableValue;
+import javafx.util.Subscription;
 
 public class ConditionalBinding<T> extends LazyObjectBinding<T> {
 

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/FlatMappedBinding.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/FlatMappedBinding.java
@@ -28,8 +28,8 @@ package com.sun.javafx.binding;
 import java.util.Objects;
 import java.util.function.Function;
 
-import javafx.beans.Subscription;
 import javafx.beans.value.ObservableValue;
+import javafx.util.Subscription;
 
 /**
  * A binding holding the value of an indirect source. The indirect source results from

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/LazyObjectBinding.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/LazyObjectBinding.java
@@ -26,9 +26,9 @@
 package com.sun.javafx.binding;
 
 import javafx.beans.InvalidationListener;
-import javafx.beans.Subscription;
 import javafx.beans.binding.ObjectBinding;
 import javafx.beans.value.ChangeListener;
+import javafx.util.Subscription;
 
 /**
  * Extends {@link ObjectBinding} with the ability to lazily register and eagerly unregister listeners on its

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/MappedBinding.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/MappedBinding.java
@@ -28,8 +28,8 @@ package com.sun.javafx.binding;
 import java.util.Objects;
 import java.util.function.Function;
 
-import javafx.beans.Subscription;
 import javafx.beans.value.ObservableValue;
+import javafx.util.Subscription;
 
 public class MappedBinding<S, T> extends LazyObjectBinding<T> {
 

--- a/modules/javafx.base/src/main/java/com/sun/javafx/binding/OrElseBinding.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/binding/OrElseBinding.java
@@ -27,8 +27,8 @@ package com.sun.javafx.binding;
 
 import java.util.Objects;
 
-import javafx.beans.Subscription;
 import javafx.beans.value.ObservableValue;
+import javafx.util.Subscription;
 
 public class OrElseBinding<T> extends LazyObjectBinding<T> {
 

--- a/modules/javafx.base/src/main/java/javafx/beans/Observable.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/Observable.java
@@ -27,6 +27,8 @@ package javafx.beans;
 
 import java.util.Objects;
 
+import javafx.util.Subscription;
+
 /**
  * An {@code Observable} is an entity that wraps content and allows to
  * observe the content for invalidations.

--- a/modules/javafx.base/src/main/java/javafx/beans/value/ObservableValue.java
+++ b/modules/javafx.base/src/main/java/javafx/beans/value/ObservableValue.java
@@ -37,7 +37,7 @@ import com.sun.javafx.binding.OrElseBinding;
 
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
-import javafx.beans.Subscription;
+import javafx.util.Subscription;
 
 /**
  * An {@code ObservableValue} is an entity that wraps a value and allows to

--- a/modules/javafx.base/src/main/java/javafx/util/Subscription.java
+++ b/modules/javafx.base/src/main/java/javafx/util/Subscription.java
@@ -23,7 +23,7 @@
  * questions.
  */
 
-package javafx.beans;
+package javafx.util;
 
 import java.util.List;
 import java.util.Objects;

--- a/modules/javafx.base/src/shims/java/com/sun/javafx/binding/LazyObjectBindingStub.java
+++ b/modules/javafx.base/src/shims/java/com/sun/javafx/binding/LazyObjectBindingStub.java
@@ -25,7 +25,7 @@
 
 package com.sun.javafx.binding;
 
-import javafx.beans.Subscription;
+import javafx.util.Subscription;
 
 /**
  * Stub to allow testing of package private LazyObjectBinding.

--- a/modules/javafx.base/src/test/java/test/javafx/beans/ObservableSubscriptionsTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/ObservableSubscriptionsTest.java
@@ -32,9 +32,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.beans.Subscription;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.util.Subscription;
 
 public class ObservableSubscriptionsTest {
     private final StringProperty value = new SimpleStringProperty("Initial");

--- a/modules/javafx.base/src/test/java/test/javafx/beans/SubscriptionTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/SubscriptionTest.java
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.beans.Subscription;
+import javafx.util.Subscription;
 
 public class SubscriptionTest {
 

--- a/modules/javafx.base/src/test/java/test/javafx/beans/value/ObservableValueSubscriptionsTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/beans/value/ObservableValueSubscriptionsTest.java
@@ -35,9 +35,9 @@ import java.util.function.Consumer;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.beans.Subscription;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
+import javafx.util.Subscription;
 
 public class ObservableValueSubscriptionsTest {
     private final StringProperty value = new SimpleStringProperty("Initial");


### PR DESCRIPTION
The Subscription interface is independent from FX beans and has uses unrelated to beans, it should therefore be placed in javafx.util.

This should be fixed before [JDK-8311123](https://bugs.openjdk.org/browse/JDK-8311123) is released.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8312529](https://bugs.openjdk.org/browse/JDK-8312529) to be approved
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8312528](https://bugs.openjdk.org/browse/JDK-8312528): Move Subscription interface from javafx.beans to javafx.util (**Enhancement** - P4)
 * [JDK-8312529](https://bugs.openjdk.org/browse/JDK-8312529): Move Subscription interface from javafx.beans to javafx.util (**CSR**)

### Reviewers
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1182/head:pull/1182` \
`$ git checkout pull/1182`

Update a local copy of the PR: \
`$ git checkout pull/1182` \
`$ git pull https://git.openjdk.org/jfx.git pull/1182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1182`

View PR using the GUI difftool: \
`$ git pr show -t 1182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1182.diff">https://git.openjdk.org/jfx/pull/1182.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1182#issuecomment-1646295085)