### PR TITLE
8321573: Improve Platform.Preferences documentation

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -470,10 +470,9 @@ public final class Platform {
      * always available.
      * <p>
      * The following preferences are potentially available on the specified platforms:
-     * <table id="preferences-table">
-     *     <caption>List of platform preferences</caption>
+     * <table id="preferences-table" class="striped">
+     *     <caption>Windows</caption>
      *     <tbody>
-     *         <tr><th colspan="2" scope="colgroup">Windows</th></tr>
      *         <tr><td>{@code Windows.SPI.HighContrast}</td><td>{@link Boolean}</td></tr>
      *         <tr><td>{@code Windows.SPI.HighContrastColorScheme}</td><td>{@link String}</td></tr>
      *         <tr><td>{@code Windows.SysColor.COLOR_3DFACE}</td><td>{@link Color}</td></tr>
@@ -494,7 +493,11 @@ public final class Platform {
      *         <tr><td>{@code Windows.UIColor.AccentLight2}</td><td>{@link Color}</td></tr>
      *         <tr><td>{@code Windows.UIColor.AccentLight3}</td><td>{@link Color}</td></tr>
      *         <tr></tr>
-     *         <tr><th colspan="2" scope="colgroup">macOS</th></tr>
+     *     </tbody>
+     * </table>
+     * <table class="striped">
+     *     <caption>macOS</caption>
+     *     <tbody>
      *         <tr><td>{@code macOS.NSColor.labelColor}</td><td>{@link Color}</td></tr>
      *         <tr><td>{@code macOS.NSColor.secondaryLabelColor}</td><td>{@link Color}</td></tr>
      *         <tr><td>{@code macOS.NSColor.tertiaryLabelColor}</td><td>{@link Color}</td></tr>
@@ -542,7 +545,11 @@ public final class Platform {
      *         <tr><td>{@code macOS.NSColor.systemTealColor}</td><td>{@link Color}</td></tr>
      *         <tr><td>{@code macOS.NSColor.systemYellowColor}</td><td>{@link Color}</td></tr>
      *         <tr></tr>
-     *         <tr><th colspan="2" scope="colgroup">Linux</th></tr>
+     *     </tbody>
+     * </table>
+     * <table class="striped">
+     *     <caption>Linux</caption>
+     *     <tbody>
      *         <tr><td>{@code GTK.theme_name}</td><td>{@link String}</td></tr>
      *         <tr><td>{@code GTK.theme_fg_color}</td><td>{@link Color}</td></tr>
      *         <tr><td>{@code GTK.theme_bg_color}</td><td>{@link Color}</td></tr>
@@ -572,8 +579,9 @@ public final class Platform {
 
         /**
          * The platform color scheme, which specifies whether applications should prefer light text on
-         * dark backgrounds, or dark text on light backgrounds. The value of this property defaults to
-         * {@link ColorScheme#LIGHT} if the platform does not report color preferences.
+         * dark backgrounds, or dark text on light backgrounds.
+         * <p>
+         * If the platform does not report color preferences, this property defaults to {@link ColorScheme#LIGHT}.
          *
          * @return the {@code colorScheme} property
          * @defaultValue {@link ColorScheme#LIGHT}
@@ -585,7 +593,7 @@ public final class Platform {
         /**
          * The color used for background regions.
          * <p>
-         * If the platform does not report a background color, this property defaults to {@code Color.WHITE}.
+         * If the platform does not report a background color, this property defaults to {@link Color#WHITE}.
          *
          * @return the {@code backgroundColor} property
          * @defaultValue {@link Color#WHITE}
@@ -597,19 +605,19 @@ public final class Platform {
         /**
          * The color used for foreground elements like text.
          * <p>
-         * If the platform does not report a foreground color, this property defaults to {@code Color.BLACK}.
+         * If the platform does not report a foreground color, this property defaults to {@link Color#BLACK}.
          *
          * @return the {@code foregroundColor} property
-         * @defaultValue {@code Color.BLACK}
+         * @defaultValue {@link Color#BLACK}
          */
         ReadOnlyObjectProperty<Color> foregroundColorProperty();
 
         Color getForegroundColor();
 
         /**
-         * The accent color, which is usually a vivid color that contrasts with the foreground
-         * and background colors. It can be used to highlight the active or important part of a
-         * control and make it stand out from the rest of the user interface.
+         * The accent color, which can be used to highlight the active or important part of a
+         * control and make it stand out from the rest of the user interface. It is usually a
+         * vivid color that contrasts with the foreground and background colors.
          * <p>
          * If the platform does not report an accent color, this property defaults to vivid blue
          * (corresponding to the hex color value {@code #157EFB}).

--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -607,7 +607,9 @@ public final class Platform {
         Color getForegroundColor();
 
         /**
-         * The accent color.
+         * The accent color, which is usually a vivid color that contrasts with the foreground
+         * and background colors. It can be used to highlight the active or important part of a
+         * control and make it stand out from the rest of the user interface.
          * <p>
          * If the platform does not report an accent color, this property defaults to vivid blue
          * (corresponding to the hex color value {@code #157EFB}).

--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -445,7 +445,9 @@ public final class Platform {
      * by JavaFX when the operating system reports that a platform preference has changed.
      *
      * @return the {@code Preferences} instance
-     * @see <a href="Platform.Preferences.html#preferences-table">List of platform preferences</a>
+     * @see <a href="Platform.Preferences.html#preferences-table-windows">Windows preferences</a>
+     * @see <a href="Platform.Preferences.html#preferences-table-macos">macOS preferences</a>
+     * @see <a href="Platform.Preferences.html#preferences-table-linux">Linux preferences</a>
      * @since 22
      */
     public static Preferences getPreferences() {
@@ -470,7 +472,7 @@ public final class Platform {
      * always available.
      * <p>
      * The following preferences are potentially available on the specified platforms:
-     * <table id="preferences-table" class="striped">
+     * <table id="preferences-table-windows" class="striped">
      *     <caption>Windows</caption>
      *     <tbody>
      *         <tr><td>{@code Windows.SPI.HighContrast}</td><td>{@link Boolean}</td></tr>
@@ -495,7 +497,7 @@ public final class Platform {
      *         <tr></tr>
      *     </tbody>
      * </table>
-     * <table class="striped">
+     * <table id="preferences-table-macos" class="striped">
      *     <caption>macOS</caption>
      *     <tbody>
      *         <tr><td>{@code macOS.NSColor.labelColor}</td><td>{@link Color}</td></tr>
@@ -547,7 +549,7 @@ public final class Platform {
      *         <tr></tr>
      *     </tbody>
      * </table>
-     * <table class="striped">
+     * <table id="preferences-table-linux" class="striped">
      *     <caption>Linux</caption>
      *     <tbody>
      *         <tr><td>{@code GTK.theme_name}</td><td>{@link String}</td></tr>
@@ -581,7 +583,7 @@ public final class Platform {
          * The platform color scheme, which specifies whether applications should prefer light text on
          * dark backgrounds, or dark text on light backgrounds.
          * <p>
-         * If the platform does not report color preferences, this property defaults to {@link ColorScheme#LIGHT}.
+         * If the platform does not report color preferences, this property defaults to {@code LIGHT}.
          *
          * @return the {@code colorScheme} property
          * @defaultValue {@link ColorScheme#LIGHT}
@@ -593,7 +595,7 @@ public final class Platform {
         /**
          * The color used for background regions.
          * <p>
-         * If the platform does not report a background color, this property defaults to {@link Color#WHITE}.
+         * If the platform does not report a background color, this property defaults to {@code WHITE}.
          *
          * @return the {@code backgroundColor} property
          * @defaultValue {@link Color#WHITE}
@@ -605,7 +607,7 @@ public final class Platform {
         /**
          * The color used for foreground elements like text.
          * <p>
-         * If the platform does not report a foreground color, this property defaults to {@link Color#BLACK}.
+         * If the platform does not report a foreground color, this property defaults to {@code BLACK}.
          *
          * @return the {@code foregroundColor} property
          * @defaultValue {@link Color#BLACK}


### PR DESCRIPTION
This PR enhances the documentation of `Platform.Preferences.accentColor`:

```
   /**
-   * The accent color.
+   * The accent color, which can be used to highlight the active or important part of a
+   * control and make it stand out from the rest of the user interface. It is usually a
+   * vivid color that contrasts with the foreground and background colors.
```

Additional changes include alternating row colors for tables.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321573](https://bugs.openjdk.org/browse/JDK-8321573): Improve Platform.Preferences documentation (**Enhancement** - P4)


### Reviewers
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1301/head:pull/1301` \
`$ git checkout pull/1301`

Update a local copy of the PR: \
`$ git checkout pull/1301` \
`$ git pull https://git.openjdk.org/jfx.git pull/1301/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1301`

View PR using the GUI difftool: \
`$ git pr show -t 1301`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1301.diff">https://git.openjdk.org/jfx/pull/1301.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1301#issuecomment-1848278783)