### PR TITLE
8313424: JavaFX controls in the title bar

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
@@ -729,6 +729,12 @@ public abstract class Application {
         return _supportsUnifiedWindows();
     }
 
+    protected abstract boolean _supportsCombinedWindows();
+    public final boolean supportsCombinedWindows() {
+        checkEventThread();
+        return _supportsCombinedWindows();
+    }
+
     protected boolean _supportsSystemMenu() {
         // Overridden in subclasses
         return false;

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/View.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/View.java
@@ -76,7 +76,9 @@ public abstract class View {
                                      int modifiers, boolean isPopupTrigger, boolean isSynthesized)
         {
         }
-
+        public boolean handleHitTest(View view, int x, int y) {
+            return false;
+        }
         /**
          * A Scroll event handler.
          *
@@ -554,6 +556,13 @@ public abstract class View {
         }
     }
 
+    private boolean handleHitTest(int x, int y) {
+        if (eventHandler != null) {
+            return eventHandler.handleHitTest(this, x, y);
+        }
+        return false;
+    }
+
     private void handleMenuEvent(int x, int y, int xAbs, int yAbs, boolean isKeyboardTrigger) {
         if (this.eventHandler != null) {
             this.eventHandler.handleMenuEvent(this, x, y, xAbs, yAbs, isKeyboardTrigger);
@@ -946,6 +955,10 @@ public abstract class View {
         } else {
             dragProcessed = false;
         }
+    }
+
+    protected boolean hitTest(int x, int y) {
+        return handleHitTest(x, y);
     }
 
     // ------------- END OF MOUSE EVENTS -----------------

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkApplication.java
@@ -461,6 +461,10 @@ final class GtkApplication extends Application implements
         return false;
     }
 
+    @Override protected boolean _supportsCombinedWindows() {
+        return false;
+    }
+
     @Override
     protected native int _getKeyCodeForChar(char c);
 

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/ios/IosApplication.java
@@ -228,6 +228,10 @@ public final class IosApplication extends Application {
         return false;
     }
 
+    @Override protected boolean _supportsCombinedWindows() {
+        return false;
+    }
+
     /**
      * Hides / Shows iOS status bar.
      * @param hidden

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
@@ -363,6 +363,10 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
         return true;
     }
 
+    @Override protected boolean _supportsCombinedWindows() {
+        return true;
+    }
+
     @Override native protected boolean _supportsSystemMenu();
 
     // NOTE: this will not return a valid result until the native _runloop

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacView.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacView.java
@@ -128,6 +128,16 @@ final class MacView extends View {
                           isPopupTrigger, isSynthesized);
     }
 
+    @Override
+    protected boolean hitTest(int x, int y) {
+        Window w = getWindow();
+        float sx = (w == null) ? 1.0f : w.getPlatformScaleX();
+        float sy = (w == null) ? 1.0f : w.getPlatformScaleY();
+        x = Math.round(x * sx);
+        y = Math.round(y * sy);
+        return super.hitTest(x, y);
+    }
+
     @Override protected long _getNativeView(long ptr) {
         return ptr;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacWindow.java
@@ -90,6 +90,7 @@ final class MacWindow extends Window {
     @Override native protected void _setEnabled(long ptr, boolean enabled);
     @Override native protected boolean _setMinimumSize(long ptr, int width, int height);
     @Override native protected boolean _setMaximumSize(long ptr, int width, int height);
+    @Override native protected boolean _setTitleBarHeight(long ptr, int height);
 
     private ByteBuffer iconBuffer;
 
@@ -131,6 +132,13 @@ final class MacWindow extends Window {
                             : WindowEvent.RESTORE);
         }
         notifyMove(x, y);
+    }
+
+    @Override
+    protected void notifyTitleBarInsetsChanged(int left, int right) {
+        left  = Math.round( left * getPlatformScaleX());
+        right = Math.round(right * getPlatformScaleY());
+        super.notifyTitleBarInsetsChanged(left, right);
     }
 
     @Override

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/monocle/MonocleApplication.java
@@ -307,6 +307,11 @@ public final class MonocleApplication extends Application {
     }
 
     @Override
+    protected boolean _supportsCombinedWindows() {
+        return false;
+    }
+
+    @Override
     public boolean hasTwoLevelFocus() {
         return deviceFlags[DEVICE_PC_KEYBOARD] == 0 && deviceFlags[DEVICE_5WAY] > 0;
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
@@ -364,6 +364,10 @@ final class WinApplication extends Application implements InvokeLaterDispatcher.
 
     @Override native protected boolean _supportsUnifiedWindows();
 
+    @Override protected boolean _supportsCombinedWindows() {
+        return true;
+    }
+
     @Override
     public String getDataDirectory() {
         checkEventThread();

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinWindow.java
@@ -275,6 +275,7 @@ class WinWindow extends Window {
     @Override native protected void _setEnabled(long ptr, boolean enabled);
     @Override native protected boolean _setMinimumSize(long ptr, int width, int height);
     @Override native protected boolean _setMaximumSize(long ptr, int width, int height);
+    @Override native protected boolean _setTitleBarHeight(long ptr, int height);
     @Override native protected void _setIcon(long ptr, Pixels pixels);
     @Override native protected void _toFront(long ptr);
     @Override native protected void _toBack(long ptr);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/StagePeerListener.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/StagePeerListener.java
@@ -38,6 +38,7 @@ public class StagePeerListener extends WindowPeerListener {
         public void setResizable(Stage stage, boolean resizable);
         public void setFullScreen(Stage stage, boolean fs);
         public void setAlwaysOnTop(Stage stage, boolean aot);
+        public void setTitleBarInsets(Stage stage, float left, float right);
     }
 
     public StagePeerListener(Stage stage, StageAccessor stageAccessor) {
@@ -72,5 +73,8 @@ public class StagePeerListener extends WindowPeerListener {
         stageAccessor.setAlwaysOnTop(stage, aot);
     }
 
-
+    @Override
+    public void changedTitleBarInsets(float left, float right) {
+        stageAccessor.setTitleBarInsets(stage, left, right);
+    }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/WindowPeerListener.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/stage/WindowPeerListener.java
@@ -91,6 +91,11 @@ public class WindowPeerListener implements TKStageListener {
     }
 
     @Override
+    public void changedTitleBarInsets(float left, float right) {
+        // Overridden in subclasses
+    }
+
+    @Override
     public void changedScreen(Object from, Object to) {
         WindowHelper.getWindowAccessor().notifyScreenChanged(window, from, to);
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKSceneListener.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKSceneListener.java
@@ -61,6 +61,9 @@ public interface TKSceneListener {
                            boolean primaryDown, boolean middleDown, boolean secondaryDown,
                            boolean backDown, boolean forwardDown);
 
+
+    public boolean hitTest(double x, double y);
+
     /**
      * Pass a key event to the scene to handle
      */

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKStage.java
@@ -121,6 +121,8 @@ public interface TKStage {
 
     public void setMaximumSize(int maxWidth, int maxHeight);
 
+    public void setTitleBarHeight(int height);
+
     public void setFullScreen(boolean fullScreen);
 
     // =================================================================================================================

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKStageListener.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/TKStageListener.java
@@ -105,6 +105,11 @@ public interface TKStageListener {
      */
     public void changedScreen(Object from, Object to);
 
+     /**
+     * The stages peer has changed it's title bar insets
+     */
+    public void changedTitleBarInsets(float left, float right);
+
     /**
      * Called if the window is closing do to something that has happened on the peer. For
      * example the user clicking the close button or choosing quit from the application menu

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/EmbeddedStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/EmbeddedStage.java
@@ -125,6 +125,11 @@ final class EmbeddedStage extends GlassStage implements EmbeddedStageInterface {
     }
 
     @Override
+    public void setTitleBarHeight(int height) {
+        // This is a no-op for embedded stages
+    }
+
+    @Override
     protected void setPlatformEnabled(boolean enabled) {
         super.setPlatformEnabled(enabled);
         host.setEnabled(enabled);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassScene.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassScene.java
@@ -347,7 +347,7 @@ abstract class GlassScene implements TKScene {
                 return Color.WHITE;
             } else if (fillPaint.isOpaque() ||
                     (windowStage != null && windowStage.getPlatformWindow() != null &&
-                    windowStage.getPlatformWindow().isUnifiedWindow())) {
+                    (windowStage.getPlatformWindow().isUnifiedWindow() || windowStage.getPlatformWindow().isCombinedWindow()))) {
                 //For bare windows the transparent fill is allowed
                 if (fillPaint.getType() == Paint.Type.COLOR) {
                     return (Color)fillPaint;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
@@ -451,6 +451,40 @@ class GlassViewEventHandler extends View.EventHandler {
         });
     }
 
+    private final HitTestNotification hitTestNotification = new HitTestNotification();
+    private class HitTestNotification implements PrivilegedAction<Boolean> {
+        View view;
+        int x, y;
+
+        @Override
+        public Boolean run() {
+            if (scene.sceneListener != null) {
+                final Window w = view.getWindow();
+                double pScaleX = 1.0;
+                double pScaleY = 1.0;
+                if (w != null) {
+                    pScaleX = w.getPlatformScaleX();
+                    pScaleY = w.getPlatformScaleY();
+                }
+                return scene.sceneListener.hitTest(x / pScaleX, y / pScaleY);
+            }
+            return false;
+        }
+    }
+
+    @SuppressWarnings("removal")
+    @Override
+    public boolean handleHitTest(View view, int x, int y)
+    {
+        hitTestNotification.view = view;
+        hitTestNotification.x = x;
+        hitTestNotification.y = y;
+
+        return QuantumToolkit.runWithoutRenderLock(() -> {
+            return AccessController.doPrivileged(hitTestNotification, scene.getAccessControlContext());
+        });
+    }
+
     @SuppressWarnings("removal")
     @Override public void handleMenuEvent(final View view,
                                           final int x, final int y, final int xAbs, final int yAbs,

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassWindowEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassWindowEventHandler.java
@@ -169,6 +169,22 @@ class GlassWindowEventHandler extends Window.EventHandler implements PrivilegedA
 
     @SuppressWarnings("removal")
     @Override
+    public void handleTitleBarInsetsChangedEvent(int left, int right) {
+        QuantumToolkit.runWithoutRenderLock(() -> {
+            AccessControlContext acc = stage.getAccessControlContext();
+            return AccessController.doPrivileged((PrivilegedAction<Void>)() -> {
+                float pScaleX = 1.0f;
+                if (window != null) {
+                    pScaleX = window.getPlatformScaleX();
+                }
+                stage.stageListener.changedTitleBarInsets(left / pScaleX, right / pScaleX);
+                return null;
+            } , acc);
+        });
+    }
+
+    @SuppressWarnings("removal")
+    @Override
     public void handleWindowEvent(final Window window, final long time, final int type) {
         this.window = window;
         this.type = type;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/QuantumToolkit.java
@@ -1232,6 +1232,8 @@ public final class QuantumToolkit extends Toolkit {
                 return Application.GetApplication().supportsTransparentWindows();
             case UNIFIED_WINDOW:
                 return Application.GetApplication().supportsUnifiedWindows();
+            case COMBINED_WINDOW:
+                return Application.GetApplication().supportsCombinedWindows();
             case TWO_LEVEL_FOCUS:
                 return Application.GetApplication().hasTwoLevelFocus();
             case VIRTUAL_KEYBOARD:

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/WindowStage.java
@@ -156,8 +156,12 @@ public class WindowStage extends GlassStage {
             } else {
                 switch (style) {
                     case UNIFIED:
-                        if (app.supportsUnifiedWindows()) {
+                    case COMBINED:
+                        if (style == StageStyle.UNIFIED && app.supportsUnifiedWindows()) {
                             windowMask |= Window.UNIFIED;
+                        }
+                        if (style == StageStyle.COMBINED && app.supportsCombinedWindows()) {
+                            windowMask |= Window.COMBINED;
                         }
                         // fall through
                     case DECORATED:
@@ -350,6 +354,11 @@ public class WindowStage extends GlassStage {
         maxWidth  = (int) Math.ceil(maxWidth  * getPlatformScaleX());
         maxHeight = (int) Math.ceil(maxHeight * getPlatformScaleY());
         platformWindow.setMaximumSize(maxWidth, maxHeight);
+    }
+
+    @Override public void setTitleBarHeight(int height) {
+        height = (int) Math.ceil(height * getPlatformScaleY());
+        platformWindow.setTitleBarHeight(height);
     }
 
     static Image findBestImage(java.util.List icons, int width, int height) {

--- a/modules/javafx.graphics/src/main/java/javafx/application/ConditionalFeature.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/ConditionalFeature.java
@@ -160,6 +160,17 @@ public enum ConditionalFeature {
     UNIFIED_WINDOW,
 
     /**
+     *  Indicates that a system supports {@link javafx.stage.StageStyle#COMBINED}
+     *  <p>
+     *  NOTE: Currently, supported on:
+     *  <ul>
+     *      <li>Mac OS X</li>
+     *  </ul>
+     * @since JavaFX 42.0
+     */
+    COMBINED_WINDOW,
+
+    /**
      * Indicates whether or not controls should use two-level focus. Two-level
      * focus is when separate operations are needed in some controls to first
      * enter a control and then to perform operations on the control. Two-level

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -1890,6 +1890,42 @@ public class Scene implements EventTarget {
         mouseHandler.process(e, false);
     }
 
+    private static Node testHit(Node node, double sceneX, double sceneY) {
+        if (node == null) {
+            return null;
+        }
+        if (!node.isVisible()) {
+            return null;
+        }
+
+        Point2D p = node.sceneToLocal(sceneX, sceneY);
+        if (node.contains(p)) {
+            return node;
+        }
+
+        if (!(node instanceof Parent)) {
+            return null;
+        }
+
+        List<Node> children = ((Parent)node).getChildrenUnmodifiable();
+        for (int i = children.size() - 1; i >= 0; i--) {
+            Node child = children.get(i);
+            Node hit = testHit(child, sceneX, sceneY);
+            if (hit != null)
+                return hit;
+        }
+        return null;
+    }
+
+    // All we need to show is that there is some visible node
+    // containing this point. As we work our way up from bottom
+    // to top we can stop whenever we encounter a visible node
+    // that contains the point.
+    private boolean processHitTest(double x, double y) {
+        Node hit = testHit(getRoot(), x, y);
+        return hit != null;
+    }
+
     private void processMenuEvent(double x2, double y2, double xAbs, double yAbs, boolean isKeyboardTrigger) {
         EventTarget eventTarget = null;
         Scene.inMousePick = true;
@@ -2708,6 +2744,10 @@ public class Scene implements EventTarget {
             processMouseEvent(mouseEvent);
         }
 
+        @Override
+        public boolean hitTest(double x, double y) {
+            return Scene.this.processHitTest(x, y);
+        }
 
         @Override
         public void keyEvent(KeyEvent keyEvent)

--- a/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
@@ -30,6 +30,8 @@ import java.util.List;
 
 import javafx.application.Platform;
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ReadOnlyDoubleProperty;
+import javafx.beans.property.ReadOnlyDoubleWrapper;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.StringProperty;
 import javafx.beans.property.StringPropertyBase;
@@ -231,6 +233,12 @@ public class Stage extends Window {
         @Override
         public void setAlwaysOnTop(Stage stage, boolean aot) {
             stage.alwaysOnTopPropertyImpl().set(aot);
+        }
+
+        @Override
+        public void setTitleBarInsets(Stage stage, float left, float right) {
+            stage.leftTitleBarInsetPropertyImpl().set(left);
+            stage.rightTitleBarInsetPropertyImpl().set(right);
         }
     };
 
@@ -1134,6 +1142,93 @@ public class Stage extends Window {
         return maxHeight;
     }
 
+    /**
+     * Defines the title bar height of this {@code Stage}.
+     *
+     * @defaultValue 0
+     * @since JavaFX 22
+     */
+    private DoubleProperty titleBarHeight;
+
+    public final void setTitleBarHeight(double value) {
+        titleBarHeightProperty().set(value);
+    }
+
+    public final double getTitleBarHeight() {
+        return titleBarHeight == null ? 0.0 : titleBarHeight.get();
+    }
+
+    public final DoubleProperty titleBarHeightProperty() {
+        if (titleBarHeight == null) {
+            titleBarHeight = new DoublePropertyBase(0.0) {
+
+                @Override
+                protected void invalidated() {
+                    if (getPeer() != null) {
+                        getPeer().setTitleBarHeight((int) get());
+                    }
+                }
+
+                @Override
+                public Object getBean() {
+                    return Stage.this;
+                }
+
+                @Override
+                public String getName() {
+                    return "titleBarHeight";
+                }
+            };
+        }
+        return titleBarHeight;
+    }
+
+    /**
+     * Defines the left title bar inset of this {@code Stage}.
+     *
+     * @defaultValue 0
+     * @since JavaFX 22
+     */
+    private ReadOnlyDoubleWrapper leftTitleBarInset;
+
+    public final double getLeftTitleBarInset() {
+        return leftTitleBarInset == null ? 0.0 : leftTitleBarInset.get();
+    }
+
+    public final ReadOnlyDoubleProperty leftTitleBarInsetProperty() {
+        return leftTitleBarInsetPropertyImpl().getReadOnlyProperty();
+    }
+
+    private ReadOnlyDoubleWrapper leftTitleBarInsetPropertyImpl() {
+        if (leftTitleBarInset == null) {
+            leftTitleBarInset = new ReadOnlyDoubleWrapper(this, "leftTitleBarInset");
+        }
+        return leftTitleBarInset;
+    }
+
+    /**
+     * Defines the right title bar inset of this {@code Stage}.
+     *
+     * @defaultValue 0
+     * @since JavaFX 22
+     */
+    private ReadOnlyDoubleWrapper rightTitleBarInset;
+
+    public final double getRightTitleBarInset() {
+        return rightTitleBarInset == null ? 0.0 : rightTitleBarInset.get();
+    }
+
+    public final ReadOnlyDoubleProperty rightTitleBarInsetProperty() {
+        return rightTitleBarInsetPropertyImpl().getReadOnlyProperty();
+    }
+
+    private ReadOnlyDoubleWrapper rightTitleBarInsetPropertyImpl() {
+        if (rightTitleBarInset == null) {
+            rightTitleBarInset = new ReadOnlyDoubleWrapper(this, "rightTitleBarInset");
+        }
+        return rightTitleBarInset;
+    }
+
     /*
      * This can be replaced by listening for the onShowing/onHiding events
      * Note: This method MUST only be called via its accessor method.
@@ -1166,6 +1261,7 @@ public class Stage extends Window {
                     (int) Math.ceil(getMinHeight()));
             getPeer().setMaximumSize((int) Math.floor(getMaxWidth()),
                     (int) Math.floor(getMaxHeight()));
+            getPeer().setTitleBarHeight((int) Math.floor(getTitleBarHeight()));
             setPeerListener(new StagePeerListener(this, STAGE_ACCESSOR));
         }
     }

--- a/modules/javafx.graphics/src/main/java/javafx/stage/StageStyle.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/StageStyle.java
@@ -66,5 +66,12 @@ public enum StageStyle {
      * NOTE: To see the effect, the {@code Scene} covering the {@code Stage} should have {@code Color.TRANSPARENT}
      * @since JavaFX 8.0
      */
-    UNIFIED
+    UNIFIED,
+
+    /**
+     * Defines a {@code Stage} style with platform decorations and yada yada
+     * {@link javafx.application.Platform#isSupported(javafx.application.ConditionalFeature)}.
+     * If the feature is not supported by the platform, this style downgrades to {@code StageStyle.DECORATED}
+     */
+    COMBINED
 }

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassHostView.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassHostView.h
@@ -24,13 +24,14 @@
  */
 
 #import <Cocoa/Cocoa.h>
-#import <jni.h>
+#import <GlassTitleBar.h>
 
 // host view to which our views attach, so we can move our view in/out
 @interface GlassHostView : NSView
 {
 @public
-        NSView *view;
+        NSView *jfxView;
+        GlassTitleBar* titleBar;
 }
 
 @end

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassHostView.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassHostView.m
@@ -25,7 +25,7 @@
 
 #import "GlassHostView.h"
 
-@implementation GlassHostView : NSView
+@implementation GlassHostView
 
 - (void)dealloc
 {
@@ -72,10 +72,11 @@
     return NO;
 }
 
-- (void)addSubview:(NSView *)aView
+- (void)mouseDown:(NSEvent*)event
 {
-    [super addSubview:aView];
-    self->view = aView;
+    if (titleBar) {
+        [titleBar handleMouseDown: event];
+    }
 }
 
 - (void)drawRect:(NSRect)rect

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassStatics.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassStatics.h
@@ -57,12 +57,14 @@ extern jmethodID jWindowNotifyFocusUngrab;
 extern jmethodID jWindowNotifyFocusDisabled;
 extern jmethodID jWindowNotifyDestroy;
 extern jmethodID jWindowNotifyDelegatePtr;
+extern jmethodID jWindowNotifyTitleBarInsetsChangedPtr;
 
 extern jmethodID jViewNotifyEvent;
 extern jmethodID jViewNotifyRepaint;
 extern jmethodID jViewNotifyResize;
 extern jmethodID jViewNotifyKey;
 extern jmethodID jViewNotifyMouse;
+extern jmethodID jViewHitTest;
 extern jmethodID jViewNotifyMenu;
 extern jmethodID jViewNotifyInputMethod;
 extern jmethodID jViewNotifyInputMethodMac;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassStatics.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassStatics.m
@@ -59,12 +59,14 @@ jmethodID jWindowNotifyFocusUngrab = NULL;
 jmethodID jWindowNotifyFocusDisabled = NULL;
 jmethodID jWindowNotifyDestroy = NULL;
 jmethodID jWindowNotifyDelegatePtr = NULL;
+jmethodID jWindowNotifyTitleBarInsetsChangedPtr = NULL;
 
 jmethodID jViewNotifyEvent = NULL;
 jmethodID jViewNotifyRepaint = NULL;
 jmethodID jViewNotifyResize = NULL;
 jmethodID jViewNotifyKey = NULL;
 jmethodID jViewNotifyMouse = NULL;
+jmethodID jViewHitTest = NULL;
 jmethodID jViewNotifyMenu = NULL;
 jmethodID jViewNotifyInputMethod = NULL;
 jmethodID jViewNotifyInputMethodMac = NULL;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassTitleBar.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassTitleBar.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import <Cocoa/Cocoa.h>
+
+@interface GlassTitleBar : NSObject
+
+// When an instance is created the NSWindow's standardWindowButton: method needs
+// to return the default buttons so we can hide them. After this is created the
+// NSWindow should defer to this object when asked for a standard window button.
+-(instancetype)initWithWindow:(NSWindow*)window;
+// When the window is transitioning to a traditional title bar
+-(void)detachFromWindow;
+
+// Called by the NSWindow's standardWindowButton: method.
+-(NSButton*)standardWindowButton:(NSWindowButton)type;
+
+// Sets the view which contains the JFX content and the host view that contains
+// it. The GlassTitleBar will add additional views above and below the content
+// to produce the title bar effect and provide the stoplight controls.
+-(void)setHostView:(NSView*)hostView jfxView:(NSView*)jfxView;
+
+// The JFX view must implement hitTest: to test whether a point hits a JavaFX
+// control or not. It must also implement mouseDown. If the hitTest returns nil
+// the mouse click will fall through to the host view which will forward it
+// here.
+-(void)handleMouseDown:(NSEvent*)event;
+
+// The height of the title bar
+@property CGFloat height;
+
+// The insets (left and right only) which allow
+// clients to avoid the platform decorations.
+@property (readonly) NSEdgeInsets insets;
+@end

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassTitleBar.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassTitleBar.m
@@ -1,0 +1,390 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#import "GlassTitleBar.h"
+
+static const CGFloat kMinTitleBarHeight = 14.0;
+static const CGFloat kDefaultTitleBarHeight = 28.0;
+
+// A view that encapsulates the close/minimize/maximize buttons
+@interface StoplightView : NSView
+{
+@private
+    BOOL mouseInside;
+}
+-(void)redrawButtons;
+@end
+
+@implementation StoplightView
+-(instancetype)initWithFrame:(NSRect)frame
+{
+    self = [super initWithFrame: frame];
+    if (self)
+    {
+        NSTrackingArea* tracking = [[NSTrackingArea alloc] initWithRect: self.bounds
+                                                                options: NSTrackingActiveAlways | NSTrackingInVisibleRect | NSTrackingMouseEnteredAndExited
+                                                                  owner: self
+                                                               userInfo: nil];
+        [self addTrackingArea: tracking];
+        mouseInside = NO;
+    }
+    return self;
+}
+
+-(void)viewDidMoveToWindow
+{
+    [NSNotificationCenter.defaultCenter addObserver: self
+                                           selector: @selector(redrawButtons)
+                                               name: NSWindowDidBecomeKeyNotification
+                                             object: self.window];
+    [NSNotificationCenter.defaultCenter addObserver: self
+                                           selector: @selector(redrawButtons)
+                                               name: NSWindowDidResignKeyNotification
+                                             object: self.window];
+}
+
+-(void)viewWillMoveToWindow:(NSWindow *)newWindow
+{
+    [NSNotificationCenter.defaultCenter removeObserver: self];
+}
+
+-(void)redrawButtons
+{
+    for (NSView* view in self.subviews)
+    {
+        [view setNeedsDisplay: YES];
+    }
+}
+
+-(void)mouseEntered:(NSEvent *)event
+{
+    mouseInside = YES;
+    [self redrawButtons];
+}
+
+-(void)mouseExited:(NSEvent *)event
+{
+    mouseInside = NO;
+    [self redrawButtons];
+}
+
+// An undocumented but well-known API. When the mouse enters
+// the area encompassing the spotlight buttons they all show
+// their icons at the same time. Their superview needs to
+// implement this method to make that magic work.
+-(BOOL)_mouseInGroup:(NSButton*)button
+{
+    return mouseInside;
+}
+@end
+
+@interface GlassTitleBar ()
+@property (readwrite) NSEdgeInsets insets;
+@end
+
+@implementation GlassTitleBar
+{
+@private
+    NSWindow*                   window;
+
+    // The jfxView contains the surface that JavaFX draws on. The hostView
+    // manages other views below and above the jfxView.
+    NSView*                     hostView;
+    NSView*                     jfxView;
+
+    CGFloat                     titleBarHeight;
+
+    // We cannot draw on top of the platform title bar (we can only draw beneath
+    // it and that content would get blurred). We set the window's title bar to
+    // be invisible and recreate the title bar effect manually by placing this
+    // view below the JFX view.
+    NSVisualEffectView*         titleBarBackground;
+
+    // We cannot control the position of the stoplight buttons. Instead we hide
+    // the original stoplight buttons and create duplicates that we can control.
+    // This view is positioned above the jfx view.
+    StoplightView*              stoplightView;
+
+    BOOL                        useOriginals;
+    NSMutableDictionary<NSNumber*, NSButton*>* buttons;
+    NSMutableDictionary<NSNumber*, NSButton*>* originals;
+}
+
+- (instancetype)initWithWindow:(NSWindow*)w
+{
+    // The window must have the NSWindowStyleMaskFullSizeContentView
+    // flag set.
+    self = [super init];
+    if (self != nil)
+    {
+        window = w;
+        window.titleVisibility = NSWindowTitleHidden;
+        window.titlebarAppearsTransparent = YES;
+
+        hostView = nil;
+        jfxView = nil;
+
+        titleBarHeight = kDefaultTitleBarHeight;
+        _insets = NSEdgeInsetsZero;
+
+        titleBarBackground = [[NSVisualEffectView alloc] initWithFrame: NSZeroRect];
+
+        // Currently this is producing a darker title bar than expected. The
+        // title bar effect blends window state (such as whether the window has
+        // focus or not) with the content underneath. This includes the NSWindow
+        // background which JavaFX defaults to black.
+        titleBarBackground.material = NSVisualEffectMaterialTitlebar;
+        titleBarBackground.blendingMode = NSVisualEffectBlendingModeWithinWindow;
+
+        stoplightView = [[StoplightView alloc] initWithFrame: NSZeroRect];
+        useOriginals = NO;
+        buttons = [[NSMutableDictionary dictionary] retain];
+        originals = [[NSMutableDictionary dictionary] retain];
+
+        [self addButton: NSWindowCloseButton];
+        [self addButton: NSWindowMiniaturizeButton];
+        [self addButton: NSWindowZoomButton];
+
+        [self positionStoplightView];
+
+        [NSNotificationCenter.defaultCenter addObserver: self
+                                               selector: @selector(restoreOriginalButtons)
+                                                   name: NSWindowWillEnterFullScreenNotification
+                                                 object: window];
+
+        // Before we exit fullscreen we ensure the layout insets are broadcast
+        // The buttons themselves cannot be restored until after we've left
+        // fullscreen.
+        [NSNotificationCenter.defaultCenter addObserver: self
+                                               selector: @selector(leavingFullscreen)
+                                                   name: NSWindowWillExitFullScreenNotification
+                                                 object: window];
+
+        [NSNotificationCenter.defaultCenter addObserver: self
+                                               selector: @selector(hideOriginalButtons)
+                                                   name: NSWindowDidExitFullScreenNotification
+                                                 object: window];
+    }
+    return self;
+}
+
+-(void)dealloc
+{
+    [buttons release];
+    [originals release];
+    [titleBarBackground release];
+    [stoplightView release];
+    [super dealloc];
+}
+
+-(void)addButton:(NSWindowButton)b
+{
+    NSButton* button = [NSWindow standardWindowButton: b forStyleMask: window.styleMask];
+    NSButton* original = [window standardWindowButton: b];
+    button.enabled = original.enabled;
+    original.hidden = YES;
+
+    NSRect frame = NSOffsetRect(button.frame, NSWidth(stoplightView.frame), 0);
+    if (!NSIsEmptyRect(stoplightView.frame))
+        frame = NSOffsetRect(frame, 6, 0);
+    stoplightView.frame = NSUnionRect(stoplightView.frame, frame);
+    button.frame = frame;
+    [stoplightView addSubview: button];
+
+    buttons[@(b)] = button;
+    originals[@(b)] = original;
+}
+
+-(void)restoreOriginalButtons
+{
+    stoplightView.hidden = YES;
+
+    for (NSNumber* key in originals.allKeys)
+    {
+        NSButton* original = originals[key];
+        NSButton* button = buttons[key];
+        original.enabled = button.enabled;
+        original.hidden = NO;
+    }
+
+    useOriginals = YES;
+
+    [self positionStoplightView];
+}
+
+-(void)hideOriginalButtons
+{
+    for (NSNumber* key in originals.allKeys)
+    {
+        NSButton* original = originals[key];
+        NSButton* button = buttons[key];
+        button.enabled = original.enabled;
+        original.hidden = YES;
+    }
+
+    stoplightView.hidden = NO;
+    useOriginals = NO;
+
+    [self positionStoplightView];
+}
+
+-(void)leavingFullscreen
+{
+    stoplightView.hidden = NO;
+    [self positionStoplightView];
+}
+
+-(NSButton*)standardWindowButton:(NSWindowButton)slot
+{
+    if (useOriginals)
+        return originals[@(slot)];
+    return buttons[@(slot)];;
+}
+
+-(void)detachFromHostView
+{
+    [titleBarBackground removeFromSuperview];
+    [stoplightView removeFromSuperview];
+
+    hostView = nil;
+    jfxView = nil;
+}
+
+-(void)detachFromWindow
+{
+    [self detachFromHostView];
+    if (!useOriginals)
+        [self restoreOriginalButtons];
+    window.titleVisibility = NSWindowTitleVisible;
+    window.titlebarAppearsTransparent = NO;
+    window = nil;
+}
+
+-(void)setHostView:(NSView*)newHostView jfxView:(NSView*)newJFX
+{
+    [self detachFromHostView];
+    hostView = newHostView;
+    jfxView = newJFX;
+
+    if (hostView)
+    {
+        // The title bar effect needs to be below the
+        // JFX content to avoid blurring.
+        NSRect titleBarFrame = hostView.bounds;
+        titleBarFrame.size.height = titleBarHeight;
+        titleBarBackground.frame = titleBarFrame;
+        titleBarBackground.autoresizingMask = NSViewWidthSizable;
+
+        [hostView addSubview: titleBarBackground
+                  positioned: NSWindowBelow
+                  relativeTo: jfxView];
+
+        // The buttons need to be above
+        [hostView addSubview: stoplightView
+                  positioned: NSWindowAbove
+                  relativeTo: jfxView];
+
+        [self positionStoplightView];
+        [stoplightView redrawButtons];
+    }
+}
+
+-(CGFloat)height
+{
+    return titleBarHeight;
+}
+
+-(void)setHeight:(CGFloat)height
+{
+    if (height < kMinTitleBarHeight)
+        height = kMinTitleBarHeight;
+
+    if (height != titleBarHeight)
+    {
+        titleBarHeight = height;
+        if (titleBarBackground) {
+            NSRect frame = titleBarBackground.frame;
+            frame.size.height = titleBarHeight;
+            titleBarBackground.frame = frame;
+        }
+    }
+    [self positionStoplightView];
+}
+
+-(void)positionStoplightView
+{
+    NSPoint closeCenter;
+    closeCenter.x = titleBarHeight / 2.0;
+    closeCenter.y = titleBarHeight / 2.0;
+
+    NSButton* closeButton = buttons[@(NSWindowCloseButton)];
+    NSSize centeringOffset = NSMakeSize(NSWidth(closeButton.frame) / 2.0, NSHeight(closeButton.frame) / 2.0);
+
+    NSRect frame = stoplightView.frame;
+    frame.origin.x = closeCenter.x - centeringOffset.width;
+    frame.origin.y = closeCenter.y - centeringOffset.height;
+    stoplightView.frame = frame;
+
+    NSEdgeInsets insets;
+    insets.top = insets.bottom = 0;
+    insets.left = NSMaxX(frame) + 6;
+    insets.right = 6;
+
+    if (stoplightView.hidden)
+    {
+        insets.left = 6;
+    }
+
+    if (!NSEdgeInsetsEqual(insets, _insets))
+    {
+        self.insets = insets;
+    }
+}
+
+// It is expected that the JFX view will implement hitTest: and
+// mouseDown: to intercept and process events for the controls it
+// draws. If the mouse down didn't hit a control it should fall
+// through to the host view which will call this routine.
+-(void)handleMouseDown:(NSEvent *)event
+{
+    NSPoint point = [hostView convertPoint: event.locationInWindow fromView: nil];
+    if (point.y > titleBarHeight)
+        return;
+
+    if (event.clickCount == 1)
+    {
+        [window performWindowDragWithEvent: event];
+    }
+    else if (event.clickCount == 2)
+    {
+        NSString* action = [NSUserDefaults.standardUserDefaults stringForKey: @"AppleActionOnDoubleClick"];
+        if ([action isEqualToString: @"Minimize"])
+            [window performMiniaturize: nil];
+        else if ([action isEqualToString: @"Maximize"])
+            [window performZoom: nil];
+    }
+}
+@end
+

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView.m
@@ -141,6 +141,12 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacView__1initIDs
         if ((*env)->ExceptionCheck(env)) return;
     }
 
+    if (jViewHitTest == NULL)
+    {
+        jViewHitTest = (*env)->GetMethodID(env, jViewClass, "hitTest", "(II)Z");
+        if ((*env)->ExceptionCheck(env)) return;
+    }
+
     if (jViewNotifyInputMethod == NULL)
     {
         jViewNotifyInputMethod = (*env)->GetMethodID(env, jViewClass, "notifyInputMethod", "(Ljava/lang/String;[I[I[BIII)V");
@@ -307,7 +313,7 @@ JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_mac_MacView__1create
         }
 
         // embed ourselves into GlassHostView, so we can later swap our view between windows (ex. fullscreen mode)
-        NSView *hostView = [[GlassHostView alloc] initWithFrame:NSMakeRect(0, 0, 0, 0)]; // alloc creates ref count of 1
+        GlassHostView *hostView = [[GlassHostView alloc] initWithFrame:NSMakeRect(0, 0, 0, 0)]; // alloc creates ref count of 1
         [hostView setAutoresizingMask:(NSViewWidthSizable|NSViewHeightSizable)];
         [hostView setAutoresizesSubviews:YES];
 
@@ -315,6 +321,8 @@ JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_mac_MacView__1create
         [view setAutoresizingMask:(NSViewWidthSizable|NSViewHeightSizable)];
 
         [hostView addSubview:view];
+        hostView->jfxView = view;
+
         jfieldID jfID = (*env)->GetFieldID(env, jViewClass, "ptr", "J");
         GLASS_CHECK_EXCEPTION(env);
         (*env)->SetLongField(env, jView, jfID, ptr_to_jlong(view));

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
@@ -375,6 +375,19 @@
     [self->_delegate sendJavaMouseEvent:theEvent];
 }
 
