### PR TITLE
8322215: [win] OS events that close the stage can cause Glass to reference freed memory

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/BaseWnd.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/BaseWnd.cpp
@@ -40,8 +40,8 @@ BaseWnd::BaseWnd(HWND ancestor) :
     m_wndClassAtom(0),
     m_isCommonDialogOwner(false),
     m_hCursor(NULL),
-    m_message_count(0),
-    m_dead(false)
+    m_messageCount(0),
+    m_isDead(false)
 {
 
 }
@@ -176,17 +176,17 @@ LRESULT CALLBACK BaseWnd::StaticWindowProc(HWND hWnd, UINT msg, WPARAM wParam, L
 void BaseWnd::BeginMessageProcessing(UINT msg)
 {
     if (msg == WM_NCDESTROY) {
-        m_dead = true;
+        m_isDead = true;
     }
-    m_message_count += 1;
+    m_messageCount += 1;
 }
 
 bool BaseWnd::EndMessageProcessing()
 {
-    if (m_message_count > 0) {
-        m_message_count -= 1;
+    if (m_messageCount > 0) {
+        m_messageCount -= 1;
     }
-    return m_dead && (m_message_count == 0);
+    return m_isDead && (m_messageCount == 0);
 }
 
 /*virtual*/

--- a/modules/javafx.graphics/src/main/native-glass/win/BaseWnd.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/BaseWnd.h
@@ -85,8 +85,8 @@ private:
     bool m_isCommonDialogOwner;
     HCURSOR m_hCursor;
 
-    LONG m_message_count;
-    bool m_dead;
+    LONG m_messageCount;
+    bool m_isDead;
 
 protected:
     virtual LRESULT WindowProc(UINT msg, WPARAM wParam, LPARAM lParam) = 0;

--- a/modules/javafx.graphics/src/main/native-glass/win/BaseWnd.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/BaseWnd.h
@@ -67,6 +67,12 @@ public:
 
     void SetCursor(HCURSOR cursor);
 
+    // Begin processing a message.
+    void BeginMessageProcessing(UINT msg);
+    // End processing a message. Returns 'true' if the BaseWnd should be
+    // deleted.
+    bool EndMessageProcessing();
+
 private:
     HWND m_hWnd;
     static LRESULT CALLBACK StaticWindowProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
@@ -78,6 +84,10 @@ private:
     ATOM m_wndClassAtom;
     bool m_isCommonDialogOwner;
     HCURSOR m_hCursor;
+
+    LONG m_message_count;
+    bool m_dead;
+
 protected:
     virtual LRESULT WindowProc(UINT msg, WPARAM wParam, LPARAM lParam) = 0;
     virtual MessageResult CommonWindowProc(UINT msg, WPARAM wParam, LPARAM lParam);


### PR DESCRIPTION
When a Stage is closed while processing an OS message the glass peer object is deleted immediately even if it's still executing member functions. As glass unwinds the stack and executes cleanup code it's referencing freed memory.

There are cases where glass generates JavaFX events back-to-back. For example, when handling the Delete key glass sends a PRESSED and TYPED event in the same routine. If the Stage is closed during the PRESSED event the code that sends the TYPED event is running inside an object that has already been deleted.

When the Stage is closed glass calls the OS routine ::DestroyWindow on the HWND causing a WM_NCDESTROY message to be sent. Currently the BaseWnd object is deleted when processing this message. This PR defers the destruction until all messages have been processed. This is the same approach used in the Linux code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8322215](https://bugs.openjdk.org/browse/JDK-8322215): [win] OS events that close the stage can cause Glass to reference freed memory (**Bug** - P3)


### Reviewers
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1309/head:pull/1309` \
`$ git checkout pull/1309`

Update a local copy of the PR: \
`$ git checkout pull/1309` \
`$ git pull https://git.openjdk.org/jfx.git pull/1309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1309`

View PR using the GUI difftool: \
`$ git pr show -t 1309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1309.diff">https://git.openjdk.org/jfx/pull/1309.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1309#issuecomment-1864875025)