### PR TITLE
8314779: [testbug] Add test to all the XYCharts to check if chart components are removed when series is cleared

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/StackedAreaChartTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/StackedAreaChartTest.java
@@ -411,6 +411,11 @@ public class StackedAreaChartTest extends XYChartTestBase {
         assertEquals(15, ValueAxisShim.get_dataMaxValue(yAxis), 1e-100);
     }
 
+    /*
+     * JDK-8314779
+     * The test checks if the line and path element of the chart
+     * are removed when series data is cleared.
+     */
     @Test
     public void testChartLineAndAreaRemovedOnClearingSeries() {
         startApp();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/StackedAreaChartTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/StackedAreaChartTest.java
@@ -38,7 +38,9 @@ import javafx.scene.chart.ValueAxisShim;
 import javafx.scene.chart.XYChart;
 import javafx.scene.chart.XYChartShim;
 import javafx.scene.shape.Path;
+import javafx.scene.shape.PathElement;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -407,6 +409,24 @@ public class StackedAreaChartTest extends XYChartTestBase {
 
         assertEquals(2, ValueAxisShim.get_dataMinValue(yAxis), 1e-100);
         assertEquals(15, ValueAxisShim.get_dataMaxValue(yAxis), 1e-100);
+    }
+
+    @Test
+    public void testChartLineAndAreaRemovedOnClearingSeries() {
+        startApp();
+        ac.getData().addAll(series1);
+        pulse();
+
+        final ObservableList<Node> children = ((Group)series1.getNode()).getChildren();
+        ObservableList<PathElement> fillElements = ((Path) children.get(0)).getElements();
+        ObservableList<PathElement> lineElements = ((Path) children.get(1)).getElements();
+
+        assertTrue(0 < fillElements.size());
+        assertTrue(0 < lineElements.size());
+        series1.getData().clear();
+        pulse();
+        assertEquals(0, fillElements.size());
+        assertEquals(0, lineElements.size());
     }
 
     @Override


### PR DESCRIPTION
Added test: `testChartLineAndAreaRemovedOnClearingSeries()` for `StackedAreaChart` to check if the line and fill elements gets removed from the series on clearing the series. This test is added similar to the tests added to `LineChart` and `AreaChart`.
This test is not required for `BarChart`, `BubbleChart` and `ScatterChart` as no node will added to the series in these charts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314779](https://bugs.openjdk.org/browse/JDK-8314779): [testbug] Add test to all the XYCharts to check if chart components are removed when series is cleared (**Bug** - P4)


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1231/head:pull/1231` \
`$ git checkout pull/1231`

Update a local copy of the PR: \
`$ git checkout pull/1231` \
`$ git pull https://git.openjdk.org/jfx.git pull/1231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1231`

View PR using the GUI difftool: \
`$ git pr show -t 1231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1231.diff">https://git.openjdk.org/jfx/pull/1231.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1231#issuecomment-1705267495)