### PR TITLE
8092272: [D3D 3D] Need a robust 3D states management for texture

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/paint/TextureData.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/paint/TextureData.java
@@ -1,0 +1,110 @@
+package com.sun.javafx.scene.paint;
+
+// When the public API is ready, move to the exported javafx.scene.paint
+/**
+ * Contains texture properties for a {@code Material}'s textures (maps).
+ * <p>
+ * Since {@code TextureData} does not depend on a {@code Material}, the same instance can be reused in multiple textures
+ * (in the same or in different materials). This is useful because many times a {@link javafx.scene.shape.Shape3D} will
+ * have all its textures use the same properties, or the same texture data will be used across the whole application.
+ */
+// Here we can support mipmaps, wrapping modes (which exists internally and can be pulled out), addressing modes etc.
+public class TextureData {
+
+    /**
+     * Filtering methods for sampling a magnified or minified texture. When a texture is used to color a surface that is
+     * larger or smaller than the texture size, the texture needs to be magnified or minified. Different algorithms
+     * exist for sampling the texture elements (texels) used to color the surface.
+     */
+    public enum MinMagFilterType {
+
+        /**
+         * Uses the texel closest to the sampling point. This sampling method is the fastest, but the results can be
+         * pixelated.
+         */
+        NEAREST_POINT,
+
+        /**
+         * Uses a weighted average of the 4 texels closest to the sampling point. This sampling method is slightly
+         * slower than {@code NEAREST_POINT}, but results in a smoother image.
+         */
+        BILINEAR;
+    }
+
+    /**
+     * Filtering methods for sampling between mipmaps. When a surface is at a distance that does not match a single
+     * mipmap different algorithms exist for interpolating between the closest mipmap levels. Mipmapping is only valid
+     * for minification since the base texture is the largest size image.
+     */
+    public enum MipmapFilterType {
+
+        /**
+         * No mimaping is used.
+         */
+        NONE,
+        /**
+         * Chooses the nearest mipmap level. This is a cheap method, but can result in abrupt changes when the mipmap
+         * level is switched.
+         */
+        NEAREST,
+        /**
+         * Linearly interpolates between the 2 closest mipmap levels. This method is slightly slower than
+         * {@code NEAREST}, but the result is a smooth transition between mipmap levels.
+         */
+        LINEAR;
+    }
+
+    private final MinMagFilterType minFilterType;
+    private final MinMagFilterType magFilterType;
+    private final MipmapFilterType mipmapFilterType;
+
+    private TextureData(MinMagFilterType minFilterType, MinMagFilterType magFilterType, MipmapFilterType mipmapFilterType) {
+        this.minFilterType = minFilterType;
+        this.magFilterType = magFilterType;
+        this.mipmapFilterType = mipmapFilterType;
+    }
+
+    public MinMagFilterType minFilterType() { return minFilterType; }
+    public MinMagFilterType magFilterType() { return magFilterType; }
+    public MipmapFilterType mipmapFilterType() { return mipmapFilterType; }
+
+    public static class Builder {
+
+        private MinMagFilterType minFilterType = MinMagFilterType.BILINEAR;
+        private MinMagFilterType magFilterType = MinMagFilterType.BILINEAR;
+        private MipmapFilterType mipmapFilterType = MipmapFilterType.NONE;
+
+        public Builder() {}
+
+        public Builder minFilterType(MinMagFilterType minFilterType) {
+            this.minFilterType = minFilterType;
+            return this;
+        }
+        
+        public Builder magFilterType(MinMagFilterType magFilterType) {
+            this.magFilterType = magFilterType;
+            return this;
+        }
+        
+        public Builder mipmapFilterType(MipmapFilterType mipmapFilterType) {
+            this.mipmapFilterType = mipmapFilterType;
+            return this;
+        }
+        
+        public TextureData build() {
+            return new TextureData(minFilterType, magFilterType, mipmapFilterType);
+        }
+    }
+
+    /**
+     * Mipmap images to be used when mipmapping is enabled. The images in this list must each be a power-of-2 smaller size
+     * than the previous one. The image used as the main texture (level 0) should not be included.
+     * To enable mipmapping, set {@link MipmapFilterType} to a value other than {@link MipmapFilterType#NONE NONE}.
+     */
+//    private ObservableList<Image> mipmaps;
+//
+//    private int mipmapLevels;
+
+//    enum WrapMode { // see com.sun.prism.Texture.WrapMode
+//    }
+}

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/paint/TextureData.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/scene/paint/TextureData.java
@@ -80,17 +80,17 @@ public class TextureData {
             this.minFilterType = minFilterType;
             return this;
         }
-        
+
         public Builder magFilterType(MinMagFilterType magFilterType) {
             this.magFilterType = magFilterType;
             return this;
         }
-        
+
         public Builder mipmapFilterType(MipmapFilterType mipmapFilterType) {
             this.mipmapFilterType = mipmapFilterType;
             return this;
         }
