### PR TITLE
8185831: Pseudo selectors do not appear to work in Node.lookupAll()

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
@@ -248,10 +248,6 @@ final public class SimpleSelector extends Selector {
             if (!styleClassMatch) return false;
         }
 
-        if(!pseudoClassState.isEmpty()){
-            return stateMatches(styleable, styleable.getPseudoClassStates());
-        }
-
         return true;
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
@@ -248,6 +248,10 @@ final public class SimpleSelector extends Selector {
             if (!styleClassMatch) return false;
         }
 
+        if(!pseudoClassState.isEmpty()){
+            return stateMatches(styleable, styleable.getPseudoClassStates());
+        }
+
         return true;
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -1988,6 +1988,7 @@ public abstract class Node implements EventTarget, Styleable {
      *
      * @param selector The Selector.
      * @param results The results.
+     * @return List of matching nodes. The returned value can be null.
      */
     List<Node> lookupAll(Selector selector, List<Node> results) {
         if (selectorMatches(selector)) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -1973,7 +1973,7 @@ public abstract class Node implements EventTarget, Styleable {
      * Finds all {@code Node}s, including this one and any children, which match
      * the given CSS selector. If no matches are found, an empty unmodifiable set is
      * returned. The set is explicitly unordered.
-     *<p>
+     * <p>
      *     For example, if there are multiple nodes with same style class "myStyle", then the lookupAll method can
      *     be used to find all these nodes as follows: <code>scene.lookupAll(".myStyle");</code>.
      * </p>

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -1986,8 +1986,8 @@ public abstract class Node implements EventTarget, Styleable {
      * Used by Node and Parent for traversing the tree and adding all nodes which
      * match the given selector.
      *
-     * @param selector The Selector. This will never be null.
-     * @param results The results. This will never be null.
+     * @param selector The Selector.
+     * @param results The results.
      */
     List<Node> lookupAll(Selector selector, List<Node> results) {
         if (selectorMatches(selector)) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -1961,7 +1961,7 @@ public abstract class Node implements EventTarget, Styleable {
     public Node lookup(String selector) {
         if (selector == null) return null;
         Selector s = Selector.createSelector(selector);
-        return s != null && s.applies(this) ? this : null;
+        return selectorMatches(s) ? this : null;
     }
 
     /**
@@ -1990,7 +1990,7 @@ public abstract class Node implements EventTarget, Styleable {
      * @param results The results. This will never be null.
      */
     List<Node> lookupAll(Selector selector, List<Node> results) {
-        if (selector.applies(this)) {
+        if (selectorMatches(selector)) {
             // Lazily create the set to reduce some trash.
             if (results == null) {
                 results = new LinkedList<>();
@@ -2022,6 +2022,19 @@ public abstract class Node implements EventTarget, Styleable {
         if (getParent() != null) {
             getParent().toFront(this);
         }
+    }
+
+    /**
+     * Checks whether the provided selector matches the node with both styles and pseudo states.
+     * @param s selector to match
+     * @return {@code true} if the selector matches
+     */
+    private boolean selectorMatches(Selector s){
+        boolean matches = s != null && s.applies(this);
+        if(matches && !s.createMatch().getPseudoClasses().isEmpty()){
+            matches = s.stateMatches(this, this.getPseudoClassStates());
+        }
+        return matches;
     }
 
     // TODO: need to verify whether this is OK to do starting from a node in

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -1950,18 +1950,15 @@ public abstract class Node implements EventTarget, Styleable {
      * into the branch until it finds a match. If more than one sub-node matches the
      * specified selector, this function returns the first of them.
      * <p>
-     *     If the lookup selector does not specify a pseudo class, the lookup will ignore pseudo class states;
-     *     it will return the first matching node whether or not it contains pseudo classes.
-     * </p>
+     * If the lookup selector does not specify a pseudo class, the lookup will ignore pseudo class states;
+     * it will return the first matching node whether or not it contains pseudo classes.
      * <p>
-     *     For example, if a Node is given the id of "myId", then the lookup method can
-     *     be used to find this node as follows: {@code scene.lookup("#myId");}.
-     * </p>
+     * For example, if a Node is given the id of "myId", then the lookup method can
+     * be used to find this node as follows: {@code scene.lookup("#myId");}.
      * <p>
-     *     For example, if two nodes, NodeA and NodeB, have the same style class "myStyle" and NodeA has
-     *     a pseudo state "myPseudo", then to find NodeA, the lookup method can be used as follows:
-     *     {@code scene.lookup(".myStyle:myPseudo");} or {@code scene.lookup(":myPseudo");}.
-     * </p>
+     * For example, if two nodes, NodeA and NodeB, have the same style class "myStyle" and NodeA has
+     * a pseudo state "myPseudo", then to find NodeA, the lookup method can be used as follows:
+     * {@code scene.lookup(".myStyle:myPseudo");} or {@code scene.lookup(":myPseudo");}.
      *
      * @param selector The css selector of the node to find
      * @return The first node, starting from this {@code Node}, which matches
@@ -1978,15 +1975,15 @@ public abstract class Node implements EventTarget, Styleable {
      * the given CSS selector. If no matches are found, an empty unmodifiable set is
      * returned. The set is explicitly unordered.
      * <p>
-     *     For example, if there are multiple nodes with same style class "myStyle", then the lookupAll method can
-     *     be used to find all these nodes as follows: {@code scene.lookupAll(".myStyle");}.
-     * </p>
+     * If the lookupAll selector does not specify a pseudo class, the lookupAll will ignore pseudo class states;
+     * it will return all matching nodes whether or not the nodes contain pseudo classes.
      * <p>
-     *     For example, if multiple nodes have same style class "myStyle" and few nodes have
-     *     a pseudo state "myPseudo", then to find all nodes with "myPseudo" state, the lookupAll method can be used as follows:
-     *     {@code scene.lookupAll(".myStyle:myPseudo");} or {@code scene.lookupAll(":myPseudo");}. If no pseudo class is specified
-     *     by the lookupAll selector, irrespective of the nodes pseudo states the result will contain all nodes matching the selector.
-     * </p>
+     * For example, if there are multiple nodes with same style class "myStyle", then the lookupAll method can
+     * be used to find all these nodes as follows: {@code scene.lookupAll(".myStyle");}.
+     * <p>
+     * For example, if multiple nodes have same style class "myStyle" and few nodes have
+     * a pseudo state "myPseudo", then to find all nodes with "myPseudo" state, the lookupAll method can be used as follows:
+     * {@code scene.lookupAll(".myStyle:myPseudo");} or {@code scene.lookupAll(":myPseudo");}.
      *
      * @param selector The css selector of the nodes to find
      * @return All nodes, starting from and including this {@code Node}, which match

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -1982,7 +1982,7 @@ public abstract class Node implements EventTarget, Styleable {
      *     If multiple nodes have same style class "myStyle" and few nodes have
      *     a pseudo state "myPseudo", then to find all nodes with "myPseudo" state, the lookupAll method can be used as follows:
      *     {@code scene.lookupAll(".myStyle:myPseudo");} or {@code scene.lookupAll(":myPseudo");}. If no pseudo class is specified
-     *     by the lookupAll selector, irrespective of their pseudo states the result will contain all nodes matching the selector.
+     *     by the lookupAll selector, irrespective of the nodes pseudo states the result will contain all nodes matching the selector.
      * </p>
      *
      * @param selector The css selector of the nodes to find

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -2030,7 +2030,7 @@ public abstract class Node implements EventTarget, Styleable {
      * @param s selector to match
      * @return {@code true} if the selector matches
      */
-    private boolean selectorMatches(Selector s){
+    private boolean selectorMatches(Selector s) {
         boolean matches = s != null && s.applies(this);
         if(matches && !s.createMatch().getPseudoClasses().isEmpty()){
             matches = s.stateMatches(this, this.getPseudoClassStates());

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -1953,6 +1953,11 @@ public abstract class Node implements EventTarget, Styleable {
      *     For example, if a Node is given the id of "myId", then the lookup method can
      *     be used to find this node as follows: <code>scene.lookup("#myId");</code>.
      * </p>
+     * <p>
+     *     If two nodes, lets say NodeA and NodeB have same style class "myStyle" and NodeA has
+     *     a pseudo state "myPseudo", then to find NodeA, the lookup method can be used as follows:
+     *     <code>scene.lookup(".myStyle:myPseudo");</code> or <code>scene.lookup(":myPseudo");</code>
+     * </p>
      *
      * @param selector The css selector of the node to find
      * @return The first node, starting from this {@code Node}, which matches
@@ -1968,6 +1973,15 @@ public abstract class Node implements EventTarget, Styleable {
      * Finds all {@code Node}s, including this one and any children, which match
      * the given CSS selector. If no matches are found, an empty unmodifiable set is
      * returned. The set is explicitly unordered.
+     *<p>
+     *     For example, if there are multiple nodes with same style class "myStyle", then the lookupAll method can
+     *     be used to find all these nodes as follows: <code>scene.lookupAll(".myStyle");</code>.
+     * </p>
+     * <p>
+     *     If multiple nodes have same style class "myStyle" and few nodes have
+     *     a pseudo state "myPseudo", then to find all nodes with "myPseudo" state, the lookupAll method can be used as follows:
+     *     <code>scene.lookupAll(".myStyle:myPseudo");</code> or <code>scene.lookupAll(":myPseudo");</code>
+     * </p>
      *
      * @param selector The css selector of the nodes to find
      * @return All nodes, starting from and including this {@code Node}, which match

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -1951,12 +1951,13 @@ public abstract class Node implements EventTarget, Styleable {
      * specified selector, this function returns the first of them.
      * <p>
      *     For example, if a Node is given the id of "myId", then the lookup method can
-     *     be used to find this node as follows: <code>scene.lookup("#myId");</code>.
+     *     be used to find this node as follows: {@code scene.lookup("#myId");}.
      * </p>
      * <p>
      *     If two nodes, lets say NodeA and NodeB have same style class "myStyle" and NodeA has
      *     a pseudo state "myPseudo", then to find NodeA, the lookup method can be used as follows:
-     *     <code>scene.lookup(".myStyle:myPseudo");</code> or <code>scene.lookup(":myPseudo");</code>
+     *     {@code scene.lookup(".myStyle:myPseudo");} or {@code scene.lookup(":myPseudo");}. If no pseudo class is specified
+     *     by the lookup selector, irrespective of the nodes pseudo states the result will contain the first node matching the selector.
      * </p>
      *
      * @param selector The css selector of the node to find
@@ -1975,12 +1976,13 @@ public abstract class Node implements EventTarget, Styleable {
      * returned. The set is explicitly unordered.
      * <p>
      *     For example, if there are multiple nodes with same style class "myStyle", then the lookupAll method can
-     *     be used to find all these nodes as follows: <code>scene.lookupAll(".myStyle");</code>.
+     *     be used to find all these nodes as follows: {@code scene.lookupAll(".myStyle");}.
      * </p>
      * <p>
      *     If multiple nodes have same style class "myStyle" and few nodes have
      *     a pseudo state "myPseudo", then to find all nodes with "myPseudo" state, the lookupAll method can be used as follows:
-     *     <code>scene.lookupAll(".myStyle:myPseudo");</code> or <code>scene.lookupAll(":myPseudo");</code>
+     *     {@code scene.lookupAll(".myStyle:myPseudo");} or {@code scene.lookupAll(":myPseudo");}. If no pseudo class is specified
+     *     by the lookupAll selector, irrespective of their pseudo states the result will contain all nodes matching the selector.
      * </p>
      *
      * @param selector The css selector of the nodes to find
@@ -2000,8 +2002,8 @@ public abstract class Node implements EventTarget, Styleable {
      * Used by Node and Parent for traversing the tree and adding all nodes which
      * match the given selector.
      *
-     * @param selector The Selector.
-     * @param results The results.
+     * @param selector The css selector of the nodes to find
+     * @param results The results
      * @return List of matching nodes. The returned value can be null.
      */
     List<Node> lookupAll(Selector selector, List<Node> results) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -2032,7 +2032,7 @@ public abstract class Node implements EventTarget, Styleable {
      */
     private boolean selectorMatches(Selector s) {
         boolean matches = s != null && s.applies(this);
-        if(matches && !s.createMatch().getPseudoClasses().isEmpty()){
+        if (matches && !s.createMatch().getPseudoClasses().isEmpty()) {
             matches = s.stateMatches(this, this.getPseudoClassStates());
         }
         return matches;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -1950,14 +1950,17 @@ public abstract class Node implements EventTarget, Styleable {
      * into the branch until it finds a match. If more than one sub-node matches the
      * specified selector, this function returns the first of them.
      * <p>
+     *     If the lookup selector does not specify a pseudo class, the lookup will ignore pseudo class states;
+     *     it will return the first matching node whether or not it contains pseudo classes.
+     * </p>
+     * <p>
      *     For example, if a Node is given the id of "myId", then the lookup method can
      *     be used to find this node as follows: {@code scene.lookup("#myId");}.
      * </p>
      * <p>
-     *     If two nodes, lets say NodeA and NodeB have same style class "myStyle" and NodeA has
+     *     For example, if two nodes, NodeA and NodeB, have the same style class "myStyle" and NodeA has
      *     a pseudo state "myPseudo", then to find NodeA, the lookup method can be used as follows:
-     *     {@code scene.lookup(".myStyle:myPseudo");} or {@code scene.lookup(":myPseudo");}. If no pseudo class is specified
-     *     by the lookup selector, irrespective of the nodes pseudo states the result will contain the first node matching the selector.
+     *     {@code scene.lookup(".myStyle:myPseudo");} or {@code scene.lookup(":myPseudo");}.
      * </p>
      *
      * @param selector The css selector of the node to find
@@ -1979,7 +1982,7 @@ public abstract class Node implements EventTarget, Styleable {
      *     be used to find all these nodes as follows: {@code scene.lookupAll(".myStyle");}.
      * </p>
      * <p>
-     *     If multiple nodes have same style class "myStyle" and few nodes have
+     *     For example, if multiple nodes have same style class "myStyle" and few nodes have
      *     a pseudo state "myPseudo", then to find all nodes with "myPseudo" state, the lookupAll method can be used as follows:
      *     {@code scene.lookupAll(".myStyle:myPseudo");} or {@code scene.lookupAll(":myPseudo");}. If no pseudo class is specified
      *     by the lookupAll selector, irrespective of the nodes pseudo states the result will contain all nodes matching the selector.
@@ -2002,9 +2005,9 @@ public abstract class Node implements EventTarget, Styleable {
      * Used by Node and Parent for traversing the tree and adding all nodes which
      * match the given selector.
      *
-     * @param selector The css selector of the nodes to find
-     * @param results The results
-     * @return List of matching nodes. The returned value can be null.
+     * @param selector the css selector of the nodes to find
+     * @param results the results
+     * @return list of matching nodes
      */
     List<Node> lookupAll(Selector selector, List<Node> results) {
         if (selectorMatches(selector)) {

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_lookup_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_lookup_Test.java
@@ -235,6 +235,5 @@ public class Node_lookup_Test {
 
         nodes = root.lookupAll(".x:random");
         assertEquals(0, nodes.size());
-
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_lookup_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_lookup_Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,34 +40,40 @@ import org.junit.Before;
 import org.junit.Test;
 
 public class Node_lookup_Test {
-    //                   Group & #root
-    //                    /        \
-    //                 #a.c       .b.c:testPseudo
-    //                /    \         \
-    //    .d:testPseudo1    #e     .d:testPseudo1:testPseudo2
-    private Group root, ac, bc, d, e, d2;
+    //                  Group & #root
+    //                /      \        \
+    //              #a      .b.c       .f:testPseudo
+    //             /   \        \         /           \
+    //           .d    #e        .d   .g:testPseudo1   .h.g:testPseudo1:testPseudo2
+    private Group root, a, bc, d, e, d2, f, g, hg;
 
     @Before public void setup() {
         root = new Group();
         root.setId("root");
-        ac = new Group();
-        ac.setId("a");
-        ac.getStyleClass().addAll("c");
+        a = new Group();
+        a.setId("a");
         d = new Group();
         d.getStyleClass().add("d");
-        d.pseudoClassStateChanged(PseudoClass.getPseudoClass("testPseudo1"),true);
         e = new Group();
         e.setId("e");
         bc = new Group();
         bc.getStyleClass().addAll("b", "c");
-        bc.pseudoClassStateChanged(PseudoClass.getPseudoClass("testPseudo"),true);
         d2 = new Group();
         d2.getStyleClass().add("d");
-        d2.pseudoClassStateChanged(PseudoClass.getPseudoClass("testPseudo1"),true);
-        d2.pseudoClassStateChanged(PseudoClass.getPseudoClass("testPseudo2"),true);
-        ParentShim.getChildren(root).addAll(ac, bc);
-        ParentShim.getChildren(ac).addAll(d, e);
+        f = new Group();
+        f.getStyleClass().add("f");
+        f.pseudoClassStateChanged(PseudoClass.getPseudoClass("testPseudo"),true);
+        g = new Group();
+        g.getStyleClass().add("g");
+        g.pseudoClassStateChanged(PseudoClass.getPseudoClass("testPseudo1"),true);
+        hg = new Group();
+        hg.getStyleClass().addAll("h", "g");
+        hg.pseudoClassStateChanged(PseudoClass.getPseudoClass("testPseudo1"),true);
+        hg.pseudoClassStateChanged(PseudoClass.getPseudoClass("testPseudo2"),true);
+        ParentShim.getChildren(root).addAll(a, bc, f);
+        ParentShim.getChildren(a).addAll(d, e);
         ParentShim.getChildren(bc).addAll(d2);
+        ParentShim.getChildren(f).addAll(g, hg);
     }
 
     @Test public void quickTest() {
@@ -75,7 +81,7 @@ public class Node_lookup_Test {
         assertSame(root, found);
 
         found = root.lookup("#a");
-        assertSame(ac, found);
+        assertSame(a, found);
 
         found = root.lookup("#a > .d");
         assertSame(d, found);
@@ -87,7 +93,7 @@ public class Node_lookup_Test {
         assertSame(d2, found);
 
         found = root.lookup(".c .d");
-        assertSame(d, found);
+        assertSame(d2, found);
 
         found = root.lookup(".b");
         assertSame(bc, found);
@@ -96,7 +102,7 @@ public class Node_lookup_Test {
     @Test public void lookupAllTest() {
         Set<Node> nodes = root.lookupAll("#a");
         assertEquals(1, nodes.size());
-        assertTrue(nodes.contains(ac));
+        assertTrue(nodes.contains(a));
 
         nodes = root.lookupAll(".d");
         assertEquals(2, nodes.size());
@@ -106,30 +112,38 @@ public class Node_lookup_Test {
 
     @Test
     public void lookupPsuedoTest(){
-        Set<Node> nodes = root.lookupAll(".d:testPseudo2");
+        Set<Node> nodes = root.lookupAll(".h:testPseudo2");
         assertEquals(1, nodes.size());
-        assertTrue(nodes.contains(d2));
+        assertTrue(nodes.contains(hg));
 
-        Node found = root.lookup(".d:testPseudo2");
-        assertSame(d2, found);
+        Node found = root.lookup(".h:testPseudo2");
+        assertSame(hg, found);
 
-        found = root.lookup(".d:testPseudo1:testPseudo2");
-        assertSame(d2, found);
+        found = root.lookup(":testPseudo2");
+        assertSame(hg, found);
 
-        nodes = root.lookupAll(".d:testPseudo1");
+        found = root.lookup(".h:testPseudo1:testPseudo2");
+        assertSame(hg, found);
+
+        nodes = root.lookupAll(".g:testPseudo1");
         assertEquals(2, nodes.size());
-        assertTrue(nodes.contains(d));
-        assertTrue(nodes.contains(d2));
+        assertTrue(nodes.contains(g));
+        assertTrue(nodes.contains(hg));
 
-        nodes = root.lookupAll("#a > .d:testPseudo1");
+        nodes = root.lookupAll(":testPseudo1");
+        assertEquals(2, nodes.size());
+        assertTrue(nodes.contains(g));
+        assertTrue(nodes.contains(hg));
+
+        nodes = root.lookupAll(".f > .h:testPseudo1");
         assertEquals(1, nodes.size());
-        assertTrue(nodes.contains(d));
+        assertTrue(nodes.contains(hg));
 
-        nodes = root.lookupAll(".c:testPseudo > .d:testPseudo1");
+        nodes = root.lookupAll(".f:testPseudo > .h:testPseudo1");
         assertEquals(1, nodes.size());
-        assertTrue(nodes.contains(d2));
+        assertTrue(nodes.contains(hg));
 
-        nodes = root.lookupAll(".d:randomPseudo");
+        nodes = root.lookupAll(".f:randomPseudo");
         assertEquals(0, nodes.size());
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_lookup_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_lookup_Test.java
@@ -111,7 +111,7 @@ public class Node_lookup_Test {
     }
 
     @Test
-    public void lookupPseudoTest(){
+    public void lookupPseudoTest() {
         Set<Node> nodes = root.lookupAll(".h:testPseudo2");
         assertEquals(1, nodes.size());
         assertTrue(nodes.contains(hg));
@@ -144,6 +144,54 @@ public class Node_lookup_Test {
         assertTrue(nodes.contains(hg));
 
         nodes = root.lookupAll(".f:randomPseudo");
+        assertEquals(0, nodes.size());
+    }
+
+    /**
+     * Verifies that the lookup ignores pseudo classes when selector contains no explicit pseudo class.
+     */
+    @Test
+    public void lookupPseudoTest2() {
+        // Except root node all the other nodes (f, g, hg) have pseudo classes set to them
+        Set<Node> nodes = root.lookupAll(".g");
+        assertEquals(2, nodes.size());
+        assertTrue(nodes.contains(g));
+        assertTrue(nodes.contains(hg));
+
+        nodes = root.lookupAll("#root .g");
+        assertEquals(2, nodes.size());
+        assertTrue(nodes.contains(g));
+        assertTrue(nodes.contains(hg));
+
+        nodes = root.lookupAll(".f .g");
+        assertEquals(2, nodes.size());
+        assertTrue(nodes.contains(g));
+        assertTrue(nodes.contains(hg));
+
+        nodes = root.lookupAll(".f .h");
+        assertEquals(1, nodes.size());
+        assertTrue(nodes.contains(hg));
+
+        nodes = root.lookupAll(".f > .h");
+        assertEquals(1, nodes.size());
+        assertTrue(nodes.contains(hg));
+
+        nodes = root.lookupAll(".h");
+        assertEquals(1, nodes.size());
+        assertTrue(nodes.contains(hg));
+
+        nodes = root.lookupAll("#root > .f");
+        assertEquals(1, nodes.size());
+        assertTrue(nodes.contains(f));
+
+        nodes = root.lookupAll("#root .f");
+        assertEquals(1, nodes.size());
+        assertTrue(nodes.contains(f));
+
+        nodes = root.lookupAll(".random");
+        assertEquals(0, nodes.size());
+
+        nodes = root.lookupAll(".random .h");
         assertEquals(0, nodes.size());
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_lookup_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_lookup_Test.java
@@ -62,21 +62,21 @@ public class Node_lookup_Test {
         d2.getStyleClass().add("d");
         f = new Group();
         f.getStyleClass().add("f");
-        f.pseudoClassStateChanged(PseudoClass.getPseudoClass("testPseudo"),true);
+        f.pseudoClassStateChanged(PseudoClass.getPseudoClass("testPseudo"), true);
         g = new Group();
         g.getStyleClass().add("g");
-        g.pseudoClassStateChanged(PseudoClass.getPseudoClass("testPseudo1"),true);
+        g.pseudoClassStateChanged(PseudoClass.getPseudoClass("testPseudo1"), true);
         hg = new Group();
         hg.getStyleClass().addAll("h", "g");
-        hg.pseudoClassStateChanged(PseudoClass.getPseudoClass("testPseudo1"),true);
-        hg.pseudoClassStateChanged(PseudoClass.getPseudoClass("testPseudo2"),true);
+        hg.pseudoClassStateChanged(PseudoClass.getPseudoClass("testPseudo1"), true);
+        hg.pseudoClassStateChanged(PseudoClass.getPseudoClass("testPseudo2"), true);
         ParentShim.getChildren(root).addAll(a, bc, f);
         ParentShim.getChildren(a).addAll(d, e);
         ParentShim.getChildren(bc).addAll(d2);
         ParentShim.getChildren(f).addAll(g, hg);
     }
 
-    @Test public void quickTest() {
+    @Test public void test_lookup_on_nodes_without_pseudo_classes() {
         Node found = root.lookup("Group");
         assertSame(root, found);
 
@@ -99,7 +99,7 @@ public class Node_lookup_Test {
         assertSame(bc, found);
     }
 
-    @Test public void lookupAllTest() {
+    @Test public void test_lookupAll_on_nodes_without_pseudo_classes() {
         Set<Node> nodes = root.lookupAll("#a");
         assertEquals(1, nodes.size());
         assertTrue(nodes.contains(a));
@@ -111,7 +111,7 @@ public class Node_lookup_Test {
     }
 
     @Test
-    public void lookupPseudoTest() {
+    public void test_lookup_and_lookupAll_on_nodes_with_pseudo_classes() {
         Set<Node> nodes = root.lookupAll(".h:testPseudo2");
         assertEquals(1, nodes.size());
         assertTrue(nodes.contains(hg));
@@ -151,7 +151,7 @@ public class Node_lookup_Test {
      * Verifies that the lookup ignores pseudo classes when selector contains no explicit pseudo class, but all the nodes have pseudo classes set to them.
      */
     @Test
-    public void lookupPseudoTest2() {
+    public void test_lookupAll_on_nodes_with_pseudo_classes_ignoring_pseudo_classes_in_selector() {
         // Except root node all the other nodes (f, g, hg) have pseudo classes set to them
         Set<Node> nodes = root.lookupAll(".g");
         assertEquals(2, nodes.size());
@@ -199,7 +199,7 @@ public class Node_lookup_Test {
      * Verifies that the lookup ignores pseudo classes when selector contains no explicit pseudo class.
      */
     @Test
-    public void lookupPseudoTest3() {
+    public void test_lookupAll_on_nodes_with_same_style_and_different_pseudo_classes() {
         Group root = new Group();
         root.setId("root");
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_lookup_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_lookup_Test.java
@@ -148,7 +148,7 @@ public class Node_lookup_Test {
     }
 
     /**
-     * Verifies that the lookup ignores pseudo classes when selector contains no explicit pseudo class.
+     * Verifies that the lookup ignores pseudo classes when selector contains no explicit pseudo class, but all the nodes have pseudo classes set to them.
      */
     @Test
     public void lookupPseudoTest2() {
@@ -193,5 +193,48 @@ public class Node_lookup_Test {
 
         nodes = root.lookupAll(".random .h");
         assertEquals(0, nodes.size());
+    }
+
+    /**
+     * Verifies that the lookup ignores pseudo classes when selector contains no explicit pseudo class.
+     */
+    @Test
+    public void lookupPseudoTest3() {
+        Group root = new Group();
+        root.setId("root");
+
+        Group xy = new Group();
+        xy.getStyleClass().addAll("x", "y");
+
+        Group x = new Group();
+        x.getStyleClass().addAll("x");
+
+        Group x1 = new Group();
+        x1.getStyleClass().addAll("x");
+        x1.pseudoClassStateChanged(PseudoClass.getPseudoClass("pseudo"), true);
+
+        ParentShim.getChildren(root).addAll(x, x1, xy);
+
+        Set<Node> nodes = root.lookupAll(".x");
+        assertEquals(3, nodes.size());
+        assertTrue(nodes.contains(x));
+        assertTrue(nodes.contains(x1));
+        assertTrue(nodes.contains(xy));
+
+        nodes = root.lookupAll(".x:pseudo");
+        assertTrue(nodes.contains(x1));
+
+        nodes = root.lookupAll("#root .x");
+        assertEquals(3, nodes.size());
+        assertTrue(nodes.contains(x));
+        assertTrue(nodes.contains(x1));
+        assertTrue(nodes.contains(xy));
+
+        nodes = root.lookupAll("#root .x:pseudo");
+        assertTrue(nodes.contains(x1));
+
+        nodes = root.lookupAll(".x:random");
+        assertEquals(0, nodes.size());
+
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_lookup_Test.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/Node_lookup_Test.java
@@ -111,7 +111,7 @@ public class Node_lookup_Test {
     }
 
     @Test
-    public void lookupPsuedoTest(){
+    public void lookupPseudoTest(){
         Set<Node> nodes = root.lookupAll(".h:testPseudo2");
         assertEquals(1, nodes.size());
         assertTrue(nodes.contains(hg));


### PR DESCRIPTION
**Issue:**
Using pseudo classes in programmatic query using Node.lookupAll() or Node.lookup() gives unexpected results.

**Cause:**
There is no check for checking the psuedo states matching in the applies() method of SimpleSelector.java. So checking for "applies()" alone is not sufficient in lookup() method.

**Fix:**
Included an extra check for the psuedo states to match.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (3 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 2 [Authors](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8185831](https://bugs.openjdk.org/browse/JDK-8185831): Pseudo selectors do not appear to work in Node.lookupAll() (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1245/head:pull/1245` \
`$ git checkout pull/1245`

Update a local copy of the PR: \
`$ git checkout pull/1245` \
`$ git pull https://git.openjdk.org/jfx.git pull/1245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1245`

View PR using the GUI difftool: \
`$ git pr show -t 1245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1245.diff">https://git.openjdk.org/jfx/pull/1245.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1245#issuecomment-1725409162)