### PR TITLE
8313227: Correct attenuation indicator for removed lights

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGShape3D.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGShape3D.java
@@ -255,7 +255,7 @@ public abstract class NGShape3D extends NGNode {
         meshView.setLight(lightIndex,
                 0, 0, 0,    // x y z
                 0, 0, 0, 0, // r g b lightOn
-                1, 0, 0, 1, 0, // ca la qa isAttenuated maxRange
+                1, 0, 0, 0, 0, // ca la qa isAttenuated maxRange
                 0, 0, 1,    // dirX Y Z
                 0, 0, 0);   // inner outer falloff
     }


### PR DESCRIPTION
A simple fix of changing the attenuation toggle from 1 to 0 for removed lights.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313227](https://bugs.openjdk.org/browse/JDK-8313227): Correct attenuation indicator for removed lights (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1186/head:pull/1186` \
`$ git checkout pull/1186`

Update a local copy of the PR: \
`$ git checkout pull/1186` \
`$ git pull https://git.openjdk.org/jfx.git pull/1186/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1186`

View PR using the GUI difftool: \
`$ git pr show -t 1186`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1186.diff">https://git.openjdk.org/jfx/pull/1186.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1186#issuecomment-1652865067)