### PR TITLE
8270996: javadoc: missing comments in serialized classes

### DIFF
--- a/modules/javafx.base/src/main/java/javafx/event/Event.java
+++ b/modules/javafx.base/src/main/java/javafx/event/Event.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,6 +41,7 @@ import javafx.beans.NamedArg;
  * to events of the same {@code Event} class.
  * @since JavaFX 2.0
  */
+@SuppressWarnings("doclint")
 public class Event extends EventObject implements Cloneable {
 
     private static final long serialVersionUID = 20121107L;

--- a/modules/javafx.base/src/main/java/javafx/event/Event.java
+++ b/modules/javafx.base/src/main/java/javafx/event/Event.java
@@ -41,7 +41,6 @@ import javafx.beans.NamedArg;
  * to events of the same {@code Event} class.
  * @since JavaFX 2.0
  */
-@SuppressWarnings("doclint")
 public class Event extends EventObject implements Cloneable {
 
     private static final long serialVersionUID = 20121107L;
@@ -171,6 +170,7 @@ public class Event extends EventObject implements Cloneable {
         }
     }
 
+    @SuppressWarnings("doclint:missing")
     private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
         in.defaultReadObject();
         source = NULL_SOURCE_TARGET;

--- a/modules/javafx.base/src/main/java/javafx/event/EventType.java
+++ b/modules/javafx.base/src/main/java/javafx/event/EventType.java
@@ -57,7 +57,6 @@ import java.util.WeakHashMap;
  * @param <T> the event class to which this type applies
  * @since JavaFX 2.0
  */
-@SuppressWarnings("doclint")
 public final class EventType<T extends Event> implements Serializable{
 
     /**
@@ -68,10 +67,13 @@ public final class EventType<T extends Event> implements Serializable{
     public static final EventType<Event> ROOT =
             new EventType<>("EVENT", null);
 
+    @SuppressWarnings("doclint:missing")
     private WeakHashMap<EventType<? extends T>, Void> subTypes;
 
+    @SuppressWarnings("doclint:missing")
     private final EventType<? super T> superType;
 
+    @SuppressWarnings("doclint:missing")
     private final String name;
 
     /**
@@ -190,6 +192,7 @@ public final class EventType<T extends Event> implements Serializable{
         subTypes.put(subType, null);
     }
 
+    @SuppressWarnings("doclint:missing")
     private Object writeReplace() {
         Deque<String> path = new LinkedList<>();
         EventType<?> t = this;

--- a/modules/javafx.base/src/main/java/javafx/event/EventType.java
+++ b/modules/javafx.base/src/main/java/javafx/event/EventType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,7 @@ import java.util.WeakHashMap;
  * @param <T> the event class to which this type applies
  * @since JavaFX 2.0
  */
+@SuppressWarnings("doclint")
 public final class EventType<T extends Event> implements Serializable{
 
     /**

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/CheckBoxTreeItem.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/CheckBoxTreeItem.java
@@ -353,11 +353,11 @@ public class CheckBoxTreeItem<T> extends TreeItem<T> {
      *      {@link CheckBoxTreeItem#valueProperty() value} property.
      * @since JavaFX 2.2
      */
-    @SuppressWarnings("doclint")
     public static class TreeModificationEvent<T> extends Event {
         private static final long serialVersionUID = -8445355590698862999L;
 
         private transient final CheckBoxTreeItem<T> treeItem;
+        @SuppressWarnings("doclint:missing")
         private final boolean selectionChanged;
 
         /**

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/CheckBoxTreeItem.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/CheckBoxTreeItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -353,6 +353,7 @@ public class CheckBoxTreeItem<T> extends TreeItem<T> {
      *      {@link CheckBoxTreeItem#valueProperty() value} property.
      * @since JavaFX 2.2
      */
+    @SuppressWarnings("doclint")
     public static class TreeModificationEvent<T> extends Event {
         private static final long serialVersionUID = -8445355590698862999L;
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1183,6 +1183,7 @@ public class ListView<T> extends Control {
      *      itself.
      * @since JavaFX 2.0
      */
+    @SuppressWarnings("doclint")
     public static class EditEvent<T> extends Event {
         private final T newValue;
         private final int editIndex;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ListView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ListView.java
@@ -1183,10 +1183,12 @@ public class ListView<T> extends Control {
      *      itself.
      * @since JavaFX 2.0
      */
-    @SuppressWarnings("doclint")
     public static class EditEvent<T> extends Event {
+        @SuppressWarnings("doclint:missing")
         private final T newValue;
+        @SuppressWarnings("doclint:missing")
         private final int editIndex;
+        @SuppressWarnings("doclint:missing")
         private final ListView<T> source;
 
         private static final long serialVersionUID = 20130724L;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ScrollToEvent.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ScrollToEvent.java
@@ -35,7 +35,6 @@ import javafx.event.EventType;
  * {@link ListView}, {@link TableView}, {@link TreeView} and {@link TreeTableView}.
  * @since JavaFX 8.0
  */
-@SuppressWarnings("doclint")
 public class ScrollToEvent<T> extends Event {
 //    /**
 //     * This event occurs if the user requests scrolling a node into view.
@@ -79,6 +78,7 @@ public class ScrollToEvent<T> extends Event {
 
     private static final long serialVersionUID = -8557345736849482516L;
 
+    @SuppressWarnings("doclint:missing")
     private final T scrollTarget;
 
     /**

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ScrollToEvent.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ScrollToEvent.java
@@ -35,6 +35,7 @@ import javafx.event.EventType;
  * {@link ListView}, {@link TableView}, {@link TreeView} and {@link TreeTableView}.
  * @since JavaFX 8.0
  */
+@SuppressWarnings("doclint")
 public class ScrollToEvent<T> extends Event {
 //    /**
 //     * This event occurs if the user requests scrolling a node into view.

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableColumn.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableColumn.java
@@ -753,7 +753,6 @@ public class TableColumn<S,T> extends TableColumnBase<S,T> implements EventTarge
      * @param <T> The type of the content in all cells in this TableColumn
      * @since JavaFX 2.0
      */
-    @SuppressWarnings("doclint")
     public static class CellEditEvent<S,T> extends Event {
         private static final long serialVersionUID = -609964441682677579L;
 
@@ -767,6 +766,7 @@ public class TableColumn<S,T> extends TableColumnBase<S,T> implements EventTarge
         // to go back into the TableView.items list - this new value represents
         // just the input for a single cell, so it is likely that it needs to go
         // back into a property within an item in the TableView.items list.
+        @SuppressWarnings("doclint:missing")
         private final T newValue;
 
         // The location of the edit event

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableColumn.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -753,6 +753,7 @@ public class TableColumn<S,T> extends TableColumnBase<S,T> implements EventTarge
      * @param <T> The type of the content in all cells in this TableColumn
      * @since JavaFX 2.0
      */
+    @SuppressWarnings("doclint")
     public static class CellEditEvent<S,T> extends Event {
         private static final long serialVersionUID = -609964441682677579L;
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeItem.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeItem.java
@@ -988,7 +988,6 @@ public class TreeItem<T> implements EventTarget { //, Comparable<TreeItem<T>> {
      * @param <T> The TreeModificationEvent
      * @since JavaFX 2.0
      */
-    @SuppressWarnings("doclint")
     public static class TreeModificationEvent<T> extends Event {
         private static final long serialVersionUID = 4741889985221719579L;
 
@@ -999,14 +998,21 @@ public class TreeItem<T> implements EventTarget { //, Comparable<TreeItem<T>> {
         public static final EventType<?> ANY = TREE_NOTIFICATION_EVENT;
 
         private transient final TreeItem<T> treeItem;
+        @SuppressWarnings("doclint:missing")
         private final T newValue;
 
+        @SuppressWarnings("doclint:missing")
         private final List<? extends TreeItem<T>> added;
+        @SuppressWarnings("doclint:missing")
         private final List<? extends TreeItem<T>> removed;
+        @SuppressWarnings("doclint:missing")
         private final ListChangeListener.Change<? extends TreeItem<T>> change;
 
+        @SuppressWarnings("doclint:missing")
         private final boolean wasExpanded;
+        @SuppressWarnings("doclint:missing")
         private final boolean wasCollapsed;
+        @SuppressWarnings("doclint:missing")
         private boolean wasPermutated;
 
         /**

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeItem.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -988,6 +988,7 @@ public class TreeItem<T> implements EventTarget { //, Comparable<TreeItem<T>> {
      * @param <T> The TreeModificationEvent
      * @since JavaFX 2.0
      */
+    @SuppressWarnings("doclint")
     public static class TreeModificationEvent<T> extends Event {
         private static final long serialVersionUID = 4741889985221719579L;
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableColumn.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableColumn.java
@@ -738,7 +738,6 @@ public class TreeTableColumn<S,T> extends TableColumnBase<TreeItem<S>,T> impleme
      * An event that is fired when a user performs an edit on a table cell.
      * @since JavaFX 8.0
      */
-    @SuppressWarnings("doclint")
     public static class CellEditEvent<S,T> extends Event {
         private static final long serialVersionUID = -609964441682677579L;
 
@@ -751,6 +750,7 @@ public class TreeTableColumn<S,T> extends TableColumnBase<TreeItem<S>,T> impleme
         // to go back into the TableView.items list - this new value represents
         // just the input for a single cell, so it is likely that it needs to go
         // back into a property within an item in the TableView.items list.
+        @SuppressWarnings("doclint:missing")
         private final T newValue;
 
         // The location of the edit event

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableColumn.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableColumn.java
@@ -738,6 +738,7 @@ public class TreeTableColumn<S,T> extends TableColumnBase<TreeItem<S>,T> impleme
      * An event that is fired when a user performs an edit on a table cell.
      * @since JavaFX 8.0
      */
+    @SuppressWarnings("doclint")
     public static class CellEditEvent<S,T> extends Event {
         private static final long serialVersionUID = -609964441682677579L;
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -2380,6 +2380,7 @@ public class TreeTableView<S> extends Control {
      *      itself.
      * @since JavaFX 8.0
      */
+    @SuppressWarnings("doclint")
     public static class EditEvent<S> extends Event {
         private static final long serialVersionUID = -4437033058917528976L;
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableView.java
@@ -2380,7 +2380,6 @@ public class TreeTableView<S> extends Control {
      *      itself.
      * @since JavaFX 8.0
      */
-    @SuppressWarnings("doclint")
     public static class EditEvent<S> extends Event {
         private static final long serialVersionUID = -4437033058917528976L;
 
@@ -2389,8 +2388,11 @@ public class TreeTableView<S> extends Control {
          */
         public static final EventType<?> ANY = EDIT_ANY_EVENT;
 
+        @SuppressWarnings("doclint:missing")
         private final TreeTableView<S> source;
+        @SuppressWarnings("doclint:missing")
         private final S oldValue;
+        @SuppressWarnings("doclint:missing")
         private final S newValue;
         private transient final TreeItem<S> treeItem;
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1254,6 +1254,7 @@ public class TreeView<T> extends Control {
      *      itself.
      * @since JavaFX 2.0
      */
+    @SuppressWarnings("doclint")
     public static class EditEvent<T> extends Event {
         private static final long serialVersionUID = -4437033058917528976L;
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeView.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeView.java
@@ -1254,7 +1254,6 @@ public class TreeView<T> extends Control {
      *      itself.
      * @since JavaFX 2.0
      */
-    @SuppressWarnings("doclint")
     public static class EditEvent<T> extends Event {
         private static final long serialVersionUID = -4437033058917528976L;
 
@@ -1264,8 +1263,11 @@ public class TreeView<T> extends Control {
          */
         public static final EventType<?> ANY = EDIT_ANY_EVENT;
 
+        @SuppressWarnings("doclint:missing")
         private final TreeView<T> source;
+        @SuppressWarnings("doclint:missing")
         private final T oldValue;
+        @SuppressWarnings("doclint:missing")
         private final T newValue;
         private transient final TreeItem<T> treeItem;
 

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/ContextMenuEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/ContextMenuEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,7 @@ import javafx.geometry.Point3D;
  * inside of bounds of current focus owner (which is the event's target).
  * @since JavaFX 2.1
  */
+@SuppressWarnings("doclint")
 public class ContextMenuEvent extends InputEvent {
 
     private static final long serialVersionUID = 20121107L;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/ContextMenuEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/ContextMenuEvent.java
@@ -46,7 +46,6 @@ import javafx.geometry.Point3D;
  * inside of bounds of current focus owner (which is the event's target).
  * @since JavaFX 2.1
  */
-@SuppressWarnings("doclint")
 public class ContextMenuEvent extends InputEvent {
 
     private static final long serialVersionUID = 20121107L;
@@ -329,6 +328,7 @@ public class ContextMenuEvent extends InputEvent {
         return sb.append("]").toString();
     }
 
+    @SuppressWarnings("doclint:missing")
     private void readObject(java.io.ObjectInputStream in)
             throws IOException, ClassNotFoundException {
         in.defaultReadObject();

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/DragEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/DragEvent.java
@@ -200,7 +200,6 @@ rect.setOnDragDropped(new EventHandler&lt;DragEvent&gt;() {
  * </p>
  * @since JavaFX 2.0
  */
-@SuppressWarnings("doclint")
 public final class DragEvent extends InputEvent {
 
     private static final long serialVersionUID = 20121107L;
@@ -591,6 +590,7 @@ public final class DragEvent extends InputEvent {
      * @return the source object of the drag and drop gesture
      */
     public final Object getGestureSource() { return gestureSource; }
+    @SuppressWarnings("doclint:missing")
     private Object gestureSource;
 
     /**
@@ -602,6 +602,7 @@ public final class DragEvent extends InputEvent {
      * @return the target object of the drag and drop gesture
      */
     public final Object getGestureTarget() { return gestureTarget; }
+    @SuppressWarnings("doclint:missing")
     private Object gestureTarget;
 
     /**
@@ -615,8 +616,10 @@ public final class DragEvent extends InputEvent {
      * @return the data transfer mode
      */
     public final TransferMode getTransferMode() { return transferMode; }
+    @SuppressWarnings("doclint:missing")
     private TransferMode transferMode;
 
+    @SuppressWarnings("doclint:missing")
     private final State state = new State();
 
     /**
@@ -749,6 +752,7 @@ public final class DragEvent extends InputEvent {
         return state.dropCompleted;
     }
 
+    @SuppressWarnings("doclint:missing")
     private void readObject(java.io.ObjectInputStream in)
             throws IOException, ClassNotFoundException {
         in.defaultReadObject();

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/DragEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/DragEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -200,6 +200,7 @@ rect.setOnDragDropped(new EventHandler&lt;DragEvent&gt;() {
  * </p>
  * @since JavaFX 2.0
  */
+@SuppressWarnings("doclint")
 public final class DragEvent extends InputEvent {
 
     private static final long serialVersionUID = 20121107L;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/GestureEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/GestureEvent.java
@@ -43,7 +43,6 @@ import javafx.geometry.Point3D;
  * </p>
  * @since JavaFX 2.2
  */
-@SuppressWarnings("doclint")
 public class GestureEvent extends InputEvent {
 
     private static final long serialVersionUID = 20121107L;
@@ -224,6 +223,7 @@ public class GestureEvent extends InputEvent {
         return z;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final double screenX;
 
     /**
@@ -236,6 +236,7 @@ public class GestureEvent extends InputEvent {
         return screenX;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final double screenY;
 
     /**
@@ -248,6 +249,7 @@ public class GestureEvent extends InputEvent {
         return screenY;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final double sceneX;
 
     /**
@@ -267,6 +269,7 @@ public class GestureEvent extends InputEvent {
         return sceneX;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final double sceneY;
 
     /**
@@ -286,6 +289,7 @@ public class GestureEvent extends InputEvent {
         return sceneY;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final boolean shiftDown;
 
     /**
@@ -296,6 +300,7 @@ public class GestureEvent extends InputEvent {
         return shiftDown;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final boolean controlDown;
 
     /**
@@ -306,6 +311,7 @@ public class GestureEvent extends InputEvent {
         return controlDown;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final boolean altDown;
 
     /**
@@ -316,6 +322,7 @@ public class GestureEvent extends InputEvent {
         return altDown;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final boolean metaDown;
 
     /**
@@ -326,6 +333,7 @@ public class GestureEvent extends InputEvent {
         return metaDown;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final boolean direct;
 
     /**
@@ -341,6 +349,7 @@ public class GestureEvent extends InputEvent {
         return direct;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final boolean inertia;
 
     /**
@@ -436,6 +445,7 @@ public class GestureEvent extends InputEvent {
         return sb.append("]").toString();
     }
 
+    @SuppressWarnings("doclint:missing")
     private void readObject(java.io.ObjectInputStream in)
             throws IOException, ClassNotFoundException {
         in.defaultReadObject();

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/GestureEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/GestureEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,7 @@ import javafx.geometry.Point3D;
  * </p>
  * @since JavaFX 2.2
  */
+@SuppressWarnings("doclint")
 public class GestureEvent extends InputEvent {
 
     private static final long serialVersionUID = 20121107L;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/InputMethodEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/InputMethodEvent.java
@@ -54,7 +54,6 @@ import javafx.scene.Node;
  * for more information.
  * @since JavaFX 2.0
  */
-@SuppressWarnings("doclint")
 public final class InputMethodEvent extends InputEvent{
 
     private static final long serialVersionUID = 20121107L;
@@ -190,11 +189,13 @@ public final class InputMethodEvent extends InputEvent{
         return (EventType<InputMethodEvent>) super.getEventType();
     }
 
+    @SuppressWarnings("doclint:missing")
     private void writeObject(ObjectOutputStream oos) throws IOException {
         oos.defaultWriteObject();
         oos.writeObject(new ArrayList(composed));
     }
 
+    @SuppressWarnings("doclint:missing")
     private void readObject(ObjectInputStream ois) throws IOException,
             ClassNotFoundException {
         ois.defaultReadObject();

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/InputMethodEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/InputMethodEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,7 @@ import javafx.scene.Node;
  * for more information.
  * @since JavaFX 2.0
  */
+@SuppressWarnings("doclint")
 public final class InputMethodEvent extends InputEvent{
 
     private static final long serialVersionUID = 20121107L;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/MouseEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/MouseEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -125,6 +125,7 @@ import java.io.IOException;
  * </ul>
  * @since JavaFX 2.0
  */
+@SuppressWarnings("doclint")
 public class MouseEvent extends InputEvent {
 
     private static final long serialVersionUID = 20121107L;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/MouseEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/MouseEvent.java
@@ -125,7 +125,6 @@ import java.io.IOException;
  * </ul>
  * @since JavaFX 2.0
  */
-@SuppressWarnings("doclint")
 public class MouseEvent extends InputEvent {
 
     private static final long serialVersionUID = 20121107L;
@@ -552,6 +551,8 @@ public class MouseEvent extends InputEvent {
         ev.recomputeCoordinatesToSource(e, source);
         return ev;
     }
+
+    @SuppressWarnings("doclint:missing")
     private final Flags flags = new Flags();
 
     /**
@@ -821,6 +822,7 @@ public class MouseEvent extends InputEvent {
         return metaDown;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final boolean synthesized;
 
     /**
@@ -1103,6 +1105,7 @@ public class MouseEvent extends InputEvent {
         }
     }
 
+    @SuppressWarnings("doclint:missing")
     private void readObject(java.io.ObjectInputStream in)
             throws IOException, ClassNotFoundException {
         in.defaultReadObject();

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/RotateEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/RotateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,7 @@ import javafx.event.EventType;
  *
  * @since JavaFX 2.2
  */
+@SuppressWarnings("doclint")
 public final class RotateEvent extends GestureEvent {
 
     private static final long serialVersionUID = 20121107L;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/RotateEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/RotateEvent.java
@@ -57,7 +57,6 @@ import javafx.event.EventType;
  *
  * @since JavaFX 2.2
  */
-@SuppressWarnings("doclint")
 public final class RotateEvent extends GestureEvent {
 
     private static final long serialVersionUID = 20121107L;
@@ -162,6 +161,7 @@ public final class RotateEvent extends GestureEvent {
                 altDown, metaDown, direct, inertia, angle, totalAngle, pickResult);
     }
 
+    @SuppressWarnings("doclint:missing")
     private final double angle;
 
     /**
@@ -174,6 +174,7 @@ public final class RotateEvent extends GestureEvent {
         return angle;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final double totalAngle;
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/ScrollEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/ScrollEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,6 +98,7 @@ import javafx.event.EventType;
  *
  * @since JavaFX 2.0
  */
+@SuppressWarnings("doclint")
 public final class ScrollEvent extends GestureEvent {
 
     private static final long serialVersionUID = 20121107L;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/ScrollEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/ScrollEvent.java
@@ -98,7 +98,6 @@ import javafx.event.EventType;
  *
  * @since JavaFX 2.0
  */
-@SuppressWarnings("doclint")
 public final class ScrollEvent extends GestureEvent {
 
     private static final long serialVersionUID = 20121107L;
@@ -315,6 +314,7 @@ public final class ScrollEvent extends GestureEvent {
                 textDeltaYUnits, textDeltaY, touchCount, pickResult);
     }
 
+    @SuppressWarnings("doclint:missing")
     private final double deltaX;
 
     /**
@@ -334,6 +334,7 @@ public final class ScrollEvent extends GestureEvent {
         return deltaX;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final double deltaY;
 
     /**
@@ -353,6 +354,7 @@ public final class ScrollEvent extends GestureEvent {
         return deltaY;
     }
 
+    @SuppressWarnings("doclint:missing")
     private double totalDeltaX;
 
     /**
@@ -373,6 +375,7 @@ public final class ScrollEvent extends GestureEvent {
         return totalDeltaX;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final double totalDeltaY;
 
     /**
@@ -393,6 +396,7 @@ public final class ScrollEvent extends GestureEvent {
         return totalDeltaY;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final HorizontalTextScrollUnits textDeltaXUnits;
 
     /**
@@ -408,6 +412,7 @@ public final class ScrollEvent extends GestureEvent {
         return textDeltaXUnits;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final VerticalTextScrollUnits textDeltaYUnits;
 
     /**
@@ -423,6 +428,7 @@ public final class ScrollEvent extends GestureEvent {
         return textDeltaYUnits;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final double textDeltaX;
 
     /**
@@ -437,6 +443,7 @@ public final class ScrollEvent extends GestureEvent {
         return textDeltaX;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final double textDeltaY;
 
     /**
@@ -451,6 +458,7 @@ public final class ScrollEvent extends GestureEvent {
         return textDeltaY;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final int touchCount;
 
     /**
@@ -464,6 +472,7 @@ public final class ScrollEvent extends GestureEvent {
         return touchCount;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final double multiplierX;
 
     /**
@@ -475,6 +484,7 @@ public final class ScrollEvent extends GestureEvent {
         return multiplierX;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final double multiplierY;
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/SwipeEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/SwipeEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,7 @@ import javafx.event.EventType;
  *
  * @since JavaFX 2.2
  */
+@SuppressWarnings("doclint")
 public final class SwipeEvent extends GestureEvent {
 
     private static final long serialVersionUID = 20121107L;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/SwipeEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/SwipeEvent.java
@@ -57,7 +57,6 @@ import javafx.event.EventType;
  *
  * @since JavaFX 2.2
  */
-@SuppressWarnings("doclint")
 public final class SwipeEvent extends GestureEvent {
 
     private static final long serialVersionUID = 20121107L;
@@ -162,6 +161,7 @@ public final class SwipeEvent extends GestureEvent {
                 altDown, metaDown, direct, touchCount, pickResult);
     }
 
+    @SuppressWarnings("doclint:missing")
     private final int touchCount;
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/TouchEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/TouchEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,6 +55,7 @@ import javafx.event.EventType;
  *
  * @since JavaFX 2.2
  */
+@SuppressWarnings("doclint")
 public final class TouchEvent extends InputEvent {
 
     private static final long serialVersionUID = 20121107L;

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/TouchEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/TouchEvent.java
@@ -55,7 +55,6 @@ import javafx.event.EventType;
  *
  * @since JavaFX 2.2
  */
-@SuppressWarnings("doclint")
 public final class TouchEvent extends InputEvent {
 
     private static final long serialVersionUID = 20121107L;
@@ -194,6 +193,7 @@ public final class TouchEvent extends InputEvent {
         return (EventType<TouchEvent>) super.getEventType();
     }
 
+    @SuppressWarnings("doclint:missing")
     private final int eventSetId;
 
     /**
@@ -265,6 +265,7 @@ public final class TouchEvent extends InputEvent {
         return metaDown;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final TouchPoint touchPoint;
 
     /**
@@ -275,6 +276,7 @@ public final class TouchEvent extends InputEvent {
         return touchPoint;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final List<TouchPoint> touchPoints;
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/TouchPoint.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/TouchPoint.java
@@ -54,7 +54,6 @@ import javafx.scene.Scene;
  *
  * @since JavaFX 2.2
  */
-@SuppressWarnings("doclint")
 public final class TouchPoint implements Serializable{
 
     static {
@@ -157,6 +156,7 @@ public final class TouchPoint implements Serializable{
         z = p.getZ();
     }
 
+    @SuppressWarnings("doclint:missing")
     private EventTarget grabbed = null;
 
     /**
@@ -199,6 +199,7 @@ public final class TouchPoint implements Serializable{
         grabbed = null;
     }
 
+    @SuppressWarnings("doclint:missing")
     private int id;
 
     /**
@@ -213,6 +214,7 @@ public final class TouchPoint implements Serializable{
         return id;
     }
 
+    @SuppressWarnings("doclint:missing")
     private State state;
 
     /**
@@ -268,6 +270,7 @@ public final class TouchPoint implements Serializable{
         return z;
     }
 
+    @SuppressWarnings("doclint:missing")
     private double screenX;
 
     /**
@@ -278,6 +281,7 @@ public final class TouchPoint implements Serializable{
         return screenX;
     }
 
+    @SuppressWarnings("doclint:missing")
     private double screenY;
 
     /**
@@ -288,6 +292,7 @@ public final class TouchPoint implements Serializable{
         return screenY;
     }
 
+    @SuppressWarnings("doclint:missing")
     private double sceneX;
 
     /**
@@ -305,6 +310,7 @@ public final class TouchPoint implements Serializable{
         return sceneX;
     }
 
+    @SuppressWarnings("doclint:missing")
     private double sceneY;
 
     /**
@@ -364,6 +370,7 @@ public final class TouchPoint implements Serializable{
         return sb.append("]").toString();
     }
 
+    @SuppressWarnings("doclint:missing")
     private void readObject(java.io.ObjectInputStream in)
             throws IOException, ClassNotFoundException {
         in.defaultReadObject();

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/TouchPoint.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/TouchPoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,7 @@ import javafx.scene.Scene;
  *
  * @since JavaFX 2.2
  */
+@SuppressWarnings("doclint")
 public final class TouchPoint implements Serializable{
 
     static {

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/ZoomEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/ZoomEvent.java
@@ -57,7 +57,6 @@ import javafx.event.EventType;
  *
  * @since JavaFX 2.2
  */
-@SuppressWarnings("doclint")
 public final class ZoomEvent extends GestureEvent {
 
     private static final long serialVersionUID = 20121107L;
@@ -165,6 +164,7 @@ public final class ZoomEvent extends GestureEvent {
                 pickResult);
     }
 
+    @SuppressWarnings("doclint:missing")
     private final double zoomFactor;
 
     /**
@@ -178,6 +178,7 @@ public final class ZoomEvent extends GestureEvent {
         return zoomFactor;
     }
 
+    @SuppressWarnings("doclint:missing")
     private final double totalZoomFactor;
 
     /**

--- a/modules/javafx.graphics/src/main/java/javafx/scene/input/ZoomEvent.java
+++ b/modules/javafx.graphics/src/main/java/javafx/scene/input/ZoomEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,7 @@ import javafx.event.EventType;
  *
  * @since JavaFX 2.2
  */
+@SuppressWarnings("doclint")
 public final class ZoomEvent extends GestureEvent {
 
     private static final long serialVersionUID = 20121107L;

--- a/modules/javafx.media/src/main/java/javafx/scene/media/MediaMarkerEvent.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/MediaMarkerEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import javafx.util.Pair;
  * @see MediaPlayer#onMarkerProperty()
  * @since JavaFX 2.0
  */
+@SuppressWarnings("doclint")
 public class MediaMarkerEvent extends ActionEvent {
 
     private static final long serialVersionUID = 20121107L;

--- a/modules/javafx.media/src/main/java/javafx/scene/media/MediaMarkerEvent.java
+++ b/modules/javafx.media/src/main/java/javafx/scene/media/MediaMarkerEvent.java
@@ -37,11 +37,11 @@ import javafx.util.Pair;
  * @see MediaPlayer#onMarkerProperty()
  * @since JavaFX 2.0
  */
-@SuppressWarnings("doclint")
 public class MediaMarkerEvent extends ActionEvent {
 
     private static final long serialVersionUID = 20121107L;
 
+    @SuppressWarnings("doclint:missing")
     private Pair<String,Duration> marker;
 
     MediaMarkerEvent(Pair<String,Duration> marker) {

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
@@ -137,12 +137,9 @@ import com.sun.javafx.embed.swing.newimpl.JFXPanelInteropN;
  * </pre>
  * <strong>Warning:</strong>
  * Serialized objects of this class will not be compatible with
- * future Swing releases. The current serialization support is
+ * future Swing or JavaFX releases. The current serialization support is
  * appropriate for short term storage or RMI between applications running
- * the same version of Swing.  As of 1.4, support for long term storage
- * of all JavaBeans
- * has been added to the <code>java.beans</code> package.
- * Please see {@link java.beans.XMLEncoder}.
+ * the same version of Swing and the same version of JavaFX.
  *
  * @since JavaFX 2.0
  */

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
@@ -146,7 +146,6 @@ import com.sun.javafx.embed.swing.newimpl.JFXPanelInteropN;
  *
  * @since JavaFX 2.0
  */
-@SuppressWarnings("doclint")
 public class JFXPanel extends JComponent {
 
     private final static PlatformLogger log = PlatformLogger.getLogger(JFXPanel.class.getName());
@@ -166,36 +165,49 @@ public class JFXPanel extends JComponent {
     private transient EmbeddedSceneInterface scenePeer;
 
     // The logical size of the FX content
+    @SuppressWarnings("doclint:missing")
     private int pWidth;
+    @SuppressWarnings("doclint:missing")
     private int pHeight;
 
     // The scale factor, used to translate b/w the logical (the FX content dimension)
     // and physical (the back buffer's dimension) coordinate spaces
+    @SuppressWarnings("doclint:missing")
     private double scaleFactorX = 1.0;
+    @SuppressWarnings("doclint:missing")
     private double scaleFactorY = 1.0;
 
     // Preferred size set from FX
+    @SuppressWarnings("doclint:missing")
     private volatile int pPreferredWidth = -1;
+    @SuppressWarnings("doclint:missing")
     private volatile int pPreferredHeight = -1;
 
     // Cached copy of this component's location on screen to avoid
     // calling getLocationOnScreen() under the tree lock on FX thread
+    @SuppressWarnings("doclint:missing")
     private volatile int screenX = 0;
+    @SuppressWarnings("doclint:missing")
     private volatile int screenY = 0;
 
     // Accessed on EDT only
+    @SuppressWarnings("doclint:missing")
     private BufferedImage pixelsIm;
 
+    @SuppressWarnings("doclint:missing")
     private volatile float opacity = 1.0f;
 
     // Indicates how many times setFxEnabled(false) has been called.
     // A value of 0 means the component is enabled.
+    @SuppressWarnings("doclint:missing")
     private AtomicInteger disableCount = new AtomicInteger(0);
 
+    @SuppressWarnings("doclint:missing")
     private boolean isCapturingMouse = false;
 
     private static boolean fxInitialized;
 
+    @SuppressWarnings("doclint:missing")
     private JFXPanelInteropN jfxPanelIOP;
 
     private synchronized void registerFinishListener() {

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/JFXPanel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,9 +135,18 @@ import com.sun.javafx.embed.swing.newimpl.JFXPanelInteropN;
  *         }
  *     }
  * </pre>
+ * <strong>Warning:</strong>
+ * Serialized objects of this class will not be compatible with
+ * future Swing releases. The current serialization support is
+ * appropriate for short term storage or RMI between applications running
+ * the same version of Swing.  As of 1.4, support for long term storage
+ * of all JavaBeans
+ * has been added to the <code>java.beans</code> package.
+ * Please see {@link java.beans.XMLEncoder}.
  *
  * @since JavaFX 2.0
  */
+@SuppressWarnings("doclint")
 public class JFXPanel extends JComponent {
 
     private final static PlatformLogger log = PlatformLogger.getLogger(JFXPanel.class.getName());

--- a/modules/javafx.web/src/main/java/javafx/scene/web/WebErrorEvent.java
+++ b/modules/javafx.web/src/main/java/javafx/scene/web/WebErrorEvent.java
@@ -37,7 +37,6 @@ import javafx.event.EventType;
  * @see WebEngine#onErrorProperty WebEngine.onError
  * @since JavaFX 8.0
  */
-@SuppressWarnings("doclint")
 public final class WebErrorEvent extends Event {
 
     /**
@@ -122,8 +121,9 @@ public final class WebErrorEvent extends Event {
             USER_DATA_DIRECTORY_SECURITY_ERROR = new EventType<>(
                     WebErrorEvent.ANY, "USER_DATA_DIRECTORY_SECURITY_ERROR");
 
-
+    @SuppressWarnings("doclint:missing")
     private final String message;
+    @SuppressWarnings("doclint:missing")
     private final Throwable exception;
 
 

--- a/modules/javafx.web/src/main/java/javafx/scene/web/WebErrorEvent.java
+++ b/modules/javafx.web/src/main/java/javafx/scene/web/WebErrorEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import javafx.event.EventType;
  * @see WebEngine#onErrorProperty WebEngine.onError
  * @since JavaFX 8.0
  */
+@SuppressWarnings("doclint")
 public final class WebErrorEvent extends Event {
 
     /**

--- a/modules/javafx.web/src/main/java/javafx/scene/web/WebEvent.java
+++ b/modules/javafx.web/src/main/java/javafx/scene/web/WebEvent.java
@@ -41,7 +41,6 @@ import javafx.event.EventType;
  * @see WebEngine#setOnVisibilityChanged
  * @since JavaFX 2.0
  */
-@SuppressWarnings("doclint")
 final public class WebEvent<T> extends Event {
 
     /**
@@ -77,6 +76,7 @@ final public class WebEvent<T> extends Event {
     public static final EventType<WebEvent> ALERT =
             new EventType<>(WebEvent.ANY, "WEB_ALERT");
 
+    @SuppressWarnings("doclint:missing")
     private final T data;
 
     /**

--- a/modules/javafx.web/src/main/java/javafx/scene/web/WebEvent.java
+++ b/modules/javafx.web/src/main/java/javafx/scene/web/WebEvent.java
@@ -41,6 +41,7 @@ import javafx.event.EventType;
  * @see WebEngine#setOnVisibilityChanged
  * @since JavaFX 2.0
  */
+@SuppressWarnings("doclint")
 final public class WebEvent<T> extends Event {
 
     /**


### PR DESCRIPTION
Adding `@SuppressWarnings("doclint:missing")` to the lines in Serializable classes that generated javadoc's "missing comments" warning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8270996](https://bugs.openjdk.org/browse/JDK-8270996): javadoc: missing comments in serialized classes (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1386/head:pull/1386` \
`$ git checkout pull/1386`

Update a local copy of the PR: \
`$ git checkout pull/1386` \
`$ git pull https://git.openjdk.org/jfx.git pull/1386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1386`

View PR using the GUI difftool: \
`$ git pr show -t 1386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1386.diff">https://git.openjdk.org/jfx/pull/1386.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1386#issuecomment-1971599436)