### PR TITLE
8324939: Editable TableView loses focus after commit

### DIFF
--- a/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/ControlUtils.java
@@ -54,20 +54,26 @@ class ControlUtils {
         });
     }
 
-    static void requestFocusOnControlOnlyIfCurrentFocusOwnerIsChild(Control c) {
+    static boolean controlShouldRequestFocusIfCurrentFocusOwnerIsChild(Control c) {
         Scene scene = c.getScene();
         final Node focusOwner = scene == null ? null : scene.getFocusOwner();
         if (focusOwner == null) {
-            c.requestFocus();
+            return true;
         } else if (! c.equals(focusOwner)) {
             Parent p = focusOwner.getParent();
             while (p != null) {
                 if (c.equals(p)) {
-                    c.requestFocus();
-                    break;
+                    return true;
                 }
                 p = p.getParent();
             }
+        }
+        return false;
+    }
+
+    static void requestFocusOnControlOnlyIfCurrentFocusOwnerIsChild(Control c) {
+        if (controlShouldRequestFocusIfCurrentFocusOwnerIsChild(c)) {
+            c.requestFocus();
         }
     }
 

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TableCell.java
@@ -354,6 +354,16 @@ public class TableCell<S,T> extends IndexedCell<T> {
         super.commitEdit(newValue);
 
         final TableView<S> table = getTableView();
+        boolean tableShouldRequestFocus = false;
+
+        if (table != null) {
+            // The cell is going to be updated, and the current focus owner might be removed from it.
+            // Before that happens, check if it has the table as a parent (otherwise the user might have
+            // clicked out of the table entirely and given focus to something else), so the table can
+            // request the focus back, once the edit commit ends.
+            tableShouldRequestFocus = ControlUtils.controlShouldRequestFocusIfCurrentFocusOwnerIsChild(table);
+        }
+
         // JDK-8187307: fire the commit after updating cell's editing state
         if (getTableColumn() != null) {
             // Inform the TableColumn of the edit being ready to be committed.
@@ -375,10 +385,11 @@ public class TableCell<S,T> extends IndexedCell<T> {
             table.edit(-1, null);
 
             // request focus back onto the table, only if the current focus
-            // owner has the table as a parent (otherwise the user might have
-            // clicked out of the table entirely and given focus to something else.
+            // owner had the table as a parent.
             // It would be rude of us to request it back again.
-            ControlUtils.requestFocusOnControlOnlyIfCurrentFocusOwnerIsChild(table);
+            if (tableShouldRequestFocus) {
+                table.requestFocus();
+            }
         }
     }
 
@@ -394,7 +405,7 @@ public class TableCell<S,T> extends IndexedCell<T> {
             if (updateEditingIndex) table.edit(-1, null);
             // request focus back onto the table, only if the current focus
             // owner has the table as a parent (otherwise the user might have
-            // clicked out of the table entirely and given focus to something else.
+            // clicked out of the table entirely and given focus to something else).
             // It would be rude of us to request it back again.
             ControlUtils.requestFocusOnControlOnlyIfCurrentFocusOwnerIsChild(table);
         }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/TreeTableCell.java
@@ -371,6 +371,16 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
         super.commitEdit(newValue);
 
         final TreeTableView<S> table = getTreeTableView();
+        boolean tableShouldRequestFocus = false;
+
+        if (table != null) {
+            // The cell is going to be updated, and the current focus owner might be removed from it.
+            // Before that happens, check if it has the table as a parent (otherwise the user might have
+            // clicked out of the table entirely and given focus to something else), so the table can
+            // request the focus back, once the edit commit ends.
+            tableShouldRequestFocus = ControlUtils.controlShouldRequestFocusIfCurrentFocusOwnerIsChild(table);
+        }
+
         // JDK-8187307: fire the commit after updating cell's editing state
         if (getTableColumn() != null) {
             // Inform the TreeTableColumn of the edit being ready to be committed.
@@ -392,10 +402,11 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
             table.edit(-1, null);
 
             // request focus back onto the table, only if the current focus
-            // owner has the table as a parent (otherwise the user might have
-            // clicked out of the table entirely and given focus to something else.
+            // owner had the table as a parent.
             // It would be rude of us to request it back again.
-            ControlUtils.requestFocusOnControlOnlyIfCurrentFocusOwnerIsChild(table);
+            if (tableShouldRequestFocus) {
+                table.requestFocus();
+            }
         }
     }
 
@@ -411,7 +422,7 @@ public class TreeTableCell<S,T> extends IndexedCell<T> {
             if (updateEditingIndex) table.edit(-1, null);
             // request focus back onto the table, only if the current focus
             // owner has the table as a parent (otherwise the user might have
-            // clicked out of the table entirely and given focus to something else.
+            // clicked out of the table entirely and given focus to something else).
             // It would be rude of us to request it back again.
             ControlUtils.requestFocusOnControlOnlyIfCurrentFocusOwnerIsChild(table);
         }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
@@ -66,6 +66,7 @@ import javafx.scene.control.TextField;
 import javafx.scene.control.cell.CheckBoxListCell;
 import javafx.scene.control.cell.ComboBoxListCell;
 import javafx.scene.control.cell.TextFieldListCell;
+import javafx.scene.control.skin.ListCellSkin;
 import javafx.scene.control.skin.VirtualFlow;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyCode;
@@ -1258,6 +1259,88 @@ public class ListViewTest {
         listView.getItems().clear();
         assertEquals(1, rt_37853_cancelCount);
         assertEquals(0, rt_37853_commitCount);
+
+        sl.dispose();
+    }
+
+    @Test
+    public void testListViewRemainsFocusedAfterEditCancel() {
+        listView.setCellFactory(TextFieldListCell.forListView());
+        listView.setEditable(true);
+        listView.getItems().add("John");
+
+        StageLoader sl = new StageLoader(new Button(), listView);
+        listView.requestFocus();
+        assertTrue(listView.isFocused());
+
+        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = true;
+        ListCell cell = (ListCell) VirtualFlowTestUtils.getCell(listView, 0);
+        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = false;
+        assertTrue(cell.getSkin() instanceof ListCellSkin);
+        assertNull(cell.getGraphic());
+        assertEquals("John", cell.getText());
+
+        listView.edit(0);
+
+        Toolkit.getToolkit().firePulse();
+        assertNotNull(cell.getGraphic());
+        assertTrue(cell.getGraphic() instanceof TextField);
+
+        TextField textField = (TextField) cell.getGraphic();
+        assertEquals("John", textField.getText());
+
+        textField.setText("Andrew");
+        textField.requestFocus();
+        Toolkit.getToolkit().firePulse();
+        assertTrue(textField.isFocused());
+        assertFalse(listView.isFocused());
+
+        KeyEventFirer keyboard = new KeyEventFirer(textField);
+        keyboard.doKeyPress(KeyCode.ESCAPE);
+
+        assertEquals("John", cell.getText());
+        assertTrue(listView.isFocused());
+
+        sl.dispose();
+    }
+
+    @Test
+    public void testListViewRemainsFocusedAfterEditCommit() {
+        listView.setCellFactory(TextFieldListCell.forListView());
+        listView.setEditable(true);
+        listView.getItems().add("John");
+
+        StageLoader sl = new StageLoader(new Button(), listView);
+        listView.requestFocus();
+        assertTrue(listView.isFocused());
+
+        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = true;
+        ListCell cell = (ListCell) VirtualFlowTestUtils.getCell(listView, 0);
+        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = false;
+        assertTrue(cell.getSkin() instanceof ListCellSkin);
+        assertNull(cell.getGraphic());
+        assertEquals("John", cell.getText());
+
+        listView.edit(0);
+
+        Toolkit.getToolkit().firePulse();
+        assertNotNull(cell.getGraphic());
+        assertTrue(cell.getGraphic() instanceof TextField);
+
+        TextField textField = (TextField) cell.getGraphic();
+        assertEquals("John", textField.getText());
+
+        textField.setText("Andrew");
+        textField.requestFocus();
+        Toolkit.getToolkit().firePulse();
+        assertTrue(textField.isFocused());
+        assertFalse(listView.isFocused());
+
+        KeyEventFirer keyboard = new KeyEventFirer(textField);
+        keyboard.doKeyPress(KeyCode.ENTER);
+
+        assertEquals("Andrew", cell.getText());
+        assertTrue(listView.isFocused());
 
         sl.dispose();
     }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/ListViewTest.java
@@ -1273,9 +1273,7 @@ public class ListViewTest {
         listView.requestFocus();
         assertTrue(listView.isFocused());
 
-        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = true;
         ListCell cell = (ListCell) VirtualFlowTestUtils.getCell(listView, 0);
-        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = false;
         assertTrue(cell.getSkin() instanceof ListCellSkin);
         assertNull(cell.getGraphic());
         assertEquals("John", cell.getText());
@@ -1314,9 +1312,7 @@ public class ListViewTest {
         listView.requestFocus();
         assertTrue(listView.isFocused());
 
-        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = true;
         ListCell cell = (ListCell) VirtualFlowTestUtils.getCell(listView, 0);
-        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = false;
         assertTrue(cell.getSkin() instanceof ListCellSkin);
         assertNull(cell.getGraphic());
         assertEquals("John", cell.getText());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -2235,9 +2235,7 @@ public class TableViewTest {
         assertTrue(table.isFocused());
 
         // get the cell at (0,0)
-        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = true;
         TableCell cell = (TableCell) VirtualFlowTestUtils.getCell(table, 0, 0);
-        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = false;
         assertTrue(cell.getSkin() instanceof TableCellSkin);
         assertNull(cell.getGraphic());
         assertEquals("John", cell.getText());
@@ -2285,9 +2283,7 @@ public class TableViewTest {
         assertTrue(table.isFocused());
 
         // get the cell at (0,0)
-        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = true;
         TableCell cell = (TableCell) VirtualFlowTestUtils.getCell(table, 0, 0);
-        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = false;
         assertTrue(cell.getSkin() instanceof TableCellSkin);
         assertNull(cell.getGraphic());
         assertEquals("John", cell.getText());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TableViewTest.java
@@ -2216,6 +2216,107 @@ public class TableViewTest {
         assertEquals(1, test_rt_34685_commitCount);
     }
 
+    @Test
+    public void testTableViewRemainsFocusedAfterEditCancel() {
+        TableView<Person> table = new TableView<>();
+        table.setEditable(true);
+
+        table.setItems(FXCollections.observableArrayList(
+                new Person("John", "Smith", "john.smith@example.com")));
+
+        TableColumn<Person,String> first = new TableColumn<>("first");
+        first.setCellValueFactory(new PropertyValueFactory<>("firstName"));
+        first.setCellFactory(TextFieldTableCell.forTableColumn());
+        table.getColumns().add(first);
+
+        StageLoader sl = new StageLoader(new Button(), table);
+
+        table.requestFocus();
+        assertTrue(table.isFocused());
+
+        // get the cell at (0,0)
+        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = true;
+        TableCell cell = (TableCell) VirtualFlowTestUtils.getCell(table, 0, 0);
+        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = false;
+        assertTrue(cell.getSkin() instanceof TableCellSkin);
+        assertNull(cell.getGraphic());
+        assertEquals("John", cell.getText());
+
+        // set the table to be editing the first cell at 0,0
+        table.edit(0, first);
+
+        Toolkit.getToolkit().firePulse();
+        assertNotNull(cell.getGraphic());
+        assertTrue(cell.getGraphic() instanceof TextField);
+
+        TextField textField = (TextField) cell.getGraphic();
+        assertEquals("John", textField.getText());
+
+        textField.setText("Andrew");
+        textField.requestFocus();
+        Toolkit.getToolkit().firePulse();
+        assertTrue(textField.isFocused());
+        assertFalse(table.isFocused());
+
+        KeyEventFirer keyboard = new KeyEventFirer(textField);
+        keyboard.doKeyPress(KeyCode.ESCAPE);
+
+        assertEquals("John", cell.getText());
+        assertTrue(table.isFocused());
+
+        sl.dispose();
+    }
+
+    @Test
+    public void testTableViewRemainsFocusedAfterEditCommit() {
+        TableView<Person> table = new TableView<>();
+        table.setEditable(true);
+
+        table.setItems(FXCollections.observableArrayList(
+                new Person("John", "Smith", "john.smith@example.com")));
+
+        TableColumn<Person,String> first = new TableColumn<>("first");
+        first.setCellValueFactory(new PropertyValueFactory<>("firstName"));
+        first.setCellFactory(TextFieldTableCell.forTableColumn());
+        table.getColumns().add(first);
+
+        StageLoader sl = new StageLoader(new Button(), table);
+        table.requestFocus();
+        assertTrue(table.isFocused());
+
+        // get the cell at (0,0)
+        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = true;
+        TableCell cell = (TableCell) VirtualFlowTestUtils.getCell(table, 0, 0);
+        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = false;
+        assertTrue(cell.getSkin() instanceof TableCellSkin);
+        assertNull(cell.getGraphic());
+        assertEquals("John", cell.getText());
+
+        // set the table to be editing the first cell at 0,0
+        table.edit(0, first);
+
+        Toolkit.getToolkit().firePulse();
+        assertNotNull(cell.getGraphic());
+        assertTrue(cell.getGraphic() instanceof TextField);
+
+        TextField textField = (TextField) cell.getGraphic();
+        assertEquals("John", textField.getText());
+
+        textField.setText("Andrew");
+        textField.requestFocus();
+        Toolkit.getToolkit().firePulse();
+        assertTrue(textField.isFocused());
+        assertFalse(table.isFocused());
+
+        KeyEventFirer keyboard = new KeyEventFirer(textField);
+        keyboard.doKeyPress(KeyCode.ENTER);
+
+        assertEquals("Andrew", cell.getText());
+        assertTrue(table.isFocused());
+
+        sl.dispose();
+    }
+
     @Test public void test_rt_35224() {
         TableView table = new TableView();
         TableColumn col1 = new TableColumn();

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -3325,9 +3325,7 @@ public class TreeTableViewTest {
         assertTrue(table.isFocused());
 
         // get the cell at (0,0)
-        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = true;
         TreeTableCell cell = (TreeTableCell) VirtualFlowTestUtils.getCell(table, 0, 0);
-        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = false;
         assertTrue(cell.getSkin() instanceof TreeTableCellSkin);
         assertNull(cell.getGraphic());
         assertEquals("John", cell.getText());
@@ -3380,9 +3378,7 @@ public class TreeTableViewTest {
         assertTrue(table.isFocused());
 
         // get the cell at (0,0)
-        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = true;
         TreeTableCell cell = (TreeTableCell) VirtualFlowTestUtils.getCell(table, 0, 0);
-        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = false;
         assertTrue(cell.getSkin() instanceof TreeTableCellSkin);
         assertNull(cell.getGraphic());
         assertEquals("John", cell.getText());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeTableViewTest.java
@@ -3302,6 +3302,116 @@ public class TreeTableViewTest {
         assertEquals(1, test_rt_34685_commitCount);
     }
 
+    @Test
+    public void testTreeTableViewRemainsFocusedAfterEditCancel() {
+        TreeTableView<Person> table = new TreeTableView<>();
+        table.setEditable(true);
+
+        TreeItem<Person> root = new TreeItem<>(new Person("Root", null, null));
+        root.setExpanded(true);
+        table.setRoot(root);
+        table.setShowRoot(false);
+        root.getChildren().setAll(FXCollections.observableArrayList(
+                new TreeItem<>(new Person("John", "Smith", "john.smith@example.com"))));
+
+        TreeTableColumn<Person,String> first = new TreeTableColumn<>("first");
+        first.setCellValueFactory(new TreeItemPropertyValueFactory<>("firstName"));
+        first.setCellFactory(TextFieldTreeTableCell.forTreeTableColumn());
+        table.getColumns().add(first);
+
+        StageLoader sl = new StageLoader(new Button(), table);
+
+        table.requestFocus();
+        assertTrue(table.isFocused());
+
+        // get the cell at (0,0)
+        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = true;
+        TreeTableCell cell = (TreeTableCell) VirtualFlowTestUtils.getCell(table, 0, 0);
+        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = false;
+        assertTrue(cell.getSkin() instanceof TreeTableCellSkin);
+        assertNull(cell.getGraphic());
+        assertEquals("John", cell.getText());
+
+        // set the table to be editing the first cell at 0,0
+        table.edit(0, first);
+
+        Toolkit.getToolkit().firePulse();
+        assertNotNull(cell.getGraphic());
+        assertTrue(cell.getGraphic() instanceof TextField);
+
+        TextField textField = (TextField) cell.getGraphic();
+        assertEquals("John", textField.getText());
+
+        textField.setText("Andrew");
+        textField.requestFocus();
+        Toolkit.getToolkit().firePulse();
+        assertTrue(textField.isFocused());
+        assertFalse(table.isFocused());
+
+        KeyEventFirer keyboard = new KeyEventFirer(textField);
+        keyboard.doKeyPress(KeyCode.ESCAPE);
+
+        assertEquals("John", cell.getText());
+        assertTrue(table.isFocused());
+
+        sl.dispose();
+    }
+
+    @Test
+    public void testTreeTableViewRemainsFocusedAfterEditCommit() {
+        TreeTableView<Person> table = new TreeTableView<>();
+        table.setEditable(true);
+
+        TreeItem<Person> root = new TreeItem<>(new Person("Root", null, null));
+        root.setExpanded(true);
+        table.setRoot(root);
+        table.setShowRoot(false);
+        root.getChildren().setAll(FXCollections.observableArrayList(
+                new TreeItem<>(new Person("John", "Smith", "john.smith@example.com"))));
+
+        TreeTableColumn<Person,String> first = new TreeTableColumn<>("first");
+        first.setCellValueFactory(new TreeItemPropertyValueFactory<>("firstName"));
+        first.setCellFactory(TextFieldTreeTableCell.forTreeTableColumn());
+        table.getColumns().add(first);
+
+        StageLoader sl = new StageLoader(new Button(), table);
+
+        table.requestFocus();
+        assertTrue(table.isFocused());
+
+        // get the cell at (0,0)
+        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = true;
+        TreeTableCell cell = (TreeTableCell) VirtualFlowTestUtils.getCell(table, 0, 0);
+        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = false;
+        assertTrue(cell.getSkin() instanceof TreeTableCellSkin);
+        assertNull(cell.getGraphic());
+        assertEquals("John", cell.getText());
+
+        // set the table to be editing the first cell at 0,0
+        table.edit(0, first);
+
+        Toolkit.getToolkit().firePulse();
+        assertNotNull(cell.getGraphic());
+        assertTrue(cell.getGraphic() instanceof TextField);
+
+        TextField textField = (TextField) cell.getGraphic();
+        assertEquals("John", textField.getText());
+
+        textField.setText("Andrew");
+        textField.requestFocus();
+        Toolkit.getToolkit().firePulse();
+        assertTrue(textField.isFocused());
+        assertFalse(table.isFocused());
+
+        KeyEventFirer keyboard = new KeyEventFirer(textField);
+        keyboard.doKeyPress(KeyCode.ENTER);
+
+        assertEquals("Andrew", cell.getText());
+        assertTrue(table.isFocused());
+
+        sl.dispose();
+    }
+
     @Test public void test_rt34694() {
         TreeItem treeNode = new TreeItem("Controls");
         treeNode.getChildren().addAll(

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
@@ -2359,9 +2359,7 @@ public class TreeViewTest {
         treeView.requestFocus();
         assertTrue(treeView.isFocused());
 
-        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = true;
         TreeCell cell = (TreeCell) VirtualFlowTestUtils.getCell(treeView, 0);
-        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = false;
         assertTrue(cell.getSkin() instanceof TreeCellSkin);
         assertNull(cell.getGraphic());
         assertEquals("John", cell.getText());
@@ -2405,9 +2403,7 @@ public class TreeViewTest {
         treeView.requestFocus();
         assertTrue(treeView.isFocused());
 
-        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = true;
         TreeCell cell = (TreeCell) VirtualFlowTestUtils.getCell(treeView, 0);
-        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = false;
         assertTrue(cell.getSkin() instanceof TreeCellSkin);
         assertNull(cell.getGraphic());
         assertEquals("John", cell.getText());

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TreeViewTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import javafx.scene.control.skin.TreeCellSkin;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -2339,6 +2340,98 @@ public class TreeViewTest {
 
         assertEquals(1, rt_37853_cancelCount);
         assertEquals(0, rt_37853_commitCount);
+
+        sl.dispose();
+    }
+
+    @Test
+    public void testTreeViewRemainsFocusedAfterEditCancel() {
+        treeView.setCellFactory(TextFieldTreeCell.forTreeView());
+        treeView.setEditable(true);
+        treeView.setRoot(new TreeItem<>("Root"));
+        treeView.getRoot().setExpanded(true);
+        treeView.setShowRoot(false);
+
+        TreeItem<String> item = new TreeItem<>("John");
+        treeView.getRoot().getChildren().add(item);
+
+        StageLoader sl = new StageLoader(new Button(), treeView);
+        treeView.requestFocus();
+        assertTrue(treeView.isFocused());
+
+        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = true;
+        TreeCell cell = (TreeCell) VirtualFlowTestUtils.getCell(treeView, 0);
+        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = false;
+        assertTrue(cell.getSkin() instanceof TreeCellSkin);
+        assertNull(cell.getGraphic());
+        assertEquals("John", cell.getText());
+
+        treeView.edit(item);
+
+        Toolkit.getToolkit().firePulse();
+        assertNotNull(cell.getGraphic());
+        assertTrue(cell.getGraphic() instanceof TextField);
+
+        TextField textField = (TextField) cell.getGraphic();
+        assertEquals("John", textField.getText());
+
+        textField.setText("Andrew");
+        textField.requestFocus();
+        Toolkit.getToolkit().firePulse();
+        assertTrue(textField.isFocused());
+        assertFalse(treeView.isFocused());
+
+        KeyEventFirer keyboard = new KeyEventFirer(textField);
+        keyboard.doKeyPress(KeyCode.ESCAPE);
+
+        assertEquals("John", cell.getText());
+        assertTrue(treeView.isFocused());
+
+        sl.dispose();
+    }
+
+    @Test
+    public void testTreeViewRemainsFocusedAfterEditCommit() {
+        treeView.setCellFactory(TextFieldTreeCell.forTreeView());
+        treeView.setEditable(true);
+        treeView.setRoot(new TreeItem<>("Root"));
+        treeView.getRoot().setExpanded(true);
+        treeView.setShowRoot(false);
+
+        TreeItem<String> item = new TreeItem<>("John");
+        treeView.getRoot().getChildren().add(item);
+
+        StageLoader sl = new StageLoader(new Button(), treeView);
+        treeView.requestFocus();
+        assertTrue(treeView.isFocused());
+
+        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = true;
+        TreeCell cell = (TreeCell) VirtualFlowTestUtils.getCell(treeView, 0);
+        VirtualFlowTestUtils.BLOCK_STAGE_LOADER_DISPOSE = false;
+        assertTrue(cell.getSkin() instanceof TreeCellSkin);
+        assertNull(cell.getGraphic());
+        assertEquals("John", cell.getText());
+
+        treeView.edit(item);
+
+        Toolkit.getToolkit().firePulse();
+        assertNotNull(cell.getGraphic());
+        assertTrue(cell.getGraphic() instanceof TextField);
+
+        TextField textField = (TextField) cell.getGraphic();
+        assertEquals("John", textField.getText());
+
+        textField.setText("Andrew");
+        textField.requestFocus();
+        Toolkit.getToolkit().firePulse();
+        assertTrue(textField.isFocused());
+        assertFalse(treeView.isFocused());
+
+        KeyEventFirer keyboard = new KeyEventFirer(textField);
+        keyboard.doKeyPress(KeyCode.ENTER);
+
+        assertEquals("Andrew", cell.getText());
+        assertTrue(treeView.isFocused());
 
         sl.dispose();
     }


### PR DESCRIPTION
This PR fixes the issue that after committing an edit on a ListView/TreeView/TableView/TreeTableView control, the control might lose the focus unexpectedly.

For that, it refactors the `ControlUtils::requestFocusOnControlOnlyIfCurrentFocusOwnerIsChild` method, in order to check if the control (`ListView`, `TreeView`, `TableView`, `TreeTableView`) should request the focus _before_ the actual focus owner (which could be the control added to the cell to edit its content, like a `TextField`) is removed from the cell, so the `Control::requestFocus` call, if needed, can be still invoked after the edit commit is done (as it was done before).

By adding `ControlUtils::controlShouldRequestFocusIfCurrentFocusOwnerIsChild` the `Cell::commitEdit` implementations can now query if the control should have the focus, after `super.commitEdit(newValue);` but before firing the `CellEditEvent` and calling `updateItem()`, and if the result is true, then request focus after the edit commit ends (like it was done before).

Two new tests per control have been included, to verify that the focus remains at the control, one for edit cancel (this passes before and after the proposed changes), one for edit commit (this fails before and passes after including the proposed fix).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324939](https://bugs.openjdk.org/browse/JDK-8324939): Editable TableView loses focus after commit (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)
 * [Marius Hanl](https://openjdk.org/census#mhanl) (@Maran23 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1411/head:pull/1411` \
`$ git checkout pull/1411`

Update a local copy of the PR: \
`$ git checkout pull/1411` \
`$ git pull https://git.openjdk.org/jfx.git pull/1411/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1411`

View PR using the GUI difftool: \
`$ git pr show -t 1411`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1411.diff">https://git.openjdk.org/jfx/pull/1411.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1411#issuecomment-2009304221)