### PR TITLE
8322748: Caret blinking in JavaFX should only stop when caret moves

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextInputControlBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextInputControlBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -320,14 +320,8 @@ public abstract class TextInputControlBehavior<T extends TextInputControl> exten
         for (Object o : map.getChildInputMaps()) {
             addKeyPadMappings((InputMap<T>)o);
         }
-
     }
 
-
-    /**
-     * Wraps the event handler to pause caret blinking when
-     * processing the key event.
-     */
     protected KeyMapping keyMapping(final KeyCode keyCode, final EventHandler<KeyEvent> eventHandler) {
         return keyMapping(new KeyBinding(keyCode), eventHandler);
     }
@@ -336,17 +330,9 @@ public abstract class TextInputControlBehavior<T extends TextInputControl> exten
         return keyMapping(keyBinding, eventHandler, null);
     }
 
-    protected KeyMapping keyMapping(KeyBinding keyBinding, final EventHandler<KeyEvent> eventHandler,
-                                    Predicate<KeyEvent> interceptor) {
-        return new KeyMapping(keyBinding,
-                              e -> {
-                                  setCaretAnimating(false);
-                                  eventHandler.handle(e);
-                                  setCaretAnimating(true);
-                              },
-                              interceptor);
+    protected KeyMapping keyMapping(KeyBinding k, final EventHandler<KeyEvent> h, Predicate<KeyEvent> interceptor) {
+        return new KeyMapping(k, h, interceptor);
     }
-
 
 
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextAreaSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextAreaSkin.java
@@ -175,10 +175,12 @@ public class TextAreaSkin extends TextInputControlSkin<TextArea> {
             }
         };
         caretPosition.addListener((observable, oldValue, newValue) -> {
+            setCaretAnimating(false);
             targetCaretX = -1;
             if (control.getWidth() > 0) {
                 setForwardBias(true);
             }
+            setCaretAnimating(true);
         });
 
         forwardBiasProperty().addListener(observable -> {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextFieldSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,6 +153,7 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
 //        control.setInputMap(behavior.getInputMap());
 
         registerChangeListener(control.caretPositionProperty(), e -> {
+            setCaretAnimating(false);
             if (control.getWidth() > 0) {
                 updateTextNodeCaretPos(control.getCaretPosition());
                 if (!isForwardBias()) {
@@ -160,6 +161,7 @@ public class TextFieldSkin extends TextInputControlSkin<TextField> {
                 }
                 updateCaretOff();
             }
+            setCaretAnimating(true);
         });
 
         forwardBiasProperty().addListener(observable -> {


### PR DESCRIPTION
Move caret animation handling due to keyboard input to the Skin, by registering a listener on the caretPosition property.  This will restart animation only when the caret position changes instead of every key press.

This also simplifies internal behaviors of TextArea, TextField, and PasswordField in light of the future InputMap RFE [JDK-8314968](https://bugs.openjdk.org/browse/JDK-8314968)
