### PR TITLE
8309374: Accessibility Focus Rectangle on ListItem is not drawn when ListView is shown for first time

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -28,6 +28,7 @@ package javafx.scene.control;
 import java.lang.ref.WeakReference;
 import java.util.List;
 
+import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.WeakInvalidationListener;
@@ -344,6 +345,36 @@ public class ListCell<T> extends IndexedCell<T> {
     /** {@inheritDoc} */
     @Override protected Skin<?> createDefaultSkin() {
         return new ListCellSkin<>(this);
+    }
+
+    /*
+     * The layoutChildren() method is overloaded to address a specific accessibility issue: JBS-8309374
+     * If the Accessibility client application requests FOCUS_ITEM before the focused
+     * ListViewSkin/ListCell is created, then JavaFX would return a null object,
+     * and hence accessibility client application cannot draw the focus rectangle.
+     * In this scenario, JavaFX should notify the accessibility application once the
+     * focused ListCell is created and its layout is completed.
+     */
+    /** {@inheritDoc} */
+    @Override protected void layoutChildren() {
+        super.layoutChildren();
+
+        if (isFocused()) {
+            ListView<T> listView = getListView();
+            if (listView != null) {
+                /*
+                 * The notifyAccessibleAttributeChanged() call is submitted on the Application thread, because:
+                 * It is possible that when accessibility client application is processing a FOCUS_ITEM notification,
+                 * it may trigger a layout of focused ListItem, and it ends up generating another FOCUS_ITEM change
+                 * notification from here.
+                 * We observed that this scenario occurs when client application is trying to get the
+                 * UIA_HasKeyboardFocusPropertyId property of a focused ListItem's parent(ListView).
+                 * This scenario is avoided by submitting the call notifyAccessibleAttributeChanged() on Application thread,
+                 * so that the notification is not sent during any getAttribute() call.
+                 */
+                Platform.runLater(() -> listView.notifyAccessibleAttributeChanged(AccessibleAttribute.FOCUS_ITEM));
+            }
+        }
     }
 
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListCell.java
@@ -348,7 +348,7 @@ public class ListCell<T> extends IndexedCell<T> {
     }
 
     /*
-     * The layoutChildren() method is overloaded to address a specific accessibility issue: JBS-8309374
+     * The layoutChildren() method is overridden to address a specific accessibility issue: JDK-8309374
      * If the Accessibility client application requests FOCUS_ITEM before the focused
      * ListViewSkin/ListCell is created, then JavaFX would return a null object,
      * and hence accessibility client application cannot draw the focus rectangle.
@@ -363,13 +363,14 @@ public class ListCell<T> extends IndexedCell<T> {
             ListView<T> listView = getListView();
             if (listView != null) {
                 /*
-                 * The notifyAccessibleAttributeChanged() call is submitted on the Application thread, because:
+                 * The notifyAccessibleAttributeChanged() call is submitted via runLater to defer it until after
+                 * the layout completes, because:
                  * It is possible that when accessibility client application is processing a FOCUS_ITEM notification,
                  * it may trigger a layout of focused ListItem, and it ends up generating another FOCUS_ITEM change
                  * notification from here.
                  * We observed that this scenario occurs when client application is trying to get the
-                 * UIA_HasKeyboardFocusPropertyId property of a focused ListItem's parent(ListView).
-                 * This scenario is avoided by submitting the call notifyAccessibleAttributeChanged() on Application thread,
+                 * the focus item property of a focused ListItem's parent(ListView).
+                 * This scenario is avoided by submitting the call via runLater,
                  * so that the notification is not sent during any getAttribute() call.
                  */
                 Platform.runLater(() -> listView.notifyAccessibleAttributeChanged(AccessibleAttribute.FOCUS_ITEM));


### PR DESCRIPTION
This is accessibility specific fix.

**Issue**: When a ListView is shown for first time then accessibility focus rectangle is not drawn around the focused ListIem

**Cause:** 
   The ListView takes a little time to create it's skin(ListViewSkin) and the skins for ListItems(ListCellSkin)
   If the Accessibility client application requests focused item before ListView is completely ready then JavaFX return null.

**Fix**: Send a focus item change notification to accessibility client application after the ListIteam is ready

**Verification:**
- On Windows machine, launch Narrator. Issue is observed only with Narrator
- Execute the [program](https://bugs.openjdk.org/secure/attachment/104180/Main.java) attached to the JBS issue [JDK-8309374](https://bugs.openjdk.org/browse/JDK-8309374)
     Move through the TextFields and press `Alt+down`, observe that focus rectangle is drawn correctly.
     Once the ListView is showing Press and hold `Up/Down` or `Ctrl + Up/Down` keys, observe that focus rectangle is always drawn.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8309374](https://bugs.openjdk.org/browse/JDK-8309374): Accessibility Focus Rectangle on ListItem is not drawn when ListView is shown for first time (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1363/head:pull/1363` \
`$ git checkout pull/1363`

Update a local copy of the PR: \
`$ git checkout pull/1363` \
`$ git pull https://git.openjdk.org/jfx.git pull/1363/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1363`

View PR using the GUI difftool: \
`$ git pr show -t 1363`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1363.diff">https://git.openjdk.org/jfx/pull/1363.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1363#issuecomment-1941423497)