### PR TITLE
8320912: IME should commit on focus change

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacView.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacView.java
@@ -78,6 +78,7 @@ final class MacView extends View {
     @Override native protected boolean _enterFullscreen(long ptr, boolean animate, boolean keepRatio, boolean hideCursor);
     @Override native protected void _exitFullscreen(long ptr, boolean animate);
     @Override native protected void _enableInputMethodEvents(long ptr, boolean enable);
+    @Override native protected void _finishInputMethodComposition(long ptr);
 
     @Override protected void _uploadPixels(long ptr, Pixels pixels) {
         Buffer data = pixels.getPixels();

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView.h
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView.h
@@ -47,6 +47,7 @@
 
 - (GlassViewDelegate*)delegate;
 - (void)setInputMethodEnabled:(BOOL)enabled;
+- (void)finishInputMethodComposition;
 
 - (void)notifyScaleFactorChanged:(CGFloat)scale;
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView.m
@@ -712,3 +712,24 @@ JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacView__1enableInputMethodEven
     GLASS_POOL_EXIT;
     GLASS_CHECK_EXCEPTION(env);
 }
+
+/*
+ * Class:     com_sun_glass_ui_mac_MacView
+ * Method:    _finishInputMethodComposition
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_com_sun_glass_ui_mac_MacView__1finishInputMethodComposition
+(JNIEnv *env, jobject jView, jlong ptr)
+{
+    LOG("Java_com_sun_glass_ui_mac_MacView__1finishInputMethodComposition");
+    if (!ptr) return;
+
+    GLASS_ASSERT_MAIN_JAVA_THREAD(env);
+    GLASS_POOL_ENTER;
+    {
+        NSView<GlassView> *view = getGlassView(env, ptr);
+        [view finishInputMethodComposition];
+    }
+    GLASS_POOL_EXIT;
+    GLASS_CHECK_EXCEPTION(env);
+}

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassView3D.m
@@ -717,9 +717,22 @@
     self->imEnabled = enabled;
 }
 
+- (void)finishInputMethodComposition
+{
+    IMLOG("finishInputMethodComposition called");
+    [self unmarkText];
+    [self.inputContext discardMarkedText];
+}
+
 /*
  NSTextInputClient protocol implementation follows here.
  */
+
+// Utility function, not part of protocol
+- (void)commitString:(NSString*)aString
+{
+    [self->_delegate notifyInputMethod:aString attr:4 length:(int)[aString length] cursor:(int)[aString length] selectedRange: NSMakeRange(NSNotFound, 0)];
+}
 
 - (void)doCommandBySelector:(SEL)aSelector
 {
@@ -733,7 +746,7 @@
 {
     IMLOG("insertText called with string: %s", [aString UTF8String]);
     if ([self->nsAttrBuffer length] > 0 || [aString length] > 1) {
-        [self->_delegate notifyInputMethod:aString attr:4 length:(int)[aString length] cursor:(int)[aString length] selectedRange: NSMakeRange(NSNotFound, 0)];
+        [self commitString: aString];
         self->shouldProcessKeyEvent = NO;
     } else {
         self->shouldProcessKeyEvent = YES;
@@ -760,9 +773,9 @@
 - (void) unmarkText
 {
     IMLOG("unmarkText called\n");
-    if (self->nsAttrBuffer != nil && self->nsAttrBuffer.length != 0) {
-        self->nsAttrBuffer = [self->nsAttrBuffer initWithString:@""];
-        [self->_delegate notifyInputMethod:@"" attr:4 length:0 cursor:0 selectedRange: NSMakeRange(NSNotFound, 0)];
+    if (nsAttrBuffer.length != 0) {
+        [self commitString: nsAttrBuffer.string];
+        nsAttrBuffer = [nsAttrBuffer initWithString:@""];
     }
     self->shouldProcessKeyEvent = YES;
 }


### PR DESCRIPTION
This is a Mac only bug. If the user was in the middle of IM text composition and clicked on a different node the partially composed text was left in the old node and the IM window wasn't dismissed. This PR implements the existing finishInputMethodComposition call so it can commit the text and dismiss the IM window before focus moves away from the node where composition was taking place.

This PR changes the implementation of `unmarkText` to match what we want and what Apple says it should do ("The text view should accept the marked text as if it had been inserted normally"). With that said I haven't found an IME that calls this routine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8320912](https://bugs.openjdk.org/browse/JDK-8320912): IME should commit on focus change (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1356/head:pull/1356` \
`$ git checkout pull/1356`

Update a local copy of the PR: \
`$ git checkout pull/1356` \
`$ git pull https://git.openjdk.org/jfx.git pull/1356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1356`

View PR using the GUI difftool: \
`$ git pr show -t 1356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1356.diff">https://git.openjdk.org/jfx/pull/1356.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1356#issuecomment-1917847932)