### PR TITLE
8323078: Incorrect length argument to g_utf8_strlen in pango.c

### DIFF
--- a/modules/javafx.graphics/src/main/native-font/pango.c
+++ b/modules/javafx.graphics/src/main/native-font/pango.c
@@ -424,7 +424,7 @@ JNIEXPORT jlong JNICALL OS_NATIVE(g_1utf8_1strlen)
     (JNIEnv *env, jclass that, jlong str, jlong pos)
 {
     if (!str) return 0;
-    return (jlong)g_utf8_strlen((const gchar *)str, (const gchar *)pos);
+    return (jlong)g_utf8_strlen((const gchar *)str, (gssize)pos);
 }
 
 JNIEXPORT jlong JNICALL OS_NATIVE(g_1utf16_1to_1utf8)


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323078](https://bugs.openjdk.org/browse/JDK-8323078): Incorrect length argument to g_utf8_strlen in pango.c (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1320/head:pull/1320` \
`$ git checkout pull/1320`

Update a local copy of the PR: \
`$ git checkout pull/1320` \
`$ git pull https://git.openjdk.org/jfx.git pull/1320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1320`

View PR using the GUI difftool: \
`$ git pr show -t 1320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1320.diff">https://git.openjdk.org/jfx/pull/1320.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1320#issuecomment-1879099332)