### PR TITLE
8318630: TextAreaBehaviorRobotTest.testNonMacBindings fails on Linux

### DIFF
--- a/tests/system/src/test/java/test/javafx/scene/control/behavior/TextAreaBehaviorRobotTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/behavior/TextAreaBehaviorRobotTest.java
@@ -330,6 +330,10 @@ public class TextAreaBehaviorRobotTest extends TextInputBehaviorRobotTest<TextAr
             return;
         }
 
+        // windows: ctrl-down goes to the start of the next paragraph
+        // linux: ctrl-down goes to the end of the current paragraph
+        int d = PlatformUtil.isWindows() ? 1 : 0;
+
         // paragraph
         execute(
             exe(() -> control.setWrapText(true)),
@@ -339,16 +343,16 @@ public class TextAreaBehaviorRobotTest extends TextInputBehaviorRobotTest<TextAr
                 "cccccccccc cccccccccc cccccccccc cccccccccc cccccccccc cccccccccc cccccccccc cccccccccc\n"
             ),
             // move
-            ctrl(DOWN), checkSelection(88),
-            ctrl(DOWN), checkSelection(176),
-            ctrl(DOWN), checkSelection(264),
+            ctrl(DOWN), checkSelection(87 + d),
+            ctrl(DOWN), checkSelection(175 + d),
+            ctrl(DOWN), checkSelection(263 + d),
             ctrl(UP), checkSelection(176),
             ctrl(UP), checkSelection(88),
             // select
             shortcut(UP), checkSelection(0),
-            key(DOWN, KeyModifier.CTRL, KeyModifier.SHIFT), checkSelection(0, 88),
-            key(DOWN, KeyModifier.CTRL, KeyModifier.SHIFT), checkSelection(0, 176),
-            key(DOWN, KeyModifier.CTRL, KeyModifier.SHIFT), checkSelection(0, 264),
+            key(DOWN, KeyModifier.CTRL, KeyModifier.SHIFT), checkSelection(0, 87 + d),
+            key(DOWN, KeyModifier.CTRL, KeyModifier.SHIFT), checkSelection(0, 175 + d),
+            key(DOWN, KeyModifier.CTRL, KeyModifier.SHIFT), checkSelection(0, 263 + d),
             key(UP, KeyModifier.CTRL, KeyModifier.SHIFT), checkSelection(0, 176),
             key(UP, KeyModifier.CTRL, KeyModifier.SHIFT), checkSelection(0, 88)
         );


### PR DESCRIPTION
Corrected the test:
ctrl-DOWN moves to the end of the current paragraph (linux) or beginning of the next paragraph (windows).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318630](https://bugs.openjdk.org/browse/JDK-8318630): TextAreaBehaviorRobotTest.testNonMacBindings fails on Linux (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1270/head:pull/1270` \
`$ git checkout pull/1270`

Update a local copy of the PR: \
`$ git checkout pull/1270` \
`$ git pull https://git.openjdk.org/jfx.git pull/1270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1270`

View PR using the GUI difftool: \
`$ git pr show -t 1270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1270.diff">https://git.openjdk.org/jfx/pull/1270.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1270#issuecomment-1778254324)