### PR TITLE
JDK-8328750: [TestBug] Improve Stub Font Support

### DIFF
--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/AreaChartTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/AreaChartTest.java
@@ -534,8 +534,8 @@ public class AreaChartTest extends XYChartTestBase {
                 .filter(pathElement -> pathElement instanceof LineTo)
                 .map(pathElement -> (LineTo) pathElement)
                 .map(lineTo -> new Point2D(
-                        Math.ceil(xAxis.getValueForDisplay(lineTo.getX()).doubleValue()),
-                        Math.ceil(yAxis.getValueForDisplay(lineTo.getY()).doubleValue()))
+                        Math.round(xAxis.getValueForDisplay(lineTo.getX()).doubleValue()),
+                        Math.round(yAxis.getValueForDisplay(lineTo.getY()).doubleValue()))
                 )
                 .collect(Collectors.toList());
         // Due to fillPath, one additional LineTo element is added to close the loop

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/AreaChartTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/AreaChartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -534,8 +534,8 @@ public class AreaChartTest extends XYChartTestBase {
                 .filter(pathElement -> pathElement instanceof LineTo)
                 .map(pathElement -> (LineTo) pathElement)
                 .map(lineTo -> new Point2D(
-                        xAxis.getValueForDisplay(lineTo.getX()).doubleValue(),
-                        yAxis.getValueForDisplay(lineTo.getY()).doubleValue())
+                        Math.ceil(xAxis.getValueForDisplay(lineTo.getX()).doubleValue()),
+                        Math.ceil(yAxis.getValueForDisplay(lineTo.getY()).doubleValue()))
                 )
                 .collect(Collectors.toList());
         // Due to fillPath, one additional LineTo element is added to close the loop

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/chart/StackedBarChartTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/chart/StackedBarChartTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,7 +108,7 @@ public class StackedBarChartTest extends XYChartTestBase {
         // compute bounds for the first series
         String bounds = computeBoundsString((Region)childrenList.get(0), (Region)childrenList.get(1),
                 (Region)childrenList.get(2));
-        assertEquals("10 478 234 37 254 432 234 83 499 375 234 140 ", bounds);
+        assertEquals("10 453 218 35 238 409 218 79 465 355 218 133 ", bounds);
 
         // compute bounds for the second series
 //        bounds = computeBoundsString((Region)childrenList.get(3), (Region)childrenList.get(4),

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextInputControlTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/TextInputControlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -150,10 +150,12 @@ public class TextInputControlTest {
      ********************************************************************/
 
     @Test public void fontSetFromCSS() {
-        textInput.setStyle("-fx-font: 24 Helvetica");
+        assertEquals(Font.font("System", 12), textInput.getFont());
+
+        textInput.setStyle("-fx-font: 24 Amble");
         Scene s = new Scene(textInput);
         textInput.applyCss();
-        assertEquals(Font.font("Helvetica", 24), textInput.getFont());
+        assertEquals(Font.font("Amble", 24), textInput.getFont());
     }
 
     /******************************************************

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/StubFontContractTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/StubFontContractTest.java
@@ -1,0 +1,175 @@
+package test.javafx.scene.control.skin;
+
+import com.sun.javafx.scene.control.skin.Utils;
+import javafx.scene.control.Label;
+import javafx.scene.text.Font;
+import javafx.scene.text.FontPosture;
+import javafx.scene.text.FontWeight;
+import org.junit.jupiter.api.Test;
+import test.com.sun.javafx.scene.control.infrastructure.StageLoader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * This is a test for fonts, font loading and their computed sizes.
+ * Note that while we only test the stub font loading here, we still want to verify some basic rules that apply
+ * for all headless tests.
+ * <p>
+ * See the javadoc for every method to get more details.
+ * @see test.com.sun.javafx.pgstub.StubFontLoader
+ * @see test.com.sun.javafx.pgstub.StubTextLayout
+ */
+class StubFontContractTest {
+
+    /**
+     * An unknown font has no text width.
+     */
+    @Test
+    public void testUnknownFont() {
+        Font font = new Font("bla", 12);
+
+        assertEquals(0, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+    }
+
+    /**
+     * Even if the font name is equal with a family name, we do not know the font by name.
+     */
+    @Test
+    public void testFamilyAsFontName() {
+        Font font = new Font("System", 12);
+
+        assertEquals(0, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+    }
+
+    /**
+     * System Regular is the default font for headless testing but also for JavaFX itself.
+     * 12 is the default font size for headless testing. This is different from JavaFX, as size from the OS will be used.
+     */
+    @Test
+    public void testDefaultFont() {
+        Label lbl = new Label();
+        Font defaultFont = lbl.getFont();
+
+        assertEquals("System Regular", defaultFont.getName());
+        assertEquals("System", defaultFont.getFamily());
+        assertEquals("Regular", defaultFont.getStyle());
+        assertEquals(12, defaultFont.getSize());
+
+        assertEquals(120, Utils.computeTextWidth(defaultFont, "ABCDEFGHIJ", -1));
+    }
+
+    @Test
+    public void testDefaultFontSet() {
+        Label lbl = new Label();
+        Font font = lbl.getFont();
+
+        assertEquals("System Regular", font.getName());
+        assertEquals(12, font.getSize());
+
+        lbl.setFont(Font.font("system", FontWeight.BOLD, 20));
+
+        font = lbl.getFont();
+        assertEquals("System Bold", font.getName());
+        assertEquals(20, font.getSize());
+
+        assertEquals(210, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+    }
+
+    @Test
+    public void testDefaultFontCssSet() {
+        Label lbl = new Label();
+        Font font = lbl.getFont();
+
+        assertEquals("System Regular", font.getName());
+        assertEquals(12, font.getSize());
+
+        StageLoader stageLoader = new StageLoader(lbl);
+
+        lbl.setStyle("-fx-font: bold 20px System;");
+        lbl.applyCss();
+
+        stageLoader.dispose();
+
+        font = lbl.getFont();
+        assertEquals("System Bold", font.getName());
+        assertEquals(20, font.getSize());
+
+        assertEquals(210, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+    }
+
+    /**
+     * System Regular is a font that is available for testing.
+     */
+    @Test
+    public void testFontByName() {
+        Font font = new Font("System Regular", 12);
+
+        assertEquals(120, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+    }
+
+    /**
+     * The System family is available for testing.
+     */
+    @Test
+    public void testFontByFamily() {
+        Font font = Font.font("System", 12);
+
+        assertEquals("Regular", font.getStyle());
+        assertEquals(120, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+    }
+
+    /**
+     * The system font can be loaded with a normal weight.
+     */
+    @Test
+    public void testFontByFamilyNormal() {
+        Font font = Font.font("System", FontWeight.NORMAL, 12);
+
+        assertEquals("Regular", font.getStyle());
+        assertEquals(120, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+    }
+
+    /**
+     * The system font can also be bold. In that case it is a bit wider than the normal one.
+     */
+    @Test
+    public void testFontByFamilyBold() {
+        Font font = Font.font("System", FontWeight.BOLD, 12);
+
+        assertEquals("Bold", font.getStyle());
+        assertEquals(130, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+    }
+
+    /**
+     * The system font can also be italic.
+     */
+    @Test
+    public void testFontByFamilyItalic() {
+        Font font = Font.font("System", FontPosture.ITALIC, 12);
+
+        assertEquals("Italic", font.getStyle());
+        assertEquals(120, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+    }
+
+    /**
+     * The system font can also be bold and Italic. In that case it is a bit wider than the normal one.
+     */
+    @Test
+    public void testFontByFamilyBoldItalic() {
+        Font font = Font.font("System", FontWeight.BOLD, FontPosture.ITALIC, 12);
+
+        assertEquals("Bold Italic", font.getStyle());
+        assertEquals(130, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+    }
+
+    /**
+     * Amble is the other font we support for headless testing.
+     */
+    @Test
+    public void testAmbleFont() {
+        Font font = Font.font("Amble", 12);
+
+        assertEquals(120, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+    }
+
+}

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/StubFontContractTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/StubFontContractTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * This is a test for fonts, font loading and their computed sizes.
  * Note that while we only test the stub font loading here, we still want to verify some basic rules that apply
- * for all headless tests.
+ * for all headless tests. Some rules are somewhat derived from the real font loading in JavaFX.
  * <p>
  * See the javadoc for every method to get more details.
  * @see test.com.sun.javafx.pgstub.StubFontLoader
@@ -22,13 +22,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 class StubFontContractTest {
 
     /**
-     * An unknown font has no text width.
+     * An unknown font will fall back to the system font. Note that this is the same behaviour in JavaFX.
      */
     @Test
     public void testUnknownFont() {
-        Font font = new Font("bla", 12);
+        Font font = new Font("bla", 10);
 
-        assertEquals(0, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals("bla", font.getName());
+        assertEquals("System", font.getFamily());
+        assertEquals("Regular", font.getStyle());
+        assertEquals(10, font.getSize());
+
+        assertEquals(100, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals(10, Utils.computeTextHeight(font, "ABCDEFGHIJ", 0, null));
     }
 
     /**
@@ -36,9 +42,15 @@ class StubFontContractTest {
      */
     @Test
     public void testFamilyAsFontName() {
-        Font font = new Font("System", 12);
+        Font font = new Font("System", 10);
 
-        assertEquals(0, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals("System", font.getName());
+        assertEquals("System", font.getFamily());
+        assertEquals("Regular", font.getStyle());
+        assertEquals(10, font.getSize());
+
+        assertEquals(100, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals(10, Utils.computeTextHeight(font, "ABCDEFGHIJ", 0, null));
     }
 
     /**
@@ -56,6 +68,7 @@ class StubFontContractTest {
         assertEquals(12, defaultFont.getSize());
 
         assertEquals(120, Utils.computeTextWidth(defaultFont, "ABCDEFGHIJ", -1));
+        assertEquals(12, Utils.computeTextHeight(defaultFont, "ABCDEFGHIJ", 0, null));
     }
 
     @Test
@@ -73,6 +86,7 @@ class StubFontContractTest {
         assertEquals(20, font.getSize());
 
         assertEquals(210, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals(20, Utils.computeTextHeight(font, "ABCDEFGHIJ", 0, null));
     }
 
     @Test
@@ -95,6 +109,7 @@ class StubFontContractTest {
         assertEquals(20, font.getSize());
 
         assertEquals(210, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals(20, Utils.computeTextHeight(font, "ABCDEFGHIJ", 0, null));
     }
 
     /**
@@ -102,9 +117,10 @@ class StubFontContractTest {
      */
     @Test
     public void testFontByName() {
-        Font font = new Font("System Regular", 12);
+        Font font = new Font("System Regular", 11);
 
-        assertEquals(120, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals(110, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals(11, Utils.computeTextHeight(font, "ABCDEFGHIJ", 0, null));
     }
 
     /**
@@ -112,10 +128,11 @@ class StubFontContractTest {
      */
     @Test
     public void testFontByFamily() {
-        Font font = Font.font("System", 12);
+        Font font = Font.font("System", 11);
 
         assertEquals("Regular", font.getStyle());
-        assertEquals(120, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals(110, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals(11, Utils.computeTextHeight(font, "ABCDEFGHIJ", 0, null));
     }
 
     /**
@@ -123,10 +140,11 @@ class StubFontContractTest {
      */
     @Test
     public void testFontByFamilyNormal() {
-        Font font = Font.font("System", FontWeight.NORMAL, 12);
+        Font font = Font.font("System", FontWeight.NORMAL, 11);
 
         assertEquals("Regular", font.getStyle());
-        assertEquals(120, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals(110, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals(11, Utils.computeTextHeight(font, "ABCDEFGHIJ", 0, null));
     }
 
     /**
@@ -134,10 +152,11 @@ class StubFontContractTest {
      */
     @Test
     public void testFontByFamilyBold() {
-        Font font = Font.font("System", FontWeight.BOLD, 12);
+        Font font = Font.font("System", FontWeight.BOLD, 13);
 
         assertEquals("Bold", font.getStyle());
-        assertEquals(130, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals(140, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals(13, Utils.computeTextHeight(font, "ABCDEFGHIJ", 0, null));
     }
 
     /**
@@ -145,10 +164,11 @@ class StubFontContractTest {
      */
     @Test
     public void testFontByFamilyItalic() {
-        Font font = Font.font("System", FontPosture.ITALIC, 12);
+        Font font = Font.font("System", FontPosture.ITALIC, 11);
 
         assertEquals("Italic", font.getStyle());
-        assertEquals(120, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals(110, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals(11, Utils.computeTextHeight(font, "ABCDEFGHIJ", 0, null));
     }
 
     /**
@@ -156,10 +176,11 @@ class StubFontContractTest {
      */
     @Test
     public void testFontByFamilyBoldItalic() {
-        Font font = Font.font("System", FontWeight.BOLD, FontPosture.ITALIC, 12);
+        Font font = Font.font("System", FontWeight.BOLD, FontPosture.ITALIC, 13);
 
         assertEquals("Bold Italic", font.getStyle());
-        assertEquals(130, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals(140, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals(13, Utils.computeTextHeight(font, "ABCDEFGHIJ", 0, null));
     }
 
     /**
@@ -167,9 +188,10 @@ class StubFontContractTest {
      */
     @Test
     public void testAmbleFont() {
-        Font font = Font.font("Amble", 12);
+        Font font = Font.font("Amble", 11);
 
-        assertEquals(120, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals(110, Utils.computeTextWidth(font, "ABCDEFGHIJ", -1));
+        assertEquals(11, Utils.computeTextHeight(font, "ABCDEFGHIJ", 0, null));
     }
 
 }

--- a/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableColumnHeaderTest.java
+++ b/modules/javafx.controls/src/test/java/test/javafx/scene/control/skin/TableColumnHeaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,8 +82,6 @@ public class TableColumnHeaderTest {
         Toolkit tk = Toolkit.getToolkit();
 
         tk.firePulse();
-        //Force the column to have default font, otherwise font Amble is applied and mess with header width size
-        column.setStyle("-fx-font: System;");
         firstColumnHeader = VirtualFlowTestUtils.getTableColumnHeader(tableView, column);
     }
 

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubFontLoader.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubFontLoader.java
@@ -37,54 +37,53 @@ import javafx.scene.text.FontPosture;
 import javafx.scene.text.FontWeight;
 
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
+/**
+ * Stub implementation of the {@link FontLoader} for testing purposes.
+ * <br>
+ * Can recognize and load some fonts we defined below, will otherwise fall back to the
+ * System font (like in the real font loader).
+ */
 public class StubFontLoader extends FontLoader {
 
     @Override
     public void loadFont(Font font) {
-        StubFont nativeFont = new StubFont();
-        nativeFont.font = font;
+        StubFont stub = new StubFont();
+        stub.font = font;
 
-        String name = font.getName().trim().toLowerCase(Locale.ROOT);
-        switch (name) {
-            case "system regular" -> FontHelper.setNativeFont(font, nativeFont, font.getName(), "System", "Regular");
-            case "system bold" -> FontHelper.setNativeFont(font, nativeFont, font.getName(), "System", "Bold");
-            case "system italic" -> FontHelper.setNativeFont(font, nativeFont, font.getName(), "System", "Italic");
-            case "system bold italic" ->
-                    FontHelper.setNativeFont(font, nativeFont, font.getName(), "System", "Bold Italic");
-            case "amble regular" -> FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble", "Regular");
-            case "amble bold" -> FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble", "Bold");
-            case "amble italic" -> FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble", "Italic");
-            case "amble bold italic" ->
-                    FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble", "Bold Italic");
-            case "amble condensed" -> FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble Cn", "Regular");
-            case "amble bold condensed" ->
-                    FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble Cn", "Bold");
-            case "amble condensed italic" ->
-                    FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble Cn", "Italic");
-            case "amble bold condensed italic" ->
-                    FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble Cn", "Bold Italic");
-            case "amble light" -> FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble Lt", "Regular");
-            case "amble light italic" ->
-                    FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble Lt", "Italic");
-            case "amble light condensed" ->
-                    FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble LtCn", "Regular");
-            case "amble light condensed italic" ->
-                    FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble LtCn", "Italic");
+        String name = font.getName();
+        String nameLower = name.trim().toLowerCase(Locale.ROOT);
+        switch (nameLower) {
+            case "system regular" -> FontHelper.setNativeFont(font, stub, name, "System", "Regular");
+            case "system bold" -> FontHelper.setNativeFont(font, stub, name, "System", "Bold");
+            case "system italic" -> FontHelper.setNativeFont(font, stub, name, "System", "Italic");
+            case "system bold italic" -> FontHelper.setNativeFont(font, stub, name, "System", "Bold Italic");
+            case "amble regular" -> FontHelper.setNativeFont(font, stub, name, "Amble", "Regular");
+            case "amble bold" -> FontHelper.setNativeFont(font, stub, name, "Amble", "Bold");
+            case "amble italic" -> FontHelper.setNativeFont(font, stub, name, "Amble", "Italic");
+            case "amble bold italic" -> FontHelper.setNativeFont(font, stub, name, "Amble", "Bold Italic");
+            case "amble condensed" -> FontHelper.setNativeFont(font, stub, name, "Amble Cn", "Regular");
+            case "amble bold condensed" -> FontHelper.setNativeFont(font, stub, name, "Amble Cn", "Bold");
+            case "amble condensed italic" -> FontHelper.setNativeFont(font, stub, name, "Amble Cn", "Italic");
+            case "amble bold condensed italic" -> FontHelper.setNativeFont(font, stub, name, "Amble Cn", "Bold Italic");
+            case "amble light" -> FontHelper.setNativeFont(font, stub, name, "Amble Lt", "Regular");
+            case "amble light italic" -> FontHelper.setNativeFont(font, stub, name, "Amble Lt", "Italic");
+            case "amble light condensed" -> FontHelper.setNativeFont(font, stub, name, "Amble LtCn", "Regular");
+            case "amble light condensed italic" -> FontHelper.setNativeFont(font, stub, name, "Amble LtCn", "Italic");
+            default -> FontHelper.setNativeFont(font, stub, name, "System", "Regular");
         }
     }
 
     @Override
     public List<String> getFamilies() {
-        return Arrays.asList("System", "Amble", "Amble Cn", "Amble Lt", "Amble LtCn");
+        return List.of("System", "Amble", "Amble Cn", "Amble Lt", "Amble LtCn");
     }
 
     @Override
     public List<String> getFontNames() {
-        return Arrays.asList("System Regular", "System Bold", "System Italic", "System Bold Italic",
+        return List.of("System Regular", "System Bold", "System Italic", "System Bold Italic",
                 "Amble Regular", "Amble Bold", "Amble Italic", "Amble Bold Italic",
                 "Amble Condensed", "Amble Bold Condensed", "Amble Condensed Italic", "Amble Bold Condensed Italic",
                 "Amble Light", "Amble Light Italic", "Amble Light Condensed", "Amble Light Condensed Italic");
@@ -97,8 +96,7 @@ public class StubFontLoader extends FontLoader {
         return switch (familyLower) {
             case "system" -> List.of("System Regular", "System Bold", "System Italic", "System Bold Italic");
             case "amble" -> List.of("Amble Regular", "Amble Bold", "Amble Italic", "Amble Bold Italic");
-            case "amble cn" -> List.of("Amble Condensed", "Amble Bold Condensed", "Amble Condensed Italic",
-                    "Amble Bold Condensed Italic");
+            case "amble cn" -> List.of("Amble Condensed", "Amble Bold Condensed", "Amble Condensed Italic", "Amble Bold Condensed Italic");
             case "amble lt" -> List.of("Amble Light", "Amble Light Italic");
             case "amble ltcn" -> List.of("Amble Light Condensed", "Amble Light Condensed Italic");
             default -> List.of();

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubFontLoader.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubFontLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,123 +47,127 @@ public class StubFontLoader extends FontLoader {
     public void loadFont(Font font) {
         StubFont nativeFont = new StubFont();
         nativeFont.font = font;
+
         String name = font.getName().trim().toLowerCase(Locale.ROOT);
-        if (name.equals("system") || name.equals("system regular")) {
-            FontHelper.setNativeFont(font, nativeFont, font.getName(), "System", "Regular");
-        } else if (name.equals("amble regular")) {
-            FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble", "Regular");
-        } else if (name.equals("amble bold")) {
-            FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble", "Bold");
-        } else if (name.equals("amble italic")) {
-            FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble", "Italic");
-        } else if (name.equals("amble bold italic")) {
-            FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble",
-                    "Bold Italic");
-        } else if (name.equals("amble condensed")) {
-            FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble Cn", "Regular");
-        } else if (name.equals("amble bold condensed")) {
-            FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble Cn", "Bold");
-        } else if (name.equals("amble condensed italic")) {
-            FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble Cn", "Italic");
-        } else if (name.equals("amble bold condensed italic")) {
-            FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble Cn",
-                    "Bold Italic");
-        } else if (name.equals("amble light")) {
-            FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble Lt", "Regular");
-        } else if (name.equals("amble light italic")) {
-            FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble Lt", "Italic");
-        } else if (name.equals("amble light condensed")) {
-            FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble LtCn",
-                    "Regular");
-        } else if (name.equals("amble light condensed italic")) {
-            FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble LtCn",
-                    "Italic");
+        switch (name) {
+            case "system regular" -> FontHelper.setNativeFont(font, nativeFont, font.getName(), "System", "Regular");
+            case "system bold" -> FontHelper.setNativeFont(font, nativeFont, font.getName(), "System", "Bold");
+            case "system italic" -> FontHelper.setNativeFont(font, nativeFont, font.getName(), "System", "Italic");
+            case "system bold italic" ->
+                    FontHelper.setNativeFont(font, nativeFont, font.getName(), "System", "Bold Italic");
+            case "amble regular" -> FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble", "Regular");
+            case "amble bold" -> FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble", "Bold");
+            case "amble italic" -> FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble", "Italic");
+            case "amble bold italic" ->
+                    FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble", "Bold Italic");
+            case "amble condensed" -> FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble Cn", "Regular");
+            case "amble bold condensed" ->
+                    FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble Cn", "Bold");
+            case "amble condensed italic" ->
+                    FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble Cn", "Italic");
+            case "amble bold condensed italic" ->
+                    FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble Cn", "Bold Italic");
+            case "amble light" -> FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble Lt", "Regular");
+            case "amble light italic" ->
+                    FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble Lt", "Italic");
+            case "amble light condensed" ->
+                    FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble LtCn", "Regular");
+            case "amble light condensed italic" ->
+                    FontHelper.setNativeFont(font, nativeFont, font.getName(), "Amble LtCn", "Italic");
         }
     }
 
     @Override
     public List<String> getFamilies() {
-        return Arrays.asList("Amble", "Amble Cn", "Amble Lt", "Amble LtCn");
+        return Arrays.asList("System", "Amble", "Amble Cn", "Amble Lt", "Amble LtCn");
     }
 
     @Override
     public List<String> getFontNames() {
-        return Arrays.asList("Amble Regular", "Amble Bold", "Amble Italic",
-                "Amble Bold Italic", "Amble Condensed", "Amble Bold Condensed",
-                "Amble Condensed Italic", "Amble Bold Condensed Italic",
-                "Amble Light", "Amble Light Italic", "Amble Light Condensed",
-                "Amble Light Condensed Italic");
+        return Arrays.asList("System Regular", "System Bold", "System Italic", "System Bold Italic",
+                "Amble Regular", "Amble Bold", "Amble Italic", "Amble Bold Italic",
+                "Amble Condensed", "Amble Bold Condensed", "Amble Condensed Italic", "Amble Bold Condensed Italic",
+                "Amble Light", "Amble Light Italic", "Amble Light Condensed", "Amble Light Condensed Italic");
     }
 
     @Override
     public List<String> getFontNames(String family) {
-        String lower = family.trim().toLowerCase(Locale.ROOT);
-        if ("amble".equals(lower)) {
-            return Arrays.asList("Amble Regular", "Amble Bold", "Amble Italic",
-                    "Amble Bold Italic");
-        } else if ("amble cn".equals(lower)) {
-            return Arrays.asList("Amble Condensed", "Amble Bold Condensed",
-                    "Amble Condensed Italic", "Amble Bold Condensed Italic");
-        } else if ("amble lt".equals(lower)) {
-            return Arrays.asList("Amble Light", "Amble Light Italic");
-        } else if ("amble ltcn".equals(lower)) {
-            return Arrays.asList("Amble Light Condensed",
-                    "Amble Light Condensed Italic");
-        } else {
-            return Arrays.asList();
-        }
+        String familyLower = family.trim().toLowerCase(Locale.ROOT);
+
+        return switch (familyLower) {
+            case "system" -> List.of("System Regular", "System Bold", "System Italic", "System Bold Italic");
+            case "amble" -> List.of("Amble Regular", "Amble Bold", "Amble Italic", "Amble Bold Italic");
+            case "amble cn" -> List.of("Amble Condensed", "Amble Bold Condensed", "Amble Condensed Italic",
+                    "Amble Bold Condensed Italic");
+            case "amble lt" -> List.of("Amble Light", "Amble Light Italic");
+            case "amble ltcn" -> List.of("Amble Light Condensed", "Amble Light Condensed Italic");
+            default -> List.of();
+        };
     }
 
     @Override
     public Font font(String family, FontWeight weight, FontPosture posture,
             float size) {
-        family = family.trim();
-        String fam = family.toLowerCase(Locale.ROOT);
+        String fam = family.trim().toLowerCase(Locale.ROOT);
         String name = "";
-        if ("amble".equals(fam)) {
-            if (weight != null
-                    && weight.ordinal() < FontWeight.NORMAL.ordinal()) {
-                name = name + " Light";
-            } else if (weight != null
-                    && weight.ordinal() > FontWeight.NORMAL.ordinal()) {
-                name = name + " Bold";
-            } else if (posture != FontPosture.ITALIC) {
-                name = name + " Regular";
-            }
-        } else if ("amble cn".equals(fam) || "amble condensed".equals(fam)) {
-            if (weight != null
-                    && weight.ordinal() < FontWeight.NORMAL.ordinal()) {
-                name = name + " Light";
-            } else if (weight != null
-                    && weight.ordinal() > FontWeight.NORMAL.ordinal()) {
-                name = name + " Bold";
-            }
-            name = name + " Condensed";
-        } else if ("amble lt".equals(fam)) {
-            if (weight.ordinal() <= FontWeight.NORMAL.ordinal()) {
-                name = name + " Light";
-            } else if (weight != null
-                    && weight.ordinal() < FontWeight.BOLD.ordinal()
-                    && posture != FontPosture.ITALIC) {
-                name = name + " Regular";
-            } else if (weight != null
-                    && weight.ordinal() >= FontWeight.BOLD.ordinal()) {
-                name = name + " Bold";
-            }
-        } else if ("amble ltcn".equals(fam)) {
-            if (weight.ordinal() <= FontWeight.NORMAL.ordinal()) {
-                name = name + " Light";
-            } else if (weight != null
-                    && weight.ordinal() >= FontWeight.BOLD.ordinal()) {
-                name = name + " Bold";
-            }
-            name = name + " Condensed";
+        if (fam.startsWith("system")) {
+            name = "System";
+        } else if (fam.startsWith("amble")) {
+            name = "Amble";
         }
+
+        switch (fam) {
+            case "amble", "system" -> {
+                if (weight != null
+                        && weight.ordinal() < FontWeight.NORMAL.ordinal()) {
+                    name = name + " Light";
+                } else if (weight != null
+                        && weight.ordinal() > FontWeight.NORMAL.ordinal()) {
+                    name = name + " Bold";
+                } else if (posture != FontPosture.ITALIC) {
+                    name = name + " Regular";
+                }
+            }
+            case "amble cn", "amble condensed" -> {
+                if (weight != null
+                        && weight.ordinal() < FontWeight.NORMAL.ordinal()) {
+                    name = name + " Light";
+                } else if (weight != null
+                        && weight.ordinal() > FontWeight.NORMAL.ordinal()) {
+                    name = name + " Bold";
+                }
+                name = name + " Condensed";
+            }
+            case "amble lt" -> {
+                if (weight != null
+                        && weight.ordinal() <= FontWeight.NORMAL.ordinal()) {
+                    name = name + " Light";
+                } else if (weight != null
+                        && weight.ordinal() < FontWeight.BOLD.ordinal()
+                        && posture != FontPosture.ITALIC) {
+                    name = name + " Regular";
+                } else if (weight != null
+                        && weight.ordinal() >= FontWeight.BOLD.ordinal()) {
+                    name = name + " Bold";
+                }
+            }
+            case "amble ltcn" -> {
+                if (weight != null
+                        && weight.ordinal() <= FontWeight.NORMAL.ordinal()) {
+                    name = name + " Light";
+                } else if (weight != null
+                        && weight.ordinal() >= FontWeight.BOLD.ordinal()) {
+                    name = name + " Bold";
+                }
+                name = name + " Condensed";
+            }
+        }
+
         if (posture == FontPosture.ITALIC) {
             name = name + " Italic";
         }
-        String fn = "Amble" + name;
-        return new Font(fn, size);
+
+        return new Font(name, size);
     }
 
     @Override

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubTextLayout.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubTextLayout.java
@@ -33,6 +33,12 @@ import com.sun.javafx.scene.text.*;
 import javafx.scene.shape.PathElement;
 import javafx.scene.text.Font;
 
+/**
+ * Stub implementation of the {@link TextLayout} for testing purposes.
+ * <br>
+ * Can calculate the bounds of text by simply using the size of the font.
+ * If the text is bold, the font will be 1 pixel bigger.
+ */
 public class StubTextLayout implements TextLayout {
 
     @Override
@@ -92,20 +98,22 @@ public class StubTextLayout implements TextLayout {
 
     @Override
     public BaseBounds getBounds(TextSpan filter, BaseBounds bounds) {
-        double fontSize = nullFontSize;
+        double fontSizeH = nullFontSize;
+        double fontSizeW = nullFontSize;
         if (font != null) {
-            fontSize = font.getSize();
+            fontSizeH = font.getSize();
+            fontSizeW = font.getSize();
 
             // For better testing, we make bold text a little bit bigger.
             boolean bold = font.getStyle().toLowerCase().contains("bold");
             if (bold) {
-                fontSize++;
+                fontSizeW++;
             }
         }
 
         final String[] lines = getText().split("\n");
         double width = 0.0;
-        double height = fontSize * lines.length + spacing * (lines.length - 1);
+        double height = fontSizeH * lines.length + spacing * (lines.length - 1);
         for (String line : lines) {
             final int length;
             if (line.contains("\t")) {
@@ -125,10 +133,10 @@ public class StubTextLayout implements TextLayout {
             } else {
                 length = line.length();
             }
-            width = Math.max(width, fontSize * length);
+            width = Math.max(width, fontSizeW * length);
         }
-        return bounds.deriveWithNewBounds(0, (float)-fontSize, 0,
-                (float)width, (float)(height-fontSize), 0);
+        return bounds.deriveWithNewBounds(0, (float)-fontSizeH, 0,
+                (float)width, (float)(height-fontSizeH), 0);
     }
 
     class StubTextLine implements TextLine {

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubTextLayout.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubTextLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,7 +92,17 @@ public class StubTextLayout implements TextLayout {
 
     @Override
     public BaseBounds getBounds(TextSpan filter, BaseBounds bounds) {
-        final double fontSize = (font == null ? nullFontSize : font.getSize());
+        double fontSize = nullFontSize;
+        if (font != null) {
+            fontSize = font.getSize();
+
+            // For better testing, we make bold text a little bit bigger.
+            boolean bold = font.getStyle().toLowerCase().contains("bold");
+            if (bold) {
+                fontSize++;
+            }
+        }
+
         final String[] lines = getText().split("\n");
         double width = 0.0;
         double height = fontSize * lines.length + spacing * (lines.length - 1);

--- a/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubTextLayout.java
+++ b/modules/javafx.graphics/src/test/java/test/com/sun/javafx/pgstub/StubTextLayout.java
@@ -37,7 +37,7 @@ import javafx.scene.text.Font;
  * Stub implementation of the {@link TextLayout} for testing purposes.
  * <br>
  * Can calculate the bounds of text by simply using the size of the font.
- * If the text is bold, the font will be 1 pixel bigger.
+ * If the text is bold, the font will be 1 pixel wider for the calculation.
  */
 public class StubTextLayout implements TextLayout {
 

--- a/modules/javafx.graphics/src/test/java/test/javafx/scene/CssStyleHelperTest.java
+++ b/modules/javafx.graphics/src/test/java/test/javafx/scene/CssStyleHelperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -107,13 +107,13 @@ public class CssStyleHelperTest {
         Toolkit.getToolkit().firePulse();
         assertEquals("Italic", C.getFont().getStyle());
         assertEquals("Italic", D.getFont().getStyle());
-        assertNull(E.getFont().getStyle());
+        assertEquals("Regular", E.getFont().getStyle());
 
         B.getChildren().add(D); //move D
         Toolkit.getToolkit().firePulse();
         assertEquals("Italic", C.getFont().getStyle());
-        assertNull(D.getFont().getStyle());
-        assertNull(E.getFont().getStyle());
+        assertEquals("Regular", D.getFont().getStyle());
+        assertEquals("Regular", E.getFont().getStyle());
     }
 
     @Test
@@ -194,7 +194,7 @@ public class CssStyleHelperTest {
         Toolkit.getToolkit().firePulse();
         assertEquals("Italic", C.getFont().getStyle());
         assertEquals("Italic", D.getFont().getStyle());
-        assertNull(E.getFont().getStyle());
+        assertEquals("Regular", E.getFont().getStyle());
 
         A.getChildren().remove(D); //move D
         Toolkit.getToolkit().firePulse();
@@ -202,8 +202,8 @@ public class CssStyleHelperTest {
         Toolkit.getToolkit().firePulse();
 
         assertEquals("Italic", C.getFont().getStyle());
-        assertNull(D.getFont().getStyle());
-        assertNull(E.getFont().getStyle());
+        assertEquals("Regular", D.getFont().getStyle());
+        assertEquals("Regular", E.getFont().getStyle());
     }
 
     @Test
@@ -482,7 +482,7 @@ public class CssStyleHelperTest {
         A.getChildren().add(C);
         Toolkit.getToolkit().firePulse();
 
-        assertNull(C.getFont().getStyle());
+        assertEquals("Regular", C.getFont().getStyle());
     }
 
     @Test
@@ -518,7 +518,7 @@ public class CssStyleHelperTest {
         A.getChildren().add(C);
         Toolkit.getToolkit().firePulse();
 
-        assertNull(C.getFont().getStyle());
+        assertEquals("Regular", C.getFont().getStyle());
     }
 
     @Test
@@ -553,7 +553,7 @@ public class CssStyleHelperTest {
         A.getChildren().add(C);
         Toolkit.getToolkit().firePulse();
 
-        assertNull(C.getFont().getStyle());
+        assertEquals("Regular", C.getFont().getStyle());
     }
 
     @Test


### PR DESCRIPTION
In https://github.com/openjdk/jfx/pull/1405, I identified some shortcomings of the stub font implementation. As I don't want to clutter the PR with that, I decided to cherrypick the improvements I did to a new ticket and PR.

The current implementation has the following shortcomings:
- It does not reliable detect the System Font, as a consequence, tests in TableColumnHeaderTest.java are failing on my local machine
- Another consequence of this is, that the font size is always estimated with 0, as it is not detected
- One shortcoming currently is, that the stub font siie estimate is not considering bold fonts. That would improve writing tests for some scenarios, e.g. for TableColumnHeader, where we would expect that the size of the header is bigger since it is bold

Some tests were failing for the following reasons:
- `AreaChartTest.java` - `expected -30.0, was -30.00000000004` - I added rounding to the data.
- `StackedBarChartTest.java` - since we now calculate correctly, the path changed
- A test tried to load `Helvetica`, which is not supported in the stub font loader. I changed it
- The default System font is considered a `Regular` one (style) - just like in JavaFX

I wrote tests and documented the stub behaviour.
I did some minor changes here:
- System font is now detected, also in bold and italic
- A bold font will be calculated with a little bit more width (1px). Checkout the test as well for that

Note: This only changes test setup, no 'production' code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328750](https://bugs.openjdk.org/browse/JDK-8328750): [TestBug] Improve Stub Font Support (**Bug** - P4)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx.git pull/1422/head:pull/1422` \
`$ git checkout pull/1422`

Update a local copy of the PR: \
`$ git checkout pull/1422` \
`$ git pull https://git.openjdk.org/jfx.git pull/1422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1422`

View PR using the GUI difftool: \
`$ git pr show -t 1422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx/pull/1422.diff">https://git.openjdk.org/jfx/pull/1422.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jfx/pull/1422#issuecomment-2013935734)