### PR TITLE
8320796: CssMetaData.combine()

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/css/CssMetaData.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CssMetaData.java
@@ -338,7 +338,7 @@ public abstract class CssMetaData<S extends Styleable, V> {
      *
      * @since 22
      */
-    public static List<CssMetaData<? extends Styleable, ?>> initStyleables(
+    public static List<CssMetaData<? extends Styleable, ?>> combine(
         List<CssMetaData<? extends Styleable, ?>> list,
         CssMetaData<? extends Styleable, ?>... items)
     {

--- a/modules/javafx.graphics/src/main/java/javafx/css/CssMetaData.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CssMetaData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package javafx.css;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javafx.scene.Node;
@@ -327,5 +328,26 @@ public abstract class CssMetaData<S extends Styleable, V> {
             .append("}").toString();
     }
 
-
+    /**
+     * Utility method which combines CssMetaData items in one unmodifiable list with the size equal to the number
+     * of items it holds (i.e. with no unnecessary overhead).
+     *
+     * @param list the css metadata items, usually from the parent, not nullable
+     * @param items the additional items
+     * @return the unmodifiable list containing all of the items
+     *
+     * @since 22
+     */
+    public static List<CssMetaData<? extends Styleable, ?>> initStyleables(
+        List<CssMetaData<? extends Styleable, ?>> list,
+        CssMetaData<? extends Styleable, ?>... items)
+    {
+        int sz = list.size() + items.length;
+        ArrayList<CssMetaData<? extends Styleable, ?>> rv = new ArrayList<>(sz);
+        rv.addAll(list);
+        for (CssMetaData<? extends Styleable, ?> p: items) {
+            rv.add(p);
+        }
+        return Collections.unmodifiableList(rv);
+    }
 }

--- a/modules/javafx.graphics/src/main/java/javafx/css/CssMetaData.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CssMetaData.java
@@ -329,12 +329,24 @@ public abstract class CssMetaData<S extends Styleable, V> {
     }
 
     /**
-     * Utility method which combines {@code CssMetaData} items in one unmodifiable list with size equal
-     * to the number of items it holds.
+     * Utility method which combines {@code CssMetaData} items in one immutable list.
+     * <p>
+     * The intended usage is to combine the parent and the child CSS meta data for
+     * the purposes of {@code getClassCssMetaData()} method, see for example {@link Node#getClassCssMetaData()}.
+     * <p>
+     * Example:
+     * <pre>
+     * private static final List&lt;CssMetaData&lt;? extends Styleable, ?>> STYLEABLES = CssMetaData.combine(
+     *      &lt;Parent>.getClassCssMetaData(),
+     *      STYLEABLE1,
+     *      STYLEABLE2
+     *  );
+     * </pre>
+     * This method returns an instance of {@link java.util.RandomAccess} interface.
      *
      * @param list the css metadata items, usually from the parent, must not be null
      * @param items the additional items
-     * @return the unmodifiable list containing all of the items
+     * @return the immutable list containing all of the items
      *
      * @since 22
      */

--- a/modules/javafx.graphics/src/main/java/javafx/css/CssMetaData.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CssMetaData.java
@@ -329,10 +329,10 @@ public abstract class CssMetaData<S extends Styleable, V> {
     }
 
     /**
-     * Utility method which combines CssMetaData items in one unmodifiable list with the size equal to the number
-     * of items it holds (i.e. with no unnecessary overhead).
+     * Utility method which combines {@code CssMetaData} items in one unmodifiable list with size equal
+     * to the number of items it holds.
      *
-     * @param list the css metadata items, usually from the parent, not nullable
+     * @param list the css metadata items, usually from the parent, must not be null
      * @param items the additional items
      * @return the unmodifiable list containing all of the items
      *

--- a/modules/javafx.graphics/src/main/java/javafx/css/CssMetaData.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CssMetaData.java
@@ -25,10 +25,10 @@
 
 package javafx.css;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javafx.scene.Node;
+import com.sun.javafx.UnmodifiableArrayList;
 
 /**
  * A CssMetaData instance provides information about the CSS style and
@@ -342,12 +342,9 @@ public abstract class CssMetaData<S extends Styleable, V> {
         List<CssMetaData<? extends Styleable, ?>> list,
         CssMetaData<? extends Styleable, ?>... items)
     {
-        int sz = list.size() + items.length;
-        ArrayList<CssMetaData<? extends Styleable, ?>> rv = new ArrayList<>(sz);
-        rv.addAll(list);
-        for (CssMetaData<? extends Styleable, ?> p: items) {
-            rv.add(p);
-        }
-        return Collections.unmodifiableList(rv);
+        CssMetaData[] combined = new CssMetaData[list.size() + items.length];
+        list.toArray(combined);
+        System.arraycopy(items, 0, combined, list.size(), items.length);
+        return new UnmodifiableArrayList<>(combined, combined.length);
     }
 }

--- a/modules/javafx.graphics/src/main/java/javafx/css/CssMetaData.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CssMetaData.java
@@ -331,32 +331,33 @@ public abstract class CssMetaData<S extends Styleable, V> {
     /**
      * Utility method which combines {@code CssMetaData} items in one immutable list.
      * <p>
-     * The intended usage is to combine the parent and the child CSS meta data for
+     * The intended usage is to combine the parent and the child {@code CssMetaData} for
      * the purposes of {@code getClassCssMetaData()} method, see for example {@link Node#getClassCssMetaData()}.
      * <p>
      * Example:
-     * <pre>
-     * private static final List&lt;CssMetaData&lt;? extends Styleable, ?>> STYLEABLES = CssMetaData.combine(
-     *      &lt;Parent>.getClassCssMetaData(),
+     * <pre>{@code
+     * private static final List<CssMetaData<? extends Styleable, ?>> STYLEABLES = CssMetaData.combine(
+     *      <Parent>.getClassCssMetaData(),
      *      STYLEABLE1,
      *      STYLEABLE2
      *  );
-     * </pre>
-     * This method returns an instance of {@link java.util.RandomAccess} interface.
+     * }</pre>
+     * This method returns an instance of a {@code List} that implements
+     * {@link java.util.RandomAccess} interface.
      *
-     * @param list the css metadata items, usually from the parent, must not be null
+     * @param inheritedFromParent the {@code CssMetaData} items inherited from parent, must not be null
      * @param items the additional items
      * @return the immutable list containing all of the items
      *
      * @since 22
      */
     public static List<CssMetaData<? extends Styleable, ?>> combine(
-        List<CssMetaData<? extends Styleable, ?>> list,
+        List<CssMetaData<? extends Styleable, ?>> inheritedFromParent,
         CssMetaData<? extends Styleable, ?>... items)
     {
-        CssMetaData[] combined = new CssMetaData[list.size() + items.length];
-        list.toArray(combined);
-        System.arraycopy(items, 0, combined, list.size(), items.length);
+        CssMetaData[] combined = new CssMetaData[inheritedFromParent.size() + items.length];
+        inheritedFromParent.toArray(combined);
+        System.arraycopy(items, 0, combined, inheritedFromParent.size(), items.length);
         return new UnmodifiableArrayList<>(combined, combined.length);
     }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/CssMetaDataTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/CssMetaDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1329,4 +1329,25 @@ public class CssMetaDataTest {
                 };
     }
 
+    @Test
+    public void testInitStyleables() {
+        CssMetaData<? extends Styleable, ?> css0 = get(Node.getClassCssMetaData(), "-fx-opacity");
+        CssMetaData<? extends Styleable, ?> css1 = get(Node.getClassCssMetaData(), "-fx-rotate");
+        CssMetaData<? extends Styleable, ?> css2 = get(Node.getClassCssMetaData(), "-fx-focus-traversable");
+        CssMetaData<? extends Styleable, ?> css3 = get(Node.getClassCssMetaData(), "-fx-effect");
+
+        List<CssMetaData<? extends Styleable, ?>> list = List.of(css0, css1);
+
+        List<CssMetaData<? extends Styleable, ?>> rv = CssMetaData.initStyleables(list, css2, css3);
+        assertEquals(4, rv.size());
+        assertSame(css0, rv.get(0));
+        assertSame(css1, rv.get(1));
+        assertSame(css2, rv.get(2));
+        assertSame(css3, rv.get(3));
+
+        rv = CssMetaData.initStyleables(List.of(), css0, css1);
+        assertEquals(2, rv.size());
+        assertSame(css0, rv.get(0));
+        assertSame(css1, rv.get(1));
+    }
 }

