### PR TITLE
8255679: RegionBackgroundImageUITest.unalignedImage_Cover fails because of wrong color

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionBackgroundImageUITest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/layout/RegionBackgroundImageUITest.java
@@ -707,7 +707,6 @@ public class RegionBackgroundImageUITest extends RegionUITestBase {
     @Test(timeout = 20000)
     public void unalignedImage_Cover() {
         assumeTrue(checkIntegralUIScale());
-        assumeTrue(!PlatformUtil.isMac()); // JDK-8255679
         setStyle("-fx-background-color: black;" +
                 "-fx-background-image: url('test/robot/javafx/scene/layout/test48x48.png');" +
                 "-fx-background-size: cover;");
@@ -1056,13 +1055,14 @@ public class RegionBackgroundImageUITest extends RegionUITestBase {
 
     private void checkNonRepeating(int size, int centerX, int centerY, boolean checkForBlack) {
         final int halfSize = size / 2;
-        final int quarterSize = size / 4;
+        final int redCenterDelta = (int)(size / 2.2f);
+        final int greenCenterDelta = (int)(size / 3.3f);
         // The image
-        int x = centerX - halfSize;
-        int y = centerY - halfSize;
+        int x = centerX - redCenterDelta;
+        int y = centerY - redCenterDelta;
         assertColorEquals(contains(x, y) ? Color.RED : SCENE_FILL, x, y, TOLERANCE);
-        x = centerX - quarterSize;
-        y = centerY - quarterSize;
+        x = centerX - greenCenterDelta;
+        y = centerY - greenCenterDelta;
         assertColorEquals(contains(x, y) ? Color.rgb(0, 255, 0) : SCENE_FILL, x, y, TOLERANCE);
         x = centerX;
         y = centerY;


### PR DESCRIPTION
Updated test to get screen capture in different platforms to see how we are picking colors. Found that this test fails because it assumes that red,green & blue bands in the test image are of equal size and picks color based on that assumption.

If we take 20 * 20 aligned image, each scanline is 3 red pixels -> 3 green pixels -> 8 blue pixels -> 3 green pixels -> 3 red pixels. So the blue pixels actually acquire more space in a scanline. Even in y direction pattern is same.

If we 48 * 48 unaligned image, each scanline is 7 red pixels -> 8 green pixels -> 19 blue pixels -> 7 green pixels -> 7 red pixels. So the blue pixels actually acquire more space in a scanline. Even in y direction pattern is same.

So when this 48 * 48 image is scaled to 336 * 336 in case of unalignedImage_Cover, we are calculating picking point for green color in such a way that it is hitting border of green and blue bands and test is failing. Only in this specific scenario we are scaling by large amount and the inappropriate color picking logic is failing.

Updated color picking logic in such a way that appropriate weightage is given to each color and we pick that color properly even when we have large scaling. With this change test is passing on all platforms and there are no regressions seen in all test run.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8255679](https://bugs.openjdk.org/browse/JDK-8255679): RegionBackgroundImageUITest.unalignedImage_Cover fails because of wrong color (**Bug** - P4)


### Reviewers
 * [Ajit Ghaisas](https://openjdk.org/census#aghaisas) (@aghaisas - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1400/head:pull/1400` \
`$ git checkout pull/1400`

Update a local copy of the PR: \
`$ git checkout pull/1400` \
`$ git pull https://git.openjdk.org/jfx.git pull/1400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1400`

View PR using the GUI difftool: \
`$ git pr show -t 1400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1400.diff">https://git.openjdk.org/jfx/pull/1400.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1400#issuecomment-1993862649)