### PR TITLE
8328667: [Testbug] Enable ignored Spinner unit tests

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
@@ -338,7 +338,7 @@ public class SpinnerTest {
      *                                                                         *
      **************************************************************************/
 
-    @Ignore("Need KeyboardEventFirer. Listener not invoked on changing value using setText method")
+    @Ignore("JDK-8328701")
     @Test public void editing_commitValidInput() {
         intSpinner.valueProperty().addListener(o -> eventCount++);
         intSpinner.getEditor().setText("3");
@@ -349,7 +349,7 @@ public class SpinnerTest {
         assertEquals("3", intSpinner.getEditor().getText());
     }
 
-    @Ignore("Need KeyboardEventFirer. Listener not invoked on changing value using setText method")
+    @Ignore("JDK-8328701")
     @Test public void editing_commitInvalidInput() {
         intSpinner.valueProperty().addListener(o -> eventCount++);
         intSpinner.getEditor().setText("300");

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/SpinnerTest.java
@@ -169,9 +169,10 @@ public class SpinnerTest {
         assertFalse(spinner.isEditable());
     }
 
-    @Ignore("Waiting for StageLoader")
     @Test public void createDefaultSpinner_defaultSkinIsInstalled() {
+        StageLoader stageLoader = new StageLoader(spinner);
         assertTrue(spinner.getSkin() instanceof SpinnerSkin);
+        stageLoader.dispose();
     }
 
 
@@ -337,7 +338,7 @@ public class SpinnerTest {
      *                                                                         *
      **************************************************************************/
 
-    @Ignore("Need KeyboardEventFirer")
+    @Ignore("Need KeyboardEventFirer. Listener not invoked on changing value using setText method")
     @Test public void editing_commitValidInput() {
         intSpinner.valueProperty().addListener(o -> eventCount++);
         intSpinner.getEditor().setText("3");
@@ -348,7 +349,7 @@ public class SpinnerTest {
         assertEquals("3", intSpinner.getEditor().getText());
     }
 
-    @Ignore("Need KeyboardEventFirer")
+    @Ignore("Need KeyboardEventFirer. Listener not invoked on changing value using setText method")
     @Test public void editing_commitInvalidInput() {
         intSpinner.valueProperty().addListener(o -> eventCount++);
         intSpinner.getEditor().setText("300");


### PR DESCRIPTION
Enabled a test in `SpinnerTest` class.
Added comment to the editing test, why it can not be enabled. When Spinner value is set using `getEditor` `setText` method, the listener added to the spinner is not invoked. There is no bug for this issue. I'm not sure about the expectation in this case.
Other set of tests which are ignored are `LocalTimeSpinnerValueFactory` tests. Since these tests are unstable and fail only at certain time of the day, not enabling this test as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328667](https://bugs.openjdk.org/browse/JDK-8328667): [Testbug] Enable ignored Spinner unit tests (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1414/head:pull/1414` \
`$ git checkout pull/1414`

Update a local copy of the PR: \
`$ git checkout pull/1414` \
`$ git pull https://git.openjdk.org/jfx.git pull/1414/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1414`

View PR using the GUI difftool: \
`$ git pr show -t 1414`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1414.diff">https://git.openjdk.org/jfx/pull/1414.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1414#issuecomment-2011366829)