### PR TITLE
8318115: Webkit build fails after gradle 8.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3792,6 +3792,8 @@ project(":web") {
     }
 
     if (IS_COMPILE_WEBKIT) {
+        drtJar.dependsOn compileJavaDOMBinding, processResources
+        compileShimsJava.dependsOn compileJavaDOMBinding
         assemble.dependsOn compileJavaDOMBinding, drtJar
     }
 


### PR DESCRIPTION
Few dependency were missed to be added for webkit build.
With this change webkit build completes successfully.
Please review

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318115](https://bugs.openjdk.org/browse/JDK-8318115): Webkit build fails after gradle 8.4 (**Bug** - P2)


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1261/head:pull/1261` \
`$ git checkout pull/1261`

Update a local copy of the PR: \
`$ git checkout pull/1261` \
`$ git pull https://git.openjdk.org/jfx.git pull/1261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1261`

View PR using the GUI difftool: \
`$ git pr show -t 1261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1261.diff">https://git.openjdk.org/jfx/pull/1261.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1261#issuecomment-1762627325)