### PR TITLE
8324658: Allow animation play/start/stop/pause methods to be called on any thread

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/util/Utils.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/util/Utils.java
@@ -26,6 +26,8 @@
 package com.sun.javafx.util;
 
 import static com.sun.javafx.FXPermissions.ACCESS_WINDOW_LIST_PERMISSION;
+
+import javafx.application.Platform;
 import javafx.geometry.BoundingBox;
 import javafx.geometry.Bounds;
 import javafx.geometry.HPos;
@@ -996,5 +998,18 @@ public class Utils {
             }
             return null;
         });
+    }
+
+    /**
+     * Ensures that a code segment is run on the FX thread.
+     *
+     * @param runnable a {@code Runnable} encapsulating the code
+     */
+    public static void runOnFxThread(Runnable runnable) {
+        if (Platform.isFxApplicationThread()) {
+            runnable.run();
+        } else {
+            Platform.runLater(runnable);
+        }
     }
 }

--- a/modules/javafx.graphics/src/main/java/javafx/animation/AnimationTimer.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/AnimationTimer.java
@@ -26,6 +26,7 @@
 package javafx.animation;
 
 import com.sun.javafx.tk.Toolkit;
+import com.sun.javafx.util.Utils;
 import com.sun.scenario.animation.AbstractPrimaryTimer;
 import com.sun.scenario.animation.shared.TimerReceiver;
 import java.security.AccessControlContext;
@@ -100,14 +101,20 @@ public abstract class AnimationTimer {
      * <p>
      * The {@code AnimationTimer} can be stopped by calling {@link #stop()}.
      * <p>
-     * This method must be called on the JavaFX Application thread.
+     * Note: if this method is not called on the JavaFX Application Thread, it is delegated to it automatically.
+     * In this case, the call is asynchronous and may not happen immediately.
+     */
+    public void start() {
+        Utils.runOnFxThread(this::startImpl);
+    }
+
+    /**
+     * This method must be run on the JavaFX Application Thread.
      *
-     * @throws IllegalStateException if this method is called on a thread
-     *                  other than the JavaFX Application Thread.
+     * @see #start()
      */
     @SuppressWarnings("removal")
-    public void start() {
-        Toolkit.getToolkit().checkFxUserThread();
+    private void startImpl() {
         if (!active) {
             // Capture the Access Control Context to be used during the animation pulse
             accessCtrlCtx = AccessController.getContext();
@@ -120,13 +127,19 @@ public abstract class AnimationTimer {
      * Stops the {@code AnimationTimer}. It can be activated again by calling
      * {@link #start()}.
      * <p>
-     * This method must be called on the JavaFX Application thread.
-     *
-     * @throws IllegalStateException if this method is called on a thread
-     *                  other than the JavaFX Application Thread.
+     * Note: if this method is not called on the JavaFX Application Thread, it is delegated to it automatically.
+     * In this case, the call is asynchronous and may not happen immediately.
      */
     public void stop() {
-        Toolkit.getToolkit().checkFxUserThread();
+        Utils.runOnFxThread(this::stopImpl);
+    }
+
+    /**
+     * This method must be run on the JavaFX Application Thread.
+     *
+     * @see #stop()
+     */
+    private void stopImpl() {
         if (active) {
             timer.removeAnimationTimer(timerReceiver);
             active = false;

--- a/modules/javafx.graphics/src/main/java/javafx/animation/Timeline.java
+++ b/modules/javafx.graphics/src/main/java/javafx/animation/Timeline.java
@@ -191,17 +191,14 @@ public final class Timeline extends Animation {
         clipCore.start(forceSync);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public void stop() {
+    void stopImpl() {
         if (parent != null) {
             throw new IllegalStateException("Cannot stop when embedded in another animation");
         }
         if (getStatus() == Status.RUNNING) {
             clipCore.abort();
         }
-        super.stop();
+        super.stopImpl();
     }
 }

--- a/tests/system/src/test/java/test/com/sun/javafx/animation/SynchronizationTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/animation/SynchronizationTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.com.sun.javafx.animation;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import javafx.application.Application;
+import javafx.application.Platform;
+import javafx.stage.Stage;
+import test.util.Util;
+
+// Based on https://bugs.openjdk.org/browse/JDK-8159048
+public class SynchronizationTest {
+
+    private static final CountDownLatch startupLatch = new CountDownLatch(1);
+    private static Stage primaryStage;
+
+    public static class TestApp extends Application {
+
+        @Override
+        public void start(Stage stage) throws Exception {
+            primaryStage = stage;
+            startupLatch.countDown();
+        }
+    }
+
+    @BeforeAll
+    public static void setup() throws Exception {
+        Util.launch(startupLatch, TestApp.class);
+    }
+
+    @AfterAll
+    public static void shutdown() {
+        Util.shutdown(primaryStage);
+    }
+
+    /**
+     * Number of seconds to wait for a failure. If an exception is not thrown in this time, it's assumed it won't be
+     * thrown later too.
+     */
+    private static final int GRACE_PERIOD = 15;
+
+    final private AtomicBoolean failed = new AtomicBoolean(false);
+    final private CountDownLatch waiter = new CountDownLatch(1);
+    final private ExecutorService executor = Executors.newCachedThreadPool();
+
+    private final AtomicReference<Thread> thread = new AtomicReference<>();
+    private final AtomicReference<Throwable> throwable = new AtomicReference<>();
+
+    protected void runTest(Runnable runnable) throws InterruptedException {
+        Platform.runLater(() -> Thread.currentThread().setUncaughtExceptionHandler(this::handleThrowable));
+
+        Runnable wrappedRunnable = wrap(runnable);
+
+        for (int i = 0; i < 10; i++) {
+            executor.submit(wrappedRunnable);
+        }
+
+        // If no exception is thrown after GRACE_PERIOD seconds, await completes and the test will succeed.
+        // If an exception is thrown, await completes via countDown() instead and the test will fail.
+        waiter.await(GRACE_PERIOD, TimeUnit.SECONDS);
+        executor.shutdownNow();
+        assertFalse(failed.get(), "<" + throwable.get() + "> was thrown on " + thread.get());
+    }
+
+    private Runnable wrap(Runnable runnable) {
+        return () -> {
+            try {
+                runnable.run();
+            } catch (Throwable e) {
+                handleThrowable(Thread.currentThread(), e);
+            }
+        };
+    }
+
+    private void handleThrowable(Thread t, Throwable e) {
+        thread.set(t);
+        throwable.set(e);
+        failed.set(true);
+        waiter.countDown();
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [c5ab220b](https://github.com/openjdk/jfx/commit/c5ab220bbc885f2aa99d8c1d5ed8f1753e39251f) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by Nir Lisker on 30 Jan 2024 and was reviewed by Kevin Rushforth and Jose Pereda.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8324796](https://bugs.openjdk.org/browse/JDK-8324796) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8324658](https://bugs.openjdk.org/browse/JDK-8324658): Allow animation play/start/stop/pause methods to be called on any thread (**Enhancement** - P3)
 * [JDK-8324796](https://bugs.openjdk.org/browse/JDK-8324796): Allow animation play/start/stop/pause methods to be called on any thread (**CSR**)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1354/head:pull/1354` \
`$ git checkout pull/1354`

Update a local copy of the PR: \
`$ git checkout pull/1354` \
`$ git pull https://git.openjdk.org/jfx.git pull/1354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1354`

View PR using the GUI difftool: \
`$ git pr show -t 1354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1354.diff">https://git.openjdk.org/jfx/pull/1354.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1354#issuecomment-1916711349)