### PR TITLE
8207379: Robot screen capture test fails with HiDPI at some screen locations

### DIFF
--- a/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
@@ -755,12 +755,12 @@ public class RobotTest {
         // this is redundant.
         // Below calculations follow how getScreenCapture should calculate screen capture dimensions. This
         // is to make this code consistent and stable on HiDPI systems.
-        int stageX = (int)stage.getX();
-        int stageY = (int)stage.getY();
-        int shouldBeMinX = (int)Math.floor(stageX * screenScaleX);
-        int shouldBeMinY = (int)Math.floor(stageY * screenScaleY);
-        int shouldBeMaxX = (int)Math.ceil((stageX + WIDTH) * screenScaleX);
-        int shouldBeMaxY = (int)Math.ceil((stageY + HEIGHT) * screenScaleY);
+        int stageX = (int) stage.getX();
+        int stageY = (int) stage.getY();
+        int shouldBeMinX = (int) Math.floor(stageX * screenScaleX);
+        int shouldBeMinY = (int) Math.floor(stageY * screenScaleY);
+        int shouldBeMaxX = (int) Math.ceil((stageX + WIDTH) * screenScaleX);
+        int shouldBeMaxY = (int) Math.ceil((stageY + HEIGHT) * screenScaleY);
         int shouldBeWidth = shouldBeMaxX - shouldBeMinX;
         int shouldBeHeight = shouldBeMaxY - shouldBeMinY;
         Assert.assertEquals((double) shouldBeWidth, screenCaptureNotScaledToFit.get().getWidth(), 0.0001);

--- a/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
@@ -725,10 +725,6 @@ public class RobotTest {
 
     @Test
     public void testScreenCapture() throws Exception {
-        if (PlatformUtil.isWindows() && Screen.getPrimary().getOutputScaleX() > 1) {
-            // Mark this test as unstable on Windows when HiDPI scale is more than 100%
-            Assume.assumeTrue(Boolean.getBoolean("unstable.test")); // JDK-8207379
-        }
         CountDownLatch setSceneLatch = new CountDownLatch(1);
         Pane pane = new StackPane();
         InvalidationListener invalidationListener = observable -> setSceneLatch.countDown();

--- a/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
@@ -753,10 +753,24 @@ public class RobotTest {
         // Should be scaled to the primary screen x and y scales. Note that screenCaptureScaledToFit and
         // screenCaptureNotScaledToFit will be the same if screenScaleX = screenScaleY = 1.0 and in that case
         // this is redundant.
-        Assert.assertEquals((double) WIDTH * screenScaleX, screenCaptureNotScaledToFit.get().getWidth(), 0.0001);
-        Assert.assertEquals((double) HEIGHT * screenScaleY, screenCaptureNotScaledToFit.get().getHeight(), 0.0001);
-        for (int x = 0; x < WIDTH * screenScaleX; x++) {
-            for (int y = 0; y < HEIGHT * screenScaleY; y++) {
+        // Below calculations follow how getScreenCapture should calculate screen capture dimensions. This
+        // is to make this code consistent and stable on HiDPI systems.
+        int stageX = (int)stage.getX();
+        int stageY = (int)stage.getY();
+        int shouldBeMinX = (int)Math.floor(stageX * screenScaleX);
+        int shouldBeMinY = (int)Math.floor(stageY * screenScaleY);
+        int shouldBeMaxX = (int)Math.ceil((stageX + WIDTH) * screenScaleX);
+        int shouldBeMaxY = (int)Math.ceil((stageY + HEIGHT) * screenScaleY);
+        int shouldBeWidth = shouldBeMaxX - shouldBeMinX;
+        int shouldBeHeight = shouldBeMaxY - shouldBeMinY;
+        Assert.assertEquals((double) shouldBeWidth, screenCaptureNotScaledToFit.get().getWidth(), 0.0001);
+        Assert.assertEquals((double) shouldBeHeight, screenCaptureNotScaledToFit.get().getHeight(), 0.0001);
+
+        // To verify the color we're going to skip the "1-pixel outside border" of the capture. On HiDPI systems
+        // (especially on Windows) stage's position might have fractional element, which will mean the capture will
+        // average those values with whatever is behind the stage. This will make their values invalid.
+        for (int x = 1; x < shouldBeWidth - 1; x++) {
+            for (int y = 1; y < shouldBeHeight - 1; y++) {
                 assertColorEquals(MAGENTA, screenCaptureNotScaledToFit.get().getPixelReader().getColor(x, y), TOLERANCE);
             }
         }
@@ -764,8 +778,9 @@ public class RobotTest {
         // Should have been shrunk to fit the requested size, but still contain the same thing (all magenta pixels).
         Assert.assertEquals((double) WIDTH, screenCaptureScaledToFit.get().getWidth(), 0.0001);
         Assert.assertEquals((double) HEIGHT, screenCaptureScaledToFit.get().getHeight(), 0.0001);
-        for (int x = 0; x < WIDTH; x++) {
-            for (int y = 0; y < HEIGHT; y++) {
+        // Because of scaling, similar estimate has to be done like above.
+        for (int x = 1; x < WIDTH - 1; x++) {
+            for (int y = 1; y < HEIGHT - 1; y++) {
                 assertColorEquals(MAGENTA, screenCaptureScaledToFit.get().getPixelReader().getColor(x, y), TOLERANCE);
             }
         }


### PR DESCRIPTION
There were two different problems with this test's stability and HiDPI and both were fixed with this change.

The whole reason for this tests lack of stability comes with how Windows calculates window position when using HiDPI. When window's X/Y coordinates are not provided by the application, they are (generally speaking) randomly selected by Windows. X/Y are picked as two integers, and afterwards the HiDPI scaling is applied. With fractional scaling like 125% this can cause X/Y coordinates to have fractional values.

When performing a screen capture, Robot takes a generous estimate of window's position and dimensions. This is done by taking provided X/Y coordinates (in case of this test, stage's X/Y coords), multiplying them by scaling (ex. 1.25) and then flooring the result. Similar estimation is done to opposite coordinates - we take X/Y coords, add width/height to them respectively, multiply them by scaling and ceiling them. As a result, we have minX/Y and maxX/Y coords of capture region, which is used to calculate capture region's width and height. The first problem with test's stability is right here - the test did not take this calculation and floor/ceil operations into account, which with appropriately randomized window coordinates could cause discrepancy between expected width/height and actual. This logic that is used by `getScreenCapture()` seems to be necessary and good, so to remedy the problem I replicated those calculations on test side.

Another problem came after that - fractional X/Y values caused capture to not always line up with pixel layout, which made the 1-pixel border of capture sometimes incorrect (an average of stage's MAGENTA color and whatever background happened to be under the displayed stage). This means we cannot exactly expect those pixels to have exactly MAGENTA color when the system has fractional HiDPI enabled. To help that, the test now doesn't check for correctness of the 1-pixel border of captured image. I feel this still gives us enough confidence that the Robot screen capture works properly, while stabilizing the test on all systems.

I briefly considered an alternative approach to hard-set X/Y values but doing it this way gives us a bit more robustness, makes the test independent of Stage's X/Y coordinates which matter quite a lot.

Verified this change on macOS and especially on Windows - ran the test on Windows 50 times each on 125% and 100% scaling and noticed no intermittent failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8207379](https://bugs.openjdk.org/browse/JDK-8207379): Robot screen capture test fails with HiDPI at some screen locations (**Bug** - P4)


### Reviewers
 * [Karthik P K](https://openjdk.org/census#kpk) (@karthikpandelu - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1403/head:pull/1403` \
`$ git checkout pull/1403`

Update a local copy of the PR: \
`$ git checkout pull/1403` \
`$ git pull https://git.openjdk.org/jfx.git pull/1403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1403`

View PR using the GUI difftool: \
`$ git pr show -t 1403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1403.diff">https://git.openjdk.org/jfx/pull/1403.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1403#issuecomment-1997819939)