### PR TITLE
JDK-8325798: Spinner throws uncatchable exception on tab out from garbled text

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/Spinner.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/Spinner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -166,7 +166,11 @@ public class Spinner<T> extends Control {
 
         focusedProperty().addListener(o -> {
             if (!isFocused()) {
-                commitValue();
+                try {
+                    commitValue();
+                } catch (Exception e) {
+                    cancelEdit();
+                }
             }
         });
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ import static junit.framework.Assert.*;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.scene.layout.HBox;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -59,6 +60,7 @@ import javafx.util.StringConverter;
 import test.com.sun.javafx.pgstub.StubToolkit;
 import test.com.sun.javafx.scene.control.infrastructure.KeyEventFirer;
 import com.sun.javafx.tk.Toolkit;
+import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
 
 import static javafx.scene.control.SpinnerValueFactoryShim.*;
 
@@ -1580,5 +1582,38 @@ public class SpinnerTest {
         });
 
         assertEquals("50%", intSpinner.getEditor().getText());
+    }
+
+    /**
+     * When Spinner looses focus with misformatted text in the editor,
+     * checks that the value is not changed, and the text is reverted to the value
+     */
+    @Test
+    public void testFocusLostWithTypo() {
+        Button button = new Button();
+        Spinner<Integer> spinner = new Spinner<>(new IntegerSpinnerValueFactory(0, 10, 0));
+        spinner.setEditable(true);
+
+        StageLoader stageLoader = new StageLoader(new HBox(spinner, button));
+
+        // initial value
+        spinner.getValueFactory().setValue(1);
+        int value = spinner.getValue();
+        assertEquals(1, value);
+        assertEquals("1", spinner.getEditor().getText());
+
+        // set misformatted text
+        spinner.requestFocus();
+        spinner.getEditor().setText("2abc");
+
+        // loosing focus triggers cancelEdit() because the text cannot be parsed
+        button.requestFocus();
+
+        // check that value remains unchanged, and text is reverted
+        value = spinner.getValue();
+        assertEquals(1, value);
+        assertEquals("1", spinner.getEditor().getText());
+
+        stageLoader.dispose();
     }
 }


### PR DESCRIPTION
When a `Spinner` is configured with e.g. Integers (`IntegerSpinnerValueFactory`) and the user types in a `String`, e.g. 'abc' and focuses another `Node`, an exception is thrown (`NumberFormatException`).
This exception is literally uncatchable, as it happens on focus lost.

The issue is the same as for the `DatePicker` component described in [JDK-8303478](https://bugs.openjdk.org/browse/JDK-8303478), which was fixed in PR: https://github.com/openjdk/jfx/pull/1274.

I did the exact same fix in this PR. Also added the same test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325798](https://bugs.openjdk.org/browse/JDK-8325798): Spinner throws uncatchable exception on tab out from garbled text (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Michael Strauß](https://openjdk.org/census#mstrauss) (@mstr2 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1365/head:pull/1365` \
`$ git checkout pull/1365`

Update a local copy of the PR: \
`$ git checkout pull/1365` \
`$ git pull https://git.openjdk.org/jfx.git pull/1365/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1365`

View PR using the GUI difftool: \
`$ git pr show -t 1365`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1365.diff">https://git.openjdk.org/jfx/pull/1365.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1365#issuecomment-1942464260)