### PR TITLE
8319079: Missing range checks in decora

### DIFF
--- a/modules/javafx.graphics/src/main/native-decora/SSEBoxBlurPeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSEBoxBlurPeer.cc
@@ -38,6 +38,20 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxBlurPeer_filterHorizontal
      jintArray dstPixels_arr, jint dstw, jint dsth, jint dstscan,
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan)
 {
+    if (srcPixels_arr == NULL ||
+        dstPixels_arr == NULL ||
+        srcw <= 0 ||
+        srch <= 0 ||
+        srcw > INT_MAX / srch ||
+        dstw <= 0 ||
+        dsth <= 0 ||
+        dstw > INT_MAX / dsth ||
+        (srcw * srch) > env->GetArrayLength(srcPixels_arr) ||
+        (dstw * dsth) > env->GetArrayLength(dstPixels_arr) ||
+        dsth > srch) { // We should not move out of source vertical bounds
+        return;
+    }
+
     jint *srcPixels = (jint *)env->GetPrimitiveArrayCritical(srcPixels_arr, 0);
     if (srcPixels == NULL) return;
     jint *dstPixels = (jint *)env->GetPrimitiveArrayCritical(dstPixels_arr, 0);
@@ -89,6 +103,20 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxBlurPeer_filterVertical
      jintArray dstPixels_arr, jint dstw, jint dsth, jint dstscan,
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan)
 {
+    if (srcPixels_arr == NULL ||
+        dstPixels_arr == NULL ||
+        srcw <= 0 ||
+        srch <= 0 ||
+        srcw > INT_MAX / srch ||
+        dstw <= 0 ||
+        dsth <= 0 ||
+        dstw > INT_MAX / dsth ||
+        (srcw * srch) > env->GetArrayLength(srcPixels_arr) ||
+        (dstw * dsth) > env->GetArrayLength(dstPixels_arr) ||
+        dstw > srcw) { // We should not move out of source horizontal bounds
+        return;
+    }
+
     jint *srcPixels = (jint *)env->GetPrimitiveArrayCritical(srcPixels_arr, 0);
     if (srcPixels == NULL) return;
     jint *dstPixels = (jint *)env->GetPrimitiveArrayCritical(dstPixels_arr, 0);
@@ -149,6 +177,20 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxBlurPeer_filterTranspose
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan,
      jint ksize)
 {
+    if (srcPixels_arr == NULL ||
+        dstPixels_arr == NULL ||
+        srcw <= 0 ||
+        srch <= 0 ||
+        srcw > INT_MAX / srch ||
+        dstw <= 0 ||
+        dsth <= 0 ||
+        dstw > INT_MAX / dsth ||
+        (srcw * srch) > env->GetArrayLength(srcPixels_arr) ||
+        (dstw * dsth) > env->GetArrayLength(dstPixels_arr) ||
+        dstw > srcw) { // We should not move out of source horizontal bounds
+        return;
+    }
+
     jint *srcPixels = (jint *)env->GetPrimitiveArrayCritical(srcPixels_arr, 0);
     if (srcPixels == NULL) return;
     jint *dstPixels = (jint *)env->GetPrimitiveArrayCritical(dstPixels_arr, 0);

--- a/modules/javafx.graphics/src/main/native-decora/SSEBoxBlurPeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSEBoxBlurPeer.cc
@@ -38,16 +38,11 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxBlurPeer_filterHorizontal
      jintArray dstPixels_arr, jint dstw, jint dsth, jint dstscan,
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan)
 {
-    if (srcPixels_arr == NULL ||
-        dstPixels_arr == NULL ||
-        srcw <= 0 ||
-        srch <= 0 ||
-        srcw > INT_MAX / srch ||
-        dstw <= 0 ||
-        dsth <= 0 ||
-        dstw > INT_MAX / dsth ||
-        (srcw * srch) > env->GetArrayLength(srcPixels_arr) ||
-        (dstw * dsth) > env->GetArrayLength(dstPixels_arr) ||
+    if ((checkRange(env,
+                    dstPixels_arr,
+                    dstw, dsth,
+                    srcPixels_arr,
+                    srcw, srch)) ||
         dsth > srch) { // We should not move out of source vertical bounds
         return;
     }
@@ -103,16 +98,11 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxBlurPeer_filterVertical
      jintArray dstPixels_arr, jint dstw, jint dsth, jint dstscan,
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan)
 {
-    if (srcPixels_arr == NULL ||
-        dstPixels_arr == NULL ||
-        srcw <= 0 ||
-        srch <= 0 ||
-        srcw > INT_MAX / srch ||
-        dstw <= 0 ||
-        dsth <= 0 ||
-        dstw > INT_MAX / dsth ||
-        (srcw * srch) > env->GetArrayLength(srcPixels_arr) ||
-        (dstw * dsth) > env->GetArrayLength(dstPixels_arr) ||
+    if ((checkRange(env,
+                    dstPixels_arr,
+                    dstw, dsth,
+                    srcPixels_arr,
+                    srcw, srch)) ||
         dstw > srcw) { // We should not move out of source horizontal bounds
         return;
     }
@@ -177,16 +167,11 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxBlurPeer_filterTranspose
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan,
      jint ksize)
 {
-    if (srcPixels_arr == NULL ||
-        dstPixels_arr == NULL ||
-        srcw <= 0 ||
-        srch <= 0 ||
-        srcw > INT_MAX / srch ||
-        dstw <= 0 ||
-        dsth <= 0 ||
-        dstw > INT_MAX / dsth ||
-        (srcw * srch) > env->GetArrayLength(srcPixels_arr) ||
-        (dstw * dsth) > env->GetArrayLength(dstPixels_arr) ||
+    if ((checkRange(env,
+                    dstPixels_arr,
+                    dstw, dsth,
+                    srcPixels_arr,
+                    srcw, srch)) ||
         dstw > srcw) { // We should not move out of source horizontal bounds
         return;
     }

--- a/modules/javafx.graphics/src/main/native-decora/SSEBoxBlurPeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSEBoxBlurPeer.cc
@@ -39,10 +39,8 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxBlurPeer_filterHorizontal
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan)
 {
     if ((checkRange(env,
-                    dstPixels_arr,
-                    dstw, dsth,
-                    srcPixels_arr,
-                    srcw, srch)) ||
+                    dstPixels_arr, dstw, dsth,
+                    srcPixels_arr, srcw, srch)) ||
         dsth > srch) { // We should not move out of source vertical bounds
         return;
     }
@@ -99,10 +97,8 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxBlurPeer_filterVertical
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan)
 {
     if ((checkRange(env,
-                    dstPixels_arr,
-                    dstw, dsth,
-                    srcPixels_arr,
-                    srcw, srch)) ||
+                    dstPixels_arr, dstw, dsth,
+                    srcPixels_arr, srcw, srch)) ||
         dstw > srcw) { // We should not move out of source horizontal bounds
         return;
     }
