### PR TITLE
JDK-8316781 Legal, Monarch paper sizes are incorrect in javafx.print.Paper

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/print/Paper.java
+++ b/modules/javafx.graphics/src/main/java/javafx/print/Paper.java
@@ -171,7 +171,7 @@ public final class Paper {
     /**
      * Specifies the North American legal size, 8.5 inches by 14 inches.
      */
-    public static final Paper LEGAL = new Paper("Legal", 8.4, 14, INCH);
+    public static final Paper LEGAL = new Paper("Legal", 8.5, 14, INCH);
 
     /**
      * Specifies the tabloid size, 11 inches by 17 inches.
@@ -190,10 +190,11 @@ public final class Paper {
     public static final Paper NA_8X10 = new Paper("8x10", 8, 10, INCH);
 
     /**
-     * Specifies the Monarch envelope size, 3.87 inch by 7.5 inch.
+     * Specifies the Monarch envelope size, 3.875 inches by 7.5 inches.
      */
     public static final Paper
-        MONARCH_ENVELOPE = new Paper("Monarch Envelope", 3.87, 7.5, INCH);
+        MONARCH_ENVELOPE = new Paper("Monarch Envelope", 3.875, 7.5, INCH);
+
     /**
      * Specifies the North American Number 10 business envelope size,
      * 4.125 inches by 9.5 inches.


### PR DESCRIPTION
The sizes should be 8.5 wide for legal, and 3.875 wide for monarch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316781](https://bugs.openjdk.org/browse/JDK-8316781): Legal, Monarch paper sizes are incorrect in javafx.print.Paper (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1248/head:pull/1248` \
`$ git checkout pull/1248`

Update a local copy of the PR: \
`$ git checkout pull/1248` \
`$ git pull https://git.openjdk.org/jfx.git pull/1248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1248`

View PR using the GUI difftool: \
`$ git pr show -t 1248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1248.diff">https://git.openjdk.org/jfx/pull/1248.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1248#issuecomment-1732395477)