### PR TITLE
8316892: Skip failing IconifyTestcanIconifyDecoratedStage on Linux

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/stage/IconifyTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/IconifyTest.java
@@ -35,7 +35,9 @@ import javafx.stage.Stage;
 import javafx.stage.StageStyle;
 import org.junit.Test;
 import test.robot.testharness.VisualTestBase;
+import com.sun.javafx.PlatformUtil;
 
+import static org.junit.Assume.assumeTrue;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static test.util.Util.TIMEOUT;
@@ -124,6 +126,7 @@ public class IconifyTest extends VisualTestBase {
 
     @Test(timeout = 15000)
     public void canIconifyDecoratedStage() throws Exception {
+        assumeTrue(!PlatformUtil.isLinux()); // Skip due to JDK-8316891
         canIconifyStage(StageStyle.DECORATED, true);
     }
 


### PR DESCRIPTION
Failing test is skipped. Verified on Ubuntu VM.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316892](https://bugs.openjdk.org/browse/JDK-8316892): Skip failing IconifyTestcanIconifyDecoratedStage on Linux (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1250/head:pull/1250` \
`$ git checkout pull/1250`

Update a local copy of the PR: \
`$ git checkout pull/1250` \
`$ git pull https://git.openjdk.org/jfx.git pull/1250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1250`

View PR using the GUI difftool: \
`$ git pr show -t 1250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1250.diff">https://git.openjdk.org/jfx/pull/1250.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1250#issuecomment-1738905277)