### PR TITLE
JDK-8313628: Column drag header, overlay and line are not correctly aligned

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
@@ -1192,7 +1192,7 @@ public class TableColumnHeader extends Region {
         final double x = getParentHeader().sceneToLocal(sceneX, sceneY).getX();
 
         // calculate where the ghost column header should be
-        double dragX = getTableSkin().getSkinnable().sceneToLocal(sceneX, sceneY).getX() - dragOffset;
+        double dragX = x - dragOffset;
         getTableHeaderRow().setDragHeaderX(dragX);
 
         double startX = 0;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
@@ -446,7 +446,8 @@ public abstract class TableViewSkinBase<M, S, C extends Control, I extends Index
         double tableHeaderRowHeight = tableHeaderRow.prefHeight(-1);
         layoutInArea(tableHeaderRow, x, y, w, tableHeaderRowHeight, baselineOffset,
                 HPos.CENTER, VPos.CENTER);
-        y += tableHeaderRowHeight;
+
+        double yWithTableHeaderRowHeight = y + tableHeaderRowHeight;
 
         // let the virtual flow take up all remaining space
         // TODO this calculation is to ensure the bottom border is visible when
@@ -455,11 +456,11 @@ public abstract class TableViewSkinBase<M, S, C extends Control, I extends Index
         double flowHeight = Math.floor(h - tableHeaderRowHeight);
         if (getItemCount() == 0 || visibleColCount == 0) {
             // show message overlay instead of empty table
-            layoutInArea(placeholderRegion, x, y,
+            layoutInArea(placeholderRegion, x, yWithTableHeaderRowHeight,
                     w, flowHeight,
                     baselineOffset, HPos.CENTER, VPos.CENTER);
         } else {
-            layoutInArea(flow, x, y,
+            layoutInArea(flow, x, yWithTableHeaderRowHeight,
                     w, flowHeight,
                     baselineOffset, HPos.CENTER, VPos.CENTER);
         }
@@ -475,38 +476,36 @@ public abstract class TableViewSkinBase<M, S, C extends Control, I extends Index
                 // either from the left-edge of the column, or 0, if the column
                 // is off the left-side of the TableView (i.e. horizontal
                 // scrolling has occured).
-                double minX = tableHeaderRow.sceneToLocal(n.localToScene(n.getBoundsInLocal())).getMinX();
+                double tableHeaderRowX = tableHeaderRow.sceneToLocal(n.localToScene(n.getBoundsInLocal())).getMinX();
                 double overlayWidth = reorderingColumnHeader.getWidth();
-                if (minX < 0) {
-                    overlayWidth += minX;
+                if (tableHeaderRowX < 0) {
+                    overlayWidth += tableHeaderRowX;
                 }
-                minX = minX < 0 ? 0 : minX;
+                tableHeaderRowX = tableHeaderRowX < 0 ? 0 : tableHeaderRowX;
 
                 // prevent the overlay going out the right-hand side of the
                 // TableView
-                if (minX + overlayWidth > w) {
-                    overlayWidth = w - minX;
+                if (tableHeaderRowX + overlayWidth > w) {
+                    overlayWidth = w - tableHeaderRowX;
 
                     if (flow.getVbar().isVisible()) {
                         overlayWidth -= flow.getVbar().getWidth() - 1;
                     }
                 }
 
-                double contentAreaHeight = flowHeight;
+                double overlayHeight = flowHeight;
                 if (flow.getHbar().isVisible()) {
-                    contentAreaHeight -= flow.getHbar().getHeight();
+                    overlayHeight -= flow.getHbar().getHeight();
                 }
 
-                columnReorderOverlay.resize(overlayWidth, contentAreaHeight);
-
-                columnReorderOverlay.setLayoutX(minX);
-                columnReorderOverlay.setLayoutY(tableHeaderRow.getHeight());
+                double columnReorderOverlayX = x + tableHeaderRowX;
+                columnReorderOverlay.resizeRelocate(columnReorderOverlayX, yWithTableHeaderRowHeight, overlayWidth, overlayHeight);
             }
 
             // paint the reorder line as well
-            double cw = columnReorderLine.snappedLeftInset() + columnReorderLine.snappedRightInset();
+            double lineWidth = columnReorderLine.snappedLeftInset() + columnReorderLine.snappedRightInset();
             double lineHeight = h - (flow.getHbar().isVisible() ? flow.getHbar().getHeight() - 1 : 0);
-            columnReorderLine.resizeRelocate(0, columnReorderLine.snappedTopInset(), cw, lineHeight);
+            columnReorderLine.resizeRelocate(x, y, lineWidth, lineHeight);
         }
 
         columnReorderLine.setVisible(tableHeaderRow.isReordering());

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/TableHeaderRowShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/skin/TableHeaderRowShim.java
@@ -41,4 +41,12 @@ public class TableHeaderRowShim {
     public static Pane getCornerRegion(TableHeaderRow tableHeaderRow) {
         return tableHeaderRow.getCornerRegion();
     }
+
+    public static void setReorderingColumn(TableHeaderRow tableHeaderRow, TableColumnBase<?, ?> tableColumnBase) {
+        tableHeaderRow.setReorderingColumn(tableColumnBase);
+    }
+
+    public static void setReorderingRegion(TableHeaderRow tableHeaderRow, TableColumnHeader tableColumnHeader) {
+        tableHeaderRow.setReorderingRegion(tableColumnHeader);
+    }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableViewSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableViewSkinTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,14 +29,13 @@ import com.sun.javafx.tk.Toolkit;
 import javafx.geometry.Bounds;
 import javafx.geometry.Insets;
 import javafx.scene.Node;
-import javafx.scene.Scene;
-import javafx.scene.control.TableColumn;
-import javafx.scene.control.TableView;
+import javafx.scene.control.TreeTableColumn;
+import javafx.scene.control.TreeTableView;
 import javafx.scene.control.skin.TableColumnHeader;
 import javafx.scene.control.skin.TableColumnHeaderShim;
 import javafx.scene.control.skin.TableHeaderRow;
 import javafx.scene.control.skin.TableHeaderRowShim;
-import javafx.scene.control.skin.TableViewSkin;
+import javafx.scene.control.skin.TreeTableViewSkin;
 import javafx.scene.layout.Region;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -44,7 +43,7 @@ import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class TableViewSkinTest {
+class TreeTableViewSkinTest {
 
     private StageLoader stageLoader;
 
@@ -56,42 +55,23 @@ class TableViewSkinTest {
     }
 
     @Test
-    void test_JDK_8188164() {
-        TableView<String> tableView = new TableView<>();
-        for (int i = 0; i < 5; i++) {
-            TableColumn<String, String> column = new TableColumn<>("Col " + i);
-            tableView.getColumns().add(column);
-        }
-
-        Scene scene = new Scene(tableView);
-        scene.getStylesheets().add(TableViewSkinTest.class.getResource("TableViewSkinTest.css").toExternalForm());
-
-        stageLoader = new StageLoader(scene);
-
-        Toolkit.getToolkit().firePulse();
-
-        TableHeaderRow header = (TableHeaderRow) tableView.lookup("TableHeaderRow");
-        assertEquals(100.0, header.getHeight(), 0.001, "Table Header height specified in CSS");
-    }
-
-    @Test
     void testInitialColumnResizeNodePositions() {
-        TableView<String> tableView = new TableView<>();
+        TreeTableView<String> treeTableView = new TreeTableView<>();
         for (int i = 0; i < 5; i++) {
-            TableColumn<String, String> column = new TableColumn<>("Col " + i);
+            TreeTableColumn<String, String> column = new TreeTableColumn<>("Col " + i);
             column.setMinWidth(100);
             column.setMaxWidth(100);
-            tableView.getColumns().add(column);
+            treeTableView.getColumns().add(column);
         }
 
-        stageLoader = new StageLoader(tableView);
+        stageLoader = new StageLoader(treeTableView);
 
-        Node columnResizeLine = tableView.lookup(".column-resize-line");
-        Node columnReorderOverlay = tableView.lookup(".column-overlay");
+        Node columnResizeLine = treeTableView.lookup(".column-resize-line");
+        Node columnReorderOverlay = treeTableView.lookup(".column-overlay");
 
-        TableHeaderRow header = (TableHeaderRow) tableView.lookup("TableHeaderRow");
+        TableHeaderRow header = (TableHeaderRow) treeTableView.lookup("TableHeaderRow");
         header.setReordering(true);
-        TableHeaderRowShim.setReorderingColumn(header, tableView.getColumns().get(0));
+        TableHeaderRowShim.setReorderingColumn(header, treeTableView.getColumns().get(0));
         TableHeaderRowShim.setReorderingRegion(header, header.getRootHeader().getColumnHeaders().get(0));
 
         Toolkit.getToolkit().firePulse();
@@ -105,23 +85,23 @@ class TableViewSkinTest {
 
     @Test
     void testColumnResizeNodePositionsWithPadding() {
-        TableView<String> tableView = new TableView<>();
-        tableView.setPadding(new Insets(5, 5, 5, 5));
+        TreeTableView<String> treeTableView = new TreeTableView<>();
+        treeTableView.setPadding(new Insets(5, 5, 5, 5));
         for (int i = 0; i < 5; i++) {
-            TableColumn<String, String> column = new TableColumn<>("Col " + i);
+            TreeTableColumn<String, String> column = new TreeTableColumn<>("Col " + i);
             column.setMinWidth(100);
             column.setMaxWidth(100);
-            tableView.getColumns().add(column);
+            treeTableView.getColumns().add(column);
         }
 
-        stageLoader = new StageLoader(tableView);
+        stageLoader = new StageLoader(treeTableView);
 
-        Node columnResizeLine = tableView.lookup(".column-resize-line");
-        Node columnReorderOverlay = tableView.lookup(".column-overlay");
+        Node columnResizeLine = treeTableView.lookup(".column-resize-line");
+        Node columnReorderOverlay = treeTableView.lookup(".column-overlay");
 
-        TableHeaderRow header = (TableHeaderRow) tableView.lookup("TableHeaderRow");
+        TableHeaderRow header = (TableHeaderRow) treeTableView.lookup("TableHeaderRow");
         header.setReordering(true);
-        TableHeaderRowShim.setReorderingColumn(header, tableView.getColumns().get(0));
+        TableHeaderRowShim.setReorderingColumn(header, treeTableView.getColumns().get(0));
         TableHeaderRowShim.setReorderingRegion(header, header.getRootHeader().getColumnHeaders().get(0));
 
         Toolkit.getToolkit().firePulse();
@@ -135,23 +115,23 @@ class TableViewSkinTest {
 
     @Test
     void testColumnResizeNodePositionsWithCustomSkin() {
-        TableView<String> tableView = new TableView<>();
-        tableView.setSkin(new CustomTableViewSkin<>(tableView));
+        TreeTableView<String> treeTableView = new TreeTableView<>();
+        treeTableView.setSkin(new CustomTreeTableViewSkin<>(treeTableView));
         for (int i = 0; i < 5; i++) {
-            TableColumn<String, String> column = new TableColumn<>("Col " + i);
+            TreeTableColumn<String, String> column = new TreeTableColumn<>("Col " + i);
             column.setMinWidth(100);
             column.setMaxWidth(100);
-            tableView.getColumns().add(column);
+            treeTableView.getColumns().add(column);
         }
 
-        stageLoader = new StageLoader(tableView);
+        stageLoader = new StageLoader(treeTableView);
 
-        Node columnResizeLine = tableView.lookup(".column-resize-line");
-        Node columnReorderOverlay = tableView.lookup(".column-overlay");
+        Node columnResizeLine = treeTableView.lookup(".column-resize-line");
+        Node columnReorderOverlay = treeTableView.lookup(".column-overlay");
 
-        TableHeaderRow header = (TableHeaderRow) tableView.lookup("TableHeaderRow");
+        TableHeaderRow header = (TableHeaderRow) treeTableView.lookup("TableHeaderRow");
         header.setReordering(true);
-        TableHeaderRowShim.setReorderingColumn(header, tableView.getColumns().get(0));
+        TableHeaderRowShim.setReorderingColumn(header, treeTableView.getColumns().get(0));
         TableHeaderRowShim.setReorderingRegion(header, header.getRootHeader().getColumnHeaders().get(0));
 
         Toolkit.getToolkit().firePulse();
@@ -165,18 +145,18 @@ class TableViewSkinTest {
 
     @Test
     void testColumnHeaderReorderCorrectTranslateX() {
-        TableView<String> tableView = new TableView<>();
-        tableView.setPadding(new Insets(0, 10, 0, 30));
+        TreeTableView<String> treeTableView = new TreeTableView<>();
+        treeTableView.setPadding(new Insets(0, 10, 0, 30));
         for (int i = 0; i < 5; i++) {
-            TableColumn<String, String> column = new TableColumn<>("Col " + i);
+            TreeTableColumn<String, String> column = new TreeTableColumn<>("Col " + i);
             column.setMinWidth(100);
             column.setMaxWidth(100);
-            tableView.getColumns().add(column);
+            treeTableView.getColumns().add(column);
         }
 
-        stageLoader = new StageLoader(tableView);
+        stageLoader = new StageLoader(treeTableView);
 
-        TableHeaderRow header = (TableHeaderRow) tableView.lookup("TableHeaderRow");
+        TableHeaderRow header = (TableHeaderRow) treeTableView.lookup("TableHeaderRow");
         Node columnDragHeader = header.lookup(".column-drag-header");
 
         assertEquals(0, columnDragHeader.getTranslateX());
@@ -188,9 +168,9 @@ class TableViewSkinTest {
         assertEquals(20, columnDragHeader.getTranslateX());
     }
 
-    private static class CustomTableViewSkin<S> extends TableViewSkin<S> {
+    private static class CustomTreeTableViewSkin<S> extends TreeTableViewSkin<S> {
 
-        CustomTableViewSkin(TableView<S> control) {
+        CustomTreeTableViewSkin(TreeTableView<S> control) {
             super(control);
         }
 


### PR DESCRIPTION
When a table has padding or the `layoutChildren` method inside the table skin is overridden (and x/y are modified), the drag drag header, column overlay and column line are not correctly aligned.

The reason is that the positions were calculated incorrectly.
- **Column overlay and column line**
Always calculate in the x and y from the table. The x and y variables contain the snapped insets (padding) and possible modifications from subclasses.
- **Drag header**
Calculate the drag x offset local bounds from the parent header (which is either the parent column header or the root header)
Before, the local bounds were calculated from the table, which will wrongly calculate in the padding.
We do not want to know the local bounds based of the whole table but of our header we are in.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8313628](https://bugs.openjdk.org/browse/JDK-8313628): Column drag header, overlay and line are not correctly aligned (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Karthik P K](https://openjdk.org/census#kpk) (@karthikpandelu - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1193/head:pull/1193` \
`$ git checkout pull/1193`

Update a local copy of the PR: \
`$ git checkout pull/1193` \
`$ git pull https://git.openjdk.org/jfx.git pull/1193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1193`

View PR using the GUI difftool: \
`$ git pr show -t 1193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1193.diff">https://git.openjdk.org/jfx/pull/1193.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1193#issuecomment-1662571815)