@@ -168,10 +164,8 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxBlurPeer_filterTranspose
      jint ksize)
 {
     if ((checkRange(env,
-                    dstPixels_arr,
-                    dstw, dsth,
-                    srcPixels_arr,
-                    srcw, srch)) ||
+                    dstPixels_arr, dstw, dsth,
+                    srcPixels_arr, srcw, srch)) ||
         dstw > srcw) { // We should not move out of source horizontal bounds
         return;
     }

--- a/modules/javafx.graphics/src/main/native-decora/SSEBoxShadowPeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSEBoxShadowPeer.cc
@@ -39,16 +39,11 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxShadowPeer_filterHorizontalBlack
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan,
      jfloat spread)
 {
-    if (srcPixels_arr == NULL ||
-        dstPixels_arr == NULL ||
-        srcw <= 0 ||
-        srch <= 0 ||
-        srcw > INT_MAX / srch ||
-        dstw <= 0 ||
-        dsth <= 0 ||
-        dstw > INT_MAX / dsth ||
-        (srcw * srch) > env->GetArrayLength(srcPixels_arr) ||
-        (dstw * dsth) > env->GetArrayLength(dstPixels_arr) ||
+    if ((checkRange(env,
+                    dstPixels_arr,
+                    dstw, dsth,
+                    srcPixels_arr,
+                    srcw, srch)) ||
         dsth > srch) { // We should not move out of source vertical bounds
         return;
     }
@@ -100,16 +95,11 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxShadowPeer_filterVerticalBlack
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan,
      jfloat spread)
 {
-    if (srcPixels_arr == NULL ||
-        dstPixels_arr == NULL ||
-        srcw <= 0 ||
-        srch <= 0 ||
-        srcw > INT_MAX / srch ||
-        dstw <= 0 ||
-        dsth <= 0 ||
-        dstw > INT_MAX / dsth ||
-        (srcw * srch) > env->GetArrayLength(srcPixels_arr) ||
-        (dstw * dsth) > env->GetArrayLength(dstPixels_arr) ||
+    if ((checkRange(env,
+                    dstPixels_arr,
+                    dstw, dsth,
+                    srcPixels_arr,
+                    srcw, srch)) ||
         dstw > srcw) { // We should not move out of source horizontal bounds
         return;
     }
@@ -162,16 +152,11 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxShadowPeer_filterVertical
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan,
      jfloat spread, jfloatArray shadowColor_arr)
 {
-    if (srcPixels_arr == NULL ||
-        dstPixels_arr == NULL ||
-        srcw <= 0 ||
-        srch <= 0 ||
-        srcw > INT_MAX / srch ||
-        dstw <= 0 ||
-        dsth <= 0 ||
-        dstw > INT_MAX / dsth ||
-        (srcw * srch) > env->GetArrayLength(srcPixels_arr) ||
-        (dstw * dsth) > env->GetArrayLength(dstPixels_arr) ||
+    if ((checkRange(env,
+                    dstPixels_arr,
+                    dstw, dsth,
+                    srcPixels_arr,
+                    srcw, srch)) ||
         dstw > srcw) { // We should not move out of source horizontal bounds
         return;
     }

--- a/modules/javafx.graphics/src/main/native-decora/SSEBoxShadowPeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSEBoxShadowPeer.cc
@@ -39,6 +39,20 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxShadowPeer_filterHorizontalBlack
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan,
      jfloat spread)
 {
+    if (srcPixels_arr == NULL ||
+        dstPixels_arr == NULL ||
+        srcw <= 0 ||
+        srch <= 0 ||
+        srcw > INT_MAX / srch ||
+        dstw <= 0 ||
+        dsth <= 0 ||
+        dstw > INT_MAX / dsth ||
+        (srcw * srch) > env->GetArrayLength(srcPixels_arr) ||
+        (dstw * dsth) > env->GetArrayLength(dstPixels_arr) ||
+        dsth > srch) { // We should not move out of source vertical bounds
+        return;
+    }
+
     jint *srcPixels = (jint *)env->GetPrimitiveArrayCritical(srcPixels_arr, 0);
     if (srcPixels == NULL) return;
     jint *dstPixels = (jint *)env->GetPrimitiveArrayCritical(dstPixels_arr, 0);
@@ -86,6 +100,20 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxShadowPeer_filterVerticalBlack
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan,
      jfloat spread)
 {
+    if (srcPixels_arr == NULL ||
+        dstPixels_arr == NULL ||
+        srcw <= 0 ||
+        srch <= 0 ||
+        srcw > INT_MAX / srch ||
+        dstw <= 0 ||
+        dsth <= 0 ||
+        dstw > INT_MAX / dsth ||
+        (srcw * srch) > env->GetArrayLength(srcPixels_arr) ||
+        (dstw * dsth) > env->GetArrayLength(dstPixels_arr) ||
+        dstw > srcw) { // We should not move out of source horizontal bounds
+        return;
+    }
+
     jint *srcPixels = (jint *)env->GetPrimitiveArrayCritical(srcPixels_arr, 0);
     if (srcPixels == NULL) return;
     jint *dstPixels = (jint *)env->GetPrimitiveArrayCritical(dstPixels_arr, 0);
@@ -134,6 +162,20 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxShadowPeer_filterVertical
      jintArray srcPixels_arr, jint srcw, jint srch, jint srcscan,
      jfloat spread, jfloatArray shadowColor_arr)
 {
+    if (srcPixels_arr == NULL ||
+        dstPixels_arr == NULL ||
+        srcw <= 0 ||
+        srch <= 0 ||
+        srcw > INT_MAX / srch ||
+        dstw <= 0 ||
+        dsth <= 0 ||
+        dstw > INT_MAX / dsth ||
+        (srcw * srch) > env->GetArrayLength(srcPixels_arr) ||
+        (dstw * dsth) > env->GetArrayLength(dstPixels_arr) ||
+        dstw > srcw) { // We should not move out of source horizontal bounds
+        return;
+    }
+
     jfloat shadowColor[4];
     env->GetFloatArrayRegion(shadowColor_arr, 0, 4, shadowColor);
 

--- a/modules/javafx.graphics/src/main/native-decora/SSEBoxShadowPeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSEBoxShadowPeer.cc
@@ -40,10 +40,8 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxShadowPeer_filterHorizontalBlack
      jfloat spread)
 {
     if ((checkRange(env,
-                    dstPixels_arr,
-                    dstw, dsth,
-                    srcPixels_arr,
-                    srcw, srch)) ||
+                    dstPixels_arr, dstw, dsth,
+                    srcPixels_arr, srcw, srch)) ||
         dsth > srch) { // We should not move out of source vertical bounds
         return;
     }
@@ -96,10 +94,8 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxShadowPeer_filterVerticalBlack
      jfloat spread)
 {
     if ((checkRange(env,
-                    dstPixels_arr,
-                    dstw, dsth,
-                    srcPixels_arr,
-                    srcw, srch)) ||
+                    dstPixels_arr, dstw, dsth,
+                    srcPixels_arr, srcw, srch)) ||
         dstw > srcw) { // We should not move out of source horizontal bounds
         return;
     }
