### PR TITLE
Add focusOwner and focusOwnerWithin properties

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -2116,7 +2116,7 @@ public class Scene implements EventTarget {
 
         Node node = getFocusOwner();
         if (node != null) {
-            node.setFocusQuietly(windowFocused, focusOwner.focusVisible);
+            node.setFocusQuietly(windowFocused, focusOwner.focusVisible, true);
             node.notifyFocusListeners();
         }
 
@@ -2233,11 +2233,11 @@ public class Scene implements EventTarget {
         @Override
         protected void invalidated() {
             if (oldFocusOwner != null) {
-                oldFocusOwner.setFocusQuietly(false, false);
+                oldFocusOwner.setFocusQuietly(false, false, false);
             }
             Node value = get();
             if (value != null) {
-                value.setFocusQuietly(windowFocused, focusVisible);
+                value.setFocusQuietly(windowFocused, focusVisible, true);
                 if (value != oldFocusOwner) {
                     value.getScene().enableInputMethodEvents(
                             value.getInputMethodRequests() != null


### PR DESCRIPTION
This PR adds `Node.focusOwner` and `Node.focusOwnerWithin`, along with the corresponding CSS classes `focus-owner` and `focus-owner-within`.

This completes the five focus-related properties of JavaFX nodes:
1. `focused`, which matches any focused node (can be more than one in a scene)
2. `focus-within`, which matches any node that contains a `focused` node
3. `focus-owner`, which matches the single node that is the scene's focus owner
4. `focus-owner-within`, which matches any node that contains the single focus owner
5. `focus-visible`, which matches a single focused node that visibly indicates focus

This enhancement allows scenarios like [JDK-8317426](https://bugs.openjdk.org/browse/JDK-8317426) to work as expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1255/head:pull/1255` \
`$ git checkout pull/1255`

Update a local copy of the PR: \
`$ git checkout pull/1255` \
`$ git pull https://git.openjdk.org/jfx.git pull/1255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1255`

View PR using the GUI difftool: \
`$ git pr show -t 1255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1255.diff">https://git.openjdk.org/jfx/pull/1255.diff</a>

</details>
