### PR TITLE
8323879: constructor Path(Path) which takes another Path object fail to draw on canvas html

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/PathJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/PathJava.cpp
@@ -118,13 +118,11 @@ PathJava::PathJava(RefPtr<RQRef>&& platformPath, std::unique_ptr<PathStream>&& e
 
 UniqueRef<PathImpl> PathJava::clone() const
 {
-    auto platformPathCopy = createEmptyPath();
-
-    RefPtr<RQRef> pathCopy(copyPath(platformPath()));
+    RefPtr<RQRef> platformPathCopy(copyPath(platformPath()));
 
     auto elementsStream = m_elementsStream ? m_elementsStream->clone().moveToUniquePtr() : nullptr;
 
-    return PathJava::create(WTFMove(pathCopy), std::unique_ptr<PathStream> { downcast<PathStream>(elementsStream.release()) });
+    return PathJava::create(WTFMove(platformPathCopy), std::unique_ptr<PathStream> { downcast<PathStream>(elementsStream.release()) });
 }
 
 PlatformPathPtr PathJava::platformPath() const

--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/PathJava.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/java/PathJava.cpp
@@ -120,9 +120,11 @@ UniqueRef<PathImpl> PathJava::clone() const
 {
     auto platformPathCopy = createEmptyPath();
 
+    RefPtr<RQRef> pathCopy(copyPath(platformPath()));
+
     auto elementsStream = m_elementsStream ? m_elementsStream->clone().moveToUniquePtr() : nullptr;
 
-    return PathJava::create(WTFMove(platformPathCopy), std::unique_ptr<PathStream> { downcast<PathStream>(elementsStream.release()) });
+    return PathJava::create(WTFMove(pathCopy), std::unique_ptr<PathStream> { downcast<PathStream>(elementsStream.release()) });
 }
 
 PlatformPathPtr PathJava::platformPath() const

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/PathContructorTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/PathContructorTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.javafx.scene.web;
+
+import com.sun.webkit.WebPage;
+import com.sun.webkit.WebPageShim;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.util.Base64;
+import javafx.scene.web.WebEngineShim;
+
+
+import org.junit.After;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+
+public class PathContructorTest extends TestBase {
+
+    @Test public void testCanvasPathConstructor() {
+        final String htmlCanvasContent = "<!DOCTYPE html>\n" +
+                "<html>\n" +
+                "<body style='margin: 0px 0px;'>\n" +
+                "<canvas id=\"myCanvas\" width=\"200\" height=\"100\" style=\"border:1px solid grey;\"></canvas>\n" +
+                "<script>\n" +
+                "const canvas = document.getElementById(\"myCanvas\");\n" +
+                "const ctx = canvas.getContext(\"2d\");\n" +
+                "p1 = new Path2D();\n" +
+                "p1.rect(0,0,200,200);\n" +
+                "ctx.fillStyle = 'yellow';\n" +
+                "ctx.fill(p1);\n" +
+                "p2 = new Path2D(p1);\n" +
+                "ctx.fillStyle = 'green';\n" +
+                "ctx.fill(p2);\n" +
+                "</script>\n" +
+                "</body>\n" +
+                "</html>";
+
+        loadContent(htmlCanvasContent);
+
+        submit(() -> {
+            int greenColor = 128;
+            assertEquals("First rect center", greenColor, (int) getEngine().executeScript(
+                    "document.getElementById('myCanvas').getContext('2d').getImageData(21, 21, 1, 1).data[1]"));
+        });
+    }
+}

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/PathContructorTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/PathContructorTest.java
@@ -25,15 +25,6 @@
 
 package test.javafx.scene.web;
 
-import com.sun.webkit.WebPage;
-import com.sun.webkit.WebPageShim;
-import java.awt.Color;
-import java.awt.image.BufferedImage;
-import java.util.Base64;
-import javafx.scene.web.WebEngineShim;
-
-
-import org.junit.After;
 import org.junit.Test;
 import static org.junit.Assert.*;
 


### PR DESCRIPTION
Issue: constructor Path(Path) which takes another Path object fails to draw on canvas html.
Solution: copy the old path while creating a new Path object from the existing Path that is already created with the same canvas rendering context.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8323879](https://bugs.openjdk.org/browse/JDK-8323879): constructor Path(Path) which takes another Path object fail to draw on canvas html (**Bug** - P2)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Hima Bindu Meda](https://openjdk.org/census#hmeda) (@HimaBinduMeda - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1339/head:pull/1339` \
`$ git checkout pull/1339`

Update a local copy of the PR: \
`$ git checkout pull/1339` \
`$ git pull https://git.openjdk.org/jfx.git pull/1339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1339`

View PR using the GUI difftool: \
`$ git pr show -t 1339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1339.diff">https://git.openjdk.org/jfx/pull/1339.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1339#issuecomment-1897747831)