### PR TITLE
8301893: IME window position is off on secondary screen

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
@@ -810,8 +810,10 @@
     IMLOG("firstRectForCharacterRange called %lu %lu",
           (unsigned long)theRange.location, (unsigned long)theRange.length);
     NSRect result = [self->_delegate getInputMethodCandidatePosRequest:0];
-    NSRect screenFrame = [[NSScreen mainScreen] frame];
-    result.origin.y = screenFrame.size.height - result.origin.y;
+    if (NSScreen.screens.count) {
+        NSRect screenFrame = NSScreen.screens[0].frame;
+        result.origin.y = screenFrame.size.height - result.origin.y;
+    }
     return result;
 }
 


### PR DESCRIPTION
The Mac screen coordinate system is inverted on the y-axis compared to JavaFX so glass needs to flip the y coordinate. IM coordinates are relative to the primary screen which is NSScreen.screens[0], not NSScreen.mainScreen (mainScreen is the screen that contains the window that has focus).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8301893](https://bugs.openjdk.org/browse/JDK-8301893): IME window position is off on secondary screen (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1313/head:pull/1313` \
`$ git checkout pull/1313`

Update a local copy of the PR: \
`$ git checkout pull/1313` \
`$ git pull https://git.openjdk.org/jfx.git pull/1313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1313`

View PR using the GUI difftool: \
`$ git pr show -t 1313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1313.diff">https://git.openjdk.org/jfx/pull/1313.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1313#issuecomment-1869831438)