### PR TITLE
8315217 JavaFX: Add Printer.printableArea(Paper) method

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/print/Printer.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/Printer.java
@@ -231,6 +231,20 @@ public final class Printer {
     }
 
     /**
+     * Returns the printable area in points for a given paper.
+     * @param paper The paper to use.
+     * @return Returns the printable area in points
+     */
+    public Rectangle2D printableArea(Paper paper) {
+        Rectangle2D imgArea = impl.printableArea(paper);
+        return new Rectangle2D(
+                imgArea.getMinX() * 72,
+                imgArea.getMinY() * 72,
+                imgArea.getWidth() * 72,
+                imgArea.getHeight() * 72);
+    }
+
+    /**
      * Obtain a new PageLayout instance for this printer using the specified
      * parameters.
      * The paper should be one of the supported papers and


### PR DESCRIPTION
We sometimes want to access the printable area for a given paper.
The printable area is currently defined in com.sun.javafx.print.PrinterImpl and we would like to make it accessible to javafx.print.Printer.
We would also return the value in points instead of inches for a more consistent API.


RFE:
I have to create an RFE for it, correct?
Any point of reference, on how to create one?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8315376](https://bugs.openjdk.org/browse/JDK-8315376) to be approved
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8315217](https://bugs.openjdk.org/browse/JDK-8315217): JavaFX: Add Printer.printableArea(Paper) method (**Enhancement** - P4)
 * [JDK-8315376](https://bugs.openjdk.org/browse/JDK-8315376): JavaFX: Add Printer.printableArea(Paper) method (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1225/head:pull/1225` \
`$ git checkout pull/1225`

Update a local copy of the PR: \
`$ git checkout pull/1225` \
`$ git pull https://git.openjdk.org/jfx.git pull/1225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1225`

View PR using the GUI difftool: \
`$ git pr show -t 1225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1225.diff">https://git.openjdk.org/jfx/pull/1225.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1225#issuecomment-1697068562)