### PR TITLE
JDK-8322795 CSS performance regression up to 10x

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
@@ -98,6 +98,7 @@ final public class SimpleSelector extends Selector {
      * styleClasses converted to a set of bit masks
      */
     private final Set<StyleClass> styleClassSet;
+    private final Set<StyleClass> unwrappedStyleClassSet;
 
     private final String id;
 
@@ -148,7 +149,7 @@ final public class SimpleSelector extends Selector {
         // then match needs to check name
         this.matchOnName = (name != null && !("".equals(name)) && !("*".equals(name)));
 
-        Set<StyleClass> scs = new StyleClassSet();
+        this.unwrappedStyleClassSet = new StyleClassSet();
 
         if (styleClasses != null) {
             for (int n = 0; n < styleClasses.size(); n++) {
@@ -156,11 +157,11 @@ final public class SimpleSelector extends Selector {
                 final String styleClassName = styleClasses.get(n);
                 if (styleClassName == null || styleClassName.isEmpty()) continue;
 
-                scs.add(StyleClassSet.getStyleClass(styleClassName));
+                unwrappedStyleClassSet.add(StyleClassSet.getStyleClass(styleClassName));
             }
         }
 
-        this.styleClassSet = Collections.unmodifiableSet(scs);
+        this.styleClassSet = Collections.unmodifiableSet(unwrappedStyleClassSet);
         this.matchOnStyleClass = (this.styleClassSet.size() > 0);
 
         PseudoClassState pcs = new PseudoClassState();
@@ -289,7 +290,8 @@ final public class SimpleSelector extends Selector {
     // This selector matches when class="pastoral blue aqua marine" but does not
     // match for class="pastoral blue".
     private boolean matchStyleClasses(StyleClassSet otherStyleClasses) {
-        return otherStyleClasses.containsAll(styleClassSet);
+        // checks against unwrapped version so BitSet can do its special casing for performance
+        return otherStyleClasses.containsAll(unwrappedStyleClassSet);
     }
 
     @Override public boolean equals(Object obj) {


### PR DESCRIPTION
The regression is caused by the `Collections.unmodifiableSet` wrapper not being recognized by `BitSet`, and a fall back is done to a less optimized version of `containsAll`.

As this is a regression fix, I've kept the fix as small as reasonable.  I'll provide a further optimized version as part of https://bugs.openjdk.org/browse/JDK-8322964 which eliminates the need for `BitSet` and `StyleClass` in the hot code paths which should result in a further CSS performance improvement.

I've tested this solution with the JFXCentral application locally and the regression seems resolved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8322795](https://bugs.openjdk.org/browse/JDK-8322795): CSS performance regression up to 10x (**Bug** - P3)


### Reviewers
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1314/head:pull/1314` \
`$ git checkout pull/1314`

Update a local copy of the PR: \
`$ git checkout pull/1314` \
`$ git pull https://git.openjdk.org/jfx.git pull/1314/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1314`

View PR using the GUI difftool: \
`$ git pr show -t 1314`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1314.diff">https://git.openjdk.org/jfx/pull/1314.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1314#issuecomment-1875727310)