### PR TITLE
8314597: Deprecate for removal protected access methods in converters

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/util/converter/CurrencyStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/CurrencyStringConverter.java
@@ -89,8 +89,12 @@ public class CurrencyStringConverter extends NumberStringConverter {
         super(null, null, numberFormat);
     }
 
-    /** {@inheritDoc} */
-    @Override protected NumberFormat getNumberFormat() {
+    /**
+    * @deprecated This method was exposed erroneously and will be removed in a future version.
+    */
+    @Deprecated(forRemoval = true, since = "22")
+    @Override
+    protected NumberFormat getNumberFormat() {
         Locale _locale = locale == null ? Locale.getDefault() : locale;
 
         if (numberFormat != null) {

--- a/modules/javafx.base/src/main/java/javafx/util/converter/DateStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/DateStringConverter.java
@@ -126,8 +126,12 @@ public class DateStringConverter extends DateTimeStringConverter {
 
     // --------------------------------------------------------- Private Methods
 
-    /** {@inheritDoc} */
-    @Override protected DateFormat getDateFormat() {
+    /**
+     * @deprecated This method was exposed erroneously and will be removed in a future version.
+     */
+    @Deprecated(forRemoval = true, since = "22")
+    @Override
+    protected DateFormat getDateFormat() {
         DateFormat df = null;
 
         if (dateFormat != null) {

--- a/modules/javafx.base/src/main/java/javafx/util/converter/DateTimeStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/DateTimeStringConverter.java
@@ -191,7 +191,7 @@ public class DateTimeStringConverter extends StringConverter<Date> {
     // --------------------------------------------------------- Private Methods
 
     /**
-     * <p>Return a <code>DateFormat</code> instance to use for formatting
+     * <p>Returns a <code>DateFormat</code> instance to use for formatting
      * and parsing in this {@link StringConverter}.</p>
      *
      * @return a {@code DateFormat} instance for formatting and parsing in this

--- a/modules/javafx.base/src/main/java/javafx/util/converter/NumberStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/NumberStringConverter.java
@@ -141,7 +141,9 @@ public class NumberStringConverter extends StringConverter<Number> {
      *
      * @return a {@code NumberFormat} instance for formatting and parsing in this
      * {@code StringConverter}
+     * @deprecated This method was exposed erroneously and will be removed in a future version.
      */
+    @Deprecated(forRemoval = true, since = "22")
     protected NumberFormat getNumberFormat() {
         Locale _locale = locale == null ? Locale.getDefault() : locale;
 

--- a/modules/javafx.base/src/main/java/javafx/util/converter/PercentageStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/PercentageStringConverter.java
@@ -65,8 +65,12 @@ public class PercentageStringConverter extends NumberStringConverter {
         super(null, null, numberFormat);
     }
 
-    /** {@inheritDoc} */
-    @Override public NumberFormat getNumberFormat() {
+    /**
+     * @deprecated This method was exposed erroneously and will be removed in a future version.
+     */
+    @Deprecated(forRemoval = true, since = "22")
+    @Override
+    public NumberFormat getNumberFormat() {
         Locale _locale = locale == null ? Locale.getDefault() : locale;
 
         if (numberFormat != null) {

--- a/modules/javafx.base/src/main/java/javafx/util/converter/TimeStringConverter.java
+++ b/modules/javafx.base/src/main/java/javafx/util/converter/TimeStringConverter.java
@@ -127,8 +127,12 @@ public class TimeStringConverter extends DateTimeStringConverter {
 
     // --------------------------------------------------------- Private Methods
 
-    /** {@inheritDoc} */
-    @Override protected DateFormat getDateFormat() {
+    /**
+     * @deprecated This method was exposed erroneously and will be removed in a future version.
+     */
+    @Deprecated(forRemoval = true, since = "22")
+    @Override
+    protected DateFormat getDateFormat() {
         DateFormat df = null;
 
         if (dateFormat != null) {


### PR DESCRIPTION
Deprecating for removal `getDateFormat()` in `TimeStringConverter` and `DateStringConverter` after it was removed already in `DateTimeStringConverter`, and `getNumberFormat()` in `NumberStringConverter` (and subclasses).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))
- [x] Change requires CSR request [JDK-8320615](https://bugs.openjdk.org/browse/JDK-8320615) to be approved

### Issues
 * [JDK-8314597](https://bugs.openjdk.org/browse/JDK-8314597): Deprecate for removal protected access methods in converters (**Bug** - P4)
 * [JDK-8320615](https://bugs.openjdk.org/browse/JDK-8320615): Deprecate for removal protected access methods in converters (**CSR**)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1294/head:pull/1294` \
`$ git checkout pull/1294`

Update a local copy of the PR: \
`$ git checkout pull/1294` \
`$ git pull https://git.openjdk.org/jfx.git pull/1294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1294`

View PR using the GUI difftool: \
`$ git pr show -t 1294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1294.diff">https://git.openjdk.org/jfx/pull/1294.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1294#issuecomment-1821715804)