### PR TITLE
8325900: Emit a warning on macOS if AWT has set the NSAppearance

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -800,4 +800,10 @@ public abstract class Application {
     public Map<String, Class<?>> getPlatformKeys() {
         return Map.of();
     }
+
+    /**
+     * Checks whether there are any problems with platform preferences detection,
+     * and emits a warning otherwise.
+     */
+    public void checkPlatformPreferencesSupport() {}
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Application.java
@@ -803,7 +803,7 @@ public abstract class Application {
 
     /**
      * Checks whether there are any problems with platform preferences detection,
-     * and emits a warning otherwise.
+     * and if so, emits a warning.
      */
     public void checkPlatformPreferencesSupport() {}
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
@@ -473,20 +473,21 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
     @Override
     public void checkPlatformPreferencesSupport() {
         if (checkSystemAppearance && AWT_APPLICATION_CLASS.equals(applicationClassName)) {
-            checkSystemAppearance = false;
-
             @SuppressWarnings("removal")
             String awtAppearanceProperty = AccessController.doPrivileged(
                 (PrivilegedAction<String>) () -> System.getProperty(AWT_APPEARANCE_PROPERTY));
 
             if (!AWT_SYSTEM_APPEARANCE.equals(awtAppearanceProperty)) {
                 Logging.getJavaFXLogger().warning(String.format(
-                    "Reported preferences may not reflect macOS system preferences unless the system property " +
-                    "%s=%s is set. This warning can be disabled by setting %s=true.",
+                    "Reported preferences may not reflect macOS system preferences unless the system%n" +
+                    "property %s=%s is set. This warning can be disabled by%n" +
+                    "setting %s=true.",
                     AWT_APPEARANCE_PROPERTY,
                     AWT_SYSTEM_APPEARANCE,
                     SUPPRESS_AWT_WARNING_PROPERTY));
             }
         }
+
+        checkSystemAppearance = false;
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -391,6 +391,8 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
     @Override
     protected native int _isKeyLocked(int keyCode);
 
+    private native String _getApplicationClassName();
+
     @Override
     public native Map<String, Object> getPlatformPreferences();
 
@@ -454,5 +456,24 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
             Map.entry("macOS.NSColor.systemTealColor", Color.class),
             Map.entry("macOS.NSColor.systemYellowColor", Color.class)
         );
+    }
+
+    private static final String SUPPRESS_AWT_WARNING_PROPERTY = "javafx.preferences.suppressAppleAwtWarning";
+    private static final String AWT_APPEARANCE_PROPERTY = "apple.awt.application.appearance";
+    private boolean checkSystemAppearance = !Boolean.getBoolean(SUPPRESS_AWT_WARNING_PROPERTY);
+
+    @Override
+    public void checkPlatformPreferencesSupport() {
+        if (checkSystemAppearance && "NSApplicationAWT".equals(_getApplicationClassName())) {
+            checkSystemAppearance = false;
+
+            if (!"system".equals(System.getProperty(AWT_APPEARANCE_PROPERTY))) {
+                Logging.getJavaFXLogger().warning(String.format(
+                    "Reported preferences may not reflect macOS system preferences unless the system property " +
+                    "%s=system is set. This warning can be disabled by setting %s=true.",
+                    AWT_APPEARANCE_PROPERTY,
+                    SUPPRESS_AWT_WARNING_PROPERTY));
+            }
+        }
     }
 }

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
@@ -59,6 +59,7 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
 
     native static int _getMacKey(int code);
 
+    private String applicationClassName;
     private boolean isTaskbarApplication = false;
     private final InvokeLaterDispatcher invokeLaterDispatcher;
 
@@ -90,6 +91,8 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
             if (isTriggerReactivation()) {
                 waitForReactivation();
             }
+
+            applicationClassName = _getApplicationClassName();
             launchable.run();
         };
 
