### PR TITLE
8327482: Fix missing image resource in HelloImage toy app

### DIFF
--- a/apps/toys/Hello/src/main/java/hello/HelloImage.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloImage.java
@@ -41,9 +41,9 @@ import javafx.stage.Stage;
 public class HelloImage extends Application {
 
     private static final String imageURL = "hello/JavaFX.png";
-    //1862x2327 size of duke
+    //3301x4000 size of duke
     private static final String slowImageURL =
-            "http://duke.kenai.com/misc/DrinkingBeer.jpg";
+            "https://cr.openjdk.org/~jeff/Duke/png/Hips.png";
     private static final String animImageURL = "hello/animated_89_c.gif";
     private static final String animCursorURL = "hello/javafx-loading-32x32.gif";
 
@@ -68,9 +68,8 @@ public class HelloImage extends Application {
         final Image slowImage = new Image(slowImageURL, true);
         addImageToObservableList(seq, 20, 160, 560, 250, slowImage, Cursor.CROSSHAIR);
 
-
         addImageToObservableList(seq, 20, 20, 120, 120, animImage,
-                           createImageCursor(slowImageURL, 1862*0.4f, 0));
+                           createImageCursor(slowImageURL, 3301*0.2f, 0));
 
         stage.getIcons().add(slowImage);
         stage.setScene(scene);


### PR DESCRIPTION
Replaced existing `slowImageURL` address to a new image (+ some extra bits related to it). Image has been taken from open-source repository of Duke images and licensed under BSD license: https://wiki.openjdk.org/display/duke/Gallery

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327482](https://bugs.openjdk.org/browse/JDK-8327482): Fix missing image resource in HelloImage toy app (**Bug** - P5)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1410/head:pull/1410` \
`$ git checkout pull/1410`

Update a local copy of the PR: \
`$ git checkout pull/1410` \
`$ git pull https://git.openjdk.org/jfx.git pull/1410/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1410`

View PR using the GUI difftool: \
`$ git pr show -t 1410`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1410.diff">https://git.openjdk.org/jfx/pull/1410.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1410#issuecomment-2007590797)