@@ -153,10 +149,8 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSEBoxShadowPeer_filterVertical
      jfloat spread, jfloatArray shadowColor_arr)
 {
     if ((checkRange(env,
-                    dstPixels_arr,
-                    dstw, dsth,
-                    srcPixels_arr,
-                    srcw, srch)) ||
+                    dstPixels_arr, dstw, dsth,
+                    srcPixels_arr, srcw, srch)) ||
         dstw > srcw) { // We should not move out of source horizontal bounds
         return;
     }

--- a/modules/javafx.graphics/src/main/native-decora/SSELinearConvolvePeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSELinearConvolvePeer.cc
@@ -111,10 +111,8 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSELinearConvolvePeer_filterHV
      jfloatArray kvals_arr)
 {
     if ((checkRange(env,
-                    dstPixels_arr,
-                    dstcols, dstrows,
-                    srcPixels_arr,
-                    srccols, srcrows)) ||
+                    dstPixels_arr, dstcols, dstrows,
+                    srcPixels_arr, srccols, srcrows)) ||
         dstrows > srcrows) { // We should not move out of source vertical bounds
         return;
     }

--- a/modules/javafx.graphics/src/main/native-decora/SSELinearConvolvePeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSELinearConvolvePeer.cc
@@ -110,6 +110,20 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSELinearConvolvePeer_filterHV
      jintArray srcPixels_arr, jint srccols, jint srcrows, jint scolinc, jint srowinc,
      jfloatArray kvals_arr)
 {
+    if (srcPixels_arr == NULL ||
+        dstPixels_arr == NULL ||
+        srccols <= 0 ||
+        srcrows <= 0 ||
+        srccols > INT_MAX / srcrows ||
+        dstcols <= 0 ||
+        dstrows <= 0 ||
+        dstcols > INT_MAX / dstrows ||
+        (srccols * srcrows) > env->GetArrayLength(srcPixels_arr) ||
+        (dstcols * dstrows) > env->GetArrayLength(dstPixels_arr) ||
+        dstrows > srcrows) { // We should not move out of source vertical bounds
+        return;
+    }
+
     jint kernelSize = env->GetArrayLength(kvals_arr) / 2;
     if (kernelSize > 128) return;
     jfloat kvals[256];

--- a/modules/javafx.graphics/src/main/native-decora/SSELinearConvolvePeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSELinearConvolvePeer.cc
@@ -110,16 +110,11 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSELinearConvolvePeer_filterHV
      jintArray srcPixels_arr, jint srccols, jint srcrows, jint scolinc, jint srowinc,
      jfloatArray kvals_arr)
 {
-    if (srcPixels_arr == NULL ||
-        dstPixels_arr == NULL ||
-        srccols <= 0 ||
-        srcrows <= 0 ||
-        srccols > INT_MAX / srcrows ||
-        dstcols <= 0 ||
-        dstrows <= 0 ||
-        dstcols > INT_MAX / dstrows ||
-        (srccols * srcrows) > env->GetArrayLength(srcPixels_arr) ||
-        (dstcols * dstrows) > env->GetArrayLength(dstPixels_arr) ||
+    if ((checkRange(env,
+                    dstPixels_arr,
+                    dstcols, dstrows,
+                    srcPixels_arr,
+                    srccols, srcrows)) ||
         dstrows > srcrows) { // We should not move out of source vertical bounds
         return;
     }

--- a/modules/javafx.graphics/src/main/native-decora/SSELinearConvolveShadowPeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSELinearConvolveShadowPeer.cc
@@ -118,16 +118,11 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSELinearConvolveShadowPeer_filterHV
      jintArray srcPixels_arr, jint srccols, jint srcrows, jint scolinc, jint srowinc,
      jfloatArray kvals_arr, jfloatArray shadowColor_arr)
 {
-    if (srcPixels_arr == NULL ||
-        dstPixels_arr == NULL ||
-        srccols <= 0 ||
-        srcrows <= 0 ||
-        srccols > INT_MAX / srcrows ||
-        dstcols <= 0 ||
-        dstrows <= 0 ||
-        dstcols > INT_MAX / dstrows ||
-        (srccols * srcrows) > env->GetArrayLength(srcPixels_arr) ||
-        (dstcols * dstrows) > env->GetArrayLength(dstPixels_arr) ||
+    if ((checkRange(env,
+                    dstPixels_arr,
+                    dstcols, dstrows,
+                    srcPixels_arr,
+                    srccols, srcrows)) ||
         dstrows > srcrows) { // We should not move out of source vertical bounds
         return;
     }

--- a/modules/javafx.graphics/src/main/native-decora/SSELinearConvolveShadowPeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSELinearConvolveShadowPeer.cc
@@ -118,6 +118,20 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSELinearConvolveShadowPeer_filterHV
      jintArray srcPixels_arr, jint srccols, jint srcrows, jint scolinc, jint srowinc,
      jfloatArray kvals_arr, jfloatArray shadowColor_arr)
 {
+    if (srcPixels_arr == NULL ||
+        dstPixels_arr == NULL ||
+        srccols <= 0 ||
+        srcrows <= 0 ||
+        srccols > INT_MAX / srcrows ||
+        dstcols <= 0 ||
+        dstrows <= 0 ||
+        dstcols > INT_MAX / dstrows ||
+        (srccols * srcrows) > env->GetArrayLength(srcPixels_arr) ||
+        (dstcols * dstrows) > env->GetArrayLength(dstPixels_arr) ||
+        dstrows > srcrows) { // We should not move out of source vertical bounds
+        return;
+    }
+
     jint kernelSize = env->GetArrayLength(kvals_arr) / 2;
     if (kernelSize > 128) return;
     jfloat kvals[256];

--- a/modules/javafx.graphics/src/main/native-decora/SSELinearConvolveShadowPeer.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSELinearConvolveShadowPeer.cc
@@ -119,10 +119,8 @@ Java_com_sun_scenario_effect_impl_sw_sse_SSELinearConvolveShadowPeer_filterHV
      jfloatArray kvals_arr, jfloatArray shadowColor_arr)
 {
     if ((checkRange(env,
-                    dstPixels_arr,
-                    dstcols, dstrows,
-                    srcPixels_arr,
-                    srccols, srcrows)) ||
+                    dstPixels_arr, dstcols, dstrows,
+                    srcPixels_arr, srccols, srcrows)) ||
         dstrows > srcrows) { // We should not move out of source vertical bounds
         return;
     }

--- a/modules/javafx.graphics/src/main/native-decora/SSEUtils.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSEUtils.cc
@@ -183,3 +183,21 @@ void fsample(jfloat *map,
         }
     }
 }
