### PR TITLE
8316419: [macos] Setting X/Y makes Stage maximization not work before show

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
@@ -1138,19 +1138,9 @@ public class Stage extends Window {
      * This can be replaced by listening for the onShowing/onHiding events
      * Note: This method MUST only be called via its accessor method.
      */
-    private boolean postVisibleFullScreen;
-    private boolean postVisibleIconified;
-    private boolean postVisibleMaximized;
-
     private void doVisibleChanging(boolean value) {
         Toolkit toolkit = Toolkit.getToolkit();
         if (value && (getPeer() == null)) {
-            // In case the platform window alters these
-            // properties while we're finishing installation.
-            postVisibleFullScreen = isFullScreen();
-            postVisibleIconified = isIconified();
-            postVisibleMaximized = isMaximized();
-
             // Setup the peer
             Window window = getOwner();
             TKStage tkStage = (window == null ? null : window.getPeer());
@@ -1191,10 +1181,10 @@ public class Stage extends Window {
             TKStage peer = getPeer();
             peer.setImportant(isImportant());
             peer.setResizable(isResizable());
-            peer.setFullScreen(postVisibleFullScreen);
+            peer.setFullScreen(isFullScreen());
             peer.setAlwaysOnTop(isAlwaysOnTop());
-            peer.setIconified(postVisibleIconified);
-            peer.setMaximized(postVisibleMaximized);
+            peer.setIconified(isIconified());
+            peer.setMaximized(isMaximized());
             peer.setTitle(getTitle());
 
             if (!isIconified()) {

--- a/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
+++ b/modules/javafx.graphics/src/main/java/javafx/stage/Stage.java
@@ -1138,9 +1138,19 @@ public class Stage extends Window {
      * This can be replaced by listening for the onShowing/onHiding events
      * Note: This method MUST only be called via its accessor method.
      */
+    private boolean postVisibleFullScreen;
+    private boolean postVisibleIconified;
+    private boolean postVisibleMaximized;
+
     private void doVisibleChanging(boolean value) {
         Toolkit toolkit = Toolkit.getToolkit();
         if (value && (getPeer() == null)) {
+            // In case the platform window alters these
+            // properties while we're finishing installation.
+            postVisibleFullScreen = isFullScreen();
+            postVisibleIconified = isIconified();
+            postVisibleMaximized = isMaximized();
+
             // Setup the peer
             Window window = getOwner();
             TKStage tkStage = (window == null ? null : window.getPeer());
@@ -1181,10 +1191,10 @@ public class Stage extends Window {
             TKStage peer = getPeer();
             peer.setImportant(isImportant());
             peer.setResizable(isResizable());
-            peer.setFullScreen(isFullScreen());
+            peer.setFullScreen(postVisibleFullScreen);
             peer.setAlwaysOnTop(isAlwaysOnTop());
-            peer.setIconified(isIconified());
-            peer.setMaximized(isMaximized());
+            peer.setIconified(postVisibleIconified);
+            peer.setMaximized(postVisibleMaximized);
             peer.setTitle(getTitle());
 
             if (!isIconified()) {

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassWindow.m
@@ -208,6 +208,22 @@ static inline NSView<GlassView> *getMacView(JNIEnv *env, jobject jview)
 
 @implementation GlassWindow_Normal
 GLASS_NS_WINDOW_IMPLEMENTATION
+
+-(NSRect)windowWillUseStandardFrame:(NSWindow*)window defaultFrame:(NSRect)newFrame
+{
+    // For windows without titlebars the OS will suggest a frame that's the
+    // same size as the existing window, not the screen.
+    if (window.screen != nil && (window.styleMask & NSWindowStyleMaskTitled) == 0) {
+        return window.screen.visibleFrame;
+    }
+    return newFrame;
+}
+
+-(BOOL)isZoomed
+{
+    // Ensure the window is not reported as maximized during initialization
+    return self.screen != nil && [super isZoomed];
+}
 @end
 
 @implementation GlassWindow_Panel

--- a/tests/system/src/test/java/test/javafx/stage/MaximizeUndecorated.java
+++ b/tests/system/src/test/java/test/javafx/stage/MaximizeUndecorated.java
@@ -77,8 +77,6 @@ public class MaximizeUndecorated {
 
     @Test
     public void testMaximize() throws Exception {
-        // temporary until JDK-8255835 is fixed
-        assumeTrue(!PlatformUtil.isMac());
         Util.sleep(200);
 
         boolean movedToTopCorner = stage.getY() != POS && stage.getX() != POS;

--- a/tests/system/src/test/java/test/robot/javafx/stage/StageAttributesTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/StageAttributesTest.java
@@ -213,9 +213,6 @@ public class StageAttributesTest extends VisualTestBase {
 
     @Test
     public void testIconifiedStageBeforeShow() throws InterruptedException {
-        // Skip on Mac due to:
-        //  - JDK-8305675
-        assumeTrue(!PlatformUtil.isMac());
         // Skip on Linux due to:
         //  - JDK-8316423
         assumeTrue(!PlatformUtil.isLinux());
@@ -245,9 +242,6 @@ public class StageAttributesTest extends VisualTestBase {
 
     @Test
     public void testMaximizedStageBeforeShow() throws InterruptedException {
-        // Skip on Mac due to:
-        //  - JDK-8316419
-        assumeTrue(!PlatformUtil.isMac());
         // Skip on Linux due to:
         //  - JDK-8316423
         //  - JDK-8316425


### PR DESCRIPTION
When a window is visible the maximized, iconified, and fullscreen properties are two-way streets; changes made in Java are sent on to the platform window and changes in the platform window are sent back into Java.

When a window is hidden these properties (and others, like location and sizing information) are not sent on to the platform window until the window is made visible. In other words, the properties don't reflect the actual state of the window but the intended state after it's shown.

There's a period when the window is transitioning from hidden to shown where the core Stage code is using the stored properties to configure the platform window and the platform window is simultaneously calling back in to update the properties. This was causing the intended state to be wiped out before it could be sent on to the platform window.

The problem is specific to Mac because on that platform any change to the size or location of a window can cause it to enter or leave the maximized (zoomed) state. So just setting the location can cause the maximized flag to be altered.

The proposed solution is to copy the intended state bits to Stage local variables to be used later in the configuration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8316419](https://bugs.openjdk.org/browse/JDK-8316419): [macos] Setting X/Y makes Stage maximization not work before show (**Bug** - P4)
 * [JDK-8255835](https://bugs.openjdk.org/browse/JDK-8255835): [macOS] Undecorated stage cannot be maximized (**Bug** - P4)
 * [JDK-8305675](https://bugs.openjdk.org/browse/JDK-8305675): [macos] Stage set to iconified before being shown is displayed on screen (**Bug** - P3)


### Reviewers
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - Committer)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1258/head:pull/1258` \
`$ git checkout pull/1258`

Update a local copy of the PR: \
`$ git checkout pull/1258` \
`$ git pull https://git.openjdk.org/jfx.git pull/1258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1258`

View PR using the GUI difftool: \
`$ git pr show -t 1258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1258.diff">https://git.openjdk.org/jfx/pull/1258.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1258#issuecomment-1758957846)