+- (NSView*)hitTest:(NSPoint)point
+{
+    point = [self convertPoint: point fromView: self.superview];
+    GET_MAIN_JENV;
+    BOOL hitControl = (*env)->CallBooleanMethod(env, self->_delegate->jView, jViewHitTest,
+                                                (jint)point.x, (jint)point.y);
+    GLASS_CHECK_EXCEPTION(env);
+    if (hitControl) {
+        return self;
+    }
+    return nil;
+}
+
 - (void)mouseDown:(NSEvent *)theEvent
 {
     MOUSELOG("mouseDown");

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassViewDelegate.m
@@ -1264,6 +1264,8 @@ static jstring convertNSStringToJString(id aString, int length)
             return;
         }
 
+        // To the best of my knowledge this code is never executed as we always
+        // use native fullscreen.
         [self->fullscreenWindow toggleFullScreen:self->fullscreenWindow];
 
         NSRect frame = [self->parentHost bounds];
@@ -1276,6 +1278,7 @@ static jstring convertNSStringToJString(id aString, int length)
             {
                 [self->nsView removeFromSuperviewWithoutNeedingDisplay];
                 [self->parentHost addSubview:self->nsView];
+                self->parentHost->jfxView = self->nsView;
             }
             [self->nsView release];
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.h
@@ -42,6 +42,7 @@
 - (void)_grabFocus;
 - (void)_setResizable;
 - (NSRect)_constrainFrame:(NSRect)frame;
