### PR TITLE
8314486: JavaFX build uses deprecated features that will be removed in gradle 8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1040,9 +1040,9 @@ List<String> computeModulePathArgs(String  pname, List<String> deps, boolean tes
 
             File dir;
             if (test && proj.sourceSets.hasProperty('shims')) {
-                dir = new File(proj.sourceSets.shims.java.outputDir, proj.ext.moduleName);
+                dir = new File(proj.sourceSets.shims.java.getDestinationDirectory().get().getAsFile(), proj.ext.moduleName);
             } else {
-                dir = new File(proj.sourceSets.main.java.outputDir, proj.ext.moduleName);
+                dir = new File(proj.sourceSets.main.java.getDestinationDirectory().get().getAsFile(), proj.ext.moduleName);
             }
             if (mp == null) {
                 mp = dir.path
@@ -1140,9 +1140,9 @@ void commonModuleSetup(Project p, List<String> moduleChain) {
     p.ext.moduleChain = moduleChain
 
     if (p.hasProperty("moduleName")) {
-        p.ext.moduleDir = new File (p.sourceSets.main.java.outputDir, "${p.moduleName}")
+        p.ext.moduleDir = new File (p.sourceSets.main.java.getDestinationDirectory().get().getAsFile(), "${p.moduleName}")
         if (p.sourceSets.hasProperty('shims')) {
-            p.ext.moduleShimsDir = new File (p.sourceSets.shims.java.outputDir, "${p.moduleName}")
+            p.ext.moduleShimsDir = new File (p.sourceSets.shims.java.getDestinationDirectory().get().getAsFile(), "${p.moduleName}")
         }
     }
 
@@ -1589,7 +1589,7 @@ void addNative(Project project, String name) {
 void addJSL(Project project, String name, String pkg, List<String> addExports, Closure compile) {
     def lowerName = name.toLowerCase()
 
-    def modulePath = "${project.sourceSets.main.java.outputDir}"
+    def modulePath = "${project.sourceSets.main.java.getDestinationDirectory().get().getAsFile()}"
     modulePath += File.pathSeparator + "${rootProject.projectDir}/modules/javafx.base/build/classes/java/main"
     def compileCompilers = project.task("compile${name}Compilers",
             type: JavaCompile,
@@ -1597,7 +1597,7 @@ void addJSL(Project project, String name, String pkg, List<String> addExports, C
         description = "Compile the $name JSL Compilers"
 
         classpath =
-               project.files(project.sourceSets.jslc.java.outputDir) +
+               project.files(project.sourceSets.jslc.java.getDestinationDirectory().get().getAsFile()) +
                project.configurations.antlr
         source = [project.file("src/main/jsl-$lowerName")]
         destinationDir = project.file("$project.buildDir/classes/jsl-compilers/$lowerName")
@@ -2337,7 +2337,7 @@ project(":graphics") {
         source += "$buildDir/gensrc/java"
         source += project.sourceSets.shaders.output
 
-        destinationDir = project.sourceSets.main.java.outputDir
+        destinationDirectory = project.sourceSets.main.java.destinationDirectory
         options.compilerArgs.addAll([
             '-h', "$buildDir/gensrc/headers/",  // Note: this creates the native headers
             '-implicit:none',
@@ -2484,7 +2484,7 @@ project(":graphics") {
     // a new task for each of the decora files, preferring instead just to create a rule?? Also
     // need "clean" tasks for each compile task.
 
-    def modulePath = "${project.sourceSets.main.java.outputDir}"
+    def modulePath = "${project.sourceSets.main.java.getDestinationDirectory().get().getAsFile()}"
     modulePath += File.pathSeparator + "${rootProject.projectDir}/modules/javafx.base/build/classes/java/main"
     addJSL(project, "Decora", "com/sun/scenario/effect/impl/hw/d3d/hlsl", decoraAddExports) { sourceDir, destinationDir ->
         [[fileName: "ColorAdjust", generator: "CompileJSL", outputs: "-all"],
@@ -2502,7 +2502,7 @@ project(":graphics") {
                 workingDir = project.projectDir
                 main = settings.generator
                 classpath = configurations.compileClasspath + configurations.antlr
-                classpath += files(project.sourceSets.jslc.java.outputDir)
+                classpath += files(project.sourceSets.jslc.java.getDestinationDirectory().get().getAsFile())
 
                 classpath += files("${project.projectDir}/src/jslc/resources")
 
@@ -2542,7 +2542,7 @@ project(":graphics") {
             def capitalVariant = variant.capitalize()
             def ccOutput = variant == "" ? nativeDir : file("$nativeDir/$variant")
 
-            def ccTask = task("compileDecoraNativeShaders$capitalTarget$capitalVariant", type: CCTask ) {
+            def ccTask = task("compileDecoraNativeShaders$capitalTarget$capitalVariant", type: CCTask, dependsOn: generateDecoraShaders) {
                 description = "Compiles Decora SSE natives for ${t.name}${capitalVariant != '' ? ' for variant ' + capitalVariant : ''}"
                 matches = ".*\\.cc"
                 source file("$buildDir/gensrc/jsl-decora")
@@ -2591,7 +2591,7 @@ project(":graphics") {
                 workingDir = project.projectDir
                 main = "CompileJSL"
                 classpath = configurations.compileClasspath + configurations.antlr
-                classpath += files(project.sourceSets.jslc.java.outputDir)
+                classpath += files(project.sourceSets.jslc.java.getDestinationDirectory().get().getAsFile())
                 classpath += files(project.sourceSets.jslc.resources)
                 classpath += files("$buildDir/classes/jsl-compilers/prism",
                     project.projectDir.path + "/src/main/jsl-prism") // for the .stg
@@ -2712,7 +2712,7 @@ project(":controls") {
             "-DCSS_META_DATA_TEST_DIR=$cssDir"
     }
 
-    def modulePath = "${project.sourceSets.main.java.outputDir}"
+    def modulePath = "${project.sourceSets.main.java.getDestinationDirectory().get().getAsFile()}"
     modulePath += File.pathSeparator + "${rootProject.projectDir}/modules/javafx.graphics/build/classes/java/main"
     modulePath += File.pathSeparator + "${rootProject.projectDir}/modules/javafx.base/build/classes/java/main"
     processResources {
@@ -2735,11 +2735,14 @@ project(":controls") {
       }
     }
 
-    processShimsResources.dependsOn(project.task("copyShimBss", type: Copy) {
+    def copyShimBssTask = project.task("copyShimBss", type: Copy,
+                            dependsOn: [project.tasks.getByName("compileJava"),
+                                        project.tasks.getByName("processResources")]) {
         from project.moduleDir
         into project.moduleShimsDir
         include "**/*.bss"
-    })
+    }
+    processShimsResources.dependsOn(copyShimBssTask)
 
     addMavenPublication(project, [ 'graphics' ])
 
@@ -2958,7 +2961,7 @@ project(":media") {
 
     compileToolsJava {
         enabled = IS_COMPILE_MEDIA
-        def modulePath = "${project.sourceSets.main.java.outputDir}"
+        def modulePath = "${project.sourceSets.main.java.getDestinationDirectory().get().getAsFile()}"
         options.compilerArgs.addAll([
             "--module-path=$modulePath",
             "--add-modules=javafx.media",
@@ -2982,7 +2985,7 @@ project(":media") {
 
             mkdir generatedHeadersDir;
 
-            def modulePath = "${project.sourceSets.main.java.outputDir}"
+            def modulePath = "${project.sourceSets.main.java.getDestinationDirectory().get().getAsFile()}"
             modulePath += File.pathSeparator + "${rootProject.projectDir}/modules/javafx.graphics/build/classes/java/main"
             modulePath += File.pathSeparator + "${rootProject.projectDir}/modules/javafx.base/build/classes/java/main"
 
@@ -3909,7 +3912,7 @@ project(":systemTests") {
         destinationDirectory = file("$buildDir/testapp1")
         archiveFileName = testapp1JarName
         includeEmptyDirs = false
-        from project.sourceSets.testapp1.java.outputDir
+        from project.sourceSets.testapp1.java.getDestinationDirectory().get().getAsFile()
         include("testapp/**")
         include("com/javafx/main/**")
 
@@ -3930,7 +3933,7 @@ project(":systemTests") {
         destinationDirectory = file("$buildDir/testapp1")
         archiveFileName = "jar2.jar";
         includeEmptyDirs = false
-        from project.sourceSets.testapp1.java.outputDir
+        from project.sourceSets.testapp1.java.getDestinationDirectory().get().getAsFile()
         include("pkg2/**")
     }
 
@@ -3944,7 +3947,7 @@ project(":systemTests") {
     modtestapps.each { testapp ->
         def testappCapital = testapp.capitalize()
         def copyTestAppTask = task("copy${testappCapital}", type: Copy) {
-            from project.sourceSets."${testapp}".java.outputDir
+            from project.sourceSets."${testapp}".java.getDestinationDirectory().get().getAsFile()
             from project.sourceSets."${testapp}".output.resourcesDir
             into "${project.buildDir}/modules/${testapp}"
         }
@@ -4124,7 +4127,7 @@ allprojects {
         project.compileShimsJava.dependsOn(project.compileJava)
 
         def copyGeneratedShimsTask = task("copyGeneratedShims", type: Copy, dependsOn: [compileShimsJava, processShimsResources]) {
-            from project.sourceSets.shims.java.outputDir
+            from project.sourceSets.shims.java.getDestinationDirectory().get().getAsFile()
             into "${rootProject.buildDir}/shims"
             if (HAS_JAVAFX_MODULES) {
                 exclude("*/module-info.class")
@@ -5153,6 +5156,16 @@ compileTargets { t ->
                 */
         }
         buildModulesTask.dependsOn(buildModuleClassesTask)
+
+        if (project.tasks.getByName("modularJarStandalone$t.capital") != null) {
+            project.tasks.getByName("modularJarStandalone$t.capital").dependsOn(buildModuleClassesTask)
+        }
+        if (project.tasks.getByName("copyClassFiles$t.capital") != null) {
+            project.tasks.getByName("copyClassFiles$t.capital").dependsOn(buildModuleClassesTask)
+        }
+        if (project.tasks.getByName("modularPublicationJar$t.capital") != null) {
+            project.tasks.getByName("modularPublicationJar$t.capital").dependsOn(buildModuleClassesTask)
+        }
     }
 
     def buildModuleLibsTask = task("buildModuleLibs$t.capital") {
@@ -5221,6 +5234,11 @@ compileTargets { t ->
             }
         }
 
+        buildModuleBaseTask.mustRunAfter([
+            baseProject.tasks.getByName("copyLibFilesStandalone$t.capital"),
+            baseProject.tasks.getByName("copyLibFiles$t.capital"),
+            baseProject.tasks.getByName("modularPublicationJar$t.capital")])
+
         def buildModuleGraphicsTask = task("buildModuleGraphics$t.capital", type: Copy, dependsOn: graphicsProject.assemble) {
             group = "Basic"
             description = "copies javafx.graphics native libraries"
@@ -5288,6 +5306,10 @@ compileTargets { t ->
                 }
             }
         }
+        buildModuleGraphicsTask.mustRunAfter([
+            graphicsProject.tasks.getByName("copyLibFilesStandalone$t.capital"),
+            graphicsProject.tasks.getByName("copyLibFiles$t.capital"),
+            graphicsProject.tasks.getByName("modularPublicationJar$t.capital")])
 
         def buildModuleMediaTask = task("buildModuleMedia$t.capital", type: Copy, dependsOn: [mediaProject.assemble, prepOpenJfxStubs]) {
             group = "Basic"
@@ -5359,6 +5381,10 @@ compileTargets { t ->
                 }
             }
         }
+        buildModuleMediaTask.mustRunAfter([
+            mediaProject.tasks.getByName("copyLibFilesStandalone$t.capital"),
+            mediaProject.tasks.getByName("copyLibFiles$t.capital"),
+            mediaProject.tasks.getByName("modularPublicationJar$t.capital")])
 
         def buildModuleWeb = task("buildModuleWeb$t.capital", type: Copy, dependsOn: [webProject.assemble, prepOpenJfxStubs]) {
             group = "Basic"
@@ -5408,6 +5434,10 @@ compileTargets { t ->
                 }
             }
         }
+        buildModuleWeb.mustRunAfter([
+            webProject.tasks.getByName("copyLibFilesStandalone$t.capital"),
+            webProject.tasks.getByName("copyLibFiles$t.capital"),
+            webProject.tasks.getByName("modularPublicationJar$t.capital")])
 
         def buildModuleSWT = task("buildModuleSWT$t.capital", type: Copy) {
             group = "Basic"
@@ -5429,6 +5459,10 @@ compileTargets { t ->
             from "${swtProject.buildDir}/libs/javafx-swt.jar"
             into "${graphicsProject.buildDir}/${platformPrefix}module-lib"
         }
+        buildModuleSWT.mustRunAfter([
+            graphicsProject.tasks.getByName("copyLibFilesStandalone$t.capital"),
+            graphicsProject.tasks.getByName("copyLibFiles$t.capital"),
+            graphicsProject.tasks.getByName("modularPublicationJar$t.capital")])
 
         dependsOn(
             buildModuleBaseTask,

--- a/build.gradle
+++ b/build.gradle
@@ -1600,7 +1600,7 @@ void addJSL(Project project, String name, String pkg, List<String> addExports, C
                project.files(project.sourceSets.jslc.java.getDestinationDirectory().get().getAsFile()) +
                project.configurations.antlr
         source = [project.file("src/main/jsl-$lowerName")]
-        destinationDir = project.file("$project.buildDir/classes/jsl-compilers/$lowerName")
+        destinationDirectory = project.file("$project.buildDir/classes/jsl-compilers/$lowerName")
 
         options.compilerArgs.addAll([
             "-implicit:none",
@@ -1951,7 +1951,7 @@ void addJCov(p, test) {
             p.javaexec {
                 workingDir = p.file("build/reports/jcov")
                 classpath = p.files(p.configurations.testClasspath.files.find { it.name.startsWith('jcov') })
-                main = "com.sun.tdk.jcov.Helper"
+                mainClass = "com.sun.tdk.jcov.Helper"
                 args = [
                         "RepGen",
                         "-exclude", "\"**.test\"",
@@ -2306,7 +2306,7 @@ project(":graphics") {
         executable = JAVA
         classpath = project.configurations.antlr
         workingDir = wd
-        main = "org.antlr.v4.Tool"
+        mainClass = "org.antlr.v4.Tool"
 
         args = [
             "-o",
@@ -2500,7 +2500,7 @@ project(":graphics") {
             javaexec {
                 executable = JAVA
                 workingDir = project.projectDir
-                main = settings.generator
+                mainClass = settings.generator
                 classpath = configurations.compileClasspath + configurations.antlr
                 classpath += files(project.sourceSets.jslc.java.getDestinationDirectory().get().getAsFile())
 
@@ -2589,7 +2589,7 @@ project(":graphics") {
             javaexec {
                 executable = JAVA
                 workingDir = project.projectDir
-                main = "CompileJSL"
+                mainClass = "CompileJSL"
                 classpath = configurations.compileClasspath + configurations.antlr
                 classpath += files(project.sourceSets.jslc.java.getDestinationDirectory().get().getAsFile())
                 classpath += files(project.sourceSets.jslc.resources)
@@ -2728,7 +2728,7 @@ project(":controls") {
                 jvmArgs += patchModuleArgs
                 jvmArgs += "--module-path=$modulePath"
                 jvmArgs += "--add-modules=javafx.graphics"
-                main = "com.sun.javafx.css.parser.Css2Bin"
+                mainClass = "com.sun.javafx.css.parser.Css2Bin"
                 args css
             }
         }
@@ -3764,7 +3764,7 @@ project(":web") {
 
         def compileJavaDOMBindingTask = task("compileJavaDOMBinding${t.capital}", type: JavaCompile,
                 dependsOn: [compileJava, compileNativeTask, copyNativeTask]) {
-            destinationDir = file("$buildDir/classes/java/main")
+            destinationDirectory = file("$buildDir/classes/java/main")
             classpath = configurations.compileClasspath
             source = project.sourceSets.main.java.srcDirs
             options.compilerArgs.addAll([
@@ -5233,11 +5233,9 @@ compileTargets { t ->
                 }
             }
         }
-
-        buildModuleBaseTask.mustRunAfter([
-            baseProject.tasks.getByName("copyLibFilesStandalone$t.capital"),
-            baseProject.tasks.getByName("copyLibFiles$t.capital"),
-            baseProject.tasks.getByName("modularPublicationJar$t.capital")])
+        baseProject.tasks.getByName("copyLibFilesStandalone$t.capital").dependsOn(buildModuleBaseTask)
+        baseProject.tasks.getByName("copyLibFiles$t.capital").dependsOn(buildModuleBaseTask)
+        baseProject.tasks.getByName("modularPublicationJar$t.capital").dependsOn(buildModuleBaseTask)
 
         def buildModuleGraphicsTask = task("buildModuleGraphics$t.capital", type: Copy, dependsOn: graphicsProject.assemble) {
             group = "Basic"
@@ -5306,10 +5304,9 @@ compileTargets { t ->
                 }
             }
         }
-        buildModuleGraphicsTask.mustRunAfter([
-            graphicsProject.tasks.getByName("copyLibFilesStandalone$t.capital"),
-            graphicsProject.tasks.getByName("copyLibFiles$t.capital"),
-            graphicsProject.tasks.getByName("modularPublicationJar$t.capital")])
+        graphicsProject.tasks.getByName("copyLibFilesStandalone$t.capital").dependsOn(buildModuleGraphicsTask)
+        graphicsProject.tasks.getByName("copyLibFiles$t.capital").dependsOn(buildModuleGraphicsTask)
+        graphicsProject.tasks.getByName("modularPublicationJar$t.capital").dependsOn(buildModuleGraphicsTask)
 
         def buildModuleMediaTask = task("buildModuleMedia$t.capital", type: Copy, dependsOn: [mediaProject.assemble, prepOpenJfxStubs]) {
             group = "Basic"
@@ -5381,10 +5378,9 @@ compileTargets { t ->
                 }
             }
         }
-        buildModuleMediaTask.mustRunAfter([
-            mediaProject.tasks.getByName("copyLibFilesStandalone$t.capital"),
-            mediaProject.tasks.getByName("copyLibFiles$t.capital"),
-            mediaProject.tasks.getByName("modularPublicationJar$t.capital")])
+        mediaProject.tasks.getByName("copyLibFilesStandalone$t.capital").dependsOn(buildModuleMediaTask)
+        mediaProject.tasks.getByName("copyLibFiles$t.capital").dependsOn(buildModuleMediaTask)
+        mediaProject.tasks.getByName("modularPublicationJar$t.capital").dependsOn(buildModuleMediaTask)
 
         def buildModuleWeb = task("buildModuleWeb$t.capital", type: Copy, dependsOn: [webProject.assemble, prepOpenJfxStubs]) {
             group = "Basic"
@@ -5434,10 +5430,9 @@ compileTargets { t ->
                 }
             }
         }
-        buildModuleWeb.mustRunAfter([
-            webProject.tasks.getByName("copyLibFilesStandalone$t.capital"),
-            webProject.tasks.getByName("copyLibFiles$t.capital"),
-            webProject.tasks.getByName("modularPublicationJar$t.capital")])
+        webProject.tasks.getByName("copyLibFilesStandalone$t.capital").dependsOn(buildModuleWeb)
+        webProject.tasks.getByName("copyLibFiles$t.capital").dependsOn(buildModuleWeb)
+        webProject.tasks.getByName("modularPublicationJar$t.capital").dependsOn(buildModuleWeb)
 
         def buildModuleSWT = task("buildModuleSWT$t.capital", type: Copy) {
             group = "Basic"
@@ -5459,10 +5454,9 @@ compileTargets { t ->
             from "${swtProject.buildDir}/libs/javafx-swt.jar"
             into "${graphicsProject.buildDir}/${platformPrefix}module-lib"
         }
-        buildModuleSWT.mustRunAfter([
-            graphicsProject.tasks.getByName("copyLibFilesStandalone$t.capital"),
-            graphicsProject.tasks.getByName("copyLibFiles$t.capital"),
-            graphicsProject.tasks.getByName("modularPublicationJar$t.capital")])
+        graphicsProject.tasks.getByName("copyLibFilesStandalone$t.capital").dependsOn(buildModuleSWT)
+        graphicsProject.tasks.getByName("copyLibFiles$t.capital").dependsOn(buildModuleSWT)
+        graphicsProject.tasks.getByName("modularPublicationJar$t.capital").dependsOn(buildModuleSWT)
 
         dependsOn(
             buildModuleBaseTask,


### PR DESCRIPTION
This is gradle only change, which fixes few warnings that are observed with gradle 7.6 and which eventually result to an error with gradle 8.3
With this change the warnings get fixed and no error is observed with gradle 8.3
Verified that several gradle tasks(all, sdk, javadoc, apps, shims, test) complete without any failure.

Warnings that are fixed:
1. The SourceDirectorySet.outputDir property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the classesDirectory property instead. See https://docs.gradle.org/7.6/dsl/org.gradle.api.file.SourceDirectorySet.html#org.gradle.api.file.SourceDirectorySet:outputDir for more details.
-> As per this [7.x to 8.0 upgrade guide](https://docs.gradle.org/8.0/userguide/upgrading_version_7.html#sourcedirectoryset_api_cleanup) outputDir should be replaced with `destinationDirectory`

2. The AbstractCompile.destinationDir property has been deprecated. This is scheduled to be removed in Gradle 8.0. Please use the destinationDirectory property instead. Consult the upgrading guide for further information: https://docs.gradle.org/7.6/userguide/upgrading_version_7.html#compile_task_wiring
-> As per the above doc, replacing `destinationDir` with `destinationDirectory` resolves the warning

3. Various dependency warnings like one below:
Gradle detected a problem with the following location: '<path>/rt/modules/javafx.base/build/module-classes'. Reason: Task ':base:modularJarStandaloneMac' uses this output of task ':base:buildModuleMac' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed. Please refer to https://docs.gradle.org/7.6/userguide/validation_problems.html#implicit_dependency for more details about this problem.
-> There are several such warning messages observed.
-> Each warning required an explicit inclusion of dependency. All dependency changes are to fix this warning.

An easy way to review would be.
1. Build with gradle 7.6 (using  `--warning-mode all`  gradle option)
1.1 All above warnings can be observed and build completes successfully.

2. Build with gradle 8.3 (using  `--warning-mode all`  gradle option)
2.1 Without this change build would fail citing above warnings as errors
2.2 With this change build completes successfully and above warnings do not occur

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8314486](https://bugs.openjdk.org/browse/JDK-8314486): JavaFX build uses deprecated features that will be removed in gradle 8 (**Bug** - P3)


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1256/head:pull/1256` \
`$ git checkout pull/1256`

Update a local copy of the PR: \
`$ git checkout pull/1256` \
`$ git pull https://git.openjdk.org/jfx.git pull/1256/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1256`

View PR using the GUI difftool: \
`$ git pr show -t 1256`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1256.diff">https://git.openjdk.org/jfx/pull/1256.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1256#issuecomment-1753186184)