### PR TITLE
JDK-8315569: Tests for the contract of SkinBase.layoutChildren(..)

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlContractTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlContractTest.java
@@ -72,6 +72,7 @@ class ControlContractTest {
         stage.renderScaleXProperty().bind(renderScaleProperty);
         stage.renderScaleYProperty().bind(renderScaleProperty);
 
+        control.setMinSize(200, 300);
         control.setPadding(new Insets(4, 5, 6, 7));
 
         AtomicBoolean layoutChildrenCalled = new AtomicBoolean(false);
@@ -118,6 +119,9 @@ class ControlContractTest {
         stage.show();
 
         assertTrue(layoutChildrenCalled.get());
+
+        assertEquals(200, control.getWidth());
+        assertEquals(300, control.getHeight());
     }
 
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlContractTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlContractTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.control;
+
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.geometry.Insets;
+import javafx.scene.Scene;
+import javafx.scene.control.SkinBase;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ControlContractTest {
+
+    private ControlStub control;
+
+    @BeforeEach
+    void setup() {
+        control = new ControlStub();
+    }
+
+    @AfterEach
+    void cleanup() {
+        control = null;
+    }
+
+    /**
+     * Tests the contract of {@link SkinBase#layoutChildren(double, double, double, double)} method that is called
+     * when a {@link javafx.scene.control.Control} should layout itself and his children.
+     * The x, y, width and height should be snapped according to the render scale.
+     * The width and height should subtract the snapped padding insets.
+     *
+     * @param scale the render scale
+     */
+    @ParameterizedTest
+    @ValueSource(doubles = { 1.0, 1.25, 1.5, 1.75, 2.0 })
+    void testLayoutChildrenContract(double scale) {
+        DoubleProperty renderScaleProperty = new SimpleDoubleProperty(scale);
+
+        Stage stage = new Stage();
+        stage.renderScaleXProperty().bind(renderScaleProperty);
+        stage.renderScaleYProperty().bind(renderScaleProperty);
+
+        control.setPadding(new Insets(4, 5, 6, 7));
+
+        AtomicBoolean layoutChildrenCalled = new AtomicBoolean(false);
+
+        control.setSkin(new SkinBase<>(control) {
+
+            @Override
+            protected void layoutChildren(double x, double y, double w, double h) {
+                layoutChildrenCalled.set(true);
+
+                Insets padding = control.getPadding();
+
+                double expectedX = control.snappedLeftInset();
+                assertEquals(expectedX, x);
+
+                expectedX = control.snapPositionX(padding.getLeft());
+                assertEquals(expectedX, x);
+
+                double expectedY = control.snappedTopInset();
+                assertEquals(expectedY, y);
+
+                expectedY = control.snapPositionY(padding.getTop());
+                assertEquals(expectedY, y);
+
+                double expectedWidth = control.snapSizeX(control.getWidth()) - control.snappedLeftInset() - control.snappedRightInset();
+                assertEquals(expectedWidth, w);
+
+                expectedWidth = control.snapSizeX(control.getWidth()) - control.snapPositionX(padding.getLeft())
+                        - control.snapPositionX(padding.getRight());
+                assertEquals(expectedWidth, w);
+
+                double expectedHeight = control.snapSizeY(control.getHeight()) - control.snappedTopInset() - control.snappedBottomInset();
+                assertEquals(expectedHeight, h);
+
+                expectedHeight = control.snapSizeY(control.getHeight()) - control.snapPositionY(padding.getTop())
+                        - control.snapPositionY(padding.getBottom());
+                assertEquals(expectedHeight, h);
+            }
+        });
+
+        Scene scene = new Scene(control);
+        stage.setScene(scene);
+
+        stage.show();
+
+        assertTrue(layoutChildrenCalled.get());
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlLayoutTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ControlLayoutTest.java
@@ -41,7 +41,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class ControlContractTest {
+class ControlLayoutTest {
+
+    private static final double EPSILON = 0.00000000001;
 
     private ControlStub control;
 
@@ -64,7 +66,7 @@ class ControlContractTest {
      * @param scale the render scale
      */
     @ParameterizedTest
-    @ValueSource(doubles = { 1.0, 1.25, 1.5, 1.75, 2.0 })
+    @ValueSource(doubles = { 1.0, 1.25, 1.5, 1.75, 2.0, 2.25 })
     void testLayoutChildrenContract(double scale) {
         DoubleProperty renderScaleProperty = new SimpleDoubleProperty(scale);
 
@@ -86,30 +88,30 @@ class ControlContractTest {
                 Insets padding = control.getPadding();
 
                 double expectedX = control.snappedLeftInset();
-                assertEquals(expectedX, x);
+                assertEquals(expectedX, x, EPSILON);
 
                 expectedX = control.snapPositionX(padding.getLeft());
-                assertEquals(expectedX, x);
+                assertEquals(expectedX, x, EPSILON);
 
                 double expectedY = control.snappedTopInset();
-                assertEquals(expectedY, y);
+                assertEquals(expectedY, y, EPSILON);
 
                 expectedY = control.snapPositionY(padding.getTop());
-                assertEquals(expectedY, y);
+                assertEquals(expectedY, y, EPSILON);
 
                 double expectedWidth = control.snapSizeX(control.getWidth()) - control.snappedLeftInset() - control.snappedRightInset();
-                assertEquals(expectedWidth, w);
+                assertEquals(expectedWidth, w, EPSILON);
 
                 expectedWidth = control.snapSizeX(control.getWidth()) - control.snapPositionX(padding.getLeft())
                         - control.snapPositionX(padding.getRight());
-                assertEquals(expectedWidth, w);
+                assertEquals(expectedWidth, w, EPSILON);
 
                 double expectedHeight = control.snapSizeY(control.getHeight()) - control.snappedTopInset() - control.snappedBottomInset();
-                assertEquals(expectedHeight, h);
+                assertEquals(expectedHeight, h, EPSILON);
 
                 expectedHeight = control.snapSizeY(control.getHeight()) - control.snapPositionY(padding.getTop())
                         - control.snapPositionY(padding.getBottom());
-                assertEquals(expectedHeight, h);
+                assertEquals(expectedHeight, h, EPSILON);
             }
         });
 


### PR DESCRIPTION
This PR adds a test that verifies the `SkinBase.layoutChildren(..)` method with different scales.
While not explicitly documented, this method will receive the snapped and correctly calculated x, y, width and height values, so that children of the Control can be layouted correctly without requiring to do many more calculations regarding padding.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315569](https://bugs.openjdk.org/browse/JDK-8315569): Tests for the contract of SkinBase.layoutChildren(..) (**Enhancement** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1229/head:pull/1229` \
`$ git checkout pull/1229`

Update a local copy of the PR: \
`$ git checkout pull/1229` \
`$ git pull https://git.openjdk.org/jfx.git pull/1229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1229`

View PR using the GUI difftool: \
`$ git pr show -t 1229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1229.diff">https://git.openjdk.org/jfx/pull/1229.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1229#issuecomment-1703826887)