### PR TITLE
8308955: MediaPlayer/AudioClip skip data on seek/loop

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-base/ext/alsa/gstalsasink.c
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gst-plugins-base/ext/alsa/gstalsasink.c
@@ -572,7 +572,14 @@ success:
       alsa->period_size);
 
   /* Check if hardware supports pause */
+#ifdef GSTREAMER_LITE
+  // See JDK-8308955. For some reason after stop we will skip ~500 ms of
+  // audio if we use hardware pause. So, for workaround we will never use
+  // hardware pause even if supported.
+  alsa->hw_support_pause = FALSE;
+#else // GSTREAMER_LITE
   alsa->hw_support_pause = snd_pcm_hw_params_can_pause (params);
+#endif // GSTREAMER_LITE
   GST_DEBUG_OBJECT (alsa, "Hw support pause: %s",
       alsa->hw_support_pause ? "yes" : "no");
 


### PR DESCRIPTION
This is regression from JDK-8262365. JDK-8262365 introduced support for hardware pause for audio device. For some reason we will skip ~500 ms of audio data after such pause. It is not noticeable for large audio files, but for anything small like sound effects 1-3 seconds long it is noticeable and makes short audio effects unusable without re-creating MediaPlayer after each playback. Fix/workaround is to disable hardware pause. I did not figure out why hardware pause skips audio data.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8308955](https://bugs.openjdk.org/browse/JDK-8308955): MediaPlayer/AudioClip skip data on seek/loop (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1346/head:pull/1346` \
`$ git checkout pull/1346`

Update a local copy of the PR: \
`$ git checkout pull/1346` \
`$ git pull https://git.openjdk.org/jfx.git pull/1346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1346`

View PR using the GUI difftool: \
`$ git pr show -t 1346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1346.diff">https://git.openjdk.org/jfx/pull/1346.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1346#issuecomment-1905222007)