### PR TITLE
8205067: Resizing window with TextField hides text value

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
@@ -811,7 +811,8 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
             } else {
                 newX = midPoint - textNodeWidth / 2;
                 // Update if there is space on the right
-                if (newX + textNodeWidth <= textRight.get() - caretWidth / 2) {
+                if (newX + textNodeWidth <= textRight.get() - caretWidth / 2 ||
+                        (textNodeWidth > textRight.get() && ((textNodeWidth - textRight.get() + caretWidth) < Math.abs(oldX)))) {
                     textTranslateX.set(newX);
                 } else if (newX < 0 && oldX > caretWidth / 2) {
                     textTranslateX.set(caretWidth / 2);
@@ -843,7 +844,8 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
           default:
             newX = caretWidth / 2;
             // Update if there is space on either side.
-            if (newX < oldX || newX + textNodeWidth <= textRight.get()) {
+            if (newX < oldX || newX + textNodeWidth <= textRight.get() ||
+                    ((textNodeWidth - textRight.get() + caretWidth) < Math.abs(oldX))) {
                 textTranslateX.set(newX);
             }
             if (usePromptText.get()) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
@@ -811,9 +811,10 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
             } else {
                 newX = midPoint - textNodeWidth / 2;
                 // Update if there is space on the right
-                if (newX + textNodeWidth <= textRight.get() - caretWidth / 2 ||
-                        (textNodeWidth > textRight.get() && ((textNodeWidth - textRight.get() + caretWidth) < Math.abs(oldX)))) {
+                if (newX + textNodeWidth <= textRight.get() - caretWidth / 2) {
                     textTranslateX.set(newX);
+                } else if ((textRight.get() - textNodeWidth - caretWidth / 2) > oldX) {
+                    textTranslateX.set(textRight.get() - textNodeWidth - caretWidth / 2);
                 } else if (newX < 0 && oldX > caretWidth / 2) {
                     textTranslateX.set(caretWidth / 2);
                 }
@@ -844,9 +845,10 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
           default:
             newX = caretWidth / 2;
             // Update if there is space on either side.
-            if (newX < oldX || newX + textNodeWidth <= textRight.get() ||
-                    ((textNodeWidth - textRight.get() + caretWidth) < Math.abs(oldX))) {
+            if (newX < oldX || newX + textNodeWidth <= textRight.get()) {
                 textTranslateX.set(newX);
+            } else if ((textRight.get() - textNodeWidth - caretWidth / 2) > oldX) {
+                textTranslateX.set(textRight.get() - textNodeWidth - caretWidth / 2);
             }
             if (usePromptText.get()) {
                 promptNode.layoutXProperty().set(newX);


### PR DESCRIPTION
Because of a missing conditional check in the `updateTextPos()`,  the `textTranslateX` value was not getting updated when TextField size was changed as a result of resizing window.

Updated the CENTER and LEFT cases in the `updateTextPos()` method to fix the issue.

The fix can be validated using MonkeyTester.
Steps to select TextField option in Monkey Tester.

- Open the MonkeyTester app and select TextField from the left option pane.
- Select Long from Text selection option and TOP_LEFT from Alignment dropdown.
- After above step, follow the steps given in the bug to validate the fix in monkey tester.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8205067](https://bugs.openjdk.org/browse/JDK-8205067): Resizing window with TextField hides text value (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1263/head:pull/1263` \
`$ git checkout pull/1263`

Update a local copy of the PR: \
`$ git checkout pull/1263` \
`$ git pull https://git.openjdk.org/jfx.git pull/1263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1263`

View PR using the GUI difftool: \
`$ git pr show -t 1263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1263.diff">https://git.openjdk.org/jfx/pull/1263.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1263#issuecomment-1766307985)