### PR TITLE
8310666: gradle validateSourceSets task not run when TEST_ONLY=true

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4326,7 +4326,8 @@ task sdk() {
     } else {
         gradle.taskGraph.whenReady { taskGraph ->
             taskGraph.allTasks.each { task ->
-                if (!isTestTask(task) && !task.name.equals("verifyJava")) {
+                if (!isTestTask(task) && !task.name.equals("verifyJava") &&
+                    !task.name.equals("validateSourceSets")) {
                     task.enabled = false
                 }
             }


### PR DESCRIPTION
The validateSourceSets task are created only for the test tasks. [check source](https://github.com/openjdk/jfx/blob/eb7de72dafecbedc83c2215b6aed7432d4ec80f9/build.gradle#L1848)
So, validateSourceSets task must be executed when running test tasks even when TEST_ONLY=true.
This had caused a regression [JDK-8310654](https://bugs.openjdk.org/browse/JDK-8310654), where we missed a failing scenario as validateSourceSets did not run with -PTEST_ONLY=true

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8310666](https://bugs.openjdk.org/browse/JDK-8310666): gradle validateSourceSets task not run when TEST_ONLY=true (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1237/head:pull/1237` \
`$ git checkout pull/1237`

Update a local copy of the PR: \
`$ git checkout pull/1237` \
`$ git pull https://git.openjdk.org/jfx.git pull/1237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1237`

View PR using the GUI difftool: \
`$ git pr show -t 1237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1237.diff">https://git.openjdk.org/jfx/pull/1237.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1237#issuecomment-1713513124)