### PR TITLE
8321722: Tab header flickering when dragging slowly other tabs and reordering uncompleted

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TabPaneSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2143,7 +2143,7 @@ public class TabPaneSkin extends SkinBase<TabPane> {
         if (dragState == DragState.NONE) {
             return;
         }
-        int dragDirection;
+        int dragDirection = 0;
         double dragHeaderNewLayoutX;
         Bounds dragHeaderBounds;
         Bounds dropHeaderBounds;
@@ -2154,12 +2154,12 @@ public class TabPaneSkin extends SkinBase<TabPane> {
         if (dragDelta > 0) {
             // Dragging the tab header towards higher indexed tab headers inside headersRegion.
             dragDirection = MIN_TO_MAX;
-        } else {
+        } else if (dragDelta < 0) {
             // Dragging the tab header towards lower indexed tab headers inside headersRegion.
             dragDirection = MAX_TO_MIN;
         }
         // Stop dropHeaderAnim if direction of drag is changed
-        if (prevDragDirection != dragDirection) {
+        if (dragDirection != 0 && prevDragDirection != dragDirection) {
             stopAnim(dropHeaderAnim);
             prevDragDirection = dragDirection;
         }


### PR DESCRIPTION
This PR prevents changes in direction when dragging a tab header over a TabPane control, if delta value is zero, which can happen with slow drag events, in order to prevent starting and stopping too frequently the animation of the target tab header in opposite directions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8321722](https://bugs.openjdk.org/browse/JDK-8321722): Tab header flickering when dragging slowly other tabs and reordering uncompleted (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1304/head:pull/1304` \
`$ git checkout pull/1304`

Update a local copy of the PR: \
`$ git checkout pull/1304` \
`$ git pull https://git.openjdk.org/jfx.git pull/1304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1304`

View PR using the GUI difftool: \
`$ git pr show -t 1304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1304.diff">https://git.openjdk.org/jfx/pull/1304.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1304#issuecomment-1850675023)