### PR TITLE
8322784: JFXPanel calls InputMethodRequests on wrong thread

### DIFF
--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/InputMethodSupport.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/InputMethodSupport.java
@@ -43,6 +43,8 @@ import java.text.AttributedString;
 import java.text.CharacterIterator;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * A utility class containing the functions to support Input Methods
@@ -60,58 +62,59 @@ class InputMethodSupport {
 
         @Override
         public Rectangle getTextLocation(TextHitInfo offset) {
-            Point2D[] location = { new Point2D(0.0, 0.0) };
+            AtomicReference<Point2D> location = new AtomicReference<>(new Point2D(0.0, 0.0));
             if (fxRequests != null) {
                 PlatformImpl.runAndWait(() -> {
-                    location[0] = fxRequests.getTextLocation(offset.getInsertionIndex());
+                    location.set(fxRequests.getTextLocation(offset.getInsertionIndex()));
                 });
             }
-            return new Rectangle((int)location[0].getX(), (int)location[0].getY(), 0, 0);
+            return new Rectangle((int)location.get().getX(), (int)location.get().getY(), 0, 0);
         }
 
         @Override
         public TextHitInfo getLocationOffset(int x, int y) {
-            int[] offset = { 0 };
+            AtomicInteger offset = new AtomicInteger(0);
             if (fxRequests != null) {
                 PlatformImpl.runAndWait(() -> {
-                    offset[0] = fxRequests.getLocationOffset(x, y);
+                    offset.set(fxRequests.getLocationOffset(x, y));
                 });
             }
-            return TextHitInfo.afterOffset(offset[0]);
+            return TextHitInfo.afterOffset(offset.get());
         }
 
         @Override
         public int getInsertPositionOffset() {
-            int[] offset = { 0 };
+            AtomicInteger offset = new AtomicInteger(0);
             if (fxRequests instanceof ExtendedInputMethodRequests) {
                 PlatformImpl.runAndWait(() -> {
-                    offset[0] = ((ExtendedInputMethodRequests)fxRequests).getInsertPositionOffset();
+                    offset.set(((ExtendedInputMethodRequests)fxRequests).getInsertPositionOffset());
                 });
             }
-            return offset[0];
+            return offset.get();
         }
 
         @Override
         public AttributedCharacterIterator getCommittedText(int beginIndex, int endIndex, AttributedCharacterIterator.Attribute[] attributes) {
-            String[] comitted = { null };
+            AtomicReference<String> committed = new AtomicReference<>(null);
             if (fxRequests instanceof ExtendedInputMethodRequests) {
                 PlatformImpl.runAndWait(() -> {
-                    comitted[0] = ((ExtendedInputMethodRequests)fxRequests).getCommittedText(beginIndex, endIndex);
+                    committed.set(((ExtendedInputMethodRequests)fxRequests).getCommittedText(beginIndex, endIndex));
                 });
             }
-            if (comitted[0] == null) comitted[0] = "";
-            return new AttributedString(comitted[0]).getIterator();
+            String text = committed.get();
+            if (text == null) text = "";
+            return new AttributedString(text).getIterator();
         }
 
         @Override
         public int getCommittedTextLength() {
-            int[] length = { 0 };
+            AtomicInteger length = new AtomicInteger(0);
             if (fxRequests instanceof ExtendedInputMethodRequests) {
                 PlatformImpl.runAndWait(() -> {
-                    length[0] = ((ExtendedInputMethodRequests)fxRequests).getCommittedTextLength();
+                    length.set(((ExtendedInputMethodRequests)fxRequests).getCommittedTextLength());
                 });
             }
-            return length[0];
+            return length.get();
         }
 
         @Override
@@ -122,14 +125,15 @@ class InputMethodSupport {
 
         @Override
         public AttributedCharacterIterator getSelectedText(AttributedCharacterIterator.Attribute[] attributes) {
-            String[] selected = { null };
+            AtomicReference<String> selected = new AtomicReference<>(null);
             if (fxRequests != null) {
                 PlatformImpl.runAndWait(() -> {
-                    selected[0] = fxRequests.getSelectedText();
+                    selected.set(fxRequests.getSelectedText());
                 });
             }
-            if (selected[0] == null) selected[0] = "";
-            return new AttributedString(selected[0]).getIterator();
+            String text = selected.get();
+            if (text == null) text = "";
+            return new AttributedString(text).getIterator();
         }
     }
 

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/InputMethodSupport.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/InputMethodSupport.java
@@ -58,64 +58,60 @@ class InputMethodSupport {
             this.fxRequests = fxRequests;
         }
 
-        private Point2D pointValue;
-        private int     intValue;
-        private String  stringValue;
-
         @Override
         public Rectangle getTextLocation(TextHitInfo offset) {
-            pointValue = new Point2D(0.0, 0.0);
+            Point2D[] location = { new Point2D(0.0, 0.0) };
             if (fxRequests != null) {
                 PlatformImpl.runAndWait(() -> {
-                    pointValue = fxRequests.getTextLocation(offset.getInsertionIndex());
+                    location[0] = fxRequests.getTextLocation(offset.getInsertionIndex());
                 });
             }
-            return new Rectangle((int)pointValue.getX(), (int)pointValue.getY(), 0, 0);
+            return new Rectangle((int)location[0].getX(), (int)location[0].getY(), 0, 0);
         }
 
         @Override
         public TextHitInfo getLocationOffset(int x, int y) {
-            intValue = 0;
+            int[] offset = { 0 };
             if (fxRequests != null) {
                 PlatformImpl.runAndWait(() -> {
-                    intValue = fxRequests.getLocationOffset(x, y);
+                    offset[0] = fxRequests.getLocationOffset(x, y);
                 });
             }
-            return TextHitInfo.afterOffset(intValue);
+            return TextHitInfo.afterOffset(offset[0]);
         }
 
         @Override
         public int getInsertPositionOffset() {
-            intValue = 0;
+            int[] offset = { 0 };
             if (fxRequests instanceof ExtendedInputMethodRequests) {
                 PlatformImpl.runAndWait(() -> {
-                    intValue = ((ExtendedInputMethodRequests)fxRequests).getInsertPositionOffset();
+                    offset[0] = ((ExtendedInputMethodRequests)fxRequests).getInsertPositionOffset();
                 });
             }
-            return intValue;
+            return offset[0];
         }
 
         @Override
         public AttributedCharacterIterator getCommittedText(int beginIndex, int endIndex, AttributedCharacterIterator.Attribute[] attributes) {
-            stringValue = null;
+            String[] comitted = { null };
             if (fxRequests instanceof ExtendedInputMethodRequests) {
                 PlatformImpl.runAndWait(() -> {
-                    stringValue = ((ExtendedInputMethodRequests)fxRequests).getCommittedText(beginIndex, endIndex);
+                    comitted[0] = ((ExtendedInputMethodRequests)fxRequests).getCommittedText(beginIndex, endIndex);
                 });
             }
-            if (stringValue == null) stringValue = "";
-            return new AttributedString(stringValue).getIterator();
+            if (comitted[0] == null) comitted[0] = "";
+            return new AttributedString(comitted[0]).getIterator();
         }
 
         @Override
         public int getCommittedTextLength() {
-            intValue = 0;
+            int[] length = { 0 };
             if (fxRequests instanceof ExtendedInputMethodRequests) {
                 PlatformImpl.runAndWait(() -> {
-                    intValue = ((ExtendedInputMethodRequests)fxRequests).getCommittedTextLength();
+                    length[0] = ((ExtendedInputMethodRequests)fxRequests).getCommittedTextLength();
                 });
             }
-            return intValue;
+            return length[0];
         }
 
         @Override
@@ -126,14 +122,14 @@ class InputMethodSupport {
 
         @Override
         public AttributedCharacterIterator getSelectedText(AttributedCharacterIterator.Attribute[] attributes) {
-            stringValue = null;
+            String[] selected = { null };
             if (fxRequests != null) {
                 PlatformImpl.runAndWait(() -> {
-                    stringValue = fxRequests.getSelectedText();
+                    selected[0] = fxRequests.getSelectedText();
                 });
             }
-            if (stringValue == null) stringValue = "";
-            return new AttributedString(stringValue).getIterator();
+            if (selected[0] == null) selected[0] = "";
+            return new AttributedString(selected[0]).getIterator();
         }
     }
 

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
@@ -956,7 +956,7 @@ public class JFXPanel extends JComponent {
     public InputMethodRequests getInputMethodRequests() {
         EmbeddedSceneInterface scene = scenePeer;
         if (scene == null) {
-            return null;
+            return new InputMethodSupport.InputMethodRequestsAdapter(null);
         }
         return new InputMethodSupport.InputMethodRequestsAdapter(scene.getInputMethodRequests());
     }


### PR DESCRIPTION
On Windows we need to ensure InputMethodRequests coming from JFXPanel are processed on the JavaFX application thread instead of the AWT EventQueue thread. This PR adds the runAndWait() calls to do that.

This would be difficult to test on Windows without a fix for [JDK-8090267](https://bugs.openjdk.org/browse/JDK-8090267) so I've included the fix first proposed by @prsadhuk in PR #1169. If a developer uses the sample code provided in the JavaDoc to create and show a JFXPanel there's a good chance the JFXPanel will get focus before the scene has been set. To ensure AWT always treats the JFXPanel as an active IME client we return a stub version of the InputMethodRequests object if there's no scene. AWT will continue to ask for the InputMethodRequests and once the scene has been set the panel will return a non-stub version.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8322784](https://bugs.openjdk.org/browse/JDK-8322784): JFXPanel calls InputMethodRequests on wrong thread (**Bug** - P3)
 * [JDK-8090267](https://bugs.openjdk.org/browse/JDK-8090267): JFXPanel Input Problem (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1337/head:pull/1337` \
`$ git checkout pull/1337`

Update a local copy of the PR: \
`$ git checkout pull/1337` \
`$ git pull https://git.openjdk.org/jfx.git pull/1337/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1337`

View PR using the GUI difftool: \
`$ git pr show -t 1337`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1337.diff">https://git.openjdk.org/jfx/pull/1337.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1337#issuecomment-1894257134)