### PR TITLE
8321636: [testbug] Skip failing 3D lighting tests on macOS 14 / aarch64

### DIFF
--- a/tests/system/src/test/java/test/robot/test3d/PointLightIlluminationTest.java
+++ b/tests/system/src/test/java/test/robot/test3d/PointLightIlluminationTest.java
@@ -31,6 +31,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.sun.javafx.PlatformUtil;
 import javafx.application.ConditionalFeature;
 import javafx.application.Platform;
 import javafx.scene.Group;
@@ -66,9 +67,17 @@ public class PointLightIlluminationTest extends VisualTestBase {
     private static final double COLOR_TOLERANCE    = 0.07;
     private static volatile Scene testScene = null;
 
+    // Used to skip failing tests until JDK-8318985 is fixed
+    private boolean isMacAarch64MacOS14;
+
     @Before
     public void setupEach() {
         assumeTrue(Platform.isSupported(ConditionalFeature.SCENE3D));
+        // JDK-8318985
+        isMacAarch64MacOS14 = PlatformUtil.isMac() &&
+                "aarch64".equals(System.getProperty("os.arch")) &&
+                System.getProperty("os.version") != null &&
+                System.getProperty("os.version").startsWith("14");
         // Use the same test scene for all tests
         if (testScene == null) {
             runAndWait(() -> {
@@ -94,6 +103,7 @@ public class PointLightIlluminationTest extends VisualTestBase {
 
     @Test(timeout = 15000)
     public void sphereUpperLeftPixelColorShouldBeDarkRed() {
+        assumeTrue(!isMacAarch64MacOS14); // JDK-8318985
         runAndWait(() -> {
             Color color = getColor(testScene, LEFT_CORNER_X, UPPER_CORNER_Y);
             assertColorEquals(Color.DARKRED, color, COLOR_TOLERANCE);
@@ -102,6 +112,7 @@ public class PointLightIlluminationTest extends VisualTestBase {
 
     @Test(timeout = 15000)
     public void sphereUpperRightPixelColorShouldBeDarkRed() {
+        assumeTrue(!isMacAarch64MacOS14); // JDK-8318985
         runAndWait(() -> {
             Color color = getColor(testScene, RIGHT_CORNER_X, UPPER_CORNER_Y);
             assertColorEquals(Color.DARKRED, color, COLOR_TOLERANCE);
@@ -110,6 +121,7 @@ public class PointLightIlluminationTest extends VisualTestBase {
 
     @Test(timeout = 15000)
     public void sphereLowerRightPixelColorShouldBeDarkRed() {
+        assumeTrue(!isMacAarch64MacOS14); // JDK-8318985
         runAndWait(() -> {
             Color color = getColor(testScene, RIGHT_CORNER_X, LOWER_CORNER_Y);
             assertColorEquals(Color.DARKRED, color, COLOR_TOLERANCE);
@@ -118,6 +130,7 @@ public class PointLightIlluminationTest extends VisualTestBase {
 
     @Test(timeout = 15000)
     public void sphereLowerLeftPixelColorShouldBeDarkRed() {
+        assumeTrue(!isMacAarch64MacOS14); // JDK-8318985
         runAndWait(() -> {
             Color color = getColor(testScene, LEFT_CORNER_X, LOWER_CORNER_Y);
             assertColorEquals(Color.DARKRED, color, COLOR_TOLERANCE);


### PR DESCRIPTION
Until [JDK-8318985](https://bugs.openjdk.org/browse/JDK-8318985) is fixed, we will skip the 4 failing 3D light tests on Mac / aarch64 if the macOS version is 14, meaning they will not be run as part of our nightly headful test runs or developer test build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321636](https://bugs.openjdk.org/browse/JDK-8321636): [testbug] Skip failing 3D lighting tests on macOS 14 / aarch64 (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1303/head:pull/1303` \
`$ git checkout pull/1303`

Update a local copy of the PR: \
`$ git checkout pull/1303` \
`$ git pull https://git.openjdk.org/jfx.git pull/1303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1303`

View PR using the GUI difftool: \
`$ git pr show -t 1303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1303.diff">https://git.openjdk.org/jfx/pull/1303.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1303#issuecomment-1850062752)