### PR TITLE
8320773: [macOS] All IME input blocked

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -799,8 +799,14 @@ static void inputDidChangeCallback(CFNotificationCenterRef center, void *observe
     [keyCodeForCharMap setObject:mapObject forKey:[event characters]];
     // getKeyCodeForChar should not just match against a character the user types
     // directly but any other character printed on the same key.
-    [keyCodeForCharMap setObject:mapObject forKey:[event charactersByApplyingModifiers: 0]];
-    [keyCodeForCharMap setObject:mapObject forKey:[event charactersByApplyingModifiers: NSEventModifierFlagShift]];
+    NSString* unshifted = GetStringForMacKey(event.keyCode, false);
+    if (unshifted != nil) {
+        [keyCodeForCharMap setObject:mapObject forKey:unshifted];
+    }
+    NSString* shifted = GetStringForMacKey(event.keyCode, true);
+    if (shifted != nil) {
+        [keyCodeForCharMap setObject:mapObject forKey:shifted];
+    }
     // On some European keyboards there are useful symbols which are only
     // accessible via the Option key. We don't query for the Option key
     // character because on most layouts just about every key has some

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassKey.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassKey.h
@@ -34,6 +34,7 @@ jint GetJavaKeyCodeFor(unsigned short keyCode);
 jint GetJavaKeyCode(NSEvent *event);
 jcharArray GetJavaKeyChars(JNIEnv *env, NSEvent *event);
 NSString* GetStringForJavaKey(jchar key);
+NSString* GetStringForMacKey(unsigned short keyCode, bool shifted);
 
 // for key event injection
 BOOL GetMacKey(jint javaKeyCode, unsigned short *outMacKeyCode);

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassKey.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassKey.m
@@ -600,6 +600,27 @@ NSString* GetStringForJavaKey(jchar jKeyCode) {
 
 }
 
+NSString* GetStringForMacKey(unsigned short keyCode, bool shifted)
+{
+    // Restrict to printable characters. UCKeyTranslate can produce
+    // odd results with keys like Home, Up Arrow, etc.
+    if (!macKeyCodeIsLayoutSensitive(keyCode)) return nil;
+
+    TISInputSourceRef keyboard = TISCopyCurrentKeyboardLayoutInputSource();
+    if (keyboard == NULL) return nil;
+
+    UInt32 modifiers = (shifted ? shiftKey : 0);
+    UniChar unicode[8];
+    UniCharCount length = queryKeyboard(keyboard, keyCode, modifiers, unicode, 8);
+    CFRelease(keyboard);
+
+    if (length == 1) {
+        return [NSString stringWithCharacters: &unicode[0] length: 1];
+    }
+
+    return nil;
+}
+
 /*
  * Class:     com_sun_glass_ui_mac_MacApplication
  * Method:    _getKeyCodeForChar

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
@@ -510,9 +510,9 @@
 - (void)keyDown:(NSEvent *)theEvent
 {
     KEYLOG("keyDown");
-    [GlassApplication registerKeyEvent:theEvent];
 
     if (![[self inputContext] handleEvent:theEvent] || shouldProcessKeyEvent) {
+        [GlassApplication registerKeyEvent:theEvent];
         [self->_delegate sendJavaKeyEvent:theEvent isDown:YES];
     }
     shouldProcessKeyEvent = YES;


### PR DESCRIPTION
The changes submitted in PR #1209 broke IME input on macOS 12 and 13 (at least on Apple Silicon). Calling charactersByApplyingModifiers on an NSEvent alters its state in some way that confuses NSTextInputContext.handleEvent. The result is that all key events are discarded if an IME is active. Apple fixed this bug in macOS 14 Sonoma.

In this PR we switch to using the same Carbon call that we started using in PR #425 (jfx21) to query the keyboard layout.

This is a new implementation of the fix for [JDK-8087700](https://bugs.openjdk.org/browse/JDK-8087700) so that bug will need to be re-tested.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8320773](https://bugs.openjdk.org/browse/JDK-8320773): [macOS] All IME input blocked (**Bug** - P1)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Jose Pereda](https://openjdk.org/census#jpereda) (@jperedadnr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1295/head:pull/1295` \
`$ git checkout pull/1295`

Update a local copy of the PR: \
`$ git checkout pull/1295` \
`$ git pull https://git.openjdk.org/jfx.git pull/1295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1295`

View PR using the GUI difftool: \
`$ git pr show -t 1295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1295.diff">https://git.openjdk.org/jfx/pull/1295.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1295#issuecomment-1828274938)