### PR TITLE
8308608: [testbug] Use Util::waitForIdle instead of Toolkit::firePulse in system tests

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
@@ -69,7 +69,6 @@ import test.util.Util;
 
 public class ChoiceBoxScrollUpOnCollectionChangeTest {
     static CountDownLatch startupLatch = new CountDownLatch(1);
-    static CountDownLatch scrollLatch = new CountDownLatch(1);
     static CountDownLatch choiceBoxDisplayLatch = new CountDownLatch(1);
     static CountDownLatch choiceBoxHiddenLatch = new CountDownLatch(1);
     static Robot robot;
@@ -91,16 +90,10 @@ public class ChoiceBoxScrollUpOnCollectionChangeTest {
     }
 
     private void scrollChoiceBox(int scrollAmt) throws Exception {
-        Util.runAndWait(() -> {
-            for (int i = 0; i < scrollAmt; i++) {
-                robot.keyType(KeyCode.DOWN);
-            }
-            scrollLatch.countDown();
-        });
-
-        Util.waitForIdle(scene);
-        Util.waitForLatch(scrollLatch, 5, "Timeout waiting for choicebox to be hidden.");
-        Thread.sleep(400); // Wait for up arrow to get loaded in UI
+        for (int i = 0; i < scrollAmt; i++) {
+            Util.runAndWait(() -> robot.keyType(KeyCode.DOWN));
+            Util.waitForIdle(scene);
+        }
 
         Util.runAndWait(() -> {
             robot.keyType(KeyCode.ENTER);

--- a/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
@@ -28,7 +28,6 @@ package test.robot.javafx.scene;
 import java.util.concurrent.CountDownLatch;
 
 import com.sun.javafx.scene.control.ContextMenuContentShim;
-import com.sun.javafx.tk.Toolkit;
 
 import javafx.application.Application;
 import javafx.collections.FXCollections;
@@ -95,11 +94,11 @@ public class ChoiceBoxScrollUpOnCollectionChangeTest {
         Util.runAndWait(() -> {
             for (int i = 0; i < scrollAmt; i++) {
                 robot.keyType(KeyCode.DOWN);
-                Toolkit.getToolkit().firePulse();
             }
             scrollLatch.countDown();
         });
 
+        Util.waitForIdle(scene);
         Util.waitForLatch(scrollLatch, 5, "Timeout waiting for choicebox to be hidden.");
         Thread.sleep(400); // Wait for up arrow to get loaded in UI
 

--- a/tests/system/src/test/java/test/robot/javafx/scene/ContextMenuNPETest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ContextMenuNPETest.java
@@ -48,7 +48,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.sun.javafx.PlatformUtil;
-import com.sun.javafx.tk.Toolkit;
 
 import test.util.Util;
 
@@ -101,9 +100,8 @@ public class ContextMenuNPETest {
             robot.keyType(KeyCode.DOWN);
             robot.keyType(KeyCode.RIGHT);
             robot.keyType(KeyCode.ENTER);
-            Toolkit.getToolkit().firePulse();
-
         });
+        Util.waitForIdle(scene);
         Thread.sleep(200); // Small delay to wait for context menu to close.
         Util.waitForLatch(onHiddenLatch, 10, "Failed to hide context menu.");
     }

--- a/tests/system/src/test/java/test/robot/javafx/scene/ContextMenuNPETest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ContextMenuNPETest.java
@@ -102,7 +102,6 @@ public class ContextMenuNPETest {
             robot.keyType(KeyCode.ENTER);
         });
         Util.waitForIdle(scene);
-        Thread.sleep(200); // Small delay to wait for context menu to close.
         Util.waitForLatch(onHiddenLatch, 10, "Failed to hide context menu.");
     }
 


### PR DESCRIPTION
Made changes to use Util::waitForIdle instead of Toolkit::firePulse in system tests. The test will wait for default value of 10 pulses to complete in the scene before executing the subsequent statements.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8308608](https://bugs.openjdk.org/browse/JDK-8308608): [testbug] Use Util::waitForIdle instead of Toolkit::firePulse in system tests (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1230/head:pull/1230` \
`$ git checkout pull/1230`

Update a local copy of the PR: \
`$ git checkout pull/1230` \
`$ git pull https://git.openjdk.org/jfx.git pull/1230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1230`

View PR using the GUI difftool: \
`$ git pr show -t 1230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1230.diff">https://git.openjdk.org/jfx/pull/1230.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1230#issuecomment-1705051170)