### PR TITLE
8328746: Remove unused imports in demo apps

### DIFF
--- a/apps/samples/3DViewer/src/main/java/com/javafx/experiments/importers/obj/MtlReader.java
+++ b/apps/samples/3DViewer/src/main/java/com/javafx/experiments/importers/obj/MtlReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,9 +31,8 @@
  */
 package com.javafx.experiments.importers.obj;
 
+import static com.javafx.experiments.importers.obj.ObjImporter.log;
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -48,8 +47,6 @@ import javafx.scene.image.Image;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.Material;
 import javafx.scene.paint.PhongMaterial;
-
-import static com.javafx.experiments.importers.obj.ObjImporter.*;
 
 /** Reader for OBJ file MTL material files. */
 public class MtlReader {

--- a/apps/samples/3DViewer/src/main/java/com/javafx/experiments/jfx3dviewer/ContentModel.java
+++ b/apps/samples/3DViewer/src/main/java/com/javafx/experiments/jfx3dviewer/ContentModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -32,8 +32,10 @@
 package com.javafx.experiments.jfx3dviewer;
 
 import javafx.animation.Timeline;
+import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.event.EventHandler;
 import javafx.scene.AmbientLight;
 import javafx.scene.Group;
 import javafx.scene.Node;
@@ -41,7 +43,10 @@ import javafx.scene.Parent;
 import javafx.scene.PerspectiveCamera;
 import javafx.scene.PointLight;
 import javafx.scene.SubScene;
-import javafx.scene.input.*;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.input.ScrollEvent;
+import javafx.scene.input.ZoomEvent;
 import javafx.scene.layout.Region;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.PhongMaterial;
@@ -51,15 +56,9 @@ import javafx.scene.shape.MeshView;
 import javafx.scene.shape.Sphere;
 import javafx.scene.transform.Rotate;
 import javafx.scene.transform.Translate;
-
+import javafx.util.Duration;
 import com.javafx.experiments.shape3d.PolygonMeshView;
 import com.javafx.experiments.shape3d.SubdivisionMesh;
-
-import javafx.beans.property.ObjectProperty;
-import javafx.event.EventHandler;
-import javafx.event.EventType;
-import javafx.scene.Scene;
-import javafx.util.Duration;
 
 /**
  * 3D Content Model for Viewer App. Contains the 3D scene and everything related to it: light, cameras etc.

--- a/apps/samples/3DViewer/src/main/java/com/javafx/experiments/jfx3dviewer/NavigationController.java
+++ b/apps/samples/3DViewer/src/main/java/com/javafx/experiments/jfx3dviewer/NavigationController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -34,7 +34,6 @@ package com.javafx.experiments.jfx3dviewer;
 import java.net.URL;
 import java.util.ResourceBundle;
 import javafx.fxml.Initializable;
-import javafx.geometry.Side;
 import javafx.scene.control.ScrollBar;
 
 /**

--- a/apps/samples/3DViewer/src/main/java/com/javafx/experiments/shape3d/PolygonMeshView.java
+++ b/apps/samples/3DViewer/src/main/java/com/javafx/experiments/shape3d/PolygonMeshView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -32,7 +32,6 @@
 package com.javafx.experiments.shape3d;
 
 import java.util.Arrays;
-
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleObjectProperty;
@@ -44,8 +43,8 @@ import javafx.scene.shape.CullFace;
 import javafx.scene.shape.DrawMode;
 import javafx.scene.shape.MeshView;
 import javafx.scene.shape.TriangleMesh;
-import static javafx.scene.shape.TriangleMesh.*;
-import static com.javafx.experiments.shape3d.SubdivisionMesh.*;
+import com.javafx.experiments.shape3d.SubdivisionMesh.BoundaryMode;
+import com.javafx.experiments.shape3d.SubdivisionMesh.MapBorderMode;
 
 /**
  * A MeshView node for Polygon Meshes

--- a/apps/samples/Ensemble8/src/app/java/ensemble/DocsPage.java
+++ b/apps/samples/Ensemble8/src/app/java/ensemble/DocsPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,12 +31,10 @@
  */
 package ensemble;
 
-import ensemble.generated.Samples;
 import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
@@ -47,6 +45,7 @@ import javafx.scene.control.ScrollPane;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import javafx.scene.web.WebView;
+import ensemble.generated.Samples;
 
 /**
  * Ensmeble page for showing a page of documentation from the web

--- a/apps/samples/Ensemble8/src/app/java/ensemble/SampleInfo.java
+++ b/apps/samples/Ensemble8/src/app/java/ensemble/SampleInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,8 +31,6 @@
  */
 package ensemble;
 
-import ensemble.playground.PlaygroundProperty;
-import ensemble.samplepage.SamplePage;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.AbstractList;
@@ -42,7 +40,6 @@ import java.util.WeakHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.application.ConditionalFeature;
-import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
@@ -53,8 +50,18 @@ import javafx.scene.Scene;
 import javafx.scene.control.Label;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.layout.*;
+import javafx.scene.layout.Background;
+import javafx.scene.layout.BackgroundFill;
+import javafx.scene.layout.BackgroundImage;
+import javafx.scene.layout.BackgroundPosition;
+import javafx.scene.layout.BackgroundRepeat;
+import javafx.scene.layout.BackgroundSize;
+import javafx.scene.layout.CornerRadii;
+import javafx.scene.layout.Pane;
+import javafx.scene.layout.Region;
 import javafx.scene.paint.Color;
+import ensemble.playground.PlaygroundProperty;
+import ensemble.samplepage.SamplePage;
 
 /**
  * Descriptor for a ensemble sample. Everything the ui needs is determined at

--- a/apps/samples/Ensemble8/src/app/java/ensemble/SearchResultPopoverList.java
+++ b/apps/samples/Ensemble8/src/app/java/ensemble/SearchResultPopoverList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,13 +31,8 @@
  */
 package ensemble;
 
-import ensemble.control.Popover;
-import ensemble.control.PopoverTreeList;
-import ensemble.search.DocumentType;
-import ensemble.search.SearchResult;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
@@ -57,6 +52,10 @@ import javafx.scene.layout.Pane;
 import javafx.scene.layout.Region;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
+import ensemble.control.Popover;
+import ensemble.control.PopoverTreeList;
+import ensemble.search.DocumentType;
+import ensemble.search.SearchResult;
 
 /**
  * Popover page that displays a list of search results.

--- a/apps/samples/Ensemble8/src/app/java/ensemble/control/BookBend.java
+++ b/apps/samples/Ensemble8/src/app/java/ensemble/control/BookBend.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -33,17 +33,23 @@ package ensemble.control;
 
 
 import javafx.animation.AnimationTimer;
-import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
-import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.geometry.Point2D;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.effect.DisplacementMap;
 import javafx.scene.effect.FloatMap;
-import javafx.scene.paint.*;
-import javafx.scene.shape.*;
+import javafx.scene.paint.Color;
+import javafx.scene.paint.CycleMethod;
+import javafx.scene.paint.LinearGradient;
+import javafx.scene.paint.Paint;
+import javafx.scene.paint.Stop;
+import javafx.scene.shape.ArcTo;
+import javafx.scene.shape.ClosePath;
+import javafx.scene.shape.LineTo;
+import javafx.scene.shape.MoveTo;
+import javafx.scene.shape.Path;
 
 public class BookBend {
     private Color bendEndColor = Color.LIGHTBLUE.interpolate(Color.BLACK, 0.6);

--- a/apps/samples/Ensemble8/src/app/java/ensemble/control/SearchBox.java
+++ b/apps/samples/Ensemble8/src/app/java/ensemble/control/SearchBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -33,7 +33,6 @@ package ensemble.control;
 
 import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
-import javafx.event.EventHandler;
 import javafx.scene.Cursor;
 import javafx.scene.control.Button;
 import javafx.scene.control.TextField;

--- a/apps/samples/Ensemble8/src/app/java/ensemble/control/TitledToolBar.java
+++ b/apps/samples/Ensemble8/src/app/java/ensemble/control/TitledToolBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -32,7 +32,6 @@
 package ensemble.control;
 
 import java.util.Arrays;
-import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.geometry.HPos;

--- a/apps/samples/Ensemble8/src/app/java/ensemble/samplepage/Description.java
+++ b/apps/samples/Ensemble8/src/app/java/ensemble/samplepage/Description.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,26 +31,28 @@
  */
 package ensemble.samplepage;
 
-import ensemble.EnsembleApp;
-import ensemble.PlatformFeatures;
-import ensemble.SampleInfo;
-import ensemble.SampleInfo.URL;
-import ensemble.generated.Samples;
+import static ensemble.samplepage.SamplePage.INDENT;
+import static ensemble.samplepage.SamplePageContent.title;
+import javafx.application.ConditionalFeature;
+import javafx.application.Platform;
 import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
 import javafx.geometry.Insets;
-import javafx.scene.control.*;
+import javafx.scene.control.ContentDisplay;
+import javafx.scene.control.Hyperlink;
+import javafx.scene.control.Label;
+import javafx.scene.control.ScrollPane;
+import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.ColumnConstraints;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
-import javafx.util.Callback;
-import static ensemble.samplepage.SamplePage.INDENT;
-import static ensemble.samplepage.SamplePageContent.title;
-import javafx.application.ConditionalFeature;
-import javafx.application.Platform;
+import ensemble.EnsembleApp;
+import ensemble.PlatformFeatures;
+import ensemble.SampleInfo;
+import ensemble.SampleInfo.URL;
+import ensemble.generated.Samples;
 
 /**
  * Description Section on Sample Page

--- a/apps/samples/Ensemble8/src/app/java/ensemble/samplepage/SamplePage.java
+++ b/apps/samples/Ensemble8/src/app/java/ensemble/samplepage/SamplePage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,11 +31,6 @@
  */
 package ensemble.samplepage;
 
-import ensemble.Page;
-import ensemble.PageBrowser;
-import ensemble.SampleInfo;
-import static ensemble.SampleInfo.SampleRuntimeInfo;
-
 import javafx.beans.binding.ObjectBinding;
 import javafx.beans.binding.StringBinding;
 import javafx.beans.property.ObjectProperty;
@@ -43,11 +38,14 @@ import javafx.beans.property.ReadOnlyStringProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
-import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.scene.Node;
 import javafx.scene.layout.StackPane;
 import javafx.util.Callback;
+import ensemble.Page;
+import ensemble.PageBrowser;
+import ensemble.SampleInfo;
+import ensemble.SampleInfo.SampleRuntimeInfo;
 
 /**
  * Page for showing a sample

--- a/apps/samples/Ensemble8/src/app/java/ensemble/samplepage/SamplePageContent.java
+++ b/apps/samples/Ensemble8/src/app/java/ensemble/samplepage/SamplePageContent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,14 +31,12 @@
  */
 package ensemble.samplepage;
 
-import ensemble.PlatformFeatures;
-import ensemble.SampleInfo;
+import static ensemble.samplepage.SamplePage.INDENT;
 import javafx.scene.Node;
 import javafx.scene.layout.Region;
 import javafx.scene.text.Text;
-import javafx.util.Callback;
-
-import static ensemble.samplepage.SamplePage.INDENT;
+import ensemble.PlatformFeatures;
+import ensemble.SampleInfo;
 
 /**
  * The content for Sample Page

--- a/apps/samples/Ensemble8/src/app/java/ensemble/samplepage/XYDataVisualizer.java
+++ b/apps/samples/Ensemble8/src/app/java/ensemble/samplepage/XYDataVisualizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,13 +31,6 @@
  */
 package ensemble.samplepage;
 
-
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.scene.chart.XYChart;
-import javafx.scene.control.TreeItem;
-import javafx.scene.control.TreeTableView;
-import ensemble.samplepage.XYDataVisualizer.XYChartItem;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -45,30 +38,34 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javafx.beans.WeakListener;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
-import javafx.beans.value.ChangeListener;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
 import javafx.scene.Node;
 import javafx.scene.chart.CategoryAxis;
 import javafx.scene.chart.NumberAxis;
+import javafx.scene.chart.XYChart;
 import javafx.scene.chart.XYChart.Data;
 import javafx.scene.chart.XYChart.Series;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeTableCell;
 import javafx.scene.control.TreeTableColumn;
 import javafx.scene.control.TreeTableColumn.CellDataFeatures;
 import javafx.scene.control.TreeTableRow;
+import javafx.scene.control.TreeTableView;
 import javafx.scene.control.cell.TextFieldTreeTableCell;
 import javafx.scene.input.ContextMenuEvent;
 import javafx.util.Callback;
 import javafx.util.StringConverter;
+import ensemble.samplepage.XYDataVisualizer.XYChartItem;
 
 
 public class XYDataVisualizer<X, Y> extends TreeTableView<XYChartItem<X, Y>> {

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/charts/candlestick/CandleStickChart.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/charts/candlestick/CandleStickChart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -37,13 +37,10 @@ import java.util.List;
 import javafx.animation.FadeTransition;
 import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
 import javafx.scene.Node;
 import javafx.scene.chart.Axis;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart;
-import javafx.scene.chart.XYChart.Data;
-import javafx.scene.chart.XYChart.Series;
 import javafx.scene.shape.LineTo;
 import javafx.scene.shape.MoveTo;
 import javafx.scene.shape.Path;

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/charts/line/stock/StockLineChartApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/charts/line/stock/StockLineChartApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -43,7 +43,6 @@ import javafx.scene.Scene;
 import javafx.scene.chart.LineChart;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.NumberAxis.DefaultFormatter;
-import javafx.scene.chart.XYChart;
 import javafx.scene.chart.XYChart.Data;
 import javafx.scene.chart.XYChart.Series;
 import javafx.stage.Stage;

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/charts/scatter/animated/LiveScatterChartApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/charts/scatter/animated/LiveScatterChartApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -42,7 +42,6 @@ import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.ScatterChart;
-import javafx.scene.chart.XYChart;
 import javafx.scene.chart.XYChart.Data;
 import javafx.stage.Stage;
 import javafx.util.Duration;

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/charts/scatter/chart/ScatterChartApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/charts/scatter/chart/ScatterChartApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -32,13 +32,11 @@
 
 package ensemble.samples.charts.scatter.chart;
 
-
 import javafx.application.Application;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.ScatterChart;
-import javafx.scene.chart.XYChart;
 import javafx.scene.chart.XYChart.Data;
 import javafx.scene.chart.XYChart.Series;
 import javafx.stage.Stage;

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/controls/button/colorbutton/ColorButtonApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/controls/button/colorbutton/ColorButtonApp.java
@@ -37,7 +37,6 @@ import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
-import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 
 /**

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/controls/listview/listviewcellfactory/ListViewCellFactoryApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/controls/listview/listviewcellfactory/ListViewCellFactoryApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,18 +31,15 @@
  */
 package ensemble.samples.controls.listview.listviewcellfactory;
 
+import java.util.Arrays;
 import javafx.application.Application;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.control.SelectionMode;
 import javafx.stage.Stage;
-import javafx.util.Callback;
-
-import java.util.Arrays;
 
 /**
  * A simple implementation of the ListView control that uses a CellFactory to

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/controls/menu/MenuApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/controls/menu/MenuApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -32,7 +32,6 @@
 package ensemble.samples.controls.menu;
 
 import javafx.application.Application;
-import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.value.ChangeListener;

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/controls/pagination/PaginationApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/controls/pagination/PaginationApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -35,7 +35,6 @@ import javafx.application.Application;
 import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
 import javafx.geometry.Pos;
-import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/controls/spinner/SpinnerApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/controls/spinner/SpinnerApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -34,7 +34,6 @@ package ensemble.samples.controls.spinner;
 import javafx.application.Application;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import javafx.scene.Group;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Spinner;
@@ -42,8 +41,6 @@ import javafx.scene.control.SpinnerValueFactory;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.TilePane;
 import javafx.stage.Stage;
-
-import java.util.Arrays;
 
 /**
  * A sample that demonstrates the Spinner control.

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/controls/tab/TabPaneApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/controls/tab/TabPaneApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,9 +31,9 @@
  */
 package ensemble.samples.controls.tab;
 
+import java.io.InputStream;
 import javafx.application.Application;
 import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
 import javafx.geometry.Side;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
@@ -52,8 +52,6 @@ import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
-
-import java.io.InputStream;
 
 /**
  * Some implementations of tabs using the TabPane class.

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/bouncingballs/Ball.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/bouncingballs/Ball.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,13 +31,17 @@
  */
 package ensemble.samples.graphics2d.bouncingballs;
 
-import static ensemble.samples.graphics2d.bouncingballs.Constants.*;
+import static ensemble.samples.graphics2d.bouncingballs.Constants.BALL_GRADIENT;
+import static ensemble.samples.graphics2d.bouncingballs.Constants.BALL_RADIUS;
+import static ensemble.samples.graphics2d.bouncingballs.Constants.HEIGHT;
+import static ensemble.samples.graphics2d.bouncingballs.Constants.HEIGHT_CORRECTION;
+import static ensemble.samples.graphics2d.bouncingballs.Constants.INFOPANEL_HEIGHT;
+import static ensemble.samples.graphics2d.bouncingballs.Constants.SPACE_X;
 import javafx.animation.Animation.Status;
 import javafx.animation.Interpolator;
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
-import javafx.event.EventHandler;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.shape.Circle;
 import javafx.util.Duration;

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/bouncingballs/BallsScreen.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/bouncingballs/BallsScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2013, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,16 +31,13 @@
  */
 package ensemble.samples.graphics2d.bouncingballs;
 
-import javafx.scene.Group;
+import static ensemble.samples.graphics2d.bouncingballs.Constants.BALL_RADIUS;
+import static ensemble.samples.graphics2d.bouncingballs.Constants.HEIGHT;
+import static ensemble.samples.graphics2d.bouncingballs.Constants.INFOPANEL_HEIGHT;
+import static ensemble.samples.graphics2d.bouncingballs.Constants.WIDTH;
 import javafx.scene.Parent;
-import javafx.scene.Scene;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Line;
-import javafx.scene.control.Button;
-import javafx.stage.Screen;
-import javafx.stage.Stage;
-
-import static ensemble.samples.graphics2d.bouncingballs.Constants.*;
 
 public class BallsScreen extends Parent {
 

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/bouncingballs/BouncingBallsApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/bouncingballs/BouncingBallsApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -32,16 +32,13 @@
 package ensemble.samples.graphics2d.bouncingballs;
 
 import javafx.application.Application;
-import javafx.stage.Stage;
+import javafx.event.ActionEvent;
+import javafx.geometry.Insets;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.paint.Color;
-import javafx.scene.Group;
-import javafx.scene.layout.VBox;
 import javafx.scene.control.Button;
-import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
-import javafx.geometry.Insets;
+import javafx.scene.layout.VBox;
+import javafx.stage.Stage;
 
 /**
  * A sample that shows animated bouncing balls.

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/brickbreaker/Level.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/brickbreaker/Level.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -33,13 +33,12 @@ package ensemble.samples.graphics2d.brickbreaker;
 
 import java.util.ArrayList;
 import java.util.Iterator;
-
+import javafx.animation.AnimationTimer;
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
 import javafx.application.Platform;
 import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
 import javafx.geometry.VPos;
 import javafx.scene.Group;
 import javafx.scene.Parent;
@@ -54,7 +53,6 @@ import javafx.scene.text.Font;
 import javafx.scene.text.Text;
 import javafx.util.Duration;
 import ensemble.samples.graphics2d.brickbreaker.BrickBreakerApp.MainFrame;
-import javafx.animation.AnimationTimer;
 
 public class Level extends Parent {
 

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/brickbreaker/Splash.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/brickbreaker/Splash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,17 +31,16 @@
  */
 package ensemble.samples.graphics2d.brickbreaker;
 
-import ensemble.samples.graphics2d.brickbreaker.BrickBreakerApp.MainFrame;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
 import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
 import javafx.scene.Group;
 import javafx.scene.Parent;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.input.MouseEvent;
 import javafx.util.Duration;
+import ensemble.samples.graphics2d.brickbreaker.BrickBreakerApp.MainFrame;
 
 public class Splash extends Parent {
 

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/calc/Calculator.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/calc/Calculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,8 +31,6 @@
  */
 package ensemble.samples.graphics2d.calc;
 
-import ensemble.samples.graphics2d.calc.Key.Code;
-import javafx.event.EventHandler;
 import javafx.geometry.VPos;
 import javafx.scene.Parent;
 import javafx.scene.input.KeyEvent;
@@ -44,6 +42,7 @@ import javafx.scene.paint.Stop;
 import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Font;
 import javafx.scene.text.Text;
+import ensemble.samples.graphics2d.calc.Key.Code;
 
 
 public class Calculator extends Parent {

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/calc/CalculatorApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/calc/CalculatorApp.java
@@ -1,6 +1,6 @@
 
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -33,11 +33,10 @@
 package ensemble.samples.graphics2d.calc;
 
 import javafx.application.Application;
-import javafx.stage.Stage;
 import javafx.scene.Group;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.paint.Color;
+import javafx.stage.Stage;
 
 
 /**

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/calc/Key.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/calc/Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,7 +31,6 @@
  */
 package ensemble.samples.graphics2d.calc;
 
-import javafx.event.EventHandler;
 import javafx.scene.Parent;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.paint.Color;

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/colorfulcircles/ColorfulCirclesApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/colorfulcircles/ColorfulCirclesApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -39,7 +39,6 @@ import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
 import javafx.application.Application;
-import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/digitalclock/Clock.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/digitalclock/Clock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -35,7 +35,6 @@ import java.util.Calendar;
 import javafx.animation.KeyFrame;
 import javafx.animation.Timeline;
 import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
 import javafx.scene.Group;
 import javafx.scene.Parent;
 import javafx.scene.effect.Glow;

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/effects/reflection/ReflectionApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/effects/reflection/ReflectionApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -32,7 +32,6 @@
 package ensemble.samples.graphics2d.effects.reflection;
 
 import javafx.application.Application;
-import javafx.geometry.Pos;
 import javafx.scene.Group;
 import javafx.scene.Parent;
 import javafx.scene.Scene;

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/images/imageoperator/ImageOperationApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/images/imageoperator/ImageOperationApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -32,13 +32,11 @@
 package ensemble.samples.graphics2d.images.imageoperator;
 
 import javafx.application.Application;
-import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.image.PixelWriter;
 import javafx.scene.image.WritableImage;

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/puzzle/Piece.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/puzzle/Piece.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,7 +31,6 @@
  */
 package ensemble.samples.graphics2d.puzzle;
 
-import javafx.event.EventHandler;
 import javafx.geometry.Point2D;
 import javafx.scene.Parent;
 import javafx.scene.effect.DropShadow;
@@ -43,9 +42,10 @@ import javafx.scene.shape.Circle;
 import javafx.scene.shape.Ellipse;
 import javafx.scene.shape.Rectangle;
 import javafx.scene.shape.Shape;
-   /**
-     * Node that represents a puzzle piece
-     */
+
+/**
+ * Node that represents a puzzle piece
+ */
 public class Piece extends Parent{
         public static final int SIZE = 100;
         private final double correctX;

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/puzzle/PuzzlePiecesApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/graphics2d/puzzle/PuzzlePiecesApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -42,13 +42,9 @@ import javafx.geometry.Insets;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
-import javafx.scene.effect.DropShadow;
 import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
 import javafx.scene.layout.HBox;
-import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
-import javafx.scene.shape.Path;
 import javafx.stage.Stage;
 import javafx.util.Duration;
 

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/language/concurrency/service/ServiceApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/language/concurrency/service/ServiceApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -33,7 +33,6 @@ package ensemble.samples.language.concurrency.service;
 
 import javafx.application.Application;
 import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
 import javafx.geometry.Insets;
 import javafx.scene.Parent;
 import javafx.scene.Scene;

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/language/fxml/LoginController.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/language/fxml/LoginController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -32,10 +32,8 @@
 
 package ensemble.samples.language.fxml;
 
-import java.awt.Color;
 import java.net.URL;
 import java.util.ResourceBundle;
-
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/language/fxml/ProfileController.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/language/fxml/ProfileController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -36,10 +36,14 @@ import java.net.URL;
 import java.util.ResourceBundle;
 import javafx.animation.FadeTransition;
 import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
-import javafx.scene.control.*;
+import javafx.scene.control.Button;
+import javafx.scene.control.CheckBox;
+import javafx.scene.control.Hyperlink;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
+import javafx.scene.control.TextField;
 import javafx.scene.layout.AnchorPane;
 import javafx.util.Duration;
 

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/layout/anchorpane/AnchorPaneApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/layout/anchorpane/AnchorPaneApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -32,7 +32,6 @@
 package ensemble.samples.layout.anchorpane;
 
 import javafx.application.Application;
-import javafx.collections.ObservableList;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;

--- a/apps/samples/Ensemble8/src/samples/java/ensemble/samples/scenegraph/events/keystrokemotion/KeyStrokeMotionApp.java
+++ b/apps/samples/Ensemble8/src/samples/java/ensemble/samples/scenegraph/events/keystrokemotion/KeyStrokeMotionApp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2016, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -34,7 +34,6 @@ package ensemble.samples.scenegraph.events.keystrokemotion;
 import javafx.application.Application;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
-import javafx.scene.layout.Pane;
 import javafx.stage.Stage;
 
 /**

--- a/apps/samples/Modena/src/main/java/modena/Modena.java
+++ b/apps/samples/Modena/src/main/java/modena/Modena.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2017, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -33,14 +33,11 @@ package modena;
 
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.URLStreamHandler;
@@ -49,7 +46,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
+import javax.imageio.ImageIO;
 import javafx.application.Application;
 import javafx.application.Platform;
 import javafx.embed.swing.SwingFXUtils;
@@ -65,7 +62,6 @@ import javafx.scene.control.Button;
 import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.ColorPicker;
 import javafx.scene.control.ComboBox;
-import javafx.scene.control.Control;
 import javafx.scene.control.Label;
 import javafx.scene.control.Menu;
 import javafx.scene.control.MenuBar;
@@ -77,7 +73,6 @@ import javafx.scene.control.TabPane;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToggleGroup;
 import javafx.scene.control.ToolBar;
-import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.image.WritableImage;
@@ -88,8 +83,6 @@ import javafx.scene.paint.Color;
 import javafx.scene.transform.Scale;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
-
-import javax.imageio.ImageIO;
 
 public class Modena extends Application {
     public static final String TEST = "test";

--- a/apps/samples/Modena/src/main/java/modena/SamplePageNavigation.java
+++ b/apps/samples/Modena/src/main/java/modena/SamplePageNavigation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,16 +31,14 @@
  */
 package modena;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.ToolBar;
 import javafx.scene.layout.BorderPane;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
 
 /**
  * Container for samplePage that has scrolling and knows how to navigate to sections

--- a/apps/samples/Modena/src/main/java/modena/SamplePageTableHelper.java
+++ b/apps/samples/Modena/src/main/java/modena/SamplePageTableHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -31,7 +31,6 @@
  */
 package modena;
 
-import javafx.beans.binding.ObjectBinding;
 import javafx.beans.binding.StringBinding;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
@@ -40,21 +39,13 @@ import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import javafx.collections.SetChangeListener;
-import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.control.SelectionMode;
 import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
-import javafx.scene.control.TableColumnBase;
 import javafx.scene.control.TableView;
 import javafx.scene.control.cell.CheckBoxTableCell;
 import javafx.scene.control.cell.PropertyValueFactory;
-import javafx.scene.image.Image;
-import javafx.scene.image.ImageView;
-import javafx.scene.paint.Color;
-import javafx.scene.paint.Paint;
-import javafx.scene.shape.Rectangle;
 
 /**
  * Helper class for creating table views for testing

--- a/apps/samples/Modena/src/main/java/modena/SimpleWindowPage.java
+++ b/apps/samples/Modena/src/main/java/modena/SimpleWindowPage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2014, Oracle and/or its affiliates.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates.
  * All rights reserved. Use is subject to license terms.
  *
  * This file is available and licensed under the following license:
@@ -42,7 +42,6 @@ import javafx.scene.Node;
 import javafx.scene.layout.Background;
 import javafx.scene.layout.BackgroundFill;
 import javafx.scene.layout.CornerRadii;
-import javafx.scene.layout.HBox;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.TilePane;
 import javafx.scene.paint.Color;

--- a/apps/tests/Robot/src/robottest/RobotBuilder.java
+++ b/apps/tests/Robot/src/robottest/RobotBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package robottest;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.nio.Buffer;
 import java.nio.IntBuffer;
 import javafx.animation.AnimationTimer;
 import javafx.collections.FXCollections;
@@ -42,13 +41,12 @@ import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListView;
 import javafx.scene.control.TextField;
-import javafx.scene.input.KeyCode;
-import javafx.scene.input.MouseButton;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.image.PixelReader;
-import javafx.scene.image.WritableImage;
 import javafx.scene.image.WritablePixelFormat;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.MouseButton;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;

--- a/apps/toys/FX8-3DFeatures/src/fx83dfeatures/LightMotion.java
+++ b/apps/toys/FX8-3DFeatures/src/fx83dfeatures/LightMotion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@ import javafx.animation.KeyValue;
 import javafx.animation.RotateTransition;
 import javafx.animation.Timeline;
 import javafx.application.Application;
-import static javafx.application.Application.launch;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.beans.value.ChangeListener;

--- a/apps/toys/FX8-3DFeatures/src/fx83dfeatures/SubSceneAndAntiAliasingTest.java
+++ b/apps/toys/FX8-3DFeatures/src/fx83dfeatures/SubSceneAndAntiAliasingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package fx83dfeatures;
 
 import javafx.application.Application;
-import static javafx.application.Application.launch;
 import javafx.application.ConditionalFeature;
 import javafx.application.Platform;
 import javafx.geometry.Point3D;

--- a/apps/toys/Hello/src/main/java/hello/HelloAccordion.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloAccordion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,14 +26,12 @@
 package hello;
 
 import javafx.application.Application;
-import javafx.scene.Group;
 import javafx.scene.Scene;
 import javafx.scene.control.Accordion;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
 import javafx.scene.control.TitledPane;
 import javafx.scene.layout.VBox;
-import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 
 public class HelloAccordion extends Application {

--- a/apps/toys/Hello/src/main/java/hello/HelloCSS.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloCSS.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 
 package hello;
 
+import java.util.List;
 import javafx.animation.Animation;
 import javafx.animation.FadeTransition;
 import javafx.application.Application;
@@ -34,7 +35,6 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.ReadOnlyObjectProperty;
 import javafx.beans.property.SimpleBooleanProperty;
-import javafx.beans.value.WritableValue;
 import javafx.css.CssMetaData;
 import javafx.css.Styleable;
 import javafx.css.StyleableProperty;
@@ -58,8 +58,6 @@ import javafx.scene.shape.Rectangle;
 import javafx.scene.text.Text;
 import javafx.stage.Stage;
 import javafx.util.Duration;
-
-import java.util.List;
 
 public class HelloCSS extends Application {
     /**

--- a/apps/toys/Hello/src/main/java/hello/HelloCheckBox.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloCheckBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import javafx.application.Application;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.StringExpression;
 import javafx.css.PseudoClass;
-import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Scene;
 import javafx.scene.control.CheckBox;

--- a/apps/toys/Hello/src/main/java/hello/HelloColorPicker.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloColorPicker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,14 +27,12 @@ package hello;
 
 import javafx.application.Application;
 import javafx.event.ActionEvent;
-import javafx.event.Event;
 import javafx.event.EventHandler;
 import javafx.geometry.Insets;
 import javafx.scene.Scene;
 import javafx.scene.control.ColorPicker;
 import javafx.scene.control.Label;
 import javafx.scene.layout.GridPane;
-import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.stage.Stage;
 

--- a/apps/toys/Hello/src/main/java/hello/HelloComboBox.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloComboBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,14 +30,13 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.Group;
 import javafx.scene.Scene;
+import javafx.scene.control.ComboBox;
+import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Font;
 import javafx.stage.Stage;
-import javafx.scene.control.ComboBox;
-import javafx.scene.Node;
-import javafx.scene.control.Label;
 
 public class HelloComboBox extends Application {
 

--- a/apps/toys/Hello/src/main/java/hello/HelloDatePicker.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloDatePicker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,14 +30,9 @@ import java.time.MonthDay;
 import java.time.chrono.ChronoLocalDate;
 import java.time.format.DateTimeParseException;
 import java.util.Locale;
-
 import javafx.application.Application;
-import javafx.beans.InvalidationListener;
-import javafx.beans.Observable;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
-import javafx.event.ActionEvent;
-import javafx.event.EventHandler;
 import javafx.geometry.HPos;
 import javafx.geometry.NodeOrientation;
 import javafx.scene.Scene;

--- a/apps/toys/Hello/src/main/java/hello/HelloFontSize.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloFontSize.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package hello;
 
-import java.util.Set;
 import javafx.application.Application;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.BooleanPropertyBase;
@@ -34,9 +33,13 @@ import javafx.beans.value.ObservableValue;
 import javafx.css.PseudoClass;
 import javafx.event.EventHandler;
 import javafx.scene.Group;
-import javafx.scene.Node;
 import javafx.scene.Scene;
-import javafx.scene.control.*;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.Skin;
+import javafx.scene.control.Slider;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.control.ToggleGroup;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;

--- a/apps/toys/Hello/src/main/java/hello/HelloFonts.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloFonts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,20 +25,24 @@
 
 package hello;
 
+import java.util.ArrayList;
+import java.util.List;
 import javafx.application.Application;
 import javafx.collections.FXCollections;
 import javafx.scene.Node;
 import javafx.scene.Scene;
-import javafx.scene.control.*;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeView;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.text.Font;
 import javafx.scene.text.FontPosture;
 import javafx.scene.text.FontWeight;
 import javafx.stage.Stage;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  */

--- a/apps/toys/Hello/src/main/java/hello/HelloListView.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloListView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package hello;
 
-
 import java.text.NumberFormat;
 import java.util.AbstractList;
 import java.util.BitSet;
@@ -38,17 +37,14 @@ import javafx.animation.Interpolator;
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
-
 import javafx.application.Application;
 import javafx.beans.InvalidationListener;
 import javafx.beans.Observable;
-import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
-import javafx.collections.transformation.SortedList;
 import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.geometry.Insets;
@@ -57,7 +53,6 @@ import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
-import javafx.scene.control.ChoiceBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
@@ -71,7 +66,13 @@ import javafx.scene.control.ToggleGroup;
 import javafx.scene.control.Tooltip;
 import javafx.scene.control.cell.ChoiceBoxListCell;
 import javafx.scene.control.cell.TextFieldListCell;
-import javafx.scene.input.*;
+import javafx.scene.input.ClipboardContent;
+import javafx.scene.input.DragEvent;
+import javafx.scene.input.Dragboard;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.input.MouseEvent;
+import javafx.scene.input.TransferMode;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;

--- a/apps/toys/Hello/src/main/java/hello/HelloMedia.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloMedia.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,8 @@
 
 package hello;
 
-import java.util.List;
 import javafx.application.Application;
 import javafx.collections.ListChangeListener;
-import javafx.collections.ListChangeListener.Change;
 import javafx.collections.MapChangeListener;
 import javafx.event.EventHandler;
 import javafx.scene.Group;

--- a/apps/toys/Hello/src/main/java/hello/HelloPagination.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloPagination.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,10 +27,9 @@ package hello;
 
 import javafx.application.Application;
 import javafx.scene.Scene;
-import javafx.scene.control.Pagination;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
-import javafx.scene.layout.AnchorPane;
+import javafx.scene.control.Pagination;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;

--- a/apps/toys/Hello/src/main/java/hello/HelloPopup.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloPopup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,6 @@
  */
 
 package hello;
-
-import java.util.Iterator;
 
 import javafx.application.Application;
 import javafx.collections.ObservableList;

--- a/apps/toys/Hello/src/main/java/hello/HelloProgressBar.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloProgressBar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package hello;
 
-import javafx.animation.Interpolator;
 import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
 import javafx.animation.Timeline;

--- a/apps/toys/Hello/src/main/java/hello/HelloProgressIndicator.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloProgressIndicator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import javafx.animation.KeyFrame;
 import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
 import javafx.application.Application;
-import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.scene.Group;
 import javafx.scene.Scene;

--- a/apps/toys/Hello/src/main/java/hello/HelloRadioButton.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloRadioButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,11 +27,9 @@ package hello;
 
 import static javafx.scene.paint.Color.GHOSTWHITE;
 import javafx.application.Application;
-import javafx.collections.ObservableList;
 import javafx.geometry.Pos;
 import javafx.geometry.Side;
 import javafx.scene.Group;
-import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;

--- a/apps/toys/Hello/src/main/java/hello/HelloSpinner.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloSpinner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,8 +37,6 @@ import javafx.scene.control.Spinner;
 import javafx.scene.control.SpinnerValueFactory;
 import javafx.scene.layout.GridPane;
 import javafx.stage.Stage;
-
-import java.util.Locale;
 
 public class HelloSpinner extends Application {
 

--- a/apps/toys/Hello/src/main/java/hello/HelloTabPane.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloTabPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,16 +50,14 @@ import javafx.scene.control.ToggleGroup;
 import javafx.scene.control.Tooltip;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
-import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;
 import javafx.scene.shape.Rectangle;
 import javafx.stage.Stage;
-
 
 public class HelloTabPane extends Application {
 

--- a/apps/toys/Hello/src/main/java/hello/HelloTextArea.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloTextArea.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,6 @@ import javafx.geometry.Insets;
 import javafx.geometry.Orientation;
 import javafx.scene.Group;
 import javafx.scene.Scene;
-import javafx.scene.control.Button;
 import javafx.scene.control.TextArea;
 import javafx.scene.control.TextField;
 import javafx.scene.control.ToggleButton;

--- a/apps/toys/Hello/src/main/java/hello/HelloTextFlow.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloTextFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,17 +25,20 @@
 
 package hello;
 
+import static javafx.scene.paint.Color.BLACK;
+import static javafx.scene.paint.Color.LIGHTBLUE;
 import javafx.application.Application;
 import javafx.geometry.Point2D;
-import javafx.scene.*;
+import javafx.scene.Cursor;
+import javafx.scene.Group;
+import javafx.scene.Scene;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
-import javafx.scene.paint.*;
 import javafx.scene.shape.Path;
-import javafx.scene.text.*;
+import javafx.scene.text.HitInfo;
+import javafx.scene.text.Text;
+import javafx.scene.text.TextFlow;
 import javafx.stage.Stage;
-
-import static javafx.scene.paint.Color.*;
 
 public class HelloTextFlow extends Application {
     final Path caret = new Path();

--- a/apps/toys/Hello/src/main/java/hello/HelloTitledPane.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloTitledPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package hello;
 
 import javafx.application.Application;
 import javafx.geometry.Insets;
-import javafx.scene.Group;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -37,7 +36,6 @@ import javafx.scene.control.TitledPane;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.GridPane;
-import javafx.scene.layout.HBox;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.scene.paint.Color;

--- a/apps/toys/Hello/src/main/java/hello/HelloToggleButton.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloToggleButton.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,7 @@
 
 package hello;
 
-import static javafx.scene.paint.Color.GHOSTWHITE;
 import javafx.application.Application;
-import javafx.collections.ObservableList;
-import javafx.scene.Group;
-import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.ToggleButton;
 import javafx.scene.control.ToggleGroup;

--- a/apps/toys/Hello/src/main/java/hello/HelloWindowManager.java
+++ b/apps/toys/Hello/src/main/java/hello/HelloWindowManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,7 @@
 
 package hello;
 
-import java.util.Iterator;
-
 import javafx.application.Application;
-import javafx.beans.InvalidationListener;
-import javafx.beans.Observable;
 import javafx.collections.ObservableList;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;

--- a/apps/toys/LayoutDemo/src/layout/CustomHBox.java
+++ b/apps/toys/LayoutDemo/src/layout/CustomHBox.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ import javafx.geometry.Pos;
 import javafx.geometry.VPos;
 import javafx.scene.Node;
 import javafx.scene.layout.HBox;
-import static javafx.scene.layout.HBox.getMargin;
 
 public class CustomHBox extends HBox {
 

--- a/apps/toys/LayoutDemo/src/layout/CustomTilePane.java
+++ b/apps/toys/LayoutDemo/src/layout/CustomTilePane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,17 +25,15 @@
 
 package layout;
 
+import static javafx.geometry.Orientation.HORIZONTAL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javafx.geometry.HPos;
-import static javafx.geometry.Orientation.HORIZONTAL;
 import javafx.geometry.Pos;
 import javafx.geometry.VPos;
 import javafx.scene.Node;
 import javafx.scene.layout.TilePane;
-import static javafx.scene.layout.TilePane.getAlignment;
-import static javafx.scene.layout.TilePane.getMargin;
 
 public class CustomTilePane extends TilePane {
 

--- a/tests/performance/3DLighting/src/main/java/attenuation/CameraScene3D.java
+++ b/tests/performance/3DLighting/src/main/java/attenuation/CameraScene3D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@ import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.scene.Group;
 import javafx.scene.PerspectiveCamera;
-import javafx.scene.PointLight;
 import javafx.scene.SceneAntialiasing;
 import javafx.scene.SubScene;
 import javafx.scene.input.MouseButton;


### PR DESCRIPTION
Using Eclipse IDE to remove unused imports in **demo apps** (3D, Ensemble, etc.) and update the copyright year to 2024. Using wildcard for more than 10 static imports.

**PROBLEM**
The code in `graphics/build/gensrc/jsl-decora/` is generated and cannot be fixed.
This means this warning **must be suppressed** in IDEs until the generator script is changed not to emit unused imports.

--

This is a trivial change (though fairly large), 1 reviewer is probably enough.