### PR TITLE
JDK-8324182 Deprecate for removal SimpleSelector and CompoundSelector classes

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/css/CompoundSelector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CompoundSelector.java
@@ -62,7 +62,7 @@ import java.util.Set;
  * @since 9
  * @deprecated This class was exposed erroneously and will be removed in a future version
  */
-@Deprecated(forRemoval = true)
+@Deprecated(since = "22", forRemoval = true)
 final public class CompoundSelector extends Selector {
 
     private final List<SimpleSelector> selectors;

--- a/modules/javafx.graphics/src/main/java/javafx/css/CompoundSelector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CompoundSelector.java
@@ -60,7 +60,9 @@ import java.util.Set;
  * <code>Combinator.DESCENDANT</code>.
  *
  * @since 9
+ * @deprecated This class was exposed erroneously and will be removed in a future version
  */
+@Deprecated(forRemoval = true)
 final public class CompoundSelector extends Selector {
 
     private final List<SimpleSelector> selectors;

--- a/modules/javafx.graphics/src/main/java/javafx/css/CompoundSelector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CompoundSelector.java
@@ -102,9 +102,9 @@ final public class CompoundSelector extends Selector {
     }
 
     @Override
-    public Set<String> getClasses() {
+    public Set<String> getStyleClassNames() {
         return selectors.stream()
-            .map(Selector::getClasses)
+            .map(Selector::getStyleClassNames)
             .flatMap(Collection::stream)
             .collect(Collectors.toUnmodifiableSet());
     }

--- a/modules/javafx.graphics/src/main/java/javafx/css/CompoundSelector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/CompoundSelector.java
@@ -32,9 +32,11 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 
 /**
@@ -62,7 +64,7 @@ import java.util.Set;
  * @since 9
  * @deprecated This class was exposed erroneously and will be removed in a future version
  */
-@Deprecated(since = "22", forRemoval = true)
+@Deprecated(since = "23", forRemoval = true)
 final public class CompoundSelector extends Selector {
 
     private final List<SimpleSelector> selectors;
@@ -97,6 +99,14 @@ final public class CompoundSelector extends Selector {
             (relationships != null)
                 ? Collections.unmodifiableList(relationships)
                 : Collections.EMPTY_LIST;
+    }
+
+    @Override
+    public Set<String> getClasses() {
+        return selectors.stream()
+            .map(Selector::getClasses)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toUnmodifiableSet());
     }
 
     @Override public Match createMatch() {

--- a/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
@@ -92,6 +92,16 @@ abstract public class Selector {
     }
 
     /**
+     * Gets the set of style class names of this Selector. The returned set
+     * is guaranteed to be immutable.
+     *
+     * @return an immutable set with style class names, never {@code null},
+     *     or contains {@code nulls}, but can be empty
+     * @since 23
+     */
+    public abstract Set<String> getClasses();
+
+    /**
      * Creates a {@code Match}.
      *
      * @return a match, never {@code null}

--- a/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
@@ -92,8 +92,7 @@ abstract public class Selector {
     }
 
     /**
-     * Gets the set of style class names of this Selector. The returned set
-     * is guaranteed to be immutable.
+     * Gets the immutable set of style class names of this Selector.
      *
      * @return an immutable set with style class names, never {@code null},
      *     or contains {@code nulls}, but can be empty

--- a/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/Selector.java
@@ -95,10 +95,10 @@ abstract public class Selector {
      * Gets the immutable set of style class names of this Selector.
      *
      * @return an immutable set with style class names, never {@code null},
-     *     or contains {@code nulls}, but can be empty
+     *     or contains {@code null}s, but can be empty
      * @since 23
      */
-    public abstract Set<String> getClasses();
+    public abstract Set<String> getStyleClassNames();
 
     /**
      * Creates a {@code Match}.

--- a/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.sun.javafx.css.ImmutablePseudoClassSetsCache;
 import com.sun.javafx.css.PseudoClassState;
@@ -51,7 +52,7 @@ import static javafx.geometry.NodeOrientation.RIGHT_TO_LEFT;
  * @since 9
  * @deprecated This class was exposed erroneously and will be removed in a future version
  */
-@Deprecated(since = "22", forRemoval = true)
+@Deprecated(since = "23", forRemoval = true)
 final public class SimpleSelector extends Selector {
 
     /**
@@ -192,6 +193,11 @@ final public class SimpleSelector extends Selector {
         // if id is not null and not empty, then match needs to check id
         this.matchOnId = (id != null && !("".equals(id)));
 
+    }
+
+    @Override
+    public Set<String> getClasses() {
+        return styleClassSet.stream().map(StyleClass::getStyleClassName).collect(Collectors.toUnmodifiableSet());
     }
 
     @Override public Match createMatch() {

--- a/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
@@ -49,7 +49,9 @@ import static javafx.geometry.NodeOrientation.RIGHT_TO_LEFT;
  * A simple selector which behaves according to the CSS standard.
  *
  * @since 9
+ * @deprecated This class was exposed erroneously and will be removed in a future version
  */
+@Deprecated(forRemoval = true)
 final public class SimpleSelector extends Selector {
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
@@ -51,7 +51,7 @@ import static javafx.geometry.NodeOrientation.RIGHT_TO_LEFT;
  * @since 9
  * @deprecated This class was exposed erroneously and will be removed in a future version
  */
-@Deprecated(forRemoval = true)
+@Deprecated(since = "22", forRemoval = true)
 final public class SimpleSelector extends Selector {
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
@@ -196,7 +196,7 @@ final public class SimpleSelector extends Selector {
     }
 
     @Override
-    public Set<String> getClasses() {
+    public Set<String> getStyleClassNames() {
         return styleClassSet.stream()
             .map(StyleClass::getStyleClassName)
             .collect(Collectors.toUnmodifiableSet());

--- a/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
+++ b/modules/javafx.graphics/src/main/java/javafx/css/SimpleSelector.java
@@ -197,7 +197,9 @@ final public class SimpleSelector extends Selector {
 
     @Override
     public Set<String> getClasses() {
-        return styleClassSet.stream().map(StyleClass::getStyleClassName).collect(Collectors.toUnmodifiableSet());
+        return styleClassSet.stream()
+            .map(StyleClass::getStyleClassName)
+            .collect(Collectors.toUnmodifiableSet());
     }
 
     @Override public Match createMatch() {


### PR DESCRIPTION
The SimpleSelector and CompoundSelector classes are public classes in an exported package, javafx.css, but they are not intended to be used by applications. They are implementation details. They cannot be constructed directly and no other JavaFX API accepts or returns a SimpleSelector or CompoundSelector.

We should deprecate them for removal so we can move them to a non-exported package, removing them from the public API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8325704](https://bugs.openjdk.org/browse/JDK-8325704) to be approved
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issues
 * [JDK-8324182](https://bugs.openjdk.org/browse/JDK-8324182): Deprecate for removal SimpleSelector and CompoundSelector classes (**Enhancement** - P4)
 * [JDK-8325704](https://bugs.openjdk.org/browse/JDK-8325704): Deprecate for removal SimpleSelector and CompoundSelector classes (**CSR**)


### Reviewers
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**) 🔄 Re-review required (review applies to [6c2a9265](https://git.openjdk.org/jfx/pull/1340/files/6c2a926519a40165e6ec09aa9a7a55ba32671ceb))
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1340/head:pull/1340` \
`$ git checkout pull/1340`

Update a local copy of the PR: \
`$ git checkout pull/1340` \
`$ git pull https://git.openjdk.org/jfx.git pull/1340/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1340`

View PR using the GUI difftool: \
`$ git pr show -t 1340`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1340.diff">https://git.openjdk.org/jfx/pull/1340.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1340#issuecomment-1900115054)