### PR TITLE
8282290: TextField Cursor Position one off

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
@@ -245,7 +245,7 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
         caretPath.layoutXProperty().bind(textTranslateX);
         textNode.caretShapeProperty().addListener(observable -> {
             caretPath.getElements().setAll(textNode.caretShapeProperty().get());
-            if (caretPath.getElements().size() == 0) {
+            if (caretPath.getElements().size() == 0 || caretPath.getElements().size() != 4) {
                 // The caret pos is invalid.
                 updateTextNodeCaretPos(control.getCaretPosition());
             } else if (caretPath.getElements().size() == 4) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
@@ -246,7 +246,10 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
         textNode.caretShapeProperty().addListener(observable -> {
             caretPath.getElements().setAll(textNode.caretShapeProperty().get());
             if (caretPath.getElements().size() != 4) {
-                // The caret pos is invalid.
+                /* On replacing same text using keyboard shortcut,
+                 * caret position is not updated.
+                 * The caret pos is invalid in this case,
+                 * hence it should be updated when caret path size is not 4 */
                 updateTextNodeCaretPos(control.getCaretPosition());
             } else if (caretPath.getElements().size() == 4) {
                 // The caret is split. Ignore and keep the previous width value.

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
@@ -245,7 +245,7 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
         caretPath.layoutXProperty().bind(textTranslateX);
         textNode.caretShapeProperty().addListener(observable -> {
             caretPath.getElements().setAll(textNode.caretShapeProperty().get());
-            if (caretPath.getElements().size() == 0 || caretPath.getElements().size() != 4) {
+            if (caretPath.getElements().size() != 4) {
                 // The caret pos is invalid.
                 updateTextNodeCaretPos(control.getCaretPosition());
             } else if (caretPath.getElements().size() == 4) {


### PR DESCRIPTION
The change listener on caretPositionProperty() was not getting invoked on replacing the content with same text as there was no change in caret position. Since the textProperty invalidation sets the forward bias to true by default, incorrect caret position was  calculated when the same text was replaced after clicking on the trailing edge of last character or empty space in the TextField.

Since caretShapeProperty invalidation listener gets invoked without changing the caret position, updating the caretBiasProperty on this listener solves the issue.

Since the caret position value will be same when the caret is present after the last character or before the last character, it can not be validated using unit test.
The fix can be validated using MonkeyTester.
Steps to select TextField option in Monkey Tester.

- Open the MonkeyTester app and select TextField from the left option pane.
- Select Short from Text selection option and click on the TextField to bring it into focus.
- Select all using cmd(ctrl) + a and copy using cmd(ctrl) + c
- Click on empty space in the TextField after the present content.
- Select all again using the keyboard shortcut and paste using cmd(ctrl) + v
- The caret should be displayed after the last character. Without the fix caret gets displayed before the last character.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8282290](https://bugs.openjdk.org/browse/JDK-8282290): TextField Cursor Position one off (**Bug** - P3)
 * [JDK-8248914](https://bugs.openjdk.org/browse/JDK-8248914): Javafx TextField positions the cursor incorrectly after pressing DEL key (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1287/head:pull/1287` \
`$ git checkout pull/1287`

Update a local copy of the PR: \
`$ git checkout pull/1287` \
`$ git pull https://git.openjdk.org/jfx.git pull/1287/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1287`

View PR using the GUI difftool: \
`$ git pr show -t 1287`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1287.diff">https://git.openjdk.org/jfx/pull/1287.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1287#issuecomment-1809941852)