### PR TITLE
JDK-8311983: ListView sometimes throws an IndexOutOfBoundsException

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/VirtualScrollBar.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/VirtualScrollBar.java
@@ -130,28 +130,29 @@ public class VirtualScrollBar extends ScrollBar {
             adjusting = true;
             double oldValue = flow.getPosition();
             double newValue = ((getMax() - getMin()) * Utils.clamp(0, pos, 1)) + getMin();
-            /**
+            /*
              * Scroll one cell further in the direction the user has clicked if only one cell is shown.
              * Otherwise, a click on the trough would have no effect when cell height > viewport height.
              */
-            IndexedCell firstVisibleCell = flow.getFirstVisibleCell();
-            IndexedCell lastVisibleCell = flow.getLastVisibleCell();
+            IndexedCell<?> firstVisibleCell = flow.getFirstVisibleCell();
+            IndexedCell<?> lastVisibleCell = flow.getLastVisibleCell();
             if (firstVisibleCell != null && firstVisibleCell == lastVisibleCell) {
                 int index = firstVisibleCell.getIndex();
                 if (newValue < oldValue) {
-                    flow.scrollTo(index - 1);
+                    index = Math.max(0, index - 1);
                 } else {
-                    flow.scrollTo(index + 1);
+                    index = Math.max(flow.getCellCount(), index + 1);
                 }
+                flow.scrollTo(index);
             } else {
                 if (newValue < oldValue) {
-                    IndexedCell cell = firstVisibleCell;
+                    IndexedCell<?> cell = firstVisibleCell;
                     if (cell == null) {
                         return;
                     }
                     flow.scrollToBottom(cell);
                 } else if (newValue > oldValue) {
-                    IndexedCell cell = lastVisibleCell;
+                    IndexedCell<?> cell = lastVisibleCell;
                     if (cell == null) {
                         return;
                     }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/VirtualScrollBar.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/VirtualScrollBar.java
@@ -141,7 +141,7 @@ public class VirtualScrollBar extends ScrollBar {
                 if (newValue < oldValue) {
                     index = Math.max(0, index - 1);
                 } else {
-                    index = Math.max(flow.getCellCount(), index + 1);
+                    index = Math.min(flow.getCellCount(), index + 1);
                 }
                 flow.scrollTo(index);
             } else {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -1672,8 +1672,10 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             // Add any necessary leading cells
             if (firstCell != null) {
                 int firstIndex = getCellIndex(firstCell);
-                double prevIndexSize = getCellLength(firstIndex - 1);
-                addLeadingCells(firstIndex - 1, getCellPosition(firstCell) - prevIndexSize);
+                int index = Math.max(0, firstIndex - 1);
+
+                double prevIndexSize = getCellLength(index);
+                addLeadingCells(index, getCellPosition(firstCell) - prevIndexSize);
             } else {
                 int currentIndex = computeCurrentIndex();
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -1790,8 +1790,57 @@ assertEquals(0, firstCell.getIndex());
         flow.shim_getVbar().adjustValue(0.9605263157894737);
         // Scroll up.
         flow.shim_getVbar().adjustValue(0.05263157894736842);
-        // Scroll up again.
-        assertDoesNotThrow(() -> flow.shim_getVbar().adjustValue(0.05263157894736842));
+
+        try {
+            flow.shim_getVbar().adjustValue(0.05263157894736842);
+        } catch (Exception e) {
+            // This should not throw any exception. It used to throw an IndexOutOfBoundsException.
+            fail();
+        }
+    }
+
+    @Test
+    public void testScrollBarValueAdjustmentShouldScrollOneDown() {
+        flow = new VirtualFlowShim<>();
+        flow.setFixedCellSize(512);
+        flow.setCellFactory(fw -> new CellStub(flow));
+        flow.setCellCount(5);
+        flow.resize(250, 300);
+
+        pulse();
+
+        assertEquals(0, flow.getLastVisibleCell().getIndex());
+
+        // Scroll down.
+        flow.shim_getVbar().adjustValue(1);
+        pulse();
+
+        assertEquals(1, flow.getLastVisibleCell().getIndex());
+    }
+
+    @Test
+    public void testScrollBarValueAdjustmentShouldScrollOneUp() {
+        flow = new VirtualFlowShim<>();
+        flow.setFixedCellSize(512);
+        flow.setCellFactory(fw -> new CellStub(flow));
+        flow.setCellCount(5);
+        flow.resize(250, 300);
+
+        pulse();
+
+        assertEquals(0, flow.getFirstVisibleCell().getIndex());
+
+        // Scroll completely down.
+        flow.shim_getVbar().setValue(1.0);
+        pulse();
+
+        assertEquals(4, flow.getFirstVisibleCell().getIndex());
+
+        // Scroll up.
+        flow.shim_getVbar().adjustValue(0.0);
+        pulse();
+
+        assertEquals(3, flow.getFirstVisibleCell().getIndex());
     }
 
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -1791,12 +1791,8 @@ assertEquals(0, firstCell.getIndex());
         // Scroll up.
         flow.shim_getVbar().adjustValue(0.05263157894736842);
 
-        try {
-            flow.shim_getVbar().adjustValue(0.05263157894736842);
-        } catch (Exception e) {
-            // This should not throw any exception. It used to throw an IndexOutOfBoundsException.
-            fail();
-        }
+        // This should not throw any exception. It used to throw an IndexOutOfBoundsException.
+        flow.shim_getVbar().adjustValue(0.05263157894736842);
     }
 
     @Test

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -1765,6 +1766,32 @@ assertEquals(0, firstCell.getIndex());
         pulse();
         idx = flow.shim_computeCurrentIndex();
         assertEquals(29, idx);
+    }
+
+    /**
+     * Scrolling via the trough (-> {@link com.sun.javafx.scene.control.VirtualScrollBar#adjustValue(double)}) should
+     * not throw any exception.
+     * This happened in the past when scrolling up (more) when we already only see the uppermost cell with the index 0.
+     * This index was subtracted by 1, leading to an {@link IndexOutOfBoundsException}.
+     *
+     * @see <a href="https://bugs.openjdk.org/browse/JDK-8311983">JDK-8311983</a>
+     */
+    @Test
+    public void testScrollBarValueAdjustmentShouldNotThrowIOOBE() {
+        flow = new VirtualFlowShim<>();
+        flow.setFixedCellSize(512);
+        flow.setCellFactory(fw -> new CellStub(flow));
+        flow.setCellCount(2);
+        flow.resize(250, 300);
+
+        pulse();
+
+        // Scroll down.
+        flow.shim_getVbar().adjustValue(0.9605263157894737);
+        // Scroll up.
+        flow.shim_getVbar().adjustValue(0.05263157894736842);
+        // Scroll up again.
+        assertDoesNotThrow(() -> flow.shim_getVbar().adjustValue(0.05263157894736842));
     }
 
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -34,7 +34,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.util.Iterator;
 import java.util.LinkedList;


### PR DESCRIPTION
An IOOBE was thrown when scrolling up via the trough (-> `VirtualScrollBar#adjustValue`).
This happened only when it has bigger cells than the viewport. 
If the the uppermost cell with the index 0 is only visible (although not completely scrolled to the top) and then an attempt is made to scroll up again, the `VirtualFlow` will try to scroll to the next cell, subtracting index 0 by 1, resulting in -1 -> IOOBE.

The code now guards against any under or overflow.

This is technically a regression from https://bugs.openjdk.org/browse/JDK-8173321

Note: While testing with very big cells, I found out that scrolling via the trough may not work after the first time. 
This is because the `VirtualFlow` still creates 2 cells, although only one can be visible at a time (at least when scrolling to the next cell) (and `VirtualScrollBar` does this check, which will never be true then: `firstVisibleCell == lastVisibleCell`). This is unrelated to this fix. I can create a ticket when I have more information.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8311983](https://bugs.openjdk.org/browse/JDK-8311983): ListView sometimes throws an IndexOutOfBoundsException (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1194/head:pull/1194` \
`$ git checkout pull/1194`

Update a local copy of the PR: \
`$ git checkout pull/1194` \
`$ git pull https://git.openjdk.org/jfx.git pull/1194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1194`

View PR using the GUI difftool: \
`$ git pr show -t 1194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1194.diff">https://git.openjdk.org/jfx/pull/1194.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1194#issuecomment-1663053033)