### PR TITLE
8328749: Remove unused imports in javafx.web

### DIFF
--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/InputMethodSupport.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/InputMethodSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,15 +25,6 @@
 
 package javafx.embed.swing;
 
-import com.sun.javafx.application.PlatformImpl;
-import com.sun.javafx.collections.ObservableListWrapper;
-import com.sun.javafx.scene.input.ExtendedInputMethodRequests;
-import javafx.application.Platform;
-import javafx.collections.ObservableList;
-import javafx.geometry.Point2D;
-import javafx.scene.input.InputMethodHighlight;
-import javafx.scene.input.InputMethodTextRun;
-
 import java.awt.Rectangle;
 import java.awt.event.InputMethodEvent;
 import java.awt.font.TextHitInfo;
@@ -45,6 +36,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import javafx.collections.ObservableList;
+import javafx.geometry.Point2D;
+import javafx.scene.input.InputMethodHighlight;
+import javafx.scene.input.InputMethodTextRun;
+import com.sun.javafx.application.PlatformImpl;
+import com.sun.javafx.collections.ObservableListWrapper;
+import com.sun.javafx.scene.input.ExtendedInputMethodRequests;
 
 /**
  * A utility class containing the functions to support Input Methods

--- a/modules/javafx.swing/src/main/java/javafx/embed/swing/InputMethodSupport.java
+++ b/modules/javafx.swing/src/main/java/javafx/embed/swing/InputMethodSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2014, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,15 @@
 
 package javafx.embed.swing;
 
+import com.sun.javafx.application.PlatformImpl;
+import com.sun.javafx.collections.ObservableListWrapper;
+import com.sun.javafx.scene.input.ExtendedInputMethodRequests;
+import javafx.application.Platform;
+import javafx.collections.ObservableList;
+import javafx.geometry.Point2D;
+import javafx.scene.input.InputMethodHighlight;
+import javafx.scene.input.InputMethodTextRun;
+
 import java.awt.Rectangle;
 import java.awt.event.InputMethodEvent;
 import java.awt.font.TextHitInfo;
@@ -36,13 +45,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import javafx.collections.ObservableList;
-import javafx.geometry.Point2D;
-import javafx.scene.input.InputMethodHighlight;
-import javafx.scene.input.InputMethodTextRun;
-import com.sun.javafx.application.PlatformImpl;
-import com.sun.javafx.collections.ObservableListWrapper;
-import com.sun.javafx.scene.input.ExtendedInputMethodRequests;
 
 /**
  * A utility class containing the functions to support Input Methods

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/DOMWindowImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/DOMWindowImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,6 @@
 
 package com.sun.webkit.dom;
 
-import com.sun.webkit.Disposer;
-import com.sun.webkit.DisposerRecord;
-import com.sun.webkit.dom.JSObject;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -37,6 +34,7 @@ import org.w3c.dom.events.EventListener;
 import org.w3c.dom.events.EventTarget;
 import org.w3c.dom.views.AbstractView;
 import org.w3c.dom.views.DocumentView;
+import com.sun.webkit.Disposer;
 
 public class DOMWindowImpl extends JSObject implements AbstractView, EventTarget {
     // We use a custom hash-table rather than java.util.HashMap,

--- a/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/NodeImpl.java
+++ b/modules/javafx.web/src/main/native/Source/WebCore/bindings/java/dom3/java/com/sun/webkit/dom/NodeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,6 @@
 
 package com.sun.webkit.dom;
 
-import com.sun.webkit.Disposer;
-import com.sun.webkit.DisposerRecord;
-import com.sun.webkit.dom.JSObject;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -38,6 +35,7 @@ import org.w3c.dom.UserDataHandler;
 import org.w3c.dom.events.Event;
 import org.w3c.dom.events.EventListener;
 import org.w3c.dom.events.EventTarget;
+import com.sun.webkit.Disposer;
 
 public class NodeImpl extends JSObject implements Node, EventTarget {
     // We use a custom hash-table rather than java.util.HashMap,

--- a/modules/javafx.web/src/test/java/test/javafx/scene/web/WebWorkerTest.java
+++ b/modules/javafx.web/src/test/java/test/javafx/scene/web/WebWorkerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,18 +25,13 @@
 
 package test.javafx.scene.web;
 
-import javafx.concurrent.Worker.State;
-
-import static javafx.concurrent.Worker.State.SUCCEEDED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import java.util.concurrent.CountDownLatch;
-
-import org.junit.Test;
 import java.io.File;
-import java.io.IOException;
-import javafx.scene.web.WebView;
+import javafx.concurrent.Worker.State;
 import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
+import org.junit.Test;
 
 public class WebWorkerTest extends TestBase {
 


### PR DESCRIPTION
Using Eclipse IDE to remove unused imports **javafx.web** module, and update the copyright year to 2024. Using wildcard for more than 10 static imports.


--

This is a trivial change, 1 reviewer is probably enough.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8328749](https://bugs.openjdk.org/browse/JDK-8328749): Remove unused imports in javafx.web (**Bug** - P4)


### Reviewers
 * [Hima Bindu Meda](https://openjdk.org/census#hmeda) (@HimaBinduMeda - Committer)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1421/head:pull/1421` \
`$ git checkout pull/1421`

Update a local copy of the PR: \
`$ git checkout pull/1421` \
`$ git pull https://git.openjdk.org/jfx.git pull/1421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1421`

View PR using the GUI difftool: \
`$ git pr show -t 1421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1421.diff">https://git.openjdk.org/jfx/pull/1421.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1421#issuecomment-2015407587)