### PR TITLE
8328751: Fix missing @Overrides in modules except javafx.web

### DIFF
--- a/modules/javafx.base/src/test/java/test/javafx/binding/GenericBindingTest.java
+++ b/modules/javafx.base/src/test/java/test/javafx/binding/GenericBindingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -427,6 +427,7 @@ public class GenericBindingTest<T> {
             return null;
         }
 
+        @Override
         public void publicUnbind(Observable... observables) {
             super.unbind(observables);
         }
@@ -464,6 +465,7 @@ public class GenericBindingTest<T> {
             return null;
         }
 
+        @Override
         public void publicUnbind(Observable... observables) {
             super.unbind(observables);
         }
@@ -501,6 +503,7 @@ public class GenericBindingTest<T> {
             return null;
         }
 
+        @Override
         public void publicUnbind(Observable... observables) {
             super.unbind(observables);
         }
@@ -538,6 +541,7 @@ public class GenericBindingTest<T> {
             return null;
         }
 
+        @Override
         public void publicUnbind(Observable... observables) {
             super.unbind(observables);
         }
@@ -575,6 +579,7 @@ public class GenericBindingTest<T> {
             return null;
         }
 
+        @Override
         public void publicUnbind(Observable... observables) {
             super.unbind(observables);
         }
@@ -612,6 +617,7 @@ public class GenericBindingTest<T> {
             return null;
         }
 
+        @Override
         public void publicUnbind(Observable... observables) {
             super.unbind(observables);
         }
@@ -649,6 +655,7 @@ public class GenericBindingTest<T> {
             return null;
         }
 
+        @Override
         public void publicUnbind(Observable... observables) {
             super.unbind(observables);
         }
@@ -686,6 +693,7 @@ public class GenericBindingTest<T> {
             return null;
         }
 
+        @Override
         public void publicUnbind(Observable... observables) {
             super.unbind(observables);
         }

--- a/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
+++ b/modules/javafx.controls/src/main/java/javafx/scene/control/skin/VirtualFlow.java
@@ -3290,14 +3290,17 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             }
         }
 
+        @Override
         public T getFirst() {
             return firstIndex == -1 ? null : array.get(firstIndex);
         }
 
+        @Override
         public T getLast() {
             return lastIndex == -1 ? null : array.get(lastIndex);
         }
 
+        @Override
         public void addFirst(T cell) {
             // if firstIndex == -1 then that means this is the first item in the
             // list and we need to initialize firstIndex and lastIndex
@@ -3316,6 +3319,7 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             }
         }
 
+        @Override
         public void addLast(T cell) {
 
             // if lastIndex == -1 then that means this is the first item in the
@@ -3362,11 +3366,13 @@ public class VirtualFlow<T extends IndexedCell> extends Region {
             firstIndex = lastIndex = -1;
         }
 
+        @Override
         public T removeFirst() {
             if (isEmpty()) return null;
             return remove(0);
         }
 
+        @Override
         public T removeLast() {
             if (isEmpty()) return null;
             return remove(lastIndex - firstIndex);

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/CompositeFontResource.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/CompositeFontResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,7 @@ public interface CompositeFontResource extends FontResource {
      */
     public int getSlotForFont(String fontName);
 
+    @Override
     default boolean isColorGlyph(int glyphCode) {
         int slot = (glyphCode >>> 24);
         int slotglyphCode = glyphCode & CompositeGlyphMapper.GLYPHMASK;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FallbackResource.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/FallbackResource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -272,6 +272,7 @@ public class FallbackResource implements CompositeFontResource {
         return ns+1;
     }
 
+    @Override
     public int addSlotFont(FontResource fr) {
         int slot = getSlotForFont(fr.getFullName());
         if (slot >= 0) {
@@ -366,6 +367,7 @@ public class FallbackResource implements CompositeFontResource {
         return strike;
     }
 
+    @Override
     public String toString() {
         int ns = getNumSlots();
         String s = "Fallback resource:\n";

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/LogicalFont.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/LogicalFont.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -304,6 +304,7 @@ public class LogicalFont implements CompositeFontResource {
         return ns;
     }
 
+    @Override
     public int addSlotFont(FontResource fr) {
         if (fr == null) {
             return -1;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFile.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/PrismFontFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1420,6 +1420,7 @@ public abstract class PrismFontFile implements FontResource, FontConstants {
        return hasColorTables;
     }
 
+    @Override
     public boolean isColorGlyph(int glyphID) {
         if (!fontSupportsColorGlyphs()) {
             return false;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/coretext/CTFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,6 +100,7 @@ public class CTFactory extends PrismFontFactory {
          return name.startsWith(".") || name.startsWith("System Font");
     }
 
+    @Override
     public FontFallbackInfo getFallbacks(FontResource primaryResource) {
         FontFallbackInfo info = new FontFallbackInfo();
         ArrayList<String> names;

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/DWFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/directwrite/DWFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -160,6 +160,7 @@ public class DWFactory extends PrismFontFactory {
     /*
      * Ignoring the primary on Windows - this should change some day.
      */
+    @Override
     public FontFallbackInfo getFallbacks(FontResource primaryResource) {
         FontFallbackInfo info = new FontFallbackInfo();
 

--- a/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/FTFactory.java
+++ b/modules/javafx.graphics/src/main/java/com/sun/javafx/font/freetype/FTFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -127,6 +127,7 @@ public class FTFactory extends PrismFontFactory {
         }
     }
 
+    @Override
     public FontFallbackInfo getFallbacks(FontResource primaryResource) {
         boolean isBold = primaryResource.isBold();
         boolean isItalic = primaryResource.isItalic();


### PR DESCRIPTION
Fix missing `@Override`s in
- javafx.base
- javafx.controls
- javafx.graphics

This is still a trivial change since all the spots are identified by the IDE.

1 reviewer is probably enough.