### PR TITLE
JDK-8313799: Remove lockItemOnEdit flag from (Tree)TableCell

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
@@ -100,8 +100,6 @@ public class TableCell<S,T> extends IndexedCell<T> {
      *                                                                         *
      **************************************************************************/
 
-    // package for testing
-    boolean lockItemOnEdit = false;
 
 
     /* *************************************************************************
@@ -319,12 +317,7 @@ public class TableCell<S,T> extends IndexedCell<T> {
             return;
         }
 
-        // We check the boolean lockItemOnEdit field here, as whilst we want to
-        // updateItem normally, when it comes to unit tests we can't have the
-        // item change in all circumstances.
-        if (! lockItemOnEdit) {
-            updateItem(-1);
-        }
+        updateItem(-1);
 
         // it makes sense to get the cell into its editing state before firing
         // the event to listeners below, so that's what we're doing here

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
@@ -98,8 +98,6 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
      *                                                                         *
      **************************************************************************/
 
-    // package for testing
-    boolean lockItemOnEdit = false;
 
 
 
@@ -336,12 +334,7 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
             return;
         }
 
-        // We check the boolean lockItemOnEdit field here, as whilst we want to
-        // updateItem normally, when it comes to unit tests we can't have the
-        // item change in all circumstances.
-        if (! lockItemOnEdit) {
-            updateItem(-1);
-        }
+        updateItem(-1);
 
         // it makes sense to get the cell into its editing state before firing
         // the event to listeners below, so that's what we're doing here

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/TableCellShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/TableCellShim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,13 +26,37 @@ package javafx.scene.control;
 
 public class TableCellShim<S,T> extends TableCell<S,T> {
 
+    /**
+     * Flag which is only used in conjunction with {@link #lockItemOnStartEdit} to lock the item when
+     * the {@link #startEdit()} method is called.
+     */
+    private boolean isStartEdit = false;
+    /**
+     * Flag to lock the item value when an edit process is started.
+     * While normally the {@link #updateItem(Object, boolean)} will change the underlying item,
+     * when locked the item will not be changed.
+     */
+    private boolean lockItemOnStartEdit = false;
+
+    @Override
+    public void startEdit() {
+        isStartEdit = true;
+        super.startEdit();
+    }
+
     @Override
     public void updateItem(T item, boolean empty) {
+        // startEdit() was called and wants to update the cell. When locked, we will ignore the update request.
+        if (lockItemOnStartEdit && isStartEdit) {
+            isStartEdit = false;
+            return;
+        }
+
         super.updateItem(item, empty);
     }
 
-    public static <S, T> void set_lockItemOnEdit(TableCell<S, T> tc, boolean b) {
-        tc.lockItemOnEdit = b;
+    public void setLockItemOnStartEdit(boolean lockItemOnEdit) {
+        this.lockItemOnStartEdit = lockItemOnEdit;
     }
 
     public static <S, T> TablePosition<S, T> getEditingCellAtStartEdit(TableCell<S, T> cell) {

--- a/modules/javafx.controls/src/shims/java/javafx/scene/control/TreeTableCellShim.java
+++ b/modules/javafx.controls/src/shims/java/javafx/scene/control/TreeTableCellShim.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,13 +26,37 @@ package javafx.scene.control;
 
 public class TreeTableCellShim<S,T> extends TreeTableCell<S,T> {
 
+    /**
+     * Flag which is only used in conjunction with {@link #lockItemOnStartEdit} to lock the item when
+     * the {@link #startEdit()} method is called.
+     */
+    private boolean isStartEdit = false;
+    /**
+     * Flag to lock the item value when an edit process is started.
+     * While normally the {@link #updateItem(Object, boolean)} will change the underlying item,
+     * when locked the item will not be changed.
+     */
+    private boolean lockItemOnStartEdit = false;
+
+    @Override
+    public void startEdit() {
+        isStartEdit = true;
+        super.startEdit();
+    }
+
     @Override
     public void updateItem(T item, boolean empty) {
+        // startEdit() was called and wants to update the cell. When locked, we will ignore the update request.
+        if (lockItemOnStartEdit && isStartEdit) {
+            isStartEdit = false;
+            return;
+        }
+
         super.updateItem(item, empty);
     }
 
-    public static <S, T> void set_lockItemOnEdit(TreeTableCell<S, T> tc, boolean b) {
-        tc.lockItemOnEdit = b;
+    public void setLockItemOnStartEdit(boolean lockItemOnEdit) {
+        this.lockItemOnStartEdit = lockItemOnEdit;
     }
 
     public static <S, T> TreeTablePosition<S, T> getEditingCellAtStartEdit(TreeTableCell<S, T> cell) {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/CellTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,10 +66,12 @@ public class CellTest {
                 {Cell.class},
                 {ListCell.class},
                 {TableRow.class},
-                {TableCell.class},
+                // Note: We use the shim here, so we can lock the item. The behaviour is the same otherwise.
+                {TableCellShim.class},
                 {TreeCell.class},
                 {TreeTableRow.class},
-                {TreeTableCell.class}
+                // Note: We use the shim here, so we can lock the item.  The behaviour is the same otherwise.
+                {TreeTableCellShim.class}
         });
     }
 
@@ -90,12 +92,12 @@ public class CellTest {
             TableRow tableRow = new TableRow();
             CellShim.updateItem(tableRow, "TableRow", false);
             ((TableCell)cell).updateTableRow(tableRow);
-            TableCellShim.set_lockItemOnEdit((TableCell)cell, true);
+            ((TableCellShim)cell).setLockItemOnStartEdit(true);
         } else if (cell instanceof TreeTableCell) {
             TreeTableRow tableRow = new TreeTableRow();
             CellShim.updateItem(tableRow, "TableRow", false);
             ((TreeTableCell)cell).updateTableRow(tableRow);
-            TreeTableCellShim.set_lockItemOnEdit((TreeTableCell)cell, true);
+            ((TreeTableCellShim)cell).setLockItemOnStartEdit(true);
         }
     }
 
@@ -274,9 +276,6 @@ public class CellTest {
     }
 
     @Test public void startEditWhenEditableIsTrue() {
-        if ((cell instanceof TableCell)) {
-            TableCellShim.set_lockItemOnEdit((TableCell) cell, true);
-        }
         CellShim.updateItem(cell, "Apples", false);
         cell.startEdit();
         assertTrue(cell.isEditing());
@@ -290,9 +289,6 @@ public class CellTest {
     }
 
     @Test public void startEditWhileAlreadyEditingIsIgnored() {
-        if (cell instanceof TableCell) {
-            TableCellShim.set_lockItemOnEdit((TableCell) cell, true);
-        }
         CellShim.updateItem(cell, "Apples", false);
         cell.startEdit();
         cell.startEdit();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
@@ -59,7 +59,7 @@ import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
 /**
  */
 public class TableCellTest {
-    private TableCell<String,String> cell;
+    private TableCellShim<String, String> cell;
     private TableView<String> table;
     private TableColumn<String, String> editingColumn;
     private TableRow<String> row;
@@ -75,7 +75,7 @@ public class TableCellTest {
             }
         });
 
-        cell = new TableCell<>();
+        cell = new TableCellShim<>();
         model = FXCollections.observableArrayList("Four", "Five", "Fear"); // "Flop", "Food", "Fizz"
         table = new TableView<>(model);
         editingColumn = new TableColumn<>("TEST");
@@ -852,7 +852,7 @@ public class TableCellTest {
          }
          if (editingColumn != null ) cell.updateTableColumn(editingColumn);
          // force into editable state (not empty)
-         TableCellShim.set_lockItemOnEdit(cell, true);
+         cell.setLockItemOnStartEdit(true);
          CellShim.updateItem(cell, "something", false);
      }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewKeyInputTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewKeyInputTest.java
@@ -1995,7 +1995,6 @@ public class TableViewKeyInputTest {
         assertEquals(0, rt29849_cancel_count);
 
         TableCell cell = (TableCell)VirtualFlowTestUtils.getCell(tableView, 0, 0);
-        TableCellShim.set_lockItemOnEdit(cell, false);
         assertTrue(cell.isEditable());
         assertFalse(cell.isEditing());
         assertEquals(0, cell.getIndex());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
@@ -57,7 +57,7 @@ import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.
 import static org.junit.Assert.*;
 
 public class TreeTableCellTest {
-    private TreeTableCell<String, String> cell;
+    private TreeTableCellShim<String, String> cell;
     private TreeTableView<String> tree;
     private TreeTableRow<String> row;
 
@@ -83,7 +83,7 @@ public class TreeTableCellTest {
             }
         });
 
-        cell = new TreeTableCell<>();
+        cell = new TreeTableCellShim<>();
 
         root = new TreeItem<>(ROOT);
         apples = new TreeItem<>(APPLES);
@@ -1163,7 +1163,7 @@ public class TreeTableCellTest {
          }
          if (editingColumn != null ) cell.updateTableColumn(editingColumn);
          // force into editable state (not empty)
-         TreeTableCellShim.set_lockItemOnEdit(cell, true);
+         cell.setLockItemOnStartEdit(true);
          CellShim.updateItem(cell, "something", false);
      }
 


### PR DESCRIPTION
The `lockItemOnEdit` only exists inside `TreeTableCell` and `TableCell` for the sake of testing.
It is only changed by some JUnit tests to remove the need of setting up the whole table framework.
This PR shifts this flag from those two classes to the shim classes, which are not inside the final JavaFX product, only used for testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8313799](https://bugs.openjdk.org/browse/JDK-8313799): Remove lockItemOnEdit flag from (Tree)TableCell (**Bug** - P4)


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1198/head:pull/1198` \
`$ git checkout pull/1198`

Update a local copy of the PR: \
`$ git checkout pull/1198` \
`$ git pull https://git.openjdk.org/jfx.git pull/1198/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1198`

View PR using the GUI difftool: \
`$ git pr show -t 1198`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1198.diff">https://git.openjdk.org/jfx/pull/1198.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1198#issuecomment-1666232304)