### PR TITLE
JDK-8283401: ArrayIndexOutOfBoundsException when disconnecting screen(s)

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPipeline.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPipeline.java
@@ -199,6 +199,12 @@ public final class D3DPipeline extends GraphicsPipeline {
 
         d3dInitialized = true;
         factories = new D3DResourceFactory[nGetAdapterCount()];
+
+        // Reassign the adapter ordinal of all the screens because the configuration has been changed
+        // and the old adapter ordinal may be outdated.
+        for (Screen screen : Screen.getScreens()) {
+            screen.setAdapterOrdinal(getAdapterOrdinal(screen));
+        }
     }
 
     @Override


### PR DESCRIPTION
When the `D3DPipeline` is reinitialized, the adapter ordinal of all the `Screen`s are outdated.
As a consequence, when a `D3DResourceFactory` is created for a `Screen` (adapter ordinal), the code may fail with an `ArrayIndexOutOfBoundsException` as the ordinal is higher than what we would expect it to be.

Example:
We have 3 screens. Adapter ordinal 0, 1, 2.
If we now disconnect 2 screens, we only have one screen left. 
The `D3DPipeline` is reinitialized as a [D3DERR_DEVICEREMOVED](https://learn.microsoft.com/en-us/windows/win32/direct3d9/d3derr) is reported from Direct3d9.
Now the remaining screen may have the adapter ordinal 1 (from before). But since we only have 1 screen left, it should have the adapter ordinal 0. 

Direct3d9 will also return 0 as adapter ordinal if you call it. And that is what we do to update the `Screen` and fix this problem.

See also the ticket for information how to reproduce this problem (Windows only).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8283401](https://bugs.openjdk.org/browse/JDK-8283401): ArrayIndexOutOfBoundsException when disconnecting screen(s) (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1200/head:pull/1200` \
`$ git checkout pull/1200`

Update a local copy of the PR: \
`$ git checkout pull/1200` \
`$ git pull https://git.openjdk.org/jfx.git pull/1200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1200`

View PR using the GUI difftool: \
`$ git pr show -t 1200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1200.diff">https://git.openjdk.org/jfx/pull/1200.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1200#issuecomment-1666501229)