### PR TITLE
JDK-8317308 JavaFX Developer build broken on Windows - NativeLibrary file contains invalid character ':'

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/utils/NativeLibLoader.java
@@ -237,6 +237,8 @@ public class NativeLibLoader {
 
     private static String cacheLibrary(InputStream is, String name, Class caller) throws IOException {
         String jfxVersion = System.getProperty("javafx.runtime.version", "versionless");
+        // This fixes an issue with windows - ":" is not allowed for file on Windows.
+        jfxVersion = jfxVersion.replace(":", "-");
         String userCache = System.getProperty("javafx.cachedir", "");
         String arch = System.getProperty("os.arch");
         if (userCache.isEmpty()) {


### PR DESCRIPTION
The format of the timestamp has changed to ISO 8601. This contains the “:” Character.
A copy of the dll is saved at <home>/.openjfx/cache/" + jfxVersion + "/" + arch .
On Windows, the character ‘:’ is invalid in files, causing internal errors.

This only happens on developer/non-hudson builds, because on hudson-builds, the timestamp is omitted.

I just replaced the disallowed character when creating the native library.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317308](https://bugs.openjdk.org/browse/JDK-8317308): JavaFX Developer build broken on Windows - NativeLibrary file contains invalid character ':' (**Bug** - P2)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1251/head:pull/1251` \
`$ git checkout pull/1251`

Update a local copy of the PR: \
`$ git checkout pull/1251` \
`$ git pull https://git.openjdk.org/jfx.git pull/1251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1251`

View PR using the GUI difftool: \
`$ git pr show -t 1251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1251.diff">https://git.openjdk.org/jfx/pull/1251.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1251#issuecomment-1740692792)