### PR TITLE
8325566: [TestBug] Util.shutdown() to hide ALL Windows

### DIFF
--- a/tests/system/src/test/java/test/com/sun/javafx/animation/SynchronizationTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/animation/SynchronizationTest.java
@@ -64,7 +64,7 @@ public class SynchronizationTest {
 
     @AfterAll
     public static void shutdown() {
-        Util.shutdown(primaryStage);
+        Util.shutdown();
     }
 
     /**

--- a/tests/system/src/test/java/test/com/sun/javafx/iio/LoadCorruptJPEGTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/iio/LoadCorruptJPEGTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,7 +91,7 @@ public class LoadCorruptJPEGTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @After

--- a/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/CloseWindowTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/CloseWindowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -74,7 +74,7 @@ public class CloseWindowTest {
 
     @AfterClass
     public static void shutdown() {
-        Util.shutdown(primaryStage);
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/WindowSceneInitDisposeTest.java
+++ b/tests/system/src/test/java/test/com/sun/javafx/tk/quantum/WindowSceneInitDisposeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,7 +73,7 @@ public class WindowSceneInitDisposeTest {
 
     @AfterClass
     public static void shutdown() {
-        Util.shutdown(primaryStage);
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/scene/CssStyleHelperTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/CssStyleHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,7 +84,7 @@ public class CssStyleHelperTest {
 
     @AfterClass
     public static void teardownOnce() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/scene/ImageCursorGetBestSizeTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/ImageCursorGetBestSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ public class ImageCursorGetBestSizeTest {
 
     @AfterClass
     public static void teardown() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Test(timeout = 20000)

--- a/tests/system/src/test/java/test/javafx/scene/InitialNodesMemoryLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/InitialNodesMemoryLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,7 @@ public class InitialNodesMemoryLeakTest {
 
     @AfterClass
     public static void teardownOnce() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/scene/NewSceneSizeTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/NewSceneSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,7 +83,7 @@ public class NewSceneSizeTest {
 
     @AfterClass
     public static void teardown() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/scene/NodeTreeShowingTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/NodeTreeShowingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -93,7 +93,7 @@ public class NodeTreeShowingTest {
 
     @AfterClass
     public static void teardownOnce() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     private StackPane createNodesRecursively(int count, int level) {

--- a/tests/system/src/test/java/test/javafx/scene/QuadraticCssTimeTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/QuadraticCssTimeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,7 +88,7 @@ public class QuadraticCssTimeTest {
 
     @AfterClass
     public static void teardownOnce() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/scene/RestoreSceneSizeTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/RestoreSceneSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,7 +90,7 @@ public class RestoreSceneSizeTest {
 
     @AfterClass
     public static void teardown() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/scene/UIRenderDialogTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/UIRenderDialogTest.java
@@ -110,7 +110,7 @@ public class UIRenderDialogTest {
                 alert.hide();
             }
         });
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/scene/UIRenderSceneTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/UIRenderSceneTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +85,7 @@ public class UIRenderSceneTest {
 
     @AfterClass
     public static void teardown() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/scene/UIRenderSnapToPixelTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/UIRenderSnapToPixelTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ public class UIRenderSnapToPixelTest {
 
     @AfterClass
     public static void teardown() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/scene/control/AccordionTitlePaneLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/AccordionTitlePaneLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,7 +75,7 @@ public class AccordionTitlePaneLeakTest {
 
     @AfterClass
     public static void teardownOnce() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/scene/control/TabPaneHeaderLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/TabPaneHeaderLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,7 +83,7 @@ public class TabPaneHeaderLeakTest {
 
     @AfterClass
     public static void teardownOnce() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/scene/control/XYChartExceptionOnAddingRemovedSeriesTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/control/XYChartExceptionOnAddingRemovedSeriesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -227,7 +227,7 @@ public class XYChartExceptionOnAddingRemovedSeriesTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Before

--- a/tests/system/src/test/java/test/javafx/scene/lighting3D/LightingTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/lighting3D/LightingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,6 +95,6 @@ public abstract class LightingTest {
 
     @AfterClass
     public static void teardown() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 }

--- a/tests/system/src/test/java/test/javafx/scene/shape/ShapeViewOrderLeakTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/shape/ShapeViewOrderLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,7 +84,7 @@ public class ShapeViewOrderLeakTest {
 
     @AfterClass
     public static void teardownOnce() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/scene/web/ColorChooserTest.java
+++ b/tests/system/src/test/java/test/javafx/scene/web/ColorChooserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ public class ColorChooserTest {
 
     @AfterAll
     public static void tearDownOnce() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     public static class ColorChooserTestApp extends Application {

--- a/tests/system/src/test/java/test/javafx/stage/DeiconifiedWithChildTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/DeiconifiedWithChildTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,7 @@ public class DeiconifiedWithChildTest {
 
     @AfterClass
     public static void teardown() {
-        Util.shutdown(childStage, stage);
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/stage/InitialSizeTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/InitialSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ public class InitialSizeTest {
 
     @AfterClass
     public static void teardown() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/stage/MaximizeUndecorated.java
+++ b/tests/system/src/test/java/test/javafx/stage/MaximizeUndecorated.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -72,7 +72,7 @@ public class MaximizeUndecorated {
 
     @AfterClass
     public static void teardown() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/stage/RestoreStagePositionTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/RestoreStagePositionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,7 +84,7 @@ public class RestoreStagePositionTest {
 
     @AfterClass
     public static void teardown() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/javafx/stage/StageAtTopPositionTest.java
+++ b/tests/system/src/test/java/test/javafx/stage/StageAtTopPositionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +85,7 @@ public class StageAtTopPositionTest {
 
     @AfterClass
     public static void teardown() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/robot/javafx/scene/AfterModalClosedTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/AfterModalClosedTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ public class AfterModalClosedTest {
 
     @AfterClass
     public static void teardown() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Test

--- a/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ChoiceBoxScrollUpOnCollectionChangeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -154,7 +154,7 @@ public class ChoiceBoxScrollUpOnCollectionChangeTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/ColorPickerTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ColorPickerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -176,7 +176,7 @@ public class ColorPickerTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/ComboBoxTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ComboBoxTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -186,7 +186,7 @@ public class ComboBoxTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/ContextMenuNPETest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/ContextMenuNPETest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -153,7 +153,7 @@ public class ContextMenuNPETest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/DatePickerTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/DatePickerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -180,7 +180,7 @@ public class DatePickerTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/DatePickerUpdateOnAlertCloseTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/DatePickerUpdateOnAlertCloseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -208,7 +208,7 @@ public class DatePickerUpdateOnAlertCloseTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/DoubleShortcutProcessingTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/DoubleShortcutProcessingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,7 +77,7 @@ public class DoubleShortcutProcessingTest {
 
     @AfterAll
     static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/PixelBufferDrawTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/PixelBufferDrawTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -293,7 +293,7 @@ public class PixelBufferDrawTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Before

--- a/tests/system/src/test/java/test/robot/javafx/scene/RTLTextCharacterIndexTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/RTLTextCharacterIndexTest.java
@@ -359,7 +359,7 @@ public class RTLTextCharacterIndexTest {
 
     @AfterAll
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/RTLTextFlowCharacterIndexTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/RTLTextFlowCharacterIndexTest.java
@@ -434,7 +434,7 @@ public class RTLTextFlowCharacterIndexTest {
 
     @AfterAll
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/RobotTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -817,7 +817,7 @@ public class RobotTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @After

--- a/tests/system/src/test/java/test/robot/javafx/scene/SceneChangeEventsTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/SceneChangeEventsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,7 +139,7 @@ public class SceneChangeEventsTest {
     @AfterClass
     public static void exit() {
         if (stage != null) {
-            Util.shutdown(stage);
+            Util.shutdown();
         }
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/SceneChangeShouldNotFocusStageTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/SceneChangeShouldNotFocusStageTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ public class SceneChangeShouldNotFocusStageTest {
     @AfterAll
     public static void exit() {
         if (stage != null) {
-            Util.shutdown(stage);
+            Util.shutdown();
         }
     }
 

--- a/tests/system/src/test/java/test/robot/javafx/scene/SliderTooltipNPETest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/SliderTooltipNPETest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -172,6 +172,6 @@ public class SliderTooltipNPETest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 }

--- a/tests/system/src/test/java/test/robot/javafx/scene/TabContextMenuCloseButtonTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TabContextMenuCloseButtonTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,7 +128,7 @@ public class TabContextMenuCloseButtonTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/TabPaneDragPolicyTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TabPaneDragPolicyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -353,7 +353,7 @@ public class TabPaneDragPolicyTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Before

--- a/tests/system/src/test/java/test/robot/javafx/scene/TabPaneReorderTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TabPaneReorderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -209,7 +209,7 @@ public class TabPaneReorderTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Before

--- a/tests/system/src/test/java/test/robot/javafx/scene/TextCharacterIndexTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TextCharacterIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -575,7 +575,7 @@ public class TextCharacterIndexTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/TextFlowSurrogatePairInsertionIndexTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TextFlowSurrogatePairInsertionIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -343,7 +343,7 @@ public class TextFlowSurrogatePairInsertionIndexTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/TextSurrogatePairInsertionIndexTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/TextSurrogatePairInsertionIndexTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -106,7 +106,7 @@ public class TextSurrogatePairInsertionIndexTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/canvas/ImageSmoothingDrawTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/canvas/ImageSmoothingDrawTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,7 +110,7 @@ public class ImageSmoothingDrawTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Before

--- a/tests/system/src/test/java/test/robot/javafx/scene/control/behavior/BehaviorRobotTestBase.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/control/behavior/BehaviorRobotTestBase.java
@@ -109,7 +109,7 @@ public abstract class BehaviorRobotTestBase<C extends Control> {
 
     @AfterAll
     public static void teardownOnce() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     /**

--- a/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogRepeatedShowHideTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogRepeatedShowHideTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,7 +95,7 @@ public class DialogRepeatedShowHideTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     private void mouseClick(double x, double y) {

--- a/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogWithOwnerSizingTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/dialog/DialogWithOwnerSizingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,7 +95,7 @@ public class DialogWithOwnerSizingTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     private void mouseClick(double x, double y) {

--- a/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewClickOnTroughTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewClickOnTroughTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,7 @@ public class TableViewClickOnTroughTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewResizeColumnToFitContentTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/tableview/TableViewResizeColumnToFitContentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -110,7 +110,7 @@ public class TableViewResizeColumnToFitContentTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/scene/treetableview/TreeTableViewResizeColumnToFitContentTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/scene/treetableview/TreeTableViewResizeColumnToFitContentTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,7 +111,7 @@ public class TreeTableViewResizeColumnToFitContentTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/stage/CheckWindowOrderTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/CheckWindowOrderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ public class CheckWindowOrderTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(lastWindow, secondWindow, firstWindow, stage);
+        Util.shutdown();
     }
 
     public static class TestApp extends Application {

--- a/tests/system/src/test/java/test/robot/javafx/stage/DualWindowTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/DualWindowTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -123,7 +123,7 @@ public class DualWindowTest {
 
     @AfterClass
     public static void teardown() {
-        Util.shutdown(stage1, stage2);
+        Util.shutdown();
     }
 
     @Before

--- a/tests/system/src/test/java/test/robot/javafx/stage/FocusParentWindowOnChildCloseTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/FocusParentWindowOnChildCloseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,7 +81,7 @@ public class FocusParentWindowOnChildCloseTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage, stage2);
+        Util.shutdown();
     }
 
     private void mouseClick(double x, double y) {

--- a/tests/system/src/test/java/test/robot/javafx/stage/WrongStageFocusWithApplicationModalityTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/stage/WrongStageFocusWithApplicationModalityTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,7 @@ public class WrongStageFocusWithApplicationModalityTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Test(timeout = 25000)

--- a/tests/system/src/test/java/test/robot/javafx/web/PointerEventTest.java
+++ b/tests/system/src/test/java/test/robot/javafx/web/PointerEventTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  p * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
@@ -190,7 +190,7 @@ public class PointerEventTest {
 
     @AfterClass
     public static void exit() {
-        Util.shutdown(stage);
+        Util.shutdown();
     }
 
     @Before

--- a/tests/system/src/test/java/test/util/Util.java
+++ b/tests/system/src/test/java/test/util/Util.java
@@ -37,19 +37,16 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.geometry.Rectangle2D;
 import javafx.scene.Node;
-import javafx.scene.robot.Robot;
 import javafx.scene.Scene;
 import javafx.scene.layout.Region;
+import javafx.scene.robot.Robot;
 import javafx.stage.Screen;
-import javafx.stage.Stage;
 import javafx.stage.Window;
 import org.junit.Assert;
-
 import junit.framework.AssertionFailedError;
 
 /**
@@ -382,7 +379,7 @@ public class Util {
      */
     public static void shutdown() {
         runAndWait(() -> {
-            for (Window w : Window.getWindows()) {
+            for (Window w : new ArrayList<>(Window.getWindows())) {
                 w.hide();
             }
             Platform.exit();

--- a/tests/system/src/test/java/test/util/Util.java
+++ b/tests/system/src/test/java/test/util/Util.java
@@ -379,9 +379,9 @@ public class Util {
      */
     public static void shutdown() {
         runAndWait(() -> {
-            for (Window w : new ArrayList<>(Window.getWindows())) {
-                w.hide();
-            }
+            List.
+                copyOf(Window.getWindows()).
+                forEach(Window::hide);
             Platform.exit();
         });
     }

--- a/tests/system/src/test/java/test/util/Util.java
+++ b/tests/system/src/test/java/test/util/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -377,15 +377,13 @@ public class Util {
     }
 
     /**
-     * This synchronous method first hides all the specified stages (ignoring any
-     * null Stages) in the platform thread, then calls {@link Platform.exit()}.
+     * This synchronous method first hides all the open {@code Window}s in the platform thread,
+     * then invokes {@link Platform.exit()}.
      */
-    public static void shutdown(Stage... stages) {
+    public static void shutdown() {
         runAndWait(() -> {
-            for (Stage s : stages) {
-                if (s != null) {
-                    s.hide();
-                }
+            for (Window w : Window.getWindows()) {
+                w.hide();
             }
             Platform.exit();
         });


### PR DESCRIPTION
Changing `Util.shutdown()` to hide **all** showing Windows and then call `Platform.exit()`.
This simplifies the tests and ensures a clean shutdown.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325566](https://bugs.openjdk.org/browse/JDK-8325566): [TestBug] Util.shutdown() to hide ALL Windows (**Enhancement** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1407/head:pull/1407` \
`$ git checkout pull/1407`

Update a local copy of the PR: \
`$ git checkout pull/1407` \
`$ git pull https://git.openjdk.org/jfx.git pull/1407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1407`

View PR using the GUI difftool: \
`$ git pr show -t 1407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1407.diff">https://git.openjdk.org/jfx/pull/1407.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1407#issuecomment-2007534789)