### PR TITLE
8314212: Crash when loading cnn.com in WebView

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/MediaPlayerPrivateJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/MediaPlayerPrivateJava.cpp
@@ -433,7 +433,7 @@ float MediaPlayerPrivate::currentTime() const
 
     // in case of hls media m3u8 format check network state
     // since jfx media do not support hls live streaming protocol
-    if ( MediaPlayerNetworkState::NetworkError == MediaPlayer::NetworkState::NetworkError)
+    if (MediaPlayerNetworkState::NetworkError == MediaPlayer::NetworkState::NetworkError)
         return MediaTime::zeroTime().toFloat();
 
     JNIEnv* env = WTF::GetJavaEnv();

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/MediaPlayerPrivateJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/MediaPlayerPrivateJava.cpp
@@ -430,6 +430,12 @@ float MediaPlayerPrivate::currentTime() const
         LOG_TRACE1("MediaPlayerPrivate currentTime returns (seekTime): %f\n", m_seekTime);
         return m_seekTime;
     }
+
+    // in case of hls media m3u8 format check network state
+    // since jfx media do not support hls live streaming protocol
+    if ( MediaPlayerNetworkState::NetworkError == MediaPlayer::NetworkState::NetworkError)
+        return MediaTime::zeroTime().toFloat();
+
     JNIEnv* env = WTF::GetJavaEnv();
     static jmethodID s_mID
         = env->GetMethodID(PG_GetMediaPlayerClass(env), "fwkGetCurrentTime", "()F");

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1198,7 +1198,7 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
 
 // in case of video data format like m3u8 error case ,check if layer needs compositing
 #if PLATFORM(JAVA)
-    if(willBeComposited != needsToBeComposited(layer, queryData))
+    if (willBeComposited != needsToBeComposited(layer, queryData))
         return;
 #endif
     ASSERT(willBeComposited == needsToBeComposited(layer, queryData));

--- a/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -1196,6 +1196,11 @@ void RenderLayerCompositor::computeCompositingRequirements(RenderLayer* ancestor
 #endif
     }
 
+// in case of video data format like m3u8 error case ,check if layer needs compositing
+#if PLATFORM(JAVA)
+    if(willBeComposited != needsToBeComposited(layer, queryData))
+        return;
+#endif
     ASSERT(willBeComposited == needsToBeComposited(layer, queryData));
 
     // Create or destroy backing here. However, we can't update geometry because layers above us may become composited


### PR DESCRIPTION
Issue: WCMediaPlayer does not support HTTP live streaming m3u8 format. Giving error com.sun.javafx.webkit.prism.WCMediaPlayerImpl onError WARNING: onError, errCode=0, msg=Unsupported protocol "data"

Solution: Do not invoke the current media time operation in an error state. As the WCMediaPlayer might not be a valid object.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8314212](https://bugs.openjdk.org/browse/JDK-8314212): Crash when loading cnn.com in WebView (**Bug** - P2)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Hima Bindu Meda](https://openjdk.org/census#hmeda) (@HimaBinduMeda - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1212/head:pull/1212` \
`$ git checkout pull/1212`

Update a local copy of the PR: \
`$ git checkout pull/1212` \
`$ git pull https://git.openjdk.org/jfx.git pull/1212/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1212`

View PR using the GUI difftool: \
`$ git pr show -t 1212`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1212.diff">https://git.openjdk.org/jfx/pull/1212.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1212#issuecomment-1681817928)