### PR TITLE
8323077: C type error (incompatible function pointer) in X11GLContext.c

### DIFF
--- a/modules/javafx.graphics/src/main/native-prism-es2/x11/X11GLContext.c
+++ b/modules/javafx.graphics/src/main/native-prism-es2/x11/X11GLContext.c
@@ -275,7 +275,8 @@ JNIEXPORT jlong JNICALL Java_com_sun_prism_es2_X11GLContext_nInitialize
                 dlsym(RTLD_DEFAULT, "glXSwapIntervalSGI");
 
         if (ctxInfo->glXSwapIntervalSGI == NULL) {
-            ctxInfo->glXSwapIntervalSGI = glXGetProcAddress("glXSwapIntervalSGI");
+            ctxInfo->glXSwapIntervalSGI = (PFNGLXSWAPINTERVALSGIPROC)
+                glXGetProcAddress("glXSwapIntervalSGI");
         }
 
     }

--- a/modules/javafx.graphics/src/main/native-prism-es2/x11/X11GLContext.c
+++ b/modules/javafx.graphics/src/main/native-prism-es2/x11/X11GLContext.c
@@ -276,7 +276,7 @@ JNIEXPORT jlong JNICALL Java_com_sun_prism_es2_X11GLContext_nInitialize
 
         if (ctxInfo->glXSwapIntervalSGI == NULL) {
             ctxInfo->glXSwapIntervalSGI = (PFNGLXSWAPINTERVALSGIPROC)
-                glXGetProcAddress("glXSwapIntervalSGI");
+                glXGetProcAddress((const GLubyte *)"glXSwapIntervalSGI");
         }
 
     }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323077](https://bugs.openjdk.org/browse/JDK-8323077): C type error (incompatible function pointer) in X11GLContext.c (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1319/head:pull/1319` \
`$ git checkout pull/1319`

Update a local copy of the PR: \
`$ git checkout pull/1319` \
`$ git pull https://git.openjdk.org/jfx.git pull/1319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1319`

View PR using the GUI difftool: \
`$ git pr show -t 1319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1319.diff">https://git.openjdk.org/jfx/pull/1319.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1319#issuecomment-1879055303)