### PR TITLE
JDK-8325402: TreeTableRow updateItem() does not check item with isItemChanged(..) unlike all other cell implementations

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableRow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableRow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -258,7 +258,7 @@ public class TreeTableRow<T> extends IndexedCell<T> {
                 weakTreeTableViewRef = new WeakReference<>(get());
             }
 
-            updateItem();
+            updateItem(-1);
             requestLayout();
         }
     };
@@ -291,14 +291,13 @@ public class TreeTableRow<T> extends IndexedCell<T> {
 
 
     @Override void indexChanged(int oldIndex, int newIndex) {
-        index = getIndex();
+        super.indexChanged(oldIndex, newIndex);
 
         // when the cell index changes, this may result in the cell
         // changing state to be selected and/or focused.
-        updateItem();
+        updateItem(oldIndex);
         updateSelection();
         updateFocus();
-//        oldIndex = index;
     }
 
 
@@ -388,25 +387,26 @@ public class TreeTableRow<T> extends IndexedCell<T> {
      *                                                                         *
      **************************************************************************/
 
-    private int index = -1;
     private boolean isFirstRun = true;
 
-    private void updateItem() {
+    private void updateItem(int oldIndex) {
         TreeTableView<T> tv = getTreeTableView();
         if (tv == null) return;
 
         // Compute whether the index for this cell is for a real item
-        boolean valid = index >=0 && index < tv.getExpandedItemCount();
+        final int newIndex = getIndex();
+        boolean valid = newIndex >= 0 && newIndex < tv.getExpandedItemCount();
 
         final TreeItem<T> oldTreeItem = getTreeItem();
         final boolean isEmpty = isEmpty();
 
         // Cause the cell to update itself
-        if (valid) {
+        outer: if (valid) {
             // update the TreeCell state.
             // get the new treeItem that is about to go in to the TreeCell
-            final TreeItem<T> newTreeItem = tv.getTreeItem(index);
+            final TreeItem<T> newTreeItem = tv.getTreeItem(newIndex);
             final T newValue = newTreeItem == null ? null : newTreeItem.getValue();
+            final T oldValue = oldTreeItem == null ? null : oldTreeItem.getValue();
 
             // For the sake of RT-14279, it is important that the order of these
             // method calls is as shown below. If the order is switched, it is
@@ -414,11 +414,17 @@ public class TreeTableRow<T> extends IndexedCell<T> {
             // though calling cell.getTreeItem().getValue() returns the value
             // as expected
 
-            // There used to be conditional code here to prevent updateItem from
-            // being called when the value didn't change, but that led us to
-            // issues such as RT-33108, where the value didn't change but the item
-            // we needed to be listening to did. Without calling updateItem we
-            // were breaking things, so once again the conditionals are gone.
+            // RT-35864 - if the index didn't change, then avoid calling updateItem
+            // unless the item has changed.
+            if (oldIndex == newIndex) {
+                if (!isItemChanged(oldValue, newValue)) {
+                    // RT-37054:  we break out of the if/else code here and
+                    // proceed with the code following this, so that we may
+                    // still update references, listeners, etc as required.
+                    break outer;
+                }
+            }
+
             updateTreeItem(newTreeItem);
             updateItem(newValue, false);
         } else {
@@ -438,7 +444,7 @@ public class TreeTableRow<T> extends IndexedCell<T> {
 
     private void updateSelection() {
         if (isEmpty()) return;
-        if (index == -1 || getTreeTableView() == null) return;
+        if (getIndex() == -1 || getTreeTableView() == null) return;
 
         TreeTableViewSelectionModel<T> sm = getTreeTableView().getSelectionModel();
         if (sm == null) {
@@ -448,7 +454,7 @@ public class TreeTableRow<T> extends IndexedCell<T> {
             return;
         }
 
-        boolean isSelected = !sm.isCellSelectionEnabled() && sm.isSelected(index);
+        boolean isSelected = !sm.isCellSelectionEnabled() && sm.isSelected(getIndex());
         if (isSelected() != isSelected) {
             updateSelected(isSelected);
         }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableRow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableRow.java
@@ -401,7 +401,7 @@ public class TreeTableRow<T> extends IndexedCell<T> {
         final boolean isEmpty = isEmpty();
 
         // Cause the cell to update itself
-        outer: if (valid) {
+        if (valid) {
             // update the TreeCell state.
             // get the new treeItem that is about to go in to the TreeCell
             final TreeItem<T> newTreeItem = tv.getTreeItem(newIndex);
@@ -421,7 +421,7 @@ public class TreeTableRow<T> extends IndexedCell<T> {
                     // RT-37054:  we break out of the if/else code here and
                     // proceed with the code following this, so that we may
                     // still update references, listeners, etc as required.
-                    break outer;
+                    return;
                 }
             }
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package test.javafx.scene.control;
 
+import javafx.scene.control.IndexedCell;
 import javafx.scene.control.skin.ListCellSkin;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 import javafx.beans.InvalidationListener;
@@ -43,11 +44,15 @@ import javafx.scene.control.SelectionMode;
 
 import java.util.List;
 import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.sun.javafx.tk.Toolkit;
+import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
 
 import static javafx.scene.control.ControlShim.*;
 import static test.com.sun.javafx.scene.control.infrastructure.ControlTestUtils.*;
@@ -1128,6 +1133,56 @@ public class ListCellTest {
         cell.commitEdit("ABCDEF");
 
         assertEquals("ABCDEF [Changed]", cell.getItem());
+    }
+
+    /**
+     * Same index and underlying item should not cause the updateItem(..) method to be called.
+     */
+    @Test
+    public void testSameIndexAndItemShouldNotUpdateItem() {
+        AtomicInteger counter = new AtomicInteger();
+
+        list.setCellFactory(e -> new ListCell<>() {
+            @Override
+            protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+
+                counter.incrementAndGet();
+            }
+        });
+
+        stageLoader = new StageLoader(list);
+
+        counter.set(0);
+        IndexedCell<String> cell = VirtualFlowTestUtils.getCell(list, 0);
+        cell.updateIndex(0);
+
+        assertEquals(0, counter.get());
+    }
+
+    /**
+     * The contract of a {@link ListCell} is that isItemChanged(..)
+     * is called when the index is 'changed' to the same number as the old one, to evaluate if we need to call
+     * updateItem(..).
+     */
+    @Test
+    public void testSameIndexIsItemsChangedShouldBeCalled() {
+        AtomicBoolean isItemChangedCalled = new AtomicBoolean();
+
+        list.setCellFactory(e -> new ListCell<>() {
+            @Override
+            protected boolean isItemChanged(String oldItem, String newItem) {
+                isItemChangedCalled.set(true);
+                return super.isItemChanged(oldItem, newItem);
+            }
+        });
+
+        stageLoader = new StageLoader(list);
+
+        IndexedCell<String> cell = VirtualFlowTestUtils.getCell(list, 0);
+        cell.updateIndex(0);
+
+        assertTrue(isItemChangedCalled.get());
     }
 
     public static class MisbehavingOnCancelListCell<T> extends ListCell<T> {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListCellTest.java
@@ -1145,9 +1145,8 @@ public class ListCellTest {
         list.setCellFactory(e -> new ListCell<>() {
             @Override
             protected void updateItem(String item, boolean empty) {
-                super.updateItem(item, empty);
-
                 counter.incrementAndGet();
+                super.updateItem(item, empty);
             }
         });
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -584,6 +584,9 @@ public class ListViewTest {
         RT_22463_Person p2 = new RT_22463_Person();
         p2.setId(2l);
         p2.setName("name2");
+
+        stageLoader = new StageLoader(list);
+
         list.setItems(FXCollections.observableArrayList(p1, p2));
         VirtualFlowTestUtils.assertCellTextEquals(list, 0, "name1");
         VirtualFlowTestUtils.assertCellTextEquals(list, 1, "name2");
@@ -598,6 +601,34 @@ public class ListViewTest {
         new_p2.setName("updated name2");
         list.getItems().clear();
         list.setItems(FXCollections.observableArrayList(new_p1, new_p2));
+        VirtualFlowTestUtils.assertCellTextEquals(list, 0, "updated name1");
+        VirtualFlowTestUtils.assertCellTextEquals(list, 1, "updated name2");
+    }
+
+    @Test public void testSetItemsShouldUpdateTheCells() {
+        final ListView<RT_22463_Person> list = new ListView<>();
+
+        RT_22463_Person p1 = new RT_22463_Person();
+        p1.setId(1L);
+        p1.setName("name1");
+        RT_22463_Person p2 = new RT_22463_Person();
+        p2.setId(2L);
+        p2.setName("name2");
+
+        stageLoader = new StageLoader(list);
+
+        list.setItems(FXCollections.observableArrayList(p1, p2));
+        VirtualFlowTestUtils.assertCellTextEquals(list, 0, "name1");
+        VirtualFlowTestUtils.assertCellTextEquals(list, 1, "name2");
+
+        // Replace all Items by the new ones. Cells should get updated.
+        RT_22463_Person newP1 = new RT_22463_Person();
+        newP1.setId(1L);
+        newP1.setName("updated name1");
+        RT_22463_Person newP2 = new RT_22463_Person();
+        newP2.setId(2L);
+        newP2.setName("updated name2");
+        list.setItems(FXCollections.observableArrayList(newP1, newP2));
         VirtualFlowTestUtils.assertCellTextEquals(list, 0, "updated name1");
         VirtualFlowTestUtils.assertCellTextEquals(list, 1, "updated name2");
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
@@ -605,7 +605,8 @@ public class ListViewTest {
         VirtualFlowTestUtils.assertCellTextEquals(list, 1, "updated name2");
     }
 
-    @Test public void testSetItemsShouldUpdateTheCells() {
+    @Test
+    public void testSetItemsShouldUpdateTheCells() {
         final ListView<RT_22463_Person> list = new ListView<>();
 
         RT_22463_Person p1 = new RT_22463_Person();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,8 +28,11 @@ package test.javafx.scene.control;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javafx.beans.property.SimpleStringProperty;
+import javafx.scene.control.IndexedCell;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -923,6 +926,58 @@ public class TableCellTest {
         cell.commitEdit("ABCDEF");
 
         assertEquals("ABCDEF [Changed]", cell.getItem());
+    }
+
+    /**
+     * Same index and underlying item should not cause the updateItem(..) method to be called.
+     */
+    @Test
+    public void testSameIndexAndItemShouldNotUpdateItem() {
+        AtomicInteger counter = new AtomicInteger();
+
+        editingColumn.setCellFactory(view -> new TableCell<>() {
+            @Override
+            protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+
+                counter.incrementAndGet();
+            }
+        });
+        setupForEditing();
+
+        stageLoader = new StageLoader(table);
+
+        counter.set(0);
+        IndexedCell<String> cell = VirtualFlowTestUtils.getCell(table, 0, 0);
+        cell.updateIndex(0);
+
+        assertEquals(0, counter.get());
+    }
+
+    /**
+     * The contract of a {@link TableCell} is that isItemChanged(..)
+     * is called when the index is 'changed' to the same number as the old one, to evaluate if we need to call
+     * updateItem(..).
+     */
+    @Test
+    public void testSameIndexIsItemsChangedShouldBeCalled() {
+        AtomicBoolean isItemChangedCalled = new AtomicBoolean();
+
+        editingColumn.setCellFactory(view -> new TableCell<>() {
+            @Override
+            protected boolean isItemChanged(String oldItem, String newItem) {
+                isItemChangedCalled.set(true);
+                return super.isItemChanged(oldItem, newItem);
+            }
+        });
+        setupForEditing();
+
+        stageLoader = new StageLoader(table);
+
+        IndexedCell<String> cell = VirtualFlowTestUtils.getCell(table, 0, 0);
+        cell.updateIndex(0);
+
+        assertTrue(isItemChangedCalled.get());
     }
 
     public static class MisbehavingOnCancelTableCell<S, T> extends TableCell<S, T> {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableCellTest.java
@@ -938,9 +938,8 @@ public class TableCellTest {
         editingColumn.setCellFactory(view -> new TableCell<>() {
             @Override
             protected void updateItem(String item, boolean empty) {
-                super.updateItem(item, empty);
-
                 counter.incrementAndGet();
+                super.updateItem(item, empty);
             }
         });
         setupForEditing();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewRowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewRowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,7 @@
  */
 package test.javafx.scene.control;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -33,10 +34,14 @@ import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
 
+import javafx.scene.control.TreeTableRow;
 import org.junit.After;
 import org.junit.Test;
 
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Contains TableViewRow tests.
@@ -153,5 +158,57 @@ public class TableViewRowTest {
         assertFalse(c1.isSelected());
         assertTrue(c2.isSelected());
         assertFalse(row.isSelected());
+    }
+
+    /**
+     * Same index and underlying item should not cause the updateItem(..) method to be called.
+     */
+    @Test
+    public void testSameIndexAndItemShouldNotUpdateItem() {
+        AtomicInteger counter = new AtomicInteger();
+
+        TableView<String> table = ControlUtils.createTableView();
+        table.setRowFactory(view -> new TableRow<>() {
+            @Override
+            protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+
+                counter.incrementAndGet();
+            }
+        });
+
+        stageLoader = new StageLoader(table);
+
+        counter.set(0);
+        TableRow<String> row = ControlUtils.getTableRow(table, 0);
+        row.updateIndex(0);
+
+        assertEquals(0, counter.get());
+    }
+
+    /**
+     * The contract of a {@link TableRow} is that isItemChanged(..)
+     * is called when the index is 'changed' to the same number as the old one, to evaluate if we need to call
+     * updateItem(..).
+     */
+    @Test
+    public void testSameIndexIsItemsChangedShouldBeCalled() {
+        AtomicBoolean isItemChangedCalled = new AtomicBoolean();
+
+        TableView<String> table = ControlUtils.createTableView();
+        table.setRowFactory(view -> new TableRow<>() {
+            @Override
+            protected boolean isItemChanged(String oldItem, String newItem) {
+                isItemChangedCalled.set(true);
+                return super.isItemChanged(oldItem, newItem);
+            }
+        });
+
+        stageLoader = new StageLoader(table);
+
+        TableRow<String> row = ControlUtils.getTableRow(table, 0);
+        row.updateIndex(0);
+
+        assertTrue(isItemChangedCalled.get());
     }
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewRowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewRowTest.java
@@ -171,9 +171,8 @@ public class TableViewRowTest {
         table.setRowFactory(view -> new TableRow<>() {
             @Override
             protected void updateItem(String item, boolean empty) {
-                super.updateItem(item, empty);
-
                 counter.incrementAndGet();
+                super.updateItem(item, empty);
             }
         });
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1080,6 +1080,9 @@ public class TableViewTest {
         RT_22463_Person p2 = new RT_22463_Person();
         p2.setId(2l);
         p2.setName("name2");
+
+        stageLoader = new StageLoader(table);
+
         table.setItems(FXCollections.observableArrayList(p1, p2));
         VirtualFlowTestUtils.assertCellTextEquals(table, 0, "1", "name1");
         VirtualFlowTestUtils.assertCellTextEquals(table, 1, "2", "name2");
@@ -1094,6 +1097,41 @@ public class TableViewTest {
         new_p2.setName("updated name2");
         table.getItems().clear();
         table.setItems(FXCollections.observableArrayList(new_p1, new_p2));
+        VirtualFlowTestUtils.assertCellTextEquals(table, 0, "1", "updated name1");
+        VirtualFlowTestUtils.assertCellTextEquals(table, 1, "2", "updated name2");
+    }
+
+    @Test public void testSetItemsShouldUpdateTheCells() {
+        final TableView<RT_22463_Person> table = new TableView<>();
+        TableColumn<RT_22463_Person, ?> c1 = new TableColumn<>("Id");
+        TableColumn<RT_22463_Person, ?> c2 = new TableColumn<>("Name");
+        c1.setCellValueFactory(new PropertyValueFactory<>("id"));
+        c2.setCellValueFactory(new PropertyValueFactory<>("name"));
+        table.getColumns().addAll(c1, c2);
+
+        RT_22463_Person p1 = new RT_22463_Person();
+        p1.setId(1L);
+        p1.setName("name1");
+        RT_22463_Person p2 = new RT_22463_Person();
+        p2.setId(2L);
+        p2.setName("name2");
+
+        stageLoader = new StageLoader(table);
+
+        table.setItems(FXCollections.observableArrayList(p1, p2));
+        VirtualFlowTestUtils.assertCellTextEquals(table, 0, "1", "name1");
+        VirtualFlowTestUtils.assertCellTextEquals(table, 1, "2", "name2");
+
+        // Replace all Items by the new ones. Cells should get updated.
+        RT_22463_Person newP1 = new RT_22463_Person();
+        newP1.setId(1L);
+        newP1.setName("updated name1");
+        RT_22463_Person newP2 = new RT_22463_Person();
+        newP2.setId(2L);
+        newP2.setName("updated name2");
+
+        table.setItems(FXCollections.observableArrayList(newP1, newP2));
+
         VirtualFlowTestUtils.assertCellTextEquals(table, 0, "1", "updated name1");
         VirtualFlowTestUtils.assertCellTextEquals(table, 1, "2", "updated name2");
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -1101,7 +1101,8 @@ public class TableViewTest {
         VirtualFlowTestUtils.assertCellTextEquals(table, 1, "2", "updated name2");
     }
 
-    @Test public void testSetItemsShouldUpdateTheCells() {
+    @Test
+    public void testSetItemsShouldUpdateTheCells() {
         final TableView<RT_22463_Person> table = new TableView<>();
         TableColumn<RT_22463_Person, ?> c1 = new TableColumn<>("Id");
         TableColumn<RT_22463_Person, ?> c2 = new TableColumn<>("Name");

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,10 @@ package test.javafx.scene.control;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import javafx.scene.control.IndexedCell;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -1058,6 +1061,56 @@ public class TreeCellTest {
         cell.commitEdit("ABCDEF");
 
         assertEquals("ABCDEF [Changed]", cell.getItem());
+    }
+
+    /**
+     * Same index and underlying item should not cause the updateItem(..) method to be called.
+     */
+    @Test
+    public void testSameIndexAndItemShouldNotUpdateItem() {
+        AtomicInteger counter = new AtomicInteger();
+
+        tree.setCellFactory(e -> new TreeCell<>() {
+            @Override
+            protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+
+                counter.incrementAndGet();
+            }
+        });
+
+        stageLoader = new StageLoader(tree);
+
+        counter.set(0);
+        IndexedCell<String> cell = VirtualFlowTestUtils.getCell(tree, 0);
+        cell.updateIndex(0);
+
+        assertEquals(0, counter.get());
+    }
+
+    /**
+     * The contract of a {@link TreeCell} is that isItemChanged(..)
+     * is called when the index is 'changed' to the same number as the old one, to evaluate if we need to call
+     * updateItem(..).
+     */
+    @Test
+    public void testSameIndexIsItemsChangedShouldBeCalled() {
+        AtomicBoolean isItemChangedCalled = new AtomicBoolean();
+
+        tree.setCellFactory(e -> new TreeCell<>() {
+            @Override
+            protected boolean isItemChanged(String oldItem, String newItem) {
+                isItemChangedCalled.set(true);
+                return super.isItemChanged(oldItem, newItem);
+            }
+        });
+
+        stageLoader = new StageLoader(tree);
+
+        IndexedCell<String> cell = VirtualFlowTestUtils.getCell(tree, 0);
+        cell.updateIndex(0);
+
+        assertTrue(isItemChangedCalled.get());
     }
 
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeCellTest.java
@@ -1073,9 +1073,8 @@ public class TreeCellTest {
         tree.setCellFactory(e -> new TreeCell<>() {
             @Override
             protected void updateItem(String item, boolean empty) {
-                super.updateItem(item, empty);
-
                 counter.incrementAndGet();
+                super.updateItem(item, empty);
             }
         });
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package test.javafx.scene.control;
 
 import javafx.beans.property.SimpleStringProperty;
+import javafx.scene.control.IndexedCell;
 import javafx.scene.control.skin.TreeTableCellSkin;
 import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 import test.com.sun.javafx.scene.control.infrastructure.VirtualFlowTestUtils;
@@ -44,6 +45,8 @@ import javafx.scene.control.TreeTableView;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.After;
 import org.junit.Before;
@@ -1235,6 +1238,58 @@ public class TreeTableCellTest {
         cell.commitEdit("ABCDEF");
 
         assertEquals("ABCDEF [Changed]", cell.getItem());
+    }
+
+    /**
+     * Same index and underlying item should not cause the updateItem(..) method to be called.
+     */
+    @Test
+    public void testSameIndexAndItemShouldNotUpdateItem() {
+        AtomicInteger counter = new AtomicInteger();
+
+        editingColumn.setCellFactory(view -> new TreeTableCell<>() {
+            @Override
+            protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+
+                counter.incrementAndGet();
+            }
+        });
+        setupForEditing();
+
+        stageLoader = new StageLoader(tree);
+
+        counter.set(0);
+        IndexedCell<String> cell = VirtualFlowTestUtils.getCell(tree, 0, 0);
+        cell.updateIndex(0);
+
+        assertEquals(0, counter.get());
+    }
+
+    /**
+     * The contract of a {@link TreeTableCell} is that isItemChanged(..)
+     * is called when the index is 'changed' to the same number as the old one, to evaluate if we need to call
+     * updateItem(..).
+     */
+    @Test
+    public void testSameIndexIsItemsChangedShouldBeCalled() {
+        AtomicBoolean isItemChangedCalled = new AtomicBoolean();
+
+        editingColumn.setCellFactory(view -> new TreeTableCell<>() {
+            @Override
+            protected boolean isItemChanged(String oldItem, String newItem) {
+                isItemChangedCalled.set(true);
+                return super.isItemChanged(oldItem, newItem);
+            }
+        });
+        setupForEditing();
+
+        stageLoader = new StageLoader(tree);
+
+        IndexedCell<String> cell = VirtualFlowTestUtils.getCell(tree, 0, 0);
+        cell.updateIndex(0);
+
+        assertTrue(isItemChangedCalled.get());
     }
 
     public static class MisbehavingOnCancelTreeTableCell<S, T> extends TreeTableCell<S, T> {

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableCellTest.java
@@ -1250,9 +1250,8 @@ public class TreeTableCellTest {
         editingColumn.setCellFactory(view -> new TreeTableCell<>() {
             @Override
             protected void updateItem(String item, boolean empty) {
-                super.updateItem(item, empty);
-
                 counter.incrementAndGet();
+                super.updateItem(item, empty);
             }
         });
         setupForEditing();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableRowTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableRowTest.java
@@ -955,9 +955,8 @@ public class TreeTableRowTest {
         tree.setRowFactory(view -> new TreeTableRow<>() {
             @Override
             protected void updateItem(String item, boolean empty) {
-                super.updateItem(item, empty);
-
                 counter.incrementAndGet();
+                super.updateItem(item, empty);
             }
         });
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1741,6 +1741,8 @@ public class TreeTableViewTest {
         TreeItem<RT_22463_Person> root = new TreeItem<>(rootPerson);
         root.setExpanded(true);
 
+        stageLoader = new StageLoader(table);
+
         table.setRoot(root);
 
         // before the change things display fine
@@ -1768,6 +1770,49 @@ public class TreeTableViewTest {
         root.getChildren().setAll(
                 new TreeItem<>(new_p1),
                 new TreeItem<>(new_p2));
+        VirtualFlowTestUtils.assertCellTextEquals(table, 1, "1", "updated name1");
+        VirtualFlowTestUtils.assertCellTextEquals(table, 2, "2", "updated name2");
+    }
+
+    @Test public void testSetChildrenShouldUpdateTheCells() {
+        final TreeTableView<RT_22463_Person> table = new TreeTableView<>();
+        TreeTableColumn<RT_22463_Person, ?> c1 = new TreeTableColumn<>("Id");
+        TreeTableColumn<RT_22463_Person, ?> c2 = new TreeTableColumn<>("Name");
+        c1.setCellValueFactory(new TreeItemPropertyValueFactory<>("id"));
+        c2.setCellValueFactory(new TreeItemPropertyValueFactory<>("name"));
+        table.getColumns().addAll(c1, c2);
+
+        RT_22463_Person rootPerson = new RT_22463_Person();
+        rootPerson.setName("Root");
+        TreeItem<RT_22463_Person> root = new TreeItem<>(rootPerson);
+        root.setExpanded(true);
+
+        stageLoader = new StageLoader(table);
+
+        table.setRoot(root);
+
+        RT_22463_Person p1 = new RT_22463_Person();
+        p1.setId(1L);
+        p1.setName("name1");
+        RT_22463_Person p2 = new RT_22463_Person();
+        p2.setId(2L);
+        p2.setName("name2");
+        root.getChildren().addAll(
+                new TreeItem<>(p1),
+                new TreeItem<>(p2));
+        VirtualFlowTestUtils.assertCellTextEquals(table, 1, "1", "name1");
+        VirtualFlowTestUtils.assertCellTextEquals(table, 2, "2", "name2");
+
+        // Replace all TreeItems by the new ones. Cells should get updated.
+        RT_22463_Person newP1 = new RT_22463_Person();
+        newP1.setId(1L);
+        newP1.setName("updated name1");
+        RT_22463_Person newP2 = new RT_22463_Person();
+        newP2.setId(2L);
+        newP2.setName("updated name2");
+        root.getChildren().setAll(
+                new TreeItem<>(newP1),
+                new TreeItem<>(newP2));
         VirtualFlowTestUtils.assertCellTextEquals(table, 1, "1", "updated name1");
         VirtualFlowTestUtils.assertCellTextEquals(table, 2, "2", "updated name2");
     }
@@ -2591,14 +2636,14 @@ public class TreeTableViewTest {
 
         StageLoader sl = new StageLoader(treeTableView);
 
-        assertEquals(22, rt_31200_count);
+        assertEquals(18, rt_31200_count);
 
         // resize the stage
         sl.getStage().setHeight(250);
         Toolkit.getToolkit().firePulse();
         sl.getStage().setHeight(50);
         Toolkit.getToolkit().firePulse();
-        assertEquals(22, rt_31200_count);
+        assertEquals(18, rt_31200_count);
 
         sl.dispose();
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -1774,7 +1774,8 @@ public class TreeTableViewTest {
         VirtualFlowTestUtils.assertCellTextEquals(table, 2, "2", "updated name2");
     }
 
-    @Test public void testSetChildrenShouldUpdateTheCells() {
+    @Test
+    public void testSetChildrenShouldUpdateTheCells() {
         final TreeTableView<RT_22463_Person> table = new TreeTableView<>();
         TreeTableColumn<RT_22463_Person, ?> c1 = new TreeTableColumn<>("Id");
         TreeTableColumn<RT_22463_Person, ?> c2 = new TreeTableColumn<>("Name");
@@ -2636,6 +2637,7 @@ public class TreeTableViewTest {
 
         StageLoader sl = new StageLoader(treeTableView);
 
+        int oldCount = rt_31200_count;
         assertEquals(18, rt_31200_count);
 
         // resize the stage
@@ -2643,7 +2645,8 @@ public class TreeTableViewTest {
         Toolkit.getToolkit().firePulse();
         sl.getStage().setHeight(50);
         Toolkit.getToolkit().firePulse();
-        assertEquals(18, rt_31200_count);
+        // Should be the same count as above.
+        assertEquals(oldCount, rt_31200_count);
 
         sl.dispose();
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -102,6 +102,8 @@ public class TreeViewTest {
     private TreeItem<String> child2;
     private TreeItem<String> child3;
 
+    private StageLoader stageLoader;
+
     // sample data #1
     private TreeItem<String> myCompanyRootNode;
         private TreeItem<String> salesDepartment;
@@ -181,6 +183,10 @@ public class TreeViewTest {
     @After
     public void cleanup() {
         Thread.currentThread().setUncaughtExceptionHandler(null);
+
+        if (stageLoader != null) {
+            stageLoader.dispose();
+        }
     }
 
     private void installChildren() {
@@ -800,6 +806,9 @@ public class TreeViewTest {
         root.setExpanded(true);
 
         final TreeView<RT_22463_Person> tree = new TreeView<>();
+
+        stageLoader = new StageLoader(tree);
+
         tree.setRoot(root);
 
         // before the change things display fine
@@ -812,6 +821,9 @@ public class TreeViewTest {
         root.getChildren().addAll(
                 new TreeItem<>(p1),
                 new TreeItem<>(p2));
+
+        Toolkit.getToolkit().firePulse();
+
         VirtualFlowTestUtils.assertCellTextEquals(tree, 1, "name1");
         VirtualFlowTestUtils.assertCellTextEquals(tree, 2, "name2");
 
@@ -827,6 +839,53 @@ public class TreeViewTest {
         root.getChildren().setAll(
                 new TreeItem<>(new_p1),
                 new TreeItem<>(new_p2));
+
+        Toolkit.getToolkit().firePulse();
+
+        VirtualFlowTestUtils.assertCellTextEquals(tree, 1, "updated name1");
+        VirtualFlowTestUtils.assertCellTextEquals(tree, 2, "updated name2");
+    }
+
+    @Test public void testSetChildrenShouldUpdateTheCells() {
+        RT_22463_Person rootPerson = new RT_22463_Person();
+        rootPerson.setName("Root");
+        TreeItem<RT_22463_Person> root = new TreeItem<>(rootPerson);
+        root.setExpanded(true);
+
+        final TreeView<RT_22463_Person> tree = new TreeView<>();
+
+        stageLoader = new StageLoader(tree);
+
+        tree.setRoot(root);
+
+        RT_22463_Person p1 = new RT_22463_Person();
+        p1.setId(1L);
+        p1.setName("name1");
+        RT_22463_Person p2 = new RT_22463_Person();
+        p2.setId(2L);
+        p2.setName("name2");
+        root.getChildren().addAll(
+                new TreeItem<>(p1),
+                new TreeItem<>(p2));
+
+        Toolkit.getToolkit().firePulse();
+
+        VirtualFlowTestUtils.assertCellTextEquals(tree, 1, "name1");
+        VirtualFlowTestUtils.assertCellTextEquals(tree, 2, "name2");
+
+        // Replace all TreeItems by the new ones. Cells should get updated.
+        RT_22463_Person newP1 = new RT_22463_Person();
+        newP1.setId(1L);
+        newP1.setName("updated name1");
+        RT_22463_Person newP2 = new RT_22463_Person();
+        newP2.setId(2L);
+        newP2.setName("updated name2");
+        root.getChildren().setAll(
+                new TreeItem<>(newP1),
+                new TreeItem<>(newP2));
+
+        Toolkit.getToolkit().firePulse();
+
         VirtualFlowTestUtils.assertCellTextEquals(tree, 1, "updated name1");
         VirtualFlowTestUtils.assertCellTextEquals(tree, 2, "updated name2");
     }


### PR DESCRIPTION
`TreeTableRow` does not check the item with `isItemChanged(..)`, unlike all other implementations of the cell.

This also means that the `TreeTableRow` always updates the item, although it should not, resulting in a performance loss as a `TreeTableRow` will always call `updateItem(..)`.

It looks like that this was forgotten in [JDK-8092593](https://bugs.openjdk.org/browse/JDK-8092593).

Checking the whole history, it looks like the following was happening:
1. There was a check if the item is the same in all cell implementations (with `.equals(..)`)
2. Check was removed as it caused bugs
3. Check was readded, but instead we first check the index (same index) and then if we also have the same item (this time with `.isItemChanged(..)`, to allow developers to subclass it)
4. Forgotten for `TreeTableRow` inbetween this chaos.

Added many tests for the case where an item should be changed and where it should not.
Improved existing tests as well. Using `stageLoader`, as before the tests only created a stage when doing the assert.

NOTE: The update logic is now the same as for all other 5 cell implementations. Especially `TreeCell` (since it is for a tree structure as well).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8325402](https://bugs.openjdk.org/browse/JDK-8325402): TreeTableRow updateItem() does not check item with isItemChanged(..) unlike all other cell implementations (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Karthik P K](https://openjdk.org/census#kpk) (@karthikpandelu - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1360/head:pull/1360` \
`$ git checkout pull/1360`

Update a local copy of the PR: \
`$ git checkout pull/1360` \
`$ git pull https://git.openjdk.org/jfx.git pull/1360/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1360`

View PR using the GUI difftool: \
`$ git pr show -t 1360`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1360.diff">https://git.openjdk.org/jfx/pull/1360.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1360#issuecomment-1934757834)