### PR TITLE
8314266: Several test failures after fix for JDK-8159048

### DIFF
--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/LeakTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/LeakTest.java
@@ -34,6 +34,7 @@ import java.lang.ref.WeakReference;
 import java.util.concurrent.CountDownLatch;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
+import javafx.application.Platform;
 import javafx.concurrent.Worker.State;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
@@ -74,7 +75,7 @@ public class LeakTest extends TestBase {
                 }
             }
         }));
-        time.play();
+        Platform.runLater(time::play);
         latch.await();
     }
 

--- a/tests/system/src/test/java/test/javafx/application/PlatformTest.java
+++ b/tests/system/src/test/java/test/javafx/application/PlatformTest.java
@@ -120,7 +120,7 @@ public class PlatformTest {
                 timelineDone.countDown();
             }
         }));
-        timeline.play();
+        Platform.runLater(timeline::play);
 
         Util.await(timelineDone);
 

--- a/tests/system/src/test/java/test/javafx/stage/ShowAndWaitTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/ShowAndWaitTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -683,7 +683,7 @@ public class ShowAndWaitTest {
             animationDone.countDown();
         });
         Timeline timeline = new Timeline(kf);
-        timeline.play();
+        Platform.runLater(timeline::play);
 
         try {
             if (!animationDone.await(TIMEOUT, TimeUnit.MILLISECONDS)) {
@@ -733,7 +733,7 @@ public class ShowAndWaitTest {
             animationDone.countDown();
         });
         Timeline timeline = new Timeline(kf);
-        timeline.play();
+        Platform.runLater(timeline::play);
 
         try {
             if (!animationDone.await(TIMEOUT, TimeUnit.MILLISECONDS)) {
@@ -788,7 +788,7 @@ public class ShowAndWaitTest {
             animationDone.countDown();
         });
         Timeline timeline = new Timeline(kf);
-        timeline.play();
+        Platform.runLater(timeline::play);
 
         try {
             if (!animationDone.await(TIMEOUT, TimeUnit.MILLISECONDS)) {


### PR DESCRIPTION
This PR fixes some failing tests that started failing after the check on animations being played on the JavaFX thread was enforced, by simply wrapping the `play` call with `Platform.runLater`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314266](https://bugs.openjdk.org/browse/JDK-8314266): Several test failures after fix for JDK-8159048 (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1211/head:pull/1211` \
`$ git checkout pull/1211`

Update a local copy of the PR: \
`$ git checkout pull/1211` \
`$ git pull https://git.openjdk.org/jfx.git pull/1211/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1211`

View PR using the GUI difftool: \
`$ git pr show -t 1211`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1211.diff">https://git.openjdk.org/jfx/pull/1211.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1211#issuecomment-1680498392)