### PR TITLE
8319147: Add regression test for JDK-8317836

### DIFF
--- a/tests/manual/swing/JFXPanelOrientationTest.java
+++ b/tests/manual/swing/JFXPanelOrientationTest.java
@@ -74,7 +74,7 @@ public class JFXPanelOrientationTest extends Application {
                 new Label(""),
                 new HBox(10, passButton, failButton), pane);
 
-        stage.setScene(new Scene(rootNode, 600, 250));
+        stage.setScene(new Scene(rootNode, 500, 150));
         stage.show();
         EventQueue.invokeLater(JFXPanelOrientationTest::initSwing);
     }
@@ -107,7 +107,7 @@ public class JFXPanelOrientationTest extends Application {
         p.add(tb, BorderLayout.NORTH);
 
         frame.setContentPane(p);
-        frame.setSize(800, 500);
+        frame.setSize(400, 200);
         frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
         frame.setTitle("FX TextArea embedded in JFXPanel");
         frame.setVisible(true);

--- a/tests/manual/swing/JFXPanelOrientationTest.java
+++ b/tests/manual/swing/JFXPanelOrientationTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+import java.awt.BorderLayout;
+import java.awt.ComponentOrientation;
+import java.awt.EventQueue;
+import javax.swing.JCheckBox;
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.JToolBar;
+import javax.swing.WindowConstants;
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.embed.swing.JFXPanel;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.VBox;
+
+
+/**
+ * https://bugs.openjdk.org/browse/JDK-8317836
+ */
+public class JFXPanelOrientationTest extends Application {
+    private static JFXPanel jfxPanel;
+    private static TextArea textArea;
+    private static JFrame frame;    
+
+    public static void main(String[] args) {
+        Application.launch(args);
+    }
+
+    @Override
+    public void start(Stage stage) {
+        Button passButton = new Button("Pass");
+        Button failButton = new Button("Fail");
+        passButton.setOnAction(e -> this.quit());
+        failButton.setOnAction(e -> {
+            this.quit();
+            throw new AssertionError("Orientation change is not working");
+        });
+
+        BorderPane pane = new BorderPane();
+        VBox rootNode = new VBox(6,
+                new Label("1. This is a test for JFXPanel orientation."),
+                new Label("2. A Left-To-Right text will be shown along with a checkbox"),
+                new Label("3. If the text's orientation is changed on clicking on checkbox, click on Pass or else click on Fail"),
+                new Label(""),
+                new HBox(10, passButton, failButton), pane);
+
+        stage.setScene(new Scene(rootNode, 600, 250));
+        stage.show();
+        EventQueue.invokeLater(JFXPanelOrientationTest::initSwing);
+    }
+
+    private void quit() {
+        frame.dispose();	    
+        Platform.exit();
+    }
+
+    private static void initSwing() {
+        frame = new JFrame();
+
+        jfxPanel = new JFXPanel();
+        
+        Platform.runLater(JFXPanelOrientationTest::initFX);
+
+        JCheckBox rtl = new JCheckBox("RTL (JFrame.componentOrientation)");
+        rtl.addActionListener((ev) -> {
+            ComponentOrientation ori = rtl.isSelected() ? ComponentOrientation.RIGHT_TO_LEFT : ComponentOrientation.LEFT_TO_RIGHT;
+            frame.applyComponentOrientation(ori);
+            frame.validate();
+            frame.repaint();
+        });
+        
+        JToolBar tb = new JToolBar();
+        tb.add(rtl);
+
+        JPanel p = new JPanel(new BorderLayout());
+        p.add(jfxPanel, BorderLayout.CENTER);
+        p.add(tb, BorderLayout.NORTH);
+
+        frame.setContentPane(p);
+        frame.setSize(800, 500);
+        frame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
+        frame.setTitle("FX TextArea embedded in JFXPanel");
+        frame.setVisible(true);
+    }
+
+    private static void initFX() {
+        textArea = new TextArea("Hebrew: עברית");
+        jfxPanel.setScene(new Scene(textArea));
+    }
+}

--- a/tests/manual/swing/JFXPanelOrientationTest.java
+++ b/tests/manual/swing/JFXPanelOrientationTest.java
@@ -50,7 +50,7 @@ import javafx.scene.layout.VBox;
 public class JFXPanelOrientationTest extends Application {
     private static JFXPanel jfxPanel;
     private static TextArea textArea;
-    private static JFrame frame;    
+    private static JFrame frame;
 
     public static void main(String[] args) {
         Application.launch(args);
@@ -80,7 +80,7 @@ public class JFXPanelOrientationTest extends Application {
     }
 
     private void quit() {
-        frame.dispose();	    
+        frame.dispose();
         Platform.exit();
     }
 
@@ -88,7 +88,7 @@ public class JFXPanelOrientationTest extends Application {
         frame = new JFrame();
 
         jfxPanel = new JFXPanel();
-        
+
         Platform.runLater(JFXPanelOrientationTest::initFX);
 
         JCheckBox rtl = new JCheckBox("RTL (JFrame.componentOrientation)");
@@ -98,7 +98,7 @@ public class JFXPanelOrientationTest extends Application {
             frame.validate();
             frame.repaint();
         });
-        
+
         JToolBar tb = new JToolBar();
         tb.add(rtl);
 

--- a/tests/manual/swing/JFXPanelOrientationTest.java
+++ b/tests/manual/swing/JFXPanelOrientationTest.java
@@ -22,6 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+
 import java.awt.BorderLayout;
 import java.awt.ComponentOrientation;
 import java.awt.EventQueue;
@@ -42,7 +43,6 @@ import javafx.scene.control.TextArea;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
-
 
 /**
  * https://bugs.openjdk.org/browse/JDK-8317836


### PR DESCRIPTION
A manual regression test for JFXPanel orientation fix in [JDK-8317836](https://bugs.openjdk.org/browse/JDK-8317836) is added

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8319147](https://bugs.openjdk.org/browse/JDK-8319147): Add regression test for JDK-8317836 (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1276/head:pull/1276` \
`$ git checkout pull/1276`

Update a local copy of the PR: \
`$ git checkout pull/1276` \
`$ git pull https://git.openjdk.org/jfx.git pull/1276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1276`

View PR using the GUI difftool: \
`$ git pr show -t 1276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1276.diff">https://git.openjdk.org/jfx/pull/1276.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1276#issuecomment-1790249053)