+
+bool checkRange(JNIEnv *env,
+                jintArray dstPixels_arr,
+                jint dstw, jint dsth,
+                jintArray srcPixels_arr,
+                jint srcw, jint srch)
+{
+    return (srcPixels_arr == NULL ||
+            dstPixels_arr == NULL ||
+            srcw <= 0 ||
+            srch <= 0 ||
+            srcw > INT_MAX / srch ||
+            dstw <= 0 ||
+            dsth <= 0 ||
+            dstw > INT_MAX / dsth ||
+            (srcw * srch) > env->GetArrayLength(srcPixels_arr) ||
+            (dstw * dsth) > env->GetArrayLength(dstPixels_arr));
+}

--- a/modules/javafx.graphics/src/main/native-decora/SSEUtils.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSEUtils.cc
@@ -184,6 +184,11 @@ void fsample(jfloat *map,
     }
 }
 
+/*
+ * checkRange function returns true if source or destination
+ * dimensions are not in the required bounds and returns false
+ * if dimensions are within required bounds.
+ */
 bool checkRange(JNIEnv *env,
                 jintArray dstPixels_arr,
                 jint dstw, jint dsth,

--- a/modules/javafx.graphics/src/main/native-decora/SSEUtils.cc
+++ b/modules/javafx.graphics/src/main/native-decora/SSEUtils.cc
@@ -190,10 +190,8 @@ void fsample(jfloat *map,
  * if dimensions are within required bounds.
  */
 bool checkRange(JNIEnv *env,
-                jintArray dstPixels_arr,
-                jint dstw, jint dsth,
-                jintArray srcPixels_arr,
-                jint srcw, jint srch)
+                jintArray dstPixels_arr, jint dstw, jint dsth,
+                jintArray srcPixels_arr, jint srcw, jint srch)
 {
     return (srcPixels_arr == NULL ||
             dstPixels_arr == NULL ||

--- a/modules/javafx.graphics/src/main/native-decora/SSEUtils.h
+++ b/modules/javafx.graphics/src/main/native-decora/SSEUtils.h
@@ -57,6 +57,12 @@ void fsample(jfloat *img,
              jint w, jint h, jint scan,
              jfloat *fvals);
 
+bool checkRange(JNIEnv *env,
+                jintArray dstPixels_arr,
+                jint dstw, jint dsth,
+                jintArray srcPixels_arr,
+                jint srcw, jint srch);
+
 #ifdef __cplusplus
 };
 #endif /* __cplusplus */

--- a/modules/javafx.graphics/src/main/native-decora/SSEUtils.h
+++ b/modules/javafx.graphics/src/main/native-decora/SSEUtils.h
@@ -58,10 +58,8 @@ void fsample(jfloat *img,
              jfloat *fvals);
 
 bool checkRange(JNIEnv *env,
-                jintArray dstPixels_arr,
-                jint dstw, jint dsth,
-                jintArray srcPixels_arr,
-                jint srcw, jint srch);
+                jintArray dstPixels_arr, jint dstw, jint dsth,
+                jintArray srcPixels_arr, jint srcw, jint srch);
 
 #ifdef __cplusplus
 };

