### PR TITLE
8315870: icu fails to compile with Visual Studio 2022 17.6.5

### DIFF
--- a/modules/javafx.web/src/main/native/Source/ThirdParty/icu/source/i18n/fmtable.cpp
+++ b/modules/javafx.web/src/main/native/Source/ThirdParty/icu/source/i18n/fmtable.cpp
@@ -56,7 +56,7 @@ using number::impl::DecimalQuantity;
 // Return true if *a == *b.
 static inline UBool objectEquals(const UObject* a, const UObject* b) {
     // LATER: return *a == *b;
-    return *((const Measure*) a) == *((const Measure*) b);
+    return *((const Measure*) a) == *b;
 }
 
 // Return a clone of *a.


### PR DESCRIPTION
Fix icu to compile with the latest VS 2022 compilers. Note that this fix is already present in the upstream ICU repo. See unicode-org/icu@c7e967c456ceff6436607ca2a3da034320ca34c3

I've built this using the current compilers on all three platforms, and on Windows using VS 2022 17.6.5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8315870](https://bugs.openjdk.org/browse/JDK-8315870): icu fails to compile with Visual Studio 2022 17.6.5 (**Bug** - P3)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1235/head:pull/1235` \
`$ git checkout pull/1235`

Update a local copy of the PR: \
`$ git checkout pull/1235` \
`$ git pull https://git.openjdk.org/jfx.git pull/1235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1235`

View PR using the GUI difftool: \
`$ git pr show -t 1235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1235.diff">https://git.openjdk.org/jfx/pull/1235.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1235#issuecomment-1710820860)