### PR TITLE
8320965: Scrolling on a touch enabled display fails on Wayland

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.cpp
@@ -596,7 +596,13 @@ glass_gdk_mouse_devices_grab_with_cursor(GdkWindow *gdkWindow, GdkCursor *cursor
     if (disableGrab) {
         return TRUE;
     }
-
+#if GTK_CHECK_VERSION(3, 20, 0)
+    GdkGrabStatus status = wrapped_gdk_seat_grab(gdkWindow,
+            1 << 0 | 1 << 1 | 1 << 2 /* GDK_SEAT_CAPABILITY_ALL_POINTING */,
+            owner_events, cursor, NULL,
+            NULL /* GdkSeatGrabPrepareFunc */,
+            NULL);
+#else
     GdkGrabStatus status = gdk_pointer_grab(gdkWindow, owner_events, (GdkEventMask)
                                             (GDK_POINTER_MOTION_MASK
                                                 | GDK_POINTER_MOTION_HINT_MASK
@@ -607,13 +613,17 @@ glass_gdk_mouse_devices_grab_with_cursor(GdkWindow *gdkWindow, GdkCursor *cursor
                                                 | GDK_BUTTON_PRESS_MASK
                                                 | GDK_BUTTON_RELEASE_MASK),
                                             NULL, cursor, GDK_CURRENT_TIME);
-
+#endif
     return (status == GDK_GRAB_SUCCESS) ? TRUE : FALSE;
 }
 
 void
-glass_gdk_mouse_devices_ungrab() {
+glass_gdk_mouse_devices_ungrab(GdkWindow *gdkWindow) {
+#if GTK_CHECK_VERSION(3, 20, 0)
+    wrapped_gdk_seat_ungrab(gdkWindow);
+#else
     gdk_pointer_ungrab(GDK_CURRENT_TIME);
+#endif
 }
 
 void

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.h
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_general.h
@@ -317,7 +317,7 @@ gboolean
 glass_gdk_mouse_devices_grab_with_cursor(GdkWindow * gdkWindow, GdkCursor *cursor, gboolean owner_events);
 
 void
-glass_gdk_mouse_devices_ungrab();
+glass_gdk_mouse_devices_ungrab(GdkWindow *gdkWindow);
 
 void
 glass_gdk_master_pointer_grab(GdkEvent *event, GdkWindow *window, GdkCursor *cursor);

--- a/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/glass_window.cpp
@@ -610,7 +610,7 @@ bool WindowContextBase::grab_mouse_drag_focus() {
 
 void WindowContextBase::ungrab_mouse_drag_focus() {
     WindowContextBase::sm_mouse_drag_window = NULL;
-    glass_gdk_mouse_devices_ungrab();
+    glass_gdk_mouse_devices_ungrab(gdk_window);
     if (WindowContextBase::sm_grab_window) {
         WindowContextBase::sm_grab_window->grab_focus();
     }
@@ -628,7 +628,7 @@ bool WindowContextBase::grab_focus() {
 
 void WindowContextBase::ungrab_focus() {
     if (!WindowContextBase::sm_mouse_drag_window) {
-        glass_gdk_mouse_devices_ungrab();
+        glass_gdk_mouse_devices_ungrab(gdk_window);
     }
     WindowContextBase::sm_grab_window = NULL;
 

--- a/modules/javafx.graphics/src/main/native-glass/gtk/wrapped.h
+++ b/modules/javafx.graphics/src/main/native-glass/gtk/wrapped.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,14 @@ gboolean wrapped_g_settings_schema_has_key (GSettingsSchema *schema, const gchar
 void wrapped_g_settings_schema_unref (GSettingsSchema *schema);
 
 void wrapped_gdk_x11_display_set_window_scale (GdkDisplay *display, gint scale);
+
+GdkGrabStatus wrapped_gdk_seat_grab(GdkWindow* window,
+                            int capabilities /* GdkSeatCapabilities capabilities */,
+                            gboolean owner_events, GdkCursor* cursor, const GdkEvent* event,
+                            void * prepare_func /* GdkSeatGrabPrepareFunc prepare_func */,
+                            gpointer prepare_func_data);
+
+void wrapped_gdk_seat_ungrab(GdkWindow* window);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR replaces the deprecated `gdk_pointer_grab` with `gdk_seat_grab`, and `gdk_pointer_ungrab ` with `gdk_seat_ungrab`, using runtime checks and wrapped functions for GTK 3.20+ (so systems without it still run with GTK 3.8+), and fixes the dragging issue on Wayland.
