### PR TITLE
JDK-8146918: ConcurrentModificationException in MediaPlayer

### DIFF
--- a/modules/javafx.media/src/main/java/javafx/scene/media/MediaPlayer.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/MediaPlayer.java
@@ -1722,12 +1722,12 @@ public final class MediaPlayer {
 
     void removeView(MediaView view) {
         synchronized (viewRefs) {
-             Iterator<WeakReference<MediaView>> iter = viewRefs.iterator();
-             while (iter.hasNext()) {
-                 MediaView v = iter.next().get();
-                 if (v != null && v.equals(view)) {
-                     iter.remove();
-                 }
+            Iterator<WeakReference<MediaView>> iter = viewRefs.iterator();
+            while (iter.hasNext()) {
+                MediaView v = iter.next().get();
+                if (v != null && v.equals(view)) {
+                    iter.remove();
+                }
             }
         }
     }

--- a/modules/javafx.media/src/main/java/javafx/scene/media/MediaPlayer.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/MediaPlayer.java
@@ -1722,11 +1722,12 @@ public final class MediaPlayer {
 
     void removeView(MediaView view) {
         synchronized (viewRefs) {
-            for (WeakReference<MediaView> vref : viewRefs) {
-                MediaView v = vref.get();
-                if (v != null && v.equals(view)) {
-                    viewRefs.remove(vref);
-                }
+             Iterator<WeakReference<MediaView>> iter = viewRefs.iterator();
+             while (iter.hasNext()) {
+                 MediaView v = iter.next().get();
+                 if (v != null && v.equals(view)) {
+                     iter.remove();
+                 }
             }
         }
     }


### PR DESCRIPTION
There is a `ConcurrentModificationException` in MediaPlayer when removing a MediaView from it. The root cause is that you can't iterate over a `HashSet` with `for (WeakReference<MediaView> vref : viewRefs)` and removing items from the collection by `viewRefs.remove(vref);` within this loop.

For details see https://bugs.openjdk.org/browse/JDK-8146918

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8146918](https://bugs.openjdk.org/browse/JDK-8146918): ConcurrentModificationException in MediaPlayer (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1376/head:pull/1376` \
`$ git checkout pull/1376`

Update a local copy of the PR: \
`$ git checkout pull/1376` \
`$ git pull https://git.openjdk.org/jfx.git pull/1376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1376`

View PR using the GUI difftool: \
`$ git pr show -t 1376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1376.diff">https://git.openjdk.org/jfx/pull/1376.diff</a>

</details>
