### PR TITLE
8087700: [KeyCombination, Mac] KeyCharacterCombinations behave erratically

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -38,6 +38,7 @@
 
 #import "ProcessInfo.h"
 #import <Security/SecRequirement.h>
+#import <Carbon/Carbon.h>
 
 //#define VERBOSE
 #ifndef VERBOSE
@@ -741,13 +742,38 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
             javaIDs.Application.leaveNestedEventLoop, (jobject)NULL);
 }
 
+static void inputDidChangeCallback(CFNotificationCenterRef center, void *observer, CFNotificationName name, const void *object, CFDictionaryRef userInfo)
+{
+    if (keyCodeForCharMap != nil) {
+        [keyCodeForCharMap removeAllObjects];
+    }
+}
+
 + (void)registerKeyEvent:(NSEvent*)event
 {
     if (!keyCodeForCharMap) {
         keyCodeForCharMap = [[NSMutableDictionary alloc] initWithCapacity:100];
         // Note: it's never released, just like, say, the jApplication reference...
+        // To avoid stale entries when the user switches layout
+        CFNotificationCenterRef center = CFNotificationCenterGetDistributedCenter();
+        CFNotificationCenterAddObserver(center, NULL, inputDidChangeCallback,
+                                        kTISNotifySelectedKeyboardInputSourceChanged,
+                                        NULL, CFNotificationSuspensionBehaviorCoalesce);
     }
-    [keyCodeForCharMap setObject:[NSNumber numberWithUnsignedShort:[event keyCode]] forKey:[event characters]];
+
+    // Add the character the user typed to the map.
+    NSNumber* mapObject = [NSNumber numberWithUnsignedShort:[event keyCode]];
+    [keyCodeForCharMap setObject:mapObject forKey:[event characters]];
+    // getKeyCodeForChar should not just match against a character the user types
+    // directly but any other character printed on the same key.
+    [keyCodeForCharMap setObject:mapObject forKey:[event charactersByApplyingModifiers: 0]];
+    [keyCodeForCharMap setObject:mapObject forKey:[event charactersByApplyingModifiers: NSEventModifierFlagShift]];
+    // On some European keyboards there are useful symbols which are only
+    // accessible via the Option key. We don't query for the Option key
+    // character because on most layouts just about every key has some
+    // random symbol assigned to that modifier which the user probably
+    // isn't even aware of. The user can get that character into the map
+    // by typing it directly.
 }
 
 + (jint)getKeyCodeForChar:(jchar)c;

