### PR TITLE
8319231: Unrecognized "minimum" key in .jcheck/conf causes /reviewers command to be ignored

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -40,7 +40,7 @@ domain=openjdk.org
 files=.*\.java$|.*\.c$|.*\.h$|.*\.cpp$|.*\.hpp$|.*\.cc$|.*\.jsl$|.*\.fxml$|.*\.css$|.*\.m$|.*\.mm$|.*\.frag$|.*\.vert$|.*\.hlsl$|.*\.metal$|.*\.gradle$|.*\.groovy$|.*\.g4$|.*\.stg$
 
 [checks "reviewers"]
-minimum=1
+reviewers=1
 
 [checks "merge"]
 message=Merge


### PR DESCRIPTION
A recent change to Skara in processing of the .jcheck/conf file ([SKARA-2080](https://bugs.openjdk.org/browse/SKARA-2080)) introduced a bug in processing the `[checks "reviewers"]` section that causes the `/reviewers` command to be ignored in some cases. This is tracked by [SKARA-2088](https://bugs.openjdk.org/browse/SKARA-2088). The reason we tripped over this bug is that the `.jcheck/conf` file used by jfx (including various update release repos) uses an unrecognized key, "minimum", instead of the expected "reviewers" key to indicate the minimum number of reviewers. We should fix this to be consistent with what Skara expects given the intent of our `[checks "reviewers"]` section.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319231](https://bugs.openjdk.org/browse/JDK-8319231): Unrecognized "minimum" key in .jcheck/conf causes /reviewers command to be ignored (**Bug** - P2)


### Reviewers
 * [Erik Duveblad](https://openjdk.org/census#ehelin) (@edvbld - no project role)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1275/head:pull/1275` \
`$ git checkout pull/1275`

Update a local copy of the PR: \
`$ git checkout pull/1275` \
`$ git pull https://git.openjdk.org/jfx.git pull/1275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1275`

View PR using the GUI difftool: \
`$ git pr show -t 1275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1275.diff">https://git.openjdk.org/jfx/pull/1275.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1275#issuecomment-1789152922)