### PR TITLE
8242616: Regression: RTL - TextField Cursor Movement Via Keyboard

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
@@ -25,6 +25,7 @@
 
 package javafx.scene.control.skin;
 
+import java.text.BreakIterator;
 import java.util.List;
 
 import com.sun.javafx.scene.control.behavior.PasswordFieldBehavior;
@@ -580,24 +581,14 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
             moveRight = !moveRight;
         }
 
-        Bounds caretBounds = caretPath.getLayoutBounds();
-        if (caretPath.getElements().size() == 4) {
-            // The caret is split
-            // TODO: Find a better way to get the primary caret position
-            // instead of depending on the internal implementation.
-            // See RT-25465.
-            caretBounds = new Path(caretPath.getElements().get(0), caretPath.getElements().get(1)).getLayoutBounds();
+        TextField textField = getSkinnable();
+        int pos = textField.getCaretPosition();
+        BreakIterator bi = BreakIterator.getCharacterInstance();
+        bi.setText(textField.getText());
+        int next = moveRight ? bi.following(pos) : bi.preceding(pos);
+        if (next != BreakIterator.DONE) {
+            textField.selectRange(next, next);
         }
-        double hitX = moveRight ? caretBounds.getMaxX() : caretBounds.getMinX();
-        double hitY = (caretBounds.getMinY() + caretBounds.getMaxY()) / 2;
-        HitInfo hit = textNode.hitTest(new Point2D(hitX, hitY));
-        boolean leading = hit.isLeading();
-        Path charShape = new Path(textNode.rangeShape(hit.getCharIndex(), hit.getCharIndex() + 1));
-        if ((moveRight && charShape.getLayoutBounds().getMaxX() > caretBounds.getMaxX()) ||
-                (!moveRight && charShape.getLayoutBounds().getMinX() < caretBounds.getMinX())) {
-            leading = !leading;
-        }
-        positionCaret(hit.getInsertionIndex(), leading, false);
     }
 
     /** {@inheritDoc} */

--- a/tests/system/src/test/java/test/robot/javafx/scene/TextFieldCursorMovementTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TextFieldCursorMovementTest.java
@@ -38,13 +38,51 @@ import javafx.scene.Scene;
 import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import test.util.Util;
 
+/*
+ * Test for verifying cursor movement in TextField using keyboard.
+ * There are 4 tests in this file
+ *
+ * Steps for testCursorMovementInMixedText()
+ * 1. Create a TextField and add text which contains both RTL and LTR text.
+ *    Set TextField node orientation to RIGHT_TO_LEFT
+ * 2. Move the cursor to the left by pressing LEFT key on keyboard.
+ * 3. Keep pressing the LEFT key until end of text.
+ * 4. Verify that cursor position changes by checking the caret position.
+ * 5. Cursor movement is verified by checking that caret position
+ *    is not equal to previous position.
+ *
+ * Steps for testCursorMovementInMixedTextRTLNotSet()
+ * 1. Create a TextField and add text which contains both RTL and LTR text.
+ *    Set TextField node orientation to LEFT_TO_RIGHT
+ * 2. Move the cursor to the left by pressing LEFT key on keyboard.
+ * 3. Keep pressing the LEFT key until end of text.
+ * 4. Verify that cursor position changes by checking the caret position.
+ * 5. Cursor movement is verified by checking that caret position
+ *    is not equal to previous position.
+ *
+ * Steps for testCursorMovementInLTRText()
+ * 1. Create a TextField and add LTR text.
+ * 2. Move the cursor to the right by pressing RIGHT key on keyboard.
+ * 3. Keep pressing the RIGHT key until end of text.
+ * 4. Verify that cursor position changes by checking the caret position.
+ * 5. Cursor movement is verified by checking that caret position
+ *    is not equal to previous position.
+ *
+ * Steps for testCursorMovementInRTLText()
+ * 1. Create a TextField and add RTL text.
+ * 2. Move the cursor to the left by pressing LEFT key on keyboard.
+ * 3. Keep pressing the LEFT key until end of text.
+ * 4. Verify that cursor position changes by checking the caret position.
+ * 5. Cursor movement is verified by checking that caret position
+ *    is not equal to previous position.
+ */
 public class TextFieldCursorMovementTest {
     static CountDownLatch startupLatch = new CountDownLatch(1);
     static CountDownLatch caretPositionLatch;
@@ -66,34 +104,78 @@ public class TextFieldCursorMovementTest {
         });
     }
 
+    private void moveCursorToRight() {
+        Util.runAndWait(() -> {
+            robot.keyType(KeyCode.RIGHT);
+        });
+    }
+
     private void addTextFieldContent(String text, boolean isRtl) {
         Util.runAndWait(() -> {
             textField.setText(text);
             if (isRtl) {
                 textField.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
+            } else {
+                textField.setNodeOrientation(NodeOrientation.LEFT_TO_RIGHT);
             }
         });
     }
 
     //JDK-8242616
     @Test
