### PR TITLE
8319066: Application window not always activated in macOS 14 Sonoma

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -53,6 +53,7 @@ static jobject nestedLoopReturnValue = NULL;
 static BOOL isFullScreenExitingLoop = NO;
 static NSMutableDictionary * keyCodeForCharMap = nil;
 static BOOL isEmbedded = NO;
+static BOOL requiresActivation = NO;
 static BOOL triggerReactivation = NO;
 static BOOL disableSyncRendering = NO;
 static BOOL firstActivation = YES;
@@ -239,7 +240,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
     [pool drain];
     GLASS_CHECK_EXCEPTION(env);
 
-     if (@available(macOS 14.0, *) && !NSApp.isActive) {
+     if (!NSApp.isActive && requiresActivation) {
         // As of macOS 14, application gets to the foreground,
         // but it doesn't get activated, so this is needed:
         LOG("-> need to active application");
@@ -553,6 +554,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
                 // anyway) as of macOS 14
                 if (@available(macOS 14.0, *)) {
                     triggerReactivation = NO;
+                    requiresActivation = YES;
                 }
 
                 // move process from background only to full on app with visible Dock icon

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -238,6 +238,15 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
     }
     [pool drain];
     GLASS_CHECK_EXCEPTION(env);
+
+     if (@available(macOS 14.0, *) && !NSApp.isActive) {
+        // As of macOS 14, application gets to the foreground,
+        // but it doesn't get activated, so this is needed:
+        LOG("-> need to active application");
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [NSApp activate];
+        });
+    }
 }
 
 - (void)applicationWillBecomeActive:(NSNotification *)aNotification


### PR DESCRIPTION
On macOS 14. when a JavaFX application is launched from the command line it is not activated, and the terminal application remains active.

This PR forces the application activation on macOS 14, in case the app didn't get activated yet (when launched from a shortcut icon, for instance).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8319066](https://bugs.openjdk.org/browse/JDK-8319066): Application window not always activated in macOS 14 Sonoma (**Bug** - P2)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1273/head:pull/1273` \
`$ git checkout pull/1273`

Update a local copy of the PR: \
`$ git checkout pull/1273` \
`$ git pull https://git.openjdk.org/jfx.git pull/1273/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1273`

View PR using the GUI difftool: \
`$ git pr show -t 1273`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1273.diff">https://git.openjdk.org/jfx/pull/1273.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1273#issuecomment-1785126075)