### PR TITLE
8321626: [testbug] Mark DualWindowTest and ContextMenuNPETest unstable on Linux

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/ContextMenuNPETest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ContextMenuNPETest.java
@@ -51,6 +51,8 @@ import com.sun.javafx.PlatformUtil;
 
 import test.util.Util;
 
+import static org.junit.Assume.assumeTrue;
+
 /*
  * Test for verifying context menu NPE error
  *
@@ -107,6 +109,10 @@ public class ContextMenuNPETest {
 
     @Test
     public void testContextMenuNPE() throws Throwable {
+        if (PlatformUtil.isLinux()) {
+            assumeTrue(Boolean.getBoolean("unstable.test")); // JDK-8321625
+        }
+
         showMenuButtonContextMenu();
         selectSubmenuItem();
 

--- a/tests/system/src/test/java/test/robot/javafx/stage/DualWindowTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/DualWindowTest.java
@@ -27,6 +27,8 @@ package test.robot.javafx.stage;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -40,6 +42,8 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.robot.Robot;
 import javafx.stage.Stage;
 import javafx.stage.WindowEvent;
+
+import com.sun.javafx.PlatformUtil;
 
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -151,6 +155,10 @@ public class DualWindowTest {
 
     @Test
     public void testTwoStages() throws Exception {
+        if (PlatformUtil.isLinux()) {
+            assumeTrue(Boolean.getBoolean("unstable.test")); // JDK-8321624
+        }
+
         Util.sleep(1000);
         Util.runAndWait(() -> {
             assertEquals(STAGE1_X, stage1.getX(), 1.0);


### PR DESCRIPTION
Until JDK-8321624 and JDK-8321625 are fixed, mark the following two tests as unstable on Linux, meaning they will not be run as part of our nightly headful test runs.

DualWindowTest - [JDK-8321624](https://bugs.openjdk.org/browse/JDK-8321624)
ContextMenuNPETest - [JDK-8321625](https://bugs.openjdk.org/browse/JDK-8321625)

These two tests are causing a lot of noise in our CI headful test runs. By skipping these two tests, we get clean test runs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321626](https://bugs.openjdk.org/browse/JDK-8321626): [testbug] Mark DualWindowTest and ContextMenuNPETest unstable on Linux (**Bug** - P3)


### Reviewers
 * [Karthik P K](https://openjdk.org/census#kpk) (@karthikpandelu - Committer)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1302/head:pull/1302` \
`$ git checkout pull/1302`

Update a local copy of the PR: \
`$ git checkout pull/1302` \
`$ git pull https://git.openjdk.org/jfx.git pull/1302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1302`

View PR using the GUI difftool: \
`$ git pr show -t 1302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1302.diff">https://git.openjdk.org/jfx/pull/1302.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1302#issuecomment-1850062151)