### PR TITLE
8262518: SwingNode.setContent does not close previous content, resulting in memory leak

### DIFF
--- a/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/Disposer.java
+++ b/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/Disposer.java
@@ -89,6 +89,10 @@ public class Disposer implements Runnable {
         return ref;
     }
 
+    /**
+     * Remove the DisposerRecord object to prevent memory leak
+     * @param ref Weak reference of the object to be removed
+     */
     public static void removeRecord(WeakReference ref) {
         disposerInstance.records.remove(ref);
     }

--- a/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/Disposer.java
+++ b/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/Disposer.java
@@ -90,7 +90,9 @@ public class Disposer implements Runnable {
     }
 
     /**
-     * Remove the DisposerRecord object to prevent memory leak
+     * Unregisters a previously registered {@link DisposerRecord}, removing it
+     * from the list of records to dispose off when the
+     * original target goes out of scope
      * @param ref Weak reference of the object to be removed
      */
     public static void removeRecord(WeakReference ref) {

--- a/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/Disposer.java
+++ b/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/Disposer.java
@@ -89,8 +89,8 @@ public class Disposer implements Runnable {
         return ref;
     }
 
-    public static void removeRecord(DisposerRecord rec) {
-        disposerInstance.records.remove(rec);
+    public static void removeRecord(WeakReference ref) {
+        disposerInstance.records.remove(ref);
     }
 
     @Override

--- a/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/Disposer.java
+++ b/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/Disposer.java
@@ -89,6 +89,10 @@ public class Disposer implements Runnable {
         return ref;
     }
 
+    public static void removeRecord(DisposerRecord rec) {
+        disposerInstance.records.remove(rec);
+    }
+
     @Override
     public void run() {
         while (true) {

--- a/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/newimpl/SwingNodeInteropN.java
+++ b/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/newimpl/SwingNodeInteropN.java
@@ -246,7 +246,6 @@ public class SwingNodeInteropN {
                 lwFrame = null;
             }
         }
-
     }
 
     private static class SwingNodeContent extends LightweightContentWrapper {

--- a/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/newimpl/SwingNodeInteropN.java
+++ b/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/newimpl/SwingNodeInteropN.java
@@ -164,9 +164,8 @@ public class SwingNodeInteropN {
         return new SwingNodeContent(content, node);
     }
 
-    public DisposerRecord createSwingNodeDisposer(Object frame) {
-        LightweightFrameWrapper lwFrame = (LightweightFrameWrapper)frame;
-        return new SwingNodeDisposer(lwFrame);
+    public DisposerRecord createSwingNodeDisposer(WeakReference<LightweightFrameWrapper> frame) {
+        return new SwingNodeDisposer(frame);
     }
 
     private static final class OptionalMethod<T> {
@@ -233,17 +232,18 @@ public class SwingNodeInteropN {
     }
 
     private static class SwingNodeDisposer implements DisposerRecord {
-        LightweightFrameWrapper lwFrame;
+        WeakReference<LightweightFrameWrapper> lwFrame;
 
-        SwingNodeDisposer(LightweightFrameWrapper ref) {
+        SwingNodeDisposer(WeakReference<LightweightFrameWrapper> ref) {
             this.lwFrame = ref;
         }
 
         @Override
         public void dispose() {
-            if (lwFrame != null) {
-                lwFrame.dispose();
-                lwFrame = null;
+            LightweightFrameWrapper lwFramePtr = lwFrame.get();
+            if (lwFramePtr != null) {
+                lwFramePtr.dispose();
+                lwFramePtr = null;
             }
         }
     }

--- a/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/newimpl/SwingNodeInteropN.java
+++ b/modules/javafx.swing/src/main/java/com/sun/javafx/embed/swing/newimpl/SwingNodeInteropN.java
@@ -164,8 +164,9 @@ public class SwingNodeInteropN {
         return new SwingNodeContent(content, node);
     }
 
-    public DisposerRecord createSwingNodeDisposer(WeakReference<LightweightFrameWrapper> frame) {
-        return new SwingNodeDisposer(frame);
+    public DisposerRecord createSwingNodeDisposer(Object frame) {
+        LightweightFrameWrapper lwFrame = (LightweightFrameWrapper)frame;
+        return new SwingNodeDisposer(lwFrame);
     }
 
     private static final class OptionalMethod<T> {
@@ -232,20 +233,20 @@ public class SwingNodeInteropN {
     }
 
     private static class SwingNodeDisposer implements DisposerRecord {
-        WeakReference<LightweightFrameWrapper> lwFrame;
+        LightweightFrameWrapper lwFrame;
 
-        SwingNodeDisposer(WeakReference<LightweightFrameWrapper> ref) {
+        SwingNodeDisposer(LightweightFrameWrapper ref) {
             this.lwFrame = ref;
         }
 
         @Override
         public void dispose() {
-            LightweightFrameWrapper lwFramePtr = lwFrame.get();
-            if (lwFramePtr != null) {
-                lwFramePtr.dispose();
-                lwFramePtr = null;
+            if (lwFrame != null) {
+                lwFrame.dispose();
+                lwFrame = null;
             }
         }
+
     }
 
     private static class SwingNodeContent extends LightweightContentWrapper {

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingNode.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingNode.java
@@ -73,6 +73,7 @@ import static javafx.stage.WindowEvent.WINDOW_HIDDEN;
 import com.sun.javafx.embed.swing.SwingNodeHelper;
 import com.sun.javafx.embed.swing.SwingEvents;
 import com.sun.javafx.embed.swing.newimpl.SwingNodeInteropN;
+import jdk.swing.interop.LightweightFrameWrapper;
 
 /**
  * This class is used to embed a Swing content into a JavaFX application.
@@ -381,7 +382,10 @@ public class SwingNode extends Node {
             swNodeIOP.setContent(lwFrame, swNodeIOP.createSwingNodeContent(content, this));
             swNodeIOP.setVisible(lwFrame, true);
 
-            Disposer.addRecord(this, swNodeIOP.createSwingNodeDisposer(lwFrame));
+            WeakReference<LightweightFrameWrapper> lwFramePtr =
+		    new WeakReference<LightweightFrameWrapper>(
+                                             (LightweightFrameWrapper)lwFrame);
+            Disposer.addRecord(this, swNodeIOP.createSwingNodeDisposer(lwFramePtr));
 
             if (getScene() != null) {
                 notifyNativeHandle(getScene().getWindow());

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingNode.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingNode.java
@@ -254,6 +254,7 @@ public class SwingNode extends Node {
     private Timer deactivate; // lwFrame deactivate delay for Linux
     private SwingNodeInteropN swNodeIOP;
     private DisposerRecord rec;
+    private WeakReference disposerRecRef;
 
     {
         // To initialize the class helper at the begining each constructor of this class
@@ -365,7 +366,7 @@ public class SwingNode extends Node {
     private void setContentImpl(JComponent content) {
         if (lwFrame != null) {
             rec.dispose();
-            Disposer.removeRecord(rec);
+            Disposer.removeRecord(disposerRecRef);
             rec = null;
             lwFrame = null;
         }
@@ -387,7 +388,7 @@ public class SwingNode extends Node {
             swNodeIOP.setVisible(lwFrame, true);
 
             rec = swNodeIOP.createSwingNodeDisposer(lwFrame);
-            Disposer.addRecord(this, rec);
+            disposerRecRef = Disposer.addRecord(this, rec);
 
             if (getScene() != null) {
                 notifyNativeHandle(getScene().getWindow());

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingNode.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingNode.java
@@ -383,7 +383,7 @@ public class SwingNode extends Node {
             swNodeIOP.setVisible(lwFrame, true);
 
             WeakReference<LightweightFrameWrapper> lwFramePtr =
-		    new WeakReference<LightweightFrameWrapper>(
+                    new WeakReference<LightweightFrameWrapper>(
                                              (LightweightFrameWrapper)lwFrame);
             Disposer.addRecord(this, swNodeIOP.createSwingNodeDisposer(lwFramePtr));
 

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingNode.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingNode.java
@@ -364,17 +364,13 @@ public class SwingNode extends Node {
      */
     private void setContentImpl(JComponent content) {
         if (lwFrame != null) {
-            if (rec != null) {
-                rec.dispose();
-                rec = null;
-            }
+            rec.dispose();
+            Disposer.removeRecord(disposerRecRef);
+            rec = null;
+            disposerRecRef = null;
             lwFrame = null;
         }
         if (content != null) {
-            if (disposerRecRef != null) {
-                Disposer.removeRecord(disposerRecRef);
-                disposerRecRef = null;
-            }
             lwFrame = swNodeIOP.createLightweightFrame();
 
             SwingNodeWindowFocusListener snfListener =

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingNode.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingNode.java
@@ -74,7 +74,6 @@ import com.sun.javafx.embed.swing.DisposerRecord;
 import com.sun.javafx.embed.swing.SwingNodeHelper;
 import com.sun.javafx.embed.swing.SwingEvents;
 import com.sun.javafx.embed.swing.newimpl.SwingNodeInteropN;
-import jdk.swing.interop.LightweightFrameWrapper;
 
 /**
  * This class is used to embed a Swing content into a JavaFX application.
@@ -365,12 +364,17 @@ public class SwingNode extends Node {
      */
     private void setContentImpl(JComponent content) {
         if (lwFrame != null) {
-            rec.dispose();
-            Disposer.removeRecord(disposerRecRef);
-            rec = null;
+            if (rec != null) {
+                rec.dispose();
+                rec = null;
+	    }
             lwFrame = null;
         }
         if (content != null) {
+            if (disposerRecRef != null) {
+                Disposer.removeRecord(disposerRecRef);
+                disposerRecRef = null;
+            }
             lwFrame = swNodeIOP.createLightweightFrame();
 
             SwingNodeWindowFocusListener snfListener =

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingNode.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/SwingNode.java
@@ -367,7 +367,7 @@ public class SwingNode extends Node {
             if (rec != null) {
                 rec.dispose();
                 rec = null;
-	    }
+            }
             lwFrame = null;
         }
         if (content != null) {


### PR DESCRIPTION
Issue is when setting the content of a SwingNode, the old content is not garbage collected owing to the fact
JLightweightFrame is never being released by SwingNodeDisposer

The SwingNodeDisposer holds an hard pointer to the JLightweightFrame that prevents its collection

Modified `SwingNode.setContentImpl`  function to use a WeakReference to properly release the memory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8262518](https://bugs.openjdk.org/browse/JDK-8262518): SwingNode.setContent does not close previous content, resulting in memory leak (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1219/head:pull/1219` \
`$ git checkout pull/1219`

Update a local copy of the PR: \
`$ git checkout pull/1219` \
`$ git pull https://git.openjdk.org/jfx.git pull/1219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1219`

View PR using the GUI difftool: \
`$ git pr show -t 1219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1219.diff">https://git.openjdk.org/jfx/pull/1219.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1219#issuecomment-1687884571)