### PR TITLE
HTTP2Loader with proxy enabled

### DIFF
--- a/modules/javafx.web/src/main/java/com/sun/webkit/network/HTTP2Loader.java
+++ b/modules/javafx.web/src/main/java/com/sun/webkit/network/HTTP2Loader.java
@@ -50,6 +50,7 @@ import java.net.http.HttpResponse.BodyHandler;
 import java.net.http.HttpResponse.BodySubscriber;
 import java.net.http.HttpResponse;
 import java.net.http.HttpTimeoutException;
+import java.net.ProxySelector;
 import java.nio.ByteBuffer;
 import java.security.AccessControlException;
 import java.security.AccessController;
@@ -97,6 +98,7 @@ final class HTTP2Loader extends URLLoaderBase {
                 .followRedirects(Redirect.NEVER) // WebCore handles redirection
                 .connectTimeout(Duration.ofSeconds(30)) // FIXME: Add a property to control the timeout
                 .cookieHandler(CookieHandler.getDefault())
+                .proxy(ProxySelector.getDefault())
                 .build());
     // Singleton instance of direct ByteBuffer to transfer downloaded bytes from
     // Java to native


### PR DESCRIPTION
There is a lack of proxy setting in http2 connection done in HTTP2Loader (which further does not allow proxy to be used in WebView)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1318/head:pull/1318` \
`$ git checkout pull/1318`

Update a local copy of the PR: \
`$ git checkout pull/1318` \
`$ git pull https://git.openjdk.org/jfx.git pull/1318/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1318`

View PR using the GUI difftool: \
`$ git pr show -t 1318`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1318.diff">https://git.openjdk.org/jfx/pull/1318.diff</a>

</details>
