### PR TITLE
8319669: [macos14] Running any JavaFX app prints Secure coding warning

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.h
@@ -31,6 +31,19 @@
 
 @end
 
+
+/*
+ * NSApplicationFX is a subclass of NSApplication that we use when we
+ * initialize the application.
+ * We need to subclass NSApplication in order to stop AWT from installing
+ * their NSApplicationDelegate delegate, overwriting the one we install.
+ *
+ * We don't override anything in NSApplication. All work is done in our
+ * NSApplicationDelegate as recommended by Apple.
+ */
+@interface NSApplicationFX : NSApplication
+@end
+
 @interface GlassApplication : NSObject <NSApplicationDelegate>
 {
     BOOL            started;

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -160,7 +160,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationWillFinishLaunching:(NSNotification *)aNotification
 {
-    NSLog(@"GlassApplication:applicationWillFinishLaunching");
+    LOG("GlassApplication:applicationWillFinishLaunching");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -237,7 +237,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
-    NSLog(@"GlassApplication:applicationDidFinishLaunching");
+    LOG("GlassApplication:applicationDidFinishLaunching");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -259,7 +259,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationWillBecomeActive:(NSNotification *)aNotification
 {
-    NSLog(@"GlassApplication:applicationWillBecomeActive");
+    LOG("GlassApplication:applicationWillBecomeActive");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -272,7 +272,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationDidBecomeActive:(NSNotification *)aNotification
 {
-    NSLog(@"GlassApplication:applicationDidBecomeActive");
+    LOG("GlassApplication:applicationDidBecomeActive");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -292,7 +292,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationWillResignActive:(NSNotification *)aNotification
 {
-    NSLog(@"GlassApplication:applicationWillResignActive");
+    LOG("GlassApplication:applicationWillResignActive");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -305,7 +305,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationDidResignActive:(NSNotification *)aNotification
 {
-    NSLog(@"GlassApplication:applicationDidResignActive");
+    LOG("GlassApplication:applicationDidResignActive");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -324,7 +324,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationWillHide:(NSNotification *)aNotification
 {
-    NSLog(@"GlassApplication:applicationWillHide");
+    LOG("GlassApplication:applicationWillHide");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -337,7 +337,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationDidHide:(NSNotification *)aNotification
 {
-    NSLog(@"GlassApplication:applicationDidHide");
+    LOG("GlassApplication:applicationDidHide");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -350,7 +350,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationWillUnhide:(NSNotification *)aNotification
 {
-    NSLog(@"GlassApplication:applicationWillUnhide");
+    LOG("GlassApplication:applicationWillUnhide");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -363,7 +363,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationDidUnhide:(NSNotification *)aNotification
 {
-    NSLog(@"GlassApplication:applicationDidUnhide");
+    LOG("GlassApplication:applicationDidUnhide");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -542,9 +542,6 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
         NSApplication *app = [NSApplicationFX sharedApplication];
         isEmbedded = isEmbedded = ![app isKindOfClass:[NSApplicationFX class]];
 
-        NSLog(@">>>> NSApplication : 0x%p", app);
-        NSLog(@">>>> isEmbedded App ??? %d", isEmbedded);
-
         if (!isEmbedded)
         {
             // Not embedded in another toolkit, so disable automatic tabbing for all windows
@@ -619,10 +616,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
                 [app setWindowsMenu:myMenu];
                 [myMenu release];
 
-                NSLog(@">>>> FX setting NSApp delegate");
-                NSLog(@">>>> old delegate = 0x%p", [app delegate]);
                 [app setDelegate:self];
-                NSLog(@">>>> new delegate = 0x%p", [app delegate]);
 
                 // [app activateIgnoringOtherApps:YES] won't activate the menu bar on OS X 10.9, so instead we do this:
                 [[NSRunningApplication currentApplication] activateWithOptions:(NSApplicationActivateIgnoringOtherApps | NSApplicationActivateAllWindows)];
@@ -646,7 +640,6 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
                         TransformProcessType(&psn, 4); // kProcessTransformToUIElementApplication
                     }
                 }
-                NSLog(@">>>> FX setDelegate called (background app)");
                 [app setDelegate:self];
             }
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -540,7 +540,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
         // Determine if we're running embedded (in AWT, SWT, elsewhere)
         NSApplication *app = [NSApplicationFX sharedApplication];
-        isEmbedded = isEmbedded = ![app isKindOfClass:[NSApplicationFX class]];
+        isEmbedded = ![app isKindOfClass:[NSApplicationFX class]];
 
         if (!isEmbedded)
         {

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -160,7 +160,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationWillFinishLaunching:(NSNotification *)aNotification
 {
-    LOG("GlassApplication:applicationWillFinishLaunching");
+    NSLog(@"GlassApplication:applicationWillFinishLaunching");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -237,7 +237,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
-    LOG("GlassApplication:applicationDidFinishLaunching");
+    NSLog(@"GlassApplication:applicationDidFinishLaunching");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -259,7 +259,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationWillBecomeActive:(NSNotification *)aNotification
 {
-    LOG("GlassApplication:applicationWillBecomeActive");
+    NSLog(@"GlassApplication:applicationWillBecomeActive");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -272,7 +272,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationDidBecomeActive:(NSNotification *)aNotification
 {
-    LOG("GlassApplication:applicationDidBecomeActive");
+    NSLog(@"GlassApplication:applicationDidBecomeActive");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -292,7 +292,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationWillResignActive:(NSNotification *)aNotification
 {
-    LOG("GlassApplication:applicationWillResignActive");
+    NSLog(@"GlassApplication:applicationWillResignActive");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -305,7 +305,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationDidResignActive:(NSNotification *)aNotification
 {
-    LOG("GlassApplication:applicationDidResignActive");
+    NSLog(@"GlassApplication:applicationDidResignActive");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -324,7 +324,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationWillHide:(NSNotification *)aNotification
 {
-    LOG("GlassApplication:applicationWillHide");
+    NSLog(@"GlassApplication:applicationWillHide");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -337,7 +337,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationDidHide:(NSNotification *)aNotification
 {
-    LOG("GlassApplication:applicationDidHide");
+    NSLog(@"GlassApplication:applicationDidHide");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -350,7 +350,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationWillUnhide:(NSNotification *)aNotification
 {
-    LOG("GlassApplication:applicationWillUnhide");
+    NSLog(@"GlassApplication:applicationWillUnhide");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -363,7 +363,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 - (void)applicationDidUnhide:(NSNotification *)aNotification
 {
-    LOG("GlassApplication:applicationDidUnhide");
+    NSLog(@"GlassApplication:applicationDidUnhide");
 
     GET_MAIN_JENV;
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
@@ -542,6 +542,9 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
         NSApplication *app = [NSApplicationFX sharedApplication];
         isEmbedded = isEmbedded = ![app isKindOfClass:[NSApplicationFX class]];
 
+        NSLog(@">>>> NSApplication : 0x%p", app);
+        NSLog(@">>>> isEmbedded App ??? %d", isEmbedded);
+
         if (!isEmbedded)
         {
             // Not embedded in another toolkit, so disable automatic tabbing for all windows
@@ -616,7 +619,10 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
                 [app setWindowsMenu:myMenu];
                 [myMenu release];
 
+                NSLog(@">>>> FX setting NSApp delegate");
+                NSLog(@">>>> old delegate = 0x%p", [app delegate]);
                 [app setDelegate:self];
+                NSLog(@">>>> new delegate = 0x%p", [app delegate]);
 
                 // [app activateIgnoringOtherApps:YES] won't activate the menu bar on OS X 10.9, so instead we do this:
                 [[NSRunningApplication currentApplication] activateWithOptions:(NSApplicationActivateIgnoringOtherApps | NSApplicationActivateAllWindows)];
@@ -640,6 +646,7 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
                         TransformProcessType(&psn, 4); // kProcessTransformToUIElementApplication
                     }
                 }
+                NSLog(@">>>> FX setDelegate called (background app)");
                 [app setDelegate:self];
             }
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -115,6 +115,9 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
 
 @end
 
+@implementation NSApplicationFX
+@end
+
 #pragma mark --- GlassApplication
 
 @implementation GlassApplication
@@ -226,6 +229,10 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
     }
     [pool drain];
     GLASS_CHECK_EXCEPTION(env);
+}
+
+- (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app {
+    return YES;
 }
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
@@ -532,8 +539,8 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
         }
 
         // Determine if we're running embedded (in AWT, SWT, elsewhere)
-        NSApplication *app = [NSApplication sharedApplication];
-        isEmbedded = [app isRunning];
+        NSApplication *app = [NSApplicationFX sharedApplication];
+        isEmbedded = isEmbedded = ![app isKindOfClass:[NSApplicationFX class]];
 
         if (!isEmbedded)
         {


### PR DESCRIPTION
Fix [JDK-8319669](https://bugs.openjdk.org/browse/JDK-8319669) as follows:

1. Override the `NSApplicationDelegate` method `applicationSupportsSecureRestorableState` in `GlassApplication` and return `YES`. This silences the warning that FX applications now get on macOS 14.
2. Create and initialize an `NSApplicationFX` subclass of `NSApplication` with no additional functionality. This stops AWT from overwriting the NSApplicationDelegate (`GlassApplication`) that JavaFX sets during toolkit initialization in the case where the AWT toolkit is used from a JavaFX Application (e.g., when using SwingNode or other Swing functionality), and is necessary in order to safely do the above. It also fixes other problems that can result from the delegate being overwritten.

As noted in the bug report, this PR solves the following problems:

* Eliminates the "Secure coding is not enabled for restorable state" warning on macOS 14
* The assertion error reported in [JDK-8318129](https://bugs.openjdk.org/browse/JDK-8318129)

* The FX application stops getting messages when the application is hidden, deactivated, reactivated, etc. We currently don't do anything with these messages once the application is running, but we might do so in the future.

* Probably related to the above, we sometimes get an odd behavior when trying to hide an application on macOS 13 using the CMD-H key after the AWT Toolkit has been initialized. Instead of hiding the window, it pops up a finder window with a folder icon and a label that shows the version of Java.

* If AWT and FX return a different answer from their delegate's `applicationSupportsSecureRestorableState` method, it will crash on macOS 13.x.

This is the FX equivalent of [JDK-8318854](https://bugs.openjdk.org/browse/JDK-8318854) in AWT.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8319669](https://bugs.openjdk.org/browse/JDK-8319669): [macos14] Running any JavaFX app prints Secure coding warning (**Bug** - P2)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - no project role)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1280/head:pull/1280` \
`$ git checkout pull/1280`

Update a local copy of the PR: \
`$ git checkout pull/1280` \
`$ git pull https://git.openjdk.org/jfx.git pull/1280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1280`

View PR using the GUI difftool: \
`$ git pr show -t 1280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1280.diff">https://git.openjdk.org/jfx/pull/1280.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1280#issuecomment-1802448357)