### PR TITLE
8313956: focusWithin on parents of a newly-added focused node is not updated

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -8322,12 +8322,7 @@ public abstract class Node implements EventTarget, Styleable {
          */
         void adjust(int change) {
             count += change;
-
-            if (change > 0) {
-                set(true);
-            } else if (count == 0) {
-                set(false);
-            }
+            set(count > 0);
         }
     };
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -8185,21 +8185,17 @@ public abstract class Node implements EventTarget, Styleable {
             return;
         }
 
-        if (oldParent != null) {
-            Node node = oldParent;
-            while (node != null) {
-                node.focusWithin.adjust(-focusWithin.count);
-                node = node.getParent();
-            }
+        Node node = oldParent;
+        while (node != null) {
+            node.focusWithin.adjust(-focusWithin.count);
+            node = node.getParent();
         }
 
-        if (newParent != null) {
-            Node node = newParent;
-            while (node != null) {
-                node.focusWithin.adjust(focusWithin.count);
-                node = node.getParent();
-            };
-        }
+        node = newParent;
+        while (node != null) {
+            node.focusWithin.adjust(focusWithin.count);
+            node = node.getParent();
+        };
 
         // Since focus changes are atomic, we only fire change notifications after
         // all changes are committed on all old and new parents.

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -8323,7 +8323,7 @@ public abstract class Node implements EventTarget, Styleable {
         void adjust(int change) {
             count += change;
 
-            if (count == 1) {
+            if (change > 0) {
                 set(true);
             } else if (count == 0) {
                 set(false);

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/FocusTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/FocusTest.java
@@ -1105,4 +1105,27 @@ public class FocusTest {
         assertNotFocusWithin(node4);
     }
 
+    @Test public void testFocusWithinBitsAreSetOnParentsWhenAddedNodeIsAlreadyFocused() {
+        class N extends Group {
+            N(Node... children) { super(children); }
+            void _setFocused(boolean value) { setFocused(value); }
+        }
+
+        N node1, node2, node3 = new N();
+
+        scene.setRoot(
+            node1 = new N(
+                node2 = new N()
+            ));
+
+        node3._setFocused(true);
+        assertNotFocusWithin(node1);
+        assertNotFocusWithin(node2);
+
+        node2.getChildren().add(node3);
+        assertIsFocusWithin(node1);
+        assertIsFocusWithin(node2);
+        assertIsFocusWithin(node3);
+    }
+
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/FocusTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/FocusTest.java
@@ -1116,7 +1116,8 @@ public class FocusTest {
         scene.setRoot(
             node1 = new N(
                 node2 = new N()
-            ));
+            )
+        );
 
         node3._setFocused(true);
         assertNotFocusWithin(node1);
@@ -1139,10 +1140,12 @@ public class FocusTest {
         scene.setRoot(
             node1 = new N(
                 node2 = new N()
-            ));
+            )
+        );
 
         node3 = new N(
-            node4 = new N());
+            node4 = new N()
+        );
 
         node3._setFocused(true);
         node4._setFocused(true);

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/FocusTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/FocusTest.java
@@ -1128,4 +1128,35 @@ public class FocusTest {
         assertIsFocusWithin(node3);
     }
 
+    @Test public void testFocusWithinBitsAreSetAndClearedOnParentsOfNodeContainingMultipleFocuses() {
+        class N extends Group {
+            N(Node... children) { super(children); }
+            void _setFocused(boolean value) { setFocused(value); }
+        }
+
+        N node1, node2, node3, node4;
+
+        scene.setRoot(
+            node1 = new N(
+                node2 = new N()
+            ));
+
+        node3 = new N(
+            node4 = new N());
+
+        node3._setFocused(true);
+        node4._setFocused(true);
+        assertNotFocusWithin(node1);
+        assertNotFocusWithin(node2);
+
+        node2.getChildren().add(node3);
+        assertIsFocusWithin(node1);
+        assertIsFocusWithin(node2);
+        assertIsFocusWithin(node3);
+
+        node2.getChildren().clear();
+        assertNotFocusWithin(node1);
+        assertNotFocusWithin(node2);
+    }
+
 }


### PR DESCRIPTION
This PR fixes an issue with the way `focusWithin` bits are adjusted in the scene graph. Previously, the `focusWithin` counts of all parents of a removed node would be decreased if the removed node has a non-zero `focusWithin` count. This PR adds logic for the opposite scenario: the `focusWithin` count is increased on all parents of a newly-added node that is already focused (or contains other focused nodes).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8313956](https://bugs.openjdk.org/browse/JDK-8313956): focusWithin on parents of a newly-added focused node is not updated (**Bug** - P4)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**) 🔄 Re-review required (review applies to [fd85c902](https://git.openjdk.org/jfx/pull/1210/files/fd85c90268bafaaaa8371d7dae9f54d228892810))
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1210/head:pull/1210` \
`$ git checkout pull/1210`

Update a local copy of the PR: \
`$ git checkout pull/1210` \
`$ git pull https://git.openjdk.org/jfx.git pull/1210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1210`

View PR using the GUI difftool: \
`$ git pr show -t 1210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1210.diff">https://git.openjdk.org/jfx/pull/1210.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1210#issuecomment-1679654885)