### PR TITLE
8221261: Deadlock on macOS in JFXPanel app when handling IME calls

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -61,6 +61,21 @@ static BOOL disableSyncRendering = NO;
 static BOOL firstActivation = YES;
 static BOOL shouldReactivate = NO;
 
+// Custom NSRunLoopMode constant that matches the one used by AWT in its
+// doAWTRunLoopImpl method. This is not formally documented, but there is
+// an open bug to do so. See https://bugs.openjdk.org/browse/JDK-8270211
+static NSString* JavaRunLoopMode = @"AWTRunLoopMode";
+
+// List of allowable runLoop modes that Java runnables can run in.
+// This is used when calling performSelectorOnMainThread from
+// the JNI _invokeAndWait and _submitForLaterInvocation methods.
+// We include JavaRunLoopMode in the list of allowable run modes in case
+// we are running on the AWT event thread. This will allow JavaFX
+// runnables to be scheduled when AWT is running doAWTRunLoopImpl
+// on the AppKit thread (which it does for IME callbacks) so that we
+// don't deadlock.
+static NSArray<NSString*> *runLoopModes = nil;
+
 #ifdef STATIC_BUILD
 jint JNICALL JNI_OnLoad_glass(JavaVM *vm, void *reserved)
 #else
@@ -568,6 +583,19 @@ jint JNICALL JNI_OnLoad(JavaVM *vm, void *reserved)
                 GLASS_CHECK_EXCEPTION(jEnv);
             }
         }
+
+        // List of RunLoopModes in which we will run runnables passed
+        // to _invokeAndWait and _invokeAndExit. This includes
+        // JavaRunLoopMode to avoid a possible deadlock with AWT.
+        // There is no harm always adding it, since it will have no
+        // effect if the run loop that receives this message does not
+        // specify it.
+        runLoopModes = [[NSArray alloc] initWithObjects:
+            NSDefaultRunLoopMode,
+            NSModalPanelRunLoopMode,
+            NSEventTrackingRunLoopMode,
+            JavaRunLoopMode,
+            nil];
 
         // Determine if we're running embedded (in AWT, SWT, elsewhere)
         NSApplication *app = [NSApplicationFX sharedApplication];
@@ -1080,7 +1108,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacApplication__1submitForLater
     if (jEnv != NULL)
     {
         GlassRunnable *runnable = [[GlassRunnable alloc] initWithRunnable:(*env)->NewGlobalRef(env, jRunnable)];
-        [runnable performSelectorOnMainThread:@selector(run) withObject:nil waitUntilDone:NO];
+        [runnable performSelectorOnMainThread:@selector(run) withObject:nil waitUntilDone:NO modes:runLoopModes];
     }
 }
 
@@ -1098,7 +1126,7 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacApplication__1invokeAndWait
     if (jEnv != NULL)
     {
         GlassRunnable *runnable = [[GlassRunnable alloc] initWithRunnable:(*env)->NewGlobalRef(env, jRunnable)];
-        [runnable performSelectorOnMainThread:@selector(run) withObject:nil waitUntilDone:YES];
+        [runnable performSelectorOnMainThread:@selector(run) withObject:nil waitUntilDone:YES modes:runLoopModes];
     }
 }
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -62,8 +62,8 @@ static BOOL firstActivation = YES;
 static BOOL shouldReactivate = NO;
 
 // Custom NSRunLoopMode constant that matches the one used by AWT in its
-// doAWTRunLoopImpl method. This is not formally documented, but there is
-// an open bug to do so. See https://bugs.openjdk.org/browse/JDK-8270211
+// doAWTRunLoopImpl method. This is not formally documented yet, but all
+// versions of the JDK use it. We might consider a request to document it.
 static NSString* JavaRunLoopMode = @"AWTRunLoopMode";
 
 // List of allowable runLoop modes that Java runnables can run in.


### PR DESCRIPTION
As described in the JBS bug, there is a long-standing deadlock that happens on macOS between the AWT EDT and the JavaFX Application thread (which on macOS is the AppKit thread) when processing Input Method Events (IME) in a WebView node in a JFXPanel.

This PR fixes the deadlock by adding `"AWTRunLoopMode"` to the list of modes that will accept the calls to `performSelectorOnMainThread` used by `_submitForLaterInvocation` and `_invokeAndWait`. These two native methods are the macOS implemention `runLater` and `runAndWait`, respectively, and are used to run Java Runnables on the JavaFX Application Thread.

This deadlock is happening much more often on recent macOS versions, and in macOS 14, pressing CAPS LOCK is sufficient to trigger IME calls.

The OS calls the AWT IME methods on the AppKit thread, which is also the JavaFX Application Thread. The AWT IME callback methods, for example `characterIndexForPoint`, call invokeAndWait to run the IME handler on the AWT Event thread. In the case of JFXPanel, the registered IME handler is in JavaFX code and we often need to run something on the JavaFX Application Thread to avoid threading problems or crashes. See [JDK-8196011](https://bugs.openjdk.org/browse/JDK-8196011) and [JDK-8322703](https://bugs.openjdk.org/browse/JDK-8322703).

A similar deadlock was observed while trying to fix a threading problem in JFXPanel's handling of  the IME calls as described in [JDK-8322784](https://bugs.openjdk.org/browse/JDK-8322784), so it isn't necessarily limited to using WebView.

Anton Tarasov @forantar proposed a fix (in a comment in the JBS bug) in AWT that would change the invokeAndWait calls used by the IME methods in CInputMethod to call `doAWTRunLoop` with the `processEvents` flag set to true, which will allow all events to be processed while in `doAWTRunLoop`.

NOTE: I had created Draft PR openjdk/jdk#17290 with Anton's proposed fix, expanded to cover all of the cases, but during the discussion it was pointed out that `doAWTRunLoop` should already be able to run selectors via `performSelectorOnMainThread` -- see [this comment](https://github.com/openjdk/jdk/pull/17290#issuecomment-1880001813). The reason `doAWTRunLoop` doesn't process our messages is that it runs the loop in a mode that only handles messages that include a custom `"AWTRunLoopMode"` mode.    
          
Adding `"AWTRunLoopMode"` to the `performSelectorOnMainThread` calls used by `_submitForLaterInvocation` and `_invokeAndWait` allows them to run when in `doAWTRunLoop` so there is no deadlock.

This is a better fix than the proposed fix in PR openjdk/jdk#17290 for two reasons. First, it is a more targeted fix. For example, it doesn't open the door for processing mouse events while in `doAWTRunLoop`. Second, by fixing it in JavaFX, we can fix additional threading bugs like [JDK-8322703](https://bugs.openjdk.org/browse/JDK-8322703) and [JDK-8322784](https://bugs.openjdk.org/browse/JDK-8322784) without worrying about introducing deadlocks if run on a JDK without the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8221261](https://bugs.openjdk.org/browse/JDK-8221261): Deadlock on macOS in JFXPanel app when handling IME calls (**Bug** - P2)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - no project role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1327/head:pull/1327` \
`$ git checkout pull/1327`

Update a local copy of the PR: \
`$ git checkout pull/1327` \
`$ git pull https://git.openjdk.org/jfx.git pull/1327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1327`

View PR using the GUI difftool: \
`$ git pr show -t 1327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1327.diff">https://git.openjdk.org/jfx/pull/1327.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1327#issuecomment-1885308253)