### PR TITLE
8325550: Grammatical error in AnchorPane.setLeftAnchor (and other setters) javadoc

### DIFF
--- a/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Node.java
@@ -6433,6 +6433,16 @@ public abstract class Node implements EventTarget, Styleable {
      *                                                                         *
      **************************************************************************/
 
+    /**
+     * Node orientation describes the flow of visual data within a node.
+     * In the English speaking world, visual data normally flows from
+     * left-to-right. In an Arabic or Hebrew world, visual data flows
+     * from right-to-left. This is consistent with the reading order
+     * of text in both worlds.
+     *
+     * @defaultValue {@code NodeOrientation.INHERIT}
+     * @since JavaFX 8.0
+     */
     private ObjectProperty<NodeOrientation> nodeOrientation;
     private EffectiveOrientationProperty effectiveNodeOrientationProperty;
 
@@ -6453,19 +6463,7 @@ public abstract class Node implements EventTarget, Styleable {
     public final NodeOrientation getNodeOrientation() {
         return nodeOrientation == null ? NodeOrientation.INHERIT : nodeOrientation.get();
     }
-    /**
-     * Property holding NodeOrientation.
-     * <p>
-     * Node orientation describes the flow of visual data within a node.
-     * In the English speaking world, visual data normally flows from
-     * left-to-right. In an Arabic or Hebrew world, visual data flows
-     * from right-to-left.  This is consistent with the reading order
-     * of text in both worlds.  The default value is left-to-right.
-     * </p>
-     *
-     * @return NodeOrientation
-     * @since JavaFX 8.0
-     */
+
     public final ObjectProperty<NodeOrientation> nodeOrientationProperty() {
         if (nodeOrientation == null) {
             nodeOrientation = new StyleableObjectProperty<NodeOrientation>(NodeOrientation.INHERIT) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/Scene.java
@@ -6244,8 +6244,17 @@ public class Scene implements EventTarget {
         AccessController.doPrivileged(
                 (PrivilegedAction<Boolean>) () -> Boolean.getBoolean("javafx.scene.nodeOrientation.RTL")) ? NodeOrientation.RIGHT_TO_LEFT : NodeOrientation.INHERIT;
 
-
-
+    /**
+     * Node orientation describes the flow of visual data within a node.
+     * In the English speaking world, visual data normally flows from
+     * left-to-right. In an Arabic or Hebrew world, visual data flows
+     * from right-to-left. This is consistent with the reading order
+     * of text in both worlds.
+     *
+     * @defaultValue if the system property {@code javafx.scene.nodeOrientation.RTL} is {@code true},
+     *     {@code NodeOrientation.RIGHT_TO_LEFT}, otherwise {@code NodeOrientation.INHERIT}
+     * @since JavaFX 8.0
+     */
     private ObjectProperty<NodeOrientation> nodeOrientation;
     private EffectiveOrientationProperty effectiveNodeOrientationProperty;
 
@@ -6259,19 +6268,6 @@ public class Scene implements EventTarget {
         return nodeOrientation == null ? defaultNodeOrientation : nodeOrientation.get();
     }
 
-    /**
-     * Property holding NodeOrientation.
-     * <p>
-     * Node orientation describes the flow of visual data within a node.
-     * In the English speaking world, visual data normally flows from
-     * left-to-right. In an Arabic or Hebrew world, visual data flows
-     * from right-to-left.  This is consistent with the reading order
-     * of text in both worlds.  The default value is left-to-right.
-     * </p>
-     *
-     * @return NodeOrientation
-     * @since JavaFX 8.0
-     */
     public final ObjectProperty<NodeOrientation> nodeOrientationProperty() {
         if (nodeOrientation == null) {
             nodeOrientation = new StyleableObjectProperty<NodeOrientation>(defaultNodeOrientation) {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/layout/AnchorPane.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/layout/AnchorPane.java
@@ -127,9 +127,9 @@ public class AnchorPane extends Pane {
     /**
      * Sets the top anchor for the child when contained by an anchor pane.
      * If set, the anchor pane will maintain the child's size and position so
-     * that it's top is always offset by that amount from the anchor pane's top
+     * that its top is always offset by that amount from the anchor pane's top
      * content edge.
-     * Setting the value to null will remove the constraint.
+     * Setting the value to {@code null} will remove the constraint.
      * @param child the child node of an anchor pane
      * @param value the offset from the top of the anchor pane
      */
@@ -138,9 +138,9 @@ public class AnchorPane extends Pane {
     }
 
     /**
-     * Returns the child's top anchor constraint if set.
+     * Returns the child's top anchor constraint, if set.
      * @param child the child node of an anchor pane
-     * @return the offset from the top of the anchor pane or null if no top anchor was set
+     * @return the offset from the top of the anchor pane, or {@code null} if no top anchor was set
      */
     public static Double getTopAnchor(Node child) {
         return (Double)getConstraint(child, TOP_ANCHOR);
@@ -149,9 +149,9 @@ public class AnchorPane extends Pane {
     /**
      * Sets the left anchor for the child when contained by an anchor pane.
      * If set, the anchor pane will maintain the child's size and position so
-     * that it's left is always offset by that amount from the anchor pane's left
+     * that its left is always offset by that amount from the anchor pane's left
      * content edge.
-     * Setting the value to null will remove the constraint.
+     * Setting the value to {@code null} will remove the constraint.
      * @param child the child node of an anchor pane
      * @param value the offset from the left of the anchor pane
      */
@@ -160,9 +160,9 @@ public class AnchorPane extends Pane {
     }
 
     /**
-     * Returns the child's left anchor constraint if set.
+     * Returns the child's left anchor constraint, if set.
      * @param child the child node of an anchor pane
-     * @return the offset from the left of the anchor pane or null if no left anchor was set
+     * @return the offset from the left of the anchor pane, or {@code null} if no left anchor was set
      */
     public static Double getLeftAnchor(Node child) {
         return (Double)getConstraint(child, LEFT_ANCHOR);
@@ -171,9 +171,9 @@ public class AnchorPane extends Pane {
     /**
      * Sets the bottom anchor for the child when contained by an anchor pane.
      * If set, the anchor pane will maintain the child's size and position so
-     * that it's bottom is always offset by that amount from the anchor pane's bottom
+     * that its bottom is always offset by that amount from the anchor pane's bottom
      * content edge.
-     * Setting the value to null will remove the constraint.
+     * Setting the value to {@code null} will remove the constraint.
      * @param child the child node of an anchor pane
      * @param value the offset from the bottom of the anchor pane
      */
@@ -182,9 +182,9 @@ public class AnchorPane extends Pane {
     }
 
     /**
-     * Returns the child's bottom anchor constraint if set.
+     * Returns the child's bottom anchor constraint, if set.
      * @param child the child node of an anchor pane
-     * @return the offset from the bottom of the anchor pane or null if no bottom anchor was set
+     * @return the offset from the bottom of the anchor pane, or {@code null} if no bottom anchor was set
      */
     public static Double getBottomAnchor(Node child) {
         return (Double)getConstraint(child, BOTTOM_ANCHOR);
@@ -193,9 +193,9 @@ public class AnchorPane extends Pane {
     /**
      * Sets the right anchor for the child when contained by an anchor pane.
      * If set, the anchor pane will maintain the child's size and position so
-     * that it's right is always offset by that amount from the anchor pane's right
+     * that its right is always offset by that amount from the anchor pane's right
      * content edge.
-     * Setting the value to null will remove the constraint.
+     * Setting the value to {@code null} will remove the constraint.
      * @param child the child node of an anchor pane
      * @param value the offset from the right of the anchor pane
      */
@@ -204,9 +204,9 @@ public class AnchorPane extends Pane {
     }
 
     /**
-     * Returns the child's right anchor constraint if set.
+     * Returns the child's right anchor constraint, if set.
      * @param child the child node of an anchor pane
-     * @return the offset from the right of the anchor pane or null if no right anchor was set
+     * @return the offset from the right of the anchor pane, or {@code null} if no right anchor was set
      */
     public static Double getRightAnchor(Node child) {
         return (Double)getConstraint(child, RIGHT_ANCHOR);
@@ -228,15 +228,15 @@ public class AnchorPane extends Pane {
      ********************************************************************/
 
     /**
-     * Creates an AnchorPane layout.
+     * Creates an {@code AnchorPane} layout.
      */
     public AnchorPane() {
         super();
     }
 
     /**
-     * Creates an AnchorPane layout with the given children.
-     * @param children    The initial set of children for this pane.
+     * Creates an {@code AnchorPane} layout with the given children.
+     * @param children the initial set of children for this pane
      * @since JavaFX 8.0
      */
     public AnchorPane(Node... children) {


### PR DESCRIPTION
Backport of commit [b43c4edf](https://github.com/openjdk/jfx/commit/b43c4edf7590429fd051d1b0e2ccb6dd49a10b8b) from the [openjdk/jfx](https://git.openjdk.org/jfx) repository.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8325550](https://bugs.openjdk.org/browse/JDK-8325550): Grammatical error in AnchorPane.setLeftAnchor (and other setters) javadoc (**Bug** - P4)
 * [JDK-8318624](https://bugs.openjdk.org/browse/JDK-8318624): API docs specify incorrect default value for nodeOrientation property (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1380/head:pull/1380` \
`$ git checkout pull/1380`

Update a local copy of the PR: \
`$ git checkout pull/1380` \
`$ git pull https://git.openjdk.org/jfx.git pull/1380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1380`

View PR using the GUI difftool: \
`$ git pr show -t 1380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1380.diff">https://git.openjdk.org/jfx/pull/1380.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1380#issuecomment-1962315619)