### PR TITLE
8321970: New table columns don't appear when using fixed cell size unless refreshing tableView

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableRowSkinBase.java
@@ -539,7 +539,8 @@ public abstract class TableRowSkinBase<T,
                 }
             }
             getChildren().removeAll(toRemove);
-        } else if (resetChildren || cellsEmpty) {
+        }
+        if (resetChildren || cellsEmpty) {
             getChildren().setAll(cells);
         }
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableRowSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableRowSkinTest.java
@@ -26,10 +26,12 @@
 package test.javafx.scene.control.skin;
 
 import com.sun.javafx.tk.Toolkit;
+import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
 import javafx.scene.Node;
+import javafx.scene.Scene;
 import javafx.scene.control.IndexedCell;
 import javafx.scene.control.Skin;
 import javafx.scene.control.TableCell;
@@ -82,7 +84,7 @@ public class TableRowSkinTest {
 
         tableView.setItems(items);
 
-        stageLoader = new StageLoader(tableView);
+        stageLoader = new StageLoader(new Scene(tableView));
         firstColumnHeader = VirtualFlowTestUtils.getTableColumnHeader(tableView, firstNameCol);
     }
 
@@ -314,6 +316,27 @@ public class TableRowSkinTest {
     @Test
     public void invisibleColumnsShouldRemoveCorrespondingCellsInRow() {
         invisibleColumnsShouldRemoveCorrespondingCellsInRowImpl();
+    }
+
+    /**
+     * The {@link TableRowSkin} should add new cells after new columns are added.
+     * See: JDK-8321970
+     */
+    @Test
+    public void cellsShouldBeAddedInRowFixedCellSize() {
+        tableView.setFixedCellSize(24);
+
+        TableColumn<Person, String> otherColumn = new TableColumn<>("other");
+        otherColumn.setPrefWidth(100);
+        otherColumn.setCellValueFactory(value -> new SimpleStringProperty("other"));
+        tableView.getColumns().add(otherColumn);
+
+        Toolkit.getToolkit().firePulse();
+        assertEquals(5, tableView.getColumns().size());
+
+        Toolkit.getToolkit().firePulse();
+        IndexedCell<?> row = VirtualFlowTestUtils.getCell(tableView, 1);
+        assertEquals(5, row.getChildrenUnmodifiable().stream().filter(TableCell.class::isInstance).count());
     }
 
     @After

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableRowSkinTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableRowSkinTest.java
@@ -31,7 +31,6 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
 import javafx.scene.Node;
-import javafx.scene.Scene;
 import javafx.scene.control.IndexedCell;
 import javafx.scene.control.Skin;
 import javafx.scene.control.TableCell;
@@ -84,7 +83,7 @@ public class TableRowSkinTest {
 
         tableView.setItems(items);
 
-        stageLoader = new StageLoader(new Scene(tableView));
+        stageLoader = new StageLoader(tableView);
         firstColumnHeader = VirtualFlowTestUtils.getTableColumnHeader(tableView, firstNameCol);
     }
 


### PR DESCRIPTION
This PR fixes an issue when a new `TableColumn` is added to a `TableView` control with fixed cell size set, where the `TableRowSkinBase` failed to add the cells for the new column.

A test is included that fails before applying this PR and passes with it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321970](https://bugs.openjdk.org/browse/JDK-8321970): New table columns don't appear when using fixed cell size unless refreshing tableView (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1308/head:pull/1308` \
`$ git checkout pull/1308`

Update a local copy of the PR: \
`$ git checkout pull/1308` \
`$ git pull https://git.openjdk.org/jfx.git pull/1308/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1308`

View PR using the GUI difftool: \
`$ git pr show -t 1308`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1308.diff">https://git.openjdk.org/jfx/pull/1308.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1308#issuecomment-1860333192)