### PR TITLE
8312603: ArrayIndexOutOfBoundsException in Marlin when scaleX is 0

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/ArrayCacheByte.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/ArrayCacheByte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/ArrayCacheByte.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/ArrayCacheByte.java
@@ -45,10 +45,9 @@ import com.sun.marlin.ArrayCacheConst.BucketStats;
 import com.sun.marlin.ArrayCacheConst.CacheStats;
 
 /*
- * Note that the ArrayCache[BYTE/INT/FLOAT/DOUBLE] files are nearly identical except
- * for a few type and name differences. Typically, the [BYTE]ArrayCache.java file
- * is edited manually and then [INT/FLOAT/DOUBLE]ArrayCache.java
- * files are generated with the following command lines:
+ * Note that the ArrayCache[Byte/Double/Int] files are nearly identical except
+ * for their array type [byte/double/int] and class name differences.
+ * ArrayCache[Byte/Double/Int] class deals with dirty arrays.
  */
 
 public final class ArrayCacheByte {

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/ArrayCacheDouble.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/ArrayCacheDouble.java
@@ -45,10 +45,9 @@ import com.sun.marlin.ArrayCacheConst.BucketStats;
 import com.sun.marlin.ArrayCacheConst.CacheStats;
 
 /*
- * Note that the ArrayCache[BYTE/INT/FLOAT/DOUBLE] files are nearly identical except
- * for a few type and name differences. Typically, the [BYTE]ArrayCache.java file
- * is edited manually and then [INT/FLOAT/DOUBLE]ArrayCache.java
- * files are generated with the following command lines:
+ * Note that the ArrayCache[Byte/Double/Int] files are nearly identical except
+ * for their array type [byte/double/int] and class name differences.
+ * ArrayCache[Byte/Double/Int] class deals with dirty arrays.
  */
 
 public final class ArrayCacheDouble {
@@ -166,7 +165,7 @@ public final class ArrayCacheDouble {
             if (array.length <= MAX_ARRAY_SIZE) {
                 if (DO_CLEAN_DIRTY && (toIndex != 0)) {
                     // clean-up array of dirty part[fromIndex; toIndex[
-                    fill(array, fromIndex, toIndex, 0.0d);
+                    fill(array, fromIndex, toIndex, /*(double)*/ 0.0);
                 }
                 // ensure to never store initial arrays in cache:
                 if (array != initial) {

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/ArrayCacheInt.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/ArrayCacheInt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/ArrayCacheInt.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/ArrayCacheInt.java
@@ -45,10 +45,9 @@ import com.sun.marlin.ArrayCacheConst.BucketStats;
 import com.sun.marlin.ArrayCacheConst.CacheStats;
 
 /*
- * Note that the ArrayCache[BYTE/INT/FLOAT/DOUBLE] files are nearly identical except
- * for a few type and name differences. Typically, the [BYTE]ArrayCache.java file
- * is edited manually and then [INT/FLOAT/DOUBLE]ArrayCache.java
- * files are generated with the following command lines:
+ * Note that the ArrayCache[Byte/Double/Int] files are nearly identical except
+ * for their array type [byte/double/int] and class name differences.
+ * ArrayCache[Byte/Double/Int] class deals with dirty arrays.
  */
 
 public final class ArrayCacheInt {
@@ -166,7 +165,7 @@ public final class ArrayCacheInt {
             if (array.length <= MAX_ARRAY_SIZE) {
                 if (DO_CLEAN_DIRTY && (toIndex != 0)) {
                     // clean-up array of dirty part[fromIndex; toIndex[
-                    fill(array, fromIndex, toIndex, 0);
+                    fill(array, fromIndex, toIndex, /*(int)*/ 0);
                 }
                 // ensure to never store initial arrays in cache:
                 if (array != initial) {

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/ArrayCacheIntClean.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/ArrayCacheIntClean.java
@@ -44,10 +44,9 @@ import com.sun.marlin.ArrayCacheConst.BucketStats;
 import com.sun.marlin.ArrayCacheConst.CacheStats;
 
 /*
- * Note that the ArrayCache[BYTE/INT/FLOAT/DOUBLE] files are nearly identical except
- * for a few type and name differences. Typically, the [BYTE]ArrayCache.java file
- * is edited manually and then [INT/FLOAT/DOUBLE]ArrayCache.java
- * files are generated with the following command lines:
+ * Note that the ArrayCache[Int/IntClean] files are nearly identical except
+ * for their array type [byte/double/int] and class name differences.
+ * ArrayCache[Int]Clean class deals with zero-filled arrays.
  */
 
 public final class ArrayCacheIntClean {
@@ -169,7 +168,7 @@ public final class ArrayCacheIntClean {
             if (array.length <= MAX_ARRAY_SIZE) {
                 if (toIndex != 0) {
                     // clean-up array of dirty part[fromIndex; toIndex[
-                    fill(array, fromIndex, toIndex, 0);
+                    fill(array, fromIndex, toIndex, /*(int)*/ 0);
                 }
                 // ensure to never store initial arrays in cache:
                 if (array != initial) {

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/DPQSSorterContext.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/DPQSSorterContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/DPQSSorterContext.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/DPQSSorterContext.java
@@ -4,13 +4,13 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation. Oracle designates this
+ * published by the Free Software Foundation.  Oracle designates this
  * particular file as subject to the "Classpath" exception as provided
  * by Oracle in the LICENSE file that accompanied this code.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
- * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
  * version 2 for more details (a copy is included in the LICENSE file that
  * accompanied this code).
  *

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/DPathConsumer2D.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/DPathConsumer2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/DPathConsumer2D.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/DPathConsumer2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,13 +26,41 @@
 package com.sun.marlin;
 
 public interface DPathConsumer2D {
-    public void moveTo(double x0, double y0);
-    public void lineTo(double x1, double y1);
-    public void quadTo(double xc, double yc,
-                       double x1, double y1);
-    public void curveTo(double xc0, double yc0,
-                        double xc1, double yc1,
-                        double x1, double y1);
+    /**
+     * @see java.awt.geom.Path2D.Double#moveTo
+     */
+    public void moveTo(double x, double y);
+
+    /**
+     * @see java.awt.geom.Path2D.Double#lineTo
+     */
+    public void lineTo(double x, double y);
+
+    /**
+     * @see java.awt.geom.Path2D.Double#quadTo
+     */
+    public void quadTo(double x1, double y1,
+                       double x2, double y2);
+
+    /**
+     * @see java.awt.geom.Path2D.Double#curveTo
+     */
+    public void curveTo(double x1, double y1,
+                        double x2, double y2,
+                        double x3, double y3);
+
+    /**
+     * @see java.awt.geom.Path2D.Double#closePath
+     */
     public void closePath();
+
+    /**
+     * Called after the last segment of the last subpath when the
+     * iteration of the path segments is completely done.  This
+     * method serves to trigger the end of path processing in the
+     * consumer that would normally be triggered when a
+     * {@link java.awt.geom.PathIterator PathIterator}
+     * returns {@code true} from its {@code done} method.
+     */
     public void pathDone();
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/Dasher.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/Dasher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/Dasher.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/Dasher.java
@@ -348,8 +348,15 @@ public final class Dasher implements StartFlagPathConsumer2D, MarlinConst {
         }
         buf[segIdx++] = type;
         len--;
-        // small arraycopy (2, 4 or 6) but with offset:
-        System.arraycopy(pts, off, buf, segIdx, len);
+
+        if (len == 2) {
+            // most probable case:
+            buf[segIdx    ] = pts[off    ];
+            buf[segIdx + 1] = pts[off + 1];
+        } else {
+            // small arraycopy (4 or 6) but with offset:
+            System.arraycopy(pts, off, buf, segIdx, len);
+        }
         firstSegidx = segIdx + len;
     }
 

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/MergeSort.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/MergeSort.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/MergeSort.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/MergeSort.java
@@ -170,7 +170,7 @@ final class MergeSort {
 
         // If arrays are inverted ie all(A) > all(B) do swap A and B to dst
         if (srcX[high - 1] <= srcX[low]) {
-            // 1561 occurences
+            // 1561 occurrences
             final int left = mid - low;
             final int right = high - mid;
             final int off = (left != right) ? 1 : 0;
@@ -185,7 +185,7 @@ final class MergeSort {
         // If arrays are already sorted, just copy from src to dest.  This is an
         // optimization that results in faster sorts for nearly ordered lists.
         if (srcX[mid - 1] <= srcX[mid]) {
-            // 14 occurences
+            // 14 occurrences
             System.arraycopy(srcX, low, dstX, low, length);
             System.arraycopy(srcY, low, dstY, low, length);
             return;

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/Renderer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/Renderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/Renderer.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/Renderer.java
@@ -624,7 +624,7 @@ public final class Renderer implements MarlinRenderer, MarlinConst {
         }
 
         if (edgeMinY != Integer.MAX_VALUE) {
-            // if context is maked as DIRTY:
+            // if context is marked as DIRTY:
             if (rdrCtx.dirty) {
                 // may happen if an exception if thrown in the pipeline processing:
                 // clear completely buckets arrays:
@@ -827,7 +827,7 @@ public final class Renderer implements MarlinRenderer, MarlinConst {
 
         final int stroking = rdrCtx.stroking;
 
-        int lastY = -1; // last emited row
+        int lastY = -1; // last emitted row
 
         final DPQSSorterContext sorter = rdrCtx.sorterCtx;
         boolean skipISort, useDPQS;
@@ -880,7 +880,7 @@ public final class Renderer implements MarlinRenderer, MarlinConst {
                             rdrCtx.stats.stat_array_renderer_edgePtrs.add(ptrEnd);
                         }
                         this.edgePtrs = _edgePtrs
-                            = edgePtrs_ref.widenArray(_edgePtrs, edgePtrsLen, // bad mark ? TODO: fix edge ptr mark
+                            = edgePtrs_ref.widenArray(_edgePtrs, edgePtrsLen,
                                                       ptrEnd);
 
                         edgePtrsLen = _edgePtrs.length;

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/RendererContext.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/RendererContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/RendererContext.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/RendererContext.java
@@ -172,7 +172,7 @@ public final class RendererContext extends ReentrantContext implements MarlinCon
         clipInvScale = 0.0d;
         firstFlags = 0;
 
-        // if context is maked as DIRTY:
+        // if context is marked as DIRTY:
         if (dirty) {
             // may happen if an exception if thrown in the pipeline processing:
             // force cleanup of all possible pipelined blocks (except Renderer):

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/Stroker.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/Stroker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/modules/javafx.graphics/src/main/java/com/sun/marlin/Stroker.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/marlin/Stroker.java
@@ -180,14 +180,14 @@ public final class Stroker implements StartFlagPathConsumer2D, MarlinConst {
             // chord:  s = 2 r * sin( phi / 2)
             // height: h = 2 r * sin( phi / 4)^2
             // small angles (phi < 90):
-            // h = s² / (8 r)
-            // so s² = (8 h * r)
+            // h = s^2 / (8 r)
+            // so s^2 = (8 h * r)
 
             // height max (note ROUND_JOIN_ERROR = 8 * JOIN_ERROR)
             final double limitMin = ((this.rdrCtx.clipInvScale == 0.0d) ? ROUND_JOIN_ERROR
                     : (ROUND_JOIN_ERROR * this.rdrCtx.clipInvScale));
 
-            // chord limit (s²):
+            // chord limit (s^2):
             this.joinLimitMinSq = limitMin * this.lineWidth2;
         }
         this.prev = CLOSE;
@@ -594,7 +594,6 @@ public final class Stroker implements StartFlagPathConsumer2D, MarlinConst {
                     return;
                 }
             }
-
             this.cOutCode = outcode1;
         }
 
@@ -1155,7 +1154,6 @@ public final class Stroker implements StartFlagPathConsumer2D, MarlinConst {
                     return;
                 }
             }
-
             this.cOutCode = outcode3;
         }
         _curveTo(x1, y1, x2, y2, x3, y3, outcode0);
@@ -1302,7 +1300,6 @@ public final class Stroker implements StartFlagPathConsumer2D, MarlinConst {
                     return;
                 }
             }
-
             this.cOutCode = outcode2;
         }
         _quadTo(x1, y1, x2, y2, outcode0);
@@ -1331,6 +1328,7 @@ public final class Stroker implements StartFlagPathConsumer2D, MarlinConst {
             lineTo(cx0, cy0);
             return;
         }
+
         // if these vectors are too small, normalize them, to avoid future
         // precision problems.
         if (Math.abs(dxs) < 0.1d && Math.abs(dys) < 0.1d) {

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/shape/DMarlinPrismUtils.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/shape/DMarlinPrismUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,17 +108,13 @@ public final class DMarlinPrismUtils {
             final double det = a * d - c * b;
 
             if (Math.abs(det) <= (2.0d * Double.MIN_VALUE)) {
-                // this rendering engine takes one dimensional curves and turns
+                // This rendering engine takes one dimensional curves and turns
                 // them into 2D shapes by giving them width.
                 // However, if everything is to be passed through a singular
                 // transformation, these 2D shapes will be squashed down to 1D
                 // again so, nothing can be drawn.
 
-                // Every path needs an initial moveTo and a pathDone. If these
-                // are not there this causes a SIGSEGV in libawt.so (at the time
-                // of writing of this comment (September 16, 2010)). Actually,
-                // I am not sure if the moveTo is necessary to avoid the SIGSEGV
-                // but the pathDone is definitely needed.
+                // Every path needs an initial moveTo and a pathDone.
                 out.moveTo(0.0d, 0.0d);
                 out.pathDone();
                 return null;

--- a/tests/system/src/test/java/test/com/sun/marlin/HugePolygonClipTest.java
+++ b/tests/system/src/test/java/test/com/sun/marlin/HugePolygonClipTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/tests/system/src/test/java/test/com/sun/marlin/HugePolygonClipTest.java
+++ b/tests/system/src/test/java/test/com/sun/marlin/HugePolygonClipTest.java
@@ -87,10 +87,7 @@ public class HugePolygonClipTest {
 
     static {
         Locale.setDefault(Locale.US);
-        /*
-            System.out.println("BLUE_PIXEL: " + BLUE_PIXEL);
-            System.out.println("RED_PIXEL:  " + RED_PIXEL);
-         */
+
         // enable Marlin logging:
         System.setProperty("prism.marlin.log", "true");
 

--- a/tests/system/src/test/java/test/com/sun/marlin/Scale0Test.java
+++ b/tests/system/src/test/java/test/com/sun/marlin/Scale0Test.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.manual.marlin;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.lang.reflect.Method;
+import static org.junit.Assert.assertEquals;
+
+import java.util.Locale;
+import java.util.concurrent.CountDownLatch;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.beans.value.ObservableValue;
+import javafx.scene.Group;
+import javafx.scene.Node;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.control.Labeled;
+import javafx.scene.control.Slider;
+import javafx.scene.layout.GridPane;
+import javafx.scene.layout.Pane;
+import javafx.scene.paint.Color;
+import javafx.scene.shape.Circle;
+import javafx.scene.shape.Rectangle;
+import javafx.stage.Stage;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import test.util.Util;
+
+/**
+ * @test
+ * @bug 8312603
+ * @summary Check the crash with MarlinFX renderer
+ */
+public class Scale0Test {
+
+    private final static int SIZE = 800;
+
+    // Used to launch the application before running any test
+    private static final CountDownLatch launchLatch = new CountDownLatch(1);
+
+    // Singleton Application instance
+    static MyApp myApp;
+
+    static final ByteArrayOutputStream out = new ByteArrayOutputStream(2048 * 1024);
+    static final PrintStream defaultErrorStream = System.err;
+
+    static {
+        Locale.setDefault(Locale.US);
+
+        System.setProperty("prism.verbose", "false");
+        // enable Marlin logging & internal checks:
+        System.setProperty("prism.marlin.log", "true");
+    }
+
+    // Application class. An instance is created and initialized before running
+    // the first test, and it lives through the execution of all tests.
+    public static class MyApp extends Application {
+
+        Stage stage = null;
+
+        public MyApp() {
+            super();
+        }
+
+        @Override
+        public void init() {
+            Scale0Test.myApp = this;
+        }
+
+        @Override
+        public void start(Stage primaryStage) throws Exception {
+            this.stage = primaryStage;
+            launchLatch.countDown();
+        }
+    }
+
+    @BeforeClass
+    public static void setupOnce() throws Exception {
+        // Capture stderr:
+        System.setErr(new PrintStream(out, true));
+
+        Util.launch(launchLatch, MyApp.class);
+        assertEquals(0, launchLatch.getCount());
+    }
+
+    @AfterClass
+    public static void teardownOnce() {
+        Util.shutdown();
+    }
+
+    @Test(timeout = 15000)
+    public void TestBug() {
+
+        Platform.runLater(() -> {
+            myApp.stage.setScene(createScene());
+            myApp.stage.show();
+        });
+
+        try {
+            Thread.sleep(2000L);
+        } catch (InterruptedException ie) {
+            Logger.getLogger(Scale0Test.class.getName()).log(Level.SEVERE, "interrupted", ie);
+        }
+
+        // Restore stderr:
+        System.setErr(defaultErrorStream);
+
+        // Get stderr to check exception:
+        final String stdErr = out.toString();
+
+        if (!stdErr.isEmpty()) {
+            System.err.println("Captured System.err output (" + stdErr.length() + " chars):");
+            System.err.println("---------------------------------------");
+            System.err.println(stdErr);
+            System.err.println("---------------------------------------");
+        }
+
+        if (stdErr.contains("ArrayIndexOutOfBoundsException")) {
+            Assert.fail("ArrayIndexOutOfBoundsException thrown !");
+        }
+    }
+
+    private Group leftPane;
+    private Slider slider;
+
+    private Scene createScene() {
+        slider = new Slider(0, 2, 0) {
+            {
+                setBlockIncrement((getMax() - getMin()) / 4);
+                setMajorTickUnit((getMax() - getMin()) / 4);
+                setMinorTickCount(2);
+                setPrefWidth(200);
+                setShowTickLabels(true);
+                setShowTickMarks(true);
+            }
+        };
+        leftPane = new Group();
+
+        final NodeAndGraphic leftNode = create();
+        preparePane(this.leftPane, leftNode.node);
+
+        try {
+            String propertyName = "scaleXProperty"; //Works fine for translateXProperty
+            Method method = leftNode.graphic.getClass().getMethod(propertyName, (Class[]) null);
+            Object bindableObj = method.invoke(leftNode.graphic);
+            Method bindMethod = bindableObj.getClass().getMethod("bind", ObservableValue.class);
+            bindMethod.invoke(bindableObj, slider.valueProperty());
+        } catch (Throwable th) {
+            Logger.getLogger(Scale0Test.class.getName()).log(Level.SEVERE, "bind exception", th);
+        }
+
+        final Pane leftContainer = new Pane() {
+            {
+                setStyle("-fx-border-color: rosybrown;");
+                getChildren().add(leftPane);
+                setPrefSize(300, 300);
+                setMaxSize(300, 300);
+                setMinSize(300, 300);
+            }
+        };
+        GridPane.setConstraints(leftContainer, 0, 2);
+
+        GridPane field = new GridPane() {
+            {
+                getChildren().addAll(slider, leftContainer);
+            }
+        };
+
+        return new Scene(field, SIZE, SIZE, Color.WHITE);
+    }
+
+    private static NodeAndGraphic create() {
+        Button button = new Button();
+        button.setLayoutX(50);
+        button.setLayoutY(50);
+        button.setPrefSize(100, 50);
+        button.setMinSize(100, 50);
+        button.setMaxSize(100, 50);
+        if (button instanceof Labeled) {
+            Labeled l = (Labeled) button;
+            Circle circle = new Circle(10);
+            circle.setFill(Color.LIGHTGREEN);
+            circle.setStroke(Color.DARKGREEN);
+            circle.getStrokeDashArray().add(10.);
+            circle.getStrokeDashArray().add(8.);
+            l.setGraphic(circle);
+        }
+        return new NodeAndGraphic(button, button.getGraphic());
+    }
+
+    private static void preparePane(Group pane, Node node) {
+        pane.getChildren().clear();
+        final Rectangle bounds = new Rectangle() {
+            {
+                setWidth(300);
+                setHeight(300);
+                setFill(Color.TRANSPARENT);
+            }
+        };
+
+        pane.getChildren().add(bounds);
+        pane.setClip(new Rectangle() {
+            {
+                setWidth(300);
+                setHeight(300);
+            }
+        });
+        pane.getChildren().add(node);
+    }
+
+    final static class NodeAndGraphic {
+
+        final Node node;
+        final Object graphic;
+
+        NodeAndGraphic(Node node, Object graphic) {
+            this.node = node;
+            this.graphic = graphic;
+        }
+    }
+
+}

--- a/tests/system/src/test/java/test/com/sun/marlin/Scale0Test.java
+++ b/tests/system/src/test/java/test/com/sun/marlin/Scale0Test.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package test.manual.marlin;
+package test.com.sun.marlin;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;


### PR DESCRIPTION
Fixed scale=0 in DMarlinPrismUtils + added new test Scale0Test.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8312603](https://bugs.openjdk.org/browse/JDK-8312603): ArrayIndexOutOfBoundsException in Marlin when scaleX is 0 (**Bug** - P4)


### Reviewers
 * [Karthik P K](https://openjdk.org/census#kpk) (@karthikpandelu - Committer)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1348/head:pull/1348` \
`$ git checkout pull/1348`

Update a local copy of the PR: \
`$ git checkout pull/1348` \
`$ git pull https://git.openjdk.org/jfx.git pull/1348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1348`

View PR using the GUI difftool: \
`$ git pr show -t 1348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1348.diff">https://git.openjdk.org/jfx/pull/1348.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1348#issuecomment-1908306329)