-        
+
         public TextureData build() {
             return new TextureData(minFilterType, magFilterType, mipmapFilterType);
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGPhongMaterial.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGPhongMaterial.java
@@ -25,6 +25,9 @@
 
 package com.sun.javafx.sg.prism;
 
+import java.util.Objects;
+
+import com.sun.javafx.scene.paint.TextureData;
 import com.sun.prism.Image;
 import com.sun.prism.Material;
 import com.sun.prism.PhongMaterial;
@@ -38,6 +41,12 @@ import com.sun.prism.paint.Color;
 public class NGPhongMaterial {
 
     private static final Image WHITE_1X1 = Image.fromIntArgbPreData(new int[]{0xffffffff}, 1, 1);
+    
+    /**
+     * A default TextureData to be used instead of null. It allows access to the default values of TextureData.
+     */
+    private static final TextureData DEFAULT = new TextureData.Builder().build();
+
     private PhongMaterial material;
 
     private Color diffuseColor;
@@ -55,7 +64,6 @@ public class NGPhongMaterial {
     private TextureMap selfIllumMap = new TextureMap(PhongMaterial.MapType.SELF_ILLUM);
 
     Material createMaterial(ResourceFactory f) {
-
         // Check whether the material is valid; dispose and recreate if needed
         if (material != null && !material.isValid()) {
             disposeMaterial();
@@ -64,7 +72,7 @@ public class NGPhongMaterial {
         if (material == null) {
             material = f.createPhongMaterial();
         }
-        validate(f);
+        validate();
         return material;
     }
 
@@ -81,8 +89,7 @@ public class NGPhongMaterial {
         material = null;
     }
 
-    private void validate(ResourceFactory f) {
-
+    private void validate() {
         if (diffuseColorDirty) {
             if (diffuseColor != null) {
                 material.setDiffuseColor(
@@ -95,19 +102,21 @@ public class NGPhongMaterial {
         }
 
         if (diffuseMap.isDirty()) {
-            if (diffuseMap.getImage() == null) {
-                diffuseMap.setImage(WHITE_1X1);
-            }
+            diffuseMap.setImage(Objects.requireNonNullElse(diffuseMap.getImage(), WHITE_1X1));
+            diffuseMap.setTextureData(Objects.requireNonNullElse(diffuseMap.getTextureData(), DEFAULT));
             material.setTextureMap(diffuseMap);
         }
         if (bumpMap.isDirty()) {
             material.setTextureMap(bumpMap);
+            bumpMap.setTextureData(Objects.requireNonNullElse(bumpMap.getTextureData(), DEFAULT));
         }
         if (selfIllumMap.isDirty()) {
             material.setTextureMap(selfIllumMap);
+            selfIllumMap.setTextureData(Objects.requireNonNullElse(selfIllumMap.getTextureData(), DEFAULT));
         }
         if (specularMap.isDirty()) {
             material.setTextureMap(specularMap);
+            specularMap.setTextureData(Objects.requireNonNullElse(specularMap.getTextureData(), DEFAULT));
         }
         if (specularColorDirty || specularPowerDirty) {
             if (specularColor != null) {
@@ -147,8 +156,18 @@ public class NGPhongMaterial {
         this.diffuseMap.setDirty(true);
     }
 
+    public void setDiffuseTextureData(TextureData textureData) {
+        this.diffuseMap.setTextureData(textureData);
+        this.diffuseMap.setDirty(true);
+    }
+
     public void setSpecularMap(Object specularMap) {
         this.specularMap.setImage((Image)specularMap);
+        this.specularMap.setDirty(true);
+    }
+
+    public void setSpecularTextureData(TextureData textureData) {
+        this.specularMap.setTextureData(textureData);
         this.specularMap.setDirty(true);
     }
 
@@ -157,8 +176,18 @@ public class NGPhongMaterial {
         this.bumpMap.setDirty(true);
     }
 
+    public void setBumpTextureData(TextureData textureData) {
+        this.bumpMap.setTextureData(textureData);
+        this.bumpMap.setDirty(true);
+    }
+
     public void setSelfIllumMap(Object selfIllumMap) {
         this.selfIllumMap.setImage((Image)selfIllumMap);
+        this.selfIllumMap.setDirty(true);
+    }
+
+    public void setSelfIllumTextureData(TextureData textureData) {
+        this.selfIllumMap.setTextureData(textureData);
         this.selfIllumMap.setDirty(true);
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGPhongMaterial.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGPhongMaterial.java
@@ -41,7 +41,7 @@ import com.sun.prism.paint.Color;
 public class NGPhongMaterial {
 
     private static final Image WHITE_1X1 = Image.fromIntArgbPreData(new int[]{0xffffffff}, 1, 1);
-    
+
     /**
      * A default TextureData to be used instead of null. It allows access to the default values of TextureData.
      */

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/TextureMap.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/TextureMap.java
@@ -25,6 +25,8 @@
 
 package com.sun.prism;
 
+import com.sun.javafx.scene.paint.TextureData;
+
 /**
  * A wrapper class to hold map related information for the PhongMaterial
  */
@@ -32,6 +34,12 @@ public class TextureMap {
 
     private final PhongMaterial.MapType type;
     private Image image;
+    private TextureData textureData;
+    /**
+     * The texture resource is requested from the resource manager with the image (and maybe later textureData) as
+     * arguments. It's not taken from the material like image, textureData, and type are. We could consider some
+     * refactoring in the texture area (texture could be removed from this class, or the whole class might be removed).
+     */
     private Texture texture;
     private boolean dirty;
 
@@ -57,6 +65,14 @@ public class TextureMap {
 
     public void setTexture(Texture texture) {
         this.texture = texture;
+    }
+
+    public TextureData getTextureData() {
+        return textureData;
+    }
+
+    public void setTextureData(TextureData textureData) {
+        this.textureData = textureData;
     }
 
     public boolean isDirty() {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
@@ -31,6 +31,7 @@ import com.sun.javafx.geom.Vec3d;
 import com.sun.javafx.geom.transform.Affine3D;
 import com.sun.javafx.geom.transform.BaseTransform;
 import com.sun.javafx.geom.transform.GeneralTransform3D;
+import com.sun.javafx.scene.paint.TextureData;
 import com.sun.javafx.sg.prism.NGCamera;
 import com.sun.javafx.sg.prism.NGDefaultCamera;
 import com.sun.prism.CompositeMode;
@@ -462,7 +463,7 @@ class D3DContext extends BaseShaderContext {
     private static native void nSetSpecularColor(long pContext, long nativePhongMaterial,
             boolean set, float r, float g, float b, float a);
     private static native void nSetMap(long pContext, long nativePhongMaterial,
-            int mapType, long texID);
+            int mapType, int minFilter, int magFilter, int mipFilter, long nativeTexture);
     private static native long nCreateD3DMeshView(long pContext, long nativeMesh);
     private static native void nReleaseD3DMeshView(long pContext, long nativeHandle);
     private static native void nSetCullingMode(long pContext, long nativeMeshView,
@@ -572,8 +573,12 @@ class D3DContext extends BaseShaderContext {
         nSetSpecularColor(pContext, nativePhongMaterial, set, r, g, b, a);
     }
 
-    void setMap(long nativePhongMaterial, int mapType, long nativeTexture) {
-        nSetMap(pContext, nativePhongMaterial, mapType, nativeTexture);
+    void setMap(long nativePhongMaterial, int mapType, TextureData textureData, long nativeTexture) {
+        if (mapType == 0) {
+            System.out.println("Context java setMap filter " + textureData.minFilterType().ordinal());
+        }
+        nSetMap(pContext, nativePhongMaterial, mapType, textureData.minFilterType().ordinal(),
+                textureData.magFilterType().ordinal(), textureData.mipmapFilterType().ordinal(), nativeTexture);
     }
 
     long createD3DMeshView(long nativeMesh) {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DContext.java
@@ -574,9 +574,6 @@ class D3DContext extends BaseShaderContext {
     }
 
     void setMap(long nativePhongMaterial, int mapType, TextureData textureData, long nativeTexture) {
-        if (mapType == 0) {
-            System.out.println("Context java setMap filter " + textureData.minFilterType().ordinal());
-        }
         nSetMap(pContext, nativePhongMaterial, mapType, textureData.minFilterType().ordinal(),
                 textureData.magFilterType().ordinal(), textureData.mipmapFilterType().ordinal(), nativeTexture);
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPhongMaterial.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/d3d/D3DPhongMaterial.java
@@ -32,6 +32,7 @@ import com.sun.prism.TextureMap;
 import com.sun.prism.impl.BasePhongMaterial;
 import com.sun.prism.impl.Disposer;
 import com.sun.javafx.logging.PlatformLogger;
+import com.sun.javafx.scene.paint.TextureData;
 
 /**
  * TODO: 3D - Need documentation
@@ -77,11 +78,12 @@ class D3DPhongMaterial extends BasePhongMaterial {
     }
 
     private Texture setupTexture(TextureMap map, boolean useMipmap) {
+        TextureData textureData = map.getTextureData();
         Image image = map.getImage();
         Texture texture = (image == null) ? null
                 : context.getResourceFactory().getCachedTexture(image, Texture.WrapMode.REPEAT, useMipmap);
         long hTexture = (texture != null) ? ((D3DTexture) texture).getNativeTextureObject() : 0;
-        context.setMap(nativeHandle, map.getType().ordinal(), hTexture);
+        context.setMap(nativeHandle, map.getType().ordinal(), textureData, hTexture);
         return texture;
     }
 
@@ -95,7 +97,8 @@ class D3DPhongMaterial extends BasePhongMaterial {
                     continue;
                 }
             }
-            // Enable mipmap if map is diffuse or self illum.
+            // Enable mipmap if map is diffuse or self illum. In D3DResourceManager::CreateTexture the mipmap level
+            // is set to 1, so the useMipmap flag has no effect until that is changed
             boolean useMipmap = (i == PhongMaterial.DIFFUSE) || (i == PhongMaterial.SELF_ILLUM);
             texture = setupTexture(maps[i], useMipmap);
             maps[i].setTexture(texture);

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.cc
@@ -626,10 +626,10 @@ HRESULT D3DContext::setDeviceParametersFor3D() {
         SUCCEEDED(res = pd3dDevice->SetRenderState(D3DRS_ALPHABLENDENABLE, TRUE)) &&
         SUCCEEDED(res = pd3dDevice->SetRenderState(D3DRS_SCISSORTESTENABLE, FALSE)) &&
         SUCCEEDED(res = pd3dDevice->SetRenderState(D3DRS_LIGHTING, TRUE)) &&
-        // TODO: 3D - RT-34415: [D3D 3D] Need a robust 3D states management for texture
         // Set texture unit 0 to its default texture addressing mode for Prism
+        // TODO: Consider giving these the same treatment as setting the filters in D3DContext::nSetMap
         SUCCEEDED(res = pd3dDevice->SetSamplerState(0, D3DSAMP_ADDRESSU, D3DTADDRESS_WRAP)) &&
-        SUCCEEDED(res = pd3dDevice->SetSamplerState(0, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP));// &&
+        SUCCEEDED(res = pd3dDevice->SetSamplerState(0, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP));
     }
     return res;
 }

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.cc
@@ -24,6 +24,7 @@
  */
 
 #include <iostream>
+#include <array>
 
 #include "D3DPipeline.h"
 #include "D3DContext.h"
@@ -353,9 +354,6 @@ JNIEXPORT void JNICALL Java_com_sun_prism_d3d_D3DContext_nSetSpecularColor
     phongMaterial->setSpecularColor(set ? true : false, r, g, b, a);
 }
 
-enum minmagFilterType { nearest_point, bilinear };
-enum mipmapFilterType { none, nearest, linear };
-
 /*
  * Class:     com_sun_prism_d3d_D3DContext
  * Method:    nSetMap
@@ -365,15 +363,15 @@ JNIEXPORT void JNICALL Java_com_sun_prism_d3d_D3DContext_nSetMap
   (JNIEnv *env, jclass, jlong ctx, jlong nativePhongMaterial,
         jint mapType, jint minFilter, jint magFilter, jint mipFilter, jlong nativeTexture)
 {
-    static const D3DTEXTUREFILTERTYPE minMagEnumMap[2] = { D3DTEXF_POINT, D3DTEXF_LINEAR };
-    static const D3DTEXTUREFILTERTYPE mipmapEnumMap[3] = { D3DTEXF_NONE, D3DTEXF_POINT, D3DTEXF_LINEAR };
+    static const std::array<D3DTEXTUREFILTERTYPE, 2> minMagEnumMap = { D3DTEXF_POINT, D3DTEXF_LINEAR };
+    static const std::array<D3DTEXTUREFILTERTYPE, 3> mipmapEnumMap = { D3DTEXF_NONE, D3DTEXF_POINT, D3DTEXF_LINEAR };
 
     TraceLn(NWT_TRACE_INFO, "D3DContext_nSetMap");
     D3DPhongMaterial *phongMaterial = (D3DPhongMaterial *) jlong_to_ptr(nativePhongMaterial);
     IDirect3DBaseTexture9 *texMap = (IDirect3DBaseTexture9 *) jlong_to_ptr(nativeTexture);
     RETURN_IF_NULL(phongMaterial);
 
-    phongMaterial->setMap(static_cast<map_type>(mapType), texMap,
+    phongMaterial->setMap(static_cast<MapType>(mapType), texMap,
             minMagEnumMap[minFilter], minMagEnumMap[magFilter], mipmapEnumMap[mipFilter]);
 }
 

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DContext.cc
@@ -352,6 +352,10 @@ JNIEXPORT void JNICALL Java_com_sun_prism_d3d_D3DContext_nSetSpecularColor
 
     phongMaterial->setSpecularColor(set ? true : false, r, g, b, a);
 }
+
+enum minmagFilterType { nearest_point, bilinear };
+enum mipmapFilterType { none, nearest, linear };
+
 /*
  * Class:     com_sun_prism_d3d_D3DContext
  * Method:    nSetMap
@@ -359,14 +363,18 @@ JNIEXPORT void JNICALL Java_com_sun_prism_d3d_D3DContext_nSetSpecularColor
  */
 JNIEXPORT void JNICALL Java_com_sun_prism_d3d_D3DContext_nSetMap
   (JNIEnv *env, jclass, jlong ctx, jlong nativePhongMaterial,
-        jint mapType, jlong nativeTexture)
+        jint mapType, jint minFilter, jint magFilter, jint mipFilter, jlong nativeTexture)
 {
+    static const D3DTEXTUREFILTERTYPE minMagEnumMap[2] = { D3DTEXF_POINT, D3DTEXF_LINEAR };
+    static const D3DTEXTUREFILTERTYPE mipmapEnumMap[3] = { D3DTEXF_NONE, D3DTEXF_POINT, D3DTEXF_LINEAR };
+
     TraceLn(NWT_TRACE_INFO, "D3DContext_nSetMap");
     D3DPhongMaterial *phongMaterial = (D3DPhongMaterial *) jlong_to_ptr(nativePhongMaterial);
-    IDirect3DBaseTexture9 *texMap = (IDirect3DBaseTexture9 *)  jlong_to_ptr(nativeTexture);
+    IDirect3DBaseTexture9 *texMap = (IDirect3DBaseTexture9 *) jlong_to_ptr(nativeTexture);
     RETURN_IF_NULL(phongMaterial);
 
-    phongMaterial->setMap(mapType, texMap);
+    phongMaterial->setMap(static_cast<map_type>(mapType), texMap,
+            minMagEnumMap[minFilter], minMagEnumMap[magFilter], mipmapEnumMap[mipFilter]);
 }
 
 /*
@@ -621,10 +629,7 @@ HRESULT D3DContext::setDeviceParametersFor3D() {
         // TODO: 3D - RT-34415: [D3D 3D] Need a robust 3D states management for texture
         // Set texture unit 0 to its default texture addressing mode for Prism
         SUCCEEDED(res = pd3dDevice->SetSamplerState(0, D3DSAMP_ADDRESSU, D3DTADDRESS_WRAP)) &&
-        SUCCEEDED(res = pd3dDevice->SetSamplerState(0, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP)) &&
-        // Set texture filter to bilinear for 3D rendering
-        SUCCEEDED(res = pd3dDevice->SetSamplerState(0, D3DSAMP_MAGFILTER, D3DTEXF_LINEAR)) &&
-        SUCCEEDED(res = pd3dDevice->SetSamplerState(0, D3DSAMP_MINFILTER, D3DTEXF_LINEAR));
+        SUCCEEDED(res = pd3dDevice->SetSamplerState(0, D3DSAMP_ADDRESSV, D3DTADDRESS_WRAP));// &&
     }
     return res;
 }

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DMeshView.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DMeshView.cc
@@ -292,7 +292,6 @@ void D3DMeshView::render() {
     // Set the textures and their filters in their corresponding samplers
     for (int i = 0; i < map_type::num_map_types; i++) {
         map_type type = static_cast<map_type>(i);
-//        cout << "D3DMeshView setting " << type << " to " << material->getMinFilterType(type) << ", " << material->getMagFilterType(type) << endl;
         SUCCEEDED(device->SetTexture(type, material->getMap(type)));
         SUCCEEDED(device->SetSamplerState(type, D3DSAMP_MINFILTER, material->getMinFilterType(type)));
         SUCCEEDED(device->SetSamplerState(type, D3DSAMP_MAGFILTER, material->getMagFilterType(type)));

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DMeshView.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DMeshView.cc
@@ -289,10 +289,15 @@ void D3DMeshView::render() {
         return;
     }
 
-    SUCCEEDED(device->SetTexture(SR_DIFFUSE_MAP, material->getMap(DIFFUSE)));
-    SUCCEEDED(device->SetTexture(SR_SPECULAR_MAP, material->getMap(SPECULAR)));
-    SUCCEEDED(device->SetTexture(SR_BUMPHEIGHT_MAP, material->getMap(BUMP)));
-    SUCCEEDED(device->SetTexture(SR_SELFILLUM_MAP, material->getMap(SELFILLUMINATION)));
+    // Set the textures and their filters in their corresponding samplers
+    for (int i = 0; i < map_type::num_map_types; i++) {
+        map_type type = static_cast<map_type>(i);
+//        cout << "D3DMeshView setting " << type << " to " << material->getMinFilterType(type) << ", " << material->getMagFilterType(type) << endl;
+        SUCCEEDED(device->SetTexture(type, material->getMap(type)));
+        SUCCEEDED(device->SetSamplerState(type, D3DSAMP_MINFILTER, material->getMinFilterType(type)));
+        SUCCEEDED(device->SetSamplerState(type, D3DSAMP_MAGFILTER, material->getMagFilterType(type)));
+        SUCCEEDED(device->SetSamplerState(type, D3DSAMP_MIPFILTER, material->getMipFilterType(type)));
+    }
 
     if (context->state.cullMode != cullMode) {
         context->state.cullMode = cullMode;
@@ -300,8 +305,7 @@ void D3DMeshView::render() {
     }
     if (context->state.wireframe != wireframe) {
         context->state.wireframe = wireframe;
-        SUCCEEDED(device->SetRenderState(D3DRS_FILLMODE,
-                wireframe ? D3DFILL_WIREFRAME : D3DFILL_SOLID));
+        SUCCEEDED(device->SetRenderState(D3DRS_FILLMODE, wireframe ? D3DFILL_WIREFRAME : D3DFILL_SOLID));
     }
 
     SUCCEEDED(device->SetStreamSource(0, mesh->getVertexBuffer(), 0, PRIMITIVE_VERTEX_SIZE));

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DMeshView.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DMeshView.cc
@@ -290,8 +290,8 @@ void D3DMeshView::render() {
     }
 
     // Set the textures and their filters in their corresponding samplers
-    for (int i = 0; i < map_type::num_map_types; i++) {
-        map_type type = static_cast<map_type>(i);
+    for (int i = 0; i < MapType::NUM_MAP_TYPES; i++) {
+        MapType type = static_cast<MapType>(i);
         SUCCEEDED(device->SetTexture(type, material->getMap(type)));
         SUCCEEDED(device->SetSamplerState(type, D3DSAMP_MINFILTER, material->getMinFilterType(type)));
         SUCCEEDED(device->SetSamplerState(type, D3DSAMP_MAGFILTER, material->getMagFilterType(type)));

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DPhongMaterial.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DPhongMaterial.cc
@@ -34,9 +34,7 @@ using std::endl;
 D3DPhongMaterial::~D3DPhongMaterial() {
     context = NULL;
     // The freeing of texture native resources is handled by its Java layer.
-    for (int i = 0; i < map_type::num_map_types; i++) {
-        map[i] = NULL;
-    }
+    map.fill(NULL);
 }
 
 D3DPhongMaterial::D3DPhongMaterial(D3DContext *ctx) :
@@ -67,38 +65,38 @@ float * D3DPhongMaterial::getSpecularColor() {
 }
 
 bool D3DPhongMaterial::isBumpMap() {
-    return map[map_type::bump] ? true : false;
+    return map[MapType::BUMP] != NULL;
 }
 
 bool D3DPhongMaterial::isSpecularMap() {
-    return map[map_type::specular] ? true : false;
+    return map[MapType::SPECULAR] != NULL;
 }
 
 bool D3DPhongMaterial::isSelfIllumMap() {
-    return map[map_type::self_illumination] ? true : false;
+    return map[MapType::SELF_ILLUMINATION] != NULL;
 }
 
 bool D3DPhongMaterial::isSpecularColor() {
     return specularColorSet;
 }
 
-IDirect3DBaseTexture9 * D3DPhongMaterial::getMap(map_type type) {
+IDirect3DBaseTexture9 * D3DPhongMaterial::getMap(MapType type) {
     return map[type];
 }
 
-D3DTEXTUREFILTERTYPE D3DPhongMaterial::getMinFilterType(map_type type) {
+D3DTEXTUREFILTERTYPE D3DPhongMaterial::getMinFilterType(MapType type) {
     return minFilter[type];
 }
 
-D3DTEXTUREFILTERTYPE D3DPhongMaterial::getMagFilterType(map_type type) {
+D3DTEXTUREFILTERTYPE D3DPhongMaterial::getMagFilterType(MapType type) {
     return magFilter[type];
 }
 
-D3DTEXTUREFILTERTYPE D3DPhongMaterial::getMipFilterType(map_type type) {
+D3DTEXTUREFILTERTYPE D3DPhongMaterial::getMipFilterType(MapType type) {
     return mipFilter[type];
 }
 
-void D3DPhongMaterial::setMap(map_type type, IDirect3DBaseTexture9 *texMap, D3DTEXTUREFILTERTYPE min,
+void D3DPhongMaterial::setMap(MapType type, IDirect3DBaseTexture9 *texMap, D3DTEXTUREFILTERTYPE min,
         D3DTEXTUREFILTERTYPE mag, D3DTEXTUREFILTERTYPE mip) {
     map[type] = texMap;
     minFilter[type] = min;

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DPhongMaterial.cc
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DPhongMaterial.cc
@@ -34,10 +34,9 @@ using std::endl;
 D3DPhongMaterial::~D3DPhongMaterial() {
     context = NULL;
     // The freeing of texture native resources is handled by its Java layer.
-    map[DIFFUSE] = NULL;
-    map[SPECULAR] = NULL;
-    map[BUMP] = NULL;
-    map[SELFILLUMINATION] = NULL;
+    for (int i = 0; i < map_type::num_map_types; i++) {
+        map[i] = NULL;
+    }
 }
 
 D3DPhongMaterial::D3DPhongMaterial(D3DContext *ctx) :
@@ -68,35 +67,41 @@ float * D3DPhongMaterial::getSpecularColor() {
 }
 
 bool D3DPhongMaterial::isBumpMap() {
-    return map[BUMP] ? true : false;
+    return map[map_type::bump] ? true : false;
 }
 
 bool D3DPhongMaterial::isSpecularMap() {
-    return map[SPECULAR] ? true : false;
+    return map[map_type::specular] ? true : false;
 }
 
 bool D3DPhongMaterial::isSelfIllumMap() {
-    return map[SELFILLUMINATION] ? true : false;
+    return map[map_type::self_illumination] ? true : false;
 }
 
 bool D3DPhongMaterial::isSpecularColor() {
     return specularColorSet;
 }
 
-IDirect3DBaseTexture9 * D3DPhongMaterial::getMap(int type) {
-    // Within the range of DIFFUSE, SPECULAR, BUMP, SELFILLUMINATION
-    if (type >= 0 && type <= 3) {
-        return map[type];
-    }
-    cerr << "D3DPhongMaterial::getMap -- type is out of range - type = " << type << endl;
-    return NULL;
+IDirect3DBaseTexture9 * D3DPhongMaterial::getMap(map_type type) {
+    return map[type];
 }
 
-void D3DPhongMaterial::setMap(int mapID, IDirect3DBaseTexture9 *texMap) {
-    // Within the range of DIFFUSE, SPECULAR, BUMP, SELFILLUMINATION
-    if (mapID >= 0 && mapID <= 3) {
-        map[mapID] = texMap;
-    } else {
-        cerr << "D3DPhongMaterial::getMap -- mapID is out of range - mapID = " << mapID << endl;
-    }
+D3DTEXTUREFILTERTYPE D3DPhongMaterial::getMinFilterType(map_type type) {
+    return minFilter[type];
+}
+
+D3DTEXTUREFILTERTYPE D3DPhongMaterial::getMagFilterType(map_type type) {
+    return magFilter[type];
+}
+
+D3DTEXTUREFILTERTYPE D3DPhongMaterial::getMipFilterType(map_type type) {
+    return mipFilter[type];
+}
+
+void D3DPhongMaterial::setMap(map_type type, IDirect3DBaseTexture9 *texMap, D3DTEXTUREFILTERTYPE min,
+        D3DTEXTUREFILTERTYPE mag, D3DTEXTUREFILTERTYPE mip) {
+    map[type] = texMap;
+    minFilter[type] = min;
+    magFilter[type] = mag;
+    mipFilter[type] = mip;
 }

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DPhongMaterial.h
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DPhongMaterial.h
@@ -30,10 +30,15 @@
 
 // See MaterialPhong.h, MaterialPhongShaders.h
 
-#define DIFFUSE 0
-#define SPECULAR 1
-#define BUMP 2
-#define SELFILLUMINATION 3
+// Map type numbered sequence used for sampling registers (we have 4 sampling registers for vs 3.0).
+// Order is defined by com.sun.prism.PhongMaterial's MapType enum
+enum map_type : unsigned int {
+    diffuse,
+    specular,
+    bump,
+    self_illumination,
+    num_map_types
+};
 
 class D3DPhongMaterial {
 public:
@@ -43,19 +48,26 @@ public:
     float *getDiffuseColor();
     void setSpecularColor(bool set, float r, float g, float b, float a);
     float *getSpecularColor();
-    void setMap(int mapID, IDirect3DBaseTexture9 *texMap);
+    void setMap(map_type mapID, IDirect3DBaseTexture9 *texMap, D3DTEXTUREFILTERTYPE min,
+            D3DTEXTUREFILTERTYPE mag, D3DTEXTUREFILTERTYPE mip);
     bool isBumpMap();
     bool isSpecularMap();
     bool isSpecularColor();
     bool isSelfIllumMap();
-    IDirect3DBaseTexture9 * getMap(int type);
+    IDirect3DBaseTexture9 * getMap(map_type type);
+    D3DTEXTUREFILTERTYPE getMinFilterType(map_type type);
+    D3DTEXTUREFILTERTYPE getMagFilterType(map_type type);
+    D3DTEXTUREFILTERTYPE getMipFilterType(map_type type);
 
 private:
     D3DContext *context = NULL;
     float diffuseColor[4] = {0};
     float specularColor[4] = {1, 1, 1, 32};
-    IDirect3DBaseTexture9 *map[4] = {NULL};
     bool specularColorSet = false;
+    IDirect3DBaseTexture9 *map[map_type::num_map_types] = {NULL};
+    D3DTEXTUREFILTERTYPE minFilter[map_type::num_map_types] = {NULL};
+    D3DTEXTUREFILTERTYPE magFilter[map_type::num_map_types] = {NULL};
+    D3DTEXTUREFILTERTYPE mipFilter[map_type::num_map_types] = {NULL};
 };
 
 #endif  /* D3DPHONGMATERIAL_H */

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DPhongMaterial.h
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DPhongMaterial.h
@@ -26,18 +26,20 @@
 #ifndef D3DPHONGMATERIAL_H
 #define D3DPHONGMATERIAL_H
 
+#include <array>
+
 #include "D3DContext.h"
 
 // See MaterialPhong.h, MaterialPhongShaders.h
 
 // Map type numbered sequence used for sampling registers (we have 4 sampling registers for vs 3.0).
 // Order is defined by com.sun.prism.PhongMaterial's MapType enum
-enum map_type : unsigned int {
-    diffuse,
-    specular,
-    bump,
-    self_illumination,
-    num_map_types
+enum MapType : unsigned int {
+    DIFFUSE,
+    SPECULAR,
+    BUMP,
+    SELF_ILLUMINATION,
+    NUM_MAP_TYPES
 };
 
 class D3DPhongMaterial {
@@ -48,26 +50,26 @@ public:
     float *getDiffuseColor();
     void setSpecularColor(bool set, float r, float g, float b, float a);
     float *getSpecularColor();
-    void setMap(map_type mapID, IDirect3DBaseTexture9 *texMap, D3DTEXTUREFILTERTYPE min,
+    void setMap(MapType mapID, IDirect3DBaseTexture9 *texMap, D3DTEXTUREFILTERTYPE min,
             D3DTEXTUREFILTERTYPE mag, D3DTEXTUREFILTERTYPE mip);
     bool isBumpMap();
     bool isSpecularMap();
     bool isSpecularColor();
     bool isSelfIllumMap();
-    IDirect3DBaseTexture9 * getMap(map_type type);
-    D3DTEXTUREFILTERTYPE getMinFilterType(map_type type);
-    D3DTEXTUREFILTERTYPE getMagFilterType(map_type type);
-    D3DTEXTUREFILTERTYPE getMipFilterType(map_type type);
+    IDirect3DBaseTexture9 *getMap(MapType type);
+    D3DTEXTUREFILTERTYPE getMinFilterType(MapType type);
+    D3DTEXTUREFILTERTYPE getMagFilterType(MapType type);
+    D3DTEXTUREFILTERTYPE getMipFilterType(MapType type);
 
 private:
     D3DContext *context = NULL;
     float diffuseColor[4] = {0};
     float specularColor[4] = {1, 1, 1, 32};
     bool specularColorSet = false;
-    IDirect3DBaseTexture9 *map[map_type::num_map_types] = {NULL};
-    D3DTEXTUREFILTERTYPE minFilter[map_type::num_map_types] = {NULL};
-    D3DTEXTUREFILTERTYPE magFilter[map_type::num_map_types] = {NULL};
-    D3DTEXTUREFILTERTYPE mipFilter[map_type::num_map_types] = {NULL};
+    std::array<IDirect3DBaseTexture9*, MapType::NUM_MAP_TYPES> map;
+    D3DTEXTUREFILTERTYPE minFilter[MapType::NUM_MAP_TYPES] = {NULL};
+    D3DTEXTUREFILTERTYPE magFilter[MapType::NUM_MAP_TYPES] = {NULL};
+    D3DTEXTUREFILTERTYPE mipFilter[MapType::NUM_MAP_TYPES] = {NULL};
 };
 
 #endif  /* D3DPHONGMATERIAL_H */

--- a/modules/javafx.graphics/src/main/native-prism-d3d/D3DPhongShader.h
+++ b/modules/javafx.graphics/src/main/native-prism-d3d/D3DPhongShader.h
@@ -65,12 +65,6 @@
 //#define PSR_LIGHT_DIRS 24        // 1 direction = 5 * 1 = 5: c24-28
 //#define PSR_LIGHT_POS 29         // 1 position = 5 * 1 = 5: c29-34
 
-// SR implies Sampler Registers
-#define SR_DIFFUSE_MAP 0
-#define SR_SPECULAR_MAP 1
-#define SR_BUMPHEIGHT_MAP 2
-#define SR_SELFILLUM_MAP 3
-
 enum SpecType {
     SpecNone,
     SpecTexture, // map only w/o alpha


### PR DESCRIPTION
Moves the filter setting of the samplers from the device parameters configuration to the use-site, allowing for dynamic changes in the sampler. This PR does internal plumbing work only to bring it close to the ES2 pipeline. A followup PR will create the public API.

Summary of the changes:
* Created a new (internal for now) `TextureData` object that is intended to contain all the data of texture (map) of `PhongMaterial`, such as filters, addressing, wrapping mode, mipmaps etc. **This PR deals only with filters** as a starting point, more settings can be added later.
* Creates an update mechanism from the Java side material to the native D3D layer. The public API `PhoneMaterial` is *not* changed yet. The peer `NGPhongMaterial` is configured to receive update from the public `PhongMaterial` when the public API is created via new `ObjectProperty<TextureData>` properties.
* Small refactoring in the D3D layer with a new map types enum to control the texture settings more easily.

The JBS issue lists some regressions in a comment, but I couldn't reproduce them. It looks like the sampler settings needed to be added anywhere, and that was the easiest to do at the time. Now they were just moved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8092272](https://bugs.openjdk.org/browse/JDK-8092272): [D3D 3D] Need a robust 3D states management for texture (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1281/head:pull/1281` \
`$ git checkout pull/1281`

Update a local copy of the PR: \
`$ git checkout pull/1281` \
`$ git pull https://git.openjdk.org/jfx.git pull/1281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1281`

View PR using the GUI difftool: \
`$ git pr show -t 1281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1281.diff">https://git.openjdk.org/jfx/pull/1281.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1281#issuecomment-1802921996)