### PR TITLE
8327471: RTLTextFlowCharacterIndexTest fails on Linux

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/RTLTextFlowCharacterIndexTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/RTLTextFlowCharacterIndexTest.java
@@ -113,7 +113,7 @@ public class RTLTextFlowCharacterIndexTest {
     static volatile Stage stage;
     static volatile Scene scene;
 
-    static final int WIDTH = 500;
+    static final int WIDTH = 600;
     static final int HEIGHT = 200;
 
     static final int Y_OFFSET = 30;

--- a/tests/system/src/test/java/test/robot/javafx/scene/RTLTextFlowCharacterIndexTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/RTLTextFlowCharacterIndexTest.java
@@ -116,8 +116,9 @@ public class RTLTextFlowCharacterIndexTest {
     static final int WIDTH = 600;
     static final int HEIGHT = 200;
 
-    static final int Y_OFFSET = 30;
-    static final int X_LEADING_OFFSET = 10;
+    static final int Y_OFFSET = 25;
+    static final int X_LEADING_OFFSET = 5;
+    static final int FONT_SIZE = 40;
 
     boolean isLeading;
     boolean textFlowIsLeading;
@@ -143,7 +144,7 @@ public class RTLTextFlowCharacterIndexTest {
     private void addRTLArabicText() {
         Util.runAndWait(() -> {
             textOne.setText("شسيبلاتنم");
-            textOne.setFont(new Font(48));
+            textOne.setFont(new Font(FONT_SIZE));
             textFlow.getChildren().setAll(textOne);
             vBox.getChildren().setAll(textFlow);
         });
@@ -152,7 +153,7 @@ public class RTLTextFlowCharacterIndexTest {
     private void addRTLEnglishText() {
         Util.runAndWait(() -> {
             textOne.setText("This is text");
-            textOne.setFont(new Font(48));
+            textOne.setFont(new Font(FONT_SIZE));
             textFlow.getChildren().setAll(textOne);
             vBox.getChildren().setAll(textFlow);
         });
@@ -161,9 +162,9 @@ public class RTLTextFlowCharacterIndexTest {
     private void addMultiNodeRTLEnglishArabicText() {
         Util.runAndWait(() -> {
             textOne.setText("Arabic:");
-            textOne.setFont(new Font(48));
+            textOne.setFont(new Font(FONT_SIZE));
             textTwo.setText("شسيبلاتنم");
-            textTwo.setFont(new Font(48));
+            textTwo.setFont(new Font(FONT_SIZE));
             textFlow.getChildren().setAll(textOne, textTwo);
             vBox.getChildren().setAll(textFlow);
         });
@@ -172,11 +173,11 @@ public class RTLTextFlowCharacterIndexTest {
     private void addMultiLineMultiNodeRTLEnglishArabicText() {
         Util.runAndWait(() -> {
             textOne.setText("Arabic:");
-            textOne.setFont(new Font(48));
+            textOne.setFont(new Font(FONT_SIZE));
             textTwo.setText("شسيبلاتنضصثقفغ");
-            textTwo.setFont(new Font(48));
+            textTwo.setFont(new Font(FONT_SIZE));
             textThree.setText("حخهعغقثصضشسيبل");
-            textThree.setFont(new Font(48));
+            textThree.setFont(new Font(FONT_SIZE));
             textFlow.getChildren().setAll(textOne, textTwo, textThree);
             vBox.getChildren().setAll(textFlow);
         });
@@ -185,11 +186,11 @@ public class RTLTextFlowCharacterIndexTest {
     private void addMutliLineMultiNodeRTLEnglishText() {
         Util.runAndWait(() -> {
             textOne.setText("First line of text");
-            textOne.setFont(new Font(48));
+            textOne.setFont(new Font(FONT_SIZE));
             textTwo.setText("Second line of text");
-            textTwo.setFont(new Font(48));
+            textTwo.setFont(new Font(FONT_SIZE));
             textThree.setText("Third line of text");
-            textThree.setFont(new Font(48));
+            textThree.setFont(new Font(FONT_SIZE));
             textFlow.getChildren().setAll(textOne, textTwo, textThree);
             vBox.getChildren().setAll(textFlow);
         });
@@ -198,11 +199,11 @@ public class RTLTextFlowCharacterIndexTest {
     private void addMutliLineMultiNodeRTLArabicText() {
         Util.runAndWait(() -> {
             textOne.setText("شسيبلا تنضصثقفغ");
-            textOne.setFont(new Font(48));
+            textOne.setFont(new Font(FONT_SIZE));
             textTwo.setText("حخهعغقث صضشسيبل");
-            textTwo.setFont(new Font(48));
+            textTwo.setFont(new Font(FONT_SIZE));
             textThree.setText("ضصثقف");
-            textThree.setFont(new Font(48));
+            textThree.setFont(new Font(FONT_SIZE));
             textFlow.getChildren().setAll(textOne, textTwo, textThree);
             vBox.getChildren().setAll(textFlow);
         });
@@ -296,7 +297,7 @@ public class RTLTextFlowCharacterIndexTest {
         int textTwoLength = textTwo.getText().length();
         int textThreeLength = textThree.getText().length();
 
-        for (int y = 0; y < 3; y++) {
+        for (int y = 0; y < 2; y++) {
             double x = WIDTH - X_LEADING_OFFSET;
             while (x > X_LEADING_OFFSET) {
                 moveMouseOverTextFlow(x, (Y_OFFSET + (Y_OFFSET * (y * 2))));
@@ -326,7 +327,7 @@ public class RTLTextFlowCharacterIndexTest {
         int textTwoLength = textTwo.getText().length();
         int textThreeLength = textThree.getText().length();
 
-        for (int y = 0; y < 3; y++) {
+        for (int y = 0; y < 2; y++) {
             double x = WIDTH - X_LEADING_OFFSET;
             while (x > X_LEADING_OFFSET) {
                 moveMouseOverTextFlow(x, (Y_OFFSET + (Y_OFFSET * (y * 2))));
@@ -356,7 +357,7 @@ public class RTLTextFlowCharacterIndexTest {
         int textTwoLength = textTwo.getText().length();
         int textThreeLength = textThree.getText().length();
 
-        for (int y = 0; y < 3; y++) {
+        for (int y = 0; y < 2; y++) {
             double x = WIDTH - X_LEADING_OFFSET;
             while (x > X_LEADING_OFFSET) {
                 moveMouseOverTextFlow(x, (Y_OFFSET + (Y_OFFSET * (y * 2))));


### PR DESCRIPTION
Because of the difference in the size of characters in default fonts in different OS, 2 tests were failing in `RTLTextFlowCharacterIndexTest`.

Increased the scene width to accommodate all the characters as required for the test to validate HitInfo values in all the platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327471](https://bugs.openjdk.org/browse/JDK-8327471): RTLTextFlowCharacterIndexTest fails on Linux (**Bug** - P3)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1399/head:pull/1399` \
`$ git checkout pull/1399`

Update a local copy of the PR: \
`$ git checkout pull/1399` \
`$ git pull https://git.openjdk.org/jfx.git pull/1399/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1399`

View PR using the GUI difftool: \
`$ git pr show -t 1399`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1399.diff">https://git.openjdk.org/jfx/pull/1399.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1399#issuecomment-1993586192)