### PR TITLE
Publish Gradle Metadata with variants and attributes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1678,6 +1678,8 @@ void addMavenPublication(Project project, List<String> projectDependencies) {
     project.version = MAVEN_VERSION
 
     if (project.name == 'base') {
+        // The 'Parent POM' publication required only for Maven profiles.
+        // This is ignored by Gradle consumers as they use the Gradle metadata (.module) files.
         project.publishing {
             publications {
                 javafx(MavenPublication) {
@@ -1686,11 +1688,8 @@ void addMavenPublication(Project project, List<String> projectDependencies) {
                 }
             }
         }
-    }
-
-    gradle.taskGraph.whenReady { g ->
-        project.tasks.findAll { it.name == 'generatePomFileForJavafxPublication'}.each { it ->
-            it.doLast {
+        project.tasks.named('generatePomFileForJavafxPublication') {
+            doLast {
                 copy {
                     into project.file("${project.buildDir}/publications/javafx")
                     from file("${rootProject.projectDir}/javafx.pom")
@@ -1719,16 +1718,38 @@ void addMavenPublication(Project project, List<String> projectDependencies) {
     }
 
     compileTargets { t ->
+        // TODO split out the correct 'os' and 'arch' values from 't.name'
+        def os = t.name
+        def arch = "x86"
+        [project.configurations.apiElements, project.configurations.runtimeElements].each { conf ->
+            conf.outgoing {
+                artifacts.clear()
+                variants.create(t.name) {
+                    artifact provider { project.tasks."modularPublicationJar$t.capital" }
+                    attributes {
+                        attribute(OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUTE, objects.named(OperatingSystemFamily, os))
+                        attribute(MachineArchitecture.ARCHITECTURE_ATTRIBUTE, objects.named(MachineArchitecture, arch))
+                    }
+                }
+            }
+            project.components.java.withVariantsFromConfiguration(conf) {
+                // Skip the empty "main" variant for Gradle Metadata
+                if (!configurationVariant.attributes.contains(OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUTE)) {
+                    skip()
+                }
+            }
+        }
+
         project.publishing {
             publications {
                 maven(MavenPublication) {
+                    from project.components.java
+
                     artifactId = "javafx-${project.name}"
 
                     afterEvaluate {
+                        // add empty Jar as it will be expected by Maven consumers
                         artifact project.tasks."moduleEmptyPublicationJar$t.capital"
-                        artifact project.tasks."modularPublicationJar$t.capital" {
-                            classifier "$t.name"
-                        }
                     }
 
                     pom.withXml {
@@ -1737,22 +1758,16 @@ void addMavenPublication(Project project, List<String> projectDependencies) {
                         parent.appendNode("artifactId", "javafx")
                         parent.appendNode("version", MAVEN_VERSION)
 
-                        Node dependencies = asNode().appendNode("dependencies")
+                        Node dependencies = asNode().getByName("dependencies")[0]
+                        if (!dependencies) {
+                            dependencies = asNode().appendNode("dependencies")
+                        }
 
                         Node projectDependencyPlatform = dependencies.appendNode("dependency")
                         projectDependencyPlatform.appendNode("groupId", MAVEN_GROUP_ID)
                         projectDependencyPlatform.appendNode("artifactId", "javafx-${project.name}")
                         projectDependencyPlatform.appendNode("version", MAVEN_VERSION)
                         projectDependencyPlatform.appendNode("classifier", "\${javafx.platform}")
-
-                        if (!projectDependencies.empty) {
-                            projectDependencies.each { dep ->
-                                Node projectDependency = dependencies.appendNode("dependency")
-                                projectDependency.appendNode("groupId", MAVEN_GROUP_ID)
-                                projectDependency.appendNode("artifactId", "javafx-$dep")
-                                projectDependency.appendNode("version", MAVEN_VERSION)
-                           }
-                        }
                     }
                 }
             }
@@ -2057,7 +2072,7 @@ allprojects {
 
     // All of our projects are java projects
 
-    apply plugin: "java"
+    apply plugin: 'java-library'
 
     // Set sourceCompatibility to the target release of Java. Most modules
     // set compiler.options.release (to the same target version), which will
@@ -2209,7 +2224,7 @@ project(":base") {
     sourceSets.main.java.srcDirs += "$buildDir/gensrc/java"
 
     compileJava.dependsOn processVersionInfo
-    addMavenPublication(project, [])
+    addMavenPublication(project)
 
     addValidateSourceSets(project, sourceSets)
 }
@@ -2249,7 +2264,7 @@ project(":graphics") {
     dependencies {
         antlr group: "org.antlr", name: "antlr4", version: "4.7.2", classifier: "complete"
         testImplementation project(":base").sourceSets.test.output
-        implementation project(':base')
+        api project(':base')
     }
 
     project.ext.moduleSourcePath = defaultModuleSourcePath_GraphicsOne
@@ -2667,7 +2682,7 @@ project(":graphics") {
         }
     }
 
-    addMavenPublication(project, [ 'base' ])
+    addMavenPublication(project)
 
     addValidateSourceSets(project, sourceSets)
 }
@@ -2702,8 +2717,7 @@ project(":controls") {
     dependencies {
         testImplementation project(":graphics").sourceSets.test.output
         testImplementation project(":base").sourceSets.test.output
-        implementation project(':base')
-        implementation project(':graphics')
+        api project(':graphics')
     }
 
     test {
@@ -2741,7 +2755,7 @@ project(":controls") {
         include "**/*.bss"
     })
 
-    addMavenPublication(project, [ 'graphics' ])
+    addMavenPublication(project)
 
     addValidateSourceSets(project, sourceSets)
 }
@@ -2785,8 +2799,7 @@ project(":swing") {
     commonModuleSetup(project, [ 'base', 'graphics', 'swing' ])
 
     dependencies {
-        implementation project(":base")
-        implementation project(":graphics")
+        api project(":graphics")
     }
 
     test {
@@ -2794,7 +2807,7 @@ project(":swing") {
     }
 
     if (COMPILE_SWING) {
-        addMavenPublication(project, [ 'graphics' ])
+        addMavenPublication(project)
     }
 
     addValidateSourceSets(project, sourceSets)
@@ -2892,8 +2905,7 @@ project(":fxml") {
     dependencies {
         testImplementation project(":graphics").sourceSets.test.output
         testImplementation project(":base").sourceSets.test.output
-        implementation project(":base")
-        implementation project(":graphics")
+        api project(":controls")
     }
 
     test {
@@ -2905,7 +2917,7 @@ project(":fxml") {
         classpath += files("$JDK_HOME/jre/lib/ext/nashorn.jar")
     }
 
-    addMavenPublication(project, [ 'controls' ])
+    addMavenPublication(project)
 
     addValidateSourceSets(project, sourceSets)
 }
@@ -2943,8 +2955,7 @@ project(":media") {
             media name: "ffmpeg-4.0.2", ext: "tar.gz"
             media name: "ffmpeg-5.1.2", ext: "tar.gz"
         }
-        implementation project(":base")
-        implementation project(":graphics")
+        api project(":graphics")
     }
 
     compileJava.dependsOn updateCacheIfNeeded
@@ -3511,7 +3522,7 @@ project(":media") {
         }
     }
 
-    addMavenPublication(project, [ 'graphics' ])
+    addMavenPublication(project)
 
     addValidateSourceSets(project, sourceSets)
 }
@@ -3553,10 +3564,8 @@ project(":web") {
             def icuFileVersion = icuVersion.replaceAll('\\.', '_')
             icu name: "icu4c-${icuFileVersion}-data-bin-l", ext: "zip"
         }
-        implementation project(":base")
-        implementation project(":graphics")
-        implementation project(":controls")
-        implementation project(":media")
+        api project(":controls")
+        api project(":media")
         testImplementation project(":base").sourceSets.test.output
     }
 
@@ -3792,7 +3801,7 @@ project(":web") {
         assemble.dependsOn compileJavaDOMBinding, drtJar
     }
 
-    addMavenPublication(project, [ 'controls', 'media' ])
+    addMavenPublication(project)
 
     addValidateSourceSets(project, sourceSets)
 }
@@ -5002,10 +5011,10 @@ compileTargets { t ->
             }
         }
 
-        def modularPublicationJarName = "${moduleName}-${t.name}.jar"
         def modularPublicationJarTask = project.task("modularPublicationJar${t.capital}", type: Jar, dependsOn: modularEmptyPublicationJarTask) {
             destinationDirectory = file("${dstModularJarDir}")
-            archiveFileName = modularPublicationJarName
+            archiveBaseName = moduleName
+            archiveClassifier = t.name
             from srcLibsDir
             from srcClassesDir
         }


### PR DESCRIPTION
This would make it possible to use JavaFX from Gradle by setting attributes for platform selection on the classpaths without using an additional plugin.

For explanation and discussions leading up to this, see:
- https://github.com/openjfx/javafx-gradle-plugin/pull/151

Note: this is not yet tested and there is one important TODO left.

If you are interested in to adopt this, maybe someone can point me at how a complete publication is built. From looking at the setup, my understanding is that first the different platforms are "built" (on different machines?) and then then all the results are combined in a separate publishing run (with COMPILE_TARGETS to "all") and published. If that is true, could I get hold a build result for all platforms to then test the publishing changes with that? (Or does it work completely different? 😃 ) 