### PR TITLE
8315657: Application window not activated in macOS 14 Sonoma

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
@@ -224,7 +224,6 @@ public abstract class Application {
     // Overridden methods need to call super.
 
     protected void notifyWillFinishLaunching() {
-        System.err.println("notifyWillFinishLaunching");
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleWillFinishLaunchingAction(this, System.nanoTime());
@@ -232,7 +231,6 @@ public abstract class Application {
     }
 
     protected void notifyDidFinishLaunching() {
-        System.err.println("notifyDidFinishLaunching");
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleDidFinishLaunchingAction(this, System.nanoTime());
@@ -240,7 +238,6 @@ public abstract class Application {
     }
 
     protected void notifyWillBecomeActive() {
-        System.err.println("notifyWillBecomeActive");
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleWillBecomeActiveAction(this, System.nanoTime());
@@ -248,7 +245,6 @@ public abstract class Application {
     }
 
     protected void notifyDidBecomeActive() {
-        System.err.println("notifyDidBecomeActive");
         this.initialActiveEventReceived = true;
         EventHandler handler = getEventHandler();
         if (handler != null) {
@@ -257,7 +253,6 @@ public abstract class Application {
     }
 
     protected void notifyWillResignActive() {
-        System.err.println("notifyWillResignActive");
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleWillResignActiveAction(this, System.nanoTime());
@@ -273,7 +268,6 @@ public abstract class Application {
     }
 
     protected void notifyDidResignActive() {
-        System.err.println("notifyDidResignActive");
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleDidResignActiveAction(this, System.nanoTime());

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
@@ -224,6 +224,7 @@ public abstract class Application {
     // Overridden methods need to call super.
 
     protected void notifyWillFinishLaunching() {
+        System.err.println("notifyWillFinishLaunching");
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleWillFinishLaunchingAction(this, System.nanoTime());
@@ -231,6 +232,7 @@ public abstract class Application {
     }
 
     protected void notifyDidFinishLaunching() {
+        System.err.println("notifyDidFinishLaunching");
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleDidFinishLaunchingAction(this, System.nanoTime());
@@ -238,6 +240,7 @@ public abstract class Application {
     }
 
     protected void notifyWillBecomeActive() {
+        System.err.println("notifyWillBecomeActive");
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleWillBecomeActiveAction(this, System.nanoTime());
@@ -245,6 +248,7 @@ public abstract class Application {
     }
 
     protected void notifyDidBecomeActive() {
+        System.err.println("notifyDidBecomeActive");
         this.initialActiveEventReceived = true;
         EventHandler handler = getEventHandler();
         if (handler != null) {
@@ -253,6 +257,7 @@ public abstract class Application {
     }
 
     protected void notifyWillResignActive() {
+        System.err.println("notifyWillResignActive");
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleWillResignActiveAction(this, System.nanoTime());
@@ -268,6 +273,7 @@ public abstract class Application {
     }
 
     protected void notifyDidResignActive() {
+        System.err.println("notifyDidResignActive");
         EventHandler handler = getEventHandler();
         if (handler != null) {
             handler.handleDidResignActiveAction(this, System.nanoTime());

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
@@ -85,7 +85,7 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
         // We need to spin up a nested event loop and wait for the reactivation
         // to finish prior to allowing the rest of the initialization to run.
         final Runnable wrappedRunnable = () -> {
-            if (isNormalTaskbarApp()) {
+            if (shouldWaitForReactivation()) {
                 waitForReactivation();
             }
             launchable.run();
@@ -113,16 +113,19 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
                 if (!reactivationLatch.await(5, TimeUnit.SECONDS)) {
                     Logging.getJavaFXLogger().warning("Timeout while waiting for app reactivation");
                 }
+                System.err.println("*** Reactivation done");
             } catch (InterruptedException ex) {
                 Logging.getJavaFXLogger().warning("Exception while waiting for app reactivation: " + ex);
             }
             Application.invokeLater(() -> {
+                System.err.println("Reactivation: Exit nested event loop");
                 eventLoop.leave(null);
             });
         });
         thr.setDaemon(true);
         thr.start();
 
+        System.err.println("Reactivation: Spin up nested event loop");
         eventLoop.enter();
     }
 
@@ -142,12 +145,14 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
 
     @Override
     protected void notifyDidResignActive() {
+        System.err.println("Mac: notifyDidResignActive  firstDidResignActive=" + firstDidResignActive);
         firstDidResignActive = true;
         super.notifyDidResignActive();
     }
 
     @Override
     protected void notifyDidBecomeActive() {
+        System.err.println("Mac: notifyDidBecomeActive  firstDidResignActive=" + firstDidResignActive);
         if (firstDidResignActive) {
             reactivationLatch.countDown();
         }
@@ -367,9 +372,9 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
 
     // NOTE: this will not return a valid result until the native _runloop
     // method has been executed and called the Runnable passed to that method.
-    native private boolean _isNormalTaskbarApp();
-    boolean isNormalTaskbarApp() {
-        return _isNormalTaskbarApp();
+    native private boolean _shouldWaitForReactivation();
+    boolean shouldWaitForReactivation() {
+        return _shouldWaitForReactivation();
     }
 
     private native String _getDataDirectory();

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
@@ -113,19 +113,16 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
                 if (!reactivationLatch.await(5, TimeUnit.SECONDS)) {
                     Logging.getJavaFXLogger().warning("Timeout while waiting for app reactivation");
                 }
-                System.err.println("*** Reactivation done");
             } catch (InterruptedException ex) {
                 Logging.getJavaFXLogger().warning("Exception while waiting for app reactivation: " + ex);
             }
             Application.invokeLater(() -> {
-                System.err.println("Reactivation: Exit nested event loop");
                 eventLoop.leave(null);
             });
         });
         thr.setDaemon(true);
         thr.start();
 
-        System.err.println("Reactivation: Spin up nested event loop");
         eventLoop.enter();
     }
 
@@ -145,14 +142,12 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
 
     @Override
     protected void notifyDidResignActive() {
-        System.err.println("Mac: notifyDidResignActive  firstDidResignActive=" + firstDidResignActive);
         firstDidResignActive = true;
         super.notifyDidResignActive();
     }
 
     @Override
     protected void notifyDidBecomeActive() {
-        System.err.println("Mac: notifyDidBecomeActive  firstDidResignActive=" + firstDidResignActive);
         if (firstDidResignActive) {
             reactivationLatch.countDown();
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
@@ -85,7 +85,7 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
         // We need to spin up a nested event loop and wait for the reactivation
         // to finish prior to allowing the rest of the initialization to run.
         final Runnable wrappedRunnable = () -> {
-            if (shouldWaitForReactivation()) {
+            if (isTriggerReactivation()) {
                 waitForReactivation();
             }
             launchable.run();
@@ -372,9 +372,9 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
 
     // NOTE: this will not return a valid result until the native _runloop
     // method has been executed and called the Runnable passed to that method.
-    native private boolean _shouldWaitForReactivation();
-    boolean shouldWaitForReactivation() {
-        return _shouldWaitForReactivation();
+    native private boolean _isTriggerReactivation();
+    boolean isTriggerReactivation() {
+        return _isTriggerReactivation();
     }
 
     private native String _getDataDirectory();

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -53,7 +53,7 @@ static jobject nestedLoopReturnValue = NULL;
 static BOOL isFullScreenExitingLoop = NO;
 static NSMutableDictionary * keyCodeForCharMap = nil;
 static BOOL isEmbedded = NO;
-static BOOL shouldWaitForReactivation = NO;
+static BOOL triggerReactivation = NO;
 static BOOL disableSyncRendering = NO;
 static BOOL firstActivation = YES;
 static BOOL shouldReactivate = NO;
@@ -265,7 +265,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
     [pool drain];
     GLASS_CHECK_EXCEPTION(env);
 
-    if (shouldWaitForReactivation && firstActivation) {
+    if (triggerReactivation && firstActivation) {
         LOG("-> deactivate (hide)  app");
         firstActivation = NO;
         shouldReactivate = YES;
@@ -298,7 +298,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
     [pool drain];
     GLASS_CHECK_EXCEPTION(env);
 
-    if (shouldWaitForReactivation && shouldReactivate) {
+    if (triggerReactivation && shouldReactivate) {
         LOG("-> reactivate  app");
         shouldReactivate = NO;
         [NSApp activateIgnoringOtherApps:YES];
@@ -536,14 +536,14 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
             }
             if (self->jTaskBarApp == JNI_TRUE)
             {
-                shouldWaitForReactivation = YES;
+                triggerReactivation = YES;
 
                 // The workaround of deactivating and reactivating
                 // the application so that the system menu bar works
                 // correctly is no longer needed (and no longer works
                 // anyway) as of macOS 14
                 if (@available(macOS 14.0, *)) {
-                    shouldWaitForReactivation = NO;
+                    triggerReactivation = NO;
                 }
 
                 // move process from background only to full on app with visible Dock icon
@@ -1075,14 +1075,14 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_mac_MacApplication__1supportsSy
 
 /*
  * Class:     com_sun_glass_ui_mac_MacApplication
- * Method:    _shouldWaitForReactivation
+ * Method:    _isTriggerReactivation
  * Signature: ()Z;
  */
-JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_mac_MacApplication__1shouldWaitForReactivation
+JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_mac_MacApplication__1isTriggerReactivation
 (JNIEnv *env, jobject japplication)
 {
-    LOG("Java_com_sun_glass_ui_mac_MacApplication__1shouldWaitForReactivation");
-    return shouldWaitForReactivation;
+    LOG("Java_com_sun_glass_ui_mac_MacApplication__1isTriggerReactivation");
+    return triggerReactivation;
 }
 
 /*


### PR DESCRIPTION
The fix for [JDK-8233678](https://bugs.openjdk.org/browse/JDK-8233678) added a step to the NSApplication initialization to deactivate and then reactivate the application. We trigger the deactivation the first time applicationDidBecomeActive is called. We then trigger the reactivation the when applicationDidResignActive is called after that. The initialization logic in MacApplication spins up a nested event loop that waits for the reactivation (a second call to applicationDidBecomeActive).

Something in macOS 14 has changed that prevents the initial call to applicationDidBecomeActive from being done until the application has finished launching (notifyDidFinishLaunching).

So the activation of the NSApplication is waiting for the launching to be finished, but the nested event loop we spin up is blocking the completion of launching until we get the activation. This is a classic deadlock.

The good news, though, is the deactivation / reactivation of the application no longer seems to be needed on macOS 14. The menus work fine without that fix.

The proposed solution is to check the version of macOS and only enable the deactivation / reactivation logic on systems prior to macOS 14. This will have the additional benefit of avoiding the brief flash when the app is first launched (see [JDK-8257835](https://bugs.openjdk.org/browse/JDK-8257835)).

This is a Draft PR with a few debugging statements. Once I get some feedback that it works for more than just me, I'll remove the debugging statements and then make it "rfr".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8315657](https://bugs.openjdk.org/browse/JDK-8315657): Application window not activated in macOS 14 Sonoma (**Bug** - P2)


### Reviewers
 * [Jose Pereda](https://openjdk.org/census#jpereda) (@jperedadnr - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1247/head:pull/1247` \
`$ git checkout pull/1247`

Update a local copy of the PR: \
`$ git checkout pull/1247` \
`$ git pull https://git.openjdk.org/jfx.git pull/1247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1247`

View PR using the GUI difftool: \
`$ git pr show -t 1247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1247.diff">https://git.openjdk.org/jfx/pull/1247.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1247#issuecomment-1731514381)