### PR TITLE
8315728: [testbug] SystemMenuBarTest prints "FAILED IS: false"

### DIFF
--- a/tests/system/src/test/java/test/javafx/stage/SystemMenuBarTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/SystemMenuBarTest.java
@@ -74,7 +74,6 @@ public class SystemMenuBarTest {
 
         menubarLatch.await();
 
-        System.err.println("FAILED IS: " + failed.get());
         assertFalse(failed.get());
     }
 


### PR DESCRIPTION
Printed line was right above the assertion testing the printed `failed` value. Failing assertion will print the value of `failed` regardless, so the printed line was redundant.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315728](https://bugs.openjdk.org/browse/JDK-8315728): [testbug] SystemMenuBarTest prints "FAILED IS: false" (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1233/head:pull/1233` \
`$ git checkout pull/1233`

Update a local copy of the PR: \
`$ git checkout pull/1233` \
`$ git pull https://git.openjdk.org/jfx.git pull/1233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1233`

View PR using the GUI difftool: \
`$ git pr show -t 1233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1233.diff">https://git.openjdk.org/jfx/pull/1233.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1233#issuecomment-1707950778)