### PR TITLE
8298500: Create test to initially show stage with various attributes (iconified, maximized, full screen)

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/stage/AttributesTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/AttributesTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.robot.javafx.stage;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+import javafx.scene.layout.Pane;
+import javafx.scene.paint.Color;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import test.robot.testharness.VisualTestBase;
+
+import static test.util.Util.TIMEOUT;
+
+public class AttributesTest extends VisualTestBase {
+
+    private static final int WIDTH = 400;
+    private static final int HEIGHT = 400;
+
+    private static final Color BOTTOM_COLOR = Color.LIME;
+    private static final Color TOP_COLOR = Color.RED;
+
+    private static final double TOLERANCE = 0.07;
+
+    private Stage bottomStage;
+    private Stage topStage;
+
+    private void setupStages(boolean overlayed) throws InterruptedException {
+        final CountDownLatch bottomShownLatch = new CountDownLatch(1);
+        final CountDownLatch topShownLatch = new CountDownLatch(1);
+
+        runAndWait(() -> {
+            // Bottom stage, should be visible after top stage is iconified
+            bottomStage = getStage(false);
+            bottomStage.initStyle(StageStyle.DECORATED);
+            Scene bottomScene = new Scene(new Pane(), WIDTH, HEIGHT);
+            bottomScene.setFill(BOTTOM_COLOR);
+            bottomStage.setScene(bottomScene);
+            bottomStage.setX(0);
+            bottomStage.setY(0);
+            bottomStage.setOnShown(e -> Platform.runLater(bottomShownLatch::countDown));
+            bottomStage.show();
+        });
+
+        assertTrue("Timeout waiting for bottom stage to be shown",
+            bottomShownLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
+
+        runAndWait(() -> {
+            // Top stage, will be inconified
+            topStage = getStage(true);
+            topStage.initStyle(StageStyle.DECORATED);
+            Scene topScene = new Scene(new Pane(), WIDTH, HEIGHT);
+            topScene.setFill(TOP_COLOR);
+            topStage.setScene(topScene);
+            if (overlayed) {
+                topStage.setX(0);
+                topStage.setY(0);
+            } else {
+                topStage.setX(WIDTH);
+                topStage.setY(HEIGHT);
+            }
+            topStage.setOnShown(e -> Platform.runLater(topShownLatch::countDown));
+            topStage.show();
+        });
+
+        assertTrue("Timeout waiting for top stage to be shown",
+            topShownLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
+    }
+
+    public @Test void testIconifiedStage() throws InterruptedException {
+        setupStages(true);
+
+        runAndWait(() -> {
+            Color color = getColor(200, 200);
+            assertColorEquals(TOP_COLOR, color, TOLERANCE);
+
+            topStage.setIconified(true);
+        });
+
+        // wait a bit to let window system animate the change
+        sleep(1000);
+
+        runAndWait(() -> {
+            assertTrue(topStage.isIconified());
+            Color color = getColor(200, 200);
+            assertColorEquals(BOTTOM_COLOR, color, TOLERANCE);
+        });
+    }
+
+    public @Test void testMaximizedStage() throws InterruptedException {
+        setupStages(false);
+
+        runAndWait(() -> {
+            Color color = getColor(200, 200);
+            assertColorEquals(BOTTOM_COLOR, color, TOLERANCE);
+
+            topStage.setMaximized(true);
+        });
+
+        // wait a bit to let window system animate the change
+        sleep(1000);
+
+        runAndWait(() -> {
+            assertTrue(topStage.isMaximized());
+
+            // maximized stage should take over the bottom stage
+            Color color = getColor(200, 200);
+            assertColorEquals(TOP_COLOR, color, TOLERANCE);
+        });
+
+        // wait a little bit between getColor() calls - on macOS the below one
+        // would fail without this wait
+        sleep(100);
+
+        runAndWait(() -> {
+            // top left corner (plus some tolerance) should show decorations (so not TOP_COLOR)
+            Color color = getColor((int)topStage.getX() + 10, (int)topStage.getY() + 10);
+            assertColorDoesNotEqual(TOP_COLOR, color, TOLERANCE);
+            assertColorDoesNotEqual(BOTTOM_COLOR, color, TOLERANCE);
+        });
+    }
+
+    public @Test void testFullscreenStage() throws InterruptedException {
+        setupStages(false);
+
+        runAndWait(() -> {
+            Color color = getColor(200, 200);
+            assertColorEquals(BOTTOM_COLOR, color, TOLERANCE);
+
+            topStage.setFullScreen(true);
+        });
+
+        // wait a bit to let window system animate the change
+        sleep(1000);
+
+        runAndWait(() -> {
+            assertTrue(topStage.isFullScreen());
+
+            // fullscreen stage should take over the bottom stage
+            Color color = getColor(200, 200);
+            assertColorEquals(TOP_COLOR, color, TOLERANCE);
+        });
+
+        // wait a little bit between getColor() calls - on macOS the below one
+        // would fail without this wait
+        sleep(100);
+
+        runAndWait(() -> {
+            // top left corner (plus some tolerance) should NOT show decorations
+            Color color = getColor((int)topStage.getX() + 5, (int)topStage.getY() + 5);
+            assertColorEquals(TOP_COLOR, color, TOLERANCE);
+        });
+    }
+}

--- a/tests/system/src/test/java/test/robot/javafx/stage/StageAttributesTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/StageAttributesTest.java
@@ -32,6 +32,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import javafx.application.Platform;
 import javafx.scene.Scene;
@@ -39,8 +41,8 @@ import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
+
+import test.util.Util;
 import test.robot.testharness.VisualTestBase;
 
 import static test.util.Util.TIMEOUT;
@@ -56,6 +58,7 @@ public class StageAttributesTest extends VisualTestBase {
     private static final double TOLERANCE = 0.07;
 
     private Stage bottomStage;
+    private Scene topScene;
     private Stage topStage;
 
     private void setupStages(boolean overlayed) throws InterruptedException {
@@ -82,7 +85,7 @@ public class StageAttributesTest extends VisualTestBase {
             // Top stage, will be inconified
             topStage = getStage(true);
             topStage.initStyle(StageStyle.DECORATED);
-            Scene topScene = new Scene(new Pane(), WIDTH, HEIGHT);
+            topScene = new Scene(new Pane(), WIDTH, HEIGHT);
             topScene.setFill(TOP_COLOR);
             topStage.setScene(topScene);
             if (overlayed) {
@@ -100,7 +103,8 @@ public class StageAttributesTest extends VisualTestBase {
             topShownLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
     }
 
-    public @Test void testIconifiedStage() throws InterruptedException {
+    @Test
+    public void testIconifiedStage() throws InterruptedException {
         setupStages(true);
 
         runAndWait(() -> {
@@ -111,7 +115,7 @@ public class StageAttributesTest extends VisualTestBase {
         });
 
         // wait a bit to let window system animate the change
-        sleep(1000);
+        Util.waitForIdle(topScene);
 
         runAndWait(() -> {
             assertTrue(topStage.isIconified());
@@ -120,7 +124,8 @@ public class StageAttributesTest extends VisualTestBase {
         });
     }
 
-    public @Test void testMaximizedStage() throws InterruptedException {
+    @Test
+    public void testMaximizedStage() throws InterruptedException {
         setupStages(false);
 
         runAndWait(() -> {
@@ -131,7 +136,7 @@ public class StageAttributesTest extends VisualTestBase {
         });
 
         // wait a bit to let window system animate the change
-        sleep(1000);
+        Util.waitForIdle(topScene);
 
         runAndWait(() -> {
             assertTrue(topStage.isMaximized());
@@ -153,7 +158,8 @@ public class StageAttributesTest extends VisualTestBase {
         });
     }
 
-    public @Test void testFullscreenStage() throws InterruptedException {
+    @Test
+    public void testFullscreenStage() throws InterruptedException {
         setupStages(false);
 
         runAndWait(() -> {
@@ -164,7 +170,7 @@ public class StageAttributesTest extends VisualTestBase {
         });
 
         // wait a bit to let window system animate the change
-        sleep(1000);
+        Util.waitForIdle(topScene);
 
         runAndWait(() -> {
             assertTrue(topStage.isFullScreen());

--- a/tests/system/src/test/java/test/robot/javafx/stage/StageAttributesTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/StageAttributesTest.java
@@ -45,7 +45,7 @@ import test.robot.testharness.VisualTestBase;
 
 import static test.util.Util.TIMEOUT;
 
-public class AttributesTest extends VisualTestBase {
+public class StageAttributesTest extends VisualTestBase {
 
     private static final int WIDTH = 400;
     private static final int HEIGHT = 400;

--- a/tests/system/src/test/java/test/robot/javafx/stage/StageAttributesTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/StageAttributesTest.java
@@ -107,6 +107,8 @@ public class StageAttributesTest extends VisualTestBase {
             assertTrue("Timeout waiting for top stage to be shown",
                 topShownLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
         }
+
+        sleep(1000);
     }
 
     @Test
@@ -125,7 +127,7 @@ public class StageAttributesTest extends VisualTestBase {
         });
 
         // wait a bit to let window system animate the change
-        Util.waitForIdle(topScene);
+        sleep(1000);
 
         runAndWait(() -> {
             assertTrue(topStage.isIconified());
@@ -150,7 +152,7 @@ public class StageAttributesTest extends VisualTestBase {
         });
 
         // wait a bit to let window system animate the change
-        Util.waitForIdle(topScene);
+        sleep(1000);
 
         runAndWait(() -> {
             assertTrue(topStage.isMaximized());
@@ -188,7 +190,7 @@ public class StageAttributesTest extends VisualTestBase {
         });
 
         // wait a bit to let window system animate the change
-        Util.waitForIdle(topScene);
+        sleep(1000);
 
         runAndWait(() -> {
             assertTrue(topStage.isFullScreen());
@@ -230,7 +232,7 @@ public class StageAttributesTest extends VisualTestBase {
         });
 
         // wait a bit to let window system animate the change
-        Util.waitForIdle(topScene);
+        sleep(1000);
 
         runAndWait(() -> {
             assertTrue(topStage.isIconified());
@@ -262,7 +264,7 @@ public class StageAttributesTest extends VisualTestBase {
         });
 
         // wait a bit to let window system animate the change
-        Util.waitForIdle(topScene);
+        sleep(1000);
 
         runAndWait(() -> {
             assertTrue(topStage.isMaximized());
@@ -302,7 +304,7 @@ public class StageAttributesTest extends VisualTestBase {
         });
 
         // wait a bit to let window system animate the change
-        Util.waitForIdle(topScene);
+        sleep(1000);
 
         runAndWait(() -> {
             assertTrue(topStage.isFullScreen());

--- a/tests/system/src/test/java/test/robot/javafx/stage/StageAttributesTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/StageAttributesTest.java
@@ -244,7 +244,7 @@ public class StageAttributesTest extends VisualTestBase {
     @Test
     public void testMaximizedStageBeforeShow() throws InterruptedException {
         // Skip on Mac due to:
-        //  - JDK-8305675
+        //  - JDK-8316419
         assumeTrue(!PlatformUtil.isMac());
         // Skip on Linux due to:
         //  - JDK-8316423

--- a/tests/system/src/test/java/test/robot/javafx/stage/StageAttributesTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/StageAttributesTest.java
@@ -34,7 +34,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
+import com.sun.javafx.PlatformUtil;
 import javafx.application.Platform;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
@@ -109,6 +111,10 @@ public class StageAttributesTest extends VisualTestBase {
 
     @Test
     public void testIconifiedStage() throws InterruptedException {
+        // Skip on Linux due to:
+        //  - JDK-8316423
+        assumeTrue(!PlatformUtil.isLinux());
+
         setupStages(true, true);
 
         runAndWait(() -> {
@@ -130,6 +136,10 @@ public class StageAttributesTest extends VisualTestBase {
 
     @Test
     public void testMaximizedStage() throws InterruptedException {
+        // Skip on Linux due to:
+        //  - JDK-8316423
+        assumeTrue(!PlatformUtil.isLinux());
+
         setupStages(false, true);
 
         runAndWait(() -> {
@@ -164,6 +174,10 @@ public class StageAttributesTest extends VisualTestBase {
 
     @Test
     public void testFullScreenStage() throws InterruptedException {
+        // Skip on Linux due to:
+        //  - JDK-8316423
+        assumeTrue(!PlatformUtil.isLinux());
+
         setupStages(false, true);
 
         runAndWait(() -> {
@@ -197,6 +211,13 @@ public class StageAttributesTest extends VisualTestBase {
 
     @Test
     public void testIconifiedStageBeforeShow() throws InterruptedException {
+        // Skip on Mac due to:
+        //  - JDK-8305675
+        assumeTrue(!PlatformUtil.isMac());
+        // Skip on Linux due to:
+        //  - JDK-8316423
+        assumeTrue(!PlatformUtil.isLinux());
+
         setupStages(true, false);
 
         runAndWait(() -> {
@@ -222,6 +243,14 @@ public class StageAttributesTest extends VisualTestBase {
 
     @Test
     public void testMaximizedStageBeforeShow() throws InterruptedException {
+        // Skip on Mac due to:
+        //  - JDK-8305675
+        assumeTrue(!PlatformUtil.isMac());
+        // Skip on Linux due to:
+        //  - JDK-8316423
+        //  - JDK-8316425
+        assumeTrue(!PlatformUtil.isLinux());
+
         setupStages(false, false);
 
         runAndWait(() -> {
@@ -257,6 +286,11 @@ public class StageAttributesTest extends VisualTestBase {
 
     @Test
     public void testFullScreenStageBeforeShow() throws InterruptedException {
+        // Skip on Linux due to:
+        //  - JDK-8316423
+        //  - JDK-8316425
+        assumeTrue(!PlatformUtil.isLinux());
+
         setupStages(false, false);
 
         runAndWait(() -> {


### PR DESCRIPTION
PR adds tests mentioned in the title - a new `AttributesTest` class is added testing iconification, maximization and full-screen-ification of a Stage.

All variants are tested with decorated stage style.

Iconification is tested via overlaying two stages on top of one another, and then iconifying the top one - this is similar to already existing `IconifyTest.java` but it tests just the iconfication process and nothing more.

Maximization and FullScreen are both tested by creating two stages _not_ overlapping each other. After maximization/fullscreen top stage (being always on top as well) should cover the bottom stage. Moreover, FullScreen and Maximize are differentiated by checking if window decoration exists - maximized Stage will have its decoration taking space on top of the screen, whereas FullScreen one will not.

**NOTE:** on macOS I had issues with `getColor()` returning a valid color when called a second time. This only happened on macOS and with FullScreen test (others worked fine). Unfortunately I couldn't figure out why it returned (0, 0, 0, 255) or (255, 255, 255, 255). To mitigate that I moved color checks into separate `runAndWait()`-s with a small sleep between them, which seemed to help `getColor()` return proper values.

Verified to work on Windows 11, macOS and Linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298500](https://bugs.openjdk.org/browse/JDK-8298500): Create test to initially show stage with various attributes (iconified, maximized, full screen) (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1240/head:pull/1240` \
`$ git checkout pull/1240`

Update a local copy of the PR: \
`$ git checkout pull/1240` \
`$ git pull https://git.openjdk.org/jfx.git pull/1240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1240`

View PR using the GUI difftool: \
`$ git pr show -t 1240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1240.diff">https://git.openjdk.org/jfx/pull/1240.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1240#issuecomment-1717468480)