### PR TITLE
8319340: [Linux] Disabled windows should not allow window operations (minimize, resize, maximize, close)

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
@@ -1211,11 +1211,11 @@ void WindowContextTop::set_enabled(bool enabled) {
     is_disabled = !enabled;
     update_window_constraints();
 
-    // If the window is disabled, not interaction is allowed
+    // If the window is disabled, no interaction is allowed
     if (enabled) {
         gdk_window_set_functions(gdk_window, gdk_windowManagerFunctions);
     } else {
-        //Don't allow window manager functions
+        // Don't allow window manager functions
         GdkWMFunction wmf = (GdkWMFunction)(gdk_windowManagerFunctions &
                             ~ (GDK_FUNC_MOVE | GDK_FUNC_MINIMIZE | GDK_FUNC_MAXIMIZE));
         gdk_window_set_functions(gdk_window, wmf);

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
@@ -1210,6 +1210,15 @@ void WindowContextTop::set_alpha(double alpha) {
 void WindowContextTop::set_enabled(bool enabled) {
     is_disabled = !enabled;
     update_window_constraints();
+
+    // If the window is disabled, not interaction is allowed
+    if (enabled) {
+        gdk_window_set_functions(gdk_window, gdk_windowManagerFunctions);
+    } else {
+        //Don't allow window manager functions
+        GdkWMFunction wmf = (GdkWMFunction)(0);
+        gdk_window_set_functions(gdk_window, wmf);
+    }
 }
 
 void WindowContextTop::set_minimum_size(int w, int h) {

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
@@ -1216,7 +1216,8 @@ void WindowContextTop::set_enabled(bool enabled) {
         gdk_window_set_functions(gdk_window, gdk_windowManagerFunctions);
     } else {
         //Don't allow window manager functions
-        GdkWMFunction wmf = (GdkWMFunction)(0);
+        GdkWMFunction wmf = (GdkWMFunction)(gdk_windowManagerFunctions &
+                            ~ (GDK_FUNC_MOVE | GDK_FUNC_MINIMIZE | GDK_FUNC_MAXIMIZE));
         gdk_window_set_functions(gdk_window, wmf);
     }
 }


### PR DESCRIPTION
JavaFX on Linux is allowing disabled windows to be minimized.

Currently close does nothing as it should, maximize disappears (on MS Windows it's greyed out - it's a platform behavior difference) and minimize is being allowed.

Thins PR removes WM functions when window is disabled and restores it back when it's re-enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8319340](https://bugs.openjdk.org/browse/JDK-8319340): [Linux] Disabled windows should not allow window operations (minimize, resize, maximize, close) (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1278/head:pull/1278` \
`$ git checkout pull/1278`

Update a local copy of the PR: \
`$ git checkout pull/1278` \
`$ git pull https://git.openjdk.org/jfx.git pull/1278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1278`

View PR using the GUI difftool: \
`$ git pr show -t 1278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1278.diff">https://git.openjdk.org/jfx/pull/1278.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1278#issuecomment-1791411090)