### PR TITLE
8326618 : Replace usage of deprecated method getId() in Thread

### DIFF
--- a/modules/javafx.base/src/main/java/com/sun/javafx/logging/PrintLogger.java
+++ b/modules/javafx.base/src/main/java/com/sun/javafx/logging/PrintLogger.java
@@ -271,7 +271,7 @@ class PrintLogger extends Logger {
         }
         pulseData.message
             .append("T")
-            .append(Thread.currentThread().getId())
+            .append(Thread.currentThread().threadId())
             .append(" : ")
             .append(message)
             .append("\n");
@@ -315,7 +315,7 @@ class PrintLogger extends Logger {
             if (pulseData != null) {
                 pulseData.message
                     .append("T")
-                    .append(Thread.currentThread().getId())
+                    .append(Thread.currentThread().threadId())
                     .append(" (").append((curPhase.phaseStart-pulseData.startTime)/1000000L)
                     .append(" +").append((curTime - curPhase.phaseStart)/1000000L).append("ms): ")
                     .append(curPhase.phaseName)

--- a/modules/javafx.web/src/main/java/com/sun/javafx/webkit/drt/DumpRenderTree.java
+++ b/modules/javafx.web/src/main/java/com/sun/javafx/webkit/drt/DumpRenderTree.java
@@ -189,7 +189,7 @@ public final class DumpRenderTree {
     private static void mlog(String msg) {
         if (log.isLoggable(Level.FINE)) {
             log.fine("PID:" + Long.toHexString(PID)
-                    + " TID:" + Thread.currentThread().getId()
+                    + " TID:" + Thread.currentThread().threadId()
                         + "(" + Thread.currentThread().getName() + ") "
                     + msg);
         }


### PR DESCRIPTION
Replace Thread.currentThread().getId() with Thread.currentThread().threadId()

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326618](https://bugs.openjdk.org/browse/JDK-8326618): Replace usage of deprecated method getId() in Thread (**Bug** - P4)


### Reviewers
 * [John Hendrikx](https://openjdk.org/census#jhendrikx) (@hjohn - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1383/head:pull/1383` \
`$ git checkout pull/1383`

Update a local copy of the PR: \
`$ git checkout pull/1383` \
`$ git pull https://git.openjdk.org/jfx.git pull/1383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1383`

View PR using the GUI difftool: \
`$ git pr show -t 1383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1383.diff">https://git.openjdk.org/jfx/pull/1383.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1383#issuecomment-1967310504)