### PR TITLE
8323880: Caret rendered at wrong position in case of a click event on RTL text

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/FontCascade.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/FontCascade.h
@@ -293,7 +293,19 @@ private:
 
     bool advancedTextRenderingMode() const
     {
+#if !PLATFORM(JAVA)
         return m_fontDescription.textRenderingMode() != TextRenderingMode::OptimizeSpeed;
+#else
+        //The current implementation of complex text rendering path on the Java platform is experiencing
+        //side effects. We need to align with WebKit 616.1 standards.
+        auto textRenderingMode = m_fontDescription.textRenderingMode();
+        if (textRenderingMode == TextRenderingMode::GeometricPrecision || textRenderingMode == TextRenderingMode::OptimizeLegibility)
+            return true;
+        if (textRenderingMode == TextRenderingMode::OptimizeSpeed)
+            return false;
+
+        return false;
+#endif
     }
 
     bool computeEnableKerning() const


### PR DESCRIPTION
Issue: The current implementation of complex text rendering paths on the Java platform is experiencing side effects. 
Solution: We need to align with WebKit 616.1 standards. The patch supports two paths simple rendering path and complex rendering path based on text rendering mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8323880](https://bugs.openjdk.org/browse/JDK-8323880): Caret rendered at wrong position in case of a click event on RTL text (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Hima Bindu Meda](https://openjdk.org/census#hmeda) (@HimaBinduMeda - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1364/head:pull/1364` \
`$ git checkout pull/1364`

Update a local copy of the PR: \
`$ git checkout pull/1364` \
`$ git pull https://git.openjdk.org/jfx.git pull/1364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1364`

View PR using the GUI difftool: \
`$ git pr show -t 1364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1364.diff">https://git.openjdk.org/jfx/pull/1364.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1364#issuecomment-1942017495)