### PR TITLE
JDK-8323543: NPE when table items are set to null

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
@@ -1919,7 +1919,7 @@ public class TableView<S> extends Control {
     public Object queryAccessibleAttribute(AccessibleAttribute attribute, Object... parameters) {
         switch (attribute) {
             case COLUMN_COUNT: return getVisibleLeafColumns().size();
-            case ROW_COUNT: return getItems().size();
+            case ROW_COUNT: return getItems() != null ? getItems().size() : 0; //No items means no rows, so the count is zero
             case SELECTED_ITEMS: {
                 // TableViewSkin returns TableRows back to TableView.
                 // TableRowSkin returns TableCells back to TableRow.

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
@@ -1919,7 +1919,7 @@ public class TableView<S> extends Control {
     public Object queryAccessibleAttribute(AccessibleAttribute attribute, Object... parameters) {
         switch (attribute) {
             case COLUMN_COUNT: return getVisibleLeafColumns().size();
-            case ROW_COUNT: return getItems() != null ? getItems().size() : 0; //No items means no rows, so the count is zero
+            case ROW_COUNT: return getItems() != null ? getItems().size() : 0;
             case SELECTED_ITEMS: {
                 // TableViewSkin returns TableRows back to TableView.
                 // TableRowSkin returns TableCells back to TableRow.

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableSkinUtils.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableSkinUtils.java
@@ -204,15 +204,4 @@ class TableSkinUtils {
     public static boolean isConstrainedResizePolicy(Callback<? extends ResizeFeaturesBase, Boolean> x) {
         return (x instanceof ConstrainedColumnResizeBase);
     }
-
-    /** returns the number of visible rows in Tree/TableView */
-    public static int getItemCount(TableViewSkinBase<?,?,?,?,?> skin) {
-        Object control = skin.getSkinnable();
-        if (control instanceof TableView table) {
-            return table.getItems().size();
-        } else if (control instanceof TreeTableView tree) {
-            return tree.getExpandedItemCount();
-        }
-        return 0;
-    }
 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
@@ -906,7 +906,7 @@ public abstract class TableViewSkinBase<M, S, C extends Control, I extends Index
             contentWidth -= flow.getVbar().getWidth();
         }
 
-        if ((contentWidth <= 0) || (TableSkinUtils.getItemCount(this) == 0)) {
+        if ((contentWidth <= 0) || (getItemCount() == 0)) {
             // when there is no content in the TableView.
             Control c = getSkinnable();
             contentWidth = c.getWidth() - (snappedLeftInset() + snappedRightInset());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -25,6 +25,7 @@
 
 package test.javafx.scene.control;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.assertStyleClassContains;
 import static javafx.scene.control.TableColumn.SortType.ASCENDING;
 import static javafx.scene.control.TableColumn.SortType.DESCENDING;
@@ -6063,5 +6064,20 @@ public class TableViewTest {
 
         table.getSelectionModel().selectIndices(1, new int[]{1, 2});
         assertEquals(2, table.getSelectionModel().getSelectedIndex());
+    }
+
+    @Test
+    public void testTableItemsNullShouldNotThrow() {
+        final TableColumn<String, String> c = new TableColumn<>("C");
+        c.setCellValueFactory(value -> new SimpleStringProperty(value.getValue()));
+        table.getColumns().add(c);
+
+        table.getItems().addAll("1", "2", "3");
+
+        stageLoader = new StageLoader(table);
+        table.setItems(null);
+
+        assertDoesNotThrow(() -> Toolkit.getToolkit().firePulse());
+
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -6082,9 +6082,6 @@ public class TableViewTest {
 
     @Test
     public void testTableItemsNullQueryAcceessibleAttributeRowCountShouldNotThrow() {
-        table.getItems().addAll("1", "2", "3");
-
-        stageLoader = new StageLoader(table);
         table.setItems(null);
 
         assertDoesNotThrow(() -> table.queryAccessibleAttribute(AccessibleAttribute.ROW_COUNT));

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -25,7 +25,6 @@
 
 package test.javafx.scene.control;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.assertStyleClassContains;
 import static javafx.scene.control.TableColumn.SortType.ASCENDING;
 import static javafx.scene.control.TableColumn.SortType.DESCENDING;
@@ -6076,14 +6075,14 @@ public class TableViewTest {
 
         stageLoader = new StageLoader(table);
         table.setItems(null);
-
-        assertDoesNotThrow(() -> Toolkit.getToolkit().firePulse());
+        // Should not throw an NPE.
+        Toolkit.getToolkit().firePulse();
     }
 
     @Test
     public void testTableItemsNullQueryAcceessibleAttributeRowCountShouldNotThrow() {
         table.setItems(null);
-
-        assertDoesNotThrow(() -> table.queryAccessibleAttribute(AccessibleAttribute.ROW_COUNT));
+        // Should not throw an NPE.
+        table.queryAccessibleAttribute(AccessibleAttribute.ROW_COUNT);
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -6078,6 +6078,15 @@ public class TableViewTest {
         table.setItems(null);
 
         assertDoesNotThrow(() -> Toolkit.getToolkit().firePulse());
+    }
 
+    @Test
+    public void testTableItemsNullQueryAcceessibleAttributeRowCountShouldNotThrow() {
+        table.getItems().addAll("1", "2", "3");
+
+        stageLoader = new StageLoader(table);
+        table.setItems(null);
+
+        assertDoesNotThrow(() -> table.queryAccessibleAttribute(AccessibleAttribute.ROW_COUNT));
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -7269,6 +7269,5 @@ public class TreeTableViewTest {
         treeTableView.setRoot(null);
 
         assertDoesNotThrow(() -> Toolkit.getToolkit().firePulse());
-
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -36,7 +36,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.assertStyleClassContains;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -7267,14 +7266,14 @@ public class TreeTableViewTest {
 
         stageLoader = new StageLoader(treeTableView);
         treeTableView.setRoot(null);
-
-        assertDoesNotThrow(() -> Toolkit.getToolkit().firePulse());
+        // Should not throw an NPE.
+        Toolkit.getToolkit().firePulse();
     }
 
     @Test
     public void testTreeTableRootNullQueryAcceessibleAttributeRowCountShouldNotThrow() {
         treeTableView.setRoot(null);
-
-        assertDoesNotThrow(() -> treeTableView.queryAccessibleAttribute(AccessibleAttribute.ROW_COUNT));
+        // Should not throw an NPE.
+        treeTableView.queryAccessibleAttribute(AccessibleAttribute.ROW_COUNT);
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -7270,4 +7270,11 @@ public class TreeTableViewTest {
 
         assertDoesNotThrow(() -> Toolkit.getToolkit().firePulse());
     }
+
+    @Test
+    public void testTreeTableRootNullQueryAcceessibleAttributeRowCountShouldNotThrow() {
+        treeTableView.setRoot(null);
+
+        assertDoesNotThrow(() -> treeTableView.queryAccessibleAttribute(AccessibleAttribute.ROW_COUNT));
+    }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.assertStyleClassContains;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -45,6 +46,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
+import javafx.scene.control.TableColumn;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -7249,5 +7252,27 @@ public class TreeTableViewTest {
 
         treeTableView.getSelectionModel().selectIndices(1, new int[]{1, 2});
         assertEquals(2, treeTableView.getSelectionModel().getSelectedIndex());
+    }
+
+    @Test
+    public void testTableItemsNullShouldNotThrow() {
+        TreeTableColumn<String, String> c = new TreeTableColumn<>("C");
+        c.setCellValueFactory(value -> new SimpleStringProperty(value.getValue().getValue()));
+        treeTableView.getColumns().add(c);
+
+        treeTableView.setRoot(new TreeItem<String>("Root"));
+        if(treeTableView.getRoot() != null) {
+            treeTableView.getRoot().setExpanded(true);
+        }
+        for (int i = 0; i < 4; i++) {
+            TreeItem<String> parent = new TreeItem<String>("item - " + i);
+            treeTableView.getRoot().getChildren().add(parent);
+        }
+
+        stageLoader = new StageLoader(treeTableView);
+        treeTableView.setRoot(null);
+
+        assertDoesNotThrow(() -> Toolkit.getToolkit().firePulse());
+
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -46,8 +46,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import javafx.scene.control.TableColumn;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -7255,15 +7253,13 @@ public class TreeTableViewTest {
     }
 
     @Test
-    public void testTableItemsNullShouldNotThrow() {
+    public void testRootNullShouldNotThrow() {
         TreeTableColumn<String, String> c = new TreeTableColumn<>("C");
         c.setCellValueFactory(value -> new SimpleStringProperty(value.getValue().getValue()));
         treeTableView.getColumns().add(c);
 
         treeTableView.setRoot(new TreeItem<String>("Root"));
-        if(treeTableView.getRoot() != null) {
-            treeTableView.getRoot().setExpanded(true);
-        }
+        treeTableView.getRoot().setExpanded(true);
         for (int i = 0; i < 4; i++) {
             TreeItem<String> parent = new TreeItem<String>("item - " + i);
             treeTableView.getRoot().getChildren().add(parent);


### PR DESCRIPTION
This PR fixes a nullpointer in TableSkinUtils that occured when the Tables items were null.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8323543](https://bugs.openjdk.org/browse/JDK-8323543): NPE when table items are set to null (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1329/head:pull/1329` \
`$ git checkout pull/1329`

Update a local copy of the PR: \
`$ git checkout pull/1329` \
`$ git pull https://git.openjdk.org/jfx.git pull/1329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1329`

View PR using the GUI difftool: \
`$ git pr show -t 1329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1329.diff">https://git.openjdk.org/jfx/pull/1329.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1329#issuecomment-1885444337)