### PR TITLE
8315074: Possible null pointer access in native glass

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
@@ -262,8 +262,13 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkApplication__1submitForLater
     (void)obj;
 
     RunnableContext* context = (RunnableContext*)malloc(sizeof(RunnableContext));
-    context->runnable = env->NewGlobalRef(runnable);
-    gdk_threads_add_idle_full(G_PRIORITY_HIGH_IDLE + 30, call_runnable, context, NULL);
+    if (context != NULL) {
+        context->runnable = env->NewGlobalRef(runnable);
+        gdk_threads_add_idle_full(G_PRIORITY_HIGH_IDLE + 30, call_runnable, context, NULL);
+        // we release this context in call_runnable
+    } else {
+        fprintf(stderr, "malloc failed in GtkApplication__1submitForLaterInvocatio\n");
+    }
 }
 
 /*

--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassApplication.cpp
@@ -267,7 +267,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkApplication__1submitForLater
         gdk_threads_add_idle_full(G_PRIORITY_HIGH_IDLE + 30, call_runnable, context, NULL);
         // we release this context in call_runnable
     } else {
-        fprintf(stderr, "malloc failed in GtkApplication__1submitForLaterInvocatio\n");
+        fprintf(stderr, "malloc failed in GtkApplication__1submitForLaterInvocation\n");
     }
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassTimer.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassTimer.cpp
@@ -45,10 +45,16 @@ JNIEXPORT jlong JNICALL Java_com_sun_glass_ui_gtk_GtkTimer__1start
     (void)obj;
 
     RunnableContext* context = (RunnableContext*) malloc(sizeof(RunnableContext));
-    context->runnable = env->NewGlobalRef(runnable);
-    context->flag = 0;
-    gdk_threads_add_timeout_full(G_PRIORITY_HIGH_IDLE, period, call_runnable_in_timer, context, NULL);
-    return PTR_TO_JLONG(context);
+    if (context != NULL) {
+        context->runnable = env->NewGlobalRef(runnable);
+        context->flag = 0;
+        gdk_threads_add_timeout_full(G_PRIORITY_HIGH_IDLE, period, call_runnable_in_timer, context, NULL);
+        return PTR_TO_JLONG(context);
+    } else {
+        // we throw RuntimeException on Java side when we can't
+        // start the timer
+        return 0L;
+    }
 }
 
 /*

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.h
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.h
@@ -96,6 +96,12 @@ private:
     jstring jmessage;
 };
 
+#define SAFE_FREE(PTR)  \
+    if ((PTR) != NULL) {  \
+        free(PTR);     \
+        (PTR) = NULL;     \
+    }
+
 #define EXCEPTION_OCCURED(env) (check_and_clear_exception(env))
 
 #define CHECK_JNI_EXCEPTION(env) \

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window_ime.cpp
@@ -59,6 +59,12 @@ bool WindowContextBase::im_filter_keypress(GdkEventKey* event) {
         buffer = (char*)malloc(buf_len * sizeof (char));
     }
 
+    if (buffer == NULL) {
+        // dont process the key event
+        fprintf(stderr, "malloc failed in im_filter_keypress\n");
+        return false;
+    }
+
     KeySym keysym;
     Status status;
     XKeyPressedEvent xevent = convert_event(event);
@@ -74,7 +80,14 @@ bool WindowContextBase::im_filter_keypress(GdkEventKey* event) {
     int len = Xutf8LookupString(xim.ic, &xevent, buffer, buf_len - 1, &keysym, &status);
     if (status == XBufferOverflow) {
         buf_len = len + 1;
-        buffer = (char*)realloc(buffer, buf_len * sizeof (char));
+        char *tmpBuffer = (char*)realloc(buffer, buf_len * sizeof (char));
+        if (tmpBuffer == NULL) {
+            SAFE_FREE(buffer);
+            // dont process the key event
+            fprintf(stderr, "realloc failed in im_filter_keypress\n");
+            return false;
+        }
+        buffer = tmpBuffer;
         len = Xutf8LookupString(xim.ic, &xevent, buffer, buf_len - 1,
                 &keysym, &status);
     }

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassKey.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassKey.m
@@ -461,6 +461,9 @@ jcharArray GetJavaKeyChars(JNIEnv *env, NSEvent *event)
     jchar jc[16];
     [chars getCharacters:jc range:NSMakeRange(0, [chars length])];
     jcharArray jChars = (*env)->NewCharArray(env, (jsize)[chars length]);
+    if (jChars == NULL) {
+        return NULL;
+    }
     (*env)->SetCharArrayRegion(env, jChars, 0, (jsize)[chars length], jc);
     GLASS_CHECK_EXCEPTION(env);
     return jChars;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassMacros.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassMacros.h
@@ -177,22 +177,34 @@ do {                                                                            
     GlassThreadData *_GlassThreadData = (GlassThreadData*)pthread_getspecific(GlassThreadDataKey); \
     if (_GlassThreadData == NULL) \
     { \
-        _GlassThreadData = malloc(sizeof(GlassThreadData)); \
-        memset(_GlassThreadData, 0x00, sizeof(GlassThreadData)); \
-        pthread_setspecific(GlassThreadDataKey, _GlassThreadData); \
+        _GlassThreadData = calloc(1, sizeof(GlassThreadData)); \
+        if (_GlassThreadData != NULL) \
+        { \
+            pthread_setspecific(GlassThreadDataKey, _GlassThreadData); \
+        } \
+        else \
+        { \
+            fprintf(stderr, "malloc failed in GLASS_POOL_ENTER\n"); \
+        } \
     } \
-    assert(_GlassThreadData->counter >= 0); \
-    if (_GlassThreadData->counter++ == 0) \
+    if (_GlassThreadData != NULL) \
     { \
-        _GlassThreadData->pool = [[NSAutoreleasePool alloc] init]; \
+        assert(_GlassThreadData->counter >= 0); \
+        if (_GlassThreadData->counter++ == 0) \
+        { \
+            _GlassThreadData->pool = [[NSAutoreleasePool alloc] init]; \
+        } \
     }
 #define GLASS_POOL_EXIT \
-    if (--_GlassThreadData->counter == 0) \
+    if (_GlassThreadData != NULL) \
     { \
-        [_GlassThreadData->pool drain]; \
-        _GlassThreadData->pool = nil; \
+        if (--_GlassThreadData->counter == 0) \
+        { \
+            [_GlassThreadData->pool drain]; \
+            _GlassThreadData->pool = nil; \
+        } \
+        assert(_GlassThreadData->counter >= 0); \
     } \
-    assert(_GlassThreadData->counter >= 0); \
 }
 
 // variations of GLASS_POOL_ENTER/GLASS_POOL_EXIT allowing them to be used accross different calls


### PR DESCRIPTION
At multiple places in native glass code we don't have appropriate NULL checks which might result in null pointer access.

Added appropriate checks and all test run is green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8315074](https://bugs.openjdk.org/browse/JDK-8315074): Possible null pointer access in native glass (**Bug** - P3)


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1223/head:pull/1223` \
`$ git checkout pull/1223`

Update a local copy of the PR: \
`$ git checkout pull/1223` \
`$ git pull https://git.openjdk.org/jfx.git pull/1223/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1223`

View PR using the GUI difftool: \
`$ git pr show -t 1223`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1223.diff">https://git.openjdk.org/jfx/pull/1223.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1223#issuecomment-1695015508)