### PR TITLE
JDK-8284445: macOS 12 prints a warning when a function key shortcut is assigned to a menu

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassSystemMenu.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassSystemMenu.java
@@ -365,7 +365,7 @@ class GlassSystemMenu implements TKSystemMenu {
             }
         }
 
-        if (kcc instanceof KeyCodeCombination) {
+        if (!PlatformUtil.isMac() && kcc instanceof KeyCodeCombination) {
             KeyCode kcode = ((KeyCodeCombination)kcc).getCode();
             int     code  = kcode.getCode();
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassSystemMenu.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassSystemMenu.java
@@ -365,7 +365,7 @@ class GlassSystemMenu implements TKSystemMenu {
             }
         }
 
-        if (!PlatformUtil.isMac() && kcc instanceof KeyCodeCombination) {
+        if (kcc instanceof KeyCodeCombination) {
             KeyCode kcode = ((KeyCodeCombination)kcc).getCode();
             int     code  = kcode.getCode();
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassMenu.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassMenu.m
@@ -236,16 +236,17 @@ static jfieldID  jPixelsScaleYField = 0;
     }
     if ((jmodifiers & com_sun_glass_events_KeyEvent_MODIFIER_FUNCTION) != 0)
     {
-        modifier = modifier | NSFunctionKeyMask;
-    }
-    if (jshortcut >= com_sun_glass_events_KeyEvent_VK_F1 &&
-        jshortcut <= com_sun_glass_events_KeyEvent_VK_F12) {
-        int delta = jshortcut - com_sun_glass_events_KeyEvent_VK_F1;
-        shortcut = [NSString stringWithFormat:@"%C", (unsigned short)(NSF1FunctionKey + delta)];
-    } else if (jshortcut >= com_sun_glass_events_KeyEvent_VK_F13 &&
-                jshortcut <= com_sun_glass_events_KeyEvent_VK_F24) {
-        int delta = jshortcut - com_sun_glass_events_KeyEvent_VK_F13;
-        shortcut = [NSString stringWithFormat:@"%C", (unsigned short)(NSF13FunctionKey + delta)];
+        if (jshortcut >= com_sun_glass_events_KeyEvent_VK_F1 &&
+            jshortcut <= com_sun_glass_events_KeyEvent_VK_F12) {
+            int delta = jshortcut - com_sun_glass_events_KeyEvent_VK_F1;
+            shortcut = [NSString stringWithFormat:@"%C", (unsigned short)(NSF1FunctionKey + delta)];
+        } else if (jshortcut >= com_sun_glass_events_KeyEvent_VK_F13 &&
+                   jshortcut <= com_sun_glass_events_KeyEvent_VK_F24) {
+            int delta = jshortcut - com_sun_glass_events_KeyEvent_VK_F13;
+            shortcut = [NSString stringWithFormat:@"%C", (unsigned short)(NSF13FunctionKey + delta)];
+        } else {
+            modifier = modifier | NSFunctionKeyMask;
+        }
     }
     [self->item setKeyEquivalent:shortcut];
     [self->item setKeyEquivalentModifierMask:modifier];

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassMenu.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassMenu.m
@@ -237,15 +237,15 @@ static jfieldID  jPixelsScaleYField = 0;
     if ((jmodifiers & com_sun_glass_events_KeyEvent_MODIFIER_FUNCTION) != 0)
     {
         modifier = modifier | NSFunctionKeyMask;
-        if (jshortcut >= com_sun_glass_events_KeyEvent_VK_F1 &&
-            jshortcut <= com_sun_glass_events_KeyEvent_VK_F12) {
-            int delta = jshortcut - com_sun_glass_events_KeyEvent_VK_F1;
-            shortcut = [NSString stringWithFormat:@"%C", (unsigned short)(NSF1FunctionKey + delta)];
-        } else if (jshortcut >= com_sun_glass_events_KeyEvent_VK_F13 &&
-                   jshortcut <= com_sun_glass_events_KeyEvent_VK_F24) {
-            int delta = jshortcut - com_sun_glass_events_KeyEvent_VK_F13;
-            shortcut = [NSString stringWithFormat:@"%C", (unsigned short)(NSF13FunctionKey + delta)];
-        }
+    }
+    if (jshortcut >= com_sun_glass_events_KeyEvent_VK_F1 &&
+        jshortcut <= com_sun_glass_events_KeyEvent_VK_F12) {
+        int delta = jshortcut - com_sun_glass_events_KeyEvent_VK_F1;
+        shortcut = [NSString stringWithFormat:@"%C", (unsigned short)(NSF1FunctionKey + delta)];
+    } else if (jshortcut >= com_sun_glass_events_KeyEvent_VK_F13 &&
+                jshortcut <= com_sun_glass_events_KeyEvent_VK_F24) {
+        int delta = jshortcut - com_sun_glass_events_KeyEvent_VK_F13;
+        shortcut = [NSString stringWithFormat:@"%C", (unsigned short)(NSF13FunctionKey + delta)];
     }
     [self->item setKeyEquivalent:shortcut];
     [self->item setKeyEquivalentModifierMask:modifier];

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassMenu.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassMenu.m
@@ -244,8 +244,6 @@ static jfieldID  jPixelsScaleYField = 0;
                    jshortcut <= com_sun_glass_events_KeyEvent_VK_F24) {
             int delta = jshortcut - com_sun_glass_events_KeyEvent_VK_F13;
             shortcut = [NSString stringWithFormat:@"%C", (unsigned short)(NSF13FunctionKey + delta)];
-        } else {
-            modifier = modifier | NSFunctionKeyMask;
         }
     }
     [self->item setKeyEquivalent:shortcut];


### PR DESCRIPTION
This PR addresses [JDK-8284445](https://bugs.openjdk.org/browse/JDK-8284445).

Context: the warning might be more important than it seems. Our JavaFX-based desktop app has [an issue](https://github.com/defold/defold/issues/7845) — when the user opens 2 instances of the app, one of the instances hangs after a while. While debugging the issue, I found that it's somehow related to the system menu bar — not refreshing it fixes the issue. Further investigations revealed that the app hangs only if we show menus that use F1-F24 shortcuts. This reminded me of the warnings we get about `NSEventModifierFlagFunction specified to -setKeyEquivalentModifierMask` for such shortcuts. I experimented with removing the modifier for these shortcuts, and it helped with our issue!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8284445](https://bugs.openjdk.org/browse/JDK-8284445): macOS 12 prints a warning when a function key shortcut is assigned to a menu (**Bug** - P4)


### Reviewers
 * [Martin Fox](https://openjdk.org/census#mfox) (@beldenfox - Author)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1252/head:pull/1252` \
`$ git checkout pull/1252`

Update a local copy of the PR: \
`$ git checkout pull/1252` \
`$ git pull https://git.openjdk.org/jfx.git pull/1252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1252`

View PR using the GUI difftool: \
`$ git pr show -t 1252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1252.diff">https://git.openjdk.org/jfx/pull/1252.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1252#issuecomment-1773016067)