### PR TITLE
8316518 javafx.print.Paper getWidth / getHeight rounds values, causing errors.

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/print/Paper.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/Paper.java
@@ -78,9 +78,9 @@ public final class Paper {
      */
     private double getSizeInPoints(double dim) {
         switch (units) {
-        case POINT : return (int)(dim+0.5);
-        case INCH  : return (int)((dim * 72) + 0.5);
-        case MM    : return (int)(((dim * 72) / 25.4) + 0.5);
+            case POINT : return dim;
+            case INCH  : return dim * 72;
+            case MM    : return (dim * 72) / 25.4;
         }
         return dim;
     }

--- a/modules/javafx.graphics/src/main/java/javafx/print/Paper.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/Paper.java
@@ -77,12 +77,11 @@ public final class Paper {
      * Translate the internally stored dimension into points.
      */
     private double getSizeInPoints(double dim) {
-        switch (units) {
-            case POINT : return dim;
-            case INCH  : return dim * 72;
-            case MM    : return (dim * 72) / 25.4;
-        }
-        return dim;
+        return switch (units) {
+            case POINT -> dim;
+            case INCH -> dim * 72;
+            case MM -> (dim * 72) / 25.4;
+        };
     }
 
     /**

--- a/modules/javafx.graphics/src/test/java/test/javafx/print/PaperUnitsTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/print/PaperUnitsTest.java
@@ -25,6 +25,7 @@
 
 package test.javafx.print;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
@@ -65,11 +66,11 @@ public class PaperUnitsTest {
      double mmWid = 100.0;
      double mmHgt = 200.0;
      Paper p = PrintHelper.createPaper("TestMM", mmWid, mmHgt, Units.MM);
-     int ptsWid = (int)p.getWidth();
-     int ptsHgt = (int)p.getHeight();
-     int expectedPtsWid = (int)(((mmWid * 72) / 25.4) + 0.5);
-     int expectedPtsHgt = (int)(((mmHgt * 72) / 25.4) + 0.5);
-     assertTrue("MM width is not as expected", ptsWid == expectedPtsWid);
-     assertTrue("MM height is not as expected", ptsHgt == expectedPtsHgt);
+     double ptsWid = p.getWidth();
+     double ptsHgt = p.getHeight();
+     double expectedPtsWid = (mmWid * 72) / 25.4;
+     double expectedPtsHgt = (mmHgt * 72) / 25.4;
+     assertEquals("MM width is not as expected", ptsWid, expectedPtsWid, 0.001);
+     assertEquals("MM height is not as expected", ptsHgt, expectedPtsHgt, 0.001);
    }
 }


### PR DESCRIPTION
The Method javafx.print.getWidth and getHeight returns a double of points.
But the values are always rounded to full integers. This causes especially problems,
with mm based Papers.

I asked in the mailing list, with the conclusion (me and John Hendrix) that is best to just fix this behavior by removing the rounding.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (4 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 3 [Authors](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8316518](https://bugs.openjdk.org/browse/JDK-8316518): javafx.print.Paper getWidth / getHeight rounds values, causing errors. (**Bug** - P4)


### Reviewers
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1244/head:pull/1244` \
`$ git checkout pull/1244`

Update a local copy of the PR: \
`$ git checkout pull/1244` \
`$ git pull https://git.openjdk.org/jfx.git pull/1244/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1244`

View PR using the GUI difftool: \
`$ git pr show -t 1244`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1244.diff">https://git.openjdk.org/jfx/pull/1244.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1244#issuecomment-1725375249)