### PR TITLE
8322215: [win] OS events that close the stage can cause Glass to reference freed memory

### DIFF
--- a/modules/javafx.graphics/src/main/native-glass/win/BaseWnd.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/BaseWnd.cpp
@@ -39,7 +39,9 @@ BaseWnd::BaseWnd(HWND ancestor) :
     m_ancestor(ancestor),
     m_wndClassAtom(0),
     m_isCommonDialogOwner(false),
-    m_hCursor(NULL)
+    m_hCursor(NULL),
+    m_messageCount(0),
+    m_isDead(false)
 {
 
 }
@@ -159,14 +161,32 @@ LRESULT CALLBACK BaseWnd::StaticWindowProc(HWND hWnd, UINT msg, WPARAM wParam, L
         pThis = (BaseWnd *)::GetProp(hWnd, szBaseWndProp);
     }
     if (pThis != NULL) {
+        pThis->BeginMessageProcessing(msg);
         LRESULT result = pThis->WindowProc(msg, wParam, lParam);
-        if (msg == WM_NCDESTROY) {
+        if (pThis->EndMessageProcessing()) {
             ::RemoveProp(hWnd, szBaseWndProp);
             delete pThis;
         }
         return result;
     }
     return ::DefWindowProc(hWnd, msg, wParam, lParam);
+}
+
+/*non-static*/
+void BaseWnd::BeginMessageProcessing(UINT msg)
+{
+    if (msg == WM_NCDESTROY) {
+        m_isDead = true;
+    }
+    m_messageCount += 1;
+}
+
+bool BaseWnd::EndMessageProcessing()
+{
+    if (m_messageCount > 0) {
+        m_messageCount -= 1;
+    }
+    return m_isDead && (m_messageCount == 0);
 }
 
 /*virtual*/

--- a/modules/javafx.graphics/src/main/native-glass/win/BaseWnd.h
+++ b/modules/javafx.graphics/src/main/native-glass/win/BaseWnd.h
@@ -67,6 +67,12 @@ public:
 
     void SetCursor(HCURSOR cursor);
 
+    // Begin processing a message.
+    void BeginMessageProcessing(UINT msg);
+    // End processing a message. Returns 'true' if the BaseWnd should be
+    // deleted.
+    bool EndMessageProcessing();
+
 private:
     HWND m_hWnd;
     static LRESULT CALLBACK StaticWindowProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
@@ -78,6 +84,10 @@ private:
     ATOM m_wndClassAtom;
     bool m_isCommonDialogOwner;
     HCURSOR m_hCursor;
+
+    LONG m_messageCount;
+    bool m_isDead;
+
 protected:
     virtual LRESULT WindowProc(UINT msg, WPARAM wParam, LPARAM lParam) = 0;
     virtual MessageResult CommonWindowProc(UINT msg, WPARAM wParam, LPARAM lParam);


### PR DESCRIPTION
This pull request contains a backport of commit [c1c52e5a](https://github.com/openjdk/jfx/commit/c1c52e5a42f9a4319487aa9db8e8fcbcf1ba02c8) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by Martin Fox on 22 Jan 2024 and was reviewed by Michael Strauß and Kevin Rushforth.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8322215](https://bugs.openjdk.org/browse/JDK-8322215): [win] OS events that close the stage can cause Glass to reference freed memory (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1347/head:pull/1347` \
`$ git checkout pull/1347`

Update a local copy of the PR: \
`$ git checkout pull/1347` \
`$ git pull https://git.openjdk.org/jfx.git pull/1347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1347`

View PR using the GUI difftool: \
`$ git pr show -t 1347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1347.diff">https://git.openjdk.org/jfx/pull/1347.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1347#issuecomment-1906487346)