--- a/tests/manual/events/KeyboardTest.java
+++ b/tests/manual/events/KeyboardTest.java
@@ -83,7 +83,7 @@ import javafx.stage.Stage;
 public class KeyboardTest extends Application {
 
     public static void main(String[] args) {
-        Application.launch(args);
+        Application.launch(KeyboardTest.class, args);
     }
 
     private static final String os = System.getProperty("os.name");
@@ -167,7 +167,7 @@ public class KeyboardTest extends Application {
             list.add(new KeyData(cd, null, null, null));
         }
 
-        /* Add a key with unshifted, shifted, and AltGr/Option characters */
+        /* Add a key with unshifted, shifted, and AltGr characters */
         private void add(KeyCode cd, String base, String shifted, String altGr) {
             list.add(new KeyData(cd, base, shifted, altGr));
         }
@@ -249,9 +249,9 @@ public class KeyboardTest extends Application {
 
             /*
              * ENTER is assigned to both Return and Enter which generate
-             * different characters.
+             * different characters. Platforms should always target Return.
              */
-            add(KeyCode.ENTER, "wild");
+            add(KeyCode.ENTER, "\r");
 
             if (onMac) {
                 add(KeyCode.COMMAND);
@@ -334,8 +334,8 @@ public class KeyboardTest extends Application {
             builder.addCommon();
             builder.addLetters();
 
-            /* Include one combination that involves AltGr/Option. */
-            final String altGrFive = (onMac ? "{" : "[");
+            /* Include one combination that involves AltGr. */
+            final String altGrFive = "[";
 
             /*
              * On a French layout the unshifted top-row keys (which generate
@@ -356,15 +356,16 @@ public class KeyboardTest extends Application {
                 builder.add(KeyCode.DIGIT2, E_ACUTE,      "2");
                 builder.add(KeyCode.DIGIT3, DOUBLE_QUOTE, "3");
                 builder.add(KeyCode.DIGIT4, QUOTE,        "4");
-                builder.add(KeyCode.DIGIT5, "(",          "5", altGrFive);
-                /* Six and eight require some tweaking, below */
+                /* Five, six, and eight require some tweaking, below */
                 builder.add(KeyCode.DIGIT7, E_GRAVE,      "7");
                 builder.add(KeyCode.DIGIT9, C_CEDILLA,    "9");
 
                 if (onMac) {
+                    builder.add(KeyCode.DIGIT5, "(",      "5");
                     builder.add(KeyCode.DIGIT6, SECTION,  "6");
                     builder.add(KeyCode.DIGIT8, "!",      "8");
                 } else {
+                    builder.add(KeyCode.DIGIT5, "(",      "5", altGrFive);
                     builder.add(KeyCode.DIGIT6, "-",      "6");
                     builder.add(KeyCode.DIGIT8, "_",      "8");
                 }
@@ -409,7 +410,14 @@ public class KeyboardTest extends Application {
             builder.add(KeyCode.DIGIT4, "4", "$");
             builder.add(KeyCode.DIGIT5, "5", "%");
             builder.add(KeyCode.DIGIT6, "6", "&");
-            builder.add(KeyCode.DIGIT7, "7", "/", altGrSeven);
+
+            if (onMac) {
+                builder.add(KeyCode.DIGIT7, "7", "/");
+            }
+            else {
+                builder.add(KeyCode.DIGIT7, "7", "/", "{");
+            }
+
             builder.add(KeyCode.DIGIT8, "8", "(");
             builder.add(KeyCode.DIGIT9, "9", ")");
 
@@ -448,7 +456,7 @@ public class KeyboardTest extends Application {
 
             builder.add(KeyCode.QUOTE,        QUOTE, "?");
             builder.add(KeyCode.INVERTED_EXCLAMATION_MARK, INV_EXCLAMATION_MARK, INV_QUESTION_MARK);
-            builder.add(KeyCode.PLUS,         "+", "*", "]");
+            builder.add(KeyCode.PLUS,         "+", "*");
             builder.add(KeyCode.LESS,         "<", ">");
             builder.add(KeyCode.COMMA,        ",", ";");
             builder.add(KeyCode.PERIOD,       ".", ":");


### PR DESCRIPTION
A KeyCharacterCombination should match a key if the target character is printed on that key. For example, the user should be able to invoke the `Shortcut+'+' ` combination by holding down the Shortcut key and pressing a key that has '+' printed on it. This should work even if '+' is a shifted symbol but the user doesn't hold down the Shift key. 

The Mac implements KeyCharacterCombinations by monitoring keystrokes to discover the relationship between keys and characters. Currently the system only records the character the user typed and no other characters on the same key. This means a shortcut targeting a shifted character may not work until the user types that character using Shift so the system learns the relationship.

This PR keeps the same mechanism in place but always records the shifted and unshifted character for each keystroke.

For the Mac the KeyboardTest app was modified to remove tests for characters accessed using Option. We don't look for these characters because under the hood just about every key has some symbol assigned to the Option modifier that the user probably isn't even aware of. For these character we fall back to the existing logic; once the user types the character it will start working as a shortcut.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8087700](https://bugs.openjdk.org/browse/JDK-8087700): [KeyCombination, Mac] KeyCharacterCombinations behave erratically (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1209/head:pull/1209` \
`$ git checkout pull/1209`

Update a local copy of the PR: \
`$ git checkout pull/1209` \
`$ git pull https://git.openjdk.org/jfx.git pull/1209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1209`

View PR using the GUI difftool: \
`$ git pr show -t 1209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1209.diff">https://git.openjdk.org/jfx/pull/1209.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1209#issuecomment-1677694793)