### PR TITLE
8189282: JavaFX: Invalid position of candidate pop-up of InputMethod in Hi-DPI on Windows

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
@@ -674,12 +674,15 @@ class GlassViewEventHandler extends View.EventHandler {
         ret[0] = p2d.getX();
         ret[1] = p2d.getY();
 
-        for (Screen scr : Screen.getScreens()) {
-            Rectangle2D bounds = new Rectangle2D(scr.getX(), scr.getY(), scr.getWidth(), scr.getHeight());
-            if (bounds.contains(p2d)) {
-                ret[0] = scr.toPlatformX((float) p2d.getX());
-                ret[1] = scr.toPlatformY((float) p2d.getY());
-                break;
+        View view = scene.getPlatformView();
+        if (view != null) {
+            Window window = view.getWindow();
+            if (window != null) {
+                Screen screen = window.getScreen();
+                if (screen != null) {
+                    ret[0] = screen.toPlatformX((float) p2d.getX());
+                    ret[1] = screen.toPlatformY((float) p2d.getY());
+                }
             }
         }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
@@ -48,7 +48,6 @@ import javafx.collections.ObservableList;
 
 import javafx.event.EventType;
 import javafx.geometry.Point2D;
-import javafx.geometry.Rectangle2D;
 import javafx.scene.input.InputMethodEvent;
 import javafx.scene.input.InputMethodHighlight;
 import javafx.scene.input.InputMethodTextRun;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
@@ -48,6 +48,7 @@ import javafx.collections.ObservableList;
 
 import javafx.event.EventType;
 import javafx.geometry.Point2D;
+import javafx.geometry.Rectangle2D;
 import javafx.scene.input.InputMethodEvent;
 import javafx.scene.input.InputMethodHighlight;
 import javafx.scene.input.InputMethodTextRun;
@@ -669,12 +670,19 @@ class GlassViewEventHandler extends View.EventHandler {
     @Override
     public double[] getInputMethodCandidatePos(int offset) {
         Point2D p2d = scene.inputMethodRequests.getTextLocation(offset);
-        final Screen s = Screen.getMainScreen();
-        float pScaleX = (s == null) ? 1.0f : s.getPlatformScaleX();
-        float pScaleY = (s == null) ? 1.0f : s.getPlatformScaleY();
         double[] ret = new double[2];
-        ret[0] = p2d.getX() * pScaleX;
-        ret[1] = p2d.getY() * pScaleY;
+        ret[0] = p2d.getX();
+        ret[1] = p2d.getY();
+
+        for (Screen scr : Screen.getScreens()) {
+            Rectangle2D bounds = new Rectangle2D(scr.getX(), scr.getY(), scr.getWidth(), scr.getHeight());
+            if (bounds.contains(p2d)) {
+                ret[0] = scr.toPlatformX((float) p2d.getX());
+                ret[1] = scr.toPlatformY((float) p2d.getY());
+                break;
+            }
+        }
+
         return ret;
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
@@ -669,9 +669,13 @@ class GlassViewEventHandler extends View.EventHandler {
     @Override
     public double[] getInputMethodCandidatePos(int offset) {
         Point2D p2d = scene.inputMethodRequests.getTextLocation(offset);
+        final WindowStage w = scene.getWindowStage();
+        float pScaleX = (w == null) ? 1.0f : w.getPlatformScaleX();
+        float pScaleY = (w == null) ? 1.0f : w.getPlatformScaleY();
+        System.out.println("Scale x " + pScaleX + " y " + pScaleY);
         double[] ret = new double[2];
-        ret[0] = p2d.getX();
-        ret[1] = p2d.getY();
+        ret[0] = p2d.getX() * pScaleX;
+        ret[1] = p2d.getY() * pScaleY;
         return ret;
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
@@ -669,9 +669,9 @@ class GlassViewEventHandler extends View.EventHandler {
     @Override
     public double[] getInputMethodCandidatePos(int offset) {
         Point2D p2d = scene.inputMethodRequests.getTextLocation(offset);
-        final WindowStage w = scene.getWindowStage();
-        float pScaleX = (w == null) ? 1.0f : w.getPlatformScaleX();
-        float pScaleY = (w == null) ? 1.0f : w.getPlatformScaleY();
+        final Screen s = Screen.getMainScreen();
+        float pScaleX = (s == null) ? 1.0f : s.getPlatformScaleX();
+        float pScaleY = (s == null) ? 1.0f : s.getPlatformScaleY();
         double[] ret = new double[2];
         ret[0] = p2d.getX() * pScaleX;
         ret[1] = p2d.getY() * pScaleY;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/tk/quantum/GlassViewEventHandler.java
@@ -672,7 +672,6 @@ class GlassViewEventHandler extends View.EventHandler {
         final WindowStage w = scene.getWindowStage();
         float pScaleX = (w == null) ? 1.0f : w.getPlatformScaleX();
         float pScaleY = (w == null) ? 1.0f : w.getPlatformScaleY();
-        System.out.println("Scale x " + pScaleX + " y " + pScaleY);
         double[] ret = new double[2];
         ret[0] = p2d.getX() * pScaleX;
         ret[1] = p2d.getY() * pScaleY;


### PR DESCRIPTION
When reporting input method candidate position the code in GlassViewEventHandler is not applying the platform scale factors. This is causing incorrect IM positions to be reported to glass on hi-dpi monitors.

This PR a no-op on Mac since the platform scale factors are always 1.0. I don't think it affects the current Linux XIM code at all but XIM is so out-of-date it has become difficult to test. PR #1080 will replace the old XIM code and needs this fix to work properly on hi-dpi screens.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8189282](https://bugs.openjdk.org/browse/JDK-8189282): JavaFX: Invalid position of candidate pop-up of InputMethod in Hi-DPI on Windows (**Bug** - P3)
 * [JDK-8254126](https://bugs.openjdk.org/browse/JDK-8254126): the position of Chinese Input Method candidates window is wrong (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1311/head:pull/1311` \
`$ git checkout pull/1311`

Update a local copy of the PR: \
`$ git checkout pull/1311` \
`$ git pull https://git.openjdk.org/jfx.git pull/1311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1311`

View PR using the GUI difftool: \
`$ git pr show -t 1311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1311.diff">https://git.openjdk.org/jfx/pull/1311.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1311#issuecomment-1869661792)