### PR TITLE
8328739: Remove unused imports in javafx.graphics

### DIFF
--- a/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Platform.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/glass/ui/Platform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,11 +24,9 @@
  */
 package com.sun.glass.ui;
 
-import com.sun.javafx.PlatformUtil;
-
 import java.security.AccessController;
 import java.security.PrivilegedAction;
-import java.util.Locale;
+import com.sun.javafx.PlatformUtil;
 
 final class Platform {
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FallbackResource.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FallbackResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,8 @@
 package com.sun.javafx.font;
 
 import java.lang.ref.WeakReference;
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
 import com.sun.javafx.geom.transform.BaseTransform;
 
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,6 @@
 package com.sun.javafx.font.coretext;
 
 import java.util.ArrayList;
-
-import com.sun.javafx.font.FallbackResource;
 import com.sun.javafx.font.FontFallbackInfo;
 import com.sun.javafx.font.FontResource;
 import com.sun.javafx.font.PrismFontFactory;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/text/GlyphLayout.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/text/GlyphLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,23 +58,19 @@ package com.sun.javafx.text;
 
 import static com.sun.javafx.scene.text.TextLayout.FLAGS_ANALYSIS_VALID;
 import static com.sun.javafx.scene.text.TextLayout.FLAGS_HAS_BIDI;
+import static com.sun.javafx.scene.text.TextLayout.FLAGS_HAS_CJK;
 import static com.sun.javafx.scene.text.TextLayout.FLAGS_HAS_COMPLEX;
 import static com.sun.javafx.scene.text.TextLayout.FLAGS_HAS_EMBEDDED;
 import static com.sun.javafx.scene.text.TextLayout.FLAGS_HAS_TABS;
-import static com.sun.javafx.scene.text.TextLayout.FLAGS_HAS_CJK;
 import static com.sun.javafx.scene.text.TextLayout.FLAGS_RTL_BASE;
-
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.text.Bidi;
-
-import com.sun.javafx.font.CharToGlyphMapper;
 import com.sun.javafx.font.FontResource;
 import com.sun.javafx.font.FontStrike;
 import com.sun.javafx.font.PGFont;
 import com.sun.javafx.font.PrismFontFactory;
-import com.sun.javafx.font.PrismFontFile;
 import com.sun.javafx.scene.text.TextSpan;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
 public abstract class GlyphLayout {
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/text/PrismTextLayout.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/text/PrismTextLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,11 @@
 
 package com.sun.javafx.text;
 
-
+import java.text.Bidi;
+import java.text.BreakIterator;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Hashtable;
 import javafx.scene.shape.LineTo;
 import javafx.scene.shape.MoveTo;
 import javafx.scene.shape.PathElement;
@@ -41,17 +45,11 @@ import com.sun.javafx.geom.Point2D;
 import com.sun.javafx.geom.RectBounds;
 import com.sun.javafx.geom.RoundRectangle2D;
 import com.sun.javafx.geom.Shape;
-import com.sun.javafx.geom.BoxBounds;
 import com.sun.javafx.geom.transform.BaseTransform;
 import com.sun.javafx.geom.transform.Translate2D;
 import com.sun.javafx.scene.text.GlyphList;
 import com.sun.javafx.scene.text.TextLayout;
 import com.sun.javafx.scene.text.TextSpan;
-import java.text.Bidi;
-import java.text.BreakIterator;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Hashtable;
 
 public class PrismTextLayout implements TextLayout {
     private static final BaseTransform IDENTITY = BaseTransform.IDENTITY_TRANSFORM;

--- a/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWGraphics.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/prism/sw/SWGraphics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package com.sun.prism.sw;
 
 import com.sun.glass.ui.Screen;
+import com.sun.javafx.font.CharToGlyphMapper;
 import com.sun.javafx.font.FontResource;
 import com.sun.javafx.font.FontStrike;
 import com.sun.javafx.font.Glyph;
@@ -58,12 +59,10 @@ import com.sun.prism.RTTexture;
 import com.sun.prism.ReadbackGraphics;
 import com.sun.prism.RenderTarget;
 import com.sun.prism.Texture;
-import com.sun.prism.Texture.WrapMode;
 import com.sun.prism.impl.PrismSettings;
 import com.sun.prism.paint.Color;
 import com.sun.prism.paint.ImagePattern;
 import com.sun.prism.paint.Paint;
-import com.sun.javafx.font.CharToGlyphMapper;
 
 final class SWGraphics implements ReadbackGraphics {
 


### PR DESCRIPTION
Using Eclipse IDE to remove unused imports in **javafx.graphics** and update the copyright year to 2024. Using wildcard for more than 10 static imports.

**PROBLEM**
The code in `graphics/build/gensrc/jsl-decora/` is generated and cannot be fixed.
This means this warning **must be suppressed** in IDEs until the generator script is changed not to emit unused imports.

--

This is a trivial change, 1 reviewer is probably enough.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328739](https://bugs.openjdk.org/browse/JDK-8328739): Remove unused imports in javafx.graphics (**Bug** - P4)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1417/head:pull/1417` \
`$ git checkout pull/1417`

Update a local copy of the PR: \
`$ git checkout pull/1417` \
`$ git pull https://git.openjdk.org/jfx.git pull/1417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1417`

View PR using the GUI difftool: \
`$ git pr show -t 1417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1417.diff">https://git.openjdk.org/jfx/pull/1417.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1417#issuecomment-2013428825)