### PR TITLE
8325093: Update CONTRIBUTING.md for build jdk version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,7 +235,7 @@ JDK 17 (at a minimum) is required to build OpenJFX. You must have the JDK
 installed on your system
 with the environment variable `JAVA_HOME` referencing the path to Java home for
 your JDK installation. By default, tests use the same runtime as `JAVA_HOME`.
-Currently OpenJFX will build and run on JDK 17 through JDK 18.
+Currently OpenJFX will build and run on JDK 17 through JDK 21.
 
 It is possible to develop in any major Java IDE (Eclipse, IntelliJ, NetBeans). IDEs can automatically configure projects based on Gradle setup.
 


### PR DESCRIPTION
[JDK-8297068](https://bugs.openjdk.org/browse/JDK-8297068) updated boot JDK to 19.0.1 from 18.0.2, and [JDK-8321434](https://bugs.openjdk.org/browse/JDK-8321434) updated boot JDK to 21.0.1. `CONTRIBUTING.md` should be updated correspondingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325093](https://bugs.openjdk.org/browse/JDK-8325093): Update CONTRIBUTING.md for build jdk version (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1357/head:pull/1357` \
`$ git checkout pull/1357`

Update a local copy of the PR: \
`$ git checkout pull/1357` \
`$ git pull https://git.openjdk.org/jfx.git pull/1357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1357`

View PR using the GUI difftool: \
`$ git pr show -t 1357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1357.diff">https://git.openjdk.org/jfx/pull/1357.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1357#issuecomment-1920611840)