### PR TITLE
JDK-8222209: Repaint properly when JFXPanel moves to another screen

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/EmbeddedScene.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/EmbeddedScene.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,6 +154,7 @@ final class EmbeddedScene extends GlassScene implements EmbeddedSceneInterface {
         renderScaleX = scalex;
         renderScaleY = scaley;
         entireSceneNeedsRepaint();
+        updateSceneState();
     }
 
     public float getRenderScaleX() {

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
@@ -617,15 +617,16 @@ public class JFXPanel extends JComponent {
         // what JavaFX embedded scenes/stages are ready to
         pWidth = Math.max(0, getWidth());
         pHeight = Math.max(0, getHeight());
-        double newScaleFactorX = scaleFactorX;
-        double newScaleFactorY = scaleFactorY;
-        Graphics g = getGraphics();
-        newScaleFactorX = GraphicsEnvironment.getLocalGraphicsEnvironment().
-                          getDefaultScreenDevice().getDefaultConfiguration().
-                          getDefaultTransform().getScaleX();
-        newScaleFactorY = GraphicsEnvironment.getLocalGraphicsEnvironment().
-                          getDefaultScreenDevice().getDefaultConfiguration().
-                          getDefaultTransform().getScaleY();
+
+        GraphicsConfiguration config = getGraphicsConfiguration();
+        if (config == null) {
+            config = GraphicsEnvironment.getLocalGraphicsEnvironment().
+                     getDefaultScreenDevice().getDefaultConfiguration();
+        }
+
+        double newScaleFactorX = config.getDefaultTransform().getScaleX();
+        double newScaleFactorY = config.getDefaultTransform().getScaleY();
+
         if (oldWidth == 0 && oldHeight == 0 && pWidth == 0 && pHeight == 0) {
             return;
         }
@@ -818,14 +819,14 @@ public class JFXPanel extends JComponent {
             }
             gg.drawImage(pixelsIm, 0, 0, pWidth, pHeight, null);
 
-            double newScaleFactorX = scaleFactorX;
-            double newScaleFactorY = scaleFactorY;
-            newScaleFactorX = GraphicsEnvironment.getLocalGraphicsEnvironment().
-                              getDefaultScreenDevice().getDefaultConfiguration().
-                              getDefaultTransform().getScaleX();
-            newScaleFactorY = GraphicsEnvironment.getLocalGraphicsEnvironment().
-                              getDefaultScreenDevice().getDefaultConfiguration().
-                              getDefaultTransform().getScaleY();
+            GraphicsConfiguration config = getGraphicsConfiguration();
+            if (config == null) {
+                config = GraphicsEnvironment.getLocalGraphicsEnvironment().
+                         getDefaultScreenDevice().getDefaultConfiguration();
+            }
+            double newScaleFactorX = config.getDefaultTransform().getScaleX();
+            double newScaleFactorY = config.getDefaultTransform().getScaleY();
+
             if (scaleFactorX != newScaleFactorX || scaleFactorY != newScaleFactorY) {
                 createResizePixelBuffer(newScaleFactorX, newScaleFactorY);
                 // The scene will request repaint.


### PR DESCRIPTION
Alternative fix for JFXPanel issues.

I added an extra line to **really** trigger the repainting in `EmbeddedScene`.  This was inspired by this code in `GlassWindowEventHandler` which reacts to `WindowEvent.RESCALE`.  It not only calls `entireSceneNeedsRepaint` but also `updateSceneState`.  Snippet:

            case WindowEvent.RESCALE: {
                float outScaleX = window.getOutputScaleX();
                float outScaleY = window.getOutputScaleY();
                stage.stageListener.changedScale(outScaleX, outScaleY);
                // We need to sync the new scales for painting
                QuantumToolkit.runWithRenderLock(() -> {
                    GlassScene scene = stage.getScene();
                    if (scene != null) {
                        scene.entireSceneNeedsRepaint();
                        scene.updateSceneState();
                    }
                    return null;
                });
                break;
            }

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8222209](https://bugs.openjdk.org/browse/JDK-8222209)

### Issue
 * [JDK-8222209](https://bugs.openjdk.org/browse/JDK-8222209): JavaFX is rendered blurry on systems with monitors in different configuration (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1189/head:pull/1189` \
`$ git checkout pull/1189`

Update a local copy of the PR: \
`$ git checkout pull/1189` \
`$ git pull https://git.openjdk.org/jfx.git pull/1189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1189`

View PR using the GUI difftool: \
`$ git pr show -t 1189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1189.diff">https://git.openjdk.org/jfx/pull/1189.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1189#issuecomment-1655380596)