### PR TITLE
8313177: Web Workers timeout with Webkit 616.1

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/ThreadTimers.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/ThreadTimers.cpp
@@ -105,13 +105,6 @@ void ThreadTimers::updateSharedTimer()
 void ThreadTimers::sharedTimerFiredInternal()
 {
     ASSERT(isMainThread() || (!isWebThread() && !isUIThread()));
-
-#if PLATFORM(JAVA)
-    if(!isMainThread()) {
-        return;
-    }
-#endif
-
     // Do a re-entrancy check.
     if (m_firingTimers)
         return;

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/WebWorkerTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/WebWorkerTest.java
@@ -32,7 +32,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import java.util.concurrent.CountDownLatch;
 
-import org.junit.After;
 import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
@@ -45,28 +44,19 @@ public class WebWorkerTest extends TestBase {
         return submit(() -> getEngine().getLoadWorker().getState());
     }
 
-    @After
-    public void after() {
-    }
-
     @Test
-    public void testWorker() {
+    public void testWorker() throws InterruptedException {
         final WebEngine webEngine = getEngine();
         webEngine.setJavaScriptEnabled(true);
         load(new File("src/test/resources/test/html/worker.html"));
         assertTrue("Load task completed successfully", getLoadState() == State.SUCCEEDED);
 
-        try {
-            // Put the thread to sleep for the specified time (in milliseconds)
-            Thread.sleep(500);
-        } catch (InterruptedException e) {
-            // Handle the exception if the thread is interrupted while sleeping
-        }
+        Thread.sleep(500);
 
         submit(() -> {
             WebView view = getView();
             String res = (String) view.getEngine().executeScript("document.getElementById('result').innerText;");
-            assertEquals("4",res);
+            assertEquals("4", res);
         });
     }
 }

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/WebWorkerTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/WebWorkerTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.web;
+
+import javafx.concurrent.Worker.State;
+
+import static javafx.concurrent.Worker.State.SUCCEEDED;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import java.util.concurrent.CountDownLatch;
+
+import org.junit.After;
+import org.junit.Test;
+import java.io.File;
+import java.io.IOException;
+import javafx.scene.web.WebView;
+import javafx.scene.web.WebEngine;
+
+public class WebWorkerTest extends TestBase {
+
+    private State getLoadState() {
+        return submit(() -> getEngine().getLoadWorker().getState());
+    }
+
+    @After
+    public void after() {
+    }
+
+    @Test
+    public void testWorker() {
+        final WebEngine webEngine = getEngine();
+        webEngine.setJavaScriptEnabled(true);
+        load(new File("src/test/resources/test/html/worker.html"));
+        assertTrue("Load task completed successfully", getLoadState() == State.SUCCEEDED);
+
+        try {
+            // Put the thread to sleep for the specified time (in milliseconds)
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            // Handle the exception if the thread is interrupted while sleeping
+        }
+
+        submit(() -> {
+            WebView view = getView();
+            String res = (String) view.getEngine().executeScript("document.getElementById('result').innerText;");
+            assertEquals("4",res);
+        });
+    }
+}

--- a/modules/javafx.web/src/test/resources/test/html/worker.html
+++ b/modules/javafx.web/src/test/resources/test/html/worker.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<body onload="startWorker()">
+
+<p id="result"></p>
+
+<script>
+
+var work;
+
+function startWorker() {
+  if (typeof(Worker) !== "undefined") {
+    if (typeof(work) == "undefined") {
+      work = new Worker("worker.js");
+    }
+    work.onmessage = function(event) {
+      document.getElementById("result").innerHTML = event.data;
+    };
+  }
+}
+
+function stopWorker() {
+  work.terminate();
+  work = undefined;
+}
+
+</script>
+
+</body>
+</html>
+

--- a/modules/javafx.web/src/test/resources/test/html/worker.js
+++ b/modules/javafx.web/src/test/resources/test/html/worker.js
@@ -1,0 +1,17 @@
+/* simple worker module to test*/
+
+var i = 0;
+let timeoutID;
+
+function doIncrement() {
+  i = i + 1;
+  postMessage(i);
+
+  if (i < 4) {
+    // If i is less than 4, schedule the next call
+    timeoutID = setTimeout(doIncrement, 50);
+  }
+}
+
+doIncrement();
+


### PR DESCRIPTION
Issue: Some web worker tests fail to finish.
Root Cause:
sharedTimerFiredInternal function from ThreadTimers class does not require an isMainThread check, The check was introduced during the initial webkit stabilization.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8313177](https://bugs.openjdk.org/browse/JDK-8313177): Web Workers timeout with Webkit 616.1 (**Bug** - P2)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Hima Bindu Meda](https://openjdk.org/census#hmeda) (@HimaBinduMeda - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1191/head:pull/1191` \
`$ git checkout pull/1191`

Update a local copy of the PR: \
`$ git checkout pull/1191` \
`$ git pull https://git.openjdk.org/jfx.git pull/1191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1191`

View PR using the GUI difftool: \
`$ git pr show -t 1191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1191.diff">https://git.openjdk.org/jfx/pull/1191.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1191#issuecomment-1657723651)