### PR TITLE
8260013: Snapshot does not work for nodes in a subscene

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGShape3D.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/sg/prism/NGShape3D.java
@@ -192,7 +192,7 @@ public abstract class NGShape3D extends NGNode {
     }
 
     private boolean noLights(NGLightBase[] lights) {
-        return lights == null || lights[0] == null;
+        return lights == null || lights.length == 0 || lights[0] == null;
     }
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -2146,7 +2146,7 @@ public abstract class Node implements EventTarget, Styleable {
             w = tempBounds.getWidth();
             h = tempBounds.getHeight();
         }
-        WritableImage result = Scene.doSnapshot(getScene(), x, y, w, h,
+        WritableImage result = Scene.doSnapshot(getScene(), getSubScene(), x, y, w, h,
                 this, transform, params.isDepthBufferInternal(),
                 params.getFill(), params.getEffectiveCamera(), img);
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -1347,7 +1347,7 @@ public class Scene implements EventTarget {
             context.camera = null;
         }
 
-        // Grab the lights from the scene and/or subscene
+        // Grab the lights from the scene or subscene
         Stream<NGLightBase> lights;
         if (subScene != null) {
             lights = Optional.of(subScene).stream().flatMap(s -> s.getLights().stream()).map(LightBase::getPeer);

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -1348,10 +1348,12 @@ public class Scene implements EventTarget {
         }
 
         // Grab the lights from the scene and/or subscene
-        Stream<NGLightBase> lights = Stream.concat(
-            Optional.ofNullable(scene).stream().flatMap(s -> s.lights.stream()).map(LightBase::getPeer),
-            Optional.ofNullable(subScene).stream().flatMap(s -> s.getLights().stream()).map(LightBase::getPeer)
-        );
+        Stream<NGLightBase> lights;
+        if (subScene != null) {
+            lights = Optional.of(subScene).stream().flatMap(s -> s.getLights().stream()).map(LightBase::getPeer);
+        } else {
+            lights = Optional.ofNullable(scene).stream().flatMap(s -> s.lights.stream()).map(LightBase::getPeer);
+        }
 
         context.lights = lights.toArray(NGLightBase[]::new);
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/SubScene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/SubScene.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/javafx/scene/SubScene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/SubScene.java
@@ -930,4 +930,7 @@ public class SubScene extends Node {
         return lightOwnerChanged;
     }
 
+    List<LightBase> getLights() {
+        return lights;
+    }
 }

--- a/tests/system/src/test/java/test/javafx/scene/SnapshotLightsTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/SnapshotLightsTest.java
@@ -25,7 +25,6 @@
 
 package test.javafx.scene;
 
-import javafx.embed.swing.SwingFXUtils;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.PointLight;
@@ -38,45 +37,39 @@ import javafx.scene.paint.Color;
 import javafx.scene.paint.PhongMaterial;
 import javafx.scene.shape.Box;
 
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import test.util.Util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.IOException;
-
-import javax.imageio.ImageIO;
-
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class SnapshotLightsTest extends SnapshotCommon {
 
     static final int BOX_DIM = 50;
 
-    @BeforeClass
+    @BeforeAll
     public static void setupOnce() {
         doSetupOnce();
     }
 
-    @AfterClass
+    @AfterAll
     public static void teardownOnce() {
         doTeardownOnce();
     }
 
-    @Before
+    @BeforeEach
     public void setupEach() {
         assertNotNull(myApp);
         assertNotNull(myApp.primaryStage);
         assertTrue(myApp.primaryStage.isShowing());
     }
 
-    @After
+    @AfterEach
     public void teardownEach() {
     }
 

--- a/tests/system/src/test/java/test/javafx/scene/SnapshotLightsTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/SnapshotLightsTest.java
@@ -1,8 +1,31 @@
-package test.robot.javafx.scene;
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 
-import javafx.application.Platform;
+package test.javafx.scene;
+
 import javafx.geometry.Pos;
-import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.PointLight;
 import javafx.scene.Scene;
@@ -13,22 +36,42 @@ import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.PhongMaterial;
 import javafx.scene.shape.Box;
-import javafx.stage.Stage;
 
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
-import test.robot.testharness.VisualTestBase;
 import test.util.Util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static test.util.Util.TIMEOUT;
+import static org.junit.Assert.assertNotNull;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
-public class SnapshotLightsTest extends VisualTestBase {
+public class SnapshotLightsTest extends SnapshotCommon {
 
     static final int BOX_DIM = 50;
+
+    @BeforeClass
+    public static void setupOnce() {
+        doSetupOnce();
+    }
+
+    @AfterClass
+    public static void teardownOnce() {
+        doTeardownOnce();
+    }
+
+    @Before
+    public void setupEach() {
+        assertNotNull(myApp);
+        assertNotNull(myApp.primaryStage);
+        assertTrue(myApp.primaryStage.isShowing());
+    }
+
+    @After
+    public void teardownEach() {
+    }
 
     private Scene buildScene(boolean inSubScene) {
         Box boxNode = new Box(BOX_DIM, BOX_DIM, BOX_DIM - 10);
@@ -58,32 +101,16 @@ public class SnapshotLightsTest extends VisualTestBase {
         PixelReader baseReader = base.getPixelReader();
         PixelReader nodeReader = node.getPixelReader();
 
-
         assertEquals(baseReader.getArgb(BOX_DIM / 2, BOX_DIM / 2), nodeReader.getArgb(BOX_DIM / 2, BOX_DIM / 2));
     }
 
     public SnapshotLightsTest() {
     }
 
-    private Scene scene;
-
     @Test
     public void testSceneNodeSnapshotLighting() throws Exception {
-        final CountDownLatch stageShownLatch = new CountDownLatch(1);
-
-        runAndWait(() -> {
-            Stage stage = getStage(false);
-
-            scene = buildScene(false);
-            stage.setScene(scene);
-            stage.setOnShown(e -> Platform.runLater(stageShownLatch::countDown));
-            stage.show();
-        });
-
-        assertTrue("Timeout waiting for stage to be shown",
-            stageShownLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
-
         Util.runAndWait(() -> {
+            Scene scene = buildScene(false);
             WritableImage baseSnapshot = scene.snapshot(null);
 
             Node boxNode = scene.getRoot().getChildrenUnmodifiable().get(0);
@@ -95,21 +122,8 @@ public class SnapshotLightsTest extends VisualTestBase {
 
     @Test
     public void testSubSceneNodeSnapshotLighting() throws Exception {
-        final CountDownLatch stageShownLatch = new CountDownLatch(1);
-
-        runAndWait(() -> {
-            Stage stage = getStage(false);
-
-            scene = buildScene(true);
-            stage.setScene(scene);
-            stage.setOnShown(e -> Platform.runLater(stageShownLatch::countDown));
-            stage.show();
-        });
-
-        assertTrue("Timeout waiting for stage to be shown",
-            stageShownLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
-
         Util.runAndWait(() -> {
+            Scene scene = buildScene(true);
             WritableImage baseSnapshot = scene.snapshot(null);
 
             SubScene ss = (SubScene)scene.getRoot().getChildrenUnmodifiable().get(0);
@@ -118,6 +132,5 @@ public class SnapshotLightsTest extends VisualTestBase {
 
             compareSnapshots(baseSnapshot, nodeSnapshot);
         });
-
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/SnapshotLightsTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/SnapshotLightsTest.java
@@ -1,0 +1,123 @@
+package test.robot.javafx.scene;
+
+import javafx.application.Platform;
+import javafx.geometry.Pos;
+import javafx.scene.Group;
+import javafx.scene.Node;
+import javafx.scene.PointLight;
+import javafx.scene.Scene;
+import javafx.scene.SubScene;
+import javafx.scene.image.PixelReader;
+import javafx.scene.image.WritableImage;
+import javafx.scene.layout.StackPane;
+import javafx.scene.paint.Color;
+import javafx.scene.paint.PhongMaterial;
+import javafx.scene.shape.Box;
+import javafx.stage.Stage;
+
+import org.junit.Test;
+import test.robot.testharness.VisualTestBase;
+import test.util.Util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static test.util.Util.TIMEOUT;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class SnapshotLightsTest extends VisualTestBase {
+
+    static final int BOX_DIM = 50;
+
+    private Scene buildScene(boolean inSubScene) {
+        Box boxNode = new Box(BOX_DIM, BOX_DIM, BOX_DIM - 10);
+        boxNode.setMaterial(new PhongMaterial(Color.WHITE));
+
+        StackPane pane = new StackPane(boxNode);
+        pane.setAlignment(Pos.CENTER);
+
+        PointLight light = new PointLight(Color.BLUE);
+        light.setTranslateZ(-150);
+        pane.getChildren().add(light);
+
+        if (inSubScene) {
+            SubScene ss = new SubScene(pane, BOX_DIM, BOX_DIM);
+            StackPane subSceneRoot = new StackPane(ss);
+            subSceneRoot.setAlignment(Pos.CENTER);
+            return new Scene(subSceneRoot, BOX_DIM, BOX_DIM);
+        } else {
+            return new Scene(pane, BOX_DIM, BOX_DIM);
+        }
+    }
+
+    private void compareSnapshots(WritableImage base, WritableImage node) {
+        assertEquals(base.getWidth(), node.getWidth(), 0.1);
+        assertEquals(base.getHeight(), node.getHeight(), 0.1);
+
+        PixelReader baseReader = base.getPixelReader();
+        PixelReader nodeReader = node.getPixelReader();
+
+
+        assertEquals(baseReader.getArgb(BOX_DIM / 2, BOX_DIM / 2), nodeReader.getArgb(BOX_DIM / 2, BOX_DIM / 2));
+    }
+
+    public SnapshotLightsTest() {
+    }
+
+    private Scene scene;
+
+    @Test
+    public void testSceneNodeSnapshotLighting() throws Exception {
+        final CountDownLatch stageShownLatch = new CountDownLatch(1);
+
+        runAndWait(() -> {
+            Stage stage = getStage(false);
+
+            scene = buildScene(false);
+            stage.setScene(scene);
+            stage.setOnShown(e -> Platform.runLater(stageShownLatch::countDown));
+            stage.show();
+        });
+
+        assertTrue("Timeout waiting for stage to be shown",
+            stageShownLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
+
+        Util.runAndWait(() -> {
+            WritableImage baseSnapshot = scene.snapshot(null);
+
+            Node boxNode = scene.getRoot().getChildrenUnmodifiable().get(0);
+            WritableImage nodeSnapshot = boxNode.snapshot(null, null);
+
+            compareSnapshots(baseSnapshot, nodeSnapshot);
+        });
+    }
+
+    @Test
+    public void testSubSceneNodeSnapshotLighting() throws Exception {
+        final CountDownLatch stageShownLatch = new CountDownLatch(1);
+
+        runAndWait(() -> {
+            Stage stage = getStage(false);
+
+            scene = buildScene(true);
+            stage.setScene(scene);
+            stage.setOnShown(e -> Platform.runLater(stageShownLatch::countDown));
+            stage.show();
+        });
+
+        assertTrue("Timeout waiting for stage to be shown",
+            stageShownLatch.await(TIMEOUT, TimeUnit.MILLISECONDS));
+
+        Util.runAndWait(() -> {
+            WritableImage baseSnapshot = scene.snapshot(null);
+
+            SubScene ss = (SubScene)scene.getRoot().getChildrenUnmodifiable().get(0);
+            Node boxNode = ss.getRoot().getChildrenUnmodifiable().get(0);
+            WritableImage nodeSnapshot = boxNode.snapshot(null, null);
+
+            compareSnapshots(baseSnapshot, nodeSnapshot);
+        });
+
+    }
+}


### PR DESCRIPTION
Originally this issue showed the problem of Node being incorrectly rendered (clipped) when snapshotting, compared to a snapshot of the whole Scene. Later on there was another problem added - lights not being taken into account if they are added to a SubScene.

As it later turned out, the original problem from this bug report is a problem with ParallelCamera incorrectly estimating near/far clipping planes, which just happened to reveal itself while snapshotting a Node. During testing I found out you can make the Node clip regardless of snapshot mechanism. Clipping issue was moved to a separate bug report and this PR only fixes the inconsistency in lights being gathered for a snapshot.

`Scene.doSnapshot()` was expanded to also check if SubScene provided to it is non-null and to fetch lights assigned to it. Scenario was tested with added SnapshotLightsTest.

Rest of the tests were checked and don't produce any noticeable regressions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8260013](https://bugs.openjdk.org/browse/JDK-8260013): Snapshot does not work for nodes in a subscene (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1332/head:pull/1332` \
`$ git checkout pull/1332`

Update a local copy of the PR: \
`$ git checkout pull/1332` \
`$ git pull https://git.openjdk.org/jfx.git pull/1332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1332`

View PR using the GUI difftool: \
`$ git pr show -t 1332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1332.diff">https://git.openjdk.org/jfx/pull/1332.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1332#issuecomment-1889323348)