### PR TITLE
8314589: javadoc build only shows the first 100 warnings and errors

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4258,6 +4258,8 @@ task javadoc(type: Javadoc, dependsOn: createMSPfile) {
 
     options.addStringOption("-since").setValue((9..jfxReleaseMajorVersion.toInteger()).join(","))
     options.addStringOption("-since-label").setValue("New API since JavaFX 9")
+    options.addStringOption("Xmaxwarns").setValue("1000")
+    options.addStringOption("Xmaxerrs").setValue("1000")
 
     options.windowTitle("${javadocTitle}")
     options.header("${javadocHeader}")


### PR DESCRIPTION
This PR bumps the limit for the number of javadoc warnings and error from 100 to 1000.

We currently use the default setting of javadoc which only shows 100 warnings and errors. This is too small, especially for warnings, and can cause us to miss new warnings that arise. Eventually we should fix all our warnings, and we have a task filed to track that, but even then I think the limit is too small.

Without this fix, our current build only shows the "first" 100 warnings it runs into. With this fix, our current build shows all 187 warnings using JDK 19.0.2 and all 191 warnings using JDK 21.