--- a/modules/javafx.graphics/src/test/java/test/javafx/css/CssMetaDataTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/css/CssMetaDataTest.java
@@ -1330,7 +1330,7 @@ public class CssMetaDataTest {
     }
 
     @Test
-    public void testInitStyleables() {
+    public void testCombine() {
         CssMetaData<? extends Styleable, ?> css0 = get(Node.getClassCssMetaData(), "-fx-opacity");
         CssMetaData<? extends Styleable, ?> css1 = get(Node.getClassCssMetaData(), "-fx-rotate");
         CssMetaData<? extends Styleable, ?> css2 = get(Node.getClassCssMetaData(), "-fx-focus-traversable");
@@ -1338,14 +1338,14 @@ public class CssMetaDataTest {
 
         List<CssMetaData<? extends Styleable, ?>> list = List.of(css0, css1);
 
-        List<CssMetaData<? extends Styleable, ?>> rv = CssMetaData.initStyleables(list, css2, css3);
+        List<CssMetaData<? extends Styleable, ?>> rv = CssMetaData.combine(list, css2, css3);
         assertEquals(4, rv.size());
         assertSame(css0, rv.get(0));
         assertSame(css1, rv.get(1));
         assertSame(css2, rv.get(2));
         assertSame(css3, rv.get(3));
 
-        rv = CssMetaData.initStyleables(List.of(), css0, css1);
+        rv = CssMetaData.combine(List.of(), css0, css1);
         assertEquals(2, rv.size());
         assertSame(css0, rv.get(0));
         assertSame(css1, rv.get(1));


### PR DESCRIPTION
Provide a public utility method for use by custom and core Nodes to simplify boilerplate around styleable properties as well as to save some memory.

```
    /**
     * Utility method which combines {@code CssMetaData} items in one immutable list.
     * <p>
     * The intended usage is to combine the parent and the child CSS meta data for
     * the purposes of {@code getClassCssMetaData()} method, see for example {@link Node#getClassCssMetaData()}.
     * <p>
     * Example:
     * <pre>
     * private static final List&lt;CssMetaData&lt;? extends Styleable, ?>> STYLEABLES = CssMetaData.combine(
     *      &lt;Parent>.getClassCssMetaData(),
     *      STYLEABLE1,
     *      STYLEABLE2
     *  );
     * </pre>
     * This method returns an instance of {@link java.util.RandomAccess} interface.
     *
     * @param list the css metadata items, usually from the parent, must not be null
     * @param items the additional items
     * @return the immutable list containing all of the items
     *
     * @since 22
     */
    public static List<CssMetaData<? extends Styleable, ?>> combine(
        List<CssMetaData<? extends Styleable, ?>> list,
        CssMetaData<? extends Styleable, ?>... items)
```

Problem(s):

- the same less-than-optimal implementation is duplicated throughout the javafx code base which combines the parent and child styleable properties, using ArrayList wrapped in a  Collections.unmodifiableList()
- the capacity of underlying ArrayList might exceed the number of items, wasting memory
- a potential exists for the custom component developer to inadvertently create a sub-standard implementation (i.e. return a List which does not implement RandomAccess interface), or forget to include parent's styleables.

Non-Goals:

- not redesigning the lazy initialization of STYLEABLES list
- not changing the way styleables are enumerated in Nodes and Controls
- not adding any new methods to JDK (collections)

To Be Discussed:

- it is not clear whether the order of styleables returned by <N extends Node>.getClassCssMetaData() is of any importance
- the current spec for Node.getCssMetaData() specifies the return value as "The CssMetaData associated with this node, which may include the CssMetaData of its superclasses.", implying that it may or may not include.  It is unclear whether it must include the parent's styleables (well, except the Node whose superclass is Object and thus has no styleable properties).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8320936](https://bugs.openjdk.org/browse/JDK-8320936) to be approved
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8320796](https://bugs.openjdk.org/browse/JDK-8320796): CssMetaData.combine() (**Enhancement** - P4)
 * [JDK-8320936](https://bugs.openjdk.org/browse/JDK-8320936): CssMetaData.combine() (**CSR**)


### Reviewers
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer) 🔄 Re-review required (review applies to [8987a125](https://git.openjdk.org/jfx/pull/1296/files/8987a125dd256eece60f754af073fd2831ded3db))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1296/head:pull/1296` \
`$ git checkout pull/1296`

Update a local copy of the PR: \
`$ git checkout pull/1296` \
`$ git pull https://git.openjdk.org/jfx.git pull/1296/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1296`

View PR using the GUI difftool: \
`$ git pr show -t 1296`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1296.diff">https://git.openjdk.org/jfx/pull/1296.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1296#issuecomment-1828481139)