### PR TITLE
8314968: Public InputMap

### DIFF
--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ColorPickerBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ColorPickerBehavior.java
@@ -27,7 +27,6 @@ package com.sun.javafx.scene.control.behavior;
 
 import javafx.scene.control.ColorPicker;
 import javafx.scene.control.PopupControl;
-
 import javafx.scene.paint.Color;
 
 public class ColorPickerBehavior extends ComboBoxBaseBehavior<Color> {
@@ -41,8 +40,8 @@ public class ColorPickerBehavior extends ComboBoxBaseBehavior<Color> {
     /**
      *
      */
-    public ColorPickerBehavior(final ColorPicker colorPicker) {
-        super(colorPicker);
+    public ColorPickerBehavior(ColorPicker c) {
+        super(c);
     }
 
      /**************************************************************************
@@ -54,14 +53,14 @@ public class ColorPickerBehavior extends ComboBoxBaseBehavior<Color> {
     @Override public void onAutoHide(PopupControl popup) {
         // when we click on some non  interactive part of the
         // Color Palette - we do not want to hide.
-        if (!popup.isShowing() && getNode().isShowing()) {
+        if (!popup.isShowing() && getControl().isShowing()) {
             // Popup was dismissed. Maybe user clicked outside or typed ESCAPE.
             // Make sure DatePicker button is in sync.
-            getNode().hide();
+            getControl().hide();
         }
         // if the ColorPicker is no longer showing, then invoke the super method
         // to keep its show/hide state in sync.
-        if (!getNode().isShowing()) {
+        if (!getControl().isShowing()) {
             super.onAutoHide(popup);
         }
     }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ComboBoxBaseBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ComboBoxBaseBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,8 @@
 
 package com.sun.javafx.scene.control.behavior;
 
-import com.sun.javafx.scene.control.inputmap.InputMap;
-
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
-import javafx.event.EventHandler;
 import javafx.event.EventTarget;
 import javafx.scene.Node;
 import javafx.scene.control.ComboBox;
@@ -37,18 +34,16 @@ import javafx.scene.control.ComboBoxBase;
 import javafx.scene.control.DatePicker;
 import javafx.scene.control.PopupControl;
 import javafx.scene.control.TextField;
+import javafx.scene.control.input.BehaviorBase;
+import javafx.scene.control.input.KeyBinding;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
 import com.sun.javafx.scene.control.skin.Utils;
-import javafx.scene.input.*;
-import com.sun.javafx.scene.control.inputmap.KeyBinding;
-
-import static javafx.scene.input.KeyCode.*;
-import static javafx.scene.input.KeyEvent.*;
-import static com.sun.javafx.scene.control.inputmap.InputMap.KeyMapping;
-import static com.sun.javafx.scene.control.inputmap.InputMap.MouseMapping;
 
 public class ComboBoxBaseBehavior<T> extends BehaviorBase<ComboBoxBase<T>> {
 
-    private final InputMap<ComboBoxBase<T>> inputMap;
     private InvalidationListener focusListener = this::focusChanged;
 
     /***************************************************************************
@@ -62,65 +57,47 @@ public class ComboBoxBaseBehavior<T> extends BehaviorBase<ComboBoxBase<T>> {
     /**
      *
      */
-    public ComboBoxBaseBehavior(final ComboBoxBase<T> comboBox) {
-        super(comboBox);
+    public ComboBoxBaseBehavior(ComboBoxBase<T> c) {
+        super(c);
+    }
 
-        // create a map for comboBox-specific mappings (this reuses the default
-        // InputMap installed on the control, if it is non-null, allowing us to pick up any user-specified mappings)
-        inputMap = createInputMap();
-
-        final EventHandler<KeyEvent> togglePopup = e -> {
-            // If popup is shown, KeyEvent causes popup to close
-            showPopupOnMouseRelease = true;
-
-            if (getNode().isShowing()) hide();
-            else show();
-        };
-
-        // comboBox-specific mappings for key and mouse input
-        KeyMapping enterPressed, enterReleased;
-        addDefaultMapping(inputMap,
-            new KeyMapping(F4, KEY_RELEASED, togglePopup),
-            new KeyMapping(new KeyBinding(UP).alt(), togglePopup),
-            new KeyMapping(new KeyBinding(DOWN).alt(), togglePopup),
-
-            new KeyMapping(SPACE, KEY_PRESSED, this::keyPressed),
-            new KeyMapping(SPACE, KEY_RELEASED, this::keyReleased),
-
-            enterPressed = new KeyMapping(ENTER, KEY_PRESSED, this::keyPressed),
-            enterReleased = new KeyMapping(ENTER, KEY_RELEASED, this::keyReleased),
-
-            // The following keys are forwarded to the parent container
-            new KeyMapping(ESCAPE, KEY_PRESSED, this::cancelEdit),
-            new KeyMapping(F10,    KEY_PRESSED, this::forwardToParent),
-
-            new MouseMapping(MouseEvent.MOUSE_PRESSED, this::mousePressed),
-            new MouseMapping(MouseEvent.MOUSE_RELEASED, this::mouseReleased),
-            new MouseMapping(MouseEvent.MOUSE_ENTERED, this::mouseEntered),
-            new MouseMapping(MouseEvent.MOUSE_EXITED, this::mouseExited)
-        );
-
-        // we don't want to consume events on enter press - let them carry on through
-        enterPressed.setAutoConsume(false);
-        enterReleased.setAutoConsume(false);
-
+    @Override
+    protected void populateSkinInputMap() {
         // ComboBoxBase also cares about focus
-        comboBox.focusedProperty().addListener(focusListener);
+        getControl().focusedProperty().addListener(focusListener);
 
         // Only add this if we're on an embedded platform that supports 5-button navigation
         if (Utils.isTwoLevelFocus()) {
-            tlFocus = new TwoLevelFocusComboBehavior(comboBox); // needs to be last.
+            tlFocus = new TwoLevelFocusComboBehavior(getControl()); // needs to be last.
         }
+
+        registerFunction(ComboBoxBase.TOGGLE_POPUP, this::togglePopup);
+
+        registerKey(KeyBinding.with(KeyCode.F4).onKeyReleased().build(), ComboBoxBase.TOGGLE_POPUP);
+        registerKey(KeyBinding.alt(KeyCode.DOWN), ComboBoxBase.TOGGLE_POPUP);
+        registerKey(KeyBinding.alt(KeyCode.UP), ComboBoxBase.TOGGLE_POPUP);
+
+        addHandler(KeyBinding.of(KeyCode.SPACE), true, this::keyPressed);
+        addHandler(KeyBinding.with(KeyCode.SPACE).onKeyReleased().build(), true, this::keyReleased);
+
+        // these two should not consume the event
+        addHandler(KeyBinding.of(KeyCode.ENTER), false, this::keyPressed);
+        addHandler(KeyBinding.with(KeyCode.ENTER).onKeyReleased().build(), false, this::keyReleased);
+
+        addHandler(KeyBinding.of(KeyCode.ESCAPE), true, this::cancelEdit);
+        addHandler(KeyBinding.of(KeyCode.F10), true, this::forwardToParent);
+
+        addHandler(MouseEvent.MOUSE_PRESSED, true, this::mousePressed);
+        addHandler(MouseEvent.MOUSE_RELEASED, true, this::mouseReleased);
+        addHandler(MouseEvent.MOUSE_ENTERED, true, this::mouseEntered);
+        addHandler(MouseEvent.MOUSE_EXITED, true, this::mouseExited);
     }
 
-    @Override public void dispose() {
-        if (tlFocus != null) tlFocus.dispose();
-        getNode().focusedProperty().removeListener(focusListener);
-        super.dispose();
-    }
-
-    @Override public InputMap<ComboBoxBase<T>> getInputMap() {
-        return inputMap;
+    public void dispose() {
+        if (tlFocus != null) {
+            tlFocus.dispose();
+        }
+        getControl().focusedProperty().removeListener(focusListener);
     }
 
     /***************************************************************************
@@ -132,7 +109,7 @@ public class ComboBoxBaseBehavior<T> extends BehaviorBase<ComboBoxBase<T>> {
     protected void focusChanged(Observable o) {
         // If we did have the key down, but are now not focused, then we must
         // disarm the box.
-        final ComboBoxBase<T> box = getNode();
+        final ComboBoxBase<T> box = getControl();
         if (keyDown && !box.isFocused()) {
             keyDown = false;
             box.disarm();
@@ -169,9 +146,9 @@ public class ComboBoxBaseBehavior<T> extends BehaviorBase<ComboBoxBase<T>> {
             }
         }
         else {
-            if (! getNode().isPressed() && ! getNode().isArmed()) {
+            if (! getControl().isPressed() && ! getControl().isArmed()) {
                 keyDown = true;
-                getNode().arm();
+                getControl().arm();
             }
         }
     }
@@ -187,16 +164,16 @@ public class ComboBoxBaseBehavior<T> extends BehaviorBase<ComboBoxBase<T>> {
         if (!Utils.isTwoLevelFocus()) {
             if (keyDown) {
                 keyDown = false;
-                if (getNode().isArmed()) {
-                    getNode().disarm();
+                if (getControl().isArmed()) {
+                    getControl().disarm();
                 }
             }
         }
     }
 
     private void forwardToParent(KeyEvent event) {
-        if (getNode().getParent() != null) {
-            getNode().getParent().fireEvent(event);
+        if (getControl().getParent() != null) {
+            getControl().getParent().fireEvent(event);
         }
     }
 
@@ -205,7 +182,7 @@ public class ComboBoxBaseBehavior<T> extends BehaviorBase<ComboBoxBase<T>> {
          * This can be cleaned up if the editor property is moved up
          * to ComboBoxBase.
          */
-        ComboBoxBase comboBoxBase = getNode();
+        ComboBoxBase comboBoxBase = getControl();
         TextField textField = null;
         if (comboBoxBase instanceof DatePicker) {
             textField = ((DatePicker)comboBoxBase).getEditor();
@@ -248,7 +225,7 @@ public class ComboBoxBaseBehavior<T> extends BehaviorBase<ComboBoxBase<T>> {
     }
 
     public void mouseEntered(MouseEvent e) {
-        if (!getNode().isEditable()) {
+        if (!getControl().isEditable()) {
             mouseInsideButton = true;
         } else {
             // This is strongly tied to ComboBoxBaseSkin
@@ -274,23 +251,23 @@ public class ComboBoxBaseBehavior<T> extends BehaviorBase<ComboBoxBase<T>> {
             ! (e.isMiddleButtonDown() || e.isSecondaryButtonDown() ||
              e.isShiftDown() || e.isControlDown() || e.isAltDown() || e.isMetaDown()));
 
-        if (! getNode().isArmed() && valid) {
-            getNode().arm();
+        if (! getControl().isArmed() && valid) {
+            getControl().arm();
         }
     }
 
     public void show() {
-        if (! getNode().isShowing()) {
-            if (getNode().isFocusTraversable()) {
-                getNode().requestFocus();
+        if (! getControl().isShowing()) {
+            if (getControl().isFocusTraversable()) {
+                getControl().requestFocus();
             }
-            getNode().show();
+            getControl().show();
         }
     }
 
     public void hide() {
-        if (getNode().isShowing()) {
-            getNode().hide();
+        if (getControl().isShowing()) {
+            getControl().hide();
         }
     }
 
@@ -307,15 +284,25 @@ public class ComboBoxBaseBehavior<T> extends BehaviorBase<ComboBoxBase<T>> {
     }
 
     public void arm() {
-        if (getNode().isPressed()) {
-            getNode().arm();
+        if (getControl().isPressed()) {
+            getControl().arm();
         }
     }
 
     public void disarm() {
-        if (! keyDown && getNode().isArmed()) {
-            getNode().disarm();
+        if (! keyDown && getControl().isArmed()) {
+            getControl().disarm();
         }
     }
 
+    private void togglePopup(ComboBoxBase<T> c) {
+        // If popup is shown, KeyEvent causes popup to close
+        showPopupOnMouseRelease = true;
+
+        if (c.isShowing()) {
+            hide();
+        } else {
+            show();
+        }
+    }
 }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ComboBoxListViewBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/ComboBoxListViewBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,10 +28,7 @@ package com.sun.javafx.scene.control.behavior;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.ComboBoxBase;
 import javafx.scene.control.SelectionModel;
-import com.sun.javafx.scene.control.inputmap.InputMap;
-
-import static javafx.scene.input.KeyCode.DOWN;
-import static javafx.scene.input.KeyCode.UP;
+import javafx.scene.input.KeyCode;
 
 public class ComboBoxListViewBehavior<T> extends ComboBoxBaseBehavior<T> {
 
@@ -44,16 +41,19 @@ public class ComboBoxListViewBehavior<T> extends ComboBoxBaseBehavior<T> {
     /**
      *
      */
-    public ComboBoxListViewBehavior(final ComboBox<T> comboBox) {
-        super(comboBox);
+    public ComboBoxListViewBehavior(ComboBoxBase<T> c) {
+        super(c);
+    }
 
-        // Add these bindings as a child input map, so they take precedence
-        InputMap<ComboBoxBase<T>> comboBoxListViewInputMap = new InputMap<>(comboBox);
-        comboBoxListViewInputMap.getMappings().addAll(
-            new InputMap.KeyMapping(UP, e -> selectPrevious()),
-            new InputMap.KeyMapping(DOWN, e -> selectNext())
-        );
-        addDefaultChildMap(getInputMap(), comboBoxListViewInputMap);
+    @Override
+    protected void populateSkinInputMap() {
+        super.populateSkinInputMap();
+
+        registerFunction(ComboBox.SELECT_PREV, this::selectPrevious);
+        registerFunction(ComboBox.SELECT_NEXT, this::selectNext);
+
+        registerKey(KeyCode.UP, ComboBox.SELECT_PREV);
+        registerKey(KeyCode.DOWN, ComboBox.SELECT_NEXT);
     }
 
     /***************************************************************************
@@ -63,16 +63,18 @@ public class ComboBoxListViewBehavior<T> extends ComboBoxBaseBehavior<T> {
      **************************************************************************/
 
     private ComboBox<T> getComboBox() {
-        return (ComboBox<T>) getNode();
+        return (ComboBox<T>) getControl();
     }
 
-    private void selectPrevious() {
+    private void selectPrevious(ComboBoxBase<T> c) {
+        // NOTE: ComboBoxBase<T> does not have getSelectionModel().  design problem?
         SelectionModel<T> sm = getComboBox().getSelectionModel();
         if (sm == null) return;
         sm.selectPrevious();
     }
 
-    private void selectNext() {
+    private void selectNext(ComboBoxBase<T> c) {
+        // NOTE: ComboBoxBase<T> does not have getSelectionModel().  design problem?
         SelectionModel<T> sm = getComboBox().getSelectionModel();
         if (sm == null) return;
         sm.selectNext();

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/DatePickerBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/DatePickerBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,9 @@
 
 package com.sun.javafx.scene.control.behavior;
 
+import java.time.LocalDate;
 import javafx.scene.control.DatePicker;
 import javafx.scene.control.PopupControl;
-
-import java.time.LocalDate;
 
 
 public class DatePickerBehavior extends ComboBoxBaseBehavior<LocalDate> {
@@ -42,8 +41,8 @@ public class DatePickerBehavior extends ComboBoxBaseBehavior<LocalDate> {
     /**
      *
      */
-    public DatePickerBehavior(final DatePicker datePicker) {
-        super(datePicker);
+    public DatePickerBehavior(DatePicker c) {
+        super(c);
     }
 
     /***************************************************************************
@@ -56,14 +55,14 @@ public class DatePickerBehavior extends ComboBoxBaseBehavior<LocalDate> {
     @Override public void onAutoHide(PopupControl popup) {
         // when we click on some non-interactive part of the
         // calendar - we do not want to hide.
-        if (!popup.isShowing() && getNode().isShowing()) {
+        if (!popup.isShowing() && getControl().isShowing()) {
             // Popup was dismissed. Maybe user clicked outside or typed ESCAPE.
             // Make sure DatePicker button is in sync.
-            getNode().hide();
+            getControl().hide();
         }
         // if the DatePicker is no longer showing, then invoke the super method
         // to keep its show/hide state in sync.
-        if (!getNode().isShowing()) {
+        if (!getControl().isShowing()) {
             super.onAutoHide(popup);
         }
     }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/FocusTraversalInputMap.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/FocusTraversalInputMap.java
@@ -139,10 +139,26 @@ public class FocusTraversalInputMap {
 
     /**
      * Calls the focus traversal engine and indicates that traversal should
+     * go the next focusTraversable Node in the focus traversal cycle.
+     */
+    public static final void traverseNext(Node n) {
+        traverse(n, com.sun.javafx.scene.traversal.Direction.NEXT, TraversalMethod.KEY);
+    }
+
+    /**
+     * Calls the focus traversal engine and indicates that traversal should
      * go the previous focusTraversable Node in the focus traversal cycle.
      */
     public static final void traversePrevious(KeyEvent e) {
         traverse(getNode(e), com.sun.javafx.scene.traversal.Direction.PREVIOUS, TraversalMethod.KEY);
+    }
+
+    /**
+     * Calls the focus traversal engine and indicates that traversal should
+     * go the previous focusTraversable Node in the focus traversal cycle.
+     */
+    public static final void traversePrevious(Node n) {
+        traverse(n, com.sun.javafx.scene.traversal.Direction.PREVIOUS, TraversalMethod.KEY);
     }
 
     private static Node getNode(KeyEvent e) {

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/PasswordFieldBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/PasswordFieldBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@
 package com.sun.javafx.scene.control.behavior;
 
 import javafx.scene.control.PasswordField;
+import javafx.scene.control.TextField;
+import javafx.scene.control.skin.TextFieldSkin;
 import javafx.scene.text.HitInfo;
 
 /**
@@ -33,31 +35,43 @@ import javafx.scene.text.HitInfo;
  */
 public class PasswordFieldBehavior extends TextFieldBehavior {
 
-    public PasswordFieldBehavior(PasswordField passwordField) {
-        super(passwordField);
+    public PasswordFieldBehavior(PasswordField c, TextFieldSkin skin) {
+        super(c, skin);
     }
 
     // RT-18711 & RT-18854: Stub out word based navigation and editing
     // for security reasons.
     @Override
-    protected void deletePreviousWord() { }
-    @Override
-    protected void deleteNextWord() { }
-    @Override
-    protected void selectPreviousWord() { }
-    @Override
-    public void selectNextWord() { }
-    @Override
-    protected void previousWord() { }
-    @Override
-    protected void nextWord() { }
-    @Override
-    protected void selectWord() {
-        selectAll();
-    }
-    @Override
-    protected void mouseDoubleClick(HitInfo hit) {
-        getNode().selectAll();
+    protected void deletePreviousWord(TextField c) {
     }
 
+    @Override
+    protected void deleteNextWord(TextField c) {
+    }
+
+    @Override
+    protected void selectPreviousWord(TextField c) {
+    }
+
+    @Override
+    public void selectNextWord(TextField c) {
+    }
+
+    @Override
+    protected void previousWord(TextField c) {
+    }
+
+    @Override
+    protected void nextWord(TextField c) {
+    }
+
+    @Override
+    protected void selectWord(TextField c) {
+        selectAll(c);
+    }
+
+    @Override
+    protected void mouseDoubleClick(HitInfo hit) {
+        getControl().selectAll();
+    }
 }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TabPaneBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TabPaneBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,75 +25,77 @@
 
 package com.sun.javafx.scene.control.behavior;
 
-import com.sun.javafx.scene.control.inputmap.InputMap;
+import java.util.List;
 import javafx.event.Event;
+import javafx.geometry.NodeOrientation;
+import javafx.scene.Node;
 import javafx.scene.control.SelectionModel;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
-import javafx.scene.input.*;
-import com.sun.javafx.scene.control.inputmap.KeyBinding;
+import javafx.scene.control.input.KeyBinding;
+import javafx.scene.control.input.SkinInputMap;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.MouseEvent;
 
-import java.util.List;
+/**
+ * The TabPaneBehavior is stateless.
+ */
+// The amount of memory saved with stateless (static) behaviors would likely not justify
+// more extensive changes that are required to convert the legacy behavior to a stateless one:
+// now we have to manually drag the control instance everywhere.
+// I don't think this is worth it.
+public class TabPaneBehavior {
+    private static final SkinInputMap<TabPane> inputMap = createInputMap();
 
-import static javafx.scene.input.KeyCode.*;
-import static com.sun.javafx.scene.control.inputmap.InputMap.KeyMapping;
-import static com.sun.javafx.scene.control.inputmap.InputMap.MouseMapping;
+    // stateless behavior: one SkinInputMap for all TabPanes
+    private TabPaneBehavior() { }
 
-public class TabPaneBehavior extends BehaviorBase<TabPane> {
+    private static SkinInputMap<TabPane> createInputMap() {
+        SkinInputMap<TabPane> m = new SkinInputMap<>();
 
-    private final InputMap<TabPane> tabPaneInputMap;
+        m.registerFunction(TabPane.Tag.SELECT_FIRST_TAB, TabPaneBehavior::selectFirstTab);
+        m.registerFunction(TabPane.Tag.SELECT_LAST_TAB, TabPaneBehavior::selectLastTab);
+        m.registerFunction(TabPane.Tag.SELECT_LEFT_TAB, TabPaneBehavior::selectLeftTab);
+        m.registerFunction(TabPane.Tag.SELECT_NEXT_TAB, TabPaneBehavior::selectNextTab);
+        m.registerFunction(TabPane.Tag.SELECT_PREV_TAB, TabPaneBehavior::selectPreviousTab);
+        m.registerFunction(TabPane.Tag.SELECT_RIGHT_TAB, TabPaneBehavior::selectRightTab);
 
-    public TabPaneBehavior(TabPane tabPane) {
-        super(tabPane);
+        m.registerKey(KeyBinding.of(KeyCode.DOWN), TabPane.Tag.SELECT_NEXT_TAB);
+        m.registerKey(KeyBinding.of(KeyCode.HOME), TabPane.Tag.SELECT_FIRST_TAB);
+        m.registerKey(KeyBinding.of(KeyCode.END), TabPane.Tag.SELECT_LAST_TAB);
+        m.registerKey(KeyBinding.of(KeyCode.LEFT), TabPane.Tag.SELECT_LEFT_TAB);
+        m.registerKey(KeyBinding.of(KeyCode.RIGHT), TabPane.Tag.SELECT_RIGHT_TAB);
+        m.registerKey(KeyBinding.of(KeyCode.UP), TabPane.Tag.SELECT_PREV_TAB);
 
-        // create a map for TabPane-specific mappings (this reuses the default
-        // InputMap installed on the control, if it is non-null, allowing us to pick up any user-specified mappings)
-        tabPaneInputMap = createInputMap();
+        m.registerKey(KeyBinding.ctrl(KeyCode.PAGE_DOWN), TabPane.Tag.SELECT_NEXT_TAB);
+        m.registerKey(KeyBinding.ctrl(KeyCode.PAGE_UP), TabPane.Tag.SELECT_PREV_TAB);
+        m.registerKey(KeyBinding.ctrl(KeyCode.TAB), TabPane.Tag.SELECT_NEXT_TAB);
+        m.registerKey(KeyBinding.ctrlShift(KeyCode.TAB), TabPane.Tag.SELECT_PREV_TAB);
 
-        // TabPane-specific mappings for key and mouse input
-        addDefaultMapping(tabPaneInputMap,
-            new KeyMapping(UP, e -> selectPreviousTab()),
-            new KeyMapping(DOWN, e -> selectNextTab()),
-            new KeyMapping(LEFT, e -> rtl(tabPane, this::selectNextTab, this::selectPreviousTab)),
-            new KeyMapping(RIGHT, e -> rtl(tabPane, this::selectPreviousTab, this::selectNextTab)),
-            new KeyMapping(HOME, e -> {
-                if (getNode().isFocused()) {
-                    moveSelection(-1, 1);
-                }
-            }),
-            new KeyMapping(END, e -> {
-                if (getNode().isFocused()) {
-                    moveSelection(getNode().getTabs().size(), -1);
-                }
-            }),
-            new KeyMapping(new KeyBinding(PAGE_UP).ctrl(), e -> selectPreviousTab()),
-            new KeyMapping(new KeyBinding(PAGE_DOWN).ctrl(), e -> selectNextTab()),
-            new KeyMapping(new KeyBinding(TAB).ctrl(), e -> selectNextTab()),
-            new KeyMapping(new KeyBinding(TAB).ctrl().shift(), e -> selectPreviousTab()),
-            new MouseMapping(MouseEvent.MOUSE_PRESSED, e -> getNode().requestFocus())
-        );
+        m.addHandler(MouseEvent.MOUSE_PRESSED, true, TabPaneBehavior::requestFocus);
+
+        return m;
     }
 
-    @Override public InputMap<TabPane> getInputMap() {
-        return tabPaneInputMap;
+    public static void install(TabPane control) {
+        control.getInputMap().setSkinInputMap(inputMap);
     }
 
-    public void selectTab(Tab tab) {
-        getNode().getSelectionModel().select(tab);
+    public static void selectTab(TabPane c, Tab tab) {
+        c.getSelectionModel().select(tab);
     }
 
-    public boolean canCloseTab(Tab tab) {
-        Event event = new Event(tab,tab,Tab.TAB_CLOSE_REQUEST_EVENT);
-        Event.fireEvent(tab, event);
-        return ! event.isConsumed();
+    public static boolean canCloseTab(Tab tab) {
+        Event ev = new Event(tab, tab, Tab.TAB_CLOSE_REQUEST_EVENT);
+        Event.fireEvent(tab, ev);
+        return !ev.isConsumed();
     }
 
-    public void closeTab(Tab tab) {
-        TabPane tabPane = getNode();
+    public static void closeTab(TabPane c, Tab tab) {
         // only switch to another tab if the selected tab is the one we're closing
-        int index = tabPane.getTabs().indexOf(tab);
+        int index = c.getTabs().indexOf(tab);
         if (index != -1) {
-            tabPane.getTabs().remove(index);
+            c.getTabs().remove(index);
         }
         if (tab.getOnClosed() != null) {
             Event.fireEvent(tab, new Event(Tab.CLOSED_EVENT));
@@ -102,34 +104,72 @@ public class TabPaneBehavior extends BehaviorBase<TabPane> {
 
     // Find a tab after the currently selected that is not disabled. Loop around
     // if no tabs are found after currently selected tab.
-    public void selectNextTab() {
-        moveSelection(1);
+    public static void selectNextTab(TabPane c) {
+        moveSelection(c, 1);
     }
 
     // Find a tab before the currently selected that is not disabled.
-    public void selectPreviousTab() {
-        moveSelection(-1);
+    public static void selectPreviousTab(TabPane c) {
+        moveSelection(c, -1);
     }
 
-    private void moveSelection(int delta) {
-        moveSelection(getNode().getSelectionModel().getSelectedIndex(), delta);
+    private static void selectLeftTab(TabPane c) {
+        if (isRTL(c)) {
+            selectNextTab(c);
+        } else {
+            selectPreviousTab(c);
+        }
     }
 
-    private void moveSelection(int startIndex, int delta) {
-        final TabPane tabPane = getNode();
-        if (tabPane.getTabs().isEmpty()) return;
+    private static void selectRightTab(TabPane c) {
+        if (isRTL(c)) {
+            selectPreviousTab(c);
+        } else {
+            selectNextTab(c);
+        }
+    }
 
-        int tabIndex = findValidTab(startIndex, delta);
+    private static boolean isRTL(TabPane c) {
+        return c.getEffectiveNodeOrientation() == NodeOrientation.RIGHT_TO_LEFT;
+    }
+
+    // TODO a bit of controversy: should this method return boolean to avoid consuming the key event
+    // when the control is not focused?
+    private static void selectFirstTab(TabPane c) {
+        if (c.isFocused()) {
+            moveSelection(c, -1, 1);
+        }
+    }
+
+    // TODO a bit of controversy: should this method return boolean to avoid consuming the key event
+    // when the control is not focused?
+    private static void selectLastTab(TabPane c) {
+        if (c.isFocused()) {
+            int sz = c.getTabs().size();
+            moveSelection(c, sz, -1);
+        }
+    }
+
+    private static void moveSelection(TabPane c, int delta) {
+        int ix = c.getSelectionModel().getSelectedIndex();
+        moveSelection(c, ix, delta);
+    }
+
+    private static void moveSelection(TabPane c, int startIndex, int delta) {
+        if (c.getTabs().isEmpty()) {
+            return;
+        }
+
+        int tabIndex = findValidTab(c, startIndex, delta);
         if (tabIndex > -1) {
-            final SelectionModel<Tab> selectionModel = tabPane.getSelectionModel();
+            final SelectionModel<Tab> selectionModel = c.getSelectionModel();
             selectionModel.select(tabIndex);
         }
-        tabPane.requestFocus();
+        c.requestFocus();
     }
 
-    private int findValidTab(int startIndex, int delta) {
-        final TabPane tabPane = getNode();
-        final List<Tab> tabs = tabPane.getTabs();
+    private static int findValidTab(TabPane c, int startIndex, int delta) {
+        final List<Tab> tabs = c.getTabs();
         final int max = tabs.size();
 
         int index = startIndex;
@@ -144,7 +184,7 @@ public class TabPaneBehavior extends BehaviorBase<TabPane> {
         return -1;
     }
 
-    private int nextIndex(int value, int max) {
+    private static int nextIndex(int value, int max) {
         final int min = 0;
         int r = value % max;
         if (r > min && max < min) {
@@ -153,5 +193,9 @@ public class TabPaneBehavior extends BehaviorBase<TabPane> {
             r = r + max - min;
         }
         return r;
+    }
+
+    private static void requestFocus(MouseEvent ev) {
+        ((Node)ev.getSource()).requestFocus();
     }
 }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextAreaBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextAreaBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,130 +25,132 @@
 
 package com.sun.javafx.scene.control.behavior;
 
-import com.sun.javafx.PlatformUtil;
-import com.sun.javafx.scene.control.Properties;
-import javafx.scene.control.skin.TextAreaSkin;
 import javafx.beans.value.ChangeListener;
 import javafx.geometry.Point2D;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Scene;
 import javafx.scene.control.TextArea;
-import com.sun.javafx.scene.control.skin.Utils;
+import javafx.scene.control.input.KeyBinding;
+import javafx.scene.control.skin.TextAreaSkin;
+import javafx.scene.control.skin.TextInputControlSkin.Direction;
+import javafx.scene.control.skin.TextInputControlSkin.TextUnit;
 import javafx.scene.input.ContextMenuEvent;
-import com.sun.javafx.scene.control.inputmap.InputMap;
-import com.sun.javafx.scene.control.inputmap.KeyBinding;
-import javafx.scene.input.KeyEvent;
+import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.text.HitInfo;
 import javafx.stage.Screen;
 import javafx.stage.Window;
-
-import java.util.function.Predicate;
-
-import static com.sun.javafx.PlatformUtil.isMac;
-import static com.sun.javafx.PlatformUtil.isWindows;
-import static javafx.scene.control.skin.TextInputControlSkin.TextUnit;
-import static javafx.scene.control.skin.TextInputControlSkin.Direction;
-import static javafx.scene.input.KeyCode.*;
+import com.sun.javafx.PlatformUtil;
+import com.sun.javafx.scene.control.Properties;
+import com.sun.javafx.scene.control.skin.Utils;
 
 
 /**
  * Text area behavior.
  */
 public class TextAreaBehavior extends TextInputControlBehavior<TextArea> {
-    private TextAreaSkin skin;
+    private final TextAreaSkin skin;
     private TwoLevelFocusBehavior tlFocus;
-
     private ChangeListener<Boolean> focusListener;
 
     /**************************************************************************
      * Constructors                                                           *
      *************************************************************************/
 
-    public TextAreaBehavior(final TextArea c) {
+    public TextAreaBehavior(TextArea c, TextAreaSkin skin) {
         super(c);
-
+        this.skin = skin;
         if (Properties.IS_TOUCH_SUPPORTED) {
             contextMenu.getStyleClass().add("text-input-context-menu");
         }
+    }
 
-        // some of the mappings are only valid when the control is editable, or
-        // only on certain platforms, so we create the following predicates that filters out the mapping when the
-        // control is not in the correct state / on the correct platform
-        final Predicate<KeyEvent> validWhenEditable = e -> !c.isEditable();
-
-        // Add these bindings as a child input map, so they take precedence
-        InputMap<TextArea> textAreaInputMap = new InputMap<>(c);
-        textAreaInputMap.getMappings().addAll(
-            keyMapping(HOME,      e -> lineStart(false)),
-            keyMapping(END,       e -> lineEnd(false)),
-            keyMapping(UP,        e -> skin.moveCaret(TextUnit.LINE, Direction.UP,   false)),
-            keyMapping(DOWN,      e -> skin.moveCaret(TextUnit.LINE, Direction.DOWN, false)),
-            keyMapping(PAGE_UP,   e -> skin.moveCaret(TextUnit.PAGE, Direction.UP,   false)),
-            keyMapping(PAGE_DOWN, e -> skin.moveCaret(TextUnit.PAGE, Direction.DOWN, false)),
-
-            keyMapping(new KeyBinding(HOME).shift(),      e -> lineStart(true)),
-            keyMapping(new KeyBinding(END).shift(),       e -> lineEnd(true)),
-            keyMapping(new KeyBinding(UP).shift(),        e -> skin.moveCaret(TextUnit.LINE, Direction.UP,   true)),
-            keyMapping(new KeyBinding(DOWN).shift(),      e -> skin.moveCaret(TextUnit.LINE, Direction.DOWN, true)),
-            keyMapping(new KeyBinding(PAGE_UP).shift(),   e -> skin.moveCaret(TextUnit.PAGE, Direction.UP,   true)),
-            keyMapping(new KeyBinding(PAGE_DOWN).shift(), e -> skin.moveCaret(TextUnit.PAGE, Direction.DOWN, true)),
-
-            // editing-only mappings
-            keyMapping(new KeyBinding(ENTER), e -> insertNewLine(), validWhenEditable),
-            keyMapping(new KeyBinding(TAB), e -> insertTab(), validWhenEditable)
-        );
-        addDefaultChildMap(getInputMap(), textAreaInputMap);
-
-        // mac os specific mappings
-        InputMap<TextArea> macOsInputMap = new InputMap<>(c);
-        macOsInputMap.setInterceptor(e -> !PlatformUtil.isMac());
-        macOsInputMap.getMappings().addAll(
-            // Mac OS specific mappings
-            keyMapping(new KeyBinding(LEFT).shortcut(),  e -> lineStart(false)),
-            keyMapping(new KeyBinding(RIGHT).shortcut(), e -> lineEnd(false)),
-            keyMapping(new KeyBinding(UP).shortcut(),    e -> c.home()),
-            keyMapping(new KeyBinding(DOWN).shortcut(),  e -> c.end()),
-
-            keyMapping(new KeyBinding(LEFT).shortcut().shift(),  e -> lineStart(true)),
-            keyMapping(new KeyBinding(RIGHT).shortcut().shift(), e -> lineEnd(true)),
-            keyMapping(new KeyBinding(UP).shortcut().shift(),    e -> selectHomeExtend()),
-            keyMapping(new KeyBinding(DOWN).shortcut().shift(),  e -> selectEndExtend()),
-
-            keyMapping(new KeyBinding(UP).alt(),           e -> skin.moveCaret(TextUnit.PARAGRAPH, Direction.UP,   false)),
-            keyMapping(new KeyBinding(DOWN).alt(),         e -> skin.moveCaret(TextUnit.PARAGRAPH, Direction.DOWN, false)),
-            keyMapping(new KeyBinding(UP).alt().shift(),   e -> skin.moveCaret(TextUnit.PARAGRAPH, Direction.UP,   true)),
-            keyMapping(new KeyBinding(DOWN).alt().shift(), e -> skin.moveCaret(TextUnit.PARAGRAPH, Direction.DOWN, true))
-        );
-        addDefaultChildMap(textAreaInputMap, macOsInputMap);
-
-        // windows / linux specific mappings
-        InputMap<TextArea> nonMacOsInputMap = new InputMap<>(c);
-        nonMacOsInputMap.setInterceptor(e -> PlatformUtil.isMac());
-        nonMacOsInputMap.getMappings().addAll(
-            keyMapping(new KeyBinding(UP).ctrl(),           e -> skin.moveCaret(TextUnit.PARAGRAPH, Direction.UP,   false)),
-            keyMapping(new KeyBinding(DOWN).ctrl(),         e -> skin.moveCaret(TextUnit.PARAGRAPH, Direction.DOWN, false)),
-            keyMapping(new KeyBinding(UP).ctrl().shift(),   e -> skin.moveCaret(TextUnit.PARAGRAPH, Direction.UP,   true)),
-            keyMapping(new KeyBinding(DOWN).ctrl().shift(), e -> skin.moveCaret(TextUnit.PARAGRAPH, Direction.DOWN, true))
-        );
-        addDefaultChildMap(textAreaInputMap, nonMacOsInputMap);
-
-        addKeyPadMappings(textAreaInputMap);
+    @Override
+    protected void populateSkinInputMap() {
+        super.populateSkinInputMap();
 
         focusListener = (src, ov, nv) -> handleFocusChange();
         // Register for change events
-        c.focusedProperty().addListener(focusListener);
+        getControl().focusedProperty().addListener(focusListener);
 
         // Only add this if we're on an embedded platform that supports 5-button navigation
         if (Utils.isTwoLevelFocus()) {
-            tlFocus = new TwoLevelFocusBehavior(c); // needs to be last.
+            tlFocus = new TwoLevelFocusBehavior(getControl()); // needs to be last.
         }
+
+        // functions
+        registerFunction(TextArea.DOCUMENT_END, this::end);
+        registerFunction(TextArea.DOCUMENT_START, this::home);
+        registerFunction(TextArea.DOWN, (c) -> skin.moveCaret(TextUnit.LINE, Direction.DOWN, false));
+        registerFunction(TextArea.LINE_START, (c) -> lineStart(false));
+        registerFunction(TextArea.LINE_END, (c) -> lineEnd(false));
+        registerFunction(TextArea.PARAGRAPH_DOWN, (c) -> skin.moveCaret(TextUnit.PARAGRAPH, Direction.DOWN, false));
+        registerFunction(TextArea.PARAGRAPH_UP, (c) -> skin.moveCaret(TextUnit.PARAGRAPH, Direction.UP, false));
+        registerFunction(TextArea.PAGE_DOWN, (c) -> skin.moveCaret(TextUnit.PAGE, Direction.DOWN, false));
+        registerFunction(TextArea.PAGE_UP, (c) -> skin.moveCaret(TextUnit.PAGE, Direction.UP, false));
+        registerFunction(TextArea.SELECT_DOWN, (c) -> skin.moveCaret(TextUnit.LINE, Direction.DOWN, true));
+        //func(TextArea.SELECT_END_EXTEND, this::selectEndExtend);
+        //func(TextArea.SELECT_HOME_EXTEND, this::selectHomeExtend);
+        registerFunction(TextArea.SELECT_LINE_END, (c) -> lineEnd(true));
+        registerFunction(TextArea.SELECT_PAGE_DOWN, (c) -> skin.moveCaret(TextUnit.PAGE, Direction.DOWN, true));
+        registerFunction(TextArea.SELECT_PAGE_UP, (c) -> skin.moveCaret(TextUnit.PAGE, Direction.UP, true));
+        registerFunction(TextArea.SELECT_PARAGRAPH_DOWN, (c) -> skin.moveCaret(TextUnit.PARAGRAPH, Direction.DOWN, true));
+        registerFunction(TextArea.SELECT_PARAGRAPH_UP, (c) -> skin.moveCaret(TextUnit.PARAGRAPH, Direction.UP, true));
+        registerFunction(TextArea.SELECT_LINE_START, (c) -> lineStart(true));
+        registerFunction(TextArea.SELECT_UP, (c) -> skin.moveCaret(TextUnit.LINE, Direction.UP, true));
+        registerFunction(TextArea.UP, (c) -> skin.moveCaret(TextUnit.LINE, Direction.UP, false));
+        registerFunction(TextArea.INSERT_NEW_LINE, this::insertNewLine);
+        registerFunction(TextArea.INSERT_TAB, this::insertTab);
+        // TODO create functions instead of the inline lambdas above
+
+        // common keys
+        registerKey(KeyCode.DOWN, TextArea.DOWN);
+        registerKey(KeyBinding.shift(KeyCode.DOWN), TextArea.SELECT_DOWN);
+        registerKey(KeyBinding.shift(KeyCode.END), TextArea.SELECT_LINE_END);
+        registerKey(KeyCode.END, TextArea.LINE_END);
+        registerKey(KeyCode.ENTER, TextArea.INSERT_NEW_LINE);
+        registerKey(KeyCode.HOME, TextArea.LINE_START);
+        registerKey(KeyBinding.shift(KeyCode.HOME), TextArea.SELECT_LINE_START);
+        registerKey(KeyCode.PAGE_UP, TextArea.PAGE_UP);
+        registerKey(KeyBinding.shift(KeyCode.PAGE_UP), TextArea.SELECT_PAGE_UP);
+        registerKey(KeyCode.PAGE_DOWN, TextArea.PAGE_DOWN);
+        registerKey(KeyBinding.shift(KeyCode.PAGE_DOWN), TextArea.SELECT_PAGE_DOWN);
+        registerKey(KeyCode.TAB, TextArea.INSERT_TAB);
+        registerKey(KeyCode.UP, TextArea.UP);
+        registerKey(KeyBinding.shift(KeyCode.UP), TextArea.SELECT_UP);
+
+        if (isMac()) {
+            // macOS specific mappings
+            registerKey(KeyBinding.alt(KeyCode.DOWN), TextArea.PARAGRAPH_DOWN);
+            registerKey(KeyBinding.with(KeyCode.DOWN).alt().shift().build(), TextArea.SELECT_PARAGRAPH_DOWN);
+            registerKey(KeyBinding.shortcut(KeyCode.DOWN), TextArea.DOCUMENT_END);
+            registerKey(KeyBinding.with(KeyCode.DOWN).shortcut().shift().build(), TextArea.SELECT_END_EXTEND);
+            registerKey(KeyBinding.shortcut(KeyCode.LEFT), TextArea.LINE_START);
+            registerKey(KeyBinding.with(KeyCode.LEFT).shortcut().shift().build(), TextArea.SELECT_LINE_START);
+            registerKey(KeyBinding.shortcut(KeyCode.RIGHT), TextArea.LINE_END);
+            registerKey(KeyBinding.with(KeyCode.RIGHT).shortcut().shift().build(), TextArea.SELECT_LINE_END);
+            registerKey(KeyBinding.alt(KeyCode.UP), TextArea.PARAGRAPH_UP);
+            registerKey(KeyBinding.with(KeyCode.UP).alt().shift().build(), TextArea.SELECT_PARAGRAPH_UP);
+            registerKey(KeyBinding.shortcut(KeyCode.UP), TextArea.DOCUMENT_START);
+            registerKey(KeyBinding.with(KeyCode.UP).shortcut().shift().build(), TextArea.SELECT_HOME_EXTEND);
+        } else {
+            // non-macOS specific mappings
+            registerKey(KeyBinding.ctrl(KeyCode.DOWN), TextArea.PARAGRAPH_DOWN);
+            registerKey(KeyBinding.ctrlShift(KeyCode.DOWN), TextArea.SELECT_PARAGRAPH_DOWN);
+            registerKey(KeyBinding.ctrl(KeyCode.UP), TextArea.PARAGRAPH_UP);
+            registerKey(KeyBinding.ctrlShift(KeyCode.UP), TextArea.SELECT_PARAGRAPH_UP);
+        }
+
+        addKeyPadMappings();
     }
 
-    @Override public void dispose() {
-        getNode().focusedProperty().removeListener(focusListener);
-        if (tlFocus != null) tlFocus.dispose();
+    @Override
+    public void dispose() {
+        getControl().focusedProperty().removeListener(focusListener);
+        if (tlFocus != null) {
+            tlFocus.dispose();
+        }
         super.dispose();
     }
 
@@ -166,7 +168,7 @@ public class TextAreaBehavior extends TextInputControlBehavior<TextArea> {
         // The only real difference is that TextFieldBehavior selects all the text when the control
         // receives focus (when not gained by mouse click), whereas TextArea doesn't, and also the
         // TextArea doesn't lose selection on focus lost, whereas the TextField does.
-        final TextArea textArea = getNode();
+        final TextArea textArea = getControl();
         if (textArea.isFocused()) {
             if (!focusGainedByMouseClick) {
                 setCaretAnimating(true);
@@ -178,38 +180,35 @@ public class TextAreaBehavior extends TextInputControlBehavior<TextArea> {
         }
     }
 
-    // An unholy back-reference!
-    public void setTextAreaSkin(TextAreaSkin skin) {
-        this.skin = skin;
-    }
-
-    private void insertNewLine() {
-        setEditing(true);
-        getNode().replaceSelection("\n");
-        setEditing(false);
-    }
-
-    private void insertTab() {
-        setEditing(true);
-        getNode().replaceSelection("\t");
-        setEditing(false);
-    }
-
-    @Override protected void deleteChar(boolean previous) {
-        if (previous) {
-            getNode().deletePreviousChar();
-        } else {
-            getNode().deleteNextChar();
+    private void insertNewLine(TextArea c) {
+        if (isEditable()) {
+            setEditing(true);
+            c.replaceSelection("\n");
+            setEditing(false);
         }
     }
 
-    @Override protected void deleteFromLineStart() {
-        TextArea textArea = getNode();
-        int end = textArea.getCaretPosition();
+    private void insertTab(TextArea c) {
+        if (isEditable()) {
+            setEditing(true);
+            c.replaceSelection("\t");
+            setEditing(false);
+        }
+    }
 
+    @Override protected void deleteChar(TextArea c, boolean previous) {
+        if (previous) {
+            c.deletePreviousChar();
+        } else {
+            c.deleteNextChar();
+        }
+    }
+
+    @Override protected void deleteFromLineStart(TextArea c) {
+        int end = c.getCaretPosition();
         if (end > 0) {
             lineStart(false);
-            int start = textArea.getCaretPosition();
+            int start = c.getCaretPosition();
             if (end > start) {
                 replaceText(start, end, "");
             }
@@ -225,7 +224,7 @@ public class TextAreaBehavior extends TextInputControlBehavior<TextArea> {
     }
 
     @Override protected void replaceText(int start, int end, String txt) {
-        getNode().replaceText(start, end, txt);
+        getControl().replaceText(start, end, txt);
     }
 
     /**
@@ -237,7 +236,7 @@ public class TextAreaBehavior extends TextInputControlBehavior<TextArea> {
     private boolean deferClick = false;
 
     @Override public void mousePressed(MouseEvent e) {
-        TextArea textArea = getNode();
+        TextArea textArea = getControl();
         // We never respond to events if disabled
         if (!textArea.isDisabled()) {
             // If the text field doesn't have focus, then we'll attempt to set
@@ -290,7 +289,7 @@ public class TextAreaBehavior extends TextInputControlBehavior<TextArea> {
                     // selection, and set the mark to be the other side and
                     // the dot to be the new position.
                     // everywhere else we just move the dot.
-                    if (isMac()) {
+                    if (PlatformUtil.isMac()) {
                         textArea.extendSelection(i);
                     } else {
                         skin.positionCaret(hit, true);
@@ -307,7 +306,7 @@ public class TextAreaBehavior extends TextInputControlBehavior<TextArea> {
     }
 
     @Override public void mouseDragged(MouseEvent e) {
-        final TextArea textArea = getNode();
+        final TextArea textArea = getControl();
         // we never respond to events if disabled, but we do notify any onXXX
         // event listeners on the control
         if (!textArea.isDisabled() && !e.isSynthesized()) {
@@ -321,7 +320,7 @@ public class TextAreaBehavior extends TextInputControlBehavior<TextArea> {
     }
 
     @Override public void mouseReleased(final MouseEvent e) {
-        final TextArea textArea = getNode();
+        final TextArea textArea = getControl();
         // we never respond to events if disabled, but we do notify any onXXX
         // event listeners on the control
         if (!textArea.isDisabled()) {
@@ -336,7 +335,7 @@ public class TextAreaBehavior extends TextInputControlBehavior<TextArea> {
     }
 
     @Override public void contextMenuRequested(ContextMenuEvent e) {
-        final TextArea textArea = getNode();
+        final TextArea textArea = getControl();
 
         if (contextMenu.isShowing()) {
             contextMenu.hide();
@@ -360,8 +359,8 @@ public class TextAreaBehavior extends TextInputControlBehavior<TextArea> {
                 }
 
                 if (menuPos != null) {
-                    Point2D p = getNode().localToScene(menuPos);
-                    Scene scene = getNode().getScene();
+                    Point2D p = getControl().localToScene(menuPos);
+                    Scene scene = getControl().getScene();
                     Window window = scene.getWindow();
                     Point2D location = new Point2D(window.getX() + scene.getX() + p.getX(),
                                                    window.getY() + scene.getY() + p.getY());
@@ -378,18 +377,18 @@ public class TextAreaBehavior extends TextInputControlBehavior<TextArea> {
             Rectangle2D bounds = currentScreen.getBounds();
 
             if (menuX < bounds.getMinX()) {
-                getNode().getProperties().put("CONTEXT_MENU_SCREEN_X", screenX);
-                getNode().getProperties().put("CONTEXT_MENU_SCENE_X", sceneX);
-                contextMenu.show(getNode(), bounds.getMinX(), screenY);
+                getControl().getProperties().put("CONTEXT_MENU_SCREEN_X", screenX);
+                getControl().getProperties().put("CONTEXT_MENU_SCENE_X", sceneX);
+                contextMenu.show(getControl(), bounds.getMinX(), screenY);
             } else if (screenX + menuWidth > bounds.getMaxX()) {
                 double leftOver = menuWidth - ( bounds.getMaxX() - screenX);
-                getNode().getProperties().put("CONTEXT_MENU_SCREEN_X", screenX);
-                getNode().getProperties().put("CONTEXT_MENU_SCENE_X", sceneX);
-                contextMenu.show(getNode(), screenX - leftOver, screenY);
+                getControl().getProperties().put("CONTEXT_MENU_SCREEN_X", screenX);
+                getControl().getProperties().put("CONTEXT_MENU_SCENE_X", sceneX);
+                contextMenu.show(getControl(), screenX - leftOver, screenY);
             } else {
-                getNode().getProperties().put("CONTEXT_MENU_SCREEN_X", 0);
-                getNode().getProperties().put("CONTEXT_MENU_SCENE_X", 0);
-                contextMenu.show(getNode(), menuX, screenY);
+                getControl().getProperties().put("CONTEXT_MENU_SCREEN_X", 0);
+                getControl().getProperties().put("CONTEXT_MENU_SCENE_X", 0);
+                contextMenu.show(getControl(), menuX, screenY);
             }
         }
 
@@ -401,9 +400,9 @@ public class TextAreaBehavior extends TextInputControlBehavior<TextArea> {
     }
 
     protected void mouseDoubleClick(HitInfo hit) {
-        final TextArea textArea = getNode();
+        final TextArea textArea = getControl();
         textArea.previousWord();
-        if (isWindows()) {
+        if (PlatformUtil.isWindows()) {
             textArea.selectNextWord();
         } else {
             textArea.selectEndOfNextWord();

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextFieldBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextFieldBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,13 +26,6 @@
 package com.sun.javafx.scene.control.behavior;
 
 
-import com.sun.javafx.geom.transform.Affine3D;
-import com.sun.javafx.scene.NodeHelper;
-import com.sun.javafx.scene.control.Properties;
-import com.sun.javafx.scene.control.skin.Utils;
-
-import static com.sun.javafx.PlatformUtil.*;
-
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.WeakChangeListener;
 import javafx.event.ActionEvent;
@@ -42,19 +35,26 @@ import javafx.geometry.Rectangle2D;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.TextField;
+import javafx.scene.control.input.KeyBinding;
 import javafx.scene.control.skin.TextFieldSkin;
 import javafx.scene.input.ContextMenuEvent;
+import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.text.HitInfo;
 import javafx.stage.Screen;
 import javafx.stage.Window;
+import com.sun.javafx.PlatformUtil;
+import com.sun.javafx.geom.transform.Affine3D;
+import com.sun.javafx.scene.NodeHelper;
+import com.sun.javafx.scene.control.Properties;
+import com.sun.javafx.scene.control.skin.Utils;
 
 /**
  * Text field behavior.
  */
 public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
-    private TextFieldSkin skin;
+    private final TextFieldSkin skin;
     private TwoLevelFocusBehavior tlFocus;
 
     // listeners to focus-related state
@@ -65,12 +65,19 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
     private WeakChangeListener<Node> weakFocusOwnerListener;
 
 
-    public TextFieldBehavior(final TextField textField) {
-        super(textField);
-
+    public TextFieldBehavior(TextField c, TextFieldSkin skin) {
+        super(c);
+        this.skin = skin;
         if (Properties.IS_TOUCH_SUPPORTED) {
             contextMenu.getStyleClass().add("text-input-context-menu");
         }
+    }
+
+    @Override
+    protected void populateSkinInputMap() {
+        super.populateSkinInputMap();
+
+        TextField textField = getControl();
 
         focusListener = (observable, oldValue, newValue) -> {
             handleFocusChange();
@@ -111,20 +118,24 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
         if (Utils.isTwoLevelFocus()) {
             tlFocus = new TwoLevelFocusBehavior(textField); // needs to be last.
         }
+
+        addHandler(KeyBinding.of(KeyCode.ENTER), false, this::fire);
+        addHandler(KeyBinding.of(KeyCode.ESCAPE), false, this::cancelEdit);
     }
 
-    @Override public void dispose() {
-        getNode().focusedProperty().removeListener(focusListener);
-        getNode().sceneProperty().removeListener(weakSceneListener);
-        if (getNode().getScene() != null) {
-            getNode().getScene().focusOwnerProperty().removeListener(weakFocusOwnerListener);
+    @Override
+    public void dispose() {
+        getControl().focusedProperty().removeListener(focusListener);
+        getControl().sceneProperty().removeListener(weakSceneListener);
+        if (getControl().getScene() != null) {
+            getControl().getScene().focusOwnerProperty().removeListener(weakFocusOwnerListener);
         }
         if (tlFocus != null) tlFocus.dispose();
         super.dispose();
     }
 
     private void handleFocusChange() {
-        TextField textField = getNode();
+        TextField textField = getControl();
 
         if (textField.isFocused()) {
             if (!focusGainedByMouseClick) {
@@ -146,13 +157,8 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
         return transform;
     }
 
-    // An unholy back-reference!
-    public void setTextFieldSkin(TextFieldSkin skin) {
-        this.skin = skin;
-    }
-
-    @Override protected void fire(KeyEvent event) {
-        TextField textField = getNode();
+    protected void fire(KeyEvent event) {
+        TextField textField = getControl();
         EventHandler<ActionEvent> onAction = textField.getOnAction();
         // use textField as target to prevent immediate copy in dispatch
         ActionEvent actionEvent = new ActionEvent(textField, textField);
@@ -166,18 +172,16 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
         }
     }
 
-    @Override
     protected void cancelEdit(KeyEvent event) {
-        TextField textField = getNode();
+        TextField textField = getControl();
         if (textField.getTextFormatter() != null) {
             textField.cancelEdit();
             event.consume();
-        } else {
-            super.cancelEdit(event);
         }
     }
 
-    @Override protected void deleteChar(boolean previous) {
+    @Override
+    protected void deleteChar(TextField c, boolean previous) {
         skin.deleteChar(previous);
     }
 
@@ -186,10 +190,9 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
         skin.replaceText(start, end, txt);
     }
 
-    @Override protected void deleteFromLineStart() {
-        TextField textField = getNode();
-        int end = textField.getCaretPosition();
-
+    @Override
+    protected void deleteFromLineStart(TextField c) {
+        int end = c.getCaretPosition();
         if (end > 0) {
             replaceText(0, end, "");
         }
@@ -219,7 +222,7 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
     private boolean deferClick = false;
 
     @Override public void mousePressed(MouseEvent e) {
-        TextField textField = getNode();
+        TextField textField = getControl();
         // We never respond to events if disabled
         if (!textField.isDisabled()) {
             // If the text field doesn't have focus, then we'll attempt to set
@@ -272,7 +275,7 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
                     // selection, and set the mark to be the other side and
                     // the dot to be the new position.
                     // everywhere else we just move the dot.
-                    if (isMac()) {
+                    if (PlatformUtil.isMac()) {
                         textField.extendSelection(i);
                     } else {
                         skin.positionCaret(hit, true);
@@ -289,7 +292,7 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
     }
 
     @Override public void mouseDragged(MouseEvent e) {
-        final TextField textField = getNode();
+        final TextField textField = getControl();
         // we never respond to events if disabled, but we do notify any onXXX
         // event listeners on the control
         if (!textField.isDisabled() && !deferClick) {
@@ -302,7 +305,7 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
     }
 
     @Override public void mouseReleased(MouseEvent e) {
-        final TextField textField = getNode();
+        final TextField textField = getControl();
         // we never respond to events if disabled, but we do notify any onXXX
         // event listeners on the control
         if (!textField.isDisabled()) {
@@ -317,7 +320,7 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
     }
 
     @Override public void contextMenuRequested(ContextMenuEvent e) {
-        final TextField textField = getNode();
+        final TextField textField = getControl();
 
         if (contextMenu.isShowing()) {
             contextMenu.hide();
@@ -341,8 +344,8 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
                 }
 
                 if (menuPos != null) {
-                    Point2D p = getNode().localToScene(menuPos);
-                    Scene scene = getNode().getScene();
+                    Point2D p = getControl().localToScene(menuPos);
+                    Scene scene = getControl().getScene();
                     Window window = scene.getWindow();
                     Point2D location = new Point2D(window.getX() + scene.getX() + p.getX(),
                                                    window.getY() + scene.getY() + p.getY());
@@ -359,18 +362,18 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
             Rectangle2D bounds = currentScreen.getBounds();
 
             if (menuX < bounds.getMinX()) {
-                getNode().getProperties().put("CONTEXT_MENU_SCREEN_X", screenX);
-                getNode().getProperties().put("CONTEXT_MENU_SCENE_X", sceneX);
-                contextMenu.show(getNode(), bounds.getMinX(), screenY);
+                getControl().getProperties().put("CONTEXT_MENU_SCREEN_X", screenX);
+                getControl().getProperties().put("CONTEXT_MENU_SCENE_X", sceneX);
+                contextMenu.show(getControl(), bounds.getMinX(), screenY);
             } else if (screenX + menuWidth > bounds.getMaxX()) {
                 double leftOver = menuWidth - ( bounds.getMaxX() - screenX);
-                getNode().getProperties().put("CONTEXT_MENU_SCREEN_X", screenX);
-                getNode().getProperties().put("CONTEXT_MENU_SCENE_X", sceneX);
-                contextMenu.show(getNode(), screenX - leftOver, screenY);
+                getControl().getProperties().put("CONTEXT_MENU_SCREEN_X", screenX);
+                getControl().getProperties().put("CONTEXT_MENU_SCENE_X", sceneX);
+                contextMenu.show(getControl(), screenX - leftOver, screenY);
             } else {
-                getNode().getProperties().put("CONTEXT_MENU_SCREEN_X", 0);
-                getNode().getProperties().put("CONTEXT_MENU_SCENE_X", 0);
-                contextMenu.show(getNode(), menuX, screenY);
+                getControl().getProperties().put("CONTEXT_MENU_SCREEN_X", 0);
+                getControl().getProperties().put("CONTEXT_MENU_SCENE_X", 0);
+                contextMenu.show(getControl(), menuX, screenY);
             }
         }
 
@@ -382,9 +385,9 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
     }
 
     protected void mouseDoubleClick(HitInfo hit) {
-        final TextField textField = getNode();
+        final TextField textField = getControl();
         textField.previousWord();
-        if (isWindows()) {
+        if (PlatformUtil.isWindows()) {
             textField.selectNextWord();
         } else {
             textField.selectEndOfNextWord();
@@ -392,7 +395,7 @@ public class TextFieldBehavior extends TextInputControlBehavior<TextField> {
     }
 
     protected void mouseTripleClick(HitInfo hit) {
-        getNode().selectAll();
+        getControl().selectAll();
     }
 
     // Enumeration of all types of text input that can be simulated on

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextInputControlBehavior.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/behavior/TextInputControlBehavior.java
@@ -24,18 +24,14 @@
  */
 package com.sun.javafx.scene.control.behavior;
 
-import com.sun.javafx.PlatformUtil;
-import com.sun.javafx.application.PlatformImpl;
-import com.sun.javafx.scene.control.Properties;
-import com.sun.javafx.scene.control.skin.FXVK;
-
-import javafx.event.ActionEvent;
-import javafx.event.Event;
-import javafx.event.EventHandler;
-import javafx.scene.control.skin.TextInputControlSkin;
+import java.text.Bidi;
+import java.util.Set;
 import javafx.application.ConditionalFeature;
 import javafx.beans.InvalidationListener;
 import javafx.collections.ObservableList;
+import javafx.event.ActionEvent;
+import javafx.event.EventHandler;
+import javafx.event.EventType;
 import javafx.geometry.NodeOrientation;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.IndexRange;
@@ -43,29 +39,22 @@ import javafx.scene.control.MenuItem;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.control.TextInputControl;
-import javafx.scene.input.ContextMenuEvent;
+import javafx.scene.control.input.BehaviorBase;
+import javafx.scene.control.input.EventCriteria;
+import javafx.scene.control.input.KeyBinding;
+import javafx.scene.control.input.SkinInputMap;
+import javafx.scene.control.skin.TextInputControlSkin;
+import javafx.scene.control.skin.TextInputControlSkin.Direction;
+import javafx.scene.control.skin.TextInputControlSkin.TextUnit;
 import javafx.scene.input.Clipboard;
-import com.sun.javafx.scene.control.inputmap.InputMap;
-import com.sun.javafx.scene.control.inputmap.InputMap.Mapping;
-import com.sun.javafx.scene.control.inputmap.KeyBinding;
+import javafx.scene.input.ContextMenuEvent;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
-
-import java.text.Bidi;
-import java.util.function.Predicate;
-
-import static com.sun.javafx.PlatformUtil.isLinux;
-import static com.sun.javafx.PlatformUtil.isMac;
-import static com.sun.javafx.PlatformUtil.isWindows;
-import static com.sun.javafx.scene.control.inputmap.KeyBinding.OptionalBoolean;
-import static com.sun.javafx.scene.control.skin.resources.ControlResources.getString;
-import static javafx.scene.control.skin.TextInputControlSkin.TextUnit;
-import static javafx.scene.control.skin.TextInputControlSkin.Direction;
-import static com.sun.javafx.scene.control.inputmap.InputMap.KeyMapping;
-import static com.sun.javafx.scene.control.inputmap.InputMap.MouseMapping;
-import static javafx.scene.input.KeyCode.*;
-import static javafx.scene.input.KeyEvent.*;
+import com.sun.javafx.application.PlatformImpl;
+import com.sun.javafx.scene.control.Properties;
+import com.sun.javafx.scene.control.skin.FXVK;
+import com.sun.javafx.scene.control.skin.resources.ControlResources;
 
 /**
  * All of the "button" types (CheckBox, RadioButton, ToggleButton, and Button)
@@ -88,15 +77,9 @@ public abstract class TextInputControlBehavior<T extends TextInputControl> exten
      * Fields                                                                 *
      *************************************************************************/
 
-    final T textInputControl;
-
     protected ContextMenu contextMenu;
 
     private InvalidationListener textListener = observable -> invalidateBidi();
-
-    private final InputMap<T> inputMap;
-
-
 
 
     /***************************************************************************
@@ -107,253 +90,225 @@ public abstract class TextInputControlBehavior<T extends TextInputControl> exten
 
     public TextInputControlBehavior(T c) {
         super(c);
-
-        this.textInputControl = c;
-
-        // create a map for text input-specific mappings (this reuses the default
-        // InputMap installed on the control, if it is non-null, allowing us to pick up any user-specified mappings)
-        inputMap = createInputMap();
-
-        // some of the mappings are only valid when the control is editable, or
-        // only on certain platforms, so we create the following predicates that filters out the mapping when the
-        // control is not in the correct state / on the correct platform
-        final Predicate<KeyEvent> validWhenEditable = e -> !c.isEditable();
-        final Predicate<KeyEvent> validOnWindows = e -> !PlatformUtil.isWindows();
-        final Predicate<KeyEvent> validOnLinux = e -> !PlatformUtil.isLinux();
-
-        KeyMapping cancelEditMapping;
-        KeyMapping fireMapping;
-        KeyMapping consumeMostPressedEventsMapping;
-
-        // create a child input map for mappings which are applicable on all
-        // platforms, and regardless of editing state
-        addDefaultMapping(inputMap,
-                // caret movement
-                keyMapping(RIGHT, e -> nextCharacterVisually(true)),
-                keyMapping(LEFT, e -> nextCharacterVisually(false)),
-                keyMapping(UP, e -> c.home()),
-                keyMapping(HOME, e -> c.home()),
-                keyMapping(DOWN, e -> c.end()),
-                keyMapping(END, e -> c.end()),
-                fireMapping = keyMapping(ENTER, this::fire),
-
-                keyMapping(new KeyBinding(HOME).shortcut(), e -> c.home()),
-                keyMapping(new KeyBinding(END).shortcut(), e -> c.end()),
-
-                // deletion (only applies when control is editable)
-                keyMapping(new KeyBinding(BACK_SPACE), e -> deletePreviousChar(), validWhenEditable),
-                keyMapping(new KeyBinding(BACK_SPACE).shift(), e -> deletePreviousChar(), validWhenEditable),
-                keyMapping(new KeyBinding(DELETE), e -> deleteNextChar(), validWhenEditable),
-
-                // cut (only applies when control is editable)
-                keyMapping(new KeyBinding(X).shortcut(), e -> cut(), validWhenEditable),
-                keyMapping(new KeyBinding(CUT), e -> cut(), validWhenEditable),
-
-                // copy
-                keyMapping(new KeyBinding(C).shortcut(), e -> c.copy()),
-                keyMapping(new KeyBinding(INSERT).shortcut(), e -> c.copy()),
-                keyMapping(COPY, e -> c.copy()),
-
-                // paste (only applies when control is editable)
-                keyMapping(new KeyBinding(V).shortcut(), e -> paste(), validWhenEditable),
-                keyMapping(new KeyBinding(PASTE), e -> paste(), validWhenEditable),
-                keyMapping(new KeyBinding(INSERT).shift(), e -> paste(), validWhenEditable),
-
-                // selection
-                keyMapping(new KeyBinding(RIGHT).shift(), e -> selectRight()),
-                keyMapping(new KeyBinding(LEFT).shift(), e -> selectLeft()),
-                keyMapping(new KeyBinding(UP).shift(), e -> selectHome()),
-                keyMapping(new KeyBinding(DOWN).shift(), e -> selectEnd()),
-                keyMapping(new KeyBinding(HOME).shortcut().shift(), e -> selectHome()),
-                keyMapping(new KeyBinding(END).shortcut().shift(), e -> selectEnd()),
-                keyMapping(new KeyBinding(A).shortcut(), e -> c.selectAll()),
-
-                // Traversal Bindings
-                new KeyMapping(new KeyBinding(TAB), FocusTraversalInputMap::traverseNext),
-                new KeyMapping(new KeyBinding(TAB).shift(), FocusTraversalInputMap::traversePrevious),
-                new KeyMapping(new KeyBinding(TAB).ctrl(), FocusTraversalInputMap::traverseNext),
-                new KeyMapping(new KeyBinding(TAB).ctrl().shift(), FocusTraversalInputMap::traversePrevious),
-
-                // The following keys are forwarded to the parent container
-                cancelEditMapping = new KeyMapping(ESCAPE, this::cancelEdit),
-
-                keyMapping(new KeyBinding(Z).shortcut(), e -> undo()),
-
-                // character input.
-                // Any other key press first goes to normal text input
-                // Note this is KEY_TYPED because otherwise the character is not available in the event.
-                keyMapping(new KeyBinding(null, KEY_TYPED)
-                                    .alt(OptionalBoolean.ANY)
-                                    .shift(OptionalBoolean.ANY)
-                                    .ctrl(OptionalBoolean.ANY)
-                                    .meta(OptionalBoolean.ANY),
-                           this::defaultKeyTyped),
-
-                // However, we want to consume other key press / release events too, for
-                // things that would have been handled by the InputCharacter normally
-                consumeMostPressedEventsMapping =
-                    keyMapping(new KeyBinding(null, KEY_PRESSED).shift(OptionalBoolean.ANY),
-                               e -> { if (!e.getCode().isFunctionKey()) e.consume(); }),
-
-                // VK
-                new KeyMapping(new KeyBinding(DIGIT9).ctrl().shift(), e -> {
-                    FXVK.toggleUseVK(textInputControl);
-                }, p -> !PlatformImpl.isSupported(ConditionalFeature.VIRTUAL_KEYBOARD)),
-
-                // mouse and context menu mappings
-                new MouseMapping(MouseEvent.MOUSE_PRESSED, this::mousePressed),
-                new MouseMapping(MouseEvent.MOUSE_DRAGGED, this::mouseDragged),
-                new MouseMapping(MouseEvent.MOUSE_RELEASED, this::mouseReleased),
-                new InputMap.Mapping<>(ContextMenuEvent.CONTEXT_MENU_REQUESTED, this::contextMenuRequested) {
-                    @Override public int getSpecificity(Event event) {
-                        return 1;
-                    }
-                }
-        );
-
-        cancelEditMapping.setAutoConsume(false);
-        // fix of JDK-8207759: don't auto-consume
-        fireMapping.setAutoConsume(false);
-        consumeMostPressedEventsMapping.setAutoConsume(false);
-
-        // mac os specific mappings
-        InputMap<T> macOsInputMap = new InputMap<>(c);
-        macOsInputMap.setInterceptor(e -> !PlatformUtil.isMac());
-        macOsInputMap.getMappings().addAll(
-            // Mac OS specific mappings
-            keyMapping(new KeyBinding(HOME).shift(), e -> selectHomeExtend()),
-            keyMapping(new KeyBinding(END).shift(), e -> selectEndExtend()),
-            keyMapping(new KeyBinding(LEFT).shortcut(), e -> c.home()),
-            keyMapping(new KeyBinding(RIGHT).shortcut(), e -> c.end()),
-            keyMapping(new KeyBinding(LEFT).alt(), e -> leftWord()),
-            keyMapping(new KeyBinding(RIGHT).alt(), e -> rightWord()),
-            keyMapping(new KeyBinding(DELETE).alt(), e -> deleteNextWord()),
-            keyMapping(new KeyBinding(BACK_SPACE).alt(), e -> deletePreviousWord()),
-            keyMapping(new KeyBinding(BACK_SPACE).shortcut(), e -> deleteFromLineStart()),
-            keyMapping(new KeyBinding(Z).shortcut().shift(), e -> redo()),
-            keyMapping(new KeyBinding(LEFT).shortcut().shift(), e -> selectHomeExtend()),
-            keyMapping(new KeyBinding(RIGHT).shortcut().shift(), e -> selectEndExtend()),
-
-            // Mac OS specific selection mappings
-            keyMapping(new KeyBinding(LEFT).shift().alt(), e -> selectLeftWord()),
-            keyMapping(new KeyBinding(RIGHT).shift().alt(), e -> selectRightWord())
-        );
-        addDefaultChildMap(inputMap, macOsInputMap);
-
-        // windows / linux specific mappings
-        InputMap<T> nonMacOsInputMap = new InputMap<>(c);
-        nonMacOsInputMap.setInterceptor(e -> PlatformUtil.isMac());
-        nonMacOsInputMap.getMappings().addAll(
-            keyMapping(new KeyBinding(HOME).shift(), e -> selectHome()),
-            keyMapping(new KeyBinding(END).shift(), e -> selectEnd()),
-            keyMapping(new KeyBinding(LEFT).ctrl(), e -> leftWord()),
-            keyMapping(new KeyBinding(RIGHT).ctrl(), e -> rightWord()),
-            keyMapping(new KeyBinding(H).ctrl(), e -> deletePreviousChar()),
-            keyMapping(new KeyBinding(DELETE).ctrl(), e -> deleteNextWord()),
-            keyMapping(new KeyBinding(BACK_SPACE).ctrl(), e -> deletePreviousWord()),
-            keyMapping(new KeyBinding(BACK_SLASH).ctrl(), e -> c.deselect()),
-            keyMapping(new KeyBinding(Y).ctrl(), e -> redo(), validOnWindows),
-            keyMapping(new KeyBinding(Z).ctrl().shift(), e -> redo(), validOnLinux),
-            keyMapping(new KeyBinding(LEFT).ctrl().shift(), e -> selectLeftWord()),
-            keyMapping(new KeyBinding(RIGHT).ctrl().shift(), e -> selectRightWord())
-        );
-        addDefaultChildMap(inputMap, nonMacOsInputMap);
-
-        addKeyPadMappings(inputMap);
-
-        textInputControl.textProperty().addListener(textListener);
-
+        // TODO create upon demand
         contextMenu = new ContextMenu();
-}
+    }
 
-    @Override public InputMap<T> getInputMap() {
-        return inputMap;
+    @Override
+    protected void populateSkinInputMap() {
+        getControl().textProperty().addListener(textListener);
+
+        registerFunction(TextInputControl.COPY, this::copy);
+        registerFunction(TextInputControl.CUT, this::cut);
+        registerFunction(TextInputControl.DELETE_FROM_LINE_START, this::deleteFromLineStart);
+        registerFunction(TextInputControl.DELETE_NEXT_CHAR, this::deleteNextChar);
+        registerFunction(TextInputControl.DELETE_NEXT_WORD, this::deleteNextWord);
+        registerFunction(TextInputControl.DELETE_PREVIOUS_CHAR, this::deletePreviousChar);
+        registerFunction(TextInputControl.DELETE_PREVIOUS_WORD, this::deletePreviousWord);
+        registerFunction(TextInputControl.DESELECT, this::deselect);
+        registerFunction(TextInputControl.DOCUMENT_START, this::home);
+        registerFunction(TextInputControl.DOCUMENT_END, this::end);
+        registerFunction(TextInputControl.LEFT, (c) -> nextCharacterVisually(c, false));
+        registerFunction(TextInputControl.LEFT_WORD, this::leftWord);
+        registerFunction(TextInputControl.PASTE, this::paste);
+        registerFunction(TextInputControl.REDO, this::redo);
+        registerFunction(TextInputControl.RIGHT, (c) -> nextCharacterVisually(c, true));
+        registerFunction(TextInputControl.RIGHT_WORD, this::rightWord);
+        registerFunction(TextInputControl.SELECT_ALL, this::selectAll);
+        registerFunction(TextInputControl.SELECT_END, this::selectEnd);
+        registerFunction(TextInputControl.SELECT_END_EXTEND, this::selectEndExtend);
+        registerFunction(TextInputControl.SELECT_HOME, this::selectHome);
+        registerFunction(TextInputControl.SELECT_HOME_EXTEND, this::selectHomeExtend);
+        registerFunction(TextInputControl.SELECT_LEFT, this::selectLeft);
+        registerFunction(TextInputControl.SELECT_LEFT_WORD, this::selectLeftWord);
+        registerFunction(TextInputControl.SELECT_RIGHT, this::selectRight);
+        registerFunction(TextInputControl.SELECT_RIGHT_WORD, this::selectRightWord);
+        registerFunction(TextInputControl.TRAVERSE_NEXT, (c) -> FocusTraversalInputMap.traverseNext(c));
+        registerFunction(TextInputControl.TRAVERSE_PREVIOUS, (c) -> FocusTraversalInputMap.traversePrevious(c));
+        registerFunction(TextInputControl.UNDO, this::undo);
+
+        // common key bindings
+        registerKey(KeyBinding.shortcut(KeyCode.C), TextInputControl.COPY);
+        registerKey(KeyBinding.of(KeyCode.COPY), TextInputControl.COPY);
+        registerKey(KeyBinding.shortcut(KeyCode.INSERT), TextInputControl.COPY);
+        registerKey(KeyBinding.of(KeyCode.CUT), TextInputControl.CUT);
+        registerKey(KeyBinding.shortcut(KeyCode.X), TextInputControl.CUT);
+        registerKey(KeyBinding.of(KeyCode.DELETE), TextInputControl.DELETE_NEXT_CHAR);
+        registerKey(KeyBinding.of(KeyCode.BACK_SPACE), TextInputControl.DELETE_PREVIOUS_CHAR);
+        registerKey(KeyBinding.shift(KeyCode.BACK_SPACE), TextInputControl.DELETE_PREVIOUS_CHAR);
+        registerKey(KeyBinding.of(KeyCode.HOME), TextInputControl.DOCUMENT_START);
+        registerKey(KeyBinding.shortcut(KeyCode.HOME), TextInputControl.DOCUMENT_START);
+        registerKey(KeyBinding.of(KeyCode.UP), TextInputControl.DOCUMENT_START);
+        registerKey(KeyBinding.of(KeyCode.DOWN), TextInputControl.DOCUMENT_END);
+        registerKey(KeyBinding.of(KeyCode.END), TextInputControl.DOCUMENT_END);
+        registerKey(KeyBinding.shortcut(KeyCode.END), TextInputControl.DOCUMENT_END);
+        registerKey(KeyBinding.of(KeyCode.LEFT), TextInputControl.LEFT);
+        registerKey(KeyBinding.of(KeyCode.PASTE), TextInputControl.PASTE);
+        registerKey(KeyBinding.shift(KeyCode.INSERT), TextInputControl.PASTE);
+        registerKey(KeyBinding.shortcut(KeyCode.V), TextInputControl.PASTE);
+        registerKey(KeyBinding.of(KeyCode.RIGHT), TextInputControl.RIGHT);
+        registerKey(KeyBinding.shift(KeyCode.DOWN), TextInputControl.SELECT_END);
+        registerKey(KeyBinding.with(KeyCode.END).shortcut().shift().build(), TextInputControl.SELECT_END);
+        registerKey(KeyBinding.with(KeyCode.HOME).shortcut().shift().build(), TextInputControl.SELECT_HOME);
+        registerKey(KeyBinding.shift(KeyCode.UP), TextInputControl.SELECT_HOME);
+        registerKey(KeyBinding.shift(KeyCode.LEFT), TextInputControl.SELECT_LEFT);
+        registerKey(KeyBinding.shift(KeyCode.RIGHT), TextInputControl.SELECT_RIGHT);
+        registerKey(KeyBinding.of(KeyCode.TAB), TextInputControl.TRAVERSE_NEXT);
+        registerKey(KeyBinding.ctrl(KeyCode.TAB), TextInputControl.TRAVERSE_NEXT);
+        registerKey(KeyBinding.shift(KeyCode.TAB), TextInputControl.TRAVERSE_PREVIOUS);
+        registerKey(KeyBinding.ctrlShift(KeyCode.TAB), TextInputControl.TRAVERSE_PREVIOUS);
+        registerKey(KeyBinding.shortcut(KeyCode.A), TextInputControl.SELECT_ALL);
+        registerKey(KeyBinding.shortcut(KeyCode.Z), TextInputControl.UNDO);
+
+        if (isMac()) {
+            // macOS key bindings
+            registerKey(KeyBinding.shortcut(KeyCode.BACK_SPACE), TextInputControl.DELETE_FROM_LINE_START);
+            registerKey(KeyBinding.alt(KeyCode.DELETE), TextInputControl.DELETE_NEXT_WORD);
+            registerKey(KeyBinding.alt(KeyCode.BACK_SPACE), TextInputControl.DELETE_PREVIOUS_WORD);
+            registerKey(KeyBinding.shift(KeyCode.HOME), TextInputControl.SELECT_HOME_EXTEND);
+            registerKey(KeyBinding.shortcut(KeyCode.LEFT), TextInputControl.DOCUMENT_START);
+            registerKey(KeyBinding.shortcut(KeyCode.RIGHT), TextInputControl.DOCUMENT_END);
+            registerKey(KeyBinding.alt(KeyCode.LEFT), TextInputControl.LEFT_WORD);
+            registerKey(KeyBinding.with(KeyCode.Z).shortcut().shift().build(), TextInputControl.REDO);
+            registerKey(KeyBinding.alt(KeyCode.RIGHT), TextInputControl.RIGHT_WORD);
+            registerKey(KeyBinding.with(KeyCode.LEFT).shortcut().shift().build(), TextInputControl.SELECT_HOME_EXTEND);
+            registerKey(KeyBinding.with(KeyCode.RIGHT).shortcut().shift().build(), TextInputControl.SELECT_END_EXTEND);
+            registerKey(KeyBinding.shift(KeyCode.END), TextInputControl.SELECT_END_EXTEND);
+            registerKey(KeyBinding.with(KeyCode.LEFT).shift().alt().build(), TextInputControl.SELECT_LEFT_WORD);
+            registerKey(KeyBinding.with(KeyCode.RIGHT).shift().alt().build(), TextInputControl.SELECT_RIGHT_WORD);
+        } else {
+            // not-mac key bindings
+            registerKey(KeyBinding.ctrl(KeyCode.DELETE), TextInputControl.DELETE_NEXT_WORD);
+            registerKey(KeyBinding.ctrl(KeyCode.H), TextInputControl.DELETE_PREVIOUS_CHAR);
+            registerKey(KeyBinding.ctrl(KeyCode.BACK_SPACE), TextInputControl.DELETE_PREVIOUS_WORD);
+            registerKey(KeyBinding.ctrl(KeyCode.BACK_SLASH), TextInputControl.DESELECT);
+            registerKey(KeyBinding.ctrl(KeyCode.LEFT), TextInputControl.LEFT_WORD);
+            registerKey(KeyBinding.ctrl(KeyCode.RIGHT), TextInputControl.RIGHT_WORD);
+            registerKey(KeyBinding.shift(KeyCode.HOME), TextInputControl.SELECT_HOME);
+            registerKey(KeyBinding.shift(KeyCode.END), TextInputControl.SELECT_END);
+            registerKey(KeyBinding.ctrlShift(KeyCode.LEFT), TextInputControl.SELECT_LEFT_WORD);
+            registerKey(KeyBinding.ctrlShift(KeyCode.RIGHT), TextInputControl.SELECT_RIGHT_WORD);
+        }
+
+        // windows key bindings
+        if (isWindows()) {
+            registerKey(KeyBinding.ctrl(KeyCode.Y), TextInputControl.REDO);
+        }
+
+        // linux key bindings
+        if (isLinux()) {
+            registerKey(KeyBinding.ctrlShift(KeyCode.Z), TextInputControl.REDO);
+        }
+
+        // key pad mappings
+        addKeyPadMappings();
+
+        addHandlerLast(KeyEvent.KEY_TYPED, true, this::defaultKeyTyped);
+
+        // However, we want to consume other key press / release events too, for
+        // things that would have been handled by the InputCharacter normally
+        addHandlerLast(
+            new EventCriteria<KeyEvent>() {
+                @Override
+                public EventType<KeyEvent> getEventType() {
+                    return KeyEvent.KEY_PRESSED;
+                }
+
+                @Override
+                public boolean isEventAcceptable(KeyEvent ev) {
+                    switch(ev.getCode()) {
+                    case ESCAPE:
+                    case ENTER:
+                        return false;
+                    };
+                    return
+                        !ev.getCode().isFunctionKey() &&
+                        !ev.isAltDown() &&
+                        !ev.isControlDown() &&
+                        !ev.isMetaDown() &&
+                        !ev.isShortcutDown();
+                }
+            },
+            false,
+            (ev) -> ev.consume()
+        );
+
+        // VK
+        // TODO can PlatformImpl.isSupported(ConditionalFeature) change at runtime?
+        if (PlatformImpl.isSupported(ConditionalFeature.VIRTUAL_KEYBOARD)) {
+            addHandler(KeyBinding.ctrlShift(KeyCode.DIGIT9), true, (ev) -> {
+                FXVK.toggleUseVK(getControl());
+            });
+        }
+
+        // mouse and context menu mappings
+        addHandler(MouseEvent.MOUSE_PRESSED, true, this::mousePressed);
+        addHandler(MouseEvent.MOUSE_DRAGGED, true, this::mouseDragged);
+        addHandler(MouseEvent.MOUSE_RELEASED, true, this::mouseReleased);
+
+        addHandler(ContextMenuEvent.CONTEXT_MENU_REQUESTED, true, this::contextMenuRequested);
     }
 
     /**
-     * Bind keypad arrow keys to the same as the regular arrow keys.
+     * Binds keypad arrow keys to the same function tags as the regular arrow keys.
      */
-    protected void addKeyPadMappings(InputMap<T> map) {
-        // First create a temporary map for the keypad mappings
-        InputMap<T> tmpMap = new InputMap<>(getNode());
-        for (Object o : map.getMappings()) {
-            if (o instanceof KeyMapping) {
-                KeyMapping mapping = (KeyMapping)o;
-                KeyBinding kb = (KeyBinding)mapping.getMappingKey();
-                if (kb.getCode() != null) {
-                    KeyCode newCode = null;
-                    switch (kb.getCode()) {
-                        case LEFT:  newCode = KP_LEFT;  break;
-                        case RIGHT: newCode = KP_RIGHT; break;
-                        case UP:    newCode = KP_UP;    break;
-                        case DOWN:  newCode = KP_DOWN;  break;
-                        default:
-                    }
-                    if (newCode != null) {
-                        KeyBinding newkb = new KeyBinding(newCode).shift(kb.getShift())
-                                                                  .ctrl(kb.getCtrl())
-                                                                  .alt(kb.getAlt())
-                                                                  .meta(kb.getMeta());
-                        tmpMap.getMappings().add(new KeyMapping(newkb, mapping.getEventHandler()));
-                    }
+    protected void addKeyPadMappings() {
+        SkinInputMap m = getSkinInputMap();
+        Set<KeyBinding> keys = m.getKeyBindings();
+        for (KeyBinding k: keys) {
+            KeyCode cd = k.getKeyCode();
+            if (cd != null) {
+                KeyCode newCode = null;
+                switch (cd) {
+                case LEFT:
+                    newCode = KeyCode.KP_LEFT;
+                    break;
+                case RIGHT:
+                    newCode = KeyCode.KP_RIGHT;
+                    break;
+                case UP:
+                    newCode = KeyCode.KP_UP;
+                    break;
+                case DOWN:
+                    newCode = KeyCode.KP_DOWN;
+                    break;
+                default:
+                    newCode = null;
+                    break;
+                }
+
+                if (newCode != null) {
+                    KeyBinding newBinding = KeyBinding.
+                        with(newCode).
+                        alt(k.isAlt()).
+                        command(k.isCommand()).
+                        ctrl(k.isCtrl()).
+                        meta(k.isMeta()).
+                        option(k.isOption()).
+                        shift(k.isShift()).
+                        build();
+                    duplicateMapping(k, newBinding);
                 }
             }
         }
-
-        if (map == getInputMap()) {
-            // install mappings in the top-level inputMap
-            // as default mappings to clear them on dispose
-            for (Mapping<?> mapping : tmpMap.getMappings()) {
-                addDefaultMapping(map, mapping);
-            }
-        } else {
-            // Install mappings in child maps
-            for (Object o : tmpMap.getMappings()) {
-                map.getMappings().add((KeyMapping)o);
-            }
-        }
-
-        // temporary inputMap must be disposed to prevent memory leak
-        tmpMap.dispose();
-
-        // Recursive call for child maps
-        for (Object o : map.getChildInputMaps()) {
-            addKeyPadMappings((InputMap<T>)o);
-        }
     }
-
-    protected KeyMapping keyMapping(final KeyCode keyCode, final EventHandler<KeyEvent> eventHandler) {
-        return keyMapping(new KeyBinding(keyCode), eventHandler);
-    }
-
-    protected KeyMapping keyMapping(KeyBinding keyBinding, final EventHandler<KeyEvent> eventHandler) {
-        return keyMapping(keyBinding, eventHandler, null);
-    }
-
-    protected KeyMapping keyMapping(KeyBinding k, final EventHandler<KeyEvent> h, Predicate<KeyEvent> interceptor) {
-        return new KeyMapping(k, h, interceptor);
-    }
-
-
-
 
     /**************************************************************************
      * Disposal methods                                                       *
      *************************************************************************/
 
-    @Override public void dispose() {
-        textInputControl.textProperty().removeListener(textListener);
-        super.dispose();
+    public void dispose() {
+        getControl().textProperty().removeListener(textListener);
     }
 
     /**************************************************************************
      * Abstract methods                                                       *
      *************************************************************************/
 
-    protected abstract void deleteChar(boolean previous);
+    protected abstract void deleteChar(T c, boolean previous);
     protected abstract void replaceText(int start, int end, String txt);
     protected abstract void setCaretAnimating(boolean play);
-    protected abstract void deleteFromLineStart();
+    protected abstract void deleteFromLineStart(T c);
 
     protected abstract void mousePressed(MouseEvent e);
     protected abstract void mouseDragged(MouseEvent e);
@@ -371,7 +326,7 @@ public abstract class TextInputControlBehavior<T extends TextInputControl> exten
      * @param event not null
      */
     private void defaultKeyTyped(KeyEvent event) {
-        final TextInputControl textInput = getNode();
+        final TextInputControl textInput = getControl();
         // I'm not sure this case can actually ever happen, maybe this
         // should be an assert instead?
         if (!textInput.isEditable() || textInput.isDisabled()) return;
@@ -420,8 +375,8 @@ public abstract class TextInputControlBehavior<T extends TextInputControl> exten
 
     private Bidi getBidi() {
         if (bidi == null) {
-            bidi = new Bidi(textInputControl.textProperty().getValueSafe(),
-                    (textInputControl.getEffectiveNodeOrientation() == NodeOrientation.RIGHT_TO_LEFT)
+            bidi = new Bidi(getControl().textProperty().getValueSafe(),
+                    (getControl().getEffectiveNodeOrientation() == NodeOrientation.RIGHT_TO_LEFT)
                             ? Bidi.DIRECTION_RIGHT_TO_LEFT
                             : Bidi.DIRECTION_LEFT_TO_RIGHT);
         }
@@ -441,207 +396,223 @@ public abstract class TextInputControlBehavior<T extends TextInputControl> exten
             rtlText =
                     (bidi.isRightToLeft() ||
                             (isMixed() &&
-                                    textInputControl.getEffectiveNodeOrientation() == NodeOrientation.RIGHT_TO_LEFT));
+                                getControl().getEffectiveNodeOrientation() == NodeOrientation.RIGHT_TO_LEFT));
         }
         return rtlText;
     }
 
-    private void nextCharacterVisually(boolean moveRight) {
+    private void nextCharacterVisually(TextInputControl c, boolean moveRight) {
         if (isMixed()) {
-            TextInputControlSkin<?> skin = (TextInputControlSkin<?>)textInputControl.getSkin();
+            TextInputControlSkin<?> skin = (TextInputControlSkin<?>)c.getSkin();
             skin.moveCaret(TextUnit.CHARACTER, moveRight ? Direction.RIGHT : Direction.LEFT, false);
         } else if (moveRight != isRTLText()) {
-            textInputControl.forward();
+            getControl().forward();
         } else {
-            textInputControl.backward();
+            getControl().backward();
         }
     }
 
-    private void selectLeft() {
+    private void selectLeft(T c) {
         if (isRTLText()) {
-            textInputControl.selectForward();
+            c.selectForward(); // TODO move impl here
         } else {
-            textInputControl.selectBackward();
+            c.selectBackward(); // TODO move impl here
         }
     }
 
-    private void selectRight() {
+    private void selectRight(T c) {
         if (isRTLText()) {
-            textInputControl.selectBackward();
+            c.selectBackward(); // TODO move impl here
         } else {
-            textInputControl.selectForward();
+            c.selectForward(); // TODO move impl here
         }
     }
 
-    private void deletePreviousChar() {
-        setEditing(true);
-        deleteChar(true);
-        setEditing(false);
+    boolean isEditable() {
+        return getControl().isEditable();
     }
 
-    private void deleteNextChar() {
-        setEditing(true);
-        deleteChar(false);
-        setEditing(false);
+    private void deletePreviousChar(T c) {
+        if (isEditable()) {
+            setEditing(true);
+            deleteChar(c, true);
+            setEditing(false);
+        }
     }
 
-    protected void deletePreviousWord() {
-        setEditing(true);
-        TextInputControl textInputControl = getNode();
-        int end = textInputControl.getCaretPosition();
+    private void deleteNextChar(T c) {
+        if (isEditable()) {
+            setEditing(true);
+            deleteChar(c, false);
+            setEditing(false);
+        }
+    }
 
+    protected void deletePreviousWord(T c) {
+        setEditing(true);
+        int end = c.getCaretPosition();
         if (end > 0) {
-            textInputControl.previousWord();
-            int start = textInputControl.getCaretPosition();
+            c.previousWord();
+            int start = c.getCaretPosition();
             replaceText(start, end, "");
         }
         setEditing(false);
     }
 
-    protected void deleteNextWord() {
+    protected void deleteNextWord(T c) {
         setEditing(true);
-        TextInputControl textInputControl = getNode();
-        int start = textInputControl.getCaretPosition();
-
-        if (start < textInputControl.getLength()) {
-            nextWord();
-            int end = textInputControl.getCaretPosition();
+        int start = c.getCaretPosition();
+        if (start < c.getLength()) {
+            nextWord(c);
+            int end = c.getCaretPosition();
             replaceText(start, end, "");
         }
         setEditing(false);
     }
 
-    public void deleteSelection() {
+    public void deleteSelection(T c) {
         setEditing(true);
-        TextInputControl textInputControl = getNode();
-        IndexRange selection = textInputControl.getSelection();
-
+        IndexRange selection = c.getSelection();
         if (selection.getLength() > 0) {
-            deleteChar(false);
+            deleteChar(c, false);
         }
         setEditing(false);
     }
 
-    public void cut() {
+    public void copy(T c) {
+        c.copy(); // TODO move implementation here
+    }
+
+    public void deselect(T c) {
+        c.deselect(); // TODO move implementation here
+    }
+
+    public void home(T c) {
+        c.home(); // TODO move implementation here
+    }
+
+    public void end(T c) {
+        c.end(); // TODO move implementation here
+    }
+
+    public void cut(T c) {
+        if (isEditable()) {
+            setEditing(true);
+            c.cut();
+            setEditing(false);
+        }
+    }
+
+    public void paste(T c) {
+        if (isEditable()) {
+            setEditing(true);
+            c.paste();
+            setEditing(false);
+        }
+    }
+
+    public void undo(T c) {
         setEditing(true);
-        getNode().cut();
+        c.undo();
         setEditing(false);
     }
 
-    public void paste() {
+    public void redo(T c) {
         setEditing(true);
-        getNode().paste();
+        c.redo();
         setEditing(false);
     }
 
-    public void undo() {
-        setEditing(true);
-        getNode().undo();
-        setEditing(false);
+    protected void selectPreviousWord(T c) {
+        c.selectPreviousWord(); // TODO move impl here
     }
 
-    public void redo() {
-        setEditing(true);
-        getNode().redo();
-        setEditing(false);
-    }
-
-    protected void selectPreviousWord() {
-        getNode().selectPreviousWord();
-    }
-
-    public void selectNextWord() {
-        TextInputControl textInputControl = getNode();
+    public void selectNextWord(T c) {
         if (isMac() || isLinux()) {
-            textInputControl.selectEndOfNextWord();
+            c.selectEndOfNextWord(); // TODO move impl here
         } else {
-            textInputControl.selectNextWord();
+            c.selectNextWord(); // TODO move impl here
         }
     }
 
-    private void selectLeftWord() {
+    private void selectLeftWord(T c) {
         if (isRTLText()) {
-            selectNextWord();
+            selectNextWord(c);
         } else {
-            selectPreviousWord();
+            selectPreviousWord(c);
         }
     }
 
-    private void selectRightWord() {
+    private void selectRightWord(T c) {
         if (isRTLText()) {
-            selectPreviousWord();
+            selectPreviousWord(c);
         } else {
-            selectNextWord();
+            selectNextWord(c);
         }
     }
 
-    protected void selectWord() {
-        final TextInputControl textInputControl = getNode();
-        textInputControl.previousWord();
+    protected void selectWord(T c) {
+        c.previousWord(); // TODO move implementation here
         if (isWindows()) {
-            textInputControl.selectNextWord();
+            c.selectNextWord(); // TODO move implementation here
         } else {
-            textInputControl.selectEndOfNextWord();
+            c.selectEndOfNextWord(); // TODO move implementation here
         }
         if (SHOW_HANDLES && contextMenu.isShowing()) {
             populateContextMenu();
         }
     }
 
-    protected void selectAll() {
-        getNode().selectAll();
+    protected void selectAll(T c) {
+        c.selectAll(); // TODO move implementation here
         if (SHOW_HANDLES && contextMenu.isShowing()) {
             populateContextMenu();
         }
     }
 
-    protected void previousWord() {
-        getNode().previousWord();
+    protected void previousWord(T c) {
+        c.previousWord(); // TODO move implementation here
     }
 
-    protected void nextWord() {
-        TextInputControl textInputControl = getNode();
+    protected void nextWord(T c) {
         if (isMac() || isLinux()) {
-            textInputControl.endOfNextWord();
+            c.endOfNextWord(); // TODO move implementation here
         } else {
-            textInputControl.nextWord();
+            c.nextWord(); // TODO move implementation here
         }
     }
 
-    private void leftWord() {
+    private void leftWord(T c) {
         if (isRTLText()) {
-            nextWord();
+            nextWord(c);
         } else {
-            previousWord();
+            previousWord(c);
         }
     }
 
-    private void rightWord() {
+    private void rightWord(T c) {
         if (isRTLText()) {
-            previousWord();
+            previousWord(c);
         } else {
-            nextWord();
+            nextWord(c);
         }
     }
 
-    protected void fire(KeyEvent event) { } // TODO move to TextFieldBehavior
-    protected void cancelEdit(KeyEvent event) { }
-
-    protected void selectHome() {
-        getNode().selectHome();
+    protected void selectHome(T c) {
+        c.selectHome(); // TODO move implementation here
     }
 
-    protected void selectEnd() {
-        getNode().selectEnd();
+    protected void selectEnd(T c) {
+        c.selectEnd(); // TODO move implementation here
     }
 
-    protected void selectHomeExtend() {
-        getNode().extendSelection(0);
+    protected void selectHomeExtend(T c) {
+        c.extendSelection(0);
     }
 
-    protected void selectEndExtend() {
-        TextInputControl textInputControl = getNode();
-        textInputControl.extendSelection(textInputControl.getLength());
+    protected void selectEndExtend(T c) {
+        int len = c.getLength();
+        c.extendSelection(len);
     }
 
     private boolean editing = false;
@@ -653,7 +624,7 @@ public abstract class TextInputControlBehavior<T extends TextInputControl> exten
     }
 
     protected void populateContextMenu() {
-        TextInputControl textInputControl = getNode();
+        TextInputControl textInputControl = getControl();
         boolean editable = textInputControl.isEditable();
         boolean hasText = (textInputControl.getLength() > 0);
         boolean hasSelection = (textInputControl.getSelection().getLength() > 0);
@@ -687,8 +658,8 @@ public abstract class TextInputControlBehavior<T extends TextInputControl> exten
             } else {
                 items.setAll(copyMI, separatorMI, selectAllMI);
             }
-            undoMI.setDisable(!getNode().isUndoable());
-            redoMI.setDisable(!getNode().isRedoable());
+            undoMI.setDisable(!getControl().isUndoable());
+            redoMI.setDisable(!getControl().isRedoable());
             cutMI.setDisable(maskText || !hasSelection);
             copyMI.setDisable(maskText || !hasSelection);
             pasteMI.setDisable(!Clipboard.getSystemClipboard().hasString());
@@ -698,19 +669,18 @@ public abstract class TextInputControlBehavior<T extends TextInputControl> exten
 
     private static class ContextMenuItem extends MenuItem {
         ContextMenuItem(final String action, EventHandler<ActionEvent> onAction) {
-            super(getString("TextInputControl.menu." + action));
+            super(ControlResources.getString("TextInputControl.menu." + action));
             setOnAction(onAction);
         }
     }
 
-    private final MenuItem undoMI   = new ContextMenuItem("Undo", e -> undo());
-    private final MenuItem redoMI   = new ContextMenuItem("Redo", e -> redo());
-    private final MenuItem cutMI    = new ContextMenuItem("Cut", e -> cut());
-    private final MenuItem copyMI   = new ContextMenuItem("Copy", e -> getNode().copy());
-    private final MenuItem pasteMI  = new ContextMenuItem("Paste", e -> paste());
-    private final MenuItem deleteMI = new ContextMenuItem("DeleteSelection", e -> deleteSelection());
-    private final MenuItem selectWordMI = new ContextMenuItem("SelectWord", e -> selectWord());
-    private final MenuItem selectAllMI = new ContextMenuItem("SelectAll", e -> selectAll());
+    private final MenuItem undoMI   = new ContextMenuItem("Undo", e -> undo(getControl()));
+    private final MenuItem redoMI   = new ContextMenuItem("Redo", e -> redo(getControl()));
+    private final MenuItem cutMI    = new ContextMenuItem("Cut", e -> cut(getControl()));
+    private final MenuItem copyMI   = new ContextMenuItem("Copy", e -> copy(getControl()));
+    private final MenuItem pasteMI  = new ContextMenuItem("Paste", e -> paste(getControl()));
+    private final MenuItem deleteMI = new ContextMenuItem("DeleteSelection", e -> deleteSelection(getControl()));
+    private final MenuItem selectWordMI = new ContextMenuItem("SelectWord", e -> selectWord(getControl()));
+    private final MenuItem selectAllMI = new ContextMenuItem("SelectAll", e -> selectAll(getControl()));
     private final MenuItem separatorMI = new SeparatorMenuItem();
-
 }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/input/EventHandlerPriority.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/input/EventHandlerPriority.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,31 +22,31 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+package com.sun.javafx.scene.control.input;
+
+import java.util.Set;
 
 /**
- * Defines the UI controls, charts, and skins that are available
- * for the JavaFX UI toolkit.
- *
- * @moduleGraph
- * @since 9
+ * Codifies priority of event handler invocation.
  */
-module javafx.controls {
-    requires transitive javafx.base;
-    requires transitive javafx.graphics;
+public enum EventHandlerPriority {
+    USER_HIGH(6000),
+    USER_KB(5000),
+    SKIN_KB(4000),
+    SKIN_HIGH(3000),
+    SKIN_LOW(2000),
+    USER_LOW(1000);
 
-    exports javafx.scene.chart;
-    exports javafx.scene.control;
-    exports javafx.scene.control.cell;
-    exports javafx.scene.control.input;
-    exports javafx.scene.control.skin;
+    /** set of priorities associated with a {@code Skin} */
+    public static final Set<EventHandlerPriority> ALL_SKIN = Set.of(
+        SKIN_KB,
+        SKIN_HIGH,
+        SKIN_LOW
+    );
 
-    exports com.sun.javafx.scene.control to
-        javafx.web;
-    exports com.sun.javafx.scene.control.behavior to
-        javafx.web;
-    exports com.sun.javafx.scene.control.inputmap to
-        javafx.web;
-    exports com.sun.javafx.scene.control.skin to
-        javafx.graphics,
-        javafx.web;
+    final int priority;
+
+    private EventHandlerPriority(int priority) {
+        this.priority = priority;
+    }
 }

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/input/KeyEventMapper.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/input/KeyEventMapper.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.javafx.scene.control.input;
+
+import javafx.event.EventType;
+import javafx.scene.control.input.KeyBinding;
+import javafx.scene.input.KeyEvent;
+
+/**
+ * Contains logic for mapping KeyBinding to a specific KeyEvent.
+ */
+public class KeyEventMapper {
+    private static final int PRESSED = 0x01;
+    private static final int RELEASED = 0x02;
+    private static final int TYPED = 0x04;
+
+    private int types;
+    
+    public KeyEventMapper() {
+    }
+
+    public EventType<KeyEvent> addType(KeyBinding k) {
+        if (k.isKeyPressed()) {
+            types |= PRESSED;
+            return KeyEvent.KEY_PRESSED;
+        } else if (k.isKeyReleased()) {
+            types |= RELEASED;
+            return KeyEvent.KEY_RELEASED;
+        } else {
+            types |= TYPED;
+            return KeyEvent.KEY_TYPED;
+        }
+    }
+
+    public boolean hasKeyPressed() {
+        return (types & PRESSED) != 0;
+    }
+    
+    public boolean hasKeyReleased() {
+        return (types & RELEASED) != 0;
+    }
+    
+    public boolean hasKeyTyped() {
+        return (types & TYPED) != 0;
+    }
+}

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/input/PHList.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/input/PHList.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package com.sun.javafx.scene.control.input;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import javafx.event.Event;
+import javafx.event.EventHandler;
+
+/**
+ * Priority Handler List.
+ * Arranges event handlers according to their EventHandlerPriority.
+ */
+public class PHList {
+    /**
+     * {@code items} is a list of {@code EventHandler}s ordered from high priority to low,
+     * with each block of same priority prefixed with the priority value.
+     * Also, USER_KB and SKIN_KB require no handler pointer, so none is added.<p>
+     * Example:
+     * [ USER_HIGH, handler1, handler2, SKIN_KB, SKIN_LOW, handler3 ]
+     */
+    private final ArrayList<Object> items = new ArrayList(4);
+    
+    public PHList() {
+    }
+
+    @Override
+    public String toString() {
+        return "PHList" + items;
+    }
+
+    /**
+     * Adds an event handler under the given priority.
+     * A newly added handler will be inserted after previously added handlers with the same priority.
+     * @param priority the priority
+     * @param handler the handler to add
+     */
+    public void add(EventHandlerPriority priority, EventHandler<?> handler) {
+        // positive: simply insert the handler there
+        // negative: insert priority and the handler if it's not null
+        int ix = findInsertionIndex(priority);
+        if (ix < 0) {
+            ix = -ix - 1;
+            insert(ix, priority);
+            // do not store the null handler
+            if (handler != null) {
+                insert(++ix, handler);
+            }
+        } else {
+            insert(ix, handler);
+        }
+    }
+
+    private void insert(int ix, Object item) {
+        if (ix < items.size()) {
+            items.add(ix, item);
+        } else {
+            items.add(item);
+        }
+    }
+
+    /**
+     * Removes all the instances of the specified handler.  Returns true if the list becomes empty as a result.
+     * Returns true if the list becomes empty as a result of the removal.
+     *
+     * @param <T> the event type
+     * @param handler the handler to remove
+     * @return true when the list becomes empty as a result
+     */
+    public <T extends Event> boolean remove(EventHandler<T> handler) {
+        for (int i = 0; i < items.size(); i++) {
+            Object x = items.get(i);
+            if (x == handler) {
+                items.remove(i);
+                if (isNullOrPriority(i) && isNullOrPriority(i - 1)) {
+                    // remove priority
+                    --i;
+                    items.remove(i);
+                }
+            }
+        }
+        return items.size() == 0;
+    }
+
+    private boolean isNullOrPriority(int ix) {
+        if ((ix >= 0) && (ix < items.size())) {
+            Object x = items.get(ix);
+            return (x instanceof EventHandlerPriority);
+        }
+        return true;
+    }
+
+    /**
+     * Returns the index into {@code items}.
+     * When the list contains no elements of the given priority, the return value is
+     * negative, equals to {@code -(insertionIndex + 1)},
+     * and the caller must insert the priority value in addition to the handler.
+     *
+     * @param priority the priority
+     * @return the insertion index (positive), or -(insertionIndex + 1) (negative)
+     */
+    private int findInsertionIndex(EventHandlerPriority priority) {
+        // don't expect many handlers, so linear search is ok
+        int sz = items.size();
+        boolean found = false;
+        for (int i = 0; i < sz; i++) {
+            Object x = items.get(i);
+            if (x instanceof EventHandlerPriority p) {
+                if (p.priority == priority.priority) {
+                    found = true;
+                    continue;
+                } else if (p.priority < priority.priority) {
+                    return found ? i : -(i + 1);
+                }
+            }
+        }
+        return found ? sz : -(sz + 1);
+    }
+
+    /**
+     * A client interface for the {@link #forEach(Client)} method.
+     * @param <T> the event type
+     */
+    @FunctionalInterface
+    public static interface Client<T extends Event> {
+        /**
+         * This method gets called for each handler in the order of priority.
+         * The client may signal to stop iterating by returning false from this method.
+         *
+         * @param pri the priority
+         * @param h the handler (can be null)
+         * @return true to continue the process, false to stop
+         */
+        public boolean accept(EventHandlerPriority pri, EventHandler<T> h);
+    }
+
+    /**
+     * Invokes the {@code client} for each handler in the order of priority.
+     * @param <T> the event type
+     * @param client the client reference
+     */
+    public <T extends Event> void forEach(Client<T> client) {
+        EventHandlerPriority pri = null;
+        boolean stop;
+        int sz = items.size();
+        for (int i = 0; i < sz; i++) {
+            Object x = items.get(i);
+            if (x instanceof EventHandlerPriority p) {
+                pri = p;
+                if (isNullOrPriority(i + 1)) {
+                    stop = !client.accept(pri, null);
+                } else {
+                    continue;
+                }
+            } else {
+                // it's a handler, cannot be null
+                stop = !client.accept(pri, (EventHandler<T>)x);
+            }
+            if (stop) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Removes all the entries with the specified priorities.
+     * @return true if list is empty as a result
+     */
+    public boolean removeHandlers(Set<EventHandlerPriority> priorities) {
+        boolean remove = false;
+        for (int i = 0; i < items.size();) {
+            Object x = items.get(i);
+            if (x instanceof EventHandlerPriority p) {
+                if (priorities.contains(p)) {
+                    remove = true;
+                    items.remove(i);
+                } else {
+                    remove = false;
+                    i++;
+                }
+            } else {
+                if (remove) {
+                    items.remove(i);
+                } else {
+                    i++;
+                }
+            }
+        }
+        return items.size() == 0;
+    }
+
+    /**
+     * An internal testing method.
+     * @param expected the expected internal structure
+     */
+    public void validateInternalState(Object... expected) {
+        if(!Arrays.equals(expected, items.toArray())) {
+            throw new RuntimeException("internal mismatch:\nitems=" + items + "\nexpected=" + List.of(expected));
+        }
+    }
+}

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/inputmap/InputMap.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/inputmap/InputMap.java
@@ -62,6 +62,7 @@ import java.util.stream.Collectors;
  * @param <N> The type of the Node that the InputMap is installed in.
  * @since 9
  */
+@Deprecated // TODO to be replaced with new InputMap
 public class InputMap<N extends Node> implements EventHandler<Event> {
 
     /***************************************************************************

--- a/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/inputmap/KeyBinding.java
+++ b/modules/javafx.controls/src/main/java/com/sun/javafx/scene/control/inputmap/KeyBinding.java
@@ -49,6 +49,7 @@ import static com.sun.javafx.scene.control.inputmap.KeyBinding.OptionalBoolean.*
  *
  * @since 9
  */
+@Deprecated // TODO remove in favor of javafx.scene.control.input.KeyBinding
 public class KeyBinding {
     private final KeyCode code;
     private final EventType<KeyEvent> eventType;
@@ -65,10 +66,12 @@ public class KeyBinding {
      * Designed for 'catch-all' situations, e.g. all KeyTyped events.
      * @param type
      */
+    @Deprecated
     public KeyBinding(EventType<KeyEvent> type) {
         this(null, type);
     }
 
+    @Deprecated
     public KeyBinding(KeyCode code, EventType<KeyEvent> type) {
         this.code = code;
         this.eventType = type != null ? type : KeyEvent.KEY_PRESSED;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBox.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBox.java
@@ -25,25 +25,30 @@
 
 package javafx.scene.control;
 
-import com.sun.javafx.scene.control.FakeFocusTextField;
+import java.lang.ref.WeakReference;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.WeakInvalidationListener;
-import javafx.collections.WeakListChangeListener;
-import javafx.scene.control.skin.ComboBoxListViewSkin;
-import javafx.beans.property.*;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.ReadOnlyObjectProperty;
+import javafx.beans.property.ReadOnlyObjectWrapper;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
+import javafx.collections.WeakListChangeListener;
 import javafx.scene.AccessibleAttribute;
 import javafx.scene.AccessibleRole;
 import javafx.scene.Node;
+import javafx.scene.control.input.FunctionTag;
+import javafx.scene.control.skin.ComboBoxListViewSkin;
 import javafx.util.Callback;
 import javafx.util.StringConverter;
-
-import java.lang.ref.WeakReference;
+import com.sun.javafx.scene.control.FakeFocusTextField;
 
 /**
  * An implementation of the {@link ComboBoxBase} abstract class for the most common
@@ -190,6 +195,10 @@ import java.lang.ref.WeakReference;
  * @since JavaFX 2.1
  */
 public class ComboBox<T> extends ComboBoxBase<T> {
+    /** Denotes the function that selects the next item. */
+    public static final FunctionTag SELECT_NEXT = new FunctionTag();
+    /** Denotes the function that selects the previous item. */
+    public static final FunctionTag SELECT_PREV = new FunctionTag();
 
     /* *************************************************************************
      *                                                                         *

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBoxBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ComboBoxBase.java
@@ -34,6 +34,7 @@ import javafx.event.EventHandler;
 import javafx.event.EventType;
 import javafx.scene.AccessibleAction;
 import javafx.scene.AccessibleAttribute;
+import javafx.scene.control.input.FunctionTag;
 
 /**
  * Abstract base class for ComboBox-like controls. A ComboBox typically has
@@ -69,13 +70,9 @@ import javafx.scene.AccessibleAttribute;
  * @since JavaFX 2.1
  */
 public abstract class ComboBoxBase<T> extends Control {
-
-
-    /* *************************************************************************
-     *                                                                         *
-     * Static properties and methods                                           *
-     *                                                                         *
-     **************************************************************************/
+    /** Denotes the function that toggles this combo box popup. */
+    public static final FunctionTag TOGGLE_POPUP = new FunctionTag();
+    //CANCEL_EDIT, // TODO forwards to parent, child class logic in the base class, looks poorly thought out
 
     /**
      * <p>Called prior to the ComboBox showing its popup/display after the user

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/Control.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/Control.java
@@ -31,34 +31,36 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import com.sun.javafx.scene.control.ControlAcceleratorSupport;
 import javafx.application.Application;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ObjectPropertyBase;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.ObservableList;
+import javafx.css.CssMetaData;
 import javafx.css.CssParser;
+import javafx.css.Styleable;
+import javafx.css.StyleableObjectProperty;
+import javafx.css.StyleableProperty;
+import javafx.css.StyleableStringProperty;
+import javafx.css.converter.StringConverter;
 import javafx.event.EventHandler;
 import javafx.scene.AccessibleAction;
 import javafx.scene.AccessibleAttribute;
 import javafx.scene.Node;
+import javafx.scene.control.input.FunctionHandler;
+import javafx.scene.control.input.FunctionTag;
+import javafx.scene.control.input.InputMap;
 import javafx.scene.input.ContextMenuEvent;
 import javafx.scene.layout.Region;
 import com.sun.javafx.application.PlatformImpl;
-import javafx.css.CssMetaData;
 import com.sun.javafx.css.StyleManager;
-import com.sun.javafx.scene.NodeHelper;
-import com.sun.javafx.scene.control.ControlHelper;
-import javafx.css.StyleableObjectProperty;
-import javafx.css.StyleableStringProperty;
-import javafx.css.converter.StringConverter;
-import com.sun.javafx.scene.control.Logging;
-import javafx.css.Styleable;
-import javafx.css.StyleableProperty;
 import com.sun.javafx.logging.PlatformLogger;
 import com.sun.javafx.logging.PlatformLogger.Level;
+import com.sun.javafx.scene.NodeHelper;
+import com.sun.javafx.scene.control.ControlAcceleratorSupport;
+import com.sun.javafx.scene.control.ControlHelper;
+import com.sun.javafx.scene.control.Logging;
 
 
 /**
@@ -201,6 +203,7 @@ public abstract class Control extends Region implements Skinnable {
         }
     };
 
+    private InputMap inputMap;
 
 
     /* *************************************************************************
@@ -451,11 +454,6 @@ public abstract class Control extends Region implements Skinnable {
         // we add a listener for menu request events to show the context menu
         // that may be set on the Control
         this.addEventHandler(ContextMenuEvent.CONTEXT_MENU_REQUESTED, contextMenuHandler);
-
-        // TODO re-enable when InputMap moves back to Node / Control
-//        // Most controls need an input map, so we set this to be non-null in
-//        // Control to save people from running into NPEs.
-//        setInputMap(new InputMap(this));
     }
 
 
@@ -466,15 +464,32 @@ public abstract class Control extends Region implements Skinnable {
      *                                                                         *
      **************************************************************************/
 
-    // Proposed dispose() API.
-    // Note that there is impl code for a dispose method in TableRowSkinBase
-    // and TableCell (just search for dispose())
-//    public void dispose() {
-//        Skin skin = getSkin();
-//        if (skin != null) {
-//            skin.dispose();
-//        }
-//    }
+    /**
+     * Returns the {@link InputMap} for this {@code Control}.
+     *
+     * @since 999 TODO
+     * @return the input map
+     */
+    public final InputMap getInputMap() {
+        if (inputMap == null) {
+            inputMap = new InputMap(this);
+        }
+        return inputMap;
+    }
+
+    /**
+     * Executes function mapped to the {@link FunctionTag}.
+     * This method does nothing if no mapping is found.
+     *
+     * @since 999 TODO
+     * @param tag the function tag
+     */
+    protected final void execute(FunctionTag tag) {
+        FunctionHandler<Control> f = getInputMap().getFunction(tag);
+        if (f != null) {
+            f.handle(this);
+        }
+    }
 
     /**
      * Returns <code>true</code> since all Controls are resizable.

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/PopupControl.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/PopupControl.java
@@ -253,6 +253,7 @@ public class PopupControl extends PopupWindow implements Skinnable, Styleable {
             // let the new skin modify this control
             if (skin != null) {
                 skin.install();
+                // TODO install skin input map
             }
 
             // calling NodeHelper.reapplyCSS() as the styleable properties may now

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/Skin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/Skin.java
@@ -26,6 +26,7 @@
 package javafx.scene.control;
 
 import javafx.scene.Node;
+import javafx.scene.control.input.SkinInputMap;
 
 /**
  * An interface for defining the visual representation of user interface controls.

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/SkinBase.java
@@ -43,6 +43,7 @@ import javafx.geometry.VPos;
 import javafx.scene.AccessibleAction;
 import javafx.scene.AccessibleAttribute;
 import javafx.scene.Node;
+import javafx.scene.control.input.SkinInputMap;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.Region;
 
@@ -161,6 +162,8 @@ public abstract class SkinBase<C extends Control> implements Skin<C> {
     /** {@inheritDoc} */
     @Override public void dispose() {
 //        control.removeEventHandler(ContextMenuEvent.CONTEXT_MENU_REQUESTED, contextMenuHandler);
+        // remove behavior handlers
+        setSkinInputMap(null);
 
         // unhook listeners
         if (lambdaChangeListenerHandler != null) {
@@ -174,7 +177,18 @@ public abstract class SkinBase<C extends Control> implements Skin<C> {
         this.control = null;
     }
 
-
+    /**
+     * Sets or removes the skin input map.
+     * Setting a non-null map adds all the event handlers to the control instance,
+     * setting a null map has an effect of removing any previously added event handlers.
+     *
+     * @param map the skin input map
+     */
+    protected final void setSkinInputMap(SkinInputMap<C> map) {
+        if (control != null) {
+            control.getInputMap().setSkinInputMap(map);
+        }
+    }
 
     /* *************************************************************************
      *                                                                         *

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TabPane.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TabPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,6 +49,7 @@ import javafx.css.CssMetaData;
 import javafx.css.PseudoClass;
 
 import javafx.css.converter.SizeConverter;
+import javafx.scene.control.input.FunctionTag;
 import javafx.scene.control.skin.TabPaneSkin;
 
 import javafx.beans.DefaultProperty;
@@ -90,6 +91,24 @@ import javafx.scene.Node;
  */
 @DefaultProperty("tabs")
 public class TabPane extends Control {
+    /** Identifiers for methods available for customization via the InputMap. */
+    public static final class Tag {
+        /** Selects the first tab. */
+        public static final FunctionTag SELECT_FIRST_TAB = new FunctionTag();
+        /** Selects the last tab. */
+        public static final FunctionTag SELECT_LAST_TAB = new FunctionTag();
+        /** Selects the left tab: previous in LTR mode, next in RTL mode. */
+        public static final FunctionTag SELECT_LEFT_TAB = new FunctionTag();
+        /** Selects the next tab. */
+        public static final FunctionTag SELECT_NEXT_TAB = new FunctionTag();
+        /** Selects the previous tab. */
+        public static final FunctionTag SELECT_PREV_TAB = new FunctionTag();
+        /** Selects the right tab: next in LTR mode, previous in RTL mode. */
+        public static final FunctionTag SELECT_RIGHT_TAB = new FunctionTag();
+
+        private Tag() { }
+    }
+
     private static final double DEFAULT_TAB_MIN_WIDTH = 0;
 
     private static final double DEFAULT_TAB_MAX_WIDTH = Double.MAX_VALUE;
@@ -166,6 +185,36 @@ public class TabPane extends Control {
      */
     public final ObservableList<Tab> getTabs() {
         return tabs;
+    }
+
+    /** Selects the first tab. */
+    public void selectFirstTab() {
+        execute(Tag.SELECT_FIRST_TAB);
+    }
+
+    /** Selects the last tab. */
+    public void selectLastTab() {
+        execute(Tag.SELECT_LAST_TAB);
+    }
+
+    /** Selects the left tab: previous in LTR mode, next in RTL mode. */
+    public void selectLeftTab() {
+        execute(Tag.SELECT_LEFT_TAB);
+    }
+
+    /** Selects the next tab. */
+    public void selectNextTab() {
+        execute(Tag.SELECT_NEXT_TAB);
+    }
+
+    /** Selects the previous tab. */
+    public void selectPreviousTab() {
+        execute(Tag.SELECT_PREV_TAB);
+    }
+
+    /** Selects the right tab: next in LTR mode, previous in RTL mode. */
+    public void selectRightTab() {
+        execute(Tag.SELECT_RIGHT_TAB);
     }
 
     /**

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TextArea.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TextArea.java
@@ -47,6 +47,7 @@ import javafx.css.StyleableProperty;
 import com.sun.javafx.collections.ListListenerHelper;
 import com.sun.javafx.collections.NonIterableChange;
 import javafx.css.converter.SizeConverter;
+import javafx.scene.control.input.FunctionTag;
 import javafx.scene.control.skin.TextAreaSkin;
 
 import javafx.css.Styleable;
@@ -81,6 +82,51 @@ import javafx.scene.AccessibleRole;
  * @since JavaFX 2.0
  */
 public class TextArea extends TextInputControl {
+    /** Denotes the function that moves the caret to the document end. */
+    public static final FunctionTag DOCUMENT_END = new FunctionTag();
+    /** Denotes the function that moves the caret to the document start. */
+    public static final FunctionTag DOCUMENT_START = new FunctionTag();
+    /** Denotes the function that moves the caret one line down. */
+    public static final FunctionTag DOWN = new FunctionTag();
+    /** Denotes the function that inserts a TAB character at the caret position. */
+    public static final FunctionTag INSERT_TAB = new FunctionTag();
+    /** Denotes the function that insert a new line at the caret position. */
+    public static final FunctionTag INSERT_NEW_LINE = new FunctionTag();
+    /** Denotes the function that moves the caret to the end of the visible line. */
+    public static final FunctionTag LINE_END = new FunctionTag();
+    /** Denotes the function that moves the caret to the start of the visible line. */
+    public static final FunctionTag LINE_START = new FunctionTag();
+    /** Denotes the function that moves the caret one paragraph down. */
+    public static final FunctionTag PARAGRAPH_DOWN = new FunctionTag();
+    /** Denotes the function that moves the caret one paragraph up. */
+    public static final FunctionTag PARAGRAPH_UP = new FunctionTag();
+    /** Denotes the function that moves the caret one page down. */
+    public static final FunctionTag PAGE_DOWN = new FunctionTag();
+    /** Denotes the function that moves the caret one page up. */
+    public static final FunctionTag PAGE_UP = new FunctionTag();
+    /** Denotes the function that moves the caret and extends selection one line down. */
+    public static final FunctionTag SELECT_DOWN = new FunctionTag();
+    /** Denotes the function that moves the caret and extends selection to the end of the current paragraph. */
+    //public static final FunctionTag SELECT_END_EXTEND = new FunctionTag();
+    /** Denotes the function that moves the caret and extends selection to the start of the current paragraph. */
+    //public static final FunctionTag SELECT_HOME_EXTEND = new FunctionTag();
+    /** Denotes the function that moves the caret and extends selection to the end of the visible line. */
+    public static final FunctionTag SELECT_LINE_END = new FunctionTag();
+    /** Denotes the function that moves the caret and extends selection to the start of the visible line. */
+    public static final FunctionTag SELECT_LINE_START = new FunctionTag();
+    /** Denotes the function that moves the caret and extends selection one page down. */
+    public static final FunctionTag SELECT_PAGE_DOWN = new FunctionTag();
+    /** Denotes the function that moves the caret and extends selection one page up. */
+    public static final FunctionTag SELECT_PAGE_UP = new FunctionTag();
+    /** Denotes the function that moves the caret and extends selection one paragraph down. */
+    public static final FunctionTag SELECT_PARAGRAPH_DOWN = new FunctionTag();
+    /** Denotes the function that moves the caret and extends selection one paragraph up. */
+    public static final FunctionTag SELECT_PARAGRAPH_UP = new FunctionTag();
+    /** Denotes the function that moves the caret and extends selection one line up. */
+    public static final FunctionTag SELECT_UP = new FunctionTag();
+    /** Denotes the function that moves the caret one line up. */
+    public static final FunctionTag UP = new FunctionTag();
+
     // Text area content model
     private static final class TextAreaContent extends ContentBase {
         private final List<StringBuilder> paragraphs = new ArrayList<>();

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TextInputControl.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TextInputControl.java
@@ -57,6 +57,7 @@ import javafx.css.StyleableObjectProperty;
 import javafx.css.StyleableProperty;
 import javafx.scene.AccessibleAction;
 import javafx.scene.AccessibleAttribute;
+import javafx.scene.control.input.FunctionTag;
 import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.text.Font;
@@ -77,6 +78,65 @@ import javafx.util.StringConverter;
  */
 @DefaultProperty("text")
 public abstract class TextInputControl extends Control {
+    /** Denotes the function that copies the content to the clipboard. */
+    public static final FunctionTag COPY = new FunctionTag();
+    /** Denotes the function that cuts the content to the clipboard. */
+    public static final FunctionTag CUT = new FunctionTag();
+    /** Denotes the function that deletes text from the line start. */
+    public static final FunctionTag DELETE_FROM_LINE_START = new FunctionTag();
+    /** Denotes the function that deletes the next character. */
+    public static final FunctionTag DELETE_NEXT_CHAR = new FunctionTag();
+    /** Denotes the function that deletes the next word. */
+    public static final FunctionTag DELETE_NEXT_WORD = new FunctionTag();
+    /** Denotes the function that deletes the previous character. */
+    public static final FunctionTag DELETE_PREVIOUS_CHAR = new FunctionTag();
+    /** Denotes the function that deletes the previous word. */
+    public static final FunctionTag DELETE_PREVIOUS_WORD = new FunctionTag();
+    /** Denotes the function that deselects. */
+    public static final FunctionTag DESELECT = new FunctionTag();
+    /** Denotes the function that moves the caret to the document start. */
+    public static final FunctionTag DOCUMENT_START = new FunctionTag();
+    /** Denotes the function that moves the caret to the document end. */
+    public static final FunctionTag DOCUMENT_END = new FunctionTag();
+    /** Denotes the function that moves the caret one symbol left. */
+    public static final FunctionTag LEFT = new FunctionTag();
+    /** Denotes the function that moves the caret one word left. */
+    public static final FunctionTag LEFT_WORD = new FunctionTag();
+    /** Denotes the function that pastes from the clipboard. */
+    public static final FunctionTag PASTE = new FunctionTag();
+    /** Denotes the function that redoes the last undo. */
+    public static final FunctionTag REDO = new FunctionTag();
+    /** Denotes the function that moves the caret one symbol right. */
+    public static final FunctionTag RIGHT = new FunctionTag();
+    /** Denotes the function that moves the caret one word right. */
+    public static final FunctionTag RIGHT_WORD = new FunctionTag();
+    /** Denotes the function that selects all. */
+    public static final FunctionTag SELECT_ALL = new FunctionTag();
+    /** Denotes the function that selects to after the last char of text. */
+    public static final FunctionTag SELECT_END = new FunctionTag();
+    /** Denotes the function that ?? TODO how is this different from SELECT_END?. */
+    public static final FunctionTag SELECT_END_EXTEND = new FunctionTag();
+    /** Denotes the function that moves the caret and extends selection to before the first char of text. */
+    public static final FunctionTag SELECT_HOME = new FunctionTag();
+    /** Denotes the function that moves the caret and extends selection to before the first char of text. */
+    // TODO how is this different from SELECT_HOME?
+    public static final FunctionTag SELECT_HOME_EXTEND = new FunctionTag();
+    /** Denotes the function that moves the caret and extends selection one character to the left. */
+    public static final FunctionTag SELECT_LEFT = new FunctionTag();
+    /** Denotes the function that moves the caret to the beginning or end of the word to the left. */
+    // TODO explain platform-specific behavior
+    public static final FunctionTag SELECT_LEFT_WORD = new FunctionTag();
+    /** Denotes the function that moves the caret and extends selection one character to the right. */
+    public static final FunctionTag SELECT_RIGHT = new FunctionTag();
+    /** Denotes the function that moves the caret to the beginning or end of the word to the right. */
+    public static final FunctionTag SELECT_RIGHT_WORD = new FunctionTag();
+    /** Denotes the function that moves the focus to the next focusTraversable Node. */
+    public static final FunctionTag TRAVERSE_NEXT = new FunctionTag();
+    /** Denotes the function that moves the focus to the previous focusTraversable Node. */
+    public static final FunctionTag TRAVERSE_PREVIOUS = new FunctionTag();
+    /** Denotes the function that undoes the last change. */
+    public static final FunctionTag UNDO = new FunctionTag();
+
     /**
      * Interface representing a text input's content. Since it is an ObservableStringValue,
      * you can also bind to, or observe the content.
@@ -1742,5 +1802,4 @@ public abstract class TextInputControl extends Control {
             return TextInputControl.this.getAnchor();
         }
     }
-
 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/input/BehaviorBase.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/input/BehaviorBase.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package javafx.scene.control.input;
+
+import javafx.event.Event;
+import javafx.event.EventHandler;
+import javafx.event.EventType;
+import javafx.scene.control.Control;
+import javafx.scene.input.KeyCode;
+import com.sun.javafx.PlatformUtil;
+
+/**
+ * Class provides a convenient foundation for the stateful behaviors.
+ * <p>
+ * A concrete behavior implementation should do the following:
+ * <ol>
+ * <li> provide default behavior methods (one for each function tag)
+ * <li> implement {@link #populateSkinInputMap()} method, in which map control's function tags to
+ *      the behavior methods, map key bindings to the function tags, add additional event handlers, using
+ *      {@link #registerFunction(FunctionTag, FunctionHandler)},
+ *      {@link #registerKey(KeyBinding, FunctionTag)},
+ *      {@link #registerKey(KeyCode, FunctionTag)},
+ *      and
+ *      {@code addHandler()} methods correspondingly.
+ * <li> in the corresponding skin's {code Skin.install()}, set the skin input map to the control's input map.
+ * </ol>
+ * Example (in the actual skin class):
+ * <pre>{@code
+ *     @Override
+ *     public void install() {
+ *         super.install();
+ *         setSkinInputMap(behavior.getSkinInputMap());
+ *   }
+ * }</pre>
+ * @param <C> the type of the control
+ * @since 999 TODO
+ */
+public abstract class BehaviorBase<C extends Control> {
+    private final C control;
+    private SkinInputMap<C> skinInputMap;
+
+    /**
+     * The constructor.
+     * @param c the owner Control instance
+     */
+    public BehaviorBase(C c) {
+        this.control = c;
+    }
+
+    /**
+     * In this method, which is called by {@link javafx.scene.control.Skin#install()},
+     * the child class populates the {@code SkinInputMap}
+     * by registering key mappings and event handlers.
+     * <p>
+     * If a subclass overrides this method, it is important to call the superclass implementation.
+     */
+    protected abstract void populateSkinInputMap();
+
+    /**
+     * Returns the associated Control instance.
+     * @return the owner
+     */
+    protected final C getControl() {
+        return control;
+    }
+
+    /**
+     * Returns the skin input map associated with this behavior.
+     * @return the input map
+     */
+    public final SkinInputMap<C> getSkinInputMap() {
+        if (skinInputMap == null) {
+            this.skinInputMap = new SkinInputMap<>();
+            populateSkinInputMap();
+        }
+        return skinInputMap;
+    }
+
+    /**
+     * Maps a function to the specified function tag.
+     * This method will not override any previous mapping added by
+     * {@link #registerFunction(FunctionTag, FunctionHandler)}.
+     *
+     * @param tag the function tag
+     * @param function the function
+     */
+    protected void registerFunction(FunctionTag tag, FunctionHandler<C> function) {
+        getSkinInputMap().registerFunction(tag, function);
+    }
+
+    /**
+     * Maps a key binding to the specified function tag.
+     * A null key binding will result in no change to this input map.
+     * This method will not override a user mapping.
+     *
+     * @param k the key binding
+     * @param tag the function tag
+     */
+    protected void registerKey(KeyBinding k, FunctionTag tag) {
+        getSkinInputMap().registerKey(k, tag);
+    }
+
+    /**
+     * Maps a key binding to the specified function tag.
+     * This method will not override a user mapping added by {@link #registerKey(KeyBinding,FunctionTag)}.
+     *
+     * @param code the key code to construct a {@link KeyBinding}
+     * @param tag the function tag
+     */
+    protected void registerKey(KeyCode code, FunctionTag tag) {
+        getSkinInputMap().registerKey(code, tag);
+    }
+
+    /**
+     * This convenience method maps the function tag to the specified function, and at the same time
+     * maps the specified key binding to that function tag.
+     * @param tag the function tag
+     * @param k the key binding
+     * @param func the function
+     */
+    protected void register(FunctionTag tag, KeyBinding k, FunctionHandler<C> func) {
+        getSkinInputMap().registerFunction(tag, func);
+        getSkinInputMap().registerKey(k, tag);
+    }
+
+    /**
+     * This convenience method maps the function tag to the specified function, and at the same time
+     * maps the specified key binding to that function tag.
+     * @param tag the function tag
+     * @param code the key code
+     * @param func the function
+     */
+    protected void register(FunctionTag tag, KeyCode code, FunctionHandler<C> func) {
+        getSkinInputMap().registerFunction(tag, func);
+        getSkinInputMap().registerKey(KeyBinding.of(code), tag);
+    }
+
+    /**
+     * This convenience method registers a copy of the behavior-specific mappings from one key binding to another.
+     * The method does nothing if no behavior specific mapping can be found.
+     * @param existing the existing key binding
+     * @param newk the new key binding
+     */
+    protected void duplicateMapping(KeyBinding existing, KeyBinding newk) {
+        getSkinInputMap().duplicateMapping(existing, newk);
+    }
+
+    /**
+     * Adds an event handler for the specified event type, in the context of this Behavior.
+     *
+     * @param <T> the actual event type
+     * @param type the event type
+     * @param consume determines whether the matching event is consumed or not
+     * @param handler the event handler
+     */
+    protected <T extends Event> void addHandler(EventType<T> type, boolean consume, EventHandler<T> handler) {
+        getSkinInputMap().addHandler(type, consume, handler);
+    }
+
+    /**
+     * Adds an event handler for the specified event type, in the context of this Behavior.
+     * This event handler will get invoked after all handlers added via map() methods.
+     *
+     * @param <T> the actual event type
+     * @param type the event type
+     * @param consume determines whether the matching event is consumed or not
+     * @param handler the event handler
+     */
+    protected <T extends Event> void addHandlerLast(EventType<T> type, boolean consume, EventHandler<T> handler) {
+        getSkinInputMap().addHandler(type, consume, handler);
+    }
+
+    /**
+     * Adds an event handler for the specific event criteria, in the context of this Behavior.
+     * This is a more specific version of {@link #addHandler(EventType,boolean,EventHandler)} method.
+     *
+     * @param <T> the actual event type
+     * @param criteria the matching criteria
+     * @param consume determines whether the matching event is consumed or not
+     * @param handler the event handler
+     */
+    protected <T extends Event> void addHandler(EventCriteria<T> criteria, boolean consume, EventHandler<T> handler) {
+        getSkinInputMap().addHandler(criteria, consume, handler);
+    }
+
+    /**
+     * Adds an event handler for the specific event criteria, in the context of this Behavior.
+     * This event handler will get invoked after all handlers added via map() methods.
+     *
+     * @param <T> the actual event type
+     * @param criteria the matching criteria
+     * @param consume determines whether the matching event is consumed or not
+     * @param h the event handler
+     */
+    protected <T extends Event> void addHandlerLast(EventCriteria<T> criteria, boolean consume, EventHandler<T> h) {
+        getSkinInputMap().addHandler(criteria, consume, h);
+    }
+
+    /**
+     * Returns true if this method is invoked on a Linux platform.
+     * @return true on a Linux platform
+     */
+    protected boolean isLinux() {
+        return PlatformUtil.isLinux();
+    }
+
+    /**
+     * Returns true if this method is invoked on a Mac OS platform.
+     * @return true on a Mac OS platform
+     */
+    protected boolean isMac() {
+        return PlatformUtil.isMac();
+    }
+
+    /**
+     * Returns true if this method is invoked on a Windows platform.
+     * @return true on a Windows platform
+     */
+    protected boolean isWindows() {
+        return PlatformUtil.isWindows();
+    }
+}

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/input/EventCriteria.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/input/EventCriteria.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,31 +22,28 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+package javafx.scene.control.input;
+
+import javafx.event.Event;
+import javafx.event.EventType;
 
 /**
- * Defines the UI controls, charts, and skins that are available
- * for the JavaFX UI toolkit.
+ * Determines whether an event passes certain criteria.
  *
- * @moduleGraph
- * @since 9
+ * @param <T> the type of the event
+ * @since 999 TODO
  */
-module javafx.controls {
-    requires transitive javafx.base;
-    requires transitive javafx.graphics;
+public interface EventCriteria<T extends Event> {
+    /**
+     * Returns the event type for which this criteria are valid.
+     * @return the event type
+     */
+    public EventType<T> getEventType();
 
-    exports javafx.scene.chart;
-    exports javafx.scene.control;
-    exports javafx.scene.control.cell;
-    exports javafx.scene.control.input;
-    exports javafx.scene.control.skin;
-
-    exports com.sun.javafx.scene.control to
-        javafx.web;
-    exports com.sun.javafx.scene.control.behavior to
-        javafx.web;
-    exports com.sun.javafx.scene.control.inputmap to
-        javafx.web;
-    exports com.sun.javafx.scene.control.skin to
-        javafx.graphics,
-        javafx.web;
+    /**
+     * Returns true if the specified event matches this criteria.
+     * @param ev the event
+     * @return true if match occurs
+     */
+    public boolean isEventAcceptable(T ev);
 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/input/FunctionHandler.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/input/FunctionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,31 +22,33 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+package javafx.scene.control.input;
+
+import javafx.event.Event;
+import javafx.scene.control.Skinnable;
 
 /**
- * Defines the UI controls, charts, and skins that are available
- * for the JavaFX UI toolkit.
+ * A functional interface which denotes code associated with a {@code FunctionTag} or a key binding.
  *
- * @moduleGraph
- * @since 9
+ * @param <C> the type of the skinnable
+ * @since 999 TODO
  */
-module javafx.controls {
-    requires transitive javafx.base;
-    requires transitive javafx.graphics;
+@FunctionalInterface
+public interface FunctionHandler<C extends Skinnable> {
+    /**
+     * Handles the event associated with a function tag or a key binding.
+     * @param control the control instance
+     */
+    public void handle(C control);
 
-    exports javafx.scene.chart;
-    exports javafx.scene.control;
-    exports javafx.scene.control.cell;
-    exports javafx.scene.control.input;
-    exports javafx.scene.control.skin;
-
-    exports com.sun.javafx.scene.control to
-        javafx.web;
-    exports com.sun.javafx.scene.control.behavior to
-        javafx.web;
-    exports com.sun.javafx.scene.control.inputmap to
-        javafx.web;
-    exports com.sun.javafx.scene.control.skin to
-        javafx.graphics,
-        javafx.web;
+    /**
+     * This method is called by the InputMap when handling the corresponding KeyEvent.
+     * Implementors may override this method to conditionally consume the event.
+     * @param ev the event
+     * @param control the control instance
+     */
+    public default void handleKeyBinding(Event ev, C control) {
+        handle(control);
+        ev.consume();
+    }
 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/input/FunctionHandlerConditional.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/input/FunctionHandlerConditional.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,31 +22,24 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
+package javafx.scene.control.input;
+
+import javafx.scene.control.Skinnable;
 
 /**
- * Defines the UI controls, charts, and skins that are available
- * for the JavaFX UI toolkit.
+ * A functional interface which denotes code associated with a {@code FunctionTag} or a key binding.
+ * Unlike {@link FunctionHandler}, this handler allows for controlling whether the matching KeyEvent
+ * will be consumed or not.
  *
- * @moduleGraph
- * @since 9
+ * @param <C> the type of the skinnable
+ * @since 999 TODO
  */
-module javafx.controls {
-    requires transitive javafx.base;
-    requires transitive javafx.graphics;
-
-    exports javafx.scene.chart;
-    exports javafx.scene.control;
-    exports javafx.scene.control.cell;
-    exports javafx.scene.control.input;
-    exports javafx.scene.control.skin;
-
-    exports com.sun.javafx.scene.control to
-        javafx.web;
-    exports com.sun.javafx.scene.control.behavior to
-        javafx.web;
-    exports com.sun.javafx.scene.control.inputmap to
-        javafx.web;
-    exports com.sun.javafx.scene.control.skin to
-        javafx.graphics,
-        javafx.web;
+@FunctionalInterface
+public interface FunctionHandlerConditional<C extends Skinnable> {
+    /**
+     * Handles the event associated with a function tag or a key binding.
+     * @param control the control instance
+     * @return true to consume the key event, false otherwise
+     */
+    public boolean handle(C control);
 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/input/FunctionTag.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/input/FunctionTag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,30 +23,15 @@
  * questions.
  */
 
+package javafx.scene.control.input;
+
 /**
- * Defines the UI controls, charts, and skins that are available
- * for the JavaFX UI toolkit.
+ * A function tag is a public handle for a function in the context of InputMap.
  *
- * @moduleGraph
- * @since 9
+ * @since 999 TODO
  */
-module javafx.controls {
-    requires transitive javafx.base;
-    requires transitive javafx.graphics;
-
-    exports javafx.scene.chart;
-    exports javafx.scene.control;
-    exports javafx.scene.control.cell;
-    exports javafx.scene.control.input;
-    exports javafx.scene.control.skin;
-
-    exports com.sun.javafx.scene.control to
-        javafx.web;
-    exports com.sun.javafx.scene.control.behavior to
-        javafx.web;
-    exports com.sun.javafx.scene.control.inputmap to
-        javafx.web;
-    exports com.sun.javafx.scene.control.skin to
-        javafx.graphics,
-        javafx.web;
+public final class FunctionTag {
+    /** Constructs the function tag. */
+    public FunctionTag() {
+    }
 }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/input/InputMap.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/input/InputMap.java
@@ -1,0 +1,458 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package javafx.scene.control.input;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.BooleanSupplier;
+import javafx.event.Event;
+import javafx.event.EventHandler;
+import javafx.event.EventType;
+import javafx.scene.control.Control;
+import javafx.scene.control.Skin;
+import javafx.scene.control.SkinBase;
+import javafx.scene.control.Skinnable;
+import javafx.scene.input.KeyEvent;
+import com.sun.javafx.scene.control.input.EventHandlerPriority;
+import com.sun.javafx.scene.control.input.KeyEventMapper;
+import com.sun.javafx.scene.control.input.PHList;
+
+/**
+ * InputMap is a class that is set on a given {@link Control}. When the Node receives
+ * an input event from the system, it passes this event in to the InputMap where
+ * the InputMap can check all installed mappings to see if there is any
+ * suitable mapping, and if so, fire the provided {@link EventHandler}.
+ *
+ * @since 999 TODO
+ */
+public final class InputMap {
+    private static final Object NULL = new Object();
+    private final Control control;
+    // KeyBinding -> FunctionTag or FunctionHandler
+    // FunctionTag -> FunctionHandler
+    // EventType -> PHList
+    private final HashMap<Object,Object> map = new HashMap<>();
+    private SkinInputMap skinInputMap;
+    private final KeyEventMapper kmapper = new KeyEventMapper();
+    private final EventHandler<Event> eventHandler = this::handleEvent;
+
+    /**
+     * The constructor.
+     * @param control the owner control
+     */
+    public InputMap(Control control) {
+        this.control = control;
+    }
+
+    /**
+     * Adds an event handler for the specified event type, at the control level.
+     * This mapping always consumes the matching event.
+     *
+     * @param <T> the actual event type
+     * @param type the event type
+     * @param handler the event handler
+     */
+    public <T extends Event> void addHandler(EventType<T> type, EventHandler<T> handler) {
+        extendHandler(type, handler, EventHandlerPriority.USER_HIGH);
+    }
+
+    /**
+     * Adds an event handler for the specified event type, at the control level.
+     * This event handler will get invoked after all handlers added via map() methods.
+     * This mapping always consumes the matching event.
+     *
+     * @param <T> the actual event type
+     * @param type the event type
+     * @param handler the event handler
+     */
+    public <T extends Event> void addHandlerLast(EventType<T> type, EventHandler<T> handler) {
+        extendHandler(type, handler, EventHandlerPriority.USER_LOW);
+    }
+
+    /**
+     * Removes the specified handler.
+     *
+     * @param <T> the event class
+     * @param type the event type
+     * @param handler the handler to remove
+     */
+    public <T extends Event> void removeHandler(EventType<T> type, EventHandler<T> handler) {
+        Object x = map.get(type);
+        if (x instanceof PHList hs) {
+            if (hs.remove(handler)) {
+                map.remove(type);
+                control.removeEventHandler(type, eventHandler);
+            }
+        }
+    }
+    
+    private <T extends Event> void removeHandler(EventType<T> type, EventHandlerPriority pri) {
+        Object x = map.get(type);
+        if (x instanceof PHList hs) {
+            if (hs.removeHandlers(Set.of(pri))) {
+                map.remove(type);
+                control.removeEventHandler(type, eventHandler);
+            }
+        }
+    }
+
+    private <T extends Event> void extendHandler(EventType<T> t, EventHandler<T> handler, EventHandlerPriority pri) {
+        Object x = map.get(t);
+        PHList hs;
+        if(x instanceof PHList h) {
+            hs = h;
+        } else {
+            // first entry for this event type
+            hs = new PHList();
+            map.put(t, hs);
+            control.addEventHandler(t, eventHandler);
+        }
+        
+        hs.add(pri, handler);
+    }
+
+    private void handleEvent(Event ev) {
+        // probably unnecessary
+        if (ev == null || ev.isConsumed()) {
+            return;
+        }
+
+        EventType<?> t = ev.getEventType();
+        Object x = map.get(t);
+        if (x instanceof PHList hs) {
+            hs.forEach((pri, h) -> {
+                if (h == null) {
+                    handleKeyBindingEvent(ev);
+                } else {
+                    h.handle(ev);
+                }
+                return !ev.isConsumed();
+            });
+        }
+    }
+
+    private void handleKeyBindingEvent(Event ev) {
+        // probably unnecessary
+        if (ev == null || ev.isConsumed()) {
+            return;
+        }
+
+        KeyBinding k = KeyBinding.from((KeyEvent)ev);
+        if (k != null) {
+            FunctionHandler f = getFunction(k);
+            if (f != null) {
+                f.handleKeyBinding(ev, control);
+            }
+        }
+    }
+
+    static <C extends Skinnable> FunctionHandler<C> toFunctionHandler(FunctionHandlerConditional<C> h) {
+        return new FunctionHandler<C>() {
+            @Override
+            public void handle(C control) {
+                boolean consume = h.handle(control);
+            }
+
+            @Override
+            public void handleKeyBinding(Event ev, C control) {
+                boolean consume = h.handle(control);
+                if (consume) {
+                    ev.consume();
+                }
+            }
+        };
+    }
+
+    /**
+     * Registers a function for the given key binding.  This mapping will  take precedence
+     * over any such mapping set by the skin.
+     * @param <C> the skinnable type
+     * @param k the key binding
+     * @param function the function
+     */
+    public <C extends Skinnable> void register(KeyBinding k, FunctionHandler<C> function) {
+        Objects.requireNonNull(k, "key binding must not be null");
+        Objects.requireNonNull(function, "function must not be null");
+        map.put(k, function);
+    }
+
+    /**
+     * Adds (or overrides) a user-specified function under the given function tag.
+     * This function will take precedence over any function set by the skin.
+     *
+     * @param <C> the skinnable type
+     * @param tag the function tag
+     * @param function the function
+     */
+    public <C extends Skinnable> void registerFunction(FunctionTag tag, FunctionHandler<C> function) {
+        Objects.requireNonNull(tag, "function tag must not be null");
+        Objects.requireNonNull(function, "function must not be null");
+        map.put(tag, function);
+    }
+
+    /**
+     * Adds (or overrides) a user-specified function under the given function tag.
+     * This function will take precedence over any function set by the skin.
+     * This method allows for controlling whether the matching event will be consumed or not.
+     *
+     * @param <C> the skinnable type
+     * @param tag the function tag
+     * @param function the function
+     */
+    public <C extends Skinnable> void registerFunctionCond(FunctionTag tag, FunctionHandlerConditional<C> function) {
+        Objects.requireNonNull(tag, "function tag must not be null");
+        Objects.requireNonNull(function, "function must not be null");
+        map.put(tag, toFunctionHandler(function));
+    }
+
+    /**
+     * Link a key binding to the specified function tag.
+     * When the key binding matches the input event, the function is executed, the event is consumed,
+     * and the process of dispatching is stopped.
+     * <p>
+     * This method will take precedence over any function set by the skin.
+     *
+     * @param k the key binding
+     * @param tag the function tag
+     */
+    public void registerKey(KeyBinding k, FunctionTag tag) {
+        Objects.requireNonNull(k, "KeyBinding must not be null");
+        Objects.requireNonNull(tag, "function tag must not be null");
+        map.put(k, tag);
+
+        EventType<KeyEvent> t = kmapper.addType(k);
+        extendHandler(t, null, EventHandlerPriority.USER_KB);
+    }
+
+    /**
+     * Returns a {@code FunctionHandler} mapped to the specified function tag, or null if no such mapping exists.
+     *
+     * @param <C> the skinnable type
+     * @param tag the function tag
+     * @return the function, or null
+     */
+    public <C extends Skinnable> FunctionHandler<C> getFunction(FunctionTag tag) {
+        Object x = map.get(tag);
+        // TODO check for NULL?
+        if (x instanceof FunctionHandler r) {
+            return r;
+        } else if (skinInputMap != null) {
+            return skinInputMap.getFunction(tag);
+        }
+        return null;
+    }
+
+    /**
+     * Returns a default {@code FunctionHandler} mapped to the specified function tag, or null if no such mapping exists.
+     *
+     * @implNote the return value might be a lambda, i.e. it will return a new instance each time this method is called.
+     *
+     * @param <C> the skinnable type
+     * @param tag the function tag
+     * @return the function, or null
+     */
+    public <C extends Skinnable> FunctionHandler<C> getDefaultFunction(FunctionTag tag) {
+        if (skinInputMap != null) {
+            return skinInputMap.getFunction(tag);
+        }
+        return null;
+    }
+
+    /**
+     * Returns a {@code FunctionHandler} mapped to the specified {@link KeyBinding},
+     * or null if no such mapping exists.
+     *
+     * @param <C> the skinnable type
+     * @param k the key binding
+     * @return the function, or null
+     */
+    public <C extends Skinnable> FunctionHandler<C> getFunction(KeyBinding k) {
+        Object x = resolve(k);
+        if (x instanceof FunctionTag tag) {
+            return getFunction(tag);
+        } else if (x instanceof FunctionHandler h) {
+            return h;
+        }
+        return null;
+    }
+
+    private Object resolve(KeyBinding k) {
+        Object x = map.get(k);
+        if (x != null) {
+            return x;
+        }
+        if (skinInputMap != null) {
+            return skinInputMap.resolve(k);
+        }
+        return null;
+    }
+
+    /**
+     * Unbinds the specified key binding.
+     *
+     * @param k the key binding
+     */
+    public void unbind(KeyBinding k) {
+        map.put(k, NULL);
+    }
+
+    /**
+     * Reverts all the key bindings set by user.
+     * This method restores key bindings set by the skin which were overwritten by the user.
+     */
+    public void resetKeyBindings() {
+        Iterator<Map.Entry<Object, Object>> it = map.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<Object, Object> me = it.next();
+            if (me.getKey() instanceof KeyBinding) {
+                it.remove();
+            }
+        }
+    }
+
+    /**
+     * Restores the specified key binding to the value set by the behavior, if any.
+     *
+     * @param k the key binding
+     */
+    public void restoreDefaultKeyBinding(KeyBinding k) {
+        Object x = map.get(k);
+        if (x != null) {
+            map.remove(k);
+        }
+    }
+
+    /**
+     * Restores the specified function tag to the value set by the behavior, if any.
+     *
+     * @param tag the function tag
+     */
+    public void restoreDefaultFunction(FunctionTag tag) {
+        Objects.requireNonNull(tag, "function tag must not be null");
+        map.remove(tag);
+    }
+
+    /**
+     * Collects all mapped key bindings (set either by the user or the behavior).
+     * @return the set of key bindings
+     */
+    public Set<KeyBinding> getKeyBindings() {
+        return collectKeyBindings(null);
+    }
+
+    /**
+     * Returns the set of key bindings mapped to the specified function tag.
+     * @param tag the function tag
+     * @return the set of KeyBindings, non-null
+     */
+    public Set<KeyBinding> getKeyBindingsFor(FunctionTag tag) {
+        return collectKeyBindings(tag);
+    }
+
+    private Set<KeyBinding> collectKeyBindings(FunctionTag tag) {
+        HashSet<KeyBinding> bindings = new HashSet<>();
+        for (Map.Entry<Object, Object> en : map.entrySet()) {
+            if (en.getKey() instanceof KeyBinding k) {
+                if ((tag == null) || (tag == en.getValue())) {
+                    bindings.add(k);
+                }
+            }
+        }
+
+        if (skinInputMap != null) {
+            skinInputMap.collectKeyBindings(bindings, tag);
+        }
+        return bindings;
+    }
+
+    /**
+     * Removes all the key bindings mapped to the specified function tag, either by the application or by the skin.
+     * This is an irreversible operation.
+     * @param tag the function tag
+     */
+    // TODO this should not affect the skin input map, but perhaps place NULL for each found KeyBinding
+    public void unbind(FunctionTag tag) {
+        if (skinInputMap != null) {
+            skinInputMap.unbind(tag);
+        }
+        Iterator<Map.Entry<Object, Object>> it = map.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<Object, Object> en = it.next();
+            if (tag == en.getValue()) {
+                // the entry must be KeyBinding -> FunctionTag
+                it.remove();
+            }
+        }
+    }
+
+    /**
+     * Sets the skin input map, adding necessary event handlers to the control instance when required.
+     * This method must be called by the skin only from its {@link Skin#install()} or
+     * {@link SkinBase#setSkinInputMap(SkinInputMap)} method.
+     * <p>
+     * This method removes all the mappings from the previous skin input map, if any.
+     * @param m the skin input map
+     */
+    public void setSkinInputMap(SkinInputMap m) {
+        if (skinInputMap != null) {
+            // uninstall all handlers with SKIN_* priority
+            Iterator<Map.Entry<Object, Object>> it = map.entrySet().iterator();
+            while (it.hasNext()) {
+                Map.Entry<Object, Object> en = it.next();
+                if (en.getKey() instanceof EventType t) {
+                    PHList hs = (PHList)en.getValue();
+                    if (hs.removeHandlers(EventHandlerPriority.ALL_SKIN)) {
+                        it.remove();
+                        control.removeEventHandler(t, eventHandler);
+                    }
+                }
+            }
+        }
+
+        skinInputMap = m;
+
+        if (skinInputMap != null) {
+            // install skin handlers with their priority
+            skinInputMap.forEach((type, pri, h) -> {
+                extendHandler(type, h, pri);
+            });
+
+            // add key bindings listeners if needed
+            if (!kmapper.hasKeyPressed() && skinInputMap.kmapper.hasKeyPressed()) {
+                extendHandler(KeyEvent.KEY_PRESSED, null, EventHandlerPriority.SKIN_KB);
+            }
+            if (!kmapper.hasKeyReleased() && skinInputMap.kmapper.hasKeyReleased()) {
+                extendHandler(KeyEvent.KEY_RELEASED, null, EventHandlerPriority.SKIN_KB);
+            }
+            if (!kmapper.hasKeyTyped() && skinInputMap.kmapper.hasKeyTyped()) {
+                extendHandler(KeyEvent.KEY_TYPED, null, EventHandlerPriority.SKIN_KB);
+            }
+        }
+    }
+}

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/input/KeyBinding.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/input/KeyBinding.java
@@ -1,0 +1,722 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package javafx.scene.control.input;
+
+import java.util.EnumSet;
+import java.util.Objects;
+import javafx.event.EventType;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import com.sun.javafx.PlatformUtil;
+
+/**
+ * Key binding provides a way to map key event to a hash table key for easy matching.
+ *
+ * @since 999 TODO
+ */
+public class KeyBinding implements EventCriteria<KeyEvent> {
+    /**
+     * Condition used to build input key mappings.
+     * <p>
+     * The KCondition values are used as keys in a hash table, so when the platform sends a key event with multiple
+     * modifiers, some modifiers are dropped in order to make the final key binding to function lookup unambiguous.
+     * <p>
+     * The mapping is as follows:
+     * <pre>
+     * KCondition    Mac         Windows/Linux
+     * ALT           OPTION      ALT
+     * COMMAND       COMMAND     (ignored)
+     * CTRL          CTRL        CTRL
+     * META          COMMAND     META
+     * OPTION        OPTION      (ignored)
+     * SHIFT         SHIFT       SHIFT
+     * SHORTCUT      COMMAND     CTRL
+     * WINDOWS       (ignored)   META
+     * </pre>
+     */
+    private enum KCondition {
+        // modifier keys
+        /** ALT modifier, mapped to OPTION on Mac, ALT on Windows/Linux */
+        ALT,
+        /** COMMAND modifier, mapped to COMMAND on Mac only */
+        COMMAND,
+        /** CTRL modifier */
+        CTRL,
+        /** META modifier, mapped to COMMAND on Mac, META on Windows/Linux */
+        META,
+        /** OPTION modifier, mapped to OPTION on Mac only */
+        OPTION,
+        /** SHIFT modifier */
+        SHIFT,
+        /** SHORTCUT modifier, mapped to COMMAND on Mac, CTRL on Windows/Linux */
+        SHORTCUT,
+        /** Windows key modifier (⊞), mapped to WINDOWS on Windows only */
+        WINDOWS,
+
+        // event types
+        /** a key pressed event */
+        KEY_PRESSED,
+        /** a key released event */
+        KEY_RELEASED,
+        /** a key typed event */
+        KEY_TYPED,
+    }
+
+    private final Object key; // KeyCode or String
+    private final EnumSet<KCondition> modifiers;
+
+    private KeyBinding(Object key, EnumSet<KCondition> modifiers) {
+        this.key = key;
+        this.modifiers = modifiers;
+    }
+
+    /**
+     * Utility method creates a KeyBinding corresponding to a key press.
+     *
+     * @param code the key code
+     * @return the KeyBinding
+     */
+    public static KeyBinding of(KeyCode code) {
+        return create(code, KCondition.KEY_PRESSED);
+    }
+
+    /**
+     * Utility method creates a KeyBinding corresponding to a command-code key press.
+     *
+     * @param code the key code
+     * @return the KeyBinding
+     */
+    public static KeyBinding command(KeyCode code) {
+        return create(code, KCondition.KEY_PRESSED, KCondition.COMMAND);
+    }
+
+    /**
+     * Utility method creates a KeyBinding corresponding to a alt-code key press.
+     *
+     * @param code the key code
+     * @return the KeyBinding
+     */
+    public static KeyBinding alt(KeyCode code) {
+        return create(code, KCondition.KEY_PRESSED, KCondition.ALT);
+    }
+
+    /**
+     * Utility method creates a KeyBinding corresponding to a ctrl-code key press.
+     *
+     * @param code the key code
+     * @return the KeyBinding
+     */
+    public static KeyBinding ctrl(KeyCode code) {
+        return create(code, KCondition.KEY_PRESSED, KCondition.CTRL);
+    }
+
+    /**
+     * Utility method creates a KeyBinding corresponding to a ctrl-shift-code key press.
+     *
+     * @param code the key code
+     * @return the KeyBinding
+     */
+    public static KeyBinding ctrlShift(KeyCode code) {
+        return create(code, KCondition.KEY_PRESSED, KCondition.CTRL, KCondition.SHIFT);
+    }
+
+    /**
+     * Utility method creates a KeyBinding corresponding to a shift-code key press.
+     *
+     * @param code the key code
+     * @return the KeyBinding
+     */
+    public static KeyBinding shift(KeyCode code) {
+        return create(code, KCondition.KEY_PRESSED, KCondition.SHIFT);
+    }
+
+    /**
+     * Utility method creates a KeyBinding corresponding to a shortcut-code key press.
+     *
+     * @param code the key code
+     * @return the KeyBinding
+     */
+    public static KeyBinding shortcut(KeyCode code) {
+        return create(code, KCondition.KEY_PRESSED, KCondition.SHORTCUT);
+    }
+
+    private static KeyBinding create(Object key, KCondition... mods) {
+        return new Builder(key).init(mods).build();
+    }
+
+    /**
+     * Determines whether this key binding if for the key pressed event.
+     * @return true if this key binding if for the key press event
+     */
+    public boolean isKeyPressed() {
+        return modifiers.contains(KCondition.KEY_PRESSED);
+    }
+
+    /**
+     * Determines whether this key binding if for the key released event.
+     * @return true if this key binding if for the key release event
+     */
+    public boolean isKeyReleased() {
+        return modifiers.contains(KCondition.KEY_RELEASED);
+    }
+
+    /**
+     * Determines whether this key binding if for the key typed event.
+     * @return true if this key binding if for the key typed event
+     */
+    public boolean isKeyTyped() {
+        return modifiers.contains(KCondition.KEY_TYPED);
+    }
+
+    /**
+     * Determines whether {@code shortcut} key is down in this key binding.
+     * @return true if {@code shortcut} key is down in this key binding
+     */
+    public boolean isShortcut() {
+        if (PlatformUtil.isMac()) {
+            return modifiers.contains(KCondition.COMMAND);
+        }
+        return modifiers.contains(KCondition.CTRL);
+    }
+
+    /**
+     * Determines whether {@code alt} key is down in this key binding.
+     * @return true if {@code alt} key is down in this key binding
+     */
+    public boolean isAlt() {
+        return modifiers.contains(KCondition.ALT);
+    }
+
+    /**
+     * Determines whether {@code control} key is down in this key binding.
+     * @return true if {@code control} key is down in this key binding
+     */
+    public boolean isCtrl() {
+        return modifiers.contains(KCondition.CTRL);
+    }
+
+    /**
+     * Determines whether {@code control} key is down in this key binding.
+     * Applies to macOS platform only.
+     * @return true if {@code control} key is down in this key binding
+     */
+    public boolean isCommand() {
+        return modifiers.contains(KCondition.COMMAND);
+    }
+
+    /**
+     * Determines whether {@code meta} key is down in this key binding.
+     * @return true if {@code meta} key is down in this key binding
+     */
+    public boolean isMeta() {
+        return modifiers.contains(KCondition.META);
+    }
+
+    /**
+     * Determines whether {@code option} key is down in this key binding.
+     * Applies to macOS only.
+     * @return true if {@code option} key is down in this key binding
+     */
+    public boolean isOption() {
+        return modifiers.contains(KCondition.OPTION);
+    }
+
+    /**
+     * Determines whether {@code shift} key is down in this key binding.
+     * @return true if {@code shift} key is down in this key binding
+     */
+    public boolean isShift() {
+        return modifiers.contains(KCondition.SHIFT);
+    }
+
+    /**
+     * Returns a {@link KeyCode} or null if the key binding is not for a key code.
+     * @return key code
+     */
+    public KeyCode getKeyCode() {
+        if (key instanceof KeyCode c) {
+            return c;
+        }
+        return null;
+    }
+
+    /**
+     * Creates a {@link Builder} with the specified KeyCode.
+     * @param code the key code
+     * @return the Builder instance
+     */
+    public static Builder builder(KeyCode code) {
+        return new Builder(code);
+    }
+
+    /**
+     * Creates a {@link Builder} with the specified KeyCode.
+     * @param character the character
+     * @return the Builder instance
+     */
+    public static Builder builder(String character) {
+        return new Builder(character);
+    }
+
+    @Override
+    public int hashCode() {
+        int h = KeyBinding.class.hashCode();
+        h = 31 * h + key.hashCode();
+        h = 31 * h + modifiers.hashCode();
+        return h;
+    }
+
+    @Override
+    public boolean equals(Object x) {
+        if (x == this) {
+            return true;
+        } else if (x instanceof KeyBinding k) {
+            return
+                Objects.equals(key, k.key) &&
+                modifiers.equals(k.modifiers);
+        }
+        return false;
+    }
+
+    /**
+     * Creates a Builder with a key pressed event.
+     * @param c key code
+     * @return Builder instance
+     */
+    public static Builder with(KeyCode c) {
+        return builder(c);
+    }
+
+    /**
+     * Creates a Builder with a key pressed event.
+     * @param c character pressed
+     * @return Builder instance
+     */
+    public static Builder with(String c) {
+        return new Builder(c);
+    }
+
+    /**
+     * Creates a KeyBinding from a KeyEvent, or a null if the event does not correspond to a valid KeyBinding.
+     * @param ev the key event
+     * @return the key binding, or null
+     */
+    static KeyBinding from(KeyEvent ev) {
+        Object key;
+        EnumSet<KCondition> m = EnumSet.noneOf(KCondition.class);
+        EventType<KeyEvent> t = ev.getEventType();
+        if(t == KeyEvent.KEY_PRESSED) {
+            m.add(KCondition.KEY_PRESSED);
+            key = ev.getCode();
+        } else if(t == KeyEvent.KEY_RELEASED) {
+            m.add(KCondition.KEY_RELEASED);
+            key = ev.getCode();
+        } else if(t == KeyEvent.KEY_TYPED) {
+            m.add(KCondition.KEY_TYPED);
+            key = ev.getCharacter();
+        } else {
+            return null;
+        }
+
+        boolean alt = ev.isAltDown();
+        boolean ctrl = ev.isControlDown();
+        boolean meta = ev.isMetaDown();
+        boolean shortcut = ev.isShortcutDown();
+        boolean option = false;
+        boolean command = false;
+
+        boolean mac = PlatformUtil.isMac();
+        boolean win = PlatformUtil.isWindows();
+
+        // drop multiple modifiers, translating when necessary
+
+        if (mac) {
+            if (alt) {
+                alt = false;
+                option = true;
+            }
+            if (shortcut) {
+                meta = false;
+                command = true;
+            }
+        } else {
+            if (ctrl) {
+                shortcut = false;
+            }
+        }
+
+        if (alt) {
+            m.add(KCondition.ALT);
+        }
+
+        if (command) {
+            m.add(KCondition.COMMAND);
+        }
+
+        if (ctrl) {
+            m.add(KCondition.CTRL);
+        }
+
+        if (meta) {
+            m.add(KCondition.META);
+        }
+
+        if (option) {
+            m.add(KCondition.OPTION);
+        }
+
+        if (ev.isShiftDown()) {
+            m.add(KCondition.SHIFT);
+        }
+
+        KeyBinding keyBinding = new KeyBinding(key, m);
+        //System.err.println("kb=" + keyBinding + " ev=" + toString(ev)); // FIX
+        return keyBinding;
+    }
+
+    // FIX remove, debug
+//    private static String toString(KeyEvent ev) {
+//        StringBuilder sb = new StringBuilder("KeyEvent{");
+//        sb.append("type=").append(ev.getEventType());
+//        sb.append(", char=").append(ev.getCharacter());
+//
+//        String ch = ev.getCharacter();
+//        int sz = ch.length();
+//        if (sz > 0) {
+//            sb.append("(");
+//            for (int i = 0; i < ch.length(); i++) {
+//                sb.append(String.format("%02X", (int)ch.charAt(i)));
+//            }
+//            sb.append(")");
+//        }
+//
+//        sb.append(", code=").append(ev.getCode());
+//
+//        if (ev.isShiftDown()) {
+//            sb.append(", shift");
+//        }
+//        if (ev.isControlDown()) {
+//            sb.append(", control");
+//        }
+//        if (ev.isAltDown()) {
+//            sb.append(", alt");
+//        }
+//        if (ev.isMetaDown()) {
+//            sb.append(", meta");
+//        }
+//        if (ev.isShortcutDown()) {
+//            sb.append(", shortcut");
+//        }
+//
+//        return sb.append("}").toString();
+//    }
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("KeyBinding{key=");
+        sb.append(key);
+        sb.append(", modifiers=");
+        sb.append(modifiers);
+        sb.append("}");
+        return sb.toString();
+    }
+
+    /**
+     * Returns the event type for this key binding.
+     * @return KeyEvent
+     */
+    @Override
+    public EventType<KeyEvent> getEventType() {
+        if (isKeyPressed()) {
+            return KeyEvent.KEY_PRESSED;
+        } else if (isKeyReleased()) {
+            return KeyEvent.KEY_RELEASED;
+        } else {
+            return KeyEvent.KEY_TYPED;
+        }
+    }
+
+    @Override
+    public boolean isEventAcceptable(KeyEvent ev) {
+        return equals(KeyBinding.from(ev));
+    }
+
+    /** Key bindings builder */
+    public static class Builder {
+        private final Object key; // KeyCode or String
+        private final EnumSet<KCondition> m = EnumSet.noneOf(KCondition.class);
+
+        /** Constructs a Builder */
+        Builder(Object key) {
+            this.key = key;
+        }
+
+        /**
+         * Sets on KEY_RELEASED condition.
+         * @return the Builder instance
+         */
+        public Builder onKeyReleased() {
+            m.remove(KCondition.KEY_PRESSED);
+            m.remove(KCondition.KEY_TYPED);
+            m.add(KCondition.KEY_RELEASED);
+            return this;
+        }
+
+        /**
+         * Sets on KEY_TYPED condition.
+         * @return the Builder instance
+         */
+        public Builder onKeyTyped() {
+            m.remove(KCondition.KEY_PRESSED);
+            m.add(KCondition.KEY_TYPED);
+            m.remove(KCondition.KEY_RELEASED);
+            return this;
+        }
+
+        /**
+         * Sets the {@code alt} key down condition (the {@code Option} key on macOS).
+         * @return this Builder
+         */
+        public Builder alt() {
+            m.add(KCondition.ALT);
+            return this;
+        }
+
+        /**
+         * Sets the {@code alt} key down condition (the {@code Option} key on macOS).
+         * @param on condition
+         * @return this Builder
+         */
+        public Builder alt(boolean on) {
+            if (on) {
+                m.add(KCondition.ALT);
+            }
+            return this;
+        }
+
+        /**
+         * Sets {@code command} key down condition.
+         * @return this Builder
+         */
+        public Builder command() {
+            m.add(KCondition.COMMAND);
+            return this;
+        }
+
+        /**
+         * Sets {@code command} key down condition.
+         * @param on condition
+         * @return this Builder
+         */
+        public Builder command(boolean on) {
+            if (on) {
+                m.add(KCondition.COMMAND);
+            }
+            return this;
+        }
+
+        /**
+         * Sets {@code control} key down condition.
+         * @return this Builder
+         */
+        public Builder ctrl() {
+            m.add(KCondition.CTRL);
+            return this;
+        }
+
+        /**
+         * Sets {@code control} key down condition.
+         * @param on condition
+         * @return this Builder
+         */
+        public Builder ctrl(boolean on) {
+            if (on) {
+                m.add(KCondition.CTRL);
+            }
+            return this;
+        }
+
+        /**
+         * Sets {@code meta} key down condition.
+         * @return this Builder
+         */
+        public Builder meta() {
+            m.add(KCondition.META);
+            return this;
+        }
+
+        /**
+         * Sets {@code meta} key down condition.
+         * @param on condition
+         * @return this Builder
+         */
+        public Builder meta(boolean on) {
+            if (on) {
+                m.add(KCondition.META);
+            }
+            return this;
+        }
+
+        /**
+         * Sets {@code option} key down condition.
+         * @return this Builder
+         */
+        public Builder option() {
+            m.add(KCondition.OPTION);
+            return this;
+        }
+
+        /**
+         * Sets {@code option} key down condition.
+         * @param on condition
+         * @return this Builder
+         */
+        public Builder option(boolean on) {
+            if (on) {
+                m.add(KCondition.OPTION);
+            }
+            return this;
+        }
+
+        /**
+         * Sets {@code shift} key down condition.
+         * @return this Builder
+         */
+        public Builder shift() {
+            m.add(KCondition.SHIFT);
+            return this;
+        }
+
+        /**
+         * Sets {@code shift} key down condition.
+         * @param on condition
+         * @return this Builder
+         */
+        public Builder shift(boolean on) {
+            if (on) {
+                m.add(KCondition.SHIFT);
+            }
+            return this;
+        }
+
+        /**
+         * Sets {@code shortcut} key down condition.
+         * @return this Builder
+         */
+        public Builder shortcut() {
+            m.add(KCondition.SHORTCUT);
+            return this;
+        }
+
+        /**
+         * Sets {@code shortcut} key down condition.
+         * @param on condition
+         * @return this Builder
+         */
+        public Builder shortcut(boolean on) {
+            if (on) {
+                m.add(KCondition.SHORTCUT);
+            }
+            return this;
+        }
+
+        private Builder init(KCondition... mods) {
+            for (KCondition c : mods) {
+                m.add(c);
+            }
+            return this;
+        }
+
+        private void replace(KCondition c, KCondition replaceWith) {
+            if (m.contains(c)) {
+                m.remove(c);
+                m.add(replaceWith);
+            }
+        }
+
+        /**
+         * Creates a new {@link KeyBinding} instance.
+         * @return a new key binding instance.
+         */
+        public KeyBinding build() {
+            boolean mac = PlatformUtil.isMac();
+            boolean win = PlatformUtil.isWindows();
+            boolean linux = PlatformUtil.isLinux();
+
+            if (mac) {
+                replace(KCondition.ALT, KCondition.OPTION);
+                replace(KCondition.META, KCondition.COMMAND);
+                replace(KCondition.SHORTCUT, KCondition.COMMAND);
+            } else if (win) {
+                replace(KCondition.SHORTCUT, KCondition.CTRL);
+            } else if (linux) {
+                replace(KCondition.SHORTCUT, KCondition.CTRL);
+            }
+
+            if (!mac) {
+                if (m.contains(KCondition.COMMAND)) {
+                    return null;
+                } else if (m.contains(KCondition.OPTION)) {
+                    return null;
+                }
+
+                replace(KCondition.WINDOWS, KCondition.META);
+            }
+
+            boolean pressed = m.contains(KCondition.KEY_PRESSED);
+            boolean released = m.contains(KCondition.KEY_RELEASED);
+            boolean typed = m.contains(KCondition.KEY_TYPED);
+
+            int ct = 0;
+            KCondition t = null;
+            if (pressed) {
+                ct++;
+                t = KCondition.KEY_PRESSED;
+            }
+            if (released) {
+                ct++;
+                t = KCondition.KEY_RELEASED;
+            }
+            if (typed) {
+                ct++;
+                t = KCondition.KEY_TYPED;
+            }
+
+            // validate event type
+            if (ct > 1) {
+                throw new IllegalArgumentException("more than one key event type is specified");
+            }
+
+            if (t == null) {
+                t = KCondition.KEY_PRESSED;
+            }
+            m.add(t);
+
+            // TODO validate: shortcut and !(other shortcut modifier)
+            return new KeyBinding(key, m);
+        }
+    }
+}

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/input/SkinInputMap.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/input/SkinInputMap.java
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package javafx.scene.control.input;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import javafx.event.Event;
+import javafx.event.EventHandler;
+import javafx.event.EventType;
+import javafx.scene.control.Skinnable;
+import javafx.scene.input.KeyCode;
+import com.sun.javafx.scene.control.input.EventHandlerPriority;
+import com.sun.javafx.scene.control.input.KeyEventMapper;
+import com.sun.javafx.scene.control.input.PHList;
+
+/**
+ * The Input Map for use by the Skin.
+ *
+ * @param <C> the control type
+ * @since 999 TODO
+ */
+public class SkinInputMap<C extends Skinnable> {
+    // KeyBinding -> FunctionTag
+    // FunctionTag -> FunctionHandler
+    // ON_KEY_ENTER/ON_KEY_EXIT -> Runnable
+    // EventType -> PHList
+    final HashMap<Object,Object> map = new HashMap<>();
+    final KeyEventMapper kmapper = new KeyEventMapper();
+
+    /**
+     * Creates a skin input map.
+     */
+    public SkinInputMap() {
+    }
+    
+    /**
+     * Adds an event handler for the specified event type, in the context of this skin.
+     *
+     * @param <T> the actual event type
+     * @param type the event type
+     * @param consume determines whether the matching event is consumed or not
+     * @param handler the event handler
+     */
+    public <T extends Event> void addHandler(EventType<T> type, boolean consume, EventHandler<T> handler) {
+        addHandler(type, consume, EventHandlerPriority.SKIN_HIGH, handler);
+    }
+
+    /**
+     * Adds an event handler for the specified event type, in the context of this skin.
+     * This event handler will get invoked after all handlers added via map() methods.
+     *
+     * @param <T> the actual event type
+     * @param type the event type
+     * @param consume determines whether the matching event is consumed or not
+     * @param handler the event handler
+     */
+    public <T extends Event> void addHandlerLast(EventType<T> type, boolean consume, EventHandler<T> handler) {
+        addHandler(type, consume, EventHandlerPriority.SKIN_LOW, handler);
+    }
+
+    /**
+     * Adds an event handler for the specific event criteria, in the context of this skin.
+     * This is a more specific version of {@link #addHandler(EventType,boolean,EventHandler)} method.
+     *
+     * @param <T> the actual event type
+     * @param criteria the matching criteria
+     * @param consume determines whether the matching event is consumed or not
+     * @param handler the event handler
+     */
+    public <T extends Event> void addHandler(EventCriteria<T> criteria, boolean consume, EventHandler<T> handler) {
+        addHandler(criteria, consume, EventHandlerPriority.SKIN_HIGH, handler);
+    }
+
+    /**
+     * Adds an event handler for the specific event criteria, in the context of this skin.
+     * This event handler will get invoked after all handlers added via map() methods.
+     *
+     * @param <T> the actual event type
+     * @param criteria the matching criteria
+     * @param consume determines whether the matching event is consumed or not
+     * @param h the event handler
+     */
+    public <T extends Event> void addHandlerLast(EventCriteria<T> criteria, boolean consume, EventHandler<T> h) {
+        addHandler(criteria, consume, EventHandlerPriority.SKIN_LOW, h);
+    }
+
+    private <T extends Event> void addHandler(
+        EventType<T> type,
+        boolean consume,
+        EventHandlerPriority pri,
+        EventHandler<T> handler)
+    {
+        if (consume) {
+            putHandler(type, pri, new EventHandler<T>() {
+                @Override
+                public void handle(T ev) {
+                    handler.handle(ev);
+                    ev.consume();
+                }
+            });
+        } else {
+            putHandler(type, pri, handler);
+        }
+    }
+
+    private <T extends Event> void addHandler(
+        EventCriteria<T> criteria,
+        boolean consume,
+        EventHandlerPriority pri,
+        EventHandler<T> handler
+    ) {
+        EventType<T> type = criteria.getEventType();
+        putHandler(type, pri, new EventHandler<T>() {
+            @Override
+            public void handle(T ev) {
+                if (criteria.isEventAcceptable(ev)) {
+                    handler.handle(ev);
+                    if (consume) {
+                        ev.consume();
+                    }
+                }
+            }
+        });
+    }
+
+    // adds the specified handler to input map with the given priority
+    // and event type.
+    private <T extends Event> void putHandler(EventType<T> type, EventHandlerPriority pri, EventHandler<T> handler)
+    {
+        Object x = map.get(type);
+        PHList hs;
+        if(x instanceof PHList h) {
+            hs = h;
+        } else {
+            hs = new PHList();
+            map.put(type, hs);
+        }
+        hs.add(pri, handler);
+    }
+
+    /**
+     * Maps a key binding to the specified function tag.
+     *
+     * @param k the key binding
+     * @param tag the function tag
+     */
+    public void registerKey(KeyBinding k, FunctionTag tag) {
+        map.put(k, tag);
+        kmapper.addType(k);
+    }
+    
+    /**
+     * Maps a key binding to the specified function tag.
+     *
+     * @param code the key code to construct a {@link KeyBinding}
+     * @param tag the function tag
+     */
+    public void registerKey(KeyCode code, FunctionTag tag) {
+        registerKey(KeyBinding.of(code), tag);
+    }
+
+    /**
+     * Maps a function to the specified function tag.
+     *
+     * @param tag the function tag
+     * @param function the function
+     */
+    public final void registerFunction(FunctionTag tag, FunctionHandler<C> function) {
+        map.put(tag, function);
+    }
+
+    /**
+     * Maps a function to the specified function tag.
+     * This method allows for controlling whether the matching event will be consumed or not.
+     *
+     * @param tag the function tag
+     * @param function the function
+     */
+    public final void registerFunction(FunctionTag tag, FunctionHandlerConditional<C> function) {
+        map.put(tag, InputMap.toFunctionHandler(function));
+    }
+    
+    /**
+     * This convenience method maps the function tag to the specified function, and at the same time
+     * maps the specified key binding to that function tag.
+     * @param tag the function tag
+     * @param k the key binding
+     * @param func the function
+     */
+    public void register(FunctionTag tag, KeyBinding k, FunctionHandler<C> func) {
+        registerFunction(tag, func);
+        registerKey(k, tag);
+    }
+
+    /**
+     * This convenience method maps the function tag to the specified function, and at the same time
+     * maps the specified key binding to that function tag.
+     * @param tag the function tag
+     * @param code the key code
+     * @param func the function
+     */
+    public void register(FunctionTag tag, KeyCode code, FunctionHandler<C> func) {
+        registerFunction(tag, func);
+        registerKey(KeyBinding.of(code), tag);
+    }
+    
+    Object resolve(KeyBinding k) {
+        return map.get(k);
+    }
+
+    /**
+     * Collects the key bindings mapped by the skin.
+     *
+     * @return a Set of key bindings
+     */
+    public Set<KeyBinding> getKeyBindings() {
+        return collectKeyBindings(null, null);
+    }
+
+    /**
+     * Returns the set of key bindings mapped to the specified function tag.
+     * @param tag the function tag
+     * @return the set of KeyBindings
+     */
+    public Set<KeyBinding> getKeyBindingsFor(FunctionTag tag) {
+        return collectKeyBindings(null, tag);
+    }
+
+    Set<KeyBinding> collectKeyBindings(Set<KeyBinding> bindings, FunctionTag tag) {
+        if (bindings == null) {
+            bindings = new HashSet<>();
+        }
+        for (Map.Entry<Object, Object> en : map.entrySet()) {
+            if (en.getKey() instanceof KeyBinding k) {
+                if ((tag == null) || (tag == en.getValue())) {
+                    bindings.add(k);
+                }
+            }
+        }
+        return bindings;
+    }
+
+    /**
+     * This convenience method registers a copy of the behavior-specific mappings from one key binding to another.
+     * The method does nothing if no behavior specific mapping can be found.
+     * @param existing the existing key binding
+     * @param newk the new key binding
+     */
+    public void duplicateMapping(KeyBinding existing, KeyBinding newk) {
+        Object x = map.get(existing);
+        if (x != null) {
+            map.put(newk, x);
+        }
+    }
+
+    final FunctionHandler<C> getFunction(FunctionTag tag) {
+        Object x = map.get(tag);
+        if (x instanceof FunctionHandler f) {
+            return f;
+        }
+        return null;
+    }
+
+    void unbind(FunctionTag tag) {
+        Iterator<Map.Entry<Object, Object>> it = map.entrySet().iterator();
+        while (it.hasNext()) {
+            Map.Entry<Object, Object> en = it.next();
+            if (tag == en.getValue()) {
+                // the entry must be KeyBinding -> FunctionTag
+                it.remove();
+            }
+        }
+    }
+
+    void forEach(TriConsumer client) {
+        for (Map.Entry<Object, Object> en : map.entrySet()) {
+            if (en.getKey() instanceof EventType type) {
+                PHList hs = (PHList)en.getValue();
+                hs.forEach((pri, h) -> {
+                    client.accept(type, pri, h);
+                    return true;
+                });
+            }
+        }
+    }
+
+    @FunctionalInterface
+    static interface TriConsumer<T extends Event> {
+        public void accept(EventType<T> type, EventHandlerPriority pri, EventHandler<T> h);
+    }
+}

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/input/package-info.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/input/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,29 +24,8 @@
  */
 
 /**
- * Defines the UI controls, charts, and skins that are available
- * for the JavaFX UI toolkit.
- *
- * @moduleGraph
- * @since 9
+ * <p>The <code>javafx.scene.control.input</code> package contains classes related
+ * to the handling of the input events by the Control: input maps, key bindings, and related classes.
+ * </p>
  */
-module javafx.controls {
-    requires transitive javafx.base;
-    requires transitive javafx.graphics;
-
-    exports javafx.scene.chart;
-    exports javafx.scene.control;
-    exports javafx.scene.control.cell;
-    exports javafx.scene.control.input;
-    exports javafx.scene.control.skin;
-
-    exports com.sun.javafx.scene.control to
-        javafx.web;
-    exports com.sun.javafx.scene.control.behavior to
-        javafx.web;
-    exports com.sun.javafx.scene.control.inputmap to
-        javafx.web;
-    exports com.sun.javafx.scene.control.skin to
-        javafx.graphics,
-        javafx.web;
-}
+package javafx.scene.control.input;

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ColorPickerSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ColorPickerSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,12 +26,10 @@
 package javafx.scene.control.skin;
 
 import static javafx.scene.paint.Color.*;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.StringProperty;
 import javafx.css.CssMetaData;
@@ -54,7 +52,6 @@ import javafx.scene.image.ImageView;
 import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
-
 import com.sun.javafx.css.StyleManager;
 import com.sun.javafx.scene.control.ListenerHelper;
 import com.sun.javafx.scene.control.Properties;
@@ -80,7 +77,6 @@ public class ColorPickerSkin extends ComboBoxPopupControl<Color> {
     private StackPane pickerColorBox;
     private Rectangle colorRect;
     private ColorPalette popupContent;
-
     private final ColorPickerBehavior behavior;
 
 
@@ -101,9 +97,6 @@ public class ColorPickerSkin extends ComboBoxPopupControl<Color> {
     public ColorPickerSkin(final ColorPicker control) {
         super(control);
 
-        // install default input map for the control
-        this.behavior = new ColorPickerBehavior(control);
-
         updateComboBoxMode();
 
         ListenerHelper.get(this).addChangeListener(control.valueProperty(), (ev) -> updateColor());
@@ -118,6 +111,8 @@ public class ColorPickerSkin extends ComboBoxPopupControl<Color> {
         pickerColorBox.getStyleClass().add("picker-color");
         colorRect = new Rectangle(12, 12);
         colorRect.getStyleClass().add("picker-color-rect");
+
+        behavior = new ColorPickerBehavior(control);
 
         updateColor();
 
@@ -259,13 +254,18 @@ public class ColorPickerSkin extends ComboBoxPopupControl<Color> {
      *                                                                         *
      **************************************************************************/
 
-    /** {@inheritDoc} */
-    @Override public void dispose() {
-        super.dispose();
+    @Override
+    public void install() {
+        super.install();
+        setSkinInputMap(behavior.getSkinInputMap());
+    }
 
+    @Override
+    public void dispose() {
         if (behavior != null) {
             behavior.dispose();
         }
+        super.dispose();
     }
 
     /** {@inheritDoc} */

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxBaseSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxBaseSkin.java
@@ -260,9 +260,7 @@ public abstract class ComboBoxBaseSkin<T> extends SkinBase<ComboBoxBase<T>> {
      *                                                                         *
      **************************************************************************/
 
-    ComboBoxBaseBehavior getBehavior() {
-        return null;
-    }
+    abstract ComboBoxBaseBehavior getBehavior();
 
     void focusLost() {
         getSkinnable().hide();

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/ComboBoxListViewSkin.java
@@ -27,7 +27,6 @@ package javafx.scene.control.skin;
 
 import java.util.List;
 import java.util.function.Supplier;
-
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.value.ObservableValue;
@@ -54,7 +53,6 @@ import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseEvent;
 import javafx.util.Callback;
 import javafx.util.StringConverter;
-
 import com.sun.javafx.scene.control.IDisconnectable;
 import com.sun.javafx.scene.control.ListenerHelper;
 import com.sun.javafx.scene.control.behavior.ComboBoxBaseBehavior;
@@ -101,7 +99,7 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
     private boolean listSelectionLock = false;
     private boolean listViewSelectionDirty = false;
 
-    private final ComboBoxListViewBehavior behavior;
+    private final ComboBoxListViewBehavior<T> behavior;
     private IDisconnectable selectedItemWatcher;
 
 
@@ -139,9 +137,6 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
     public ComboBoxListViewSkin(final ComboBox<T> control) {
         super(control);
 
-        // install default input map for the control
-        this.behavior = new ComboBoxListViewBehavior<>(control);
-
         this.comboBox = control;
         updateComboBoxItems();
 
@@ -167,6 +162,8 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
 
         // Fix for RT-19431 (also tested via ComboBoxListViewSkinTest)
         updateValue();
+
+        behavior = new ComboBoxListViewBehavior<>(control);
 
         lh.addChangeListener(control.itemsProperty(), e -> {
             updateComboBoxItems();
@@ -235,13 +232,18 @@ public class ComboBoxListViewSkin<T> extends ComboBoxPopupControl<T> {
      *                                                                         *
      **************************************************************************/
 
-    /** {@inheritDoc} */
-    @Override public void dispose() {
-        super.dispose();
+    @Override
+    public void install() {
+        super.install();
+        setSkinInputMap(behavior.getSkinInputMap());
+    }
 
+    @Override
+    public void dispose() {
         if (behavior != null) {
             behavior.dispose();
         }
+        super.dispose();
     }
 
     /** {@inheritDoc} */

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/DatePickerSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/DatePickerSkin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package javafx.scene.control.skin;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.time.chrono.HijrahChronology;
-
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.event.ActionEvent;
@@ -38,7 +37,6 @@ import javafx.scene.control.Control;
 import javafx.scene.control.DatePicker;
 import javafx.scene.control.TextField;
 import javafx.util.StringConverter;
-
 import com.sun.javafx.scene.control.DatePickerContent;
 import com.sun.javafx.scene.control.DatePickerHijrahContent;
 import com.sun.javafx.scene.control.ListenerHelper;
@@ -62,7 +60,6 @@ public class DatePickerSkin extends ComboBoxPopupControl<LocalDate> {
     private final DatePicker datePicker;
     private TextField displayNode;
     private DatePickerContent datePickerContent;
-
     private final DatePickerBehavior behavior;
 
 
@@ -84,9 +81,7 @@ public class DatePickerSkin extends ComboBoxPopupControl<LocalDate> {
         super(control);
 
         this.datePicker = control;
-
-        // install default input map for the control
-        this.behavior = new DatePickerBehavior(control);
+        behavior = new DatePickerBehavior(control);
 
         ListenerHelper lh = ListenerHelper.get(this);
 
@@ -163,13 +158,18 @@ public class DatePickerSkin extends ComboBoxPopupControl<LocalDate> {
      *                                                                         *
      **************************************************************************/
 
-    /** {@inheritDoc} */
-    @Override public void dispose() {
-        super.dispose();
+    @Override
+    public void install() {
+        super.install();
+        setSkinInputMap(behavior.getSkinInputMap());
+    }
 
+    @Override
+    public void dispose() {
         if (behavior != null) {
             behavior.dispose();
         }
+        super.dispose();
     }
 
     /** {@inheritDoc} */

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextAreaSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextAreaSkin.java
@@ -25,8 +25,6 @@
 
 package javafx.scene.control.skin;
 
-import static com.sun.javafx.PlatformUtil.isMac;
-import static com.sun.javafx.PlatformUtil.isWindows;
 import java.util.List;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
@@ -60,6 +58,7 @@ import javafx.scene.shape.PathElement;
 import javafx.scene.text.HitInfo;
 import javafx.scene.text.Text;
 import javafx.util.Duration;
+import com.sun.javafx.PlatformUtil;
 import com.sun.javafx.scene.control.behavior.TextAreaBehavior;
 import com.sun.javafx.scene.control.skin.Utils;
 /**
@@ -161,11 +160,6 @@ public class TextAreaSkin extends TextInputControlSkin<TextArea> {
     public TextAreaSkin(final TextArea control) {
         super(control);
 
-        // install default input map for the text area control
-        this.behavior = new TextAreaBehavior(control);
-        this.behavior.setTextAreaSkin(this);
-//        control.setInputMap(behavior.getInputMap());
-
         this.textArea = control;
 
         caretPosition = new IntegerBinding() {
@@ -228,6 +222,9 @@ public class TextAreaSkin extends TextInputControlSkin<TextArea> {
             }
         });
         contentView.getChildren().add(caretPath);
+
+        // instantiate, but not install, the behavior
+        behavior = new TextAreaBehavior(control, this);
 
         if (SHOW_HANDLES) {
             contentView.getChildren().addAll(caretHandle, selectionHandle1, selectionHandle2);
@@ -523,10 +520,10 @@ public class TextAreaSkin extends TextInputControlSkin<TextArea> {
                         nextLine(select);
                         break;
                     case BEGINNING:
-                        lineStart(select, select && isMac());
+                        lineStart(select, select && PlatformUtil.isMac());
                         break;
                     case END:
-                        lineEnd(select, select && isMac());
+                        lineEnd(select, select && PlatformUtil.isMac());
                         break;
                     default:
                         throw new IllegalArgumentException(""+dir);
@@ -716,7 +713,7 @@ public class TextAreaSkin extends TextInputControlSkin<TextArea> {
         int pos = textArea.getCaretPosition();
         int len = text.length();
         boolean wentPastInitialNewline = false;
-        boolean goPastTrailingNewline = isWindows();
+        boolean goPastTrailingNewline = PlatformUtil.isWindows();
 
         if (pos < len) {
             if (goPastInitialNewline && text.codePointAt(pos) == 0x0a) {
@@ -834,15 +831,23 @@ public class TextAreaSkin extends TextInputControlSkin<TextArea> {
         }
     }
 
-    /** {@inheritDoc} */
-    @Override public void dispose() {
-        if (getSkinnable() == null) return;
-        getSkinnable().removeEventFilter(ScrollEvent.ANY, scrollEventFilter);
-        getChildren().remove(scrollPane);
-        super.dispose();
+    @Override
+    public void install() {
+        super.install();
+        setSkinInputMap(behavior.getSkinInputMap());
+    }
 
-        if (behavior != null) {
-            behavior.dispose();
+    @Override
+    public void dispose() {
+        if (getSkinnable() != null) {
+            getSkinnable().removeEventFilter(ScrollEvent.ANY, scrollEventFilter);
+            getChildren().remove(scrollPane);
+
+            if (behavior != null) {
+                behavior.dispose();
+            }
+
+            super.dispose();
         }
     }
 
@@ -1020,11 +1025,6 @@ public class TextAreaSkin extends TextInputControlSkin<TextArea> {
      * Private implementation
      *
      **************************************************************************/
-
-    @Override
-    TextAreaBehavior getBehavior() {
-        return behavior;
-    }
 
     private void createPromptNode() {
         if (promptNode == null && usePromptText.get()) {

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextInputControlSkin.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TextInputControlSkin.java
@@ -31,17 +31,6 @@ import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import com.sun.javafx.PlatformUtil;
-import com.sun.javafx.scene.control.Properties;
-import com.sun.javafx.scene.control.behavior.TextInputControlBehavior;
-import com.sun.javafx.scene.control.skin.FXVK;
-import com.sun.javafx.scene.input.ExtendedInputMethodRequests;
-import com.sun.javafx.tk.FontMetrics;
-import com.sun.javafx.tk.Toolkit;
-
-import static com.sun.javafx.PlatformUtil.*;
-
 import javafx.animation.Animation.Status;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
@@ -90,6 +79,12 @@ import javafx.scene.shape.Shape;
 import javafx.scene.shape.VLineTo;
 import javafx.stage.Window;
 import javafx.util.Duration;
+import com.sun.javafx.PlatformUtil;
+import com.sun.javafx.scene.control.Properties;
+import com.sun.javafx.scene.control.skin.FXVK;
+import com.sun.javafx.scene.input.ExtendedInputMethodRequests;
+import com.sun.javafx.tk.FontMetrics;
+import com.sun.javafx.tk.Toolkit;
 
 /**
  * Abstract base class for text input skins.
@@ -236,7 +231,7 @@ public abstract class TextInputControlSkin<T extends TextInputControl> extends S
             @Override protected boolean computeValue() {
                 // RT-10682: On Windows, we show the caret during selection, but on others we hide it
                 return !blinkProperty().get() && displayCaret.get() && control.isFocused() &&
-                        (isWindows() || (control.getCaretPosition() == control.getAnchor())) &&
+                        (PlatformUtil.isWindows() || (control.getCaretPosition() == control.getAnchor())) &&
                         !control.isDisabled() &&
                         control.isEditable();
             }
@@ -826,10 +821,6 @@ public abstract class TextInputControlSkin<T extends TextInputControl> extends S
      * Private implementation
      *
      **************************************************************************/
-
-    TextInputControlBehavior getBehavior() {
-        return null;
-    }
 
     ObservableBooleanValue caretVisibleProperty() {
         return caretVisible;

--- a/modules/javafx.controls/src/test/addExports
+++ b/modules/javafx.controls/src/test/addExports
@@ -28,6 +28,7 @@
 --add-exports javafx.controls/com.sun.javafx.charts=ALL-UNNAMED
 --add-exports javafx.controls/com.sun.javafx.scene.control=ALL-UNNAMED
 --add-exports javafx.controls/com.sun.javafx.scene.control.behavior=ALL-UNNAMED
+--add-exports javafx.controls/com.sun.javafx.scene.control.input=ALL-UNNAMED
 --add-exports javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED
 --add-exports javafx.controls/com.sun.javafx.scene.control.skin=ALL-UNNAMED
 --add-opens javafx.controls/javafx.scene.control=ALL-UNNAMED

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorCleanupTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorCleanupTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,37 +25,36 @@
 
 package test.com.sun.javafx.scene.control.behavior;
 
+import static javafx.collections.FXCollections.observableArrayList;
+import static javafx.scene.control.skin.TextInputSkinShim.isCaretBlinking;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory.createBehavior;
 import java.lang.ref.WeakReference;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import com.sun.javafx.scene.control.behavior.BehaviorBase;
-import com.sun.javafx.scene.control.behavior.ListCellBehavior;
-import com.sun.javafx.scene.control.behavior.TextFieldBehavior;
-import com.sun.javafx.scene.control.inputmap.InputMap;
-import com.sun.javafx.scene.control.inputmap.KeyBinding;
-import com.sun.javafx.scene.control.inputmap.InputMap.KeyMapping;
-
-import static com.sun.javafx.scene.control.behavior.TextBehaviorShim.*;
-import static javafx.collections.FXCollections.*;
-import static javafx.scene.control.skin.TextInputSkinShim.*;
-import static org.junit.Assert.*;
-import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory.*;
-
+import java.util.Set;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Control;
+import javafx.scene.control.ControlShim;
 import javafx.scene.control.ListView;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
+import javafx.scene.control.input.KeyBinding;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import com.sun.javafx.PlatformUtil;
+import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.ListCellBehavior;
 
 /**
  * Test for misbehavior of individual implementations that turned
@@ -175,31 +174,33 @@ public class BehaviorCleanupTest {
 
 //---------- TextInputControl
 
-    @Test
-    public void testChildMapsCleared() {
-        TextField control = new TextField("some text");
-        TextFieldBehavior behavior = (TextFieldBehavior) createBehavior(control);
-        InputMap<?> inputMap = behavior.getInputMap();
-        assertFalse("sanity: inputMap has child maps", inputMap.getChildInputMaps().isEmpty());
-        behavior.dispose();
-        assertEquals("default child maps must be cleared", 0, inputMap.getChildInputMaps().size());
-    }
+//    @Test
+//    public void testChildMapsCleared() {
+//        TextField control = new TextField("some text");
+//        TextFieldBehavior behavior = (TextFieldBehavior) createBehavior(control);
+//        InputMap<?> inputMap = behavior.getInputMap();
+//        // child maps are not used anymore
+//        //assertFalse("sanity: inputMap has child maps", inputMap.getChildInputMaps().isEmpty());
+//        behavior.dispose();
+//        assertEquals("default child maps must be cleared", 0, inputMap.getChildInputMaps().size());
+//    }
 
-    @Test
-    public void testDefaultMappingsCleared() {
-        TextField control = new TextField("some text");
-        TextFieldBehavior behavior = (TextFieldBehavior) createBehavior(control);
-        InputMap<?> inputMap = behavior.getInputMap();
-        assertFalse("sanity: inputMap has mappings", inputMap.getMappings().isEmpty());
-        behavior.dispose();
-        assertEquals("default mappings must be cleared", 0, inputMap.getMappings().size());
-    }
+//    @Test
+//    public void testDefaultMappingsCleared() {
+//        TextField control = new TextField("some text");
+//        TextFieldBehavior behavior = (TextFieldBehavior) createBehavior(control);
+//        InputMap<?> inputMap = behavior.getInputMap();
+//        assertFalse("sanity: inputMap has mappings", inputMap.getMappings().isEmpty());
+//        behavior.dispose();
+//        assertEquals("default mappings must be cleared", 0, inputMap.getMappings().size());
+//    }
 
     /**
      * Sanity test: mappings to key pad keys.
      */
     @Test
     public void testKeyPadMapping() {
+        /*
         TextField control = new TextField("some text");
         TextFieldBehavior behavior = (TextFieldBehavior) createBehavior(control);
         InputMap<?> inputMap = behavior.getInputMap();
@@ -209,11 +210,28 @@ public class BehaviorCleanupTest {
         KeyCode expectedCode = KeyCode.KP_LEFT;
         KeyMapping expectedMapping = new KeyMapping(expectedCode, null);
         assertTrue(inputMap.getMappings().contains(expectedMapping));
+        */
+        TextField control = new TextField("some text");
+        ControlShim.installDefaultSkin(control);
+        KeyCode[] codes = {
+            KeyCode.KP_DOWN,
+            KeyCode.KP_LEFT,
+            KeyCode.KP_RIGHT,
+            KeyCode.KP_UP,
+        };
+
+        Set<KeyBinding> keys = control.getInputMap().getKeyBindings();
+        for (KeyCode c: codes) {
+            KeyBinding k = KeyBinding.of(c);
+            assertTrue(keys.contains(k));
+        }
     }
 
     /**
      * Sanity test: child mappings to key pad keys.
      */
+    /*
+    // this test relies on too many assumptions on internals
     @Test
     public void testKeyPadMappingChildInputMap() {
         TextField control = new TextField("some text");
@@ -232,22 +250,51 @@ public class BehaviorCleanupTest {
         KeyMapping expectedNotMac = new KeyMapping(new KeyBinding(expectedCode).ctrl(), null);
         assertTrue(childInputMapNotMac.getMappings().contains(expectedNotMac));
     }
+    */
+
+    /**
+     * Ensures that ctrl- key pad keys are also mapped.
+     * This test executes different code path between Mac and non-Mac platforms.
+     */
+    @Test
+    public void testKeyPadMappingOnPlatform() {
+        TextField control = new TextField("some text");
+        ControlShim.installDefaultSkin(control);
+        KeyCode[] codes = {
+            KeyCode.KP_LEFT,
+            KeyCode.KP_RIGHT,
+        };
+
+        Set<KeyBinding> keys = control.getInputMap().getKeyBindings();
+        System.out.println(keys);
+        for (KeyCode c: codes) {
+            if (PlatformUtil.isMac()) {
+                KeyBinding expectedMac = KeyBinding.command(c);
+                System.out.println(expectedMac);
+                assertTrue("code=" + c, keys.contains(expectedMac));
+            } else {
+                KeyBinding expectedNotMac = KeyBinding.ctrl(c);
+                assertTrue("code=" + c, keys.contains(expectedNotMac));
+            }
+        }
+    }
 
     /**
      * Sanity test: listener to textProperty still effective after fix
      * (accidentally added twice)
      */
-    @Test
-    public void testTextPropertyListener() {
-        TextField control = new TextField("some text");
-        TextFieldBehavior behavior = (TextFieldBehavior) createBehavior(control);
-        assertNull("sanity: initial bidi", getRawBidi(behavior));
-        // validate bidi field
-        isRTLText(behavior);
-        assertNotNull(getRawBidi(behavior));
-        control.setText("dummy");
-        assertNull("listener working (bidi is reset)", getRawBidi(behavior));
-    }
+    // behavior must be added in Skin.install() now
+//    @Test
+//    public void testTextPropertyListener() {
+//        TextField control = new TextField("some text");
+//        TextFieldBehavior behavior = new TextFieldBehavior();
+//        assertNull("sanity: initial bidi", getRawBidi(behavior));
+//        // validate bidi field
+//        isRTLText(behavior);
+//        assertNotNull(getRawBidi(behavior));
+//        control.setText("dummy");
+//        assertNull("listener working (bidi is reset)", getRawBidi(behavior));
+//    }
 
 //----------- TreeView
 

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorMemoryLeakTest.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/behavior/BehaviorMemoryLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,25 +25,32 @@
 
 package test.com.sun.javafx.scene.control.behavior;
 
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory.asArrays;
+import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory.attemptGC;
+import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory.createBehavior;
+import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory.createControl;
+import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory.getControlClassesWithBehavior;
 import java.lang.ref.WeakReference;
 import java.util.Collection;
 import java.util.List;
-
+import javafx.scene.control.ColorPicker;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Control;
+import javafx.scene.control.DatePicker;
+import javafx.scene.control.PasswordField;
+import javafx.scene.control.TabPane;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TextArea;
+import javafx.scene.control.TextField;
+import javafx.scene.control.TreeTableView;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-
 import com.sun.javafx.scene.control.behavior.BehaviorBase;
-
-import static org.junit.Assert.*;
-import static test.com.sun.javafx.scene.control.infrastructure.ControlSkinFactory.*;
-
-import javafx.scene.control.Control;
-import javafx.scene.control.PasswordField;
-import javafx.scene.control.TableView;
-import javafx.scene.control.TreeTableView;
 
 /**
  * Test for memory leaks in Behavior implementations.
@@ -79,9 +86,18 @@ public class BehaviorMemoryLeakTest {
         // step 1: file issues (where not yet done), add informal ignore to entry
         // step 2: fix and remove from list
         List<Class<? extends Control>> leakingClasses = List.of(
-                PasswordField.class,
-                TableView.class,
-                TreeTableView.class
+            // the following use Behavior that must be installed by Skin.install()
+            TabPane.class,
+            TextField.class,
+            TextArea.class,
+            PasswordField.class,
+            ColorPicker.class,
+            DatePicker.class,
+            ComboBox.class,
+            // FIX as part of JDK-8241364
+            TableView.class,
+            // FIX as part of JDK-8241364
+            TreeTableView.class
          );
         // remove the known issues to make the test pass
         controlClasses.removeAll(leakingClasses);

--- a/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/ControlSkinFactory.java
+++ b/modules/javafx.controls/src/test/java/test/com/sun/javafx/scene/control/infrastructure/ControlSkinFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,21 +25,14 @@
 
 package test.com.sun.javafx.scene.control.infrastructure;
 
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.fail;
 import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
-
-import com.sun.javafx.scene.control.behavior.BehaviorBase;
-import com.sun.javafx.scene.control.behavior.ButtonBehavior;
-import com.sun.javafx.scene.control.behavior.ComboBoxListViewBehavior;
-import com.sun.javafx.scene.control.behavior.ToggleButtonBehavior;
-
-import static java.util.stream.Collectors.*;
-import static org.junit.Assert.*;
-
 import javafx.scene.control.Accordion;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonBar;
@@ -125,6 +118,9 @@ import javafx.scene.control.skin.TreeTableCellSkin;
 import javafx.scene.control.skin.TreeTableRowSkin;
 import javafx.scene.control.skin.TreeTableViewSkin;
 import javafx.scene.control.skin.TreeViewSkin;
+import com.sun.javafx.scene.control.behavior.BehaviorBase;
+import com.sun.javafx.scene.control.behavior.ButtonBehavior;
+import com.sun.javafx.scene.control.behavior.ToggleButtonBehavior;
 
 /**
  * Utility class to create Controls, alternative Skins and access/create behaviors.
@@ -234,22 +230,32 @@ public class ControlSkinFactory {
     static {
         specialBehaviorMap.put(Button.class, (Function<Control, BehaviorBase>) c -> new ButtonBehavior((ButtonBase) c));
         specialBehaviorMap.put(CheckBox.class, (Function<Control, BehaviorBase>) c -> new ButtonBehavior((ButtonBase) c));
-        specialBehaviorMap.put(ComboBox.class, (Function<Control, BehaviorBase>) c -> new ComboBoxListViewBehavior((ComboBox) c));
+        // TODO temporarily, while migration to new behavior is ongoing
+        //specialBehaviorMap.put(ComboBox.class, (Function<Control, BehaviorBase>) c -> new ComboBoxListViewBehavior());
         specialBehaviorMap.put(Hyperlink.class, (Function<Control, BehaviorBase>) c -> new ButtonBehavior((ButtonBase) c));
         specialBehaviorMap.put(RadioButton.class, (Function<Control, BehaviorBase>) c -> new ToggleButtonBehavior((ToggleButton) c));
         specialBehaviorMap.put(ToggleButton.class, (Function<Control, BehaviorBase>) c -> new ToggleButtonBehavior((ToggleButton) c));
     }
 
-    // list of control classes that have no behavior
+    /** list of control classes that have no behavior, or use BehaviorBase2 */
     static List<Class<? extends Control>> withoutBehaviors = List.of(
-            ButtonBar.class,
-            Label.class,
-            MenuBar.class,
-            ProgressBar.class,
-            ProgressIndicator.class,
-            Separator.class,
-            SplitPane.class
-            );
+        ButtonBar.class,
+        Label.class,
+        MenuBar.class,
+        ProgressBar.class,
+        ProgressIndicator.class,
+        Separator.class,
+        SplitPane.class,
+        // stateless behavior
+        TabPane.class,
+        // these use BehaviorBase2
+        ColorPicker.class,
+        ComboBox.class,
+        DatePicker.class,
+        PasswordField.class,
+        TextArea.class,
+        TextField.class
+    );
 
 ///---------------- misc
 

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/behavior/TestInputMap.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/behavior/TestInputMap.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.javafx.scene.control.behavior;
+
+import java.util.Set;
+import javafx.scene.control.Control;
+import javafx.scene.control.SkinBase;
+import javafx.scene.control.input.FunctionHandler;
+import javafx.scene.control.input.FunctionTag;
+import javafx.scene.control.input.InputMap;
+import javafx.scene.control.input.KeyBinding;
+import javafx.scene.control.input.SkinInputMap;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the basic functionality of InputMap.
+ */
+public class TestInputMap {
+    private static final KeyBinding KB1 = KeyBinding.ctrl(KeyCode.C);
+    private static final KeyBinding KB2 = KeyBinding.ctrl(KeyCode.J);
+    private static final KeyBinding KB3 = KeyBinding.ctrl(KeyCode.V);
+    private static final FunctionTag TAG1 = new FunctionTag();
+    private static final FunctionTag TAG2 = new FunctionTag();
+    private static final FunctionTag TAG3 = new FunctionTag();
+
+    // TODO test all public functions
+
+    @Test
+    public void testGetKeyBindings() {
+        InputMap m = create(
+            TAG1,
+            TAG2,
+            KB1, TAG1,
+            KB2, TAG1,
+            KB3, TAG2
+        );
+
+        Assertions.assertEquals(Set.of(KB1, KB2, KB3), m.getKeyBindings());
+    }
+
+    @Test
+    public void testGetKeyBindingFor() {
+        InputMap m = create(
+            TAG1,
+            KB1, TAG1,
+            KB2, TAG1
+        );
+
+        Assertions.assertEquals(Set.of(KB1, KB2), m.getKeyBindingsFor(TAG1));
+        Assertions.assertEquals(Set.of(), m.getKeyBindingsFor(TAG2));
+    }
+
+    @Test
+    public void testRegisterFunction() {
+        FunctionHandler<TestControl> func = (TestControl c) -> { };
+        FunctionHandler<TestControl> defaultFunc;
+
+        TestControl c = new TestControl();
+        InputMap m = c.getInputMap();
+        defaultFunc = m.getDefaultFunction(TAG1);
+        Assertions.assertNotNull(defaultFunc);
+        Assertions.assertEquals(null, m.getDefaultFunction(TAG3));
+
+        m.registerFunction(TAG1, func);
+        // TODO can't equals() two lambdas
+        //Assertions.assertEquals(defaultFunc, m.getDefaultFunction(TAG1));
+    }
+
+    @Test
+    public void testUnbind() {
+        InputMap m = create(
+            TAG1,
+            KB1, TAG1,
+            KB2, TAG1
+        );
+
+        m.unbind(TAG1);
+        Assertions.assertEquals(Set.of(), m.getKeyBindingsFor(TAG1));
+    }
+
+    @Test
+    public void testAddHandler() {
+        TestControl c = new TestControl();
+        c.getInputMap().addHandler(KeyEvent.ANY, (ev) -> System.out.println("KeyEvent.ANY (A1) ev=" + ev));
+        c.getInputMap().addHandler(KeyEvent.KEY_PRESSED, (ev) -> System.out.println("KeyEvent.KEY_PRESSED (A2) ev=" + ev));
+        
+        KeyEvent ev = new KeyEvent(this, c, KeyEvent.KEY_PRESSED, "A", "A", KeyCode.A, false, false, false, false);
+        c.fireEvent(ev);
+    }
+
+    @Test
+    public void testAddHandlerReverse() {
+        TestControl c = new TestControl();
+        c.getInputMap().addHandler(KeyEvent.KEY_PRESSED, (ev) -> System.out.println("KeyEvent.KEY_PRESSED (B1) ev=" + ev));
+        c.getInputMap().addHandler(KeyEvent.ANY, (ev) -> System.out.println("KeyEvent.ANY (B2) ev=" + ev));
+        
+        KeyEvent ev = new KeyEvent(this, c, KeyEvent.KEY_PRESSED, "A", "A", KeyCode.A, false, false, false, false);
+        c.fireEvent(ev);
+    }
+
+    // TODO test skin input map functions
+
+    /**
+     * Creates an input map from the list of items:
+     * <pre>
+     *    FunctionTag,
+     *    KeyBinding, FunctionTag
+     * </pre>
+     * @param items
+     * @return the input map
+     */
+    private static InputMap create(Object... items) {
+        InputMap m = new InputMap(new TestControl());
+        for (int i = 0; i < items.length;) {
+            Object x = items[i++];
+            if (x instanceof FunctionTag t) {
+                m.registerFunction(t, (c) -> { });
+            } else if (x instanceof KeyBinding kb) {
+                FunctionTag t = (FunctionTag)items[i++];
+                m.registerKey(kb, t);
+            }
+        }
+        return m;
+    }
+
+    /** test control */
+    static class TestControl extends Control {
+        private int value = -1;
+
+        public TestControl() {
+            setSkin(new TestSkin(this));
+        }
+
+        public void setValue(int x) {
+            value = x;
+        }
+
+        public int getValue() {
+            return value;
+        }
+    }
+
+    /** test skin */
+    static class TestSkin extends SkinBase<TestControl> {
+        protected TestSkin(TestControl c) {
+            super(c);
+        }
+
+        @Override
+        public void install() {
+            SkinInputMap<TestControl> m = new SkinInputMap<>();
+            m.register(TAG1, KB1, (c) -> c.setValue(1));
+            m.register(TAG2, KeyCode.A, (c) -> c.setValue(2));
+            setSkinInputMap(m);
+        }
+    }
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/behavior/TestPHList.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/behavior/TestPHList.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package test.javafx.scene.control.behavior;
+
+import java.util.ArrayList;
+import java.util.Set;
+import javafx.event.Event;
+import javafx.event.EventHandler;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import com.sun.javafx.scene.control.input.EventHandlerPriority;
+import com.sun.javafx.scene.control.input.PHList;
+
+/**
+ * Tests PHList as its implementation is not trivial due to optimization for space.
+ * Not explicitly testing forEach() since it's used in most of the test cases.
+ */
+public class TestPHList {
+    @Test
+    public void testAdd() {
+        Handler h1 = new Handler("u.high");
+        Handler h2 = new Handler("s.high");
+        Handler h3 = new Handler("u.low");
+        PHList hs = new PHList();
+        hs.add(EventHandlerPriority.USER_HIGH, h1);
+        hs.add(EventHandlerPriority.SKIN_KB, null);
+        hs.add(EventHandlerPriority.SKIN_HIGH, h2);
+        hs.add(EventHandlerPriority.USER_LOW, h3);
+        //System.out.println(hs);
+        checkForEach(
+            hs,
+            EventHandlerPriority.USER_HIGH, h1,
+            EventHandlerPriority.SKIN_KB, null,
+            EventHandlerPriority.SKIN_HIGH, h2,
+            EventHandlerPriority.USER_LOW, h3
+        );
+    }
+
+    @Test
+    public void testAddSame() {
+        Handler h1 = new Handler("u.high1");
+        Handler h2 = new Handler("u.high2");
+        PHList hs = new PHList();
+        hs.add(EventHandlerPriority.USER_HIGH, h1);
+        hs.add(EventHandlerPriority.USER_HIGH, h2);
+        checkForEach(
+            hs,
+            EventHandlerPriority.USER_HIGH, h1,
+            EventHandlerPriority.USER_HIGH, h2
+        );
+        hs.validateInternalState(
+            EventHandlerPriority.USER_HIGH,
+            h1,
+            h2
+        );
+    }
+
+    @Test
+    public void testRemove() {
+        Handler h1 = new Handler("u.high");
+        Handler h2 = new Handler("s.high");
+        Handler h3 = new Handler("u.low");
+        PHList hs = new PHList();
+        hs.add(EventHandlerPriority.USER_HIGH, h1);
+        hs.add(EventHandlerPriority.SKIN_KB, null);
+        hs.add(EventHandlerPriority.SKIN_HIGH, h2);
+        hs.add(EventHandlerPriority.USER_LOW, h3);
+
+        hs.remove(h2);
+        checkForEach(
+            hs,
+            EventHandlerPriority.USER_HIGH, h1,
+            EventHandlerPriority.SKIN_KB, null,
+            EventHandlerPriority.USER_LOW, h3
+        );
+        
+        hs.remove(h3);
+        checkForEach(
+            hs,
+            EventHandlerPriority.USER_HIGH, h1,
+            EventHandlerPriority.SKIN_KB, null
+        );
+    }
+
+    @Test
+    public void testRemoveHandlers() {
+        Handler h1 = new Handler("u.high");
+        Handler h2 = new Handler("s.high");
+        Handler h3 = new Handler("u.low");
+        PHList hs = new PHList();
+        hs.add(EventHandlerPriority.USER_HIGH, h1);
+        hs.add(EventHandlerPriority.SKIN_KB, null);
+        hs.add(EventHandlerPriority.SKIN_HIGH, h2);
+        hs.add(EventHandlerPriority.USER_LOW, h3);
+
+        hs.removeHandlers(Set.of(EventHandlerPriority.SKIN_KB));
+        checkForEach(
+            hs,
+            EventHandlerPriority.USER_HIGH, h1,
+            EventHandlerPriority.SKIN_HIGH, h2,
+            EventHandlerPriority.USER_LOW, h3
+        );
+        
+        boolean empty = hs.removeHandlers(Set.of(
+            EventHandlerPriority.USER_HIGH,
+            EventHandlerPriority.USER_LOW,
+            EventHandlerPriority.SKIN_HIGH
+            ));
+        checkForEach(hs);
+        Assertions.assertTrue(empty);
+    }
+    
+    private void checkForEach(PHList hs, Object ... expected) {
+        ArrayList<Object> items = new ArrayList<>();
+        hs.forEach((p, h) -> {
+            items.add(p);
+            items.add(h);
+            return true;
+        });
+        Assertions.assertArrayEquals(expected, items.toArray());
+    }
+
+    // test handler
+    static class Handler implements EventHandler<Event> {
+        private final String name;
+
+        public Handler(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public void handle(Event ev) {
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
+}

--- a/tests/system/src/test/java/test/robot/javafx/scene/control/behavior/TextAreaBehaviorRobotTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/control/behavior/TextAreaBehaviorRobotTest.java
@@ -164,7 +164,10 @@ public class TextAreaBehaviorRobotTest extends TextInputBehaviorRobotTest<TextAr
             HOME, checkSelection(0), shortcut(A), checkSelection(0, 7)
         );
         */
+    }
 
+    @Test
+    public void testPageSelection() {
         execute(
             setText("1\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n====\n"),
             checkSelection(0),


### PR DESCRIPTION
## Summary

Add the **InputMap** property in the Control class which enables customization of controls with the application key mappings and event handlers, and to guarantee specific order of event handlers invocation and priority of application mappings over those created by the skin.

Add **SkinInputMap** and optional **BehaviorBase** classes to simplify creation of skins for existing and new controls.



## Goals

The goals of this proposal are:

- allow for customization of a control behavior by changing the existing or adding new key mappings
- support dynamic modification of key mappings
- allow for accessing the default functionality even when it was overwritten by the application
- allow for reverting customization to the default implementation
- guarantee priorities between the application and the skin event handlers and key mappings
- allow for *gradual* migration of the existing controls to use the new InputMap
- support stateful and stateless (fully static) behavior implementations



## Non-Goals

It is not the goal of this proposal:

- to require specific base class for the behavior implementations
- to allow for complete decoupling of the skin from the behavior
- to make the legacy internal InputMap class public
- to make existing core behaviors public


Complete proposal:
https://github.com/andy-goryachev-oracle/Test/blob/ag.jep.input.map.v2/doc/InputMap/InputMapV2.md

