### PR TITLE
8305709: [testbug] Tree/TableViewResizeColumnToFitContentTest fails with fractional screen scale

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewResizeColumnToFitContentTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewResizeColumnToFitContentTest.java
@@ -25,7 +25,6 @@
 
 package test.robot.javafx.scene.tableview;
 
-import static org.junit.Assert.fail;
 import java.util.concurrent.CountDownLatch;
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -56,6 +55,7 @@ public class TableViewResizeColumnToFitContentTest {
     static volatile Scene scene;
     static final int SCENE_WIDTH = 450;
     static final int SCENE_HEIGHT = 100;
+    private static final double EPSILON = 1e-10;
     static CountDownLatch startupLatch = new CountDownLatch(1);
 
     public static void main(String[] args) {
@@ -93,9 +93,14 @@ public class TableViewResizeColumnToFitContentTest {
         wid1 = table.getColumns().get(1).getWidth();
         wid2 = table.getColumns().get(2).getWidth();
         double colsWidthAfterResize = wid0 + wid1 + wid2;
-        double tolerance = getTolerance(stage);
-        Assert.assertEquals("TableView.CONSTRAINED_RESIZE_POLICY ignored.",
-            colsWidthBeforeResize, colsWidthAfterResize, tolerance);
+        double tolerance = Util.getTolerance(table);
+        String message = "TableView.CONSTRAINED_RESIZE_POLICY ignored" +
+            ", before=" + colsWidthBeforeResize +
+            ", after=" + colsWidthAfterResize +
+            ", diff=" + Math.abs(colsWidthBeforeResize - colsWidthAfterResize) +
+            ", tolerance=" + tolerance +
+            ", tol+eps=" + (tolerance + EPSILON);
+        Assert.assertEquals(message, colsWidthBeforeResize, colsWidthAfterResize, tolerance + EPSILON);
     }
 
     @BeforeClass
@@ -155,17 +160,5 @@ public class TableViewResizeColumnToFitContentTest {
             this.lastNameProperty = new SimpleObjectProperty<>(lastName);
             this.descriptionProperty = new SimpleObjectProperty<>(description);
         }
-    }
-
-    // FIX move to util
-    public static double getTolerance(Stage stage) {
-        // x and y usually have the same scale, so we'll use x
-        double scale = stage.getRenderScaleX();
-        if (scale == 1.0) {
-            return 0.0;
-        }
-        double r = 1.0 / scale;
-        r += Math.ulp(r);
-        return r;
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/treetableview/TreeTableViewResizeColumnToFitContentTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/treetableview/TreeTableViewResizeColumnToFitContentTest.java
@@ -25,7 +25,6 @@
 
 package test.robot.javafx.scene.treetableview;
 
-import static org.junit.Assert.fail;
 import java.util.concurrent.CountDownLatch;
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -68,15 +67,14 @@ public class TreeTableViewResizeColumnToFitContentTest {
 
     @Test
     public void resizeColumnToFitContentTest() {
-        double colOneWidth = treeTableView.getColumns().get(0).getWidth();
-        double colTwoWidth = treeTableView.getColumns().get(1).getWidth();
-        double colThreeWidth = treeTableView.getColumns().get(2).getWidth();
-        double colsWidthBeforeResize = colOneWidth + colTwoWidth + colThreeWidth;
+        double wid0 = treeTableView.getColumns().get(0).getWidth();
+        double wid1 = treeTableView.getColumns().get(1).getWidth();
+        double wid2 = treeTableView.getColumns().get(2).getWidth();
+        double colsWidthBeforeResize = wid0 + wid1 + wid2;
         double colHeaderHeight = 25;
-        double posX = scene.getWindow().getX() + treeTableView.getLayoutX() +
-                colOneWidth + colTwoWidth;
-        double posY = scene.getWindow().getY() + treeTableView.getLayoutY() +
-                colHeaderHeight / 2;
+        double posX = scene.getWindow().getX() + treeTableView.getLayoutX() + wid0 + wid1;
+        double posY = scene.getWindow().getY() + treeTableView.getLayoutY() + colHeaderHeight / 2;
+
         CountDownLatch latch = new CountDownLatch(1);
         Platform.runLater(() -> {
             robot.mouseMove((int) posX, (int) posY);
@@ -86,23 +84,24 @@ public class TreeTableViewResizeColumnToFitContentTest {
             robot.mouseRelease(MouseButton.PRIMARY);
             latch.countDown();
         });
-        Util.waitForLatch(latch, 5, "Timeout while waiting for mouse double click");
-        try {
-            Thread.sleep(1000); // Delay for table resizing of table columns.
-        } catch (Exception e) {
-            fail("Thread was interrupted." + e);
-        }
-        Assert.assertTrue("resizeColumnToFitContent failed",
-                (colTwoWidth != treeTableView.getColumns().get(1).getWidth()));
 
-        // Skip this check on platforms with fractional scale until JDK-8299753 gets implemented
-        if (!Util.isFractionalScaleX(treeTableView)) {
-            colTwoWidth = treeTableView.getColumns().get(1).getWidth();
-            colThreeWidth = treeTableView.getColumns().get(2).getWidth();
-            double colsWidthAfterResize = colOneWidth + colTwoWidth + colThreeWidth;
-            Assert.assertEquals("TreeTableView.CONSTRAINED_RESIZE_POLICY ignored.",
-                    colsWidthBeforeResize, colsWidthAfterResize, EPSILON);
-        }
+        Util.waitForLatch(latch, 5, "Timeout while waiting for mouse double click");
+        Util.waitForIdle(scene);
+
+        Assert.assertTrue("resizeColumnToFitContent failed",
+                (wid1 != treeTableView.getColumns().get(1).getWidth()));
+
+        wid1 = treeTableView.getColumns().get(1).getWidth();
+        wid2 = treeTableView.getColumns().get(2).getWidth();
+        double colsWidthAfterResize = wid0 + wid1 + wid2;
+        double tolerance = Util.getTolerance(treeTableView);
+        String message = "TreeTableView.CONSTRAINED_RESIZE_POLICY ignored" +
+            ", before=" + colsWidthBeforeResize +
+            ", after=" + colsWidthAfterResize +
+            ", diff=" + Math.abs(colsWidthBeforeResize - colsWidthAfterResize) +
+            ", tolerance=" + tolerance +
+            ", tol+eps=" + (tolerance + EPSILON);
+        Assert.assertEquals(message, colsWidthBeforeResize, colsWidthAfterResize, tolerance + EPSILON);
     }
 
     @BeforeClass

--- a/tests/system/src/test/java/test/util/Util.java
+++ b/tests/system/src/test/java/test/util/Util.java
@@ -44,9 +44,10 @@ import javafx.geometry.Rectangle2D;
 import javafx.scene.Node;
 import javafx.scene.robot.Robot;
 import javafx.scene.Scene;
+import javafx.scene.layout.Region;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
-
+import javafx.stage.Window;
 import org.junit.Assert;
 
 import junit.framework.AssertionFailedError;
@@ -465,5 +466,33 @@ public class Util {
 
     private static boolean isFractional(double x) {
         return x != Math.rint(x);
+    }
+
+    /**
+     * Returns the tolerance which should be used when comparing values,
+     * when {@link Region#isSnapToPixel()} returns true and the scale can
+     * be determined from the region's parent {@code Window}.
+     * When scale cannot be determined it is assumed to be 1.0.
+     * Otherwise, returns 0.0.
+     *
+     * @param r the region in question
+     * @return the tolerance value
+     */
+    public static double getTolerance(Region r) {
+        if (r.isSnapToPixel()) {
+            Scene scene = r.getScene();
+            if (scene != null) {
+                Window win = scene.getWindow();
+                if (win != null) {
+                    // x and y usually have the same scale, so we'll use x
+                    double scale = win.getRenderScaleX();
+                    // distance between pixels in the local (unscaled) coordinates is (1 / scale)
+                    return 1.0 / scale;
+                }
+            }
+            // default to 1 when the scale cannot be determited
+            return 1.0;
+        }
+        return 0.0;
     }
 }


### PR DESCRIPTION
Snapping introduces differences between computed values and snapped values, so we need to use non-zero tolerance when checking for equality.  The maximum tolerance is (1 / scale) - one display pixel scaled back to the local coordinates.

The tests have been modified to use the scale-specific tolerance.

Tested with macOS at scale 1.0 and win11 at scales (100%, 125%, 150%, 175%).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305709](https://bugs.openjdk.org/browse/JDK-8305709): [testbug] Tree/TableViewResizeColumnToFitContentTest fails with fractional screen scale (**Bug** - P4)


### Reviewers
 * [Karthik P K](https://openjdk.org/census#kpk) (@karthikpandelu - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1234/head:pull/1234` \
`$ git checkout pull/1234`

Update a local copy of the PR: \
`$ git checkout pull/1234` \
`$ git pull https://git.openjdk.org/jfx.git pull/1234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1234`

View PR using the GUI difftool: \
`$ git pr show -t 1234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1234.diff">https://git.openjdk.org/jfx/pull/1234.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1234#issuecomment-1710618643)