### PR TITLE
8318204: Use new EventTarget methods in ListenerHelper

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ListenerHelper.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/ListenerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,18 +41,11 @@ import javafx.collections.ObservableList;
 import javafx.collections.ObservableMap;
 import javafx.collections.ObservableSet;
 import javafx.collections.SetChangeListener;
-import javafx.concurrent.Task;
 import javafx.event.Event;
 import javafx.event.EventHandler;
+import javafx.event.EventTarget;
 import javafx.event.EventType;
-import javafx.scene.Node;
-import javafx.scene.Scene;
-import javafx.scene.control.MenuItem;
 import javafx.scene.control.SkinBase;
-import javafx.scene.control.TableColumnBase;
-import javafx.scene.control.TreeItem;
-import javafx.scene.transform.Transform;
-import javafx.stage.Window;
 
 /**
  * This class provides convenience methods for adding various listeners, both
@@ -393,92 +386,34 @@ public class ListenerHelper implements IDisconnectable {
 
     // event handlers
 
-    public <T extends Event> IDisconnectable addEventHandler(Object x, EventType<T> t, EventHandler<T> handler) {
+    public <T extends Event> IDisconnectable addEventHandler(EventTarget x, EventType<T> t, EventHandler<T> handler) {
         EvHa<T> h = new EvHa<>(handler) {
             @Override
             public void disconnect() {
-                if (x instanceof Node n) {
-                    n.removeEventHandler(t, this);
-                } else if (x instanceof Window y) {
-                    y.removeEventHandler(t, this);
-                } else if (x instanceof Scene y) {
-                    y.removeEventHandler(t, this);
-                } else if (x instanceof MenuItem y) {
-                    y.removeEventHandler(t, this);
-                } else if (x instanceof TreeItem y) {
-                    y.removeEventHandler(t, this);
-                } else if (x instanceof TableColumnBase y) {
-                    y.removeEventHandler(t, this);
-                } else if (x instanceof Transform y) {
-                    y.removeEventHandler(t, this);
-                } else if (x instanceof Task y) {
-                    y.removeEventHandler(t, this);
-                }
+                x.removeEventHandler(t, this);
             }
         };
 
         items.add(h);
 
-        // we really need an interface here ... "HasEventHandlers"
-        if (x instanceof Node y) {
-            y.addEventHandler(t, h);
-        } else if (x instanceof Window y) {
-            y.addEventHandler(t, h);
-        } else if (x instanceof Scene y) {
-            y.addEventHandler(t, h);
-        } else if (x instanceof MenuItem y) {
-            y.addEventHandler(t, h);
-        } else if (x instanceof TreeItem y) {
-            y.addEventHandler(t, h);
-        } else if (x instanceof TableColumnBase y) {
-            y.addEventHandler(t, h);
-        } else if (x instanceof Transform y) {
-            y.addEventHandler(t, h);
-        } else if (x instanceof Task y) {
-            y.addEventHandler(t, h);
-        } else {
-            throw new IllegalArgumentException("Cannot add event handler to " + x);
-        }
+        x.addEventHandler(t, h);
 
         return h;
     }
 
     // event filters
 
-    public <T extends Event> IDisconnectable addEventFilter(Object x, EventType<T> t, EventHandler<T> handler) {
+    public <T extends Event> IDisconnectable addEventFilter(EventTarget x, EventType<T> t, EventHandler<T> handler) {
         EvHa<T> h = new EvHa<>(handler) {
             @Override
             public void disconnect() {
-                if (x instanceof Node n) {
-                    n.removeEventFilter(t, this);
-                } else if (x instanceof Window y) {
-                    y.removeEventFilter(t, this);
-                } else if (x instanceof Scene y) {
-                    y.removeEventFilter(t, this);
-                } else if (x instanceof Transform y) {
-                    y.removeEventFilter(t, this);
-                } else if (x instanceof Task y) {
-                    y.removeEventFilter(t, this);
-                }
+                x.removeEventFilter(t, this);
             }
         };
 
         items.add(h);
 
-        // we really need an interface here ... "HasEventFilters"
-        if (x instanceof Node y) {
-            y.addEventFilter(t, h);
-        } else if (x instanceof Window y) {
-            y.addEventFilter(t, h);
-        } else if (x instanceof Scene y) {
-            y.addEventFilter(t, h);
-        } else if (x instanceof Transform y) {
-            y.addEventFilter(t, h);
-        } else if (x instanceof Task y) {
-            y.addEventFilter(t, h);
-        } else {
-            throw new IllegalArgumentException("Cannot add event filter to " + x);
-        }
+        x.addEventFilter(t, h);
 
         return h;
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TestListenerHelper.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TestListenerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -392,12 +392,6 @@ public class TestListenerHelper {
         }
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testEventHandlerCheck() {
-        ListenerHelper h = new ListenerHelper();
-        h.addEventHandler(new Object(), MouseEvent.ANY, (ev) -> { throw new Error(); });
-    }
-
     // event filters
 
     @Test
@@ -420,12 +414,6 @@ public class TestListenerHelper {
             EventUtil.fireEvent(ev, item);
             assertEquals(1, ct.get());
         }
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void testEventFilterCheck() {
-        ListenerHelper h = new ListenerHelper();
-        h.addEventFilter(new Object(), MouseEvent.ANY, (ev) -> { throw new Error(); });
     }
 
     //


### PR DESCRIPTION
As of OpenJFX 21, `EventTarget` has methods to add and remove event listeners.
The `instanceof` checks in `com.sun.javafx.scene.control.ListenerHelper` should be removed and replaced by a simple call to the respective interface method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318204](https://bugs.openjdk.org/browse/JDK-8318204): Use new EventTarget methods in ListenerHelper (**Enhancement** - P4)


### Reviewers
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer)
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1262/head:pull/1262` \
`$ git checkout pull/1262`

Update a local copy of the PR: \
`$ git checkout pull/1262` \
`$ git pull https://git.openjdk.org/jfx.git pull/1262/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1262`

View PR using the GUI difftool: \
`$ git pr show -t 1262`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1262.diff">https://git.openjdk.org/jfx/pull/1262.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1262#issuecomment-1765663754)