### PR TITLE
8311492: FontSmoothingType LCD produces wrong color when transparency is used

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/prism/impl/ps/BaseShaderGraphics.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/impl/ps/BaseShaderGraphics.java
@@ -2016,9 +2016,10 @@ public abstract class BaseShaderGraphics
 
         CompositeMode blendMode = getCompositeMode();
         // LCD support requires several attributes to function:
-        // FontStrike supports LCD, SRC_OVER CompositeMode and Paint is a COLOR
+        // FontStrike supports LCD, SRC_OVER CompositeMode and Paint is an opaque COLOR
         boolean lcdSupported = blendMode == CompositeMode.SRC_OVER &&
                                textColor != null &&
+                               textColor.getAlpha() == 1.0 &&
                                xform.is2D() &&
                                !getRenderTarget().isMSAA();
 

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWGraphics.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWGraphics.java
@@ -660,8 +660,8 @@ final class SWGraphics implements ReadbackGraphics {
         final boolean doLCDText = drawAsMasks &&
                 (strike.getAAMode() == FontResource.AA_LCD) &&
                 getRenderTarget().isOpaque() &&
-                (this.paint.getType() == Paint.Type.COLOR) &&
-                ((Color)this.paint).getAlpha() == 1.0f &&
+                this.paint instanceof Color c &&
+                c.getAlpha() == 1.0f &&
                 tx.is2D();
         BaseTransform glyphTx = null;
 

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWGraphics.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWGraphics.java
@@ -661,6 +661,7 @@ final class SWGraphics implements ReadbackGraphics {
                 (strike.getAAMode() == FontResource.AA_LCD) &&
                 getRenderTarget().isOpaque() &&
                 (this.paint.getType() == Paint.Type.COLOR) &&
+                ((Color)this.paint).getAlpha() == 1.0f &&
                 tx.is2D();
         BaseTransform glyphTx = null;
 

--- a/tests/system/src/test/java/test/robot/javafx/scene/TransparentLCDTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TransparentLCDTest.java
@@ -78,7 +78,7 @@ public class TransparentLCDTest {
     // and only sample outside the text, where we expect to read the background
     // color, or in the middle of the text fill area, where we expect to find
     // the unadjusted text color.
-    private static final double TOLERANCE = 2.0 / 255.0;
+    private static final double TOLERANCE = 2.5 / 255.0;
 
     private static final int TEXT_X_LEFT = 5;
     private static final int TEXT_Y_BOTTOM = 30;
@@ -187,7 +187,7 @@ public class TransparentLCDTest {
 
     @AfterEach
     public void doTeardown() {
-        Platform.runLater(() -> {
+        Util.runAndWait(() -> {
             if (testStage != null) {
                 testStage.hide();
             }
@@ -269,5 +269,4 @@ public class TransparentLCDTest {
     public void testOpaqueLCD() {
         runTest(true);
     }
-
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/TransparentLCDTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TransparentLCDTest.java
@@ -92,8 +92,8 @@ public class TransparentLCDTest {
     private static final int TEST_X_RIGHT = TEST_WIDTH - 1;
     private static final int TEST_X_MID = TEST_WIDTH / 2;
 
-    private static final Color transpColor = Color.color(0.5, 0.5, 0.5, 0.6);
-    private static final Color opaqueColor = makeOpaque(transpColor);
+    private static final Color TRANSP_COLOR = Color.color(0.5, 0.5, 0.5, 0.6);
+    private static final Color OPAQUE_COLOR = makeOpaque(TRANSP_COLOR);
 
     private Robot robot;
     private Stage testStage;
@@ -124,8 +124,7 @@ public class TransparentLCDTest {
 
    private void assertColorEquals(Color expected, Color actual) {
         if (!testColorEquals(expected, actual, TOLERANCE)) {
-            fail("expected:" + colorToString(expected) +
-                    " but was:" + colorToString(actual));
+            fail("expected:" + expected + " but was:" + actual);
         }
     }
 
@@ -135,14 +134,6 @@ public class TransparentLCDTest {
         double deltaBlue = Math.abs(expected.getBlue() - actual.getBlue());
         double deltaOpacity = Math.abs(expected.getOpacity() - actual.getOpacity());
         return (deltaRed <= delta && deltaGreen <= delta && deltaBlue <= delta && deltaOpacity <= delta);
-    }
-
-    private static String colorToString(Color c) {
-        int r = (int)(c.getRed() * 255.0);
-        int g = (int)(c.getGreen() * 255.0);
-        int b = (int)(c.getBlue() * 255.0);
-        int a = (int)(c.getOpacity() * 255.0);
-        return "rgba(" + r + "," + g + "," + b + "," + a + ")";
     }
 
     private List<Color> getColors(Scene scene, int x, int y, int width) {
@@ -206,7 +197,7 @@ public class TransparentLCDTest {
     // Called by the test methods to run the test either using an opaque color,
     // which should use LCD, or a transparent color, which should not.
     private void runTest(boolean opaque) {
-        final Color textColor = opaque ? opaqueColor : transpColor;
+        final Color textColor = opaque ? OPAQUE_COLOR : TRANSP_COLOR;
 
         Font font = Font.font("System", FontWeight.BOLD, 36);
 
@@ -239,11 +230,11 @@ public class TransparentLCDTest {
             List<Color> colors = getColors(testScene, SAMPLE_X_START, SAMPLE_Y, TEST_WIDTH);
 
             if (DEBUG) {
-                System.err.println("transpColor = " + colorToString(transpColor));
-                System.err.println("opaqueColor = " + colorToString(opaqueColor));
+                System.err.println("TRANSP_COLOR = " + TRANSP_COLOR);
+                System.err.println("OPAQUE_COLOR = " + OPAQUE_COLOR);
                 System.err.println("");
                 colors.stream()
-                        .map(TransparentLCDTest::colorToString)
+                        .map(Color::toString)
                         .forEach(System.err::println);
             }
 
@@ -254,7 +245,7 @@ public class TransparentLCDTest {
 
             assertColorEquals(Color.WHITE, cLeft);
             assertColorEquals(Color.WHITE, cRight);
-            assertColorEquals(opaqueColor, cMid);
+            assertColorEquals(OPAQUE_COLOR, cMid);
 
             // Check whether LCD or GRAY scale AA is used
             boolean isGray = isGrayScale(colors);

--- a/tests/system/src/test/java/test/robot/javafx/scene/TransparentLCDTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TransparentLCDTest.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package test.robot.javafx.scene;
+
+import com.sun.javafx.PlatformUtil;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import javafx.application.ConditionalFeature;
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.scene.image.Image;
+import javafx.scene.layout.Pane;
+import javafx.scene.paint.Color;
+import javafx.scene.robot.Robot;
+import javafx.scene.text.Font;
+import javafx.scene.text.FontSmoothingType;
+import javafx.scene.text.FontWeight;
+import javafx.scene.text.Text;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import test.util.Util;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Basic visual tests using glass Robot to sample pixels.
+ */
+public class TransparentLCDTest {
+
+    private static final boolean DEBUG = false;
+
+    private static final int WIDTH = 400;
+    private static final int HEIGHT = 300;
+
+    // We use a very tight color tolerance, which requires some extra care.
+    // We force a screen scale of 1, stay away from the edes of the window,
+    // and only sample where we expect to read the background color or in
+    // the middle of the text fill area.
+    private static final double TOLERANCE = 2.0 / 255.0;
+
+    private static final int TEXT_X_LEFT = 5;
+    private static final int TEXT_Y_BOTTOM = 30;
+
+    // The following are chosen to test before the first part of the 'V', after
+    // the first part of the 'V', and in the middle of the first part of the 'V'
+    private static final int SAMPLE_X_START = TEXT_X_LEFT;
+    private static final int SAMPLE_Y = 11;
+    private static final int TEST_WIDTH = 12;
+    private static final int TEST_X_LEFT = 0;
+    private static final int TEST_X_RIGHT = TEST_WIDTH - 1;
+    private static final int TEST_X_MID = TEST_WIDTH / 2;
+
+    private static final Color transpColor = Color.color(0.5, 0.5, 0.5, 0.6);
+    private static final Color opaqueColor = makeOpaque(transpColor);
+
+    private Robot robot;
+    private Stage testStage;
+    private Scene testScene;
+
+    private static Color makeOpaque(Color c) {
+        double a = c.getOpacity();
+        double r = c.getRed() * a + (1.0 - a);
+        double g = c.getGreen() * a + (1.0 - a);
+        double b = c.getBlue() * a + (1.0 - a);
+        return Color.color(r, g, b);
+    }
+
+    private boolean isGrayScale(List<Color> colors) {
+        long nonGrayCount = colors.stream()
+                .filter(c -> c.getRed() != c.getGreen() || c.getRed() != c.getBlue())
+                .count();
+        return nonGrayCount == 0;
+    }
+
+   protected void assertColorEquals(Color expected, Color actual) {
+        if (!testColorEquals(expected, actual, TOLERANCE)) {
+            fail("expected:" + colorToString(expected) +
+                    " but was:" + colorToString(actual));
+        }
+    }
+
+    protected boolean testColorEquals(Color expected, Color actual, double delta) {
+        double deltaRed = Math.abs(expected.getRed() - actual.getRed());
+        double deltaGreen = Math.abs(expected.getGreen() - actual.getGreen());
+        double deltaBlue = Math.abs(expected.getBlue() - actual.getBlue());
+        double deltaOpacity = Math.abs(expected.getOpacity() - actual.getOpacity());
+        return (deltaRed <= delta && deltaGreen <= delta && deltaBlue <= delta && deltaOpacity <= delta);
+    }
+
+    protected static String colorToString(Color c) {
+        int r = (int)(c.getRed() * 255.0);
+        int g = (int)(c.getGreen() * 255.0);
+        int b = (int)(c.getBlue() * 255.0);
+        int a = (int)(c.getOpacity() * 255.0);
+        return "rgba(" + r + "," + g + "," + b + "," + a + ")";
+    }
+
+    private List<Color> getColors(Scene scene, int x, int y, int width) {
+        x += scene.getX() + scene.getWindow().getX();
+        y += scene.getY() + scene.getWindow().getY();
+        Image image = robot.getScreenCapture(null, x, y, width, 1);
+        List<Color> colors = new ArrayList<>(width);
+        for (int i = 0; i < width; i++) {
+            colors.add(image.getPixelReader().getColor(i, 0));
+        }
+        return colors;
+    }
+
+    // This must be called on the FX app thread
+    private Stage createStage() {
+        Stage stage = new Stage();
+        stage.initStyle(StageStyle.UNDECORATED);
+        stage.setAlwaysOnTop(true);
+        return stage;
+    }
+
+    @BeforeAll
+    public static void doSetupOnce() {
+        System.setProperty("prism.lcdText", "true");
+        System.setProperty("glass.win.uiScale", "1");
+        System.setProperty("glass.gtk.uiScale", "1");
+
+        Platform.setImplicitExit(false);
+        final CountDownLatch launchLatch = new CountDownLatch(1);
+        Util.startup(launchLatch, launchLatch::countDown);
+        assertEquals(0, launchLatch.getCount());
+    }
+
+    @AfterAll
+    public static void doTeardownOnce() {
+        Util.shutdown();
+    }
+
+    @BeforeEach
+    public void doSetup() {
+        // LCD text is disabled on macOS
+        assumeFalse(PlatformUtil.isMac());
+
+        // Test is not valid for SW pipeline. We don't have a utility to
+        // check the GraphicsPipeline, so we check for 3D support instead.
+        assumeTrue(Platform.isSupported(ConditionalFeature.SCENE3D));
+
+        Util.runAndWait(() -> robot = new Robot());
+        Util.parkCursor(robot);
+    }
+
+    @AfterEach
+    public void doTeardown() {
+        Platform.runLater(() -> {
+            if (testStage != null) {
+                testStage.hide();
+            }
+        });
+    }
+
+    // Called by the test methods to run the test either using an opaque color,
+    // which should use LCD, and a transparent color, which should not.
+    private void runTest(boolean opaque) {
+        final Color textColor = opaque ? opaqueColor : transpColor;
+
+        Font font = Font.font("System", FontWeight.BOLD, 36);
+
+        Util.runAndWait(() -> {
+            testStage = createStage();
+
+            Pane root = new Pane();
+            testScene = new Scene(root, WIDTH, HEIGHT);
+
+            Text text = new Text("V");
+            text.setFont(font);
+            text.setFill(textColor);
+            text.setFontSmoothingType(FontSmoothingType.LCD);
+            text.setLayoutX(TEXT_X_LEFT);
+            text.setLayoutY(TEXT_Y_BOTTOM);
+            root.getChildren().add(text);
+
+            testStage.setScene(testScene);
+            testStage.show();
+        });
+
+        Util.waitForIdle(testScene);
+        Util.sleep(1000);
+
+        Util.runAndWait(() -> {
+            if (DEBUG) {
+                System.err.println("transpColor = " + colorToString(transpColor));
+                System.err.println("opaqueColor = " + colorToString(opaqueColor));
+                System.err.println("");
+            }
+            List<Color> colors = getColors(testScene, SAMPLE_X_START, SAMPLE_Y, TEST_WIDTH);
+
+            if (DEBUG) {
+                colors.stream()
+                        .map(TransparentLCDTest::colorToString)
+                        .forEach(System.err::println);
+            }
+
+            // Verify the colors outside and in the middle of the text
+            Color cLeft = colors.get(TEST_X_LEFT);
+            Color cRight = colors.get(TEST_X_RIGHT);
+            Color cMid = colors.get(TEST_X_MID);
+
+            assertColorEquals(Color.WHITE, cLeft);
+            assertColorEquals(Color.WHITE, cRight);
+            assertColorEquals(opaqueColor, cMid);
+
+            // Check whether LCD or GRAY scale AA is used
+            boolean isGray = isGrayScale(colors);
+            if (opaque) {
+                assertFalse(isGray, "opaque color should use LCD antialiasing");
+            } else {
+                assertTrue(isGray, "transparent color should use GRAY scale antialiasing");
+            }
+
+        });
+    }
+
+    @Test
+    @Timeout(15)
+    public void testTransparentLCD() {
+        runTest(false);
+    }
+
+    @Test
+    @Timeout(15)
+    public void testOpaqueLCD() {
+        runTest(true);
+    }
+
+}

--- a/tests/system/src/test/java/test/robot/javafx/scene/TransparentLCDTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TransparentLCDTest.java
@@ -195,6 +195,7 @@ public class TransparentLCDTest {
 
         Font font = Font.font("System", FontWeight.BOLD, 36);
 
+        CountDownLatch latch = new CountDownLatch(1);
         Util.runAndWait(() -> {
             testStage = createStage();
 
@@ -209,12 +210,15 @@ public class TransparentLCDTest {
             text.setLayoutY(TEXT_Y_BOTTOM);
             root.getChildren().add(text);
 
+            testStage.setOnShowing(e -> Platform.runLater(latch::countDown));
             testStage.setScene(testScene);
             testStage.show();
         });
 
+        // Wait until stage is showing and scene is rendered
+        Util.waitForLatch(latch, 5, "Timeout showing stage");
         Util.waitForIdle(testScene);
-        Util.sleep(1000);
+        Util.sleep(500);
 
         Util.runAndWait(() -> {
             if (DEBUG) {


### PR DESCRIPTION
JavaFX LCD text rendering (aka sub-pixel antialiasing) uses a pixel shader and alpha blending. The alpha channel is used is ways that interfere with its use for transparency. The existing logic checks that the current blend equation is SRC_OVER and that the surface is opaque, and that we are rendering using a Paint of type Color. It fails to check that the text color is opaque. When it isn't, the resulting alpha value is not preserved, even in the middle of the filled portion of the text, resulting in a visually noticeable difference in color.

![transparent-lcd-text](https://github.com/openjdk/jfx/assets/34689748/81f9503c-c706-44d8-b4db-6b47f0eb5fea)

The solution is to add the missing check for alpha == 1 to the test that checks whether we can use LCD text rendering. I note that Java2D falls back to gray scale when the text color is transparent for a similar reason.

I added a robot test that checks the color in the middle of the filled portion of a rendered text character and also checks that we use LCD for opaque colors and GRAY scale for transparent colors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8311492](https://bugs.openjdk.org/browse/JDK-8311492): FontSmoothingType LCD produces wrong color when transparency is used (**Bug** - P3)


### Reviewers
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1361/head:pull/1361` \
`$ git checkout pull/1361`

Update a local copy of the PR: \
`$ git checkout pull/1361` \
`$ git pull https://git.openjdk.org/jfx.git pull/1361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1361`

View PR using the GUI difftool: \
`$ git pr show -t 1361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1361.diff">https://git.openjdk.org/jfx/pull/1361.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1361#issuecomment-1935892929)