### PR TITLE
8314149: Clipboard does inexact string comparison on mime type

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/GlassClipboard.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/GlassClipboard.cpp
@@ -581,16 +581,13 @@ public:
         static const STGMEDIUM empty_data = {0};
         for (jsize i = 0; i < ckeys; ++i) {
             JString mime(env, (jstring)env->GetObjectArrayElement(keys, i));
-            static const size_t fcsSize = wcslen(MS_FILE_CONTENT);
-            static const size_t gulSize = wcslen(GLASS_URI_LIST);
-            static const size_t gulAFNSize = wcslen(GLASS_IE_URL_SHORTCUT_FILENAME);
-            if (wcsncmp(MS_FILE_CONTENT, mime, fcsSize) == 0) {
+            if (wcscmp(MS_FILE_CONTENT, mime) == 0) {
                 //File content transfer.
                 //Need to be rewritten.
                 hasFileContent = true;
-            } else if (wcsncmp(GLASS_URI_LIST, mime, gulSize) == 0) {
+            } else if (wcscmp(GLASS_URI_LIST, mime) == 0) {
                 hasUrl = true;
-            } else if (wcsncmp(GLASS_IE_URL_SHORTCUT_FILENAME, mime, gulAFNSize) == 0) {
+            } else if (wcscmp(GLASS_IE_URL_SHORTCUT_FILENAME, mime) == 0) {
                 hasIEShortcutName = true;
                 //that is the synthetic mime, it would be translated to
                 //system pair MS_FILE_DESCRIPTOR_UNICODE/MS_FILE_CONTENT

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/input/ClipboardContentTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/input/ClipboardContentTest.java
@@ -34,7 +34,6 @@ import com.sun.javafx.tk.Toolkit;
 import java.util.Arrays;
 import javafx.scene.image.Image;
 import javafx.scene.input.ClipboardContent;
-import javafx.scene.input.DataFormat;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -233,15 +232,5 @@ public class ClipboardContentTest {
 
         assertFalse(cc.hasFiles());
         assertNull(cc.getFiles());
-    }
-
-    @Test
-    public void invalidMimeType() {
-        ClipboardContent cc = new ClipboardContent();
-        DataFormat customFormat = new DataFormat("text/plain-invalid");
-        cc.put(customFormat, "text");
-
-        assertFalse(cc.hasString());
-        assertEquals(null, cc.getString());
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/input/ClipboardContentTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/input/ClipboardContentTest.java
@@ -34,6 +34,7 @@ import com.sun.javafx.tk.Toolkit;
 import java.util.Arrays;
 import javafx.scene.image.Image;
 import javafx.scene.input.ClipboardContent;
+import javafx.scene.input.DataFormat;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
@@ -232,5 +233,15 @@ public class ClipboardContentTest {
 
         assertFalse(cc.hasFiles());
         assertNull(cc.getFiles());
+    }
+
+    @Test
+    public void invalidMimeType() {
+        ClipboardContent cc = new ClipboardContent();
+        DataFormat customFormat = new DataFormat("text/plain-invalid");
+        cc.put(customFormat, "text");
+
+        assertFalse(cc.hasString());
+        assertEquals(null, cc.getString());
     }
 }


### PR DESCRIPTION
The mime name should be exactly same as the mime type supported by platform.
Hence the comparison should not match partially similar names.
Added an invalid unit test.

@kevinrushforth @jayathirthrao please review

/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8314149](https://bugs.openjdk.org/browse/JDK-8314149): Clipboard does inexact string comparison on mime type (**Bug** - P4)


### Reviewers
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - Author)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer) 🔄 Re-review required (review applies to [270f9abc](https://git.openjdk.org/jfx/pull/1207/files/270f9abc36e073c404370075391aa5f6c0424b4e))
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1207/head:pull/1207` \
`$ git checkout pull/1207`

Update a local copy of the PR: \
`$ git checkout pull/1207` \
`$ git pull https://git.openjdk.org/jfx.git pull/1207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1207`

View PR using the GUI difftool: \
`$ git pr show -t 1207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1207.diff">https://git.openjdk.org/jfx/pull/1207.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1207#issuecomment-1674334629)