--- a/modules/javafx.graphics/src/main/native-decora/SSEUtils.h
+++ b/modules/javafx.graphics/src/main/native-decora/SSEUtils.h
@@ -38,6 +38,10 @@ extern "C" {
 #define FVAL_G   1
 #define FVAL_B   2
 
+#ifndef INT_MAX
+#define INT_MAX 2147483647
+#endif /* INT_MAX */
+
 void lsample(jint *img,
              jfloat floc_x, jfloat floc_y,
              jint w, jint h, jint scan,


### PR DESCRIPTION
In SW pipeline path of Box/Gaussian Blur/Shadow effects we are not checking for range when we read data from the source/destination buffers in native code.

We need to add appropriate range checks in native JNI code also apart from range checks in Java side to make sure that wherever these JNI methods are used we are not performing out of bounds access.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8319079](https://bugs.openjdk.org/browse/JDK-8319079): Missing range checks in decora (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1272/head:pull/1272` \
`$ git checkout pull/1272`

Update a local copy of the PR: \
`$ git checkout pull/1272` \
`$ git pull https://git.openjdk.org/jfx.git pull/1272/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1272`

View PR using the GUI difftool: \
`$ git pr show -t 1272`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1272.diff">https://git.openjdk.org/jfx/pull/1272.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1272#issuecomment-1784587846)