### PR TITLE
8284544: [Win] Name-Property of Spinner cannot be changed

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/Spinner.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/Spinner.java
@@ -769,7 +769,7 @@ public class Spinner<T> extends Control {
             }
         }
 
-        notifyAccessibleAttributeChanged(AccessibleAttribute.TEXT);
+        notifyAccessibleAttributeChanged(AccessibleAttribute.VALUE_STRING);
         if (text == null) {
             if (value == null) {
                 getEditor().clear();
@@ -834,7 +834,7 @@ public class Spinner<T> extends Control {
     @Override
     public Object queryAccessibleAttribute(AccessibleAttribute attribute, Object... parameters) {
         switch (attribute) {
-            case TEXT: {
+            case VALUE_STRING: {
                 T value = getValue();
                 SpinnerValueFactory<T> factory = getValueFactory();
                 if (factory != null) {
@@ -845,6 +845,15 @@ public class Spinner<T> extends Control {
                 }
                 return value != null ? value.toString() : "";
             }
+
+            case TEXT: {
+                String accText = getAccessibleText();
+                return (accText != null) ? accText : "";
+            }
+
+            case EDITABLE:
+                return isEditable();
+
             default: return super.queryAccessibleAttribute(attribute, parameters);
         }
     }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacAccessible.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacAccessible.java
@@ -801,6 +801,11 @@ final class MacAccessible extends Accessible {
                     macNotification = MacNotification.NSAccessibilityValueChangedNotification;
                 }
                 break;
+            case VALUE_STRING:
+                if (getAttribute(ROLE) == AccessibleRole.SPINNER) {
+                    macNotification = MacNotification.NSAccessibilityValueChangedNotification;
+                }
+                break;
             case PARENT:
                 if (peer != 0L) {
                     _invalidateParent(peer);
@@ -1208,6 +1213,10 @@ final class MacAccessible extends Accessible {
                         case TEXT_AREA:
                         case COMBO_BOX:
                             jfxAttr = TEXT;
+                            map = MacVariant::createNSString;
+                            break;
+                        case SPINNER:
+                            jfxAttr = VALUE_STRING;
                             map = MacVariant::createNSString;
                             break;
                         case CHECK_BOX:

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinAccessible.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinAccessible.java
@@ -363,16 +363,24 @@ final class WinAccessible extends Accessible {
                     WinVariant vn = new WinVariant();
                     vn.vt = WinVariant.VT_BSTR;
                     vn.bstrVal = value;
-                    if (getAttribute(ROLE) == AccessibleRole.SPINNER) {
-                        UiaRaiseAutomationPropertyChangedEvent(peer, UIA_NamePropertyId, vo, vn);
-                    } else {
-                        /* Combo and Text both implement IValueProvider */
-                        UiaRaiseAutomationPropertyChangedEvent(peer, UIA_ValueValuePropertyId, vo, vn);
-                    }
+                    /* Combo and Text both implement IValueProvider */
+                    UiaRaiseAutomationPropertyChangedEvent(peer, UIA_ValueValuePropertyId, vo, vn);
                 }
 
                 if (selectionRange != null || documentRange != null) {
                     UiaRaiseAutomationEvent(peer, UIA_Text_TextChangedEventId);
+                }
+                break;
+            case VALUE_STRING:
+                String val = (String)getAttribute(VALUE_STRING);
+                if (val != null) {
+                    WinVariant vo = new WinVariant();
+                    vo.vt = WinVariant.VT_BSTR;
+                    vo.bstrVal = "";
+                    WinVariant vn = new WinVariant();
+                    vn.vt = WinVariant.VT_BSTR;
+                    vn.bstrVal = val;
+                    UiaRaiseAutomationPropertyChangedEvent(peer, UIA_ValueValuePropertyId, vo, vn);
                 }
                 break;
             case EXPANDED: {
@@ -685,6 +693,9 @@ final class WinAccessible extends Accessible {
             case COMBO_BOX:
                 impl = patternId == UIA_ExpandCollapsePatternId ||
                        patternId == UIA_ValuePatternId;
+                break;
+            case SPINNER:
+                impl = patternId == UIA_ValuePatternId;
                 break;
             case SCROLL_BAR:
             case SLIDER:
@@ -1319,6 +1330,7 @@ final class WinAccessible extends Accessible {
                 case SCROLL_BAR: return true;
                 case TEXT_FIELD:
                 case TEXT_AREA:
+                case SPINNER:
                 case COMBO_BOX: return Boolean.FALSE.equals(getAttribute(EDITABLE));
                 default:
             }
@@ -1367,6 +1379,14 @@ final class WinAccessible extends Accessible {
 
     private String get_ValueString() {
         if (isDisposed()) return null;
+        AccessibleRole role = (AccessibleRole)getAttribute(ROLE);
+        if (role != null) {
+            switch (role) {
+                case SPINNER:
+                    return (String)getAttribute(VALUE_STRING);
+                default:
+            }
+        }
         return (String)getAttribute(TEXT);
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleAttribute.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleAttribute.java
@@ -782,6 +782,8 @@ public enum AccessibleAttribute {
      * <li>Return Type: {@link String} </li>
      * <li>Parameters: </li>
      * </ul>
+     *
+     * @since 22
      */
     VALUE_STRING(String.class),
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleAttribute.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/AccessibleAttribute.java
@@ -775,6 +775,17 @@ public enum AccessibleAttribute {
     VALUE(Double.class),
 
     /**
+     * Returns the value as string for the node.
+     * <ul>
+     * <li>Used by: Spinner </li>
+     * <li>Needs notify: yes </li>
+     * <li>Return Type: {@link String} </li>
+     * <li>Parameters: </li>
+     * </ul>
+     */
+    VALUE_STRING(String.class),
+
+    /**
      * Returns the vertical scroll bar for the node.
      * <ul>
      * <li>Used by: ListView, ScrollPane, and others </li>


### PR DESCRIPTION
Currently we use the value of spinner as it's `UIA_NamePropertyId` when a11y client application requests for it.
Ideally we should use the text set by `Node.setAccessibleText()` as the `UIA_NamePropertyId`.
For other controls such as Slider, ListView we use the text set by setAccessibleText() API.

Fix:
Use the text set by `Node.setAccessibleText()` as the `UIA_NamePropertyId`.
This means, when a11y client requests `UIA_NamePropertyId`, which is mapped to AccessibleAttribute.TEXT attribute,  we shall return the accessible text.
So we need another way to read out the VALUE of the Spinner.
- For this we need to implement `IValueProvider` pattern for Spinner control
- IValueProvider requests the value of the control using it's API `get_ValueString()`
- It required to introduce a new AccessibleAttribute `VALUE_STRING`
- IValueProvider  also reads out if the control is editable or not, hence added `EDITABLE `case in `Spinner.queryAccessibleAttribute()`

Verification:
- Run any spinner app, with setAccessibleText set on spinner 
- Run Windows narrator and observe
- Without this fix:
- 1. Narrator does not read the text set by setAccessibleText
- 2. In application "Accessibility Insights for Windows", you can see the value of Spinner as the Name property
- After this fix:
- 1. Narrator reads the accessible text then value of Spinner and then if editable or not
- 2. In application "Accessibility Insights for Windows", you can see the text set by `setAccessibleText()` for Spinner as the Name property and the Spinner's value as value property

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8320505](https://bugs.openjdk.org/browse/JDK-8320505) to be approved
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8284544](https://bugs.openjdk.org/browse/JDK-8284544): [Win] Name-Property of Spinner cannot be changed (**Bug** - P3)
 * [JDK-8320505](https://bugs.openjdk.org/browse/JDK-8320505): [Win] Name-Property of Spinner cannot be changed (**CSR**)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1291/head:pull/1291` \
`$ git checkout pull/1291`

Update a local copy of the PR: \
`$ git checkout pull/1291` \
`$ git pull https://git.openjdk.org/jfx.git pull/1291/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1291`

View PR using the GUI difftool: \
`$ git pr show -t 1291`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1291.diff">https://git.openjdk.org/jfx/pull/1291.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1291#issuecomment-1818264436)