### PR TITLE
8319341: [Linux] Remove operation to show or hide children because it is unnecessary

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkWindow.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/gtk/GtkWindow.java
@@ -140,14 +140,7 @@ class GtkWindow extends Window {
         return maximize;
     }
 
-    private native void _showOrHideChildren(long ptr, boolean show);
-
     protected void notifyStateChanged(final int state) {
-        if (state == WindowEvent.MINIMIZE) {
-            _showOrHideChildren(getNativeHandle(), false);
-        } else if (state == WindowEvent.RESTORE) {
-            _showOrHideChildren(getNativeHandle(), true);
-        }
         switch (state) {
             case WindowEvent.MINIMIZE:
             case WindowEvent.MAXIMIZE:

--- a/modules/javafx.graphics/src/main/native-glass/gtk/GlassWindow.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/GlassWindow.cpp
@@ -124,20 +124,6 @@ JNIEXPORT jboolean JNICALL Java_com_sun_glass_ui_gtk_GtkWindow__1setView
     WindowContext* ctx = JLONG_TO_WINDOW_CTX(ptr);
     return (ctx->set_view(view)) ? JNI_TRUE : JNI_FALSE;
 }
-/*
- * Class:     com_sun_glass_ui_gtk_GtkWindow
- * Method:    _showOrHideChildren
- * Signature: (JZ)V
- */
-JNIEXPORT void JNICALL Java_com_sun_glass_ui_gtk_GtkWindow__1showOrHideChildren
-  (JNIEnv *env, jobject obj, jlong ptr, jboolean show)
-{
-    (void)env;
-    (void)obj;
-
-    WindowContext* ctx = JLONG_TO_WINDOW_CTX(ptr);
-    ctx->show_or_hide_children(show);
-}
 
 /*
  * Class:     com_sun_glass_ui_gtk_GtkWindow

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
@@ -553,14 +553,6 @@ void WindowContextBase::remove_child(WindowContextTop* child) {
     gtk_window_set_transient_for(child->get_gtk_window(), NULL);
 }
 
-void WindowContextBase::show_or_hide_children(bool show) {
-    std::set<WindowContextTop*>::iterator it;
-    for (it = children.begin(); it != children.end(); ++it) {
-        (*it)->set_minimized(!show);
-        (*it)->show_or_hide_children(show);
-    }
-}
-
 void WindowContextBase::set_visible(bool visible) {
     if (visible) {
         gtk_widget_show(gtk_widget);

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.h
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.h
@@ -104,7 +104,6 @@ public:
 
     virtual void enter_fullscreen() = 0;
     virtual void exit_fullscreen() = 0;
-    virtual void show_or_hide_children(bool) = 0;
     virtual void set_visible(bool) = 0;
     virtual bool is_visible() = 0;
     virtual void set_bounds(int, int, bool, bool, int, int, int, int, float, float) = 0;
@@ -218,7 +217,6 @@ public:
 
     void add_child(WindowContextTop*);
     void remove_child(WindowContextTop*);
-    void show_or_hide_children(bool);
     void set_visible(bool);
     bool is_visible();
     bool set_view(jobject);


### PR DESCRIPTION
Observed that the window manager takes care of showing and hiding children because we set `gtk_window_set_transient_for`.

Works since Ubuntu 16.04.

This PR removes the code to show or hide children because it "duplicates" the operation and might lead to unknown bugs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8319341](https://bugs.openjdk.org/browse/JDK-8319341): [Linux] Remove operation to show or hide children because it is unnecessary (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Lukasz Kostyra](https://openjdk.org/census#lkostyra) (@lukostyra - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1279/head:pull/1279` \
`$ git checkout pull/1279`

Update a local copy of the PR: \
`$ git checkout pull/1279` \
`$ git pull https://git.openjdk.org/jfx.git pull/1279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1279`

View PR using the GUI difftool: \
`$ git pr show -t 1279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1279.diff">https://git.openjdk.org/jfx/pull/1279.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1279#issuecomment-1791465923)