### PR TITLE
8315958: Missing range checks in GlassPasteboard

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/ios/GlassPasteboard.m
+++ b/modules/javafx.graphics/src/main/native-glass/ios/GlassPasteboard.m
@@ -93,11 +93,12 @@ static inline void DumpPasteboard(UIPasteboard *pasteboard)
 }
 #endif //VERBOSE
 
-static inline jbyteArray ByteArrayFromPixels(JNIEnv *env, void *data, int width, int height)
+static inline jbyteArray ByteArrayFromPixels(JNIEnv *env, void *data, size_t width, size_t height)
 {
     jbyteArray javaArray = NULL;
 
-    if ((data != NULL) && (width > 0) && (height > 0))
+    if ((data != NULL) && (width > 0) && (height > 0) &&
+        (width <= ((INT_MAX / 4) - 2) / height))
     {
         javaArray = (*env)->NewByteArray(env, 4*(width*height) + 4*(1+1));
         GLASS_CHECK_EXCEPTION(env);
@@ -364,7 +365,13 @@ JNIEXPORT jbyteArray JNICALL Java_com_sun_glass_ui_ios_IosPasteboard__1getItemAs
 
             size_t width = CGImageGetWidth(cgImage);
             size_t height = CGImageGetHeight(cgImage);
-            uint32_t *pixels = malloc(4*width*height);
+            uint32_t *pixels = NULL;
+            if (width > 0 && height > 0 &&
+                width <= (INT_MAX / 4) / height)
+            {
+                pixels = malloc(4 * width * height);
+            }
+
             if (pixels != NULL)
             {
                 CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassPasteboard.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassPasteboard.m
@@ -144,7 +144,8 @@ static inline jbyteArray ByteArrayFromPixels(JNIEnv *env, void *data, size_t wid
 {
     jbyteArray javaArray = NULL;
 
-    if (data != NULL)
+    if ((data != NULL) && (width > 0) && (height > 0) &&
+        (width <= ((INT_MAX / 4) - 2) / height))
     {
         jsize length = 4*(jsize)(width*height);
 
@@ -624,7 +625,13 @@ JNIEXPORT jbyteArray JNICALL Java_com_sun_glass_ui_mac_MacPasteboard__1getItemAs
 
                     size_t width = CGImageGetWidth(cgImage);
                     size_t height = CGImageGetHeight(cgImage);
-                    uint32_t *pixels = malloc(4*width*height);
+                    uint32_t *pixels = NULL;
+                    if (width > 0 && height > 0 &&
+                        width <= (INT_MAX / 4) / height)
+                    {
+                        pixels = malloc(4 * width * height);
+                    }
+
                     if (pixels != NULL)
                     {
                         CGColorSpaceRef space = CGColorSpaceCreateDeviceRGB();


### PR DESCRIPTION
This PR adds missing range checks in the native `_getItemAsRawImage` and `ByteArrayFromPixels` methods in `GlassPasteboard.m` (for both mac and ios).

Note that these checks are _very_ unlikely to ever detect an error in practice, since they would require a huge image to be copied to the macOS system clipboard (larger than can be created using a Java program). If this were to be detected, no exception would (or should be) thrown, given that the method that triggers this is the reading of the clipboard (so there is nothing that the application is doing wrong for which an exception would make sense).

/reviewers 2

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8315958](https://bugs.openjdk.org/browse/JDK-8315958): Missing range checks in GlassPasteboard (**Bug** - P3)


### Reviewers
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1238/head:pull/1238` \
`$ git checkout pull/1238`

Update a local copy of the PR: \
`$ git checkout pull/1238` \
`$ git pull https://git.openjdk.org/jfx.git pull/1238/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1238`

View PR using the GUI difftool: \
`$ git pr show -t 1238`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1238.diff">https://git.openjdk.org/jfx/pull/1238.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1238#issuecomment-1714175914)