### PR TITLE
JDK-8323615: PopupControl.skin.setSkin(Skin) fails to call dispose() on discarded Skin

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/PopupControl.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/PopupControl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -212,18 +212,6 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
         // only needed because invalidated() does not currently take
         // a reference to the old value.
         private Skin<?> oldValue;
-
-        @Override
-        public void set(Skin<?> v) {
-
-            if (v == null
-                    ? oldValue == null
-                    : oldValue != null && v.getClass().equals(oldValue.getClass()))
-                return;
-
-            super.set(v);
-
-        }
 
         @Override protected void invalidated() {
             Skin<?> skin = get();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/PopupControlTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/PopupControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,10 @@ import javafx.scene.control.Tooltip;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.lang.ref.WeakReference;
+
 import static org.junit.Assert.*;
+import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory.attemptGC;
 
 /**
  *
@@ -649,5 +652,30 @@ public class PopupControlTest {
     }
 
     //TODO: test computePref____ methods
+
+    /**
+     * Set a skin -> set another instance of the same skin (class).
+     */
+    @Test
+    public void testMemoryLeakSameSkinClass() {
+        popup.setSkin(new PopupControlSkin<>());
+        Skin<?> skin = popup.getSkin();
+        popup.setSkin(new PopupControlSkin<>());
+
+        WeakReference<?> weakRef = new WeakReference<>(skin);
+        skin = null;
+        attemptGC(weakRef);
+        assertNull("Unused Skin must be gc'ed", weakRef.get());
+    }
+
+    @Test
+    public void testSetSkinOfSameClass() {
+        popup.setSkin(new PopupControlSkin<>());
+        Skin<?> oldSkin = popup.getSkin();
+        popup.setSkin(new PopupControlSkin<>());
+        Skin<?> newSkin = popup.getSkin();
+
+        assertNotEquals("New skin was not set", oldSkin, newSkin);
+    }
 
 }


### PR DESCRIPTION
For some reason the `skinProperty` did not allow to set a new skin when it is the same class as the previous one.
This leads to multiple issues:
1. When creating a new skin (same class as previous), the skin will likely install listener but is then rejected when setting it due to the `skinProperty` class constraint
-> `PopupControl` is in a weird state as the current skin was not disposed since it is still set, although we already created and 'set' a new skin
2. A skin of the same class can behave differently, so it is not really valid to reject a skin just because it is the same class as the previous
-> Just imagine we have the following skin class
```
class MyCustomSkin<C extends PopupControl> extends Skin<C> {
    public MyCustomSkin(C skinnable, boolean someFlag) { ... }
}
```
Now if we would change the skin of the `PopupControl` two times like this:
```
popup.setSkin(new MyCustomSkin(popup, true));
popup.setSkin(new MyCustomSkin(popup, false));
```
The second time the skin will be rejected as it is the same class, although I may changed the skin behaviour, in this case demonstrated by a boolean flag for showing purposes.

This is the same issue and fix as done for `Control` in [JDK-8276056](https://bugs.openjdk.org/browse/JDK-8276056) (PR: https://github.com/openjdk/jfx/pull/806)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8323615](https://bugs.openjdk.org/browse/JDK-8323615): PopupControl.skin.setSkin(Skin) fails to call dispose() on discarded Skin (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1331/head:pull/1331` \
`$ git checkout pull/1331`

Update a local copy of the PR: \
`$ git checkout pull/1331` \
`$ git pull https://git.openjdk.org/jfx.git pull/1331/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1331`

View PR using the GUI difftool: \
`$ git pr show -t 1331`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1331.diff">https://git.openjdk.org/jfx/pull/1331.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1331#issuecomment-1887911803)