### PR TITLE
8324239: JFXPanelHiDPITest fails on Windows 11

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/JFXPanelHiDPITest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/JFXPanelHiDPITest.java
@@ -82,7 +82,7 @@ public class JFXPanelHiDPITest {
         launchLatch = new CountDownLatch(1);
 
         // Start the Application
-        SwingUtilities.invokeLater(() -> myApp = new MyApp());
+        SwingUtilities.invokeAndWait(() -> myApp = new MyApp());
 
         assertTrue("Timeout waiting for Application to launch",
                 launchLatch.await(5 * TIMEOUT, TimeUnit.MILLISECONDS));

--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/JFXPanelHiDPITest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/JFXPanelHiDPITest.java
@@ -32,7 +32,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import com.sun.javafx.PlatformUtil;
-import com.sun.javafx.application.PlatformImpl;
 
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
@@ -58,6 +57,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
+import test.util.Util;
 import static test.util.Util.TIMEOUT;
 
 public class JFXPanelHiDPITest {
@@ -151,7 +151,7 @@ public class JFXPanelHiDPITest {
         }
 
         private void createScene(final JFXPanel fxPanel) {
-            PlatformImpl.runAndWait(() -> {
+            Util.runAndWait(() -> {
                 StackPane root = new StackPane();
 
                 Rectangle rect = new Rectangle(PANEL_WIDTH - 100, (double) PANEL_HEIGHT / 8);

--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/JFXPanelHiDPITest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/JFXPanelHiDPITest.java
@@ -84,7 +84,7 @@ public class JFXPanelHiDPITest {
         launchLatch = new CountDownLatch(1);
 
         // Start the Application
-        SwingUtilities.invokeLater(() -> myApp = new MyApp());
+        SwingUtilities.invokeAndWait(() -> myApp = new MyApp());
 
         assertTrue("Timeout waiting for Application to launch",
                 launchLatch.await(5 * TIMEOUT, TimeUnit.MILLISECONDS));

--- a/tests/system/src/test/java/test/robot/javafx/embed/swing/JFXPanelHiDPITest.java
+++ b/tests/system/src/test/java/test/robot/javafx/embed/swing/JFXPanelHiDPITest.java
@@ -32,6 +32,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import com.sun.javafx.PlatformUtil;
+import com.sun.javafx.application.PlatformImpl;
+
 import javafx.application.Platform;
 import javafx.embed.swing.JFXPanel;
 import javafx.embed.swing.JFXPanelShim;
@@ -82,7 +84,7 @@ public class JFXPanelHiDPITest {
         launchLatch = new CountDownLatch(1);
 
         // Start the Application
-        SwingUtilities.invokeAndWait(() -> myApp = new MyApp());
+        SwingUtilities.invokeLater(() -> myApp = new MyApp());
 
         assertTrue("Timeout waiting for Application to launch",
                 launchLatch.await(5 * TIMEOUT, TimeUnit.MILLISECONDS));
@@ -149,7 +151,7 @@ public class JFXPanelHiDPITest {
         }
 
         private void createScene(final JFXPanel fxPanel) {
-            Platform.runLater(() -> {
+            PlatformImpl.runAndWait(() -> {
                 StackPane root = new StackPane();
 
                 Rectangle rect = new Rectangle(PANEL_WIDTH - 100, (double) PANEL_HEIGHT / 8);


### PR DESCRIPTION
Test fails with
```
JFXPanelHiDPITest > testScale FAILED
    java.lang.NullPointerException: Cannot invoke "java.awt.image.BufferedImage.getWidth()" because "pixelsIm" is null 
```
because scenePeer is not yet created as the test is run with invokeLater.
FIx is to make it run with invokeAndWait so that it waits for the scene to be created..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324239](https://bugs.openjdk.org/browse/JDK-8324239): JFXPanelHiDPITest fails on Windows 11 (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1344/head:pull/1344` \
`$ git checkout pull/1344`

Update a local copy of the PR: \
`$ git checkout pull/1344` \
`$ git pull https://git.openjdk.org/jfx.git pull/1344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1344`

View PR using the GUI difftool: \
`$ git pr show -t 1344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1344.diff">https://git.openjdk.org/jfx/pull/1344.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1344#issuecomment-1903542209)