### PR TITLE
8255079: RobotTest::testPixelCaptureAverage fails intermittently on Windows with HiDPI scaling

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -673,10 +673,6 @@ public class RobotTest {
 
     @Test
     public void testPixelCaptureAverage() throws Exception {
-        if (PlatformUtil.isWindows() && Screen.getPrimary().getOutputScaleX() > 1) {
-            // Mark this test as unstable on Windows when HiDPI scale is more than 100%
-            Assume.assumeTrue(Boolean.getBoolean("unstable.test")); // JDK-8255079
-        }
         CountDownLatch setSceneLatch = new CountDownLatch(1);
         Pane pane = new StackPane();
         InvalidationListener invalidationListener = observable -> setSceneLatch.countDown();
@@ -694,8 +690,8 @@ public class RobotTest {
         AtomicReference<Color> captureColor = new AtomicReference<>();
         Thread.sleep(1000);
         Util.runAndWait(() -> {
-            int x = (int) stage.getX();
-            int y = (int) stage.getY();
+            int x = (int)(Math.round(stage.getX()));
+            int y = (int)(Math.round(stage.getY()));
             // Subtracting one pixel from x makes the result RED, so we are on the border.
             // If the implementation of getPixelColor is ever chaged to interpolate the
             // colors on HiDPI screens, this test will fail and the resulting color will


### PR DESCRIPTION
The instability came from the way Windows sets window's default position. When it is not predefined on Stage creation (which was the case in these Robot tests) the window is created at some arbitrary position chosen by Windows near top-left corner. It also seems like Windows first picks the position assuming 100% scaling and then multiplies it by UI scale, which can provide X/Y coordinates of Stage with a fractional value.

Due to above behavior, there is a chance that the fractional part of X/Y will be above .5 which fails the test (X/Y values were fetched via casting directly to `int`, which drops the fractional part without rounding). Adding rounding makes the test always pass and the assumption in the comment below consistent.

`unstable.test` property check was removed, since this change stabilizes the test and its results.

Verified also on macOS to ensure the change did not affect the tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8255079](https://bugs.openjdk.org/browse/JDK-8255079): RobotTest::testPixelCaptureAverage fails intermittently on Windows with HiDPI scaling (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1242/head:pull/1242` \
`$ git checkout pull/1242`

Update a local copy of the PR: \
`$ git checkout pull/1242` \
`$ git pull https://git.openjdk.org/jfx.git pull/1242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1242`

View PR using the GUI difftool: \
`$ git pr show -t 1242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1242.diff">https://git.openjdk.org/jfx/pull/1242.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1242#issuecomment-1721465318)