### PR TITLE
JDK-8316590: Rendering artifact after JDK-8311983

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -1671,11 +1671,10 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
 
             // Add any necessary leading cells
             if (firstCell != null) {
-                int firstIndex = getCellIndex(firstCell);
-                int index = Math.max(0, firstIndex - 1);
-
-                double prevIndexSize = getCellLength(index);
-                addLeadingCells(index, getCellPosition(firstCell) - prevIndexSize);
+                // NOTE: The index might be -1, but the call to addLeadingCells() is still required.
+                int previousIndex = getCellIndex(firstCell) - 1;
+                double prevIndexSize = getCellLength(previousIndex);
+                addLeadingCells(previousIndex, getCellPosition(firstCell) - prevIndexSize);
             } else {
                 int currentIndex = computeCurrentIndex();
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -1838,6 +1838,29 @@ assertEquals(0, firstCell.getIndex());
         assertEquals(3, flow.getFirstVisibleCell().getIndex());
     }
 
+    /**
+     * The first cell should always be the same when scrolling down just a little bit.
+     * This is mainly a regression test to check that no leading cells are added where they should not be.
+     *
+     * @see <a href="https://bugs.openjdk.org/browse/JDK-8316590">JDK-8316590</a>
+     */
+    @Test
+    public void testFirstCellShouldBeTheSameOnScroll() {
+        flow = new VirtualFlowShim<>();
+        flow.setCellFactory(fw -> new CellStub(flow));
+        flow.setCellCount(50);
+        flow.resize(250, 300);
+
+        pulse();
+
+        IndexedCell<?> cell1 = flow.cells_get(flow.cells, 0);
+
+        flow.scrollPixels(0.01);
+        IndexedCell<?> cell2 = flow.cells_get(flow.cells, 0);
+
+        assertSame(cell1, cell2);
+    }
+
 }
 
 class GraphicalCellStub extends IndexedCellShim<Node> {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/VirtualFlowTest.java
@@ -1861,6 +1861,45 @@ assertEquals(0, firstCell.getIndex());
         assertSame(cell1, cell2);
     }
 
+    @Test
+    public void testFirstCellShouldHaveTheSameIndexOnScroll() {
+        flow = new VirtualFlowShim<>();
+        flow.setCellFactory(fw -> new CellStub(flow));
+        flow.setCellCount(50);
+        flow.resize(250, 300);
+
+        pulse();
+
+        IndexedCell<?> cell1 = flow.cells_get(flow.cells, 0);
+        assertEquals(0, cell1.getIndex());
+
+        flow.scrollPixels(0.01);
+
+        assertEquals(0, cell1.getIndex());
+    }
+
+    /**
+     * The first cell should always be at the same position (when visible), no matter if we scroll down or not.
+     *
+     * @see <a href="https://bugs.openjdk.org/browse/JDK-8316590">JDK-8316590</a>
+     */
+    @Test
+    public void testFirstCellShouldBeAtPosition0OnScroll() {
+        flow = new VirtualFlowShim<>();
+        flow.setCellFactory(fw -> new CellStub(flow));
+        flow.setCellCount(50);
+        flow.resize(250, 300);
+
+        pulse();
+
+        IndexedCell<?> cell1 = flow.cells_get(flow.cells, 0);
+        assertEquals(0.0, cell1.getLayoutY(), 0);
+
+        flow.scrollPixels(0.01);
+
+        assertEquals(0.0, cell1.getLayoutY(), 0);
+    }
+
 }
 
 class GraphicalCellStub extends IndexedCellShim<Node> {


### PR DESCRIPTION
Fixes the regression by basically reverting one change introduced in https://bugs.openjdk.org/browse/JDK-8311983.
The problem is that it is actually required to get the size from a cell with the index -1, which technically does not exist (the accumCell is used then).

Furthermore, unlike the name suggests, the call to `addLeadingCells()` is always needed, even if there are none.
This is because the method does much more than what you would think first. 

In future, it would probably be good to revisit this code. Also performance wise, since this looks like something that can be optimized. But that is another story, not related to this fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8316590](https://bugs.openjdk.org/browse/JDK-8316590): Rendering artifact after JDK-8311983 (**Bug** - P2)


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)
 * [Karthik P K](https://openjdk.org/census#kpk) (@karthikpandelu - Committer)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1246/head:pull/1246` \
`$ git checkout pull/1246`

Update a local copy of the PR: \
`$ git checkout pull/1246` \
`$ git pull https://git.openjdk.org/jfx.git pull/1246/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1246`

View PR using the GUI difftool: \
`$ git pr show -t 1246`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1246.diff">https://git.openjdk.org/jfx/pull/1246.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1246#issuecomment-1729711788)