+- (void)_setTitleBarHeight:(NSNumber*)height;
 - (void)_setVisible;
 - (void)_setBounds:(jint)x y:(jint)y xSet:(jboolean)xSet ySet:(jboolean)ySet w:(jint)w h:(jint)h cw:(jint)cw ch:(jint)ch;
 - (void)_setWindowFrameWithRect:(NSRect)rect withDisplay:(jboolean)display withAnimate:(jboolean)animate;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow+Java.m
@@ -277,6 +277,13 @@ extern NSSize maxScreenDimensions;
     return constrained;
 }
 
+- (void)_setTitleBarHeight:(NSNumber*)height
+{
+    if (self->titleBar) {
+        self->titleBar.height = height.integerValue;
+    }
+}
+
 - (void)_setVisible
 {
     LOG("_setVisible: focusable %d enabled %d", self->isFocusable, self->isEnabled);

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.h
@@ -28,6 +28,7 @@
 
 #import "GlassMenu.h"
 #import "GlassView.h"
+#import "GlassTitleBar.h"
 
 // normal Glass window delegate
 @interface GlassWindow : NSObject <NSWindowDelegate>
@@ -42,6 +43,7 @@
     NSView<GlassView>   *view;
     NSScreen            *currentScreen;
     GlassMenubar        *menubar;
+    GlassTitleBar       *titleBar;
     NSRect              preZoomedRect;
     NSWindow            *fullscreenWindow;
 
@@ -50,6 +52,8 @@
     NSUInteger          enabledStyleMask; // valid while the window is disabled
     BOOL                isTransparent;
     BOOL                isDecorated;
+    BOOL                isUnified;
+    BOOL                isCombined;
     BOOL                isResizable;
     BOOL                suppressWindowMoveEvent;
     BOOL                suppressWindowResizeEvent;

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassView.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassView.cpp
@@ -179,6 +179,10 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_win_WinView__1initIDs
      ASSERT(javaIDs.View.notifyMouse);
      if (env->ExceptionCheck()) return;
 
+     javaIDs.View.hitTest = env->GetMethodID(cls, "hitTest", "(II)Z");
+     ASSERT(javaIDs.View.hitTest);
+     if (env->ExceptionCheck()) return;
+
      javaIDs.View.notifyMenu = env->GetMethodID(cls, "notifyMenu", "(IIIIZ)V");
      ASSERT(javaIDs.View.notifyMenu);
      if (env->ExceptionCheck()) return;

--- a/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassWindow.h
@@ -32,7 +32,7 @@
 
 class GlassWindow : public BaseWnd, public ViewContainer {
 public:
-    GlassWindow(jobject jrefThis, bool isTransparent, bool isDecorated, bool isUnified, HWND parentOrOwner);
+    GlassWindow(jobject jrefThis, bool isTransparent, bool isDecorated, bool isUnified, bool isCombined, HWND parentOrOwner);
     virtual ~GlassWindow();
 
     static GlassWindow* FromHandle(HWND hWnd) {
@@ -46,6 +46,9 @@ public:
     void setMaxSize(long width, long height);
     POINT getMinSize() { return m_minSize; }
     POINT getMaxSize() { return m_maxSize; }
+
+    void SetTitleBarHeight(long height);
+    void UpdateTitleBarInsets();
 
     HMONITOR GetMonitor();
     void SetMonitor(HMONITOR hMonitor);
@@ -129,6 +132,8 @@ private:
     POINT m_minSize;
     POINT m_maxSize;
 
+    LONG  m_titleBarHeight;
+
     HMONITOR m_hMonitor;
 
     bool m_isFocusable;
@@ -144,6 +149,7 @@ private:
     const bool m_isTransparent;
     const bool m_isDecorated;
     const bool m_isUnified;
+    const bool m_isCombined;
 
     bool m_isResizable;
 

--- a/modules/javafx.graphics/src/main/native-glass/win/Utils.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/Utils.h
@@ -443,12 +443,14 @@ typedef struct _tagJavaIDs {
         jmethodID notifyFocusUngrab;
         jmethodID notifyDestroy;
         jmethodID notifyDelegatePtr;
+        jmethodID notifyTitleBarInsetsChanged;
     } Window;
     struct {
         jmethodID notifyResize;
         jmethodID notifyRepaint;
         jmethodID notifyKey;
         jmethodID notifyMouse;
+        jmethodID hitTest;
         jmethodID notifyMenu;
         jmethodID notifyScroll;
         jmethodID notifyInputMethod;

--- a/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.cpp
@@ -929,6 +929,18 @@ BOOL ViewContainer::HandleViewMouseEvent(HWND hwnd, UINT msg, WPARAM wParam, LPA
     return TRUE;
 }
 
+BOOL ViewContainer::HandleViewHitTest(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    POINT pt;
+    pt.x = GET_X_LPARAM(lParam);
+    pt.y = GET_Y_LPARAM(lParam);
+    ::ScreenToClient(hwnd, &pt);
+    JNIEnv *env = GetEnv();
+    jboolean hit = env->CallBooleanMethod(GetView(), javaIDs.View.hitTest, pt.x, pt.y);
+    CheckAndClearException(env);
+    return hit;
+}
+
 void ViewContainer::NotifyCaptureChanged(HWND hwnd, HWND to)
 {
     m_mouseButtonDownCounter = 0;

--- a/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/ViewContainer.h
@@ -70,6 +70,7 @@ class ViewContainer {
         void HandleViewDeadKeyEvent(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
         void HandleViewTypedEvent(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
         BOOL HandleViewMouseEvent(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+        BOOL HandleViewHitTest(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
         BOOL HandleViewInputMethodEvent(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
         LRESULT HandleViewGetAccessible(HWND hwnd, WPARAM wParam, LPARAM lParam);
 

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DContextInit.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DContextInit.cc
@@ -39,6 +39,7 @@ HRESULT D3DContext::InitContext(bool isVsyncEnabled) {
     params.Windowed = TRUE;
     params.SwapEffect = D3DSWAPEFFECT_DISCARD;
     params.hDeviceWindow = GetDesktopWindow();
+    params.BackBufferFormat = D3DFMT_A8R8G8B8;
     params.PresentationInterval = isVsyncEnabled ?
         D3DPRESENT_INTERVAL_ONE :
         D3DPRESENT_INTERVAL_IMMEDIATE;

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DResourceManager.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DResourceManager.cc
@@ -553,6 +553,7 @@ D3DResourceManager::CreateSwapChain(HWND hWnd, UINT numBuffers,
 
     newParams.BackBufferWidth = width;
     newParams.BackBufferHeight = height;
+    newParams.BackBufferFormat = D3DFMT_A8R8G8B8;
     newParams.hDeviceWindow = hWnd;
     newParams.Windowed = TRUE;
     newParams.BackBufferCount = numBuffers;

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubStage.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubStage.java
@@ -175,6 +175,10 @@ public class StubStage implements TKStage {
     }
 
     @Override
+    public void setTitleBarHeight(int height) {
+    }
+
+    @Override
     public void setVisible(boolean visible) {
         this.visible = visible;
 
@@ -370,6 +374,10 @@ public class StubStage implements TKStage {
             process(listener1 -> listener1.changedAlwaysOnTop(alwaysOnTop));
         }
 
+        @Override
+        public void changedTitleBarInsets(float left, float right) {
+            process(listener1 -> listener1.changedTitleBarInsets(left, right));
+        }
 
         @Override
         public void changedResizable(final boolean resizable) {

--- a/tests/manual/stage/CombinedStage.java
+++ b/tests/manual/stage/CombinedStage.java
@@ -1,0 +1,135 @@
+/*
+ *  Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.  Oracle designates this
+ *  particular file as subject to the "Classpath" exception as provided
+ *  by Oracle in the LICENSE file that accompanied this code.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.geometry.Point2D;
+import javafx.scene.control.Button;
+import javafx.scene.control.TextField;
+import javafx.scene.control.TextArea;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+import javafx.scene.layout.Priority;
+import javafx.scene.layout.Region;
+import javafx.scene.paint.Color;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+
+public class CombinedStage extends Application {
+    public static void main(String[] args) {
+        launch(CombinedStage.class, args);
+    }
+
+    private class ClickThroughRegion extends Region {
+        @Override public boolean contains(Point2D p) {
+            return false;
+        }
+    }
+
+    private class ClickThroughHBox extends HBox {
+        public ClickThroughHBox(Node... children) {
+            super(children);
+            setBackground(null);
+        }
+        @Override public boolean contains(Point2D p) {
+            return false;
+        }
+    }
+
+    private class ClickThroughVBox extends VBox {
+        public ClickThroughVBox(Node... children) {
+            super(children);
+            setBackground(null);
+        }
+        @Override public boolean contains(Point2D p) {
+            return false;
+        }
+    }
+
+    private class ThreeBox extends ClickThroughHBox {
+        private final Region leftPadding = new ClickThroughRegion();
+        private final Region rightPadding = new ClickThroughRegion();
+
+        public ThreeBox(Region left, Region center, Region right) {
+            HBox.setHgrow(leftPadding, Priority.ALWAYS);
+            HBox.setHgrow(rightPadding, Priority.ALWAYS);
+            getChildren().addAll(left, leftPadding, center, rightPadding, right);
+        }
+    }
+
+    @Override
+    public void start(Stage stage) {
+
+        TextArea logArea = new TextArea();
+
+        Region leftDecorationRegion = new ClickThroughRegion();
+        Button leftButton = new Button("Left");
+        leftButton.setOnAction(e -> {
+            logArea.appendText("Left button pushed\n");
+        });
+
+        Region rightDecorationRegion = new ClickThroughRegion();
+        Button rightButton = new Button("Right");
+        rightButton.setOnAction(e -> {
+            logArea.appendText("Right button pushed\n");
+        });
+
+        TextField address = new TextField();
+        address.setOnAction(e -> {
+            logArea.appendText("Typed: " + address.getText() + "\n");
+            address.clear();
+        });
+
+        HBox leftContainer = new ClickThroughHBox(leftDecorationRegion, leftButton);
+        HBox centerContainer = new ClickThroughHBox(address);
+        HBox rightContainer = new ClickThroughHBox(rightButton, rightDecorationRegion);
+
+        HBox toolbar = new ThreeBox(
+            leftContainer,
+            centerContainer,
+            rightContainer
+        );
+        toolbar.setPadding(new Insets(5, 0, 5, 0));
+
+        VBox vBox = new ClickThroughVBox(toolbar, logArea);
+        VBox.setVgrow(logArea, Priority.ALWAYS);
+        vBox.setAlignment(Pos.TOP_CENTER);
+
+        Scene scene = new Scene(vBox, 640, 480, Color.TRANSPARENT);
+        stage.setScene(scene);
+        stage.initStyle(StageStyle.COMBINED);
+
+        leftDecorationRegion.prefWidthProperty().bind(stage.leftTitleBarInsetProperty());
+        rightDecorationRegion.prefWidthProperty().bind(stage.rightTitleBarInsetProperty());
+        stage.titleBarHeightProperty().bind(toolbar.heightProperty());
+
+        stage.show();
+    }
+}


### PR DESCRIPTION
This proof-of-concept PR introduces the COMBINED StageStyle which extends the JavaFX Scene to share the title bar space with the platform decorations. Currently this only works for Mac and Windows.

There’s a very simple demo app in tests/manual/stage/CombinedStage.java. 

If you take an existing app and switch the stage style to COMBINED the size you set for the Stage will now include the title bar. Compared to DECORATED the title bar will be shifted downward to overlap the Scene. The application can use the read-write titleBarHeight property to set the height of the title bar area. The platform uses this value to position the window decorations and handle title bar clicks. The platform exports the read-only properties leftTitleBarInset and rightTitleBarInset to indicate how far the application should inset content in the title bar area to avoid overlapping the platform controls.

I tried to use existing platform API’s to achieve the title bar/Scene integration so the platform still draws window drop shadows and resize handles. I also wanted to make click-dragging in the title bar area transparent to JavaFX i.e. clicking in an empty area of the title bar initiates a drag without creating a JavaFX event (see the hitTest code).

A few observations:

- In this PR the platform draws the title bar background so the user sees appropriate visuals for active and inactive windows. To set this up in JavaFX you need to turn off backgrounds for every Node that might overlap the title bar. It would probably be easier to draw the background inside JavaFX if we have access to the correct platform colors.

- Click-to-drag in the title bar area is difficult to set up since layout controls like HBox and VBox prevent clicks from reaching lower nodes. An app can create Box subclasses which allow click-through but controls like Toolbar have skins which create boxes under the hood which will still block clicks.

- On Windows 10 the platform buttons draw under the JavaFX content and there’s no way to control their colors or positions. It would probably be easier to remove them and use JavaFX controls.

- On the Mac there’s a lot of value in re-using the platform “stoplight” controls. They have a fair amount of behavior associated with them that would be hard to reproduce and which varies across OS versions.

Still investigating this on Linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313424](https://bugs.openjdk.org/browse/JDK-8313424): JavaFX controls in the title bar (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1192/head:pull/1192` \
`$ git checkout pull/1192`

Update a local copy of the PR: \
`$ git checkout pull/1192` \
`$ git pull https://git.openjdk.org/jfx.git pull/1192/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1192`

View PR using the GUI difftool: \
`$ git pr show -t 1192`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1192.diff">https://git.openjdk.org/jfx/pull/1192.diff</a>

</details>
