### PR TITLE
8310885: Width/height of window is not set after calling sizeToScene

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/stage/Window.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/Window.java
@@ -632,6 +632,7 @@ public class Window implements EventTarget {
         width.set(value);
         peerBoundsConfigurator.setWindowWidth(value);
         widthExplicit = true;
+        sizeToScene = false;
     }
     public final double getWidth() { return width.get(); }
     public final ReadOnlyDoubleProperty widthProperty() { return width.getReadOnlyProperty(); }
@@ -664,6 +665,7 @@ public class Window implements EventTarget {
         height.set(value);
         peerBoundsConfigurator.setWindowHeight(value);
         heightExplicit = true;
+        sizeToScene = false;
     }
     public final double getHeight() { return height.get(); }
     public final ReadOnlyDoubleProperty heightProperty() { return height.getReadOnlyProperty(); }

--- a/modules/javafx.graphics/src/test/java/test/javafx/stage/WindowTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/stage/WindowTest.java
@@ -82,8 +82,7 @@ public final class WindowTest {
         assertEquals(1.0f, peer.opacity);
     }
 
-    @Test
-    public void testProperties() {
+    @Test public void testProperties() {
         javafx.collections.ObservableMap<Object, Object> properties = testWindow.getProperties();
 
         /* If we ask for it, we should get it.
@@ -112,8 +111,7 @@ public final class WindowTest {
         return (StubStage) unkPeer;
     }
 
-    @Test
-    public void testGetWindowsIsObservable() {
+    @Test public void testGetWindowsIsObservable() {
         ObservableList<Window> windows = Window.getWindows();
 
         final int initialWindowCount = windows.size();
@@ -154,16 +152,14 @@ public final class WindowTest {
 
     // There is no UOE here because the window being removed is not in the list of windows,
     // so no modification of the windows list occurs.
-    @Test
-    public void testGetWindowsIsUnmodifiable_removeNonShowingWindow_emptyList() {
+    @Test public void testGetWindowsIsUnmodifiable_removeNonShowingWindow_emptyList() {
         Stage anotherTestWindow = new Stage();
         Window.getWindows().remove(anotherTestWindow);
     }
 
     // There is no UOE here because the window being removed is not in the list of windows,
     // so no modification of the windows list occurs.
-    @Test
-    public void testGetWindowsIsUnmodifiable_removeNonShowingWindow_nonEmptyList() {
+    @Test public void testGetWindowsIsUnmodifiable_removeNonShowingWindow_nonEmptyList() {
         ObservableList<Window> windows = Window.getWindows();
 
         final int initialWindowCount = windows.size();

--- a/modules/javafx.graphics/src/test/java/test/javafx/stage/WindowTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/stage/WindowTest.java
@@ -181,8 +181,8 @@ public final class WindowTest {
         testWindow.sizeToScene();
         testWindow.setWidth(800);
         testWindow.show();
-        assertEquals(800, testWindow.getWidth(), 1);
-        assertEquals(500, testWindow.getHeight(), 1);
+        assertEquals(800.0, testWindow.getWidth());
+        assertEquals(500.0, testWindow.getHeight());
     }
 
     @Test
@@ -192,8 +192,8 @@ public final class WindowTest {
         testWindow.sizeToScene();
         testWindow.setHeight(600);
         testWindow.show();
-        assertEquals(400, testWindow.getWidth(), 1);
-        assertEquals(600, testWindow.getHeight(), 1);
+        assertEquals(400.0, testWindow.getWidth());
+        assertEquals(600.0, testWindow.getHeight());
     }
 
     @Test
@@ -204,8 +204,8 @@ public final class WindowTest {
         testWindow.setWidth(800);
         testWindow.setHeight(600);
         testWindow.show();
-        assertEquals(800, testWindow.getWidth(), 1);
-        assertEquals(600, testWindow.getHeight(), 1);
+        assertEquals(800.0, testWindow.getWidth());
+        assertEquals(600.0, testWindow.getHeight());
     }
 
     @Test
@@ -214,8 +214,8 @@ public final class WindowTest {
         testWindow.setScene(scene);
         testWindow.sizeToScene();
         testWindow.show();
-        assertEquals(400, testWindow.getWidth(), 1);
-        assertEquals(500, testWindow.getHeight(), 1);
+        assertEquals(400.0, testWindow.getWidth());
+        assertEquals(500.0, testWindow.getHeight());
     }
 
     @Test
@@ -224,7 +224,7 @@ public final class WindowTest {
         testWindow.setScene(scene);
         testWindow.show();
         testWindow.sizeToScene();
-        assertEquals(400, testWindow.getWidth(), 1);
-        assertEquals(500, testWindow.getHeight(), 1);
+        assertEquals(400.0, testWindow.getWidth());
+        assertEquals(500.0, testWindow.getHeight());
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/stage/WindowTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/stage/WindowTest.java
@@ -33,12 +33,12 @@ import static junit.framework.Assert.assertNotNull;
 import javafx.beans.InvalidationListener;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
-
 import javafx.collections.ObservableList;
+import javafx.scene.Scene;
+import javafx.scene.layout.Region;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 import test.com.sun.javafx.pgstub.StubStage;
 import test.com.sun.javafx.pgstub.StubToolkit;
 import com.sun.javafx.tk.TKStage;
@@ -82,7 +82,8 @@ public final class WindowTest {
         assertEquals(1.0f, peer.opacity);
     }
 
-    @Test public void testProperties() {
+    @Test
+    public void testProperties() {
         javafx.collections.ObservableMap<Object, Object> properties = testWindow.getProperties();
 
         /* If we ask for it, we should get it.
@@ -111,7 +112,8 @@ public final class WindowTest {
         return (StubStage) unkPeer;
     }
 
-    @Test public void testGetWindowsIsObservable() {
+    @Test
+    public void testGetWindowsIsObservable() {
         ObservableList<Window> windows = Window.getWindows();
 
         final int initialWindowCount = windows.size();
@@ -152,14 +154,16 @@ public final class WindowTest {
 
     // There is no UOE here because the window being removed is not in the list of windows,
     // so no modification of the windows list occurs.
-    @Test public void testGetWindowsIsUnmodifiable_removeNonShowingWindow_emptyList() {
+    @Test
+    public void testGetWindowsIsUnmodifiable_removeNonShowingWindow_emptyList() {
         Stage anotherTestWindow = new Stage();
         Window.getWindows().remove(anotherTestWindow);
     }
 
     // There is no UOE here because the window being removed is not in the list of windows,
     // so no modification of the windows list occurs.
-    @Test public void testGetWindowsIsUnmodifiable_removeNonShowingWindow_nonEmptyList() {
+    @Test
+    public void testGetWindowsIsUnmodifiable_removeNonShowingWindow_nonEmptyList() {
         ObservableList<Window> windows = Window.getWindows();
 
         final int initialWindowCount = windows.size();
@@ -172,5 +176,59 @@ public final class WindowTest {
 
         windows.remove(anotherTestWindow);
         assertEquals(initialWindowCount + 1, windows.size());
+    }
+
+    @Test
+    public void testSetWidthAfterSizeToScene() {
+        final var scene = new Scene(new Region(), 400, 500);
+        testWindow.setScene(scene);
+        testWindow.sizeToScene();
+        testWindow.setWidth(800);
+        testWindow.show();
+        assertEquals(800, testWindow.getWidth(), 1);
+        assertEquals(500, testWindow.getHeight(), 1);
+    }
+
+    @Test
+    public void testSetHeightAfterSizeToScene() {
+        final var scene = new Scene(new Region(), 400, 500);
+        testWindow.setScene(scene);
+        testWindow.sizeToScene();
+        testWindow.setHeight(600);
+        testWindow.show();
+        assertEquals(400, testWindow.getWidth(), 1);
+        assertEquals(600, testWindow.getHeight(), 1);
+    }
+
+    @Test
+    public void testSetSizeAfterSizeToScene() {
+        final var scene = new Scene(new Region(), 400, 500);
+        testWindow.setScene(scene);
+        testWindow.sizeToScene();
+        testWindow.setWidth(800);
+        testWindow.setHeight(600);
+        testWindow.show();
+        assertEquals(800, testWindow.getWidth(), 1);
+        assertEquals(600, testWindow.getHeight(), 1);
+    }
+
+    @Test
+    public void testSizeToSceneBeforeShowing() {
+        final var scene = new Scene(new Region(), 400, 500);
+        testWindow.setScene(scene);
+        testWindow.sizeToScene();
+        testWindow.show();
+        assertEquals(400, testWindow.getWidth(), 1);
+        assertEquals(500, testWindow.getHeight(), 1);
+    }
+
+    @Test
+    public void testSizeToSceneAfterShowing() {
+        final var scene = new Scene(new Region(), 400, 500);
+        testWindow.setScene(scene);
+        testWindow.show();
+        testWindow.sizeToScene();
+        assertEquals(400, testWindow.getWidth(), 1);
+        assertEquals(500, testWindow.getHeight(), 1);
     }
 }


### PR DESCRIPTION
`setHeight()` / `setWidth()` were ignored if called after `sizeToScene()` and before `show()`.      
Now the `sizeToScene` flag is unset in these methods to ensure the right values are set when the window is shown.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8310885](https://bugs.openjdk.org/browse/JDK-8310885): Width/height of window is not set after calling sizeToScene (**Bug** - P4)


### Reviewers
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - Committer) 🔄 Re-review required (review applies to [fd3fb463](https://git.openjdk.org/jfx/pull/1195/files/fd3fb4633c26eae21be2c46b1d2083e79ecc2a46))
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer) 🔄 Re-review required (review applies to [fd3fb463](https://git.openjdk.org/jfx/pull/1195/files/fd3fb4633c26eae21be2c46b1d2083e79ecc2a46))
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1195/head:pull/1195` \
`$ git checkout pull/1195`

Update a local copy of the PR: \
`$ git checkout pull/1195` \
`$ git pull https://git.openjdk.org/jfx.git pull/1195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1195`

View PR using the GUI difftool: \
`$ git pr show -t 1195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1195.diff">https://git.openjdk.org/jfx/pull/1195.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1195#issuecomment-1664154798)