@@ -464,7 +467,7 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
 
     @Override
     public void checkPlatformPreferencesSupport() {
-        if (checkSystemAppearance && "NSApplicationAWT".equals(_getApplicationClassName())) {
+        if (checkSystemAppearance && "NSApplicationAWT".equals(applicationClassName)) {
             checkSystemAppearance = false;
 
             if (!"system".equals(System.getProperty(AWT_APPEARANCE_PROPERTY))) {

--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/mac/MacApplication.java
@@ -463,18 +463,28 @@ final class MacApplication extends Application implements InvokeLaterDispatcher.
 
     private static final String SUPPRESS_AWT_WARNING_PROPERTY = "javafx.preferences.suppressAppleAwtWarning";
     private static final String AWT_APPEARANCE_PROPERTY = "apple.awt.application.appearance";
-    private boolean checkSystemAppearance = !Boolean.getBoolean(SUPPRESS_AWT_WARNING_PROPERTY);
+    private static final String AWT_APPLICATION_CLASS = "NSApplicationAWT";
+    private static final String AWT_SYSTEM_APPEARANCE = "system";
+
+    @SuppressWarnings("removal")
+    private boolean checkSystemAppearance = AccessController.doPrivileged(
+            (PrivilegedAction<Boolean>) () -> !Boolean.getBoolean(SUPPRESS_AWT_WARNING_PROPERTY));
 
     @Override
     public void checkPlatformPreferencesSupport() {
-        if (checkSystemAppearance && "NSApplicationAWT".equals(applicationClassName)) {
+        if (checkSystemAppearance && AWT_APPLICATION_CLASS.equals(applicationClassName)) {
             checkSystemAppearance = false;
 
-            if (!"system".equals(System.getProperty(AWT_APPEARANCE_PROPERTY))) {
+            @SuppressWarnings("removal")
+            String awtAppearanceProperty = AccessController.doPrivileged(
+                (PrivilegedAction<String>) () -> System.getProperty(AWT_APPEARANCE_PROPERTY));
+
+            if (!AWT_SYSTEM_APPEARANCE.equals(awtAppearanceProperty)) {
                 Logging.getJavaFXLogger().warning(String.format(
                     "Reported preferences may not reflect macOS system preferences unless the system property " +
-                    "%s=system is set. This warning can be disabled by setting %s=true.",
+                    "%s=%s is set. This warning can be disabled by setting %s=true.",
                     AWT_APPEARANCE_PROPERTY,
+                    AWT_SYSTEM_APPEARANCE,
                     SUPPRESS_AWT_WARNING_PROPERTY));
             }
         }

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/application/PlatformImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1038,6 +1038,17 @@ public class PlatformImpl {
             // because the preferences map may contain null values.
             Map<String, Object> preferencesCopy = new HashMap<>(preferences);
             runLater(() -> updatePreferences(preferencesCopy));
+        }
+    }
+
+    /**
+     * Emits a one-time warning on macOS if we're running with AWT and the
+     * "apple.awt.application.appearance=system" property is not set (see JDK-8235363).
+     */
+    public static void checkPreferencesSupport() {
+        var application = com.sun.glass.ui.Application.GetApplication();
+        if (application != null) {
+            application.checkPlatformPreferencesSupport();
         }
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -451,15 +451,7 @@ public final class Platform {
      * @since 22
      */
     public static Preferences getPreferences() {
-        // Emits a one-time warning on macOS if we're running with AWT and the
-        // "apple.awt.application.appearance=system" property is not set (see also: JDK-8235363).
-        var application = com.sun.glass.ui.Application.GetApplication();
-        if (application != null) {
-            application.checkPlatformPreferencesSupport();
-        }
-
-        // If "application" is null, PlatformImpl.getPlatformPreferences() will
-        // fail by throwing an exception.
+        PlatformImpl.checkPreferencesSupport();
         return PlatformImpl.getPlatformPreferences();
     }
 

--- a/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
+++ b/modules/javafx.graphics/src/main/java/javafx/application/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -451,6 +451,15 @@ public final class Platform {
      * @since 22
      */
     public static Preferences getPreferences() {
+        // Emits a one-time warning on macOS if we're running with AWT and the
+        // "apple.awt.application.appearance=system" property is not set (see also: JDK-8235363).
+        var application = com.sun.glass.ui.Application.GetApplication();
+        if (application != null) {
+            application.checkPlatformPreferencesSupport();
+        }
+
+        // If "application" is null, PlatformImpl.getPlatformPreferences() will
+        // fail by throwing an exception.
         return PlatformImpl.getPlatformPreferences();
     }
 

--- a/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
+++ b/modules/javafx.graphics/src/main/native-glass/mac/GlassApplication.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1271,7 +1271,19 @@ JNIEXPORT jint JNICALL Java_com_sun_glass_ui_mac_MacApplication__1getMacKey
 
 /*
  * Class:     com_sun_glass_ui_mac_MacApplication
- * Method:    getPreferences
+ * Method:    _getApplicationClassName
+ * Signature: ()Ljava/lang/String;
+ */
+JNIEXPORT jobject JNICALL Java_com_sun_glass_ui_mac_MacApplication__1getApplicationClassName
+(JNIEnv *env, jobject self)
+{
+    NSString* className = NSStringFromClass([[NSApplicationFX sharedApplication] class]);
+    return (*env)->NewStringUTF(env, [className UTF8String]);
+}
+
+/*
+ * Class:     com_sun_glass_ui_mac_MacApplication
+ * Method:    getPlatformPreferences
  * Signature: ()Ljava/util/Map;
  */
 JNIEXPORT jobject JNICALL Java_com_sun_glass_ui_mac_MacApplication_getPlatformPreferences


### PR DESCRIPTION
Platform preferences detection doesn't pick up effective macOS system preferences if AWT owns the NSApplication and has set its NSAppearance to a fixed value.

The workaround is to set the system property "apple.awt.application.appearance=system".

If this property is not set, the following warning will be emitted if a JavaFX application attempts to use the platform preferences API:

```
WARNING: Reported preferences may not reflect the macOS system preferences unless the sytem
property apple.awt.application.appearance=system is set. This warning can be disabled by
setting javafx.preferences.suppressAppleAwtWarning=true.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8325900](https://bugs.openjdk.org/browse/JDK-8325900): Emit a warning on macOS if AWT has set the NSAppearance (**Enhancement** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Martin Fox](https://openjdk.org/census#mfox) (@beldenfox - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1367/head:pull/1367` \
`$ git checkout pull/1367`

Update a local copy of the PR: \
`$ git checkout pull/1367` \
`$ git pull https://git.openjdk.org/jfx.git pull/1367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1367`

View PR using the GUI difftool: \
`$ git pr show -t 1367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1367.diff">https://git.openjdk.org/jfx/pull/1367.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1367#issuecomment-1944608604)