### PR TITLE
8324219: Remove incorrect documentation from Animation methods

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/Animation.java
@@ -883,14 +883,16 @@ public abstract class Animation {
      *
      * Note that unlike {@link #playFromStart()} calling this method will not
      * change the playing direction of this {@code Animation}.
+     * <p>
+     * This method must be called on the JavaFX Application thread.
      *
      * @param cuePoint
      *            name of the cue point
      * @throws NullPointerException
      *             if {@code cuePoint} is {@code null}
-     * @throws IllegalStateException
-     *             if embedded in another animation,
-     *                such as {@link SequentialTransition} or {@link ParallelTransition}
+     * @throws IllegalStateException if this method is called on a thread
+     *             other than the JavaFX Application Thread, or if embedded in another animation,
+     *             such as {@link SequentialTransition} or {@link ParallelTransition}
      * @see #getCuePoints()
      */
     public void playFrom(String cuePoint) {
@@ -911,6 +913,8 @@ public abstract class Animation {
      *
      * Note that unlike {@link #playFromStart()} calling this method will not
      * change the playing direction of this {@code Animation}.
+     * <p>
+     * This method must be called on the JavaFX Application thread.
      *
      * @param time
      *            position where to play from
@@ -918,9 +922,9 @@ public abstract class Animation {
      *             if {@code time} is {@code null}
      * @throws IllegalArgumentException
      *             if {@code time} is {@link Duration#UNKNOWN}
-     * @throws IllegalStateException
-     *             if embedded in another animation,
-     *                such as {@link SequentialTransition} or {@link ParallelTransition}
+     * @throws IllegalStateException if this method is called on a thread
+     *             other than the JavaFX Application Thread, or if embedded in another animation,
+     *             such as {@link SequentialTransition} or {@link ParallelTransition}
      */
     public void playFrom(Duration time) {
         jumpTo(time);
@@ -937,15 +941,12 @@ public abstract class Animation {
      *      animation.setRate = setRate(Math.abs(animation.getRate())); <br>
      *      animation.jumpTo(Duration.ZERO);<br>
      *      animation.play();<br>
-     *  </code>
-     *
+     * </code>
      * <p>
-     * Note: <ul>
-     * <li>{@code playFromStart()} is an asynchronous call, {@code Animation} may
-     * not start immediately. </ul>
+     * This method must be called on the JavaFX Application thread.
      *
-     * @throws IllegalStateException
-     *             if embedded in another animation,
+     * @throws IllegalStateException if this method is called on a thread
+     *                other than the JavaFX Application Thread, or if embedded in another animation,
      *                such as {@link SequentialTransition} or {@link ParallelTransition}
      */
     public void playFromStart() {
@@ -975,10 +976,6 @@ public abstract class Animation {
      *  animation.jumpTo(overall duration of animation);<br>
      *  animation.play();<br>
      * </code>
-     * <p>
-     * Note: <ul>
-     * <li>{@code play()} is an asynchronous call, the {@code Animation} may not
-     * start immediately. </ul>
      * <p>
      * This method must be called on the JavaFX Application thread.
      *
@@ -1036,10 +1033,6 @@ public abstract class Animation {
      * Stops the animation and resets the play head to its initial position. If
      * the animation is already stopped, this method has no effect.
      * <p>
-     * Note: <ul>
-     * <li>{@code stop()} is an asynchronous call, the {@code Animation} may not stop
-     * immediately. </ul>
-     * <p>
      * This method must be called on the JavaFX Application thread.
      *
      * @throws IllegalStateException if this method is called on a thread
@@ -1070,10 +1063,6 @@ public abstract class Animation {
     /**
      * Pauses the animation. If the animation is not currently running, this
      * method has no effect.
-     * <p>
-     * Note: <ul>
-     * <li>{@code pause()} is an asynchronous call, the {@code Animation} may not pause
-     * immediately. </ul>
      * <p>
      * This method must be called on the JavaFX Application thread.
      *


### PR DESCRIPTION
The `Animation` class states in the documentation of various methods that the method call would be asynchronous, using language similar to:

```
{@code stop()} is an asynchronous call, the {@code Animation} may not stop immediately.
```

This is factually wrong, there are no asynchronous calls. In fact, the methods in question can only be called synchronously on the JavaFX Application thread, and the state of the animation is changed immediately. For example, when `stop()` is called, the animation transitions to the stopped state instantly, without waiting for the next animation pulse.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion jfx23 to be approved (needs to be created)
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8324219](https://bugs.openjdk.org/browse/JDK-8324219): Remove incorrect documentation from Animation methods (**Bug** - P4)


### Reviewers
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer)
 * [Nir Lisker](https://openjdk.org/census#nlisker) (@nlisker - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1342/head:pull/1342` \
`$ git checkout pull/1342`

Update a local copy of the PR: \
`$ git checkout pull/1342` \
`$ git pull https://git.openjdk.org/jfx.git pull/1342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1342`

View PR using the GUI difftool: \
`$ git pr show -t 1342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1342.diff">https://git.openjdk.org/jfx/pull/1342.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1342#issuecomment-1900701819)