### PR TITLE
JDK-8320444: Column drag header is positioned wrong for nested columns

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableColumnHeader.java
@@ -1192,7 +1192,8 @@ public class TableColumnHeader extends Region {
         final double x = getParentHeader().sceneToLocal(sceneX, sceneY).getX();
 
         // calculate where the ghost column header should be
-        double dragX = x - dragOffset;
+        double headerX = getTableHeaderRow().sceneToLocal(sceneX, sceneY).getX();
+        double dragX = headerX - dragOffset;
         getTableHeaderRow().setDragHeaderX(dragX);
 
         double startX = 0;

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableViewSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableViewSkinTest.java
@@ -32,6 +32,7 @@ import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
+import javafx.scene.control.skin.NestedTableColumnHeader;
 import javafx.scene.control.skin.TableColumnHeader;
 import javafx.scene.control.skin.TableColumnHeaderShim;
 import javafx.scene.control.skin.TableHeaderRow;
@@ -186,6 +187,43 @@ class TableViewSkinTest {
         TableColumnHeaderShim.columnReordering(tableColumnHeader, bounds.getMinX() + 20, bounds.getMinY());
 
         assertEquals(20, columnDragHeader.getTranslateX());
+    }
+
+    @Test
+    void testHeaderReorderWithinNestedColumns() {
+        TableView<String> tableView = new TableView<>();
+        for (int i = 0; i < 2; i++) {
+            TableColumn<String, String> column = new TableColumn<>("Col " + i);
+            column.setMinWidth(100);
+            column.setMaxWidth(100);
+            tableView.getColumns().add(column);
+        }
+
+        TableColumn<String, String> column = new TableColumn<>("Column with nested");
+        for (int i = 0; i < 2; i++) {
+            TableColumn<String, String> nestedCol = new TableColumn<>("NestedCol " + i);
+            nestedCol.setMinWidth(100);
+            nestedCol.setMaxWidth(100);
+            column.getColumns().add(nestedCol);
+        }
+        tableView.getColumns().add(column);
+
+        stageLoader = new StageLoader(tableView);
+
+        TableHeaderRow header = (TableHeaderRow) tableView.lookup("TableHeaderRow");
+        Node columnDragHeader = header.lookup(".column-drag-header");
+
+        assertEquals(0, columnDragHeader.getTranslateX());
+
+        NestedTableColumnHeader nestedTableColumnHeader =
+                (NestedTableColumnHeader) header.getRootHeader().getColumnHeaders().get(2);
+        TableColumnHeader tableColumnHeader = nestedTableColumnHeader.getColumnHeaders().get(0);
+
+        Bounds bounds = tableColumnHeader.localToScene(tableColumnHeader.getLayoutBounds());
+        TableColumnHeaderShim.columnReordering(tableColumnHeader, bounds.getMinX() + 20, bounds.getMinY());
+
+        // 200, since we have 2 columns to the left with a size of 100.
+        assertEquals(220, columnDragHeader.getTranslateX());
     }
 
     private static class CustomTableViewSkin<S> extends TableViewSkin<S> {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableViewSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableViewSkinTest.java
@@ -166,6 +166,8 @@ class TableViewSkinTest {
 
     @Test
     void testColumnHeaderReorderCorrectTranslateX() {
+        int dragAmount = 20;
+
         TableView<String> tableView = new TableView<>();
         tableView.setPadding(new Insets(0, 10, 0, 30));
         for (int i = 0; i < 5; i++) {
@@ -184,26 +186,29 @@ class TableViewSkinTest {
 
         TableColumnHeader tableColumnHeader = header.getRootHeader().getColumnHeaders().get(0);
         Bounds bounds = tableColumnHeader.localToScene(tableColumnHeader.getLayoutBounds());
-        TableColumnHeaderShim.columnReordering(tableColumnHeader, bounds.getMinX() + 20, bounds.getMinY());
+        TableColumnHeaderShim.columnReordering(tableColumnHeader, bounds.getMinX() + dragAmount, bounds.getMinY());
 
-        assertEquals(20, columnDragHeader.getTranslateX());
+        assertEquals(dragAmount, columnDragHeader.getTranslateX());
     }
 
     @Test
     void testHeaderReorderWithinNestedColumns() {
+        int width = 100;
+        int dragAmount = 20;
+
         TableView<String> tableView = new TableView<>();
         for (int i = 0; i < 2; i++) {
             TableColumn<String, String> column = new TableColumn<>("Col " + i);
-            column.setMinWidth(100);
-            column.setMaxWidth(100);
+            column.setMinWidth(width);
+            column.setMaxWidth(width);
             tableView.getColumns().add(column);
         }
 
         TableColumn<String, String> column = new TableColumn<>("Column with nested");
         for (int i = 0; i < 2; i++) {
             TableColumn<String, String> nestedCol = new TableColumn<>("NestedCol " + i);
-            nestedCol.setMinWidth(100);
-            nestedCol.setMaxWidth(100);
+            nestedCol.setMinWidth(width);
+            nestedCol.setMaxWidth(width);
             column.getColumns().add(nestedCol);
         }
         tableView.getColumns().add(column);
@@ -220,10 +225,10 @@ class TableViewSkinTest {
         TableColumnHeader tableColumnHeader = nestedTableColumnHeader.getColumnHeaders().get(0);
 
         Bounds bounds = tableColumnHeader.localToScene(tableColumnHeader.getLayoutBounds());
-        TableColumnHeaderShim.columnReordering(tableColumnHeader, bounds.getMinX() + 20, bounds.getMinY());
+        TableColumnHeaderShim.columnReordering(tableColumnHeader, bounds.getMinX() + dragAmount, bounds.getMinY());
 
-        // 200, since we have 2 columns to the left with a size of 100.
-        assertEquals(220, columnDragHeader.getTranslateX());
+        // 220, since we have 2 columns to the left with a size of 100 and a dragged this column by 20.
+        assertEquals(width * 2 + dragAmount, columnDragHeader.getTranslateX());
     }
 
     private static class CustomTableViewSkin<S> extends TableViewSkin<S> {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableViewSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableViewSkinTest.java
@@ -146,6 +146,8 @@ class TreeTableViewSkinTest {
 
     @Test
     void testColumnHeaderReorderCorrectTranslateX() {
+        int dragAmount = 20;
+
         TreeTableView<String> treeTableView = new TreeTableView<>();
         treeTableView.setPadding(new Insets(0, 10, 0, 30));
         for (int i = 0; i < 5; i++) {
@@ -164,13 +166,16 @@ class TreeTableViewSkinTest {
 
         TableColumnHeader tableColumnHeader = header.getRootHeader().getColumnHeaders().get(0);
         Bounds bounds = tableColumnHeader.localToScene(tableColumnHeader.getLayoutBounds());
-        TableColumnHeaderShim.columnReordering(tableColumnHeader, bounds.getMinX() + 20, bounds.getMinY());
+        TableColumnHeaderShim.columnReordering(tableColumnHeader, bounds.getMinX() + dragAmount, bounds.getMinY());
 
-        assertEquals(20, columnDragHeader.getTranslateX());
+        assertEquals(dragAmount, columnDragHeader.getTranslateX());
     }
 
     @Test
     void testHeaderReorderWithinNestedColumns() {
+        int width = 100;
+        int dragAmount = 20;
+
         TreeTableView<String> treeTableView = new TreeTableView<>();
         for (int i = 0; i < 2; i++) {
             TreeTableColumn<String, String> column = new TreeTableColumn<>("Col " + i);
@@ -200,10 +205,10 @@ class TreeTableViewSkinTest {
         TableColumnHeader tableColumnHeader = nestedTableColumnHeader.getColumnHeaders().get(0);
 
         Bounds bounds = tableColumnHeader.localToScene(tableColumnHeader.getLayoutBounds());
-        TableColumnHeaderShim.columnReordering(tableColumnHeader, bounds.getMinX() + 20, bounds.getMinY());
+        TableColumnHeaderShim.columnReordering(tableColumnHeader, bounds.getMinX() + dragAmount, bounds.getMinY());
 
-        // 200, since we have 2 columns to the left with a size of 100.
-        assertEquals(220, columnDragHeader.getTranslateX());
+        // 220, since we have 2 columns to the left with a size of 100 and a dragged this column by 20.
+        assertEquals(width * 2 + dragAmount, columnDragHeader.getTranslateX());
     }
 
     private static class CustomTreeTableViewSkin<S> extends TreeTableViewSkin<S> {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableViewSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TreeTableViewSkinTest.java
@@ -31,6 +31,7 @@ import javafx.geometry.Insets;
 import javafx.scene.Node;
 import javafx.scene.control.TreeTableColumn;
 import javafx.scene.control.TreeTableView;
+import javafx.scene.control.skin.NestedTableColumnHeader;
 import javafx.scene.control.skin.TableColumnHeader;
 import javafx.scene.control.skin.TableColumnHeaderShim;
 import javafx.scene.control.skin.TableHeaderRow;
@@ -166,6 +167,43 @@ class TreeTableViewSkinTest {
         TableColumnHeaderShim.columnReordering(tableColumnHeader, bounds.getMinX() + 20, bounds.getMinY());
 
         assertEquals(20, columnDragHeader.getTranslateX());
+    }
+
+    @Test
+    void testHeaderReorderWithinNestedColumns() {
+        TreeTableView<String> treeTableView = new TreeTableView<>();
+        for (int i = 0; i < 2; i++) {
+            TreeTableColumn<String, String> column = new TreeTableColumn<>("Col " + i);
+            column.setMinWidth(100);
+            column.setMaxWidth(100);
+            treeTableView.getColumns().add(column);
+        }
+
+        TreeTableColumn<String, String> column = new TreeTableColumn<>("Column with nested");
+        for (int i = 0; i < 2; i++) {
+            TreeTableColumn<String, String> nestedCol = new TreeTableColumn<>("NestedCol " + i);
+            nestedCol.setMinWidth(100);
+            nestedCol.setMaxWidth(100);
+            column.getColumns().add(nestedCol);
+        }
+        treeTableView.getColumns().add(column);
+
+        stageLoader = new StageLoader(treeTableView);
+
+        TableHeaderRow header = (TableHeaderRow) treeTableView.lookup("TableHeaderRow");
+        Node columnDragHeader = header.lookup(".column-drag-header");
+
+        assertEquals(0, columnDragHeader.getTranslateX());
+
+        NestedTableColumnHeader nestedTableColumnHeader =
+                (NestedTableColumnHeader) header.getRootHeader().getColumnHeaders().get(2);
+        TableColumnHeader tableColumnHeader = nestedTableColumnHeader.getColumnHeaders().get(0);
+
+        Bounds bounds = tableColumnHeader.localToScene(tableColumnHeader.getLayoutBounds());
+        TableColumnHeaderShim.columnReordering(tableColumnHeader, bounds.getMinX() + 20, bounds.getMinY());
+
+        // 200, since we have 2 columns to the left with a size of 100.
+        assertEquals(220, columnDragHeader.getTranslateX());
     }
 
     private static class CustomTreeTableViewSkin<S> extends TreeTableViewSkin<S> {


### PR DESCRIPTION
When a nested column is dragged, the column drag header (blue) is positioned wrong.
It appears at the very left of the table and not where the column is.

![image](https://github.com/openjdk/jfx/assets/66004280/6c2a0f61-f32d-4c38-9549-e2e20f5bd4f8)

The fix is to calculate the bound based off the `TableHeaderRow` (and not the parent `NestedTableColumnHeader`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320444](https://bugs.openjdk.org/browse/JDK-8320444): Column drag header is positioned wrong for nested columns (**Bug** - P4)


### Reviewers
 * [Karthik P K](https://openjdk.org/census#kpk) (@karthikpandelu - Committer)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1292/head:pull/1292` \
`$ git checkout pull/1292`

Update a local copy of the PR: \
`$ git checkout pull/1292` \
`$ git pull https://git.openjdk.org/jfx.git pull/1292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1292`

View PR using the GUI difftool: \
`$ git pr show -t 1292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1292.diff">https://git.openjdk.org/jfx/pull/1292.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1292#issuecomment-1819908818)