### PR TITLE
8323543: NPE when table items are set to null

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableView.java
@@ -1919,7 +1919,7 @@ public class TableView<S> extends Control {
     public Object queryAccessibleAttribute(AccessibleAttribute attribute, Object... parameters) {
         switch (attribute) {
             case COLUMN_COUNT: return getVisibleLeafColumns().size();
-            case ROW_COUNT: return getItems().size();
+            case ROW_COUNT: return getItems() != null ? getItems().size() : 0;
             case SELECTED_ITEMS: {
                 // TableViewSkin returns TableRows back to TableView.
                 // TableRowSkin returns TableCells back to TableRow.

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableSkinUtils.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableSkinUtils.java
@@ -204,15 +204,4 @@ class TableSkinUtils {
     public static boolean isConstrainedResizePolicy(Callback<? extends ResizeFeaturesBase, Boolean> x) {
         return (x instanceof ConstrainedColumnResizeBase);
     }
-
-    /** returns the number of visible rows in Tree/TableView */
-    public static int getItemCount(TableViewSkinBase<?,?,?,?,?> skin) {
-        Object control = skin.getSkinnable();
-        if (control instanceof TableView table) {
-            return table.getItems().size();
-        } else if (control instanceof TreeTableView tree) {
-            return tree.getExpandedItemCount();
-        }
-        return 0;
-    }
 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TableViewSkinBase.java
@@ -906,7 +906,7 @@ public abstract class TableViewSkinBase<M, S, C extends Control, I extends Index
             contentWidth -= flow.getVbar().getWidth();
         }
 
-        if ((contentWidth <= 0) || (TableSkinUtils.getItemCount(this) == 0)) {
+        if ((contentWidth <= 0) || (getItemCount() == 0)) {
             // when there is no content in the TableView.
             Control c = getSkinnable();
             contentWidth = c.getWidth() - (snappedLeftInset() + snappedRightInset());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -6064,4 +6064,25 @@ public class TableViewTest {
         table.getSelectionModel().selectIndices(1, new int[]{1, 2});
         assertEquals(2, table.getSelectionModel().getSelectedIndex());
     }
+
+    @Test
+    public void testTableItemsNullShouldNotThrow() {
+        final TableColumn<String, String> c = new TableColumn<>("C");
+        c.setCellValueFactory(value -> new SimpleStringProperty(value.getValue()));
+        table.getColumns().add(c);
+
+        table.getItems().addAll("1", "2", "3");
+
+        stageLoader = new StageLoader(table);
+        table.setItems(null);
+        // Should not throw an NPE.
+        Toolkit.getToolkit().firePulse();
+    }
+
+    @Test
+    public void testTableItemsNullQueryAcceessibleAttributeRowCountShouldNotThrow() {
+        table.setItems(null);
+        // Should not throw an NPE.
+        table.queryAccessibleAttribute(AccessibleAttribute.ROW_COUNT);
+    }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -7250,4 +7250,30 @@ public class TreeTableViewTest {
         treeTableView.getSelectionModel().selectIndices(1, new int[]{1, 2});
         assertEquals(2, treeTableView.getSelectionModel().getSelectedIndex());
     }
+
+    @Test
+    public void testRootNullShouldNotThrow() {
+        TreeTableColumn<String, String> c = new TreeTableColumn<>("C");
+        c.setCellValueFactory(value -> new SimpleStringProperty(value.getValue().getValue()));
+        treeTableView.getColumns().add(c);
+
+        treeTableView.setRoot(new TreeItem<String>("Root"));
+        treeTableView.getRoot().setExpanded(true);
+        for (int i = 0; i < 4; i++) {
+            TreeItem<String> parent = new TreeItem<String>("item - " + i);
+            treeTableView.getRoot().getChildren().add(parent);
+        }
+
+        stageLoader = new StageLoader(treeTableView);
+        treeTableView.setRoot(null);
+        // Should not throw an NPE.
+        Toolkit.getToolkit().firePulse();
+    }
+
+    @Test
+    public void testTreeTableRootNullQueryAcceessibleAttributeRowCountShouldNotThrow() {
+        treeTableView.setRoot(null);
+        // Should not throw an NPE.
+        treeTableView.queryAccessibleAttribute(AccessibleAttribute.ROW_COUNT);
+    }
 }


### PR DESCRIPTION
This pull request contains a (clean) backport of commit [872dbc8a](https://github.com/openjdk/jfx/commit/872dbc8a2d254cba4df33fcc778b15b1a3c9b69f) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

Target branch is **jfx22**.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323543](https://bugs.openjdk.org/browse/JDK-8323543): NPE when table items are set to null (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1341/head:pull/1341` \
`$ git checkout pull/1341`

Update a local copy of the PR: \
`$ git checkout pull/1341` \
`$ git pull https://git.openjdk.org/jfx.git pull/1341/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1341`

View PR using the GUI difftool: \
`$ git pr show -t 1341`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1341.diff">https://git.openjdk.org/jfx/pull/1341.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1341#issuecomment-1900360321)