-    public void testCursorMovementInRTLText() throws Exception {
-        String str = "Aracbic يشترشسيرشي";
+    public void testCursorMovementInMixedText() throws Exception {
+        String str = "Arabic يشترشسيرشي";
         addTextFieldContent(str, true);
 
         for (int i =0; i< str.length(); i++) {
             moveCursorToLeft();
-            Assert.assertNotEquals(curIndex, prevIndex);
+            Assertions.assertNotEquals(curIndex, prevIndex);
             prevIndex = curIndex;
         }
     }
 
-    @BeforeClass
+    @Test
+    public void testCursorMovementInMixedTextRTLNotSet() throws Exception {
+        String str = "Arabic يشترشسيرشي";
+        addTextFieldContent(str, false);
+
+        for (int i =0; i< str.length(); i++) {
+            moveCursorToRight();
+            Assertions.assertNotEquals(curIndex, prevIndex);
+            prevIndex = curIndex;
+        }
+    }
+
+    @Test
+    public void testCursorMovementInLTRText() throws Exception {
+        String str = "This is a text";
+        addTextFieldContent(str, false);
+
+        for (int i =0; i< str.length(); i++) {
+            moveCursorToRight();
+            Assertions.assertNotEquals(curIndex, prevIndex);
+            prevIndex = curIndex;
+        }
+    }
+
+    @Test
+    public void testCursorMovementInRTLText() throws Exception {
+        String str = "يشترشسيرشي";
+        addTextFieldContent(str, true);
+
+        for (int i =0; i< str.length(); i++) {
+            moveCursorToLeft();
+            Assertions.assertNotEquals(curIndex, prevIndex);
+            prevIndex = curIndex;
+        }
+    }
+
+    @BeforeAll
     public static void initFX() throws Exception {
         Util.launch(startupLatch, TestApp.class);
     }
 
-    @AfterClass
+    @AfterAll
     public static void exit() {
         Util.shutdown(stage);
     }

--- a/tests/system/src/test/java/test/robot/javafx/scene/TextFieldCursorMovementTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TextFieldCursorMovementTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.robot.javafx.scene;
+
+import java.util.concurrent.CountDownLatch;
+
+import javafx.application.Application;
+import javafx.scene.input.KeyCode;
+import javafx.application.Platform;
+import javafx.geometry.NodeOrientation;
+import javafx.scene.control.TextField;
+import javafx.scene.Group;
+import javafx.scene.robot.Robot;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import test.util.Util;
+
+public class TextFieldCursorMovementTest {
+    static CountDownLatch startupLatch = new CountDownLatch(1);
+    static CountDownLatch caretPositionLatch;
+    static Robot robot;
+    static TextField textField;
+
+    static volatile Stage stage;
+    static volatile Scene scene;
+
+    static int curIndex = 0;
+    static int prevIndex = -1;
+
+    static final int SCENE_WIDTH = 250;
+    static final int SCENE_HEIGHT = SCENE_WIDTH;
+
+    private void moveCursorToLeft() {
+        Util.runAndWait(() -> {
+            robot.keyType(KeyCode.LEFT);
+        });
+    }
+
+    private void addTextFieldContent(String text, boolean isRtl) {
+        Util.runAndWait(() -> {
+            textField.setText(text);
+            if (isRtl) {
+                textField.setNodeOrientation(NodeOrientation.RIGHT_TO_LEFT);
+            }
+        });
+    }
+
+    //JDK-8242616
+    @Test
+    public void testCursorMovementInRTLText() throws Exception {
+        String str = "Aracbic يشترشسيرشي";
+        addTextFieldContent(str, true);
+
+        for (int i =0; i< str.length(); i++) {
+            moveCursorToLeft();
+            Assert.assertNotEquals(curIndex, prevIndex);
+            prevIndex = curIndex;
+        }
+    }
+
+    @BeforeClass
+    public static void initFX() throws Exception {
+        Util.launch(startupLatch, TestApp.class);
+    }
+
+    @AfterClass
+    public static void exit() {
+        Util.shutdown(stage);
+    }
+
+    public static class TestApp extends Application {
+        @Override
+        public void start(Stage primaryStage) {
+            robot = new Robot();
+            stage = primaryStage;
+
+            textField = new TextField();
+            textField.caretPositionProperty().addListener((event) -> {
+                curIndex = textField.getCaretPosition();
+            });
+            Group group = new Group(textField);
+            scene = new Scene(group, SCENE_WIDTH, SCENE_HEIGHT);
+            stage.setScene(scene);
+            stage.initStyle(StageStyle.UNDECORATED);
+            stage.setAlwaysOnTop(true);
+            stage.setOnShown(event -> Platform.runLater(startupLatch::countDown));
+            stage.show();
+        }
+    }
+}


### PR DESCRIPTION
The old logic for cursor movement was buggy when both RTL and LTR text was present in the TextField. Used character BreakIterator instead of finding the character index using hitTest.

Added system test to validate the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8242616](https://bugs.openjdk.org/browse/JDK-8242616): Regression: RTL - TextField Cursor Movement Via Keyboard (**Bug** - P3)


### Contributors
 * Andy Goryachev `<angorya@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1222/head:pull/1222` \
`$ git checkout pull/1222`

Update a local copy of the PR: \
`$ git checkout pull/1222` \
`$ git pull https://git.openjdk.org/jfx.git pull/1222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1222`

View PR using the GUI difftool: \
`$ git pr show -t 1222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1222.diff">https://git.openjdk.org/jfx/pull/1222.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1222#issuecomment-1693233797)