### PR TITLE
8324879: Platform-specific preferences keys are incorrect for Windows toolkit

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/win/WinApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -372,12 +372,13 @@ final class WinApplication extends Application implements InvokeLaterDispatcher.
     @Override
     public native Map<String, Object> getPlatformPreferences();
 
+    // This list needs to be kept in sync with PlatformSupport.cpp in the Glass toolkit for Windows.
     @Override
     public Map<String, String> getPlatformKeyMappings() {
         return Map.of(
-            "Windows.UIColor.ForegroundColor", "foregroundColor",
-            "Windows.UIColor.BackgroundColor", "backgroundColor",
-            "Windows.UIColor.AccentColor", "accentColor"
+            "Windows.UIColor.Foreground", "foregroundColor",
+            "Windows.UIColor.Background", "backgroundColor",
+            "Windows.UIColor.Accent", "accentColor"
         );
     }
 

--- a/modules/javafx.graphics/src/main/native-glass/win/PlatformSupport.cpp
+++ b/modules/javafx.graphics/src/main/native-glass/win/PlatformSupport.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -129,6 +129,8 @@ void PlatformSupport::queryHighContrastScheme(jobject properties) const
     HIGHCONTRAST contrastInfo;
     contrastInfo.cbSize = sizeof(HIGHCONTRAST);
     ::SystemParametersInfo(SPI_GETHIGHCONTRAST, sizeof(HIGHCONTRAST), &contrastInfo, 0);
+
+    // Property names need to be kept in sync with WinApplication.java:
     if (contrastInfo.dwFlags & HCF_HIGHCONTRASTON) {
         putBoolean(properties, "Windows.SPI.HighContrast", true);
         putString(properties, "Windows.SPI.HighContrastColorScheme", contrastInfo.lpszDefaultScheme);
@@ -140,6 +142,7 @@ void PlatformSupport::queryHighContrastScheme(jobject properties) const
 
 void PlatformSupport::querySystemColors(jobject properties) const
 {
+    // Property names need to be kept in sync with WinApplication.java:
     putColor(properties, "Windows.SysColor.COLOR_3DFACE", GetSysColor(COLOR_3DFACE));
     putColor(properties, "Windows.SysColor.COLOR_BTNTEXT", GetSysColor(COLOR_BTNTEXT));
     putColor(properties, "Windows.SysColor.COLOR_GRAYTEXT", GetSysColor(COLOR_GRAYTEXT));
@@ -178,6 +181,7 @@ void PlatformSupport::queryUIColors(jobject properties) const
         settings3->GetColorValue(UIColorType::UIColorType_AccentLight2, &accentLight2);
         settings3->GetColorValue(UIColorType::UIColorType_AccentLight3, &accentLight3);
 
+        // Property names need to be kept in sync with WinApplication.java:
         putColor(properties, "Windows.UIColor.Background", background);
         putColor(properties, "Windows.UIColor.Foreground", foreground);
         putColor(properties, "Windows.UIColor.AccentDark3", accentDark3);

--- a/tests/manual/events/PlatformPreferencesChangedTest.java
+++ b/tests/manual/events/PlatformPreferencesChangedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,6 +63,19 @@ public class PlatformPreferencesChangedTest extends Application {
         var clearButton = new Button("Clear Log");
         clearButton.setOnAction(e -> textArea.setText(""));
 
+        var backgroundColorLabel = new Label();
+        var foregroundColorLabel = new Label();
+        var accentColorLabel = new Label();
+        var colorSchemeLabel = new Label();
+
+        Runnable updateColorProperties = () -> {
+            var preferences = Platform.getPreferences();
+            backgroundColorLabel.setText(preferences.getBackgroundColor().toString());
+            foregroundColorLabel.setText(preferences.getForegroundColor().toString());
+            accentColorLabel.setText(preferences.getAccentColor().toString());
+            colorSchemeLabel.setText(preferences.getColorScheme().toString());
+        };
+
         var box = new VBox();
         box.setSpacing(20);
         box.getChildren().add(new VBox(10,
@@ -72,7 +85,13 @@ public class PlatformPreferencesChangedTest extends Application {
             new VBox(
                 new Label("2. Observe whether the changed preferences are reported in the log below."),
                 new Label("    Added or removed preferences are marked with a plus or minus sign.")),
-            new Label("3. Click \"Pass\" if the changes were correctly reported, otherwise click \"Fail\"."),
+            new VBox(
+                new Label("3. Check whether the following computed properties reflect the reported preferences:"),
+                new HBox(new BoldLabel("    backgroundColor: "), backgroundColorLabel),
+                new HBox(new BoldLabel("    foregroundColor: "), foregroundColorLabel),
+                new HBox(new BoldLabel("    accentColor: "), accentColorLabel),
+                new HBox(new BoldLabel("    colorScheme: "), colorSchemeLabel)),
+            new Label("4. Click \"Pass\" if the changes were correctly reported, otherwise click \"Fail\"."),
             new HBox(5, passButton, failButton, clearButton)
         ));
 
@@ -83,9 +102,11 @@ public class PlatformPreferencesChangedTest extends Application {
         BorderPane.setMargin(textArea, new Insets(20, 0, 0, 0));
 
         appendText(textArea, "preferences: " + formatPrefs(Platform.getPreferences().entrySet()));
+        updateColorProperties.run();
 
         Platform.getPreferences().addListener((InvalidationListener)observable -> {
             appendText(textArea, "\r\nchanged:");
+            updateColorProperties.run();
         });
 
         Platform.getPreferences().addListener((MapChangeListener<String, Object>)change -> {
@@ -125,5 +146,12 @@ public class PlatformPreferencesChangedTest extends Application {
         }
 
         return key + "=" + value;
+    }
+
+    private static class BoldLabel extends Label {
+        BoldLabel(String text) {
+            super(text);
+            setStyle("-fx-font-weight: bold");
+        }
     }
 }


### PR DESCRIPTION
This pull request contains a backport of commit [af7e0571](https://github.com/openjdk/jfx/commit/af7e05716711d942df20eb1f807b384810a4a839) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

The commit being backported was authored by Michael Strauß on 30 Jan 2024 and was reviewed by Kevin Rushforth and Andy Goryachev.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324879](https://bugs.openjdk.org/browse/JDK-8324879): Platform-specific preferences keys are incorrect for Windows toolkit (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1355/head:pull/1355` \
`$ git checkout pull/1355`

Update a local copy of the PR: \
`$ git checkout pull/1355` \
`$ git pull https://git.openjdk.org/jfx.git pull/1355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1355`

View PR using the GUI difftool: \
`$ git pr show -t 1355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1355.diff">https://git.openjdk.org/jfx/pull/1355.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1355#